### PR TITLE
Add foundational Swift app state model and shell UI

### DIFF
--- a/AtelierCode/AppModel.swift
+++ b/AtelierCode/AppModel.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class AppModel {
+    private(set) var recentWorkspaces: [WorkspaceRecord]
+    private(set) var lastSelectedWorkspacePath: String?
+    private(set) var codexPathOverride: String?
+    private(set) var uiPreferences: UIPreferences
+    private(set) var startupDiagnostics: [StartupDiagnostic]
+    private(set) var activeWorkspaceController: WorkspaceController?
+
+    @ObservationIgnored private let preferencesStore: any AppPreferencesStore
+    @ObservationIgnored private let fileManager: FileManager
+    @ObservationIgnored private let bridgeDiagnosticProvider: () -> StartupDiagnostic
+    @ObservationIgnored private let now: () -> Date
+
+    init(
+        preferencesStore: any AppPreferencesStore = UserDefaultsAppPreferencesStore(),
+        fileManager: FileManager = .default,
+        bridgeDiagnosticProvider: @escaping () -> StartupDiagnostic = { StartupDiagnostic.defaultBridgeDiagnostic() },
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.preferencesStore = preferencesStore
+        self.fileManager = fileManager
+        self.bridgeDiagnosticProvider = bridgeDiagnosticProvider
+        self.now = now
+
+        let loadedSnapshot = try? preferencesStore.loadSnapshot()
+        let normalizedRecentWorkspaces = Self.normalizeRecentWorkspaces(loadedSnapshot?.recentWorkspaces ?? [])
+        let selectedPath = loadedSnapshot?.lastSelectedWorkspacePath.map(WorkspaceRecord.canonicalizedPath(for:))
+        let codexOverridePath = loadedSnapshot?.codexPathOverride
+        let preferences = loadedSnapshot?.uiPreferences ?? UIPreferences()
+
+        recentWorkspaces = normalizedRecentWorkspaces
+        lastSelectedWorkspacePath = selectedPath
+        codexPathOverride = codexOverridePath
+        uiPreferences = preferences
+        startupDiagnostics = [bridgeDiagnosticProvider()]
+        activeWorkspaceController = nil
+
+        if let codexOverridePath {
+            startupDiagnostics.append(Self.codexOverrideDiagnostic(path: codexOverridePath, fileManager: fileManager))
+        }
+
+        if let selectedPath {
+            if Self.workspaceExists(atPath: selectedPath, fileManager: fileManager) {
+                let restoredWorkspace = normalizedRecentWorkspaces.first(where: { $0.canonicalPath == selectedPath })
+                    ?? WorkspaceRecord(
+                        canonicalPath: selectedPath,
+                        displayName: URL(fileURLWithPath: selectedPath).lastPathComponent,
+                        lastOpenedAt: now()
+                    )
+                activeWorkspaceController = WorkspaceController(workspace: restoredWorkspace)
+                startupDiagnostics.append(.restoredWorkspacePresent(restoredWorkspace))
+            } else {
+                lastSelectedWorkspacePath = nil
+                startupDiagnostics.append(.restoredWorkspaceMissing(path: selectedPath))
+            }
+        }
+
+        if let loadedSnapshot, loadedSnapshot != snapshot {
+            persistPreferences()
+        }
+    }
+
+    var snapshot: AppPreferencesSnapshot {
+        AppPreferencesSnapshot(
+            recentWorkspaces: recentWorkspaces,
+            lastSelectedWorkspacePath: lastSelectedWorkspacePath,
+            codexPathOverride: codexPathOverride,
+            uiPreferences: uiPreferences
+        )
+    }
+
+    func activateWorkspace(at url: URL) {
+        let workspace = WorkspaceRecord(url: url, lastOpenedAt: now())
+        activeWorkspaceController = WorkspaceController(workspace: workspace)
+        lastSelectedWorkspacePath = workspace.canonicalPath
+        recentWorkspaces = Self.upsertingRecentWorkspace(workspace, into: recentWorkspaces)
+        persistPreferences()
+    }
+
+    func reopenWorkspace(_ workspace: WorkspaceRecord) {
+        activateWorkspace(at: workspace.url)
+    }
+
+    func clearSelectedWorkspace() {
+        activeWorkspaceController = nil
+        lastSelectedWorkspacePath = nil
+        persistPreferences()
+    }
+
+    func setCodexPathOverride(_ path: String?) {
+        codexPathOverride = path?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        persistPreferences()
+    }
+
+    func updateUIPreferences(_ update: (inout UIPreferences) -> Void) {
+        update(&uiPreferences)
+        persistPreferences()
+    }
+
+    private func persistPreferences() {
+        try? preferencesStore.saveSnapshot(snapshot)
+    }
+
+    private static func normalizeRecentWorkspaces(_ workspaces: [WorkspaceRecord]) -> [WorkspaceRecord] {
+        var seenPaths = Set<String>()
+        let normalized = workspaces
+            .map {
+                WorkspaceRecord(
+                    canonicalPath: $0.canonicalPath,
+                    displayName: $0.displayName,
+                    lastOpenedAt: $0.lastOpenedAt
+                )
+            }
+            .sorted { $0.lastOpenedAt > $1.lastOpenedAt }
+
+        var uniqueWorkspaces: [WorkspaceRecord] = []
+
+        for workspace in normalized where seenPaths.insert(workspace.canonicalPath).inserted {
+            uniqueWorkspaces.append(workspace)
+
+            if uniqueWorkspaces.count == 20 {
+                break
+            }
+        }
+
+        return uniqueWorkspaces
+    }
+
+    private static func upsertingRecentWorkspace(
+        _ workspace: WorkspaceRecord,
+        into workspaces: [WorkspaceRecord]
+    ) -> [WorkspaceRecord] {
+        var updated = workspaces.filter { $0.canonicalPath != workspace.canonicalPath }
+        updated.insert(workspace, at: 0)
+        return Array(updated.prefix(20))
+    }
+
+    private static func workspaceExists(atPath path: String, fileManager: FileManager) -> Bool {
+        var isDirectory = ObjCBool(false)
+        let exists = fileManager.fileExists(atPath: path, isDirectory: &isDirectory)
+        return exists && isDirectory.boolValue
+    }
+
+    private static func codexOverrideDiagnostic(path: String, fileManager: FileManager) -> StartupDiagnostic {
+        let canonicalPath = URL(fileURLWithPath: path)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+            .path
+        let exists = fileManager.fileExists(atPath: canonicalPath)
+        return exists ? .codexOverridePresent(path: canonicalPath) : .codexOverrideMissing(path: canonicalPath)
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/AtelierCode/AppPreferencesStore.swift
+++ b/AtelierCode/AppPreferencesStore.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+protocol AppPreferencesStore {
+    func loadSnapshot() throws -> AppPreferencesSnapshot?
+    func saveSnapshot(_ snapshot: AppPreferencesSnapshot) throws
+}
+
+struct AppPreferencesSnapshot: Codable, Equatable, Sendable {
+    var recentWorkspaces: [WorkspaceRecord]
+    var lastSelectedWorkspacePath: String?
+    var codexPathOverride: String?
+    var uiPreferences: UIPreferences
+}
+
+struct UserDefaultsAppPreferencesStore: AppPreferencesStore {
+    private let userDefaults: UserDefaults
+    private let storageKey: String
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(
+        userDefaults: UserDefaults = .standard,
+        storageKey: String = "ateliercode.app-preferences"
+    ) {
+        self.userDefaults = userDefaults
+        self.storageKey = storageKey
+        self.encoder.dateEncodingStrategy = .iso8601
+        self.decoder.dateDecodingStrategy = .iso8601
+    }
+
+    func loadSnapshot() throws -> AppPreferencesSnapshot? {
+        guard let data = userDefaults.data(forKey: storageKey) else {
+            return nil
+        }
+
+        return try decoder.decode(AppPreferencesSnapshot.self, from: data)
+    }
+
+    func saveSnapshot(_ snapshot: AppPreferencesSnapshot) throws {
+        let data = try encoder.encode(snapshot)
+        userDefaults.set(data, forKey: storageKey)
+    }
+}

--- a/AtelierCode/AppStateTypes.swift
+++ b/AtelierCode/AppStateTypes.swift
@@ -1,0 +1,251 @@
+import Foundation
+
+struct WorkspaceRecord: Codable, Equatable, Sendable, Identifiable {
+    let canonicalPath: String
+    let displayName: String
+    let lastOpenedAt: Date
+
+    var id: String { canonicalPath }
+
+    var url: URL {
+        URL(fileURLWithPath: canonicalPath, isDirectory: true)
+    }
+
+    init(canonicalPath: String, displayName: String, lastOpenedAt: Date) {
+        self.canonicalPath = WorkspaceRecord.canonicalizedPath(for: canonicalPath)
+        self.displayName = displayName
+        self.lastOpenedAt = lastOpenedAt
+    }
+
+    init(url: URL, lastOpenedAt: Date) {
+        let canonicalURL = WorkspaceRecord.canonicalizedURL(for: url)
+        let name = canonicalURL.lastPathComponent.isEmpty ? canonicalURL.path : canonicalURL.lastPathComponent
+
+        self.init(canonicalPath: canonicalURL.path, displayName: name, lastOpenedAt: lastOpenedAt)
+    }
+
+    static func canonicalizedPath(for path: String) -> String {
+        canonicalizedURL(for: URL(fileURLWithPath: path, isDirectory: true)).path
+    }
+
+    static func canonicalizedURL(for url: URL) -> URL {
+        URL(fileURLWithPath: url.path, isDirectory: true)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+    }
+}
+
+struct UIPreferences: Codable, Equatable, Sendable {
+    var showsStartupDiagnostics = true
+}
+
+enum StartupDiagnosticSource: String, Codable, Equatable, Sendable {
+    case embeddedBridge
+    case restoredWorkspace
+    case codexOverridePath
+}
+
+enum StartupDiagnosticSeverity: String, Codable, Equatable, Sendable {
+    case info
+    case warning
+    case error
+}
+
+struct StartupDiagnostic: Equatable, Sendable, Identifiable {
+    let source: StartupDiagnosticSource
+    let severity: StartupDiagnosticSeverity
+    let message: String
+
+    var id: String {
+        "\(source.rawValue)-\(severity.rawValue)-\(message)"
+    }
+}
+
+extension StartupDiagnostic {
+    static func bridgePresent(at url: URL) -> Self {
+        Self(
+            source: .embeddedBridge,
+            severity: .info,
+            message: "Embedded bridge available at \(url.path)."
+        )
+    }
+
+    static func bridgeMissing(expectedPath: URL) -> Self {
+        Self(
+            source: .embeddedBridge,
+            severity: .error,
+            message: "Embedded bridge missing at \(expectedPath.path)."
+        )
+    }
+
+    static func restoredWorkspacePresent(_ workspace: WorkspaceRecord) -> Self {
+        Self(
+            source: .restoredWorkspace,
+            severity: .info,
+            message: "Restored workspace \(workspace.displayName) from \(workspace.canonicalPath)."
+        )
+    }
+
+    static func restoredWorkspaceMissing(path: String) -> Self {
+        Self(
+            source: .restoredWorkspace,
+            severity: .warning,
+            message: "Could not restore workspace at \(path) because it no longer exists."
+        )
+    }
+
+    static func codexOverridePresent(path: String) -> Self {
+        Self(
+            source: .codexOverridePath,
+            severity: .info,
+            message: "Codex override path available at \(path)."
+        )
+    }
+
+    static func codexOverrideMissing(path: String) -> Self {
+        Self(
+            source: .codexOverridePath,
+            severity: .warning,
+            message: "Codex override path set to \(path), but that location does not exist."
+        )
+    }
+
+    static func defaultBridgeDiagnostic(locator: BridgeExecutableLocator = BridgeExecutableLocator()) -> Self {
+        do {
+            return .bridgePresent(at: try locator.embeddedBridgeURL())
+        } catch BridgeExecutableLocatorError.missingEmbeddedBridge(let expectedPath) {
+            return .bridgeMissing(expectedPath: expectedPath)
+        } catch {
+            let expectedPath = locator.bundle.bundleURL
+                .appendingPathComponent("Contents", isDirectory: true)
+                .appendingPathComponent("MacOS", isDirectory: true)
+                .appendingPathComponent(BridgeExecutableLocator.executableName, isDirectory: false)
+            return .bridgeMissing(expectedPath: expectedPath)
+        }
+    }
+}
+
+enum BridgeLifecycleState: String, Equatable, Sendable {
+    case idle
+    case starting
+    case stopping
+}
+
+enum ConnectionStatus: Equatable, Sendable {
+    case disconnected
+    case connecting
+    case ready
+    case streaming
+    case cancelling
+    case error(message: String)
+}
+
+enum AuthState: Equatable, Sendable {
+    case unknown
+    case signedOut
+    case signedIn(accountDescription: String)
+}
+
+struct ThreadSummary: Equatable, Sendable, Identifiable {
+    let id: String
+    var title: String
+    var previewText: String
+    var updatedAt: Date
+}
+
+enum ConversationRole: String, Equatable, Sendable {
+    case system
+    case user
+    case assistant
+    case tool
+}
+
+struct ConversationMessage: Equatable, Sendable, Identifiable {
+    let id: String
+    let role: ConversationRole
+    var text: String
+}
+
+struct TurnState: Equatable, Sendable {
+    enum Phase: String, Equatable, Sendable {
+        case idle
+        case inProgress
+        case completed
+        case cancelled
+        case failed
+    }
+
+    var phase: Phase = .idle
+    var assistantMessageID: String?
+    var thinkingText = ""
+    var failureDescription: String?
+}
+
+enum ActivityKind: String, Equatable, Sendable {
+    case tool
+    case fileChange
+}
+
+enum ActivityStatus: String, Equatable, Sendable {
+    case running
+    case completed
+    case failed
+    case cancelled
+}
+
+struct ActivityItem: Equatable, Sendable, Identifiable {
+    let id: String
+    let kind: ActivityKind
+    var title: String
+    var detail: String
+    var status: ActivityStatus
+}
+
+enum ApprovalKind: String, Equatable, Sendable {
+    case command
+    case fileChange
+    case generic
+}
+
+enum ApprovalResolution: String, Equatable, Sendable {
+    case approved
+    case declined
+    case cancelled
+    case stale
+}
+
+struct ApprovalRequest: Equatable, Sendable, Identifiable {
+    let id: String
+    let kind: ApprovalKind
+    var title: String
+    var detail: String
+}
+
+enum PlanStepStatus: String, Equatable, Sendable {
+    case pending
+    case inProgress
+    case completed
+}
+
+struct PlanStep: Equatable, Sendable, Identifiable {
+    let id: String
+    var title: String
+    var status: PlanStepStatus
+}
+
+struct PlanState: Equatable, Sendable {
+    var summary: String?
+    var steps: [PlanStep]
+}
+
+struct DiffFileChange: Equatable, Sendable, Identifiable {
+    let id: String
+    var path: String
+    var additions: Int
+    var deletions: Int
+}
+
+struct AggregatedDiff: Equatable, Sendable {
+    var summary: String
+    var files: [DiffFileChange]
+}

--- a/AtelierCode/AtelierCodeApp.swift
+++ b/AtelierCode/AtelierCodeApp.swift
@@ -9,9 +9,12 @@ import SwiftUI
 
 @main
 struct AtelierCodeApp: App {
+    @State private var appModel = AppModel()
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environment(appModel)
         }
     }
 }

