### PR TITLE
Add collapsed transcript sections for tool and file-change activity

### DIFF
--- a/AtelierCode/AppBootstrap.swift
+++ b/AtelierCode/AppBootstrap.swift
@@ -145,11 +145,11 @@ private final class UITestWorkspaceRuntime: WorkspaceConversationRuntime {
                 DiffFileChange(id: "phase2-session", path: "AtelierCode/ThreadSession.swift", additions: 18, deletions: 4)
             ]
 
-            try await Task.sleep(nanoseconds: 30_000_000)
+            try await Task.sleep(nanoseconds: 900_000_000)
             session.appendAssistantTextDelta("I grouped the current turn details under the transcript.")
             session.appendThinkingDelta("Inspecting activity, approvals, plan state, and diff summaries for the active turn.")
             session.startActivity(
-                id: "phase2-tool",
+                id: "phase2-tool-success",
                 kind: .tool,
                 title: "Run tests",
                 detail: "Checking the session and runtime wiring.",
@@ -157,14 +157,32 @@ private final class UITestWorkspaceRuntime: WorkspaceConversationRuntime {
                 workingDirectory: controller.workspace.canonicalPath
             )
             session.appendActivityOutput(
-                id: "phase2-tool",
+                id: "phase2-tool-success",
                 delta: "Building AtelierCode...\nRunning ThreadSessionTests...\n"
             )
             session.completeActivity(
-                id: "phase2-tool",
+                id: "phase2-tool-success",
                 status: .completed,
                 detail: "ThreadSessionTests finished successfully.",
                 exitCode: 0
+            )
+            session.startActivity(
+                id: "phase2-tool-failed",
+                kind: .tool,
+                title: "Run runtime tests",
+                detail: "Validating the grouped failure state.",
+                command: "swift test --filter WorkspaceBridgeRuntimeTests",
+                workingDirectory: controller.workspace.canonicalPath
+            )
+            session.appendActivityOutput(
+                id: "phase2-tool-failed",
+                delta: "Running WorkspaceBridgeRuntimeTests...\nAssertion failed.\n"
+            )
+            session.completeActivity(
+                id: "phase2-tool-failed",
+                status: .failed,
+                detail: "WorkspaceBridgeRuntimeTests failed.",
+                exitCode: 1
             )
             session.startActivity(
                 id: "phase2-files",
@@ -178,6 +196,18 @@ private final class UITestWorkspaceRuntime: WorkspaceConversationRuntime {
                 status: .completed,
                 detail: "Applied the current patch set.",
                 files: changedFiles
+            )
+            session.startActivity(
+                id: "phase2-tool-running",
+                kind: .tool,
+                title: "Run final verification",
+                detail: "Collecting final UI polish output.",
+                command: "xcodebuild test -scheme AtelierCode",
+                workingDirectory: controller.workspace.canonicalPath
+            )
+            session.appendActivityOutput(
+                id: "phase2-tool-running",
+                delta: "Testing in progress...\n"
             )
             session.replacePlanState(
                 PlanState(

--- a/AtelierCode/AppStateTypes.swift
+++ b/AtelierCode/AppStateTypes.swift
@@ -275,28 +275,66 @@ enum TranscriptActivitySectionStatus: String, Equatable, Sendable {
     case cancelled
 }
 
+struct TranscriptActivitySectionStatusCounts: Equatable, Sendable {
+    let running: Int
+    let completed: Int
+    let failed: Int
+    let cancelled: Int
+
+    var distinctStatusCount: Int {
+        [running, completed, failed, cancelled].filter { $0 > 0 }.count
+    }
+
+    var isMixed: Bool {
+        distinctStatusCount > 1
+    }
+
+    func count(for status: TranscriptActivitySectionStatus) -> Int {
+        switch status {
+        case .running:
+            return running
+        case .completed:
+            return completed
+        case .failed:
+            return failed
+        case .cancelled:
+            return cancelled
+        }
+    }
+}
+
 struct TranscriptActivitySection: Equatable, Sendable, Identifiable {
     let id: String
     let kind: TranscriptActivitySectionKind
     let ordinal: Int
     let items: [TurnItem]
     let status: TranscriptActivitySectionStatus
+    let statusCounts: TranscriptActivitySectionStatusCounts
     let summary: String
 
     var itemCount: Int {
         items.count
     }
 
+    var hasMixedStatuses: Bool {
+        statusCounts.isMixed
+    }
+
     var defaultExpanded: Bool {
-        status == .running
+        statusCounts.running > 0
     }
 }
 
 struct TranscriptTurnPresentation: Equatable, Sendable {
     let entries: [TranscriptTurnEntry]
+    let showsAssistantWaitingIndicator: Bool
 
-    init(turnItems: [TurnItem]) {
+    init(turnState: TurnState = TurnState(), turnItems: [TurnItem]) {
         entries = Self.makeEntries(from: turnItems)
+        showsAssistantWaitingIndicator = Self.shouldShowAssistantWaitingIndicator(
+            turnState: turnState,
+            turnItems: turnItems
+        )
     }
 
     private static func makeEntries(from turnItems: [TurnItem]) -> [TranscriptTurnEntry] {
@@ -325,6 +363,7 @@ struct TranscriptTurnPresentation: Equatable, Sendable {
                         ordinal: ordinal,
                         items: section.items,
                         status: makeSectionStatus(for: section.items),
+                        statusCounts: makeSectionStatusCounts(for: section.items),
                         summary: makeSectionSummary(for: section.items, kind: section.kind)
                     )
                 )
@@ -352,6 +391,19 @@ struct TranscriptTurnPresentation: Equatable, Sendable {
         return entries
     }
 
+    private static func shouldShowAssistantWaitingIndicator(
+        turnState: TurnState,
+        turnItems: [TurnItem]
+    ) -> Bool {
+        guard turnState.phase == .inProgress else {
+            return false
+        }
+
+        return turnItems.contains {
+            $0.kind == .assistant || $0.kind == .tool || $0.kind == .fileChange
+        } == false
+    }
+
     private static func makeSectionStatus(for items: [TurnItem]) -> TranscriptActivitySectionStatus {
         if items.contains(where: { $0.status == .running }) {
             return .running
@@ -366,6 +418,15 @@ struct TranscriptTurnPresentation: Equatable, Sendable {
         }
 
         return .completed
+    }
+
+    private static func makeSectionStatusCounts(for items: [TurnItem]) -> TranscriptActivitySectionStatusCounts {
+        TranscriptActivitySectionStatusCounts(
+            running: items.filter { $0.status == .running }.count,
+            completed: items.filter { $0.status == .completed }.count,
+            failed: items.filter { $0.status == .failed }.count,
+            cancelled: items.filter { $0.status == .cancelled }.count
+        )
     }
 
     private static func makeSectionSummary(

--- a/AtelierCode/ContentView.swift
+++ b/AtelierCode/ContentView.swift
@@ -399,12 +399,20 @@ private struct TurnDetailsStack: View {
     let maxWidth: CGFloat
     @State private var expandedActivitySectionIDs: Set<String> = []
 
+    private var presentation: TranscriptTurnPresentation {
+        TranscriptTurnPresentation(turnState: session.turnState, turnItems: session.turnItems)
+    }
+
     private var transcriptEntries: [TranscriptTurnEntry] {
-        TranscriptTurnPresentation(turnItems: session.turnItems).entries
+        presentation.entries
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
+            if presentation.showsAssistantWaitingIndicator {
+                AssistantWaitingIndicatorRow(maxWidth: maxWidth)
+            }
+
             if session.turnItems.isEmpty == false {
                 ForEach(transcriptEntries) { entry in
                     TranscriptTurnEntryRow(
@@ -528,8 +536,23 @@ private struct ActivitySectionCard: View {
                         Spacer(minLength: 0)
 
                         HStack(spacing: 8) {
-                            PlanCountBadge(text: itemCountLabel)
-                            ActivityStatusBadge(status: section.status.activityStatus)
+                            if section.hasMixedStatuses {
+                                ForEach(section.statusCountChips) { chip in
+                                    ActivityStatusCountChip(
+                                        chip: chip,
+                                        accessibilityIdentifier: section.statusCountAccessibilityIdentifier(
+                                            for: chip.status
+                                        )
+                                    )
+                                }
+                            } else {
+                                PlanCountBadge(text: itemCountLabel)
+                                ActivityStatusAccessory(
+                                    status: section.status.activityStatus,
+                                    accessibilityIdentifier: section.statusAccessoryAccessibilityIdentifier
+                                )
+                            }
+
                             Image(systemName: isExpanded ? "chevron.up.circle.fill" : "chevron.down.circle.fill")
                                 .font(.system(size: 16, weight: .semibold))
                                 .foregroundStyle(.secondary)
@@ -540,6 +563,7 @@ private struct ActivitySectionCard: View {
             }
             .buttonStyle(.plain)
             .accessibilityIdentifier(section.toggleAccessibilityIdentifier)
+            .accessibilityValue(section.accessibilityValue)
 
             if isExpanded {
                 VStack(alignment: .leading, spacing: 12) {
@@ -576,15 +600,9 @@ private struct AssistantTurnItemRow: View {
     var body: some View {
         HStack {
             VStack(alignment: .leading, spacing: 8) {
-                HStack(alignment: .top, spacing: 12) {
-                    Text("Assistant")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(Color.blue)
-
-                    Spacer(minLength: 0)
-
-                    ActivityStatusBadge(status: item.status)
-                }
+                Text("Assistant")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Color.blue)
 
                 Text(item.text)
                     .textSelection(.enabled)
@@ -593,6 +611,35 @@ private struct AssistantTurnItemRow: View {
             .padding(16)
             .frame(maxWidth: maxWidth, alignment: .leading)
             .background(Color.blue.opacity(0.08), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+
+            Spacer(minLength: 48)
+        }
+    }
+}
+
+private struct AssistantWaitingIndicatorRow: View {
+    let maxWidth: CGFloat
+    @State private var isAnimating = false
+
+    var body: some View {
+        HStack {
+            HStack(spacing: 0) {
+                Text("...")
+                    .font(.system(size: 24, weight: .semibold, design: .rounded))
+                    .foregroundStyle(Color.accentColor)
+                    .opacity(isAnimating ? 1 : 0.35)
+                    .onAppear {
+                        withAnimation(.easeInOut(duration: 0.7).repeatForever(autoreverses: true)) {
+                            isAnimating = true
+                        }
+                    }
+
+                Text("assistant waiting indicator")
+                    .font(.system(size: 1))
+                    .foregroundStyle(.clear)
+                    .accessibilityIdentifier("assistant-waiting-indicator")
+            }
+            .frame(maxWidth: maxWidth, alignment: .leading)
 
             Spacer(minLength: 48)
         }
@@ -705,6 +752,14 @@ private struct ActivityTurnItemRow: View {
     let item: TurnItem
     let maxWidth: CGFloat
 
+    private var visibleDetail: String? {
+        guard let detail = item.detail, detail.isEmpty == false else {
+            return nil
+        }
+
+        return detail.isMeaningfullyDifferent(from: [item.title, item.command]) ? detail : nil
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .top, spacing: 12) {
@@ -712,7 +767,7 @@ private struct ActivityTurnItemRow: View {
                     Text(item.title)
                         .font(.headline)
 
-                    if let detail = item.detail, detail.isEmpty == false {
+                    if let detail = visibleDetail {
                         Text(detail)
                             .font(.subheadline)
                             .foregroundStyle(.secondary)
@@ -722,7 +777,10 @@ private struct ActivityTurnItemRow: View {
 
                 Spacer(minLength: 0)
 
-                ActivityStatusBadge(status: item.status)
+                ActivityStatusAccessory(
+                    status: item.status,
+                    accessibilityIdentifier: "turn-item-\(item.id)-status-accessory"
+                )
             }
 
             if item.command?.isEmpty == false || item.workingDirectory != nil {
@@ -743,10 +801,10 @@ private struct ActivityTurnItemRow: View {
                 FileSummaryList(files: item.files)
             }
 
-            if let exitCode = item.exitCode {
+            if let exitCode = item.exitCode, exitCode != 0 {
                 Text("Exit code: \(exitCode)")
                     .font(.caption.weight(.medium))
-                    .foregroundStyle(exitCode == 0 ? .green : .secondary)
+                    .foregroundStyle(.secondary)
                     .monospacedDigit()
             }
         }
@@ -969,6 +1027,49 @@ private struct ActivityStatusBadge: View {
     }
 }
 
+private struct ActivityStatusAccessory: View {
+    let status: ActivityStatus
+    let accessibilityIdentifier: String
+
+    var body: some View {
+        if status == .running {
+            HStack(spacing: 0) {
+                ProgressView()
+                    .controlSize(.small)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Running")
+                .accessibilityIdentifier(accessibilityIdentifier)
+        } else {
+            ActivityStatusBadge(status: status)
+                .accessibilityIdentifier(accessibilityIdentifier)
+        }
+    }
+}
+
+private struct ActivityStatusCountChip: View {
+    let chip: TranscriptActivityStatusCountChip
+    let accessibilityIdentifier: String
+
+    var body: some View {
+        HStack(spacing: 6) {
+            if chip.status == .running {
+                ProgressView()
+                    .controlSize(.small)
+            }
+
+            Text(chip.text)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(chip.status.activityStatus.tintColor)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(chip.status.activityStatus.tintColor.opacity(0.14), in: Capsule())
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier(accessibilityIdentifier)
+    }
+}
+
 private struct RiskBadge: View {
     let riskLevel: ApprovalRiskLevel
 
@@ -1005,6 +1106,19 @@ private struct DiffCountBadge: View {
             .font(.caption.weight(.semibold))
             .monospacedDigit()
             .foregroundStyle(color)
+    }
+}
+
+private struct TranscriptActivityStatusCountChip: Identifiable {
+    let status: TranscriptActivitySectionStatus
+    let count: Int
+
+    var id: String {
+        status.rawValue
+    }
+
+    var text: String {
+        "\(count) \(status.countLabel)"
     }
 }
 
@@ -1471,6 +1585,34 @@ private extension ActivityStatus {
     }
 }
 
+private extension TranscriptActivitySectionStatus {
+    var activityStatus: ActivityStatus {
+        switch self {
+        case .running:
+            return .running
+        case .completed:
+            return .completed
+        case .failed:
+            return .failed
+        case .cancelled:
+            return .cancelled
+        }
+    }
+
+    var countLabel: String {
+        switch self {
+        case .running:
+            return "running"
+        case .completed:
+            return "completed"
+        case .failed:
+            return "failed"
+        case .cancelled:
+            return "cancelled"
+        }
+    }
+}
+
 private extension TranscriptActivitySectionKind {
     var title: String {
         switch self {
@@ -1500,28 +1642,63 @@ private extension TranscriptActivitySectionKind {
     }
 }
 
-private extension TranscriptActivitySectionStatus {
-    var activityStatus: ActivityStatus {
-        switch self {
-        case .running:
-            return .running
-        case .completed:
-            return .completed
-        case .failed:
-            return .failed
-        case .cancelled:
-            return .cancelled
-        }
-    }
-}
-
 private extension TranscriptActivitySection {
+    var statusCountChips: [TranscriptActivityStatusCountChip] {
+        [
+            TranscriptActivityStatusCountChip(status: .running, count: statusCounts.running),
+            TranscriptActivityStatusCountChip(status: .completed, count: statusCounts.completed),
+            TranscriptActivityStatusCountChip(status: .failed, count: statusCounts.failed),
+            TranscriptActivityStatusCountChip(status: .cancelled, count: statusCounts.cancelled)
+        ]
+        .filter { $0.count > 0 }
+    }
+
     var accessibilityIdentifier: String {
         "\(kind.accessibilityIdentifierPrefix)-\(ordinal)"
     }
 
     var toggleAccessibilityIdentifier: String {
         "\(accessibilityIdentifier)-toggle"
+    }
+
+    var statusAccessoryAccessibilityIdentifier: String {
+        "\(accessibilityIdentifier)-status-accessory"
+    }
+
+    func statusCountAccessibilityIdentifier(
+        for status: TranscriptActivitySectionStatus
+    ) -> String {
+        "\(accessibilityIdentifier)-status-count-\(status.rawValue)"
+    }
+
+    var accessibilityValue: String {
+        if hasMixedStatuses {
+            return statusCountChips
+                .map(\.text)
+                .joined(separator: ", ")
+        }
+
+        return "\(itemCount) \(itemCount == 1 ? "item" : "items"), \(status.countLabel)"
+    }
+}
+
+private extension String {
+    func isMeaningfullyDifferent(from candidates: [String?]) -> Bool {
+        let normalizedSelf = normalizedComparisonValue
+        guard normalizedSelf.isEmpty == false else {
+            return false
+        }
+
+        return candidates
+            .compactMap { $0?.normalizedComparisonValue }
+            .filter { $0.isEmpty == false }
+            .contains(normalizedSelf) == false
+    }
+
+    var normalizedComparisonValue: String {
+        lowercased()
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
     }
 }
 

--- a/AtelierCodeTests/ThreadSessionTests.swift
+++ b/AtelierCodeTests/ThreadSessionTests.swift
@@ -56,6 +56,7 @@ struct ThreadSessionTests {
 
     @Test func transcriptPresentationGroupsContiguousActivityAndPreservesTurnOrdering() async throws {
         let presentation = TranscriptTurnPresentation(
+            turnState: TurnState(phase: .inProgress, failureDescription: nil),
             turnItems: [
                 makeTurnItem(id: "assistant-1", kind: .assistant, text: "First"),
                 makeTurnItem(id: "tool-1", kind: .tool, detail: "Preparing"),
@@ -102,9 +103,44 @@ struct ThreadSessionTests {
 
         #expect(sections.map(\.kind) == [.tools, .fileChanges, .tools])
         #expect(sections.map(\.status) == [.failed, .running, .completed])
+        #expect(sections.map(\.hasMixedStatuses) == [true, false, false])
         #expect(sections.map(\.defaultExpanded) == [false, true, false])
         #expect(sections.map(\.summary) == ["Build failed", "Applying patch", "Finished"])
         #expect(sections.map(\.ordinal) == [1, 1, 2])
+        #expect(sections[0].statusCounts.completed == 1)
+        #expect(sections[0].statusCounts.failed == 1)
+        #expect(sections[1].statusCounts.running == 1)
+        #expect(presentation.showsAssistantWaitingIndicator == false)
+    }
+
+    @Test func transcriptPresentationShowsAssistantWaitingIndicatorOnlyBeforeAssistantOrActivityAppears() async throws {
+        let waitingPresentation = TranscriptTurnPresentation(
+            turnState: TurnState(phase: .inProgress, failureDescription: nil),
+            turnItems: [
+                makeTurnItem(id: "reasoning-1", kind: .reasoning, text: "Thinking")
+            ]
+        )
+        let assistantPresentation = TranscriptTurnPresentation(
+            turnState: TurnState(phase: .inProgress, failureDescription: nil),
+            turnItems: [
+                makeTurnItem(id: "assistant-1", kind: .assistant, text: "Started")
+            ]
+        )
+        let activityPresentation = TranscriptTurnPresentation(
+            turnState: TurnState(phase: .inProgress, failureDescription: nil),
+            turnItems: [
+                makeTurnItem(id: "tool-1", kind: .tool, status: .running)
+            ]
+        )
+        let completedPresentation = TranscriptTurnPresentation(
+            turnState: TurnState(phase: .completed, failureDescription: nil),
+            turnItems: []
+        )
+
+        #expect(waitingPresentation.showsAssistantWaitingIndicator)
+        #expect(assistantPresentation.showsAssistantWaitingIndicator == false)
+        #expect(activityPresentation.showsAssistantWaitingIndicator == false)
+        #expect(completedPresentation.showsAssistantWaitingIndicator == false)
     }
 
     @Test func approvalQueueHandlesResolveDuplicateAndStaleCases() async throws {

--- a/AtelierCodeUITests/AtelierCodeUITests.swift
+++ b/AtelierCodeUITests/AtelierCodeUITests.swift
@@ -63,6 +63,7 @@ final class AtelierCodeUITests: XCTestCase {
         composer.typeText("Show the grouped turn details")
 
         app.buttons["conversation-send-button"].click()
+        XCTAssertTrue(app.staticTexts["I grouped the current turn details under the transcript."].waitForExistence(timeout: 5))
         app.scrollViews.firstMatch.swipeUp()
 
         XCTAssertTrue(app.buttons["Approve"].waitForExistence(timeout: 5))
@@ -72,16 +73,22 @@ final class AtelierCodeUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Plan"].exists)
         XCTAssertTrue(app.staticTexts["Turn Diff"].exists)
         XCTAssertTrue(app.buttons["Approve"].exists)
-        XCTAssertTrue(app.buttons["turn-tools-section-1-toggle"].exists)
+        let mixedToolsToggle = app.buttons["turn-tools-section-1-toggle"]
+        XCTAssertTrue(mixedToolsToggle.exists)
         XCTAssertTrue(app.buttons["turn-file-changes-section-1-toggle"].exists)
+        XCTAssertEqual(mixedToolsToggle.value as? String, "1 completed, 1 failed")
+        XCTAssertTrue(app.otherElements["turn-item-phase2-tool-running-status-accessory"].exists)
+        XCTAssertFalse(app.otherElements["turn-item-assistant-status-accessory"].exists)
         XCTAssertFalse(app.staticTexts["Run tests"].exists)
         XCTAssertFalse(app.staticTexts["swift test --filter ThreadSessionTests"].exists)
+        XCTAssertTrue(app.staticTexts["Run final verification"].exists)
 
-        app.buttons["turn-tools-section-1-toggle"].click()
+        mixedToolsToggle.click()
         app.buttons["turn-file-changes-section-1-toggle"].click()
 
         XCTAssertTrue(app.staticTexts["Run tests"].exists)
         XCTAssertTrue(app.staticTexts["swift test --filter ThreadSessionTests"].exists)
+        XCTAssertTrue(app.staticTexts["Run runtime tests"].exists)
 
         app.buttons["Approve"].click()
 
@@ -108,6 +115,7 @@ final class AtelierCodeUITests: XCTestCase {
         XCTAssertTrue(app.buttons["Decline"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.buttons["turn-tools-section-1-toggle"].exists)
         XCTAssertTrue(app.buttons["turn-file-changes-section-1-toggle"].exists)
+        XCTAssertTrue(app.staticTexts["Run final verification"].exists)
         XCTAssertTrue(app.buttons["Decline"].exists)
 
         app.buttons["Decline"].click()


### PR DESCRIPTION
## Summary
- Group transcript turn items into ordered `Tools` and `File Changes` sections on the Swift side without changing bridge payloads
- Render grouped activity as collapsible section cards while keeping assistant and reasoning items in their existing transcript positions
- Auto-expand running activity, default completed sections to collapsed, and add accessibility identifiers for grouped sections and toggles
- Add unit and UI coverage for grouping behavior, aggregate section status, disclosure defaults, and transcript ordering

## Testing
- `BuildProject` via Xcode MCP
- `RunSomeTests`: `ThreadSessionTests/*`
- `RunSomeTests`: `WorkspaceBridgeRuntimeTests/structuredTurnEventsPopulateRichSessionState()`
- `RunSomeTests`: updated phase 2 UI tests
- `xcodebuild test -project AtelierCode.xcodeproj -scheme AtelierCode -destination 'platform=macOS'`