### PR TITLE
Refactor the chat window to keep ordered inline turn streams visible

### DIFF
--- a/AtelierCode/AppStateTypes.swift
+++ b/AtelierCode/AppStateTypes.swift
@@ -208,8 +208,6 @@ struct TurnState: Equatable, Sendable {
     }
 
     var phase: Phase = .idle
-    var assistantMessageID: String?
-    var thinkingText = ""
     var failureDescription: String?
 }
 
@@ -228,6 +226,27 @@ enum ActivityStatus: String, Equatable, Sendable {
 struct ApprovalCommandContext: Equatable, Sendable {
     var command: String
     var workingDirectory: String?
+}
+
+enum TurnItemKind: String, Equatable, Sendable {
+    case assistant
+    case reasoning
+    case tool
+    case fileChange
+}
+
+struct TurnItem: Equatable, Sendable, Identifiable {
+    let id: String
+    let kind: TurnItemKind
+    var title: String
+    var text: String
+    var detail: String?
+    var command: String?
+    var workingDirectory: String?
+    var output: String
+    var files: [DiffFileChange]
+    var status: ActivityStatus
+    var exitCode: Int?
 }
 
 struct ActivityItem: Equatable, Sendable, Identifiable {

--- a/AtelierCode/ContentView.swift
+++ b/AtelierCode/ContentView.swift
@@ -251,7 +251,11 @@ private struct ConversationSurface: View {
             return false
         }
 
-        return session.messages.isEmpty == false
+        return session.messages.isEmpty == false ||
+            session.turnItems.isEmpty == false ||
+            session.pendingApprovals.isEmpty == false ||
+            session.planState != nil ||
+            session.aggregatedDiff != nil
     }
 }
 