--- a/AtelierCode/ContentView.swift
+++ b/AtelierCode/ContentView.swift
@@ -8,17 +8,321 @@
 import SwiftUI
 
 struct ContentView: View {
+    @Environment(AppModel.self) private var appModel
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        NavigationSplitView {
+            List {
+                Section("Recent Workspaces") {
+                    if appModel.recentWorkspaces.isEmpty {
+                        Text("No recent workspaces yet.")
+                            .foregroundStyle(.secondary)
+                            .accessibilityIdentifier("recent-workspaces-empty-state")
+                    } else {
+                        ForEach(appModel.recentWorkspaces) { workspace in
+                            Button {
+                                appModel.reopenWorkspace(workspace)
+                            } label: {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(workspace.displayName)
+                                    Text(workspace.canonicalPath)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(2)
+                                }
+                                .padding(.vertical, 2)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Workspaces")
+            .frame(minWidth: 280)
+        } detail: {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("AtelierCode")
+                            .font(.largeTitle.weight(.semibold))
+                            .accessibilityIdentifier("app-shell-title")
+                        Text("State-driven shell for workspace, thread, and startup diagnostics.")
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if appModel.uiPreferences.showsStartupDiagnostics {
+                        DiagnosticsSection(diagnostics: appModel.startupDiagnostics)
+                    }
+
+                    WorkspaceSummarySection(
+                        appModel: appModel,
+                        controller: appModel.activeWorkspaceController
+                    )
+
+                    ThreadSessionSection(session: appModel.activeWorkspaceController?.activeThreadSession)
+                }
+                .padding(24)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
         }
-        .padding()
+    }
+}
+
+private struct DiagnosticsSection: View {
+    let diagnostics: [StartupDiagnostic]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Startup Diagnostics")
+                .font(.title2.weight(.semibold))
+
+            if diagnostics.isEmpty {
+                Text("No startup diagnostics recorded.")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(diagnostics) { diagnostic in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(diagnostic.severity.label)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(diagnostic.severity.color)
+                        Text(diagnostic.message)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .padding(12)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 12))
+                }
+            }
+        }
+        .accessibilityIdentifier("startup-diagnostics-section")
+    }
+}
+
+private struct WorkspaceSummarySection: View {
+    let appModel: AppModel
+    let controller: WorkspaceController?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Selected Workspace")
+                .font(.title2.weight(.semibold))
+
+            if let controller {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(controller.workspace.displayName)
+                        .font(.headline)
+                    Text(controller.workspace.canonicalPath)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                    Text("Bridge lifecycle: \(controller.bridgeLifecycleState.rawValue.capitalized)")
+                    Text("Connection: \(controller.connectionStatus.label)")
+                    Text("Auth: \(controller.authState.label)")
+                    Text("Threads in sidebar: \(controller.threadSummaries.count)")
+
+                    Button("Clear Selection") {
+                        appModel.clearSelectedWorkspace()
+                    }
+                }
+                .padding(16)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 12))
+            } else {
+                Text("Select or restore a workspace to see controller state.")
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("workspace-summary-empty-state")
+            }
+        }
+    }
+}
+
+private struct ThreadSessionSection: View {
+    let session: ThreadSession?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Thread Session")
+                .font(.title2.weight(.semibold))
+
+            if let session {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(session.title)
+                        .font(.headline)
+                    Text("Messages: \(session.messages.count)")
+                    Text("Turn: \(session.turnState.phase.label)")
+                    Text("Pending approvals: \(session.pendingApprovals.count)")
+                    Text("Activity items: \(session.activityItems.count)")
+                    Text("Plan steps: \(session.planState?.steps.count ?? 0)")
+                    Text("Diff files: \(session.aggregatedDiff?.files.count ?? 0)")
+                }
+                .padding(16)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 12))
+            } else {
+                Text("No active thread yet. Open or resume a thread once bridge integration arrives.")
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("thread-session-empty-state")
+            }
+        }
     }
 }
 
 #Preview {
-    ContentView()
+    let workspaceRoot = FileManager.default.temporaryDirectory
+        .appendingPathComponent("AtelierCodePreview", isDirectory: true)
+    try? FileManager.default.createDirectory(at: workspaceRoot, withIntermediateDirectories: true)
+
+    let preferencesStore = PreviewPreferencesStore()
+    try? preferencesStore.saveSnapshot(
+        AppPreferencesSnapshot(
+            recentWorkspaces: [WorkspaceRecord(url: workspaceRoot, lastOpenedAt: .now)],
+            lastSelectedWorkspacePath: workspaceRoot.path,
+            codexPathOverride: "/usr/local/bin/codex",
+            uiPreferences: UIPreferences(showsStartupDiagnostics: true)
+        )
+    )
+
+    let appModel = AppModel(
+        preferencesStore: preferencesStore,
+        bridgeDiagnosticProvider: {
+            .bridgePresent(at: URL(fileURLWithPath: "/Applications/AtelierCode.app/Contents/MacOS/ateliercode-agent-bridge"))
+        }
+    )
+
+    if let controller = appModel.activeWorkspaceController {
+        controller.setBridgeLifecycleState(.starting)
+        controller.setConnectionStatus(.ready)
+        controller.setAuthState(.signedIn(accountDescription: "Preview Account"))
+        controller.replaceThreadList([
+            ThreadSummary(
+                id: "preview-thread",
+                title: "App state foundation",
+                previewText: "State shell is wired.",
+                updatedAt: .now
+            )
+        ])
+
+        let session = controller.resumeThread(
+            id: "preview-thread",
+            title: "App state foundation",
+            messages: [
+                ConversationMessage(id: "user-1", role: .user, text: "Show the state model preview."),
+                ConversationMessage(id: "assistant-1", role: .assistant, text: "Preview shell is ready.")
+            ]
+        )
+        session.beginTurn()
+        session.appendThinkingDelta("Wiring placeholder session state.")
+        session.startActivity(
+            id: "activity-1",
+            kind: .tool,
+            title: "Preview bridge activity",
+            detail: "Populating sample data"
+        )
+        session.completeActivity(id: "activity-1")
+        session.enqueueApprovalRequest(
+            ApprovalRequest(
+                id: "approval-1",
+                kind: .command,
+                title: "Run preview command",
+                detail: "xcodebuild test"
+            )
+        )
+        session.replacePlanState(
+            PlanState(
+                summary: "Finish the shell pass",
+                steps: [
+                    PlanStep(id: "step-1", title: "Model graph", status: .completed),
+                    PlanStep(id: "step-2", title: "Shell UI", status: .inProgress)
+                ]
+            )
+        )
+        session.replaceAggregatedDiff(
+            AggregatedDiff(
+                summary: "Adds initial app state scaffolding.",
+                files: [
+                    DiffFileChange(id: "diff-1", path: "AtelierCode/AppModel.swift", additions: 120, deletions: 0)
+                ]
+            )
+        )
+    }
+
+    return ContentView()
+        .environment(appModel)
+}
+
+private final class PreviewPreferencesStore: AppPreferencesStore {
+    private var storedSnapshot: AppPreferencesSnapshot?
+
+    func loadSnapshot() throws -> AppPreferencesSnapshot? {
+        storedSnapshot
+    }
+
+    func saveSnapshot(_ snapshot: AppPreferencesSnapshot) throws {
+        storedSnapshot = snapshot
+    }
+}
+
+private extension StartupDiagnosticSeverity {
+    var label: String {
+        rawValue.capitalized
+    }
+
+    var color: Color {
+        switch self {
+        case .info:
+            return .blue
+        case .warning:
+            return .orange
+        case .error:
+            return .red
+        }
+    }
+}
+
+private extension ConnectionStatus {
+    var label: String {
+        switch self {
+        case .disconnected:
+            return "Disconnected"
+        case .connecting:
+            return "Connecting"
+        case .ready:
+            return "Ready"
+        case .streaming:
+            return "Streaming"
+        case .cancelling:
+            return "Cancelling"
+        case .error(let message):
+            return "Error: \(message)"
+        }
+    }
+}
+
+private extension AuthState {
+    var label: String {
+        switch self {
+        case .unknown:
+            return "Unknown"
+        case .signedOut:
+            return "Signed Out"
+        case .signedIn(let accountDescription):
+            return "Signed In (\(accountDescription))"
+        }
+    }
+}
+
+private extension TurnState.Phase {
+    var label: String {
+        switch self {
+        case .idle:
+            return "Idle"
+        case .inProgress:
+            return "In Progress"
+        case .completed:
+            return "Completed"
+        case .cancelled:
+            return "Cancelled"
+        case .failed:
+            return "Failed"
+        }
+    }
 }