@@ -286,12 +290,12 @@ private struct TranscriptBody: View {
     var body: some View {
         ScrollViewReader { proxy in
             VStack(alignment: .leading, spacing: 16) {
-                ForEach(session.messages) { message in
+                ForEach(visibleMessages) { message in
                     ConversationMessageBubble(
                         message: message,
                         maxWidth: min(transcriptWidth * 0.72, 720)
                     )
-                        .id(message.id)
+                    .id(message.id)
                 }
 
                 TurnDetailsStack(
@@ -331,13 +335,24 @@ private struct TranscriptBody: View {
 
     private var scrollAnchor: TranscriptScrollAnchor {
         TranscriptScrollAnchor(
-            messages: session.messages,
+            messages: visibleMessages,
             turnState: session.turnState,
+            turnItems: session.turnItems,
             pendingApprovals: session.pendingApprovals,
-            activityItems: session.activityItems,
             planState: session.planState,
             aggregatedDiff: session.aggregatedDiff
         )
+    }
+
+    private var visibleMessages: [ConversationMessage] {
+        guard session.turnState.phase == .completed,
+              session.turnItems.contains(where: { $0.kind == .assistant }),
+              let lastMessage = session.messages.last,
+              lastMessage.role == .assistant else {
+            return session.messages
+        }
+
+        return Array(session.messages.dropLast())
     }
 
     private func scrollToLatest(using proxy: ScrollViewProxy) {
@@ -373,6 +388,8 @@ private struct ConversationMessageBubble: View {
                 Spacer(minLength: 48)
             }
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("conversation-message-\(message.id)")
     }
 }
 
@@ -381,23 +398,12 @@ private struct TurnDetailsStack: View {
     let session: ThreadSession
     let maxWidth: CGFloat
 
-    @State private var isReasoningExpanded: Bool
-
-    init(appModel: AppModel, session: ThreadSession, maxWidth: CGFloat) {
-        self.appModel = appModel
-        self.session = session
-        self.maxWidth = maxWidth
-        _isReasoningExpanded = State(initialValue: session.turnState.phase == .inProgress)
-    }
-
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            if session.turnState.thinkingText.isEmpty == false {
-                ReasoningSection(
-                    text: session.turnState.thinkingText,
-                    isExpanded: $isReasoningExpanded,
-                    maxWidth: maxWidth
-                )
+            if session.turnItems.isEmpty == false {
+                ForEach(session.turnItems) { item in
+                    TurnItemRow(item: item, maxWidth: maxWidth)
+                }
             }
 
             if session.pendingApprovals.isEmpty == false {
@@ -410,21 +416,6 @@ private struct TurnDetailsStack: View {
                     VStack(alignment: .leading, spacing: 12) {
                         ForEach(session.pendingApprovals) { approval in
                             ApprovalCard(appModel: appModel, approval: approval)
-                        }
-                    }
-                }
-            }
-
-            if session.activityItems.isEmpty == false {
-                TurnSectionCard(
-                    title: "Activity",
-                    systemImage: "waveform.path.ecg",
-                    maxWidth: maxWidth,
-                    accessibilityIdentifier: "turn-activity-section"
-                ) {
-                    VStack(alignment: .leading, spacing: 12) {
-                        ForEach(session.activityItems) { activity in
-                            ActivityCard(activity: activity)
                         }
                     }
                 }
@@ -443,9 +434,58 @@ private struct TurnDetailsStack: View {
     }
 }
 
-private struct ReasoningSection: View {
-    let text: String
-    @Binding var isExpanded: Bool
+private struct TurnItemRow: View {
+    let item: TurnItem
+    let maxWidth: CGFloat
+
+    var body: some View {
+        Group {
+            switch item.kind {
+            case .assistant:
+                AssistantTurnItemRow(item: item, maxWidth: maxWidth)
+            case .reasoning:
+                ReasoningTurnItemRow(item: item, maxWidth: maxWidth)
+            case .tool, .fileChange:
+                ActivityTurnItemRow(item: item, maxWidth: maxWidth)
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("turn-item-\(item.id)")
+    }
+}
+
+private struct AssistantTurnItemRow: View {
+    let item: TurnItem
+    let maxWidth: CGFloat
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .top, spacing: 12) {
+                    Text("Assistant")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(Color.blue)
+
+                    Spacer(minLength: 0)
+
+                    ActivityStatusBadge(status: item.status)
+                }
+
+                Text(item.text)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(16)
+            .frame(maxWidth: maxWidth, alignment: .leading)
+            .background(Color.blue.opacity(0.08), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+
+            Spacer(minLength: 48)
+        }
+    }
+}
+
+private struct ReasoningTurnItemRow: View {
+    let item: TurnItem
     let maxWidth: CGFloat
 
     var body: some View {
@@ -455,16 +495,22 @@ private struct ReasoningSection: View {
             maxWidth: maxWidth,
             accessibilityIdentifier: "turn-reasoning-section"
         ) {
-            DisclosureGroup(isExpanded: $isExpanded) {
-                Text(text)
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 12) {
+                    Text(item.status.label)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.secondary)
+
+                    Spacer(minLength: 0)
+
+                    ActivityStatusBadge(status: item.status)
+                }
+
+                Text(item.text)
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
                     .textSelection(.enabled)
-                    .padding(.top, 4)
-            } label: {
-                Text(isExpanded ? "Hide details" : "Show details")
-                    .font(.subheadline.weight(.medium))
             }
         }
     }
@@ -540,17 +586,18 @@ private struct ApprovalCard: View {
     }
 }
 
-private struct ActivityCard: View {
-    let activity: ActivityItem
+private struct ActivityTurnItemRow: View {
+    let item: TurnItem
+    let maxWidth: CGFloat
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .top, spacing: 12) {
                 VStack(alignment: .leading, spacing: 6) {
-                    Text(activity.title)
+                    Text(item.title)
                         .font(.headline)
 
-                    if let detail = activity.detail, detail.isEmpty == false {
+                    if let detail = item.detail, detail.isEmpty == false {
                         Text(detail)
                             .font(.subheadline)
                             .foregroundStyle(.secondary)
@@ -560,15 +607,15 @@ private struct ActivityCard: View {
 
                 Spacer(minLength: 0)
 
-                ActivityStatusBadge(status: activity.status)
+                ActivityStatusBadge(status: item.status)
             }
 
-            if activity.command?.isEmpty == false || activity.workingDirectory != nil {
-                CommandContextView(command: activity.command ?? "", workingDirectory: activity.workingDirectory)
+            if item.command?.isEmpty == false || item.workingDirectory != nil {
+                CommandContextView(command: item.command ?? "", workingDirectory: item.workingDirectory)
             }
 
-            if activity.output.isEmpty == false {
-                Text(activity.output)
+            if item.output.isEmpty == false {
+                Text(item.output)
                     .font(.system(.caption, design: .monospaced))
                     .foregroundStyle(.secondary)
                     .textSelection(.enabled)
@@ -577,11 +624,11 @@ private struct ActivityCard: View {
                     .background(Color.black.opacity(0.06), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
             }
 
-            if activity.files.isEmpty == false {
-                FileSummaryList(files: activity.files)
+            if item.files.isEmpty == false {
+                FileSummaryList(files: item.files)
             }
 
-            if let exitCode = activity.exitCode {
+            if let exitCode = item.exitCode {
                 Text("Exit code: \(exitCode)")
                     .font(.caption.weight(.medium))
                     .foregroundStyle(exitCode == 0 ? .green : .secondary)
@@ -589,7 +636,7 @@ private struct ActivityCard: View {
             }
         }
         .padding(14)
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: maxWidth, alignment: .leading)
         .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
     }
 }
@@ -1190,8 +1237,8 @@ private final class PreviewWorkspaceRuntime: WorkspaceConversationRuntime {
 private struct TranscriptScrollAnchor: Equatable {
     let messages: [ConversationMessage]
     let turnState: TurnState
+    let turnItems: [TurnItem]
     let pendingApprovals: [ApprovalRequest]
-    let activityItems: [ActivityItem]
     let planState: PlanState?
     let aggregatedDiff: AggregatedDiff?
 }

--- a/AtelierCode/Runtime/WorkspaceBridgeRuntime.swift
+++ b/AtelierCode/Runtime/WorkspaceBridgeRuntime.swift
@@ -397,13 +397,19 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
                 return
             }
 
-            session.appendAssistantTextDelta(payload.delta)
+            session.appendAssistantTextDelta(
+                payload.delta,
+                itemID: event.itemID ?? payload.messageID
+            )
         case .thinkingDelta(let payload):
             guard let session = session(for: event.threadID) else {
                 return
             }
 
-            session.appendThinkingDelta(payload.delta)
+            session.appendThinkingDelta(
+                payload.delta,
+                itemID: event.itemID ?? "reasoning-\(event.turnID ?? "active")"
+            )
         case .toolStarted(let payload):
             guard let session = session(for: event.threadID) else {
                 return

--- a/AtelierCode/ThreadSession.swift
+++ b/AtelierCode/ThreadSession.swift
@@ -8,8 +8,8 @@ final class ThreadSession {
     private(set) var title: String
     private(set) var messages: [ConversationMessage]
     private(set) var turnState: TurnState
+    private(set) var turnItems: [TurnItem]
     private(set) var pendingApprovals: [ApprovalRequest]
-    private(set) var activityItems: [ActivityItem]
     private(set) var planState: PlanState?
     private(set) var aggregatedDiff: AggregatedDiff?
 
@@ -18,8 +18,8 @@ final class ThreadSession {
         title: String,
         messages: [ConversationMessage] = [],
         turnState: TurnState? = nil,
+        turnItems: [TurnItem] = [],
         pendingApprovals: [ApprovalRequest] = [],
-        activityItems: [ActivityItem] = [],
         planState: PlanState? = nil,
         aggregatedDiff: AggregatedDiff? = nil
     ) {
@@ -27,10 +27,21 @@ final class ThreadSession {
         self.title = title
         self.messages = messages
         self.turnState = turnState ?? TurnState()
+        self.turnItems = turnItems
         self.pendingApprovals = pendingApprovals
-        self.activityItems = activityItems
         self.planState = planState
         self.aggregatedDiff = aggregatedDiff
+    }
+
+    var activityItems: [ActivityItem] {
+        turnItems.compactMap(\.activityItem)
+    }
+
+    var reasoningText: String {
+        turnItems
+            .filter { $0.kind == .reasoning }
+            .map(\.text)
+            .joined()
     }
 
     func updateThreadIdentity(id: String, title: String) {
@@ -63,39 +74,27 @@ final class ThreadSession {
             )
         }
 
-        turnState = TurnState(phase: .inProgress, assistantMessageID: nil, thinkingText: "", failureDescription: nil)
+        turnState = TurnState(phase: .inProgress, failureDescription: nil)
+        turnItems.removeAll()
         pendingApprovals.removeAll()
-        activityItems.removeAll()
         planState = nil
         aggregatedDiff = nil
     }
 
-    func appendAssistantTextDelta(_ delta: String) {
+    func appendAssistantTextDelta(_ delta: String, itemID: String = "assistant") {
         guard delta.isEmpty == false else {
             return
         }
 
-        if let assistantMessageID = turnState.assistantMessageID,
-           let index = messages.firstIndex(where: { $0.id == assistantMessageID }) {
-            messages[index].text += delta
-            return
-        }
-
-        let message = ConversationMessage(
-            id: UUID().uuidString,
-            role: .assistant,
-            text: delta
-        )
-        messages.append(message)
-        turnState.assistantMessageID = message.id
+        appendTextDelta(delta, to: itemID, kind: .assistant, title: "Assistant")
     }
 
-    func appendThinkingDelta(_ delta: String) {
+    func appendThinkingDelta(_ delta: String, itemID: String = "reasoning") {
         guard delta.isEmpty == false else {
             return
         }
 
-        turnState.thinkingText += delta
+        appendTextDelta(delta, to: itemID, kind: .reasoning, title: "Reasoning")
     }
 
     func startActivity(
@@ -107,22 +106,23 @@ final class ThreadSession {
         workingDirectory: String? = nil,
         files: [DiffFileChange] = []
     ) {
-        if let index = activityItems.firstIndex(where: { $0.id == id }) {
-            activityItems[index].title = title
-            activityItems[index].detail = detail
-            activityItems[index].command = command
-            activityItems[index].workingDirectory = workingDirectory
-            activityItems[index].files = files
-            activityItems[index].status = .running
-            activityItems[index].exitCode = nil
+        if let index = turnItems.firstIndex(where: { $0.id == id }) {
+            turnItems[index].title = title
+            turnItems[index].detail = detail
+            turnItems[index].command = command
+            turnItems[index].workingDirectory = workingDirectory
+            turnItems[index].files = files
+            turnItems[index].status = .running
+            turnItems[index].exitCode = nil
             return
         }
 
-        activityItems.append(
-            ActivityItem(
+        turnItems.append(
+            TurnItem(
                 id: id,
-                kind: kind,
+                kind: kind.turnItemKind,
                 title: title,
+                text: "",
                 detail: detail,
                 command: command,
                 workingDirectory: workingDirectory,
@@ -135,23 +135,23 @@ final class ThreadSession {
     }
 
     func updateActivity(id: String, detail: String?) {
-        guard let index = activityItems.firstIndex(where: { $0.id == id }) else {
+        guard let index = turnItems.firstIndex(where: { $0.id == id }) else {
             return
         }
 
-        activityItems[index].detail = detail
+        turnItems[index].detail = detail
     }
 
     func appendActivityOutput(id: String, delta: String) {
         guard delta.isEmpty == false,
-              let index = activityItems.firstIndex(where: { $0.id == id }) else {
+              let index = turnItems.firstIndex(where: { $0.id == id }) else {
             return
         }
 
-        if activityItems[index].output.isEmpty {
-            activityItems[index].output = delta
+        if turnItems[index].output.isEmpty {
+            turnItems[index].output = delta
         } else {
-            activityItems[index].output += delta
+            turnItems[index].output += delta
         }
     }
 
@@ -162,21 +162,21 @@ final class ThreadSession {
         files: [DiffFileChange]? = nil,
         exitCode: Int? = nil
     ) {
-        guard let index = activityItems.firstIndex(where: { $0.id == id }) else {
+        guard let index = turnItems.firstIndex(where: { $0.id == id }) else {
             return
         }
 
-        activityItems[index].status = status
+        turnItems[index].status = status
 
         if let detail {
-            activityItems[index].detail = detail
+            turnItems[index].detail = detail
         }
 
         if let files {
-            activityItems[index].files = files
+            turnItems[index].files = files
         }
 
-        activityItems[index].exitCode = exitCode
+        turnItems[index].exitCode = exitCode
     }
 
     func enqueueApprovalRequest(_ request: ApprovalRequest) {
@@ -224,13 +224,14 @@ final class ThreadSession {
     func completeTurn() {
         turnState.phase = .completed
         pendingApprovals.removeAll()
-        markRunningActivities(as: .completed)
+        markRunningTurnItems(as: .completed)
+        appendCompletedAssistantTranscript()
     }
 
     func cancelTurn() {
         turnState.phase = .cancelled
         pendingApprovals.removeAll()
-        markRunningActivities(as: .cancelled)
+        markRunningTurnItems(as: .cancelled)
 
         planState = nil
         aggregatedDiff = nil
@@ -240,7 +241,7 @@ final class ThreadSession {
         turnState.phase = .failed
         turnState.failureDescription = message
         pendingApprovals.removeAll()
-        markRunningActivities(as: .failed)
+        markRunningTurnItems(as: .failed)
 
         planState = nil
         aggregatedDiff = nil
@@ -249,14 +250,100 @@ final class ThreadSession {
     func clearVolatilePerTurnState() {
         turnState = TurnState()
         pendingApprovals.removeAll()
-        activityItems.removeAll()
+        turnItems.removeAll()
         planState = nil
         aggregatedDiff = nil
     }
 
-    private func markRunningActivities(as status: ActivityStatus) {
-        for index in activityItems.indices where activityItems[index].status == .running {
-            activityItems[index].status = status
+    private func appendTextDelta(_ delta: String, to itemID: String, kind: TurnItemKind, title: String) {
+        if let index = turnItems.firstIndex(where: { $0.id == itemID }) {
+            turnItems[index].text += delta
+            turnItems[index].status = .running
+            return
+        }
+
+        turnItems.append(
+            TurnItem(
+                id: itemID,
+                kind: kind,
+                title: title,
+                text: delta,
+                detail: nil,
+                command: nil,
+                workingDirectory: nil,
+                output: "",
+                files: [],
+                status: .running,
+                exitCode: nil
+            )
+        )
+    }
+
+    private func appendCompletedAssistantTranscript() {
+        let assistantText = turnItems
+            .filter { $0.kind == .assistant }
+            .map(\.text)
+            .joined()
+
+        guard assistantText.isEmpty == false else {
+            return
+        }
+
+        messages.append(
+            ConversationMessage(
+                id: UUID().uuidString,
+                role: .assistant,
+                text: assistantText
+            )
+        )
+    }
+
+    private func markRunningTurnItems(as status: ActivityStatus) {
+        for index in turnItems.indices where turnItems[index].status == .running {
+            turnItems[index].status = status
+        }
+    }
+}
+
+private extension TurnItem {
+    var activityItem: ActivityItem? {
+        guard let kind = activityKind else {
+            return nil
+        }
+
+        return ActivityItem(
+            id: id,
+            kind: kind,
+            title: title,
+            detail: detail,
+            command: command,
+            workingDirectory: workingDirectory,
+            output: output,
+            files: files,
+            status: status,
+            exitCode: exitCode
+        )
+    }
+
+    var activityKind: ActivityKind? {
+        switch kind {
+        case .assistant, .reasoning:
+            return nil
+        case .tool:
+            return .tool
+        case .fileChange:
+            return .fileChange
+        }
+    }
+}
+
+private extension ActivityKind {
+    var turnItemKind: TurnItemKind {
+        switch self {
+        case .tool:
+            return .tool
+        case .fileChange:
+            return .fileChange
         }
     }
 }

--- a/AtelierCodeTests/ThreadSessionTests.swift
+++ b/AtelierCodeTests/ThreadSessionTests.swift
@@ -3,18 +3,24 @@ import Testing
 
 @MainActor
 struct ThreadSessionTests {
-    @Test func assistantAndThinkingDeltasAppendCorrectly() async throws {
+    @Test func orderedTurnItemsUpdateInPlaceAsEventsArrive() async throws {
         let session = ThreadSession(threadID: "thread-1", title: "Thread")
 
         session.beginTurn(userPrompt: "Hello")
-        session.appendAssistantTextDelta("Hello")
-        session.appendAssistantTextDelta(", world")
-        session.appendThinkingDelta("Reasoning")
-        session.appendThinkingDelta(" continues")
+        session.appendAssistantTextDelta("Hello", itemID: "assistant-1")
+        session.appendThinkingDelta("Reasoning", itemID: "reasoning-1")
+        session.startActivity(id: "tool-1", kind: .tool, title: "swift test", detail: "Running")
+        session.appendAssistantTextDelta(", world", itemID: "assistant-1")
+        session.appendAssistantTextDelta("Follow-up", itemID: "assistant-2")
+        session.appendThinkingDelta(" continues", itemID: "reasoning-1")
 
-        #expect(session.messages.count == 2)
-        #expect(session.messages.last?.text == "Hello, world")
-        #expect(session.turnState.thinkingText == "Reasoning continues")
+        #expect(session.messages.map(\.text) == ["Hello"])
+        #expect(session.turnItems.map(\.id) == ["assistant-1", "reasoning-1", "tool-1", "assistant-2"])
+        #expect(session.turnItems.map(\.kind) == [.assistant, .reasoning, .tool, .assistant])
+        #expect(session.turnItems[0].text == "Hello, world")
+        #expect(session.turnItems[1].text == "Reasoning continues")
+        #expect(session.turnItems[2].detail == "Running")
+        #expect(session.turnItems[3].text == "Follow-up")
     }
 
     @Test func activityItemsProgressCorrectly() async throws {
@@ -45,6 +51,7 @@ struct ThreadSessionTests {
         #expect(session.activityItems[1].kind == .fileChange)
         #expect(session.activityItems[1].files == changedFiles)
         #expect(session.activityItems[1].status == .completed)
+        #expect(session.turnItems.map(\.kind) == [.tool, .fileChange])
     }
 
     @Test func approvalQueueHandlesResolveDuplicateAndStaleCases() async throws {
@@ -98,6 +105,8 @@ struct ThreadSessionTests {
         let session = ThreadSession(threadID: "thread-1", title: "Thread")
 
         session.beginTurn()
+        session.appendAssistantTextDelta("First")
+        session.appendAssistantTextDelta(" response", itemID: "assistant-2")
         session.startActivity(id: "tool-1", kind: .tool, title: "xcodebuild")
         session.enqueueApprovalRequest(
             ApprovalRequest(
@@ -113,28 +122,31 @@ struct ThreadSessionTests {
         session.completeTurn()
         #expect(session.turnState.phase == .completed)
         #expect(session.pendingApprovals.isEmpty)
-        #expect(session.activityItems.allSatisfy { $0.status == .completed })
+        #expect(session.turnItems.allSatisfy { $0.status == .completed })
+        #expect(session.messages.last?.text == "First response")
 
         session.beginTurn()
+        session.appendAssistantTextDelta("Partial")
         session.startActivity(id: "tool-2", kind: .tool, title: "swift test")
         session.replacePlanState(PlanState(summary: nil, steps: [PlanStep(id: "step-1", title: "Run tests", status: .inProgress)]))
         session.cancelTurn()
         #expect(session.turnState.phase == .cancelled)
-        #expect(session.activityItems.allSatisfy { $0.status == .cancelled })
+        #expect(session.turnItems.allSatisfy { $0.status == .cancelled })
         #expect(session.planState == nil)
 
         session.beginTurn()
+        session.appendThinkingDelta("Checking")
         session.startActivity(id: "tool-3", kind: .tool, title: "Build")
         session.replaceAggregatedDiff(AggregatedDiff(summary: "Temp", files: []))
         session.failTurn("Bridge disconnected")
         #expect(session.turnState.phase == .failed)
         #expect(session.turnState.failureDescription == "Bridge disconnected")
-        #expect(session.activityItems.allSatisfy { $0.status == .failed || $0.status == .cancelled })
+        #expect(session.turnItems.allSatisfy { $0.status == .failed || $0.status == .cancelled })
         #expect(session.aggregatedDiff == nil)
 
         session.clearVolatilePerTurnState()
         #expect(session.turnState.phase == .idle)
-        #expect(session.activityItems.isEmpty)
+        #expect(session.turnItems.isEmpty)
         #expect(session.pendingApprovals.isEmpty)
         #expect(session.planState == nil)
     }

--- a/AtelierCodeTests/WorkspaceBridgeRuntimeTests.swift
+++ b/AtelierCodeTests/WorkspaceBridgeRuntimeTests.swift
@@ -222,6 +222,7 @@ struct WorkspaceBridgeRuntimeTests {
 
         try await runtime.startTurn(prompt: "Inspect the current turn")
         socketClient.enqueue(turnStartedJSON(requestID: "ateliercode-turn-start-4", threadID: "thread-1", turnID: "turn-1"))
+        socketClient.enqueue(messageDeltaJSON(threadID: "thread-1", turnID: "turn-1", itemID: "assistant-1", delta: "Checking the transcript."))
         socketClient.enqueue(thinkingDeltaJSON(threadID: "thread-1", turnID: "turn-1", delta: "Checking the streamed reasoning."))
         socketClient.enqueue(toolStartedJSON(
             threadID: "thread-1",
@@ -241,6 +242,7 @@ struct WorkspaceBridgeRuntimeTests {
             detail: "All tests passed.",
             exitCode: 0
         ))
+        socketClient.enqueue(messageDeltaJSON(threadID: "thread-1", turnID: "turn-1", itemID: "assistant-2", delta: "I have the tool result."))
         socketClient.enqueue(fileChangeStartedJSON(
             threadID: "thread-1",
             turnID: "turn-1",
@@ -260,19 +262,23 @@ struct WorkspaceBridgeRuntimeTests {
         socketClient.enqueue(diffUpdatedJSON(threadID: "thread-1", turnID: "turn-1"))
 
         try await waitUntil {
-            session.turnState.thinkingText.isEmpty == false &&
-            session.activityItems.count == 2 &&
+            session.turnItems.count == 5 &&
             session.pendingApprovals.count == 1 &&
             session.planState != nil &&
             session.aggregatedDiff != nil
         }
 
-        #expect(session.turnState.thinkingText == "Checking the streamed reasoning.")
-        #expect(session.activityItems[0].command == "swift test")
-        #expect(session.activityItems[0].workingDirectory == workspace.canonicalPath)
-        #expect(session.activityItems[0].output == "Compiling...\n")
-        #expect(session.activityItems[0].exitCode == 0)
-        #expect(session.activityItems[1].files == [
+        #expect(session.messages.map(\.text) == ["Inspect the current turn"])
+        #expect(session.turnItems.map(\.id) == ["assistant-1", "reasoning-turn-1", "tool-1", "assistant-2", "file-1"])
+        #expect(session.turnItems.map(\.kind) == [.assistant, .reasoning, .tool, .assistant, .fileChange])
+        #expect(session.turnItems[0].text == "Checking the transcript.")
+        #expect(session.turnItems[1].text == "Checking the streamed reasoning.")
+        #expect(session.turnItems[2].command == "swift test")
+        #expect(session.turnItems[2].workingDirectory == workspace.canonicalPath)
+        #expect(session.turnItems[2].output == "Compiling...\n")
+        #expect(session.turnItems[2].exitCode == 0)
+        #expect(session.turnItems[3].text == "I have the tool result.")
+        #expect(session.turnItems[4].files == [
             DiffFileChange(id: "AtelierCode/ContentView.swift", path: "AtelierCode/ContentView.swift", additions: 4, deletions: 1)
         ])
         #expect(session.pendingApprovals[0].command == ApprovalCommandContext(command: "xcodebuild test -scheme AtelierCode", workingDirectory: workspace.canonicalPath))
@@ -291,6 +297,77 @@ struct WorkspaceBridgeRuntimeTests {
             summary: "1 file changed",
             files: [DiffFileChange(id: "AtelierCode/ContentView.swift", path: "AtelierCode/ContentView.swift", additions: 4, deletions: 1)]
         ))
+    }
+
+    @Test func completedTurnArchivesAssistantTranscriptAndCancelledTurnKeepsInlineRows() async throws {
+        let workspace = WorkspaceRecord(url: try temporaryDirectory(named: "runtime-inline-turn-terminal"), lastOpenedAt: .now)
+        let controller = WorkspaceController(workspace: workspace)
+        let bundle = try bridgeFixtureBundle()
+        let processHandle = FakeBridgeProcessHandle(lines: [startupRecordJSON(port: 4667)])
+        let socketClient = FakeBridgeSocketClient(messages: [
+            welcomeJSON(requestID: "ateliercode-hello-1"),
+            authChangedJSON(requestID: "ateliercode-account-read-2", state: "signed_out", displayName: nil),
+            threadListResultJSON(requestID: "ateliercode-thread-list-3", threadTitle: "Thread")
+        ])
+        let runtime = WorkspaceBridgeRuntime(
+            controller: controller,
+            executableLocator: BridgeExecutableLocator(bundle: bundle),
+            processLauncher: { _ in processHandle },
+            socketFactory: { _ in socketClient },
+            openURLAction: { _ in }
+        )
+
+        try await runtime.start()
+        try await waitUntil { controller.connectionStatus == .ready }
+
+        let session = controller.openThread(id: "thread-1", title: "Thread")
+
+        try await runtime.startTurn(prompt: "Ship it")
+        socketClient.enqueue(turnStartedJSON(requestID: "ateliercode-turn-start-4", threadID: "thread-1", turnID: "turn-1"))
+        socketClient.enqueue(messageDeltaJSON(threadID: "thread-1", turnID: "turn-1", itemID: "assistant-1", delta: "First"))
+        socketClient.enqueue(toolStartedJSON(
+            threadID: "thread-1",
+            turnID: "turn-1",
+            activityID: "tool-1",
+            title: "Run tests",
+            detail: "Preparing",
+            command: "swift test",
+            workingDirectory: workspace.canonicalPath
+        ))
+        socketClient.enqueue(messageDeltaJSON(threadID: "thread-1", turnID: "turn-1", itemID: "assistant-2", delta: " reply"))
+        socketClient.enqueue(turnCompletedJSON(threadID: "thread-1", turnID: "turn-1", status: "completed"))
+
+        try await waitUntil {
+            session.turnState.phase == .completed &&
+            session.messages.map(\.text) == ["Ship it", "First reply"]
+        }
+
+        #expect(session.messages.map(\.text) == ["Ship it", "First reply"])
+        #expect(session.turnItems.map(\.kind) == [.assistant, .tool, .assistant])
+        #expect(session.turnItems.map(\.status) == [.completed, .completed, .completed])
+
+        try await runtime.startTurn(prompt: "Cancel it")
+        socketClient.enqueue(turnStartedJSON(requestID: "ateliercode-turn-start-5", threadID: "thread-1", turnID: "turn-2"))
+        socketClient.enqueue(messageDeltaJSON(threadID: "thread-1", turnID: "turn-2", itemID: "assistant-3", delta: "Partial"))
+        socketClient.enqueue(toolStartedJSON(
+            threadID: "thread-1",
+            turnID: "turn-2",
+            activityID: "tool-2",
+            title: "Patch files",
+            detail: "Applying changes",
+            command: "apply_patch",
+            workingDirectory: workspace.canonicalPath
+        ))
+        socketClient.enqueue(turnCompletedJSON(threadID: "thread-1", turnID: "turn-2", status: "cancelled"))
+
+        try await waitUntil {
+            session.turnState.phase == .cancelled &&
+            session.turnItems.count == 2
+        }
+
+        #expect(session.messages.map(\.text) == ["Ship it", "First reply", "Cancel it"])
+        #expect(session.turnItems.map(\.status) == [.cancelled, .cancelled])
+        #expect(session.turnItems.map(\.kind) == [.assistant, .tool])
     }
 
     @Test func startThreadAndWaitReturnsCreatedSession() async throws {
@@ -584,9 +661,11 @@ private func threadStartedJSON(requestID: String, threadID: String, threadTitle:
     """
 }
 
-private func messageDeltaJSON(threadID: String, turnID: String, delta: String) -> String {
-    """
-    {"type":"message.delta","timestamp":"2026-03-24T10:00:06Z","threadID":"\(threadID)","turnID":"\(turnID)","payload":{"messageID":"assistant-1","delta":"\(delta)"}}
+private func messageDeltaJSON(threadID: String, turnID: String, itemID: String? = nil, delta: String) -> String {
+    let itemFragment = itemID.map { "\"itemID\":\"\($0)\"," } ?? ""
+    let messageID = itemID ?? "assistant-1"
+    return """
+    {"type":"message.delta","timestamp":"2026-03-24T10:00:06Z","threadID":"\(threadID)","turnID":"\(turnID)",\(itemFragment)"payload":{"messageID":"\(messageID)","delta":"\(jsonEscaped(delta))"}}
     """
 }
 

--- a/AtelierCodeUITests/AtelierCodeUITests.swift
+++ b/AtelierCodeUITests/AtelierCodeUITests.swift
@@ -53,7 +53,7 @@ final class AtelierCodeUITests: XCTestCase {
         XCTAssertFalse(app.staticTexts["Activity"].exists)
     }
 
-    func testPhase2TurnShowsGroupedSectionsAndApproveRemovesApproval() throws {
+    func testPhase2TurnShowsInlineRowsAndApproveKeepsCompletedTurnVisible() throws {
         let app = try makeApp(scenario: "phase2", workspaceName: "Phase2ApproveWorkspace")
         app.launch()
 
@@ -67,7 +67,9 @@ final class AtelierCodeUITests: XCTestCase {
 
         XCTAssertTrue(app.buttons["Approve"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.staticTexts["Approvals"].exists)
-        XCTAssertTrue(app.staticTexts["Activity"].exists)
+        XCTAssertTrue(app.staticTexts["I grouped the current turn details under the transcript."].exists)
+        XCTAssertTrue(app.staticTexts["Reasoning"].exists)
+        XCTAssertTrue(app.staticTexts["Run tests"].exists)
         XCTAssertTrue(app.staticTexts["Plan"].exists)
         XCTAssertTrue(app.staticTexts["Turn Diff"].exists)
         XCTAssertTrue(app.buttons["Approve"].exists)
@@ -75,8 +77,11 @@ final class AtelierCodeUITests: XCTestCase {
         app.buttons["Approve"].click()
 
         XCTAssertFalse(app.staticTexts["Approvals"].waitForExistence(timeout: 1))
-        XCTAssertTrue(app.staticTexts["Activity"].exists)
+        XCTAssertTrue(app.staticTexts["Reasoning"].exists)
+        XCTAssertTrue(app.staticTexts["Plan"].exists)
         XCTAssertTrue(app.staticTexts["Turn Diff"].exists)
+        XCTAssertTrue(app.staticTexts["Run tests"].exists)
+        XCTAssertTrue(app.staticTexts["I grouped the current turn details under the transcript."].exists)
     }
 
     func testPhase2TurnDeclineRemovesApprovalAndKeepsTurnDetailsVisible() throws {
@@ -99,6 +104,38 @@ final class AtelierCodeUITests: XCTestCase {
         XCTAssertFalse(app.staticTexts["Approvals"].waitForExistence(timeout: 1))
         XCTAssertTrue(app.staticTexts["Reasoning"].exists)
         XCTAssertTrue(app.staticTexts["Plan"].exists)
+        XCTAssertTrue(app.staticTexts["Turn Diff"].exists)
+        XCTAssertTrue(app.staticTexts["I grouped the current turn details under the transcript."].exists)
+    }
+
+    func testPhase2InlineTurnRowsAppearBeforeFooterPanels() throws {
+        let app = try makeApp(scenario: "phase2", workspaceName: "Phase2OrderingWorkspace")
+        app.launch()
+
+        let composer = app.textViews["conversation-composer"]
+        XCTAssertTrue(composer.waitForExistence(timeout: 5))
+        composer.click()
+        composer.typeText("Check inline ordering")
+
+        app.buttons["conversation-send-button"].click()
+        app.scrollViews.firstMatch.swipeUp()
+
+        let promptText = app.staticTexts["Check inline ordering"]
+        let assistantText = app.staticTexts["I grouped the current turn details under the transcript."]
+        let reasoningHeading = app.staticTexts["Reasoning"]
+        let toolTitle = app.staticTexts["Run tests"]
+        let approvalsHeading = app.staticTexts["Approvals"]
+
+        XCTAssertTrue(promptText.waitForExistence(timeout: 5))
+        XCTAssertTrue(assistantText.exists)
+        XCTAssertTrue(reasoningHeading.exists)
+        XCTAssertTrue(toolTitle.exists)
+        XCTAssertTrue(approvalsHeading.exists)
+
+        XCTAssertLessThan(promptText.frame.minY, assistantText.frame.minY)
+        XCTAssertLessThan(assistantText.frame.minY, reasoningHeading.frame.minY)
+        XCTAssertLessThan(reasoningHeading.frame.minY, toolTitle.frame.minY)
+        XCTAssertLessThan(toolTitle.frame.minY, approvalsHeading.frame.minY)
     }
 
     func testRetryRecoversFromConnectionError() throws {


### PR DESCRIPTION
## Summary
- add ordered `TurnItem` models for assistant, reasoning, tool, and file-change rows in the active turn
- render live and completed turns inline in chronological order instead of splitting reasoning and activity into separate grouped sections
- preserve completed inline turn details while archiving the assistant transcript, and hide the duplicate trailing assistant bubble
- pass provider item IDs through the runtime so streamed rows update in place
- update session, runtime, and UI test coverage for ordering, completion, cancellation, and visibility behavior

## Testing
- `xcodebuild test -project AtelierCode.xcodeproj -scheme AtelierCode -destination 'platform=macOS' -only-testing:AtelierCodeTests/ThreadSessionTests -only-testing:AtelierCodeTests/WorkspaceBridgeRuntimeTests`
- `xcodebuild test -project AtelierCode.xcodeproj -scheme AtelierCode -destination 'platform=macOS' -only-testing:AtelierCodeUITests/AtelierCodeUITests`