--- a/AtelierCode/ThreadSession.swift
+++ b/AtelierCode/ThreadSession.swift
@@ -1,0 +1,196 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class ThreadSession {
+    private(set) var threadID: String
+    private(set) var title: String
+    private(set) var messages: [ConversationMessage]
+    private(set) var turnState: TurnState
+    private(set) var pendingApprovals: [ApprovalRequest]
+    private(set) var activityItems: [ActivityItem]
+    private(set) var planState: PlanState?
+    private(set) var aggregatedDiff: AggregatedDiff?
+
+    init(
+        threadID: String,
+        title: String,
+        messages: [ConversationMessage] = [],
+        turnState: TurnState = TurnState(),
+        pendingApprovals: [ApprovalRequest] = [],
+        activityItems: [ActivityItem] = [],
+        planState: PlanState? = nil,
+        aggregatedDiff: AggregatedDiff? = nil
+    ) {
+        self.threadID = threadID
+        self.title = title
+        self.messages = messages
+        self.turnState = turnState
+        self.pendingApprovals = pendingApprovals
+        self.activityItems = activityItems
+        self.planState = planState
+        self.aggregatedDiff = aggregatedDiff
+    }
+
+    func startThread(id: String, title: String) {
+        threadID = id
+        self.title = title
+        messages.removeAll()
+        clearVolatilePerTurnState()
+    }
+
+    func resumeThread(id: String, title: String, messages: [ConversationMessage]) {
+        threadID = id
+        self.title = title
+        self.messages = messages
+        clearVolatilePerTurnState()
+    }
+
+    func beginTurn(userPrompt: String? = nil) {
+        if let userPrompt, userPrompt.isEmpty == false {
+            messages.append(
+                ConversationMessage(
+                    id: UUID().uuidString,
+                    role: .user,
+                    text: userPrompt
+                )
+            )
+        }
+
+        turnState = TurnState(phase: .inProgress, assistantMessageID: nil, thinkingText: "", failureDescription: nil)
+        pendingApprovals.removeAll()
+        activityItems.removeAll()
+        planState = nil
+        aggregatedDiff = nil
+    }
+
+    func appendAssistantTextDelta(_ delta: String) {
+        guard delta.isEmpty == false else {
+            return
+        }
+
+        if let assistantMessageID = turnState.assistantMessageID,
+           let index = messages.firstIndex(where: { $0.id == assistantMessageID }) {
+            messages[index].text += delta
+            return
+        }
+
+        let message = ConversationMessage(
+            id: UUID().uuidString,
+            role: .assistant,
+            text: delta
+        )
+        messages.append(message)
+        turnState.assistantMessageID = message.id
+    }
+
+    func appendThinkingDelta(_ delta: String) {
+        guard delta.isEmpty == false else {
+            return
+        }
+
+        turnState.thinkingText += delta
+    }
+
+    func startActivity(id: String, kind: ActivityKind, title: String, detail: String = "") {
+        if let index = activityItems.firstIndex(where: { $0.id == id }) {
+            activityItems[index].title = title
+            activityItems[index].detail = detail
+            activityItems[index].status = .running
+            return
+        }
+
+        activityItems.append(
+            ActivityItem(
+                id: id,
+                kind: kind,
+                title: title,
+                detail: detail,
+                status: .running
+            )
+        )
+    }
+
+    func updateActivity(id: String, detail: String) {
+        guard let index = activityItems.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+
+        activityItems[index].detail = detail
+    }
+
+    func completeActivity(id: String, status: ActivityStatus = .completed, detail: String? = nil) {
+        guard let index = activityItems.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+
+        activityItems[index].status = status
+
+        if let detail {
+            activityItems[index].detail = detail
+        }
+    }
+
+    func enqueueApprovalRequest(_ request: ApprovalRequest) {
+        guard pendingApprovals.contains(where: { $0.id == request.id }) == false else {
+            return
+        }
+
+        pendingApprovals.append(request)
+    }
+
+    func resolveApprovalRequest(id: String, resolution _: ApprovalResolution) {
+        guard let index = pendingApprovals.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+
+        pendingApprovals.remove(at: index)
+    }
+
+    func replacePlanState(_ planState: PlanState?) {
+        self.planState = planState
+    }
+
+    func replaceAggregatedDiff(_ aggregatedDiff: AggregatedDiff?) {
+        self.aggregatedDiff = aggregatedDiff
+    }
+
+    func completeTurn() {
+        turnState.phase = .completed
+        pendingApprovals.removeAll()
+    }
+
+    func cancelTurn() {
+        turnState.phase = .cancelled
+        pendingApprovals.removeAll()
+
+        for index in activityItems.indices where activityItems[index].status == .running {
+            activityItems[index].status = .cancelled
+        }
+
+        planState = nil
+        aggregatedDiff = nil
+    }
+
+    func failTurn(_ message: String) {
+        turnState.phase = .failed
+        turnState.failureDescription = message
+        pendingApprovals.removeAll()
+
+        for index in activityItems.indices where activityItems[index].status == .running {
+            activityItems[index].status = .failed
+        }
+
+        planState = nil
+        aggregatedDiff = nil
+    }
+
+    func clearVolatilePerTurnState() {
+        turnState = TurnState()
+        pendingApprovals.removeAll()
+        activityItems.removeAll()
+        planState = nil
+        aggregatedDiff = nil
+    }
+}

--- a/AtelierCode/WorkspaceController.swift
+++ b/AtelierCode/WorkspaceController.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class WorkspaceController {
+    private(set) var workspace: WorkspaceRecord
+    private(set) var bridgeLifecycleState: BridgeLifecycleState
+    private(set) var connectionStatus: ConnectionStatus
+    private(set) var threadSummaries: [ThreadSummary]
+    private(set) var authState: AuthState
+    private(set) var activeThreadSession: ThreadSession?
+
+    init(workspace: WorkspaceRecord) {
+        self.workspace = workspace
+        self.bridgeLifecycleState = .idle
+        self.connectionStatus = .disconnected
+        self.threadSummaries = []
+        self.authState = .unknown
+        self.activeThreadSession = nil
+    }
+
+    func activate(workspace: WorkspaceRecord) {
+        self.workspace = workspace
+        resetWorkspace()
+    }
+
+    func resetWorkspace() {
+        bridgeLifecycleState = .idle
+        connectionStatus = .disconnected
+        threadSummaries.removeAll()
+        authState = .unknown
+        activeThreadSession = nil
+    }
+
+    func setBridgeLifecycleState(_ state: BridgeLifecycleState) {
+        bridgeLifecycleState = state
+    }
+
+    func setConnectionStatus(_ status: ConnectionStatus) {
+        connectionStatus = status
+    }
+
+    func setAuthState(_ authState: AuthState) {
+        self.authState = authState
+    }
+
+    func replaceThreadList(_ threadSummaries: [ThreadSummary]) {
+        self.threadSummaries = threadSummaries
+    }
+
+    @discardableResult
+    func openThread(id: String, title: String) -> ThreadSession {
+        let session = ThreadSession(threadID: id, title: title)
+        session.startThread(id: id, title: title)
+        activeThreadSession = session
+        return session
+    }
+
+    @discardableResult
+    func resumeThread(
+        id: String,
+        title: String,
+        messages: [ConversationMessage] = []
+    ) -> ThreadSession {
+        let session = ThreadSession(threadID: id, title: title)
+        session.resumeThread(id: id, title: title, messages: messages)
+        activeThreadSession = session
+        return session
+    }
+
+    func clearActiveThreadSession() {
+        activeThreadSession = nil
+    }
+}

--- a/AtelierCodeTests/AtelierCodeTests.swift
+++ b/AtelierCodeTests/AtelierCodeTests.swift
@@ -5,13 +5,143 @@
 //  Created by Jeremy Margaritondo on 3/23/26.
 //
 
+import Foundation
 import Testing
 @testable import AtelierCode
 
-struct AtelierCodeTests {
+@MainActor
+struct AppModelTests {
+    @Test func loadsPersistedPreferences() async throws {
+        let workspaceURL = try temporaryDirectory()
+        let codexURL = workspaceURL.appendingPathComponent("codex", isDirectory: false)
+        FileManager.default.createFile(atPath: codexURL.path, contents: Data())
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+        let snapshot = AppPreferencesSnapshot(
+            recentWorkspaces: [WorkspaceRecord(url: workspaceURL, lastOpenedAt: .distantPast)],
+            lastSelectedWorkspacePath: nil,
+            codexPathOverride: codexURL.path,
+            uiPreferences: UIPreferences(showsStartupDiagnostics: false)
+        )
+        let store = InMemoryAppPreferencesStore(snapshot: snapshot)
+
+        let appModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) }
+        )
+
+        #expect(appModel.recentWorkspaces == snapshot.recentWorkspaces)
+        #expect(appModel.codexPathOverride == codexURL.path)
+        #expect(appModel.uiPreferences == UIPreferences(showsStartupDiagnostics: false))
+        #expect(appModel.startupDiagnostics.contains(where: { $0.source == .embeddedBridge }))
+        #expect(appModel.startupDiagnostics.contains(where: { $0.source == .codexOverridePath }))
     }
 
+    @Test func restoresValidLastSelectedWorkspace() async throws {
+        let workspaceURL = try temporaryDirectory()
+        let snapshot = AppPreferencesSnapshot(
+            recentWorkspaces: [WorkspaceRecord(url: workspaceURL, lastOpenedAt: .now)],
+            lastSelectedWorkspacePath: workspaceURL.path,
+            codexPathOverride: nil,
+            uiPreferences: UIPreferences()
+        )
+        let store = InMemoryAppPreferencesStore(snapshot: snapshot)
+
+        let appModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) }
+        )
+
+        #expect(appModel.lastSelectedWorkspacePath == workspaceURL.path)
+        #expect(appModel.activeWorkspaceController?.workspace.canonicalPath == workspaceURL.path)
+        #expect(appModel.startupDiagnostics.contains(where: { $0.source == .restoredWorkspace && $0.severity == .info }))
+    }
+
+    @Test func clearsInvalidRestoredWorkspaceAndRecordsDiagnostic() async throws {
+        let workspaceURL = try temporaryDirectory()
+        try FileManager.default.removeItem(at: workspaceURL)
+
+        let snapshot = AppPreferencesSnapshot(
+            recentWorkspaces: [],
+            lastSelectedWorkspacePath: workspaceURL.path,
+            codexPathOverride: nil,
+            uiPreferences: UIPreferences()
+        )
+        let store = InMemoryAppPreferencesStore(snapshot: snapshot)
+
+        let appModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) }
+        )
+
+        #expect(appModel.lastSelectedWorkspacePath == nil)
+        #expect(appModel.activeWorkspaceController == nil)
+        #expect(appModel.startupDiagnostics.contains(where: { $0.source == .restoredWorkspace && $0.severity == .warning }))
+        #expect(try store.loadSnapshot()?.lastSelectedWorkspacePath == nil)
+    }
+
+    @Test func deduplicatesAndCapsRecentWorkspaces() async throws {
+        let store = InMemoryAppPreferencesStore()
+        let appModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) }
+        )
+        var workspaceURLs: [URL] = []
+
+        for index in 0..<21 {
+            let workspaceURL = try temporaryDirectory(named: "workspace-\(index)")
+            workspaceURLs.append(workspaceURL)
+            appModel.activateWorkspace(at: workspaceURL)
+        }
+
+        appModel.activateWorkspace(at: workspaceURLs[5])
+
+        #expect(appModel.recentWorkspaces.count == 20)
+        #expect(appModel.recentWorkspaces.first?.canonicalPath == workspaceURLs[5].path)
+        #expect(Set(appModel.recentWorkspaces.map(\.canonicalPath)).count == appModel.recentWorkspaces.count)
+    }
+
+    @Test func roundTripsCodexOverrideAndUIPreferences() async throws {
+        let store = InMemoryAppPreferencesStore()
+        let appModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) }
+        )
+        let codexURL = try temporaryDirectory(named: "codex-bin").appendingPathComponent("codex")
+        FileManager.default.createFile(atPath: codexURL.path, contents: Data())
+
+        appModel.setCodexPathOverride(codexURL.path)
+        appModel.updateUIPreferences { preferences in
+            preferences.showsStartupDiagnostics = false
+        }
+
+        let restoredModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) }
+        )
+
+        #expect(restoredModel.codexPathOverride == codexURL.path)
+        #expect(restoredModel.uiPreferences == UIPreferences(showsStartupDiagnostics: false))
+    }
+}
+
+func temporaryDirectory(named name: String = UUID().uuidString) throws -> URL {
+    let url = FileManager.default.temporaryDirectory.appendingPathComponent(name, isDirectory: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+}
+
+private final class InMemoryAppPreferencesStore: AppPreferencesStore {
+    private var storedSnapshot: AppPreferencesSnapshot?
+
+    init(snapshot: AppPreferencesSnapshot? = nil) {
+        self.storedSnapshot = snapshot
+    }
+
+    func loadSnapshot() throws -> AppPreferencesSnapshot? {
+        storedSnapshot
+    }
+
+    func saveSnapshot(_ snapshot: AppPreferencesSnapshot) throws {
+        storedSnapshot = snapshot
+    }
 }

--- a/AtelierCodeTests/ThreadSessionTests.swift
+++ b/AtelierCodeTests/ThreadSessionTests.swift
@@ -1,0 +1,99 @@
+import Testing
+@testable import AtelierCode
+
+@MainActor
+struct ThreadSessionTests {
+    @Test func assistantAndThinkingDeltasAppendCorrectly() async throws {
+        let session = ThreadSession(threadID: "thread-1", title: "Thread")
+
+        session.beginTurn(userPrompt: "Hello")
+        session.appendAssistantTextDelta("Hello")
+        session.appendAssistantTextDelta(", world")
+        session.appendThinkingDelta("Reasoning")
+        session.appendThinkingDelta(" continues")
+
+        #expect(session.messages.count == 2)
+        #expect(session.messages.last?.text == "Hello, world")
+        #expect(session.turnState.thinkingText == "Reasoning continues")
+    }
+
+    @Test func activityItemsProgressCorrectly() async throws {
+        let session = ThreadSession(threadID: "thread-1", title: "Thread")
+
+        session.startActivity(id: "tool-1", kind: .tool, title: "xcodebuild", detail: "Launching")
+        session.updateActivity(id: "tool-1", detail: "Streaming output")
+        session.completeActivity(id: "tool-1")
+        session.startActivity(id: "file-1", kind: .fileChange, title: "ContentView.swift", detail: "Editing")
+        session.completeActivity(id: "file-1", status: .completed, detail: "Applied patch")
+
+        #expect(session.activityItems.count == 2)
+        #expect(session.activityItems[0].detail == "Streaming output")
+        #expect(session.activityItems[0].status == .completed)
+        #expect(session.activityItems[1].kind == .fileChange)
+        #expect(session.activityItems[1].status == .completed)
+    }
+
+    @Test func approvalQueueHandlesResolveDuplicateAndStaleCases() async throws {
+        let session = ThreadSession(threadID: "thread-1", title: "Thread")
+        let request = ApprovalRequest(id: "approval-1", kind: .command, title: "Run command", detail: "swift test")
+
+        session.enqueueApprovalRequest(request)
+        session.enqueueApprovalRequest(request)
+        session.resolveApprovalRequest(id: "approval-1", resolution: .approved)
+        session.resolveApprovalRequest(id: "approval-1", resolution: .stale)
+
+        #expect(session.pendingApprovals.isEmpty)
+    }
+
+    @Test func planAndDiffReplacementUpdatesSessionState() async throws {
+        let session = ThreadSession(threadID: "thread-1", title: "Thread")
+        let plan = PlanState(
+            summary: "Ship the feature",
+            steps: [PlanStep(id: "step-1", title: "Implement", status: .inProgress)]
+        )
+        let diff = AggregatedDiff(
+            summary: "One file changed",
+            files: [DiffFileChange(id: "diff-1", path: "AtelierCode/ContentView.swift", additions: 20, deletions: 5)]
+        )
+
+        session.replacePlanState(plan)
+        session.replaceAggregatedDiff(diff)
+
+        #expect(session.planState == plan)
+        #expect(session.aggregatedDiff == diff)
+    }
+
+    @Test func turnCompletionCancellationAndFailureCleanUpVolatileState() async throws {
+        let session = ThreadSession(threadID: "thread-1", title: "Thread")
+
+        session.beginTurn()
+        session.startActivity(id: "tool-1", kind: .tool, title: "xcodebuild")
+        session.enqueueApprovalRequest(ApprovalRequest(id: "approval-1", kind: .command, title: "Run", detail: "xcodebuild"))
+        session.completeTurn()
+        #expect(session.turnState.phase == .completed)
+        #expect(session.pendingApprovals.isEmpty)
+
+        session.beginTurn()
+        session.startActivity(id: "tool-2", kind: .tool, title: "swift test")
+        session.replacePlanState(PlanState(summary: nil, steps: [PlanStep(id: "step-1", title: "Run tests", status: .inProgress)]))
+        session.cancelTurn()
+        #expect(session.turnState.phase == .cancelled)
+        #expect(session.activityItems.allSatisfy { $0.status == .cancelled })
+        #expect(session.planState == nil)
+
+        session.beginTurn()
+        session.startActivity(id: "tool-3", kind: .tool, title: "Build")
+        session.replaceAggregatedDiff(AggregatedDiff(summary: "Temp", files: []))
+        session.failTurn("Bridge disconnected")
+        #expect(session.turnState.phase == .failed)
+        #expect(session.turnState.failureDescription == "Bridge disconnected")
+        #expect(session.activityItems.allSatisfy { $0.status == .failed || $0.status == .cancelled })
+        #expect(session.aggregatedDiff == nil)
+
+        session.clearVolatilePerTurnState()
+        #expect(session.turnState.phase == .idle)
+        #expect(session.activityItems.isEmpty)
+        #expect(session.pendingApprovals.isEmpty)
+        #expect(session.planState == nil)
+    }
+}

--- a/AtelierCodeTests/WorkspaceControllerTests.swift
+++ b/AtelierCodeTests/WorkspaceControllerTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+@testable import AtelierCode
+
+@MainActor
+struct WorkspaceControllerTests {
+    @Test func workspaceSwitchResetsVolatileState() async throws {
+        let firstWorkspace = WorkspaceRecord(url: try temporaryDirectory(named: "workspace-one"), lastOpenedAt: .now)
+        let secondWorkspace = WorkspaceRecord(url: try temporaryDirectory(named: "workspace-two"), lastOpenedAt: .now)
+        let controller = WorkspaceController(workspace: firstWorkspace)
+
+        controller.setBridgeLifecycleState(.starting)
+        controller.setConnectionStatus(.ready)
+        controller.setAuthState(.signedIn(accountDescription: "Preview"))
+        controller.replaceThreadList([
+            ThreadSummary(id: "thread-1", title: "One", previewText: "Preview", updatedAt: .now)
+        ])
+        controller.openThread(id: "thread-1", title: "One")
+
+        controller.activate(workspace: secondWorkspace)
+
+        #expect(controller.workspace == secondWorkspace)
+        #expect(controller.bridgeLifecycleState == .idle)
+        #expect(controller.connectionStatus == .disconnected)
+        #expect(controller.threadSummaries.isEmpty)
+        #expect(controller.authState == .unknown)
+        #expect(controller.activeThreadSession == nil)
+    }
+
+    @Test func threadListReplacementAndActiveThreadChangesAreDeterministic() async throws {
+        let workspace = WorkspaceRecord(url: try temporaryDirectory(named: "workspace-threads"), lastOpenedAt: .now)
+        let controller = WorkspaceController(workspace: workspace)
+        let threadSummaries = [
+            ThreadSummary(id: "thread-1", title: "First", previewText: "One", updatedAt: .now),
+            ThreadSummary(id: "thread-2", title: "Second", previewText: "Two", updatedAt: .now)
+        ]
+
+        controller.replaceThreadList(threadSummaries)
+        let session = controller.openThread(id: "thread-2", title: "Second")
+        controller.clearActiveThreadSession()
+
+        #expect(controller.threadSummaries == threadSummaries)
+        #expect(session.threadID == "thread-2")
+        #expect(controller.activeThreadSession == nil)
+    }
+
+    @Test func authAndConnectionMutationsUpdateExpectedState() async throws {
+        let workspace = WorkspaceRecord(url: try temporaryDirectory(named: "workspace-auth"), lastOpenedAt: .now)
+        let controller = WorkspaceController(workspace: workspace)
+
+        controller.setConnectionStatus(.streaming)
+        controller.setAuthState(.signedOut)
+
+        #expect(controller.connectionStatus == .streaming)
+        #expect(controller.authState == .signedOut)
+    }
+}

--- a/AtelierCodeUITests/AtelierCodeUITests.swift
+++ b/AtelierCodeUITests/AtelierCodeUITests.swift
@@ -24,11 +24,11 @@ final class AtelierCodeUITests: XCTestCase {
 
     @MainActor
     func testExample() throws {
-        // UI tests must launch the application that they test.
         let app = XCUIApplication()
         app.launch()
 
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 5))
+        XCTAssertFalse(app.staticTexts["Hello, world!"].exists)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- add `AppModel`, `WorkspaceController`, and `ThreadSession` as the Swift-side state foundation
- add app-owned preference persistence for recent workspaces, restored workspace path, Codex override path, and UI preferences
- replace the placeholder view with a thin shell showing startup diagnostics, workspace summary, and thread/session placeholders
- add unit coverage for app model, workspace controller, and thread session behavior
- update the UI smoke test to validate the new shell instead of the starter template

## Testing
- `xcodebuild -project AtelierCode.xcodeproj -scheme AtelierCode -destination 'platform=macOS' -only-testing:AtelierCodeTests test`
- `xcodebuild -project AtelierCode.xcodeproj -scheme AtelierCode -destination 'platform=macOS' -only-testing:AtelierCodeUITests/AtelierCodeUITests/testExample test`
- `xcodebuild -project AtelierCode.xcodeproj -scheme AtelierCode -destination 'platform=macOS' -only-testing:AtelierCodeUITests test`