### PR TITLE
Collapse contiguous activity items into grouped transcript sections

### DIFF
--- a/AtelierCode/AppBootstrap.swift
+++ b/AtelierCode/AppBootstrap.swift
@@ -14,8 +14,7 @@ enum AppBootstrap {
             snapshot: AppPreferencesSnapshot(
                 recentWorkspaces: [WorkspaceRecord(url: workspaceURL, lastOpenedAt: .now)],
                 lastSelectedWorkspacePath: scenario.startsWithSelectedWorkspace ? workspaceURL.path : nil,
-                codexPathOverride: nil,
-                uiPreferences: UIPreferences(showsStartupDiagnostics: true)
+                codexPathOverride: nil
             )
         )
         let coordinator = UITestRuntimeCoordinator(scenario: scenario.kind)

--- a/AtelierCode/AppBootstrap.swift
+++ b/AtelierCode/AppBootstrap.swift
@@ -34,6 +34,7 @@ private struct UITestScenario {
         case ready
         case retry
         case phase2
+        case repeatedWaiting = "repeated-waiting"
     }
 
     let kind: Kind
@@ -79,6 +80,7 @@ private final class InMemoryBootstrapPreferencesStore: AppPreferencesStore {
 private final class UITestRuntimeCoordinator {
     let scenario: UITestScenario.Kind
     private(set) var startAttempts = 0
+    private(set) var startedTurnCount = 0
 
     init(scenario: UITestScenario.Kind) {
         self.scenario = scenario
@@ -87,6 +89,11 @@ private final class UITestRuntimeCoordinator {
     func nextStartAttempt() -> Int {
         startAttempts += 1
         return startAttempts
+    }
+
+    func nextTurnCount() -> Int {
+        startedTurnCount += 1
+        return startedTurnCount
     }
 }
 
@@ -134,6 +141,7 @@ private final class UITestWorkspaceRuntime: WorkspaceConversationRuntime {
 
     func startTurn(prompt: String, configuration: BridgeTurnStartConfiguration?) async throws {
         let session = controller.activeThreadSession ?? controller.openThread(id: "ui-test-thread", title: "New Conversation")
+        let turnNumber = coordinator.nextTurnCount()
 
         session.beginTurn(userPrompt: prompt)
         controller.setAwaitingTurnStart(false)
@@ -239,6 +247,35 @@ private final class UITestWorkspaceRuntime: WorkspaceConversationRuntime {
                     riskLevel: .medium
                 )
             )
+            return
+        }
+
+        if coordinator.scenario == .repeatedWaiting {
+            Task { @MainActor [controller] in
+                try? await Task.sleep(nanoseconds: 900_000_000)
+                session.startActivity(
+                    id: "repeated-waiting-tool-\(turnNumber)",
+                    kind: .tool,
+                    title: "Read Files",
+                    detail: "Scanning the current workspace.",
+                    command: "find . -type f | head -20",
+                    workingDirectory: controller.workspace.canonicalPath
+                )
+                session.appendActivityOutput(
+                    id: "repeated-waiting-tool-\(turnNumber)",
+                    delta: "Collecting Swift files...\n"
+                )
+                try? await Task.sleep(nanoseconds: 900_000_000)
+                session.completeActivity(
+                    id: "repeated-waiting-tool-\(turnNumber)",
+                    status: .completed,
+                    detail: "Finished reading files.",
+                    exitCode: 0
+                )
+                session.appendAssistantTextDelta("Completed repeated waiting test turn \(turnNumber).")
+                session.completeTurn()
+                controller.setConnectionStatus(.ready)
+            }
             return
         }
 

--- a/AtelierCode/AppModel.swift
+++ b/AtelierCode/AppModel.swift
@@ -10,7 +10,6 @@ final class AppModel {
     private(set) var recentWorkspaces: [WorkspaceRecord]
     private(set) var lastSelectedWorkspacePath: String?
     private(set) var codexPathOverride: String?
-    private(set) var uiPreferences: UIPreferences
     private(set) var startupDiagnostics: [StartupDiagnostic]
     private(set) var activeWorkspaceController: WorkspaceController?
 
@@ -43,12 +42,10 @@ final class AppModel {
         let normalizedRecentWorkspaces = Self.normalizeRecentWorkspaces(loadedSnapshot?.recentWorkspaces ?? [])
         let selectedPath = loadedSnapshot?.lastSelectedWorkspacePath.map(WorkspaceRecord.canonicalizedPath(for:))
         let codexOverridePath = loadedSnapshot?.codexPathOverride
-        let preferences = loadedSnapshot?.uiPreferences ?? UIPreferences()
 
         recentWorkspaces = normalizedRecentWorkspaces
         lastSelectedWorkspacePath = selectedPath
         codexPathOverride = codexOverridePath
-        uiPreferences = preferences
         startupDiagnostics = [resolvedBridgeDiagnosticProvider()]
         activeWorkspaceController = nil
 
@@ -87,8 +84,7 @@ final class AppModel {
         AppPreferencesSnapshot(
             recentWorkspaces: recentWorkspaces,
             lastSelectedWorkspacePath: lastSelectedWorkspacePath,
-            codexPathOverride: codexPathOverride,
-            uiPreferences: uiPreferences
+            codexPathOverride: codexPathOverride
         )
     }
 
@@ -125,11 +121,6 @@ final class AppModel {
 
     func setCodexPathOverride(_ path: String?) {
         codexPathOverride = path?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
-        persistPreferences()
-    }
-
-    func updateUIPreferences(_ update: (inout UIPreferences) -> Void) {
-        update(&uiPreferences)
         persistPreferences()
     }
 

--- a/AtelierCode/AppModel.swift
+++ b/AtelierCode/AppModel.swift
@@ -46,11 +46,11 @@ final class AppModel {
         recentWorkspaces = normalizedRecentWorkspaces
         lastSelectedWorkspacePath = selectedPath
         codexPathOverride = codexOverridePath
-        startupDiagnostics = [resolvedBridgeDiagnosticProvider()]
+        startupDiagnostics = []
         activeWorkspaceController = nil
 
         if let codexOverridePath {
-            startupDiagnostics.append(Self.codexOverrideDiagnostic(path: codexOverridePath, fileManager: fileManager))
+            appendStartupDiagnostic(Self.codexOverrideDiagnostic(path: codexOverridePath, fileManager: fileManager))
         }
 
         if let selectedPath {
@@ -60,16 +60,18 @@ final class AppModel {
                         canonicalPath: selectedPath,
                         displayName: URL(fileURLWithPath: selectedPath).lastPathComponent,
                         lastOpenedAt: now()
-                    )
+                )
                 let controller = WorkspaceController(workspace: restoredWorkspace)
                 activeWorkspaceController = controller
                 activeWorkspaceRuntime = resolvedRuntimeFactory(controller)
-                startupDiagnostics.append(.restoredWorkspacePresent(restoredWorkspace))
+                appendStartupDiagnostic(.restoredWorkspacePresent(restoredWorkspace))
             } else {
                 lastSelectedWorkspacePath = nil
-                startupDiagnostics.append(.restoredWorkspaceMissing(path: selectedPath))
+                appendStartupDiagnostic(.restoredWorkspaceMissing(path: selectedPath))
             }
         }
+
+        appendStartupDiagnostic(resolvedBridgeDiagnosticProvider())
 
         if let loadedSnapshot, loadedSnapshot != snapshot {
             persistPreferences()
@@ -240,6 +242,14 @@ final class AppModel {
 
     private func persistPreferences() {
         try? preferencesStore.saveSnapshot(snapshot)
+    }
+
+    private func appendStartupDiagnostic(_ diagnostic: StartupDiagnostic) {
+        guard diagnostic.severity != .info else {
+            return
+        }
+
+        startupDiagnostics.append(diagnostic)
     }
 
     private func replaceActiveWorkspace(with workspace: WorkspaceRecord) {

--- a/AtelierCode/AppPreferencesStore.swift
+++ b/AtelierCode/AppPreferencesStore.swift
@@ -9,7 +9,6 @@ struct AppPreferencesSnapshot: Codable, Equatable, Sendable {
     var recentWorkspaces: [WorkspaceRecord]
     var lastSelectedWorkspacePath: String?
     var codexPathOverride: String?
-    var uiPreferences: UIPreferences
 }
 
 struct UserDefaultsAppPreferencesStore: AppPreferencesStore {

--- a/AtelierCode/AppStateTypes.swift
+++ b/AtelierCode/AppStateTypes.swift
@@ -35,10 +35,6 @@ struct WorkspaceRecord: Codable, Equatable, Sendable, Identifiable {
     }
 }
 
-struct UIPreferences: Codable, Equatable, Sendable {
-    var showsStartupDiagnostics = true
-}
-
 enum StartupDiagnosticSource: String, Codable, Equatable, Sendable {
     case embeddedBridge
     case restoredWorkspace

--- a/AtelierCode/AppStateTypes.swift
+++ b/AtelierCode/AppStateTypes.swift
@@ -321,7 +321,7 @@ struct TranscriptActivitySection: Equatable, Sendable, Identifiable {
     }
 
     var defaultExpanded: Bool {
-        statusCounts.running > 0
+        false
     }
 }
 
@@ -399,9 +399,17 @@ struct TranscriptTurnPresentation: Equatable, Sendable {
             return false
         }
 
-        return turnItems.contains {
-            $0.kind == .assistant || $0.kind == .tool || $0.kind == .fileChange
-        } == false
+        if turnItems.contains(where: {
+            ($0.kind == .tool || $0.kind == .fileChange) && $0.status == .running
+        }) {
+            return false
+        }
+
+        if let latestMeaningfulItem = turnItems.last(where: { $0.kind != .reasoning }) {
+            return latestMeaningfulItem.kind != .assistant || latestMeaningfulItem.status != .running
+        }
+
+        return true
     }
 
     private static func makeSectionStatus(for items: [TurnItem]) -> TranscriptActivitySectionStatus {

--- a/AtelierCode/ContentView.swift
+++ b/AtelierCode/ContentView.swift
@@ -134,11 +134,6 @@ private struct ActiveWorkspaceConversationView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
                     WorkspaceHeader(appModel: appModel, controller: controller)
-
-                    if appModel.uiPreferences.showsStartupDiagnostics {
-                        DiagnosticsSection(diagnostics: appModel.startupDiagnostics)
-                    }
-
                     ConversationSurface(appModel: appModel, controller: controller)
                 }
                 .padding(24)
@@ -1352,39 +1347,6 @@ private final class ComposerNSTextView: NSTextView {
     }
 }
 
-private struct DiagnosticsSection: View {
-    let diagnostics: [StartupDiagnostic]
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Startup Diagnostics")
-                .font(.headline)
-
-            ForEach(diagnostics) { diagnostic in
-                HStack(alignment: .top, spacing: 12) {
-                    Circle()
-                        .fill(diagnostic.severity.color)
-                        .frame(width: 10, height: 10)
-                        .padding(.top, 6)
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(diagnostic.severity.label)
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(diagnostic.severity.color)
-                        Text(diagnostic.message)
-                            .font(.subheadline)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                }
-                .padding(14)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 16))
-            }
-        }
-        .accessibilityIdentifier("startup-diagnostics-section")
-    }
-}
-
 private struct StateCard: View {
     let title: String
     let message: String
@@ -1426,8 +1388,7 @@ private struct ConnectionBadge: View {
         AppPreferencesSnapshot(
             recentWorkspaces: [WorkspaceRecord(url: workspaceRoot, lastOpenedAt: .now)],
             lastSelectedWorkspacePath: workspaceRoot.path,
-            codexPathOverride: "/usr/local/bin/codex",
-            uiPreferences: UIPreferences(showsStartupDiagnostics: true)
+            codexPathOverride: "/usr/local/bin/codex"
         )
     )
 
@@ -1523,23 +1484,6 @@ private struct TranscriptWidthPreferenceKey: PreferenceKey {
 
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = nextValue()
-    }
-}
-
-private extension StartupDiagnosticSeverity {
-    var label: String {
-        rawValue.capitalized
-    }
-
-    var color: Color {
-        switch self {
-        case .info:
-            return .blue
-        case .warning:
-            return .orange
-        case .error:
-            return .red
-        }
     }
 }
 

--- a/AtelierCode/ContentView.swift
+++ b/AtelierCode/ContentView.swift
@@ -103,24 +103,27 @@ private struct ConversationDetailView: View {
     @Binding var isShowingWorkspacePicker: Bool
 
     var body: some View {
-        if let controller = appModel.activeWorkspaceController {
-            ActiveWorkspaceConversationView(
-                appModel: appModel,
-                controller: controller,
-                composerText: $composerText
-            )
-        } else {
-            ContentUnavailableView {
-                Label("Pick a Workspace", systemImage: "folder.badge.plus")
-            } description: {
-                Text("Select a recent workspace or open a new one to start the bridge runtime.")
-            } actions: {
-                Button("Open Workspace...") {
-                    isShowingWorkspacePicker = true
+        Group {
+            if let controller = appModel.activeWorkspaceController {
+                ActiveWorkspaceConversationView(
+                    appModel: appModel,
+                    controller: controller,
+                    composerText: $composerText
+                )
+            } else {
+                ContentUnavailableView {
+                    Label("Pick a Workspace", systemImage: "folder.badge.plus")
+                } description: {
+                    Text("Select a recent workspace or open a new one to start the bridge runtime.")
+                } actions: {
+                    Button("Open Workspace...") {
+                        isShowingWorkspacePicker = true
+                    }
                 }
+                .accessibilityIdentifier("conversation-empty-state")
             }
-            .accessibilityIdentifier("conversation-empty-state")
         }
+        .navigationTitle(appModel.activeWorkspaceController?.workspace.displayName ?? "AtelierCode")
     }
 }
 
@@ -133,7 +136,6 @@ private struct ActiveWorkspaceConversationView: View {
         VStack(spacing: 0) {
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
-                    WorkspaceHeader(appModel: appModel, controller: controller)
                     ConversationSurface(appModel: appModel, controller: controller)
                 }
                 .padding(24)
@@ -146,39 +148,11 @@ private struct ActiveWorkspaceConversationView: View {
                 .padding(20)
                 .background(.regularMaterial)
         }
-    }
-}
-
-private struct WorkspaceHeader: View {
-    let appModel: AppModel
-    let controller: WorkspaceController
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack(alignment: .top, spacing: 16) {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(controller.workspace.displayName)
-                        .font(.largeTitle.weight(.semibold))
-                    Text(controller.workspace.canonicalPath)
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                        .textSelection(.enabled)
-                }
-
-                Spacer(minLength: 0)
-
+        .toolbar {
+            ToolbarItemGroup {
                 ConnectionBadge(status: controller.connectionStatus)
                     .accessibilityIdentifier("workspace-connection-status")
-            }
 
-            HStack(spacing: 12) {
-                Label(controller.bridgeLifecycleState.label, systemImage: "bolt.horizontal.circle")
-                Label(controller.authState.label, systemImage: "person.crop.circle")
-            }
-            .font(.subheadline)
-            .foregroundStyle(.secondary)
-
-            HStack(spacing: 12) {
                 if appModel.canRetryActiveWorkspace {
                     Button("Retry Connection") {
                         appModel.retryActiveWorkspaceConnection()
@@ -192,16 +166,6 @@ private struct WorkspaceHeader: View {
                 .accessibilityIdentifier("clear-selection-button")
             }
         }
-        .padding(20)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            LinearGradient(
-                colors: [Color.accentColor.opacity(0.18), Color.accentColor.opacity(0.05)],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            ),
-            in: RoundedRectangle(cornerRadius: 20, style: .continuous)
-        )
     }
 }
 
@@ -232,8 +196,6 @@ private struct ConversationSurface: View {
 
     private var conversationState: ConversationSurfaceState {
         switch controller.connectionStatus {
-        case .connecting where hasTranscript == false:
-            return .connecting
         case .error(let message) where hasTranscript == false:
             return .error(message)
         default:
@@ -268,10 +230,12 @@ private struct ConversationTranscript: View {
         if let session {
             TranscriptBody(appModel: appModel, session: session)
         } else {
-            StateCard(
-                title: "Start the First Turn",
-                message: "Send a prompt to create a new thread for this workspace. Existing threads stay hidden for now."
-            )
+            ContentUnavailableView {
+                Label("Start a Thread", systemImage: "square.and.pencil")
+            } description: {
+                Text("Send your first prompt below to create a new thread for this workspace.")
+            }
+            .frame(maxWidth: .infinity, minHeight: 420)
             .accessibilityIdentifier("conversation-ready-empty-state")
         }
     }

--- a/AtelierCode/ContentView.swift
+++ b/AtelierCode/ContentView.swift
@@ -409,10 +409,6 @@ private struct TurnDetailsStack: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            if presentation.showsAssistantWaitingIndicator {
-                AssistantWaitingIndicatorRow(maxWidth: maxWidth)
-            }
-
             if session.turnItems.isEmpty == false {
                 ForEach(transcriptEntries) { entry in
                     TranscriptTurnEntryRow(
@@ -421,6 +417,10 @@ private struct TurnDetailsStack: View {
                         expandedActivitySectionIDs: $expandedActivitySectionIDs
                     )
                 }
+            }
+
+            if presentation.showsAssistantWaitingIndicator {
+                AssistantWaitingIndicatorRow(maxWidth: maxWidth)
             }
 
             if session.pendingApprovals.isEmpty == false {
@@ -545,6 +545,13 @@ private struct ActivitySectionCard: View {
                                         )
                                     )
                                 }
+
+                                if section.status.activityStatus == .running {
+                                    ActivityStatusAccessory(
+                                        status: .running,
+                                        accessibilityIdentifier: section.statusAccessoryAccessibilityIdentifier
+                                    )
+                                }
                             } else {
                                 PlanCountBadge(text: itemCountLabel)
                                 ActivityStatusAccessory(
@@ -619,30 +626,20 @@ private struct AssistantTurnItemRow: View {
 
 private struct AssistantWaitingIndicatorRow: View {
     let maxWidth: CGFloat
-    @State private var isAnimating = false
 
     var body: some View {
         HStack {
-            HStack(spacing: 0) {
-                Text("...")
-                    .font(.system(size: 24, weight: .semibold, design: .rounded))
-                    .foregroundStyle(Color.accentColor)
-                    .opacity(isAnimating ? 1 : 0.35)
-                    .onAppear {
-                        withAnimation(.easeInOut(duration: 0.7).repeatForever(autoreverses: true)) {
-                            isAnimating = true
-                        }
-                    }
-
-                Text("assistant waiting indicator")
-                    .font(.system(size: 1))
-                    .foregroundStyle(.clear)
-                    .accessibilityIdentifier("assistant-waiting-indicator")
+            HStack(spacing: 8) {
+                AnimatedEllipsisIndicator()
             }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(Color.secondary.opacity(0.10), in: Capsule())
             .frame(maxWidth: maxWidth, alignment: .leading)
 
             Spacer(minLength: 48)
         }
+        .accessibilityIdentifier("assistant-waiting-indicator")
     }
 }
 
@@ -1027,18 +1024,68 @@ private struct ActivityStatusBadge: View {
     }
 }
 
+private struct ActivitySpinner: View {
+    let color: Color
+    var size: CGFloat = 12
+    var lineWidth: CGFloat = 2
+
+    var body: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { context in
+            let elapsed = context.date.timeIntervalSinceReferenceDate
+            let rotation = Angle.degrees((elapsed * 220).truncatingRemainder(dividingBy: 360))
+
+            ZStack {
+                Circle()
+                    .stroke(color.opacity(0.18), lineWidth: lineWidth)
+
+                Circle()
+                    .trim(from: 0.12, to: 0.72)
+                    .stroke(color, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+                    .rotationEffect(rotation)
+            }
+            .frame(width: size, height: size)
+        }
+        .frame(width: size, height: size)
+    }
+}
+
+private struct AnimatedEllipsisIndicator: View {
+    var body: some View {
+        TimelineView(.animation(minimumInterval: 0.24)) { context in
+            let visibleDots = (Int(context.date.timeIntervalSinceReferenceDate / 0.24) % 3) + 1
+
+            HStack(spacing: 4) {
+                ForEach(0..<3, id: \.self) { index in
+                    Circle()
+                        .fill(Color.accentColor)
+                        .frame(width: 6, height: 6)
+                        .opacity(index < visibleDots ? 1 : 0.28)
+                }
+            }
+            .frame(height: 10)
+        }
+    }
+}
+
+private struct RunningActivityStatusAccessory: View {
+    let status: ActivityStatus
+
+    var body: some View {
+        ActivitySpinner(color: status.tintColor, size: 18, lineWidth: 2.6)
+            .padding(9)
+            .background(Color.secondary.opacity(0.10), in: Circle())
+    }
+}
+
 private struct ActivityStatusAccessory: View {
     let status: ActivityStatus
     let accessibilityIdentifier: String
 
     var body: some View {
         if status == .running {
-            HStack(spacing: 0) {
-                ProgressView()
-                    .controlSize(.small)
-            }
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel("Running")
+            RunningActivityStatusAccessory(status: status)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel("Running")
                 .accessibilityIdentifier(accessibilityIdentifier)
         } else {
             ActivityStatusBadge(status: status)
@@ -1054,8 +1101,7 @@ private struct ActivityStatusCountChip: View {
     var body: some View {
         HStack(spacing: 6) {
             if chip.status == .running {
-                ProgressView()
-                    .controlSize(.small)
+                ActivitySpinner(color: chip.status.activityStatus.tintColor)
             }
 
             Text(chip.text)

--- a/AtelierCode/ContentView.swift
+++ b/AtelierCode/ContentView.swift
@@ -131,23 +131,58 @@ private struct ActiveWorkspaceConversationView: View {
     let appModel: AppModel
     let controller: WorkspaceController
     @Binding var composerText: String
+    @State private var composerHeight: CGFloat = 260
+
+    private let floatingComposerMaxWidth: CGFloat = 740
+    private let contentPadding: CGFloat = 24
+    private let floatingComposerBottomPadding: CGFloat = 20
+    private let transcriptComposerSpacing: CGFloat = 20
+
+    private var composerClearance: CGFloat {
+        composerHeight + floatingComposerBottomPadding + transcriptComposerSpacing
+    }
 
     var body: some View {
-        VStack(spacing: 0) {
+        ZStack(alignment: .bottom) {
             ScrollView {
                 VStack(alignment: .leading, spacing: 20) {
-                    ConversationSurface(appModel: appModel, controller: controller)
+                    ConversationSurface(
+                        appModel: appModel,
+                        controller: controller,
+                        bottomInset: composerClearance
+                    )
+                    .frame(maxWidth: floatingComposerMaxWidth, alignment: .leading)
+                    .frame(maxWidth: .infinity, alignment: .center)
                 }
-                .padding(24)
+                .padding(.horizontal, contentPadding)
+                .padding(.top, contentPadding)
+                .padding(.bottom, composerClearance)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
 
-            Divider()
-
             ComposerBar(appModel: appModel, composerText: $composerText)
-                .padding(20)
-                .background(.regularMaterial)
+                .padding(.horizontal, 18)
+                .padding(.vertical, 16)
+                .frame(maxWidth: floatingComposerMaxWidth)
+                .background(
+                    Color(nsColor: .windowBackgroundColor),
+                    in: RoundedRectangle(cornerRadius: 22, style: .continuous)
+                )
+                .overlay {
+                    RoundedRectangle(cornerRadius: 22, style: .continuous)
+                        .stroke(Color(nsColor: .separatorColor).opacity(0.35), lineWidth: 1)
+                }
+                .shadow(color: Color.black.opacity(0.16), radius: 24, y: 10)
+                .background {
+                    GeometryReader { geometry in
+                        Color.clear
+                            .preference(key: ComposerHeightPreferenceKey.self, value: geometry.size.height)
+                    }
+                }
+                .padding(.horizontal, contentPadding)
+                .padding(.bottom, floatingComposerBottomPadding)
         }
+        .onPreferenceChange(ComposerHeightPreferenceKey.self) { composerHeight = $0 }
         .toolbar {
             ToolbarItemGroup {
                 ConnectionBadge(status: controller.connectionStatus)
@@ -172,6 +207,7 @@ private struct ActiveWorkspaceConversationView: View {
 private struct ConversationSurface: View {
     let appModel: AppModel
     let controller: WorkspaceController
+    let bottomInset: CGFloat
 
     var body: some View {
         Group {
@@ -181,15 +217,21 @@ private struct ConversationSurface: View {
                     title: "Connecting to the Bridge",
                     message: "The selected workspace has been restored and the runtime is starting."
                 )
+                .padding(.bottom, bottomInset)
                 .accessibilityIdentifier("conversation-connecting-state")
             case .error(let message):
                 StateCard(
                     title: "Connection Error",
                     message: message
                 )
+                .padding(.bottom, bottomInset)
                 .accessibilityIdentifier("workspace-error-state")
             case .ready:
-                ConversationTranscript(appModel: appModel, session: controller.activeThreadSession)
+                ConversationTranscript(
+                    appModel: appModel,
+                    session: controller.activeThreadSession,
+                    bottomInset: bottomInset
+                )
             }
         }
     }
@@ -225,16 +267,18 @@ private enum ConversationSurfaceState {
 private struct ConversationTranscript: View {
     let appModel: AppModel
     let session: ThreadSession?
+    let bottomInset: CGFloat
 
     var body: some View {
         if let session {
-            TranscriptBody(appModel: appModel, session: session)
+            TranscriptBody(appModel: appModel, session: session, bottomInset: bottomInset)
         } else {
             ContentUnavailableView {
                 Label("Start a Thread", systemImage: "square.and.pencil")
             } description: {
                 Text("Send your first prompt below to create a new thread for this workspace.")
             }
+            .padding(.bottom, bottomInset)
             .frame(maxWidth: .infinity, minHeight: 420)
             .accessibilityIdentifier("conversation-ready-empty-state")
         }
@@ -244,6 +288,7 @@ private struct ConversationTranscript: View {
 private struct TranscriptBody: View {
     let appModel: AppModel
     let session: ThreadSession
+    let bottomInset: CGFloat
     @State private var transcriptWidth: CGFloat = 720
 
     var body: some View {
@@ -272,7 +317,7 @@ private struct TranscriptBody: View {
                 }
 
                 Color.clear
-                    .frame(height: 1)
+                    .frame(height: bottomInset)
                     .id("transcript-end")
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -287,6 +332,9 @@ private struct TranscriptBody: View {
                 scrollToLatest(using: proxy)
             }
             .onChange(of: scrollAnchor) { _, _ in
+                scrollToLatest(using: proxy)
+            }
+            .onChange(of: bottomInset) { _, _ in
                 scrollToLatest(using: proxy)
             }
         }
@@ -315,8 +363,10 @@ private struct TranscriptBody: View {
     }
 
     private func scrollToLatest(using proxy: ScrollViewProxy) {
-        withAnimation(.easeOut(duration: 0.2)) {
-            proxy.scrollTo("transcript-end", anchor: .bottom)
+        DispatchQueue.main.async {
+            withAnimation(.easeOut(duration: 0.2)) {
+                proxy.scrollTo("transcript-end", anchor: .bottom)
+            }
         }
     }
 }
@@ -1445,6 +1495,14 @@ private struct TranscriptScrollAnchor: Equatable {
 
 private struct TranscriptWidthPreferenceKey: PreferenceKey {
     static let defaultValue: CGFloat = 720
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
+private struct ComposerHeightPreferenceKey: PreferenceKey {
+    static let defaultValue: CGFloat = 260
 
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = nextValue()

--- a/AtelierCode/Runtime/WorkspaceBridgeRuntime.swift
+++ b/AtelierCode/Runtime/WorkspaceBridgeRuntime.swift
@@ -42,6 +42,7 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
     typealias ProcessLauncher = (URL) throws -> any BridgeProcessHandle
     typealias SocketFactory = (URL) -> any BridgeSocketClient
     typealias OpenURLAction = (URL) -> Void
+    typealias SleepAction = @Sendable (TimeInterval) async -> Void
 
     private enum PendingCommand {
         case threadStart
@@ -67,6 +68,9 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
     private let socketFactory: SocketFactory
     private let openURLAction: OpenURLAction
     private let appVersion: String
+    private let minimumVisibleRunningActivityDuration: TimeInterval
+    private let now: () -> Date
+    private let sleep: SleepAction
 
     private var processHandle: (any BridgeProcessHandle)?
     private var socketClient: (any BridgeSocketClient)?
@@ -77,6 +81,8 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
     private var abandonedThreadRequestIDs: Set<String> = []
     private var requestCounter = 0
     private var currentTurnID: String?
+    private var runningActivityStartedAt: [String: Date] = [:]
+    private var pendingActivityCompletions: [String: Task<Void, Never>] = [:]
     private var isStopping = false
 
     init(
@@ -85,7 +91,10 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
         processLauncher: ProcessLauncher? = nil,
         socketFactory: SocketFactory? = nil,
         openURLAction: OpenURLAction? = nil,
-        appVersion: String? = nil
+        appVersion: String? = nil,
+        minimumVisibleRunningActivityDuration: TimeInterval = 0.2,
+        now: @escaping () -> Date = Date.init,
+        sleep: SleepAction? = nil
     ) {
         let resolvedExecutableLocator = executableLocator ?? BridgeExecutableLocator()
         let resolvedProcessLauncher = processLauncher ?? { try DefaultBridgeProcessHandle(executableURL: $0) }
@@ -93,6 +102,14 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
         let resolvedOpenURLAction = openURLAction ?? { NSWorkspace.shared.open($0) }
         let resolvedAppVersion = appVersion
             ?? (Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.0.0")
+        let resolvedSleep = sleep ?? { duration in
+            let nanoseconds = UInt64(max(0, duration) * 1_000_000_000)
+            guard nanoseconds > 0 else {
+                return
+            }
+
+            try? await Task.sleep(nanoseconds: nanoseconds)
+        }
 
         self.controller = controller
         self.executableLocator = resolvedExecutableLocator
@@ -100,6 +117,9 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
         self.socketFactory = resolvedSocketFactory
         self.openURLAction = resolvedOpenURLAction
         self.appVersion = resolvedAppVersion
+        self.minimumVisibleRunningActivityDuration = max(0, minimumVisibleRunningActivityDuration)
+        self.now = now
+        self.sleep = resolvedSleep
     }
 
     func start() async throws {
@@ -153,6 +173,7 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
         isStopping = true
         controller.setBridgeLifecycleState(.stopping)
 
+        cancelPendingActivityCompletions()
         receiveTask?.cancel()
         receiveTask = nil
         socketClient?.close()
@@ -294,6 +315,10 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
             throw WorkspaceBridgeRuntimeError.missingActiveThread
         }
 
+        if session.turnState.phase != .inProgress {
+            session.beginTurn(userPrompt: prompt)
+        }
+
         let requestID = nextRequestID(prefix: "turn-start")
         pendingCommands[requestID] = .turnStart(prompt: prompt)
         controller.setAwaitingTurnStart(true)
@@ -387,6 +412,8 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
     }
 
     private func handleEvent(_ event: BridgeEventEnvelope) {
+        adoptTurnContextIfNeeded(from: event)
+
         switch event.payload {
         case .threadStarted(let payload):
             handleThreadStarted(payload, requestID: event.requestID)
@@ -415,6 +442,10 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
                 return
             }
 
+            if let activityID = event.activityID {
+                markActivityStarted(id: activityID)
+            }
+
             session.startActivity(
                 id: event.activityID ?? UUID().uuidString,
                 kind: .tool,
@@ -429,6 +460,16 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
                 return
             }
 
+            if session.hasTurnItem(id: activityID) == false {
+                markActivityStarted(id: activityID)
+                session.startActivity(
+                    id: activityID,
+                    kind: .tool,
+                    title: "Tool Call",
+                    detail: "Running"
+                )
+            }
+
             session.appendActivityOutput(id: activityID, delta: payload.delta)
         case .toolCompleted(let payload):
             guard let session = session(for: event.threadID),
@@ -436,15 +477,31 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
                 return
             }
 
-            session.completeActivity(
-                id: activityID,
-                status: payload.status.activityStatus,
-                detail: payload.detail,
-                exitCode: payload.exitCode
-            )
+            if session.hasTurnItem(id: activityID) == false {
+                markActivityStarted(id: activityID)
+                session.startActivity(
+                    id: activityID,
+                    kind: .tool,
+                    title: "Tool Call",
+                    detail: "Running"
+                )
+            }
+
+            completeActivityWhenVisible(threadID: event.threadID, activityID: activityID) { session in
+                session.completeActivity(
+                    id: activityID,
+                    status: payload.status.activityStatus,
+                    detail: payload.detail,
+                    exitCode: payload.exitCode
+                )
+            }
         case .fileChangeStarted(let payload):
             guard let session = session(for: event.threadID) else {
                 return
+            }
+
+            if let activityID = event.activityID {
+                markActivityStarted(id: activityID)
             }
 
             session.startActivity(
@@ -460,12 +517,25 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
                 return
             }
 
-            session.completeActivity(
-                id: activityID,
-                status: payload.status.activityStatus,
-                detail: payload.detail,
-                files: payload.files.map { $0.toDiffFileChange() }
-            )
+            if session.hasTurnItem(id: activityID) == false {
+                markActivityStarted(id: activityID)
+                session.startActivity(
+                    id: activityID,
+                    kind: .fileChange,
+                    title: payload.detail ?? "File Change",
+                    detail: "Running",
+                    files: payload.files.map { $0.toDiffFileChange() }
+                )
+            }
+
+            completeActivityWhenVisible(threadID: event.threadID, activityID: activityID) { session in
+                session.completeActivity(
+                    id: activityID,
+                    status: payload.status.activityStatus,
+                    detail: payload.detail,
+                    files: payload.files.map { $0.toDiffFileChange() }
+                )
+            }
         case .approvalRequested(let payload):
             guard let session = session(for: event.threadID) else {
                 return
@@ -612,6 +682,7 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
             currentTurnID = nil
         }
 
+        cancelPendingActivityCompletions()
         controller.setAwaitingTurnStart(false)
 
         switch payload.status {
@@ -706,6 +777,20 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
         }
     }
 
+    private func adoptTurnContextIfNeeded(from event: BridgeEventEnvelope) {
+        guard currentTurnID == nil,
+              controller.isAwaitingTurnStart,
+              let turnID = event.turnID,
+              let threadID = event.threadID,
+              controller.activeThreadSession?.threadID == threadID else {
+            return
+        }
+
+        currentTurnID = turnID
+        controller.setAwaitingTurnStart(false)
+        controller.setConnectionStatus(.streaming)
+    }
+
     private func session(for threadID: String?) -> ThreadSession? {
         guard let threadID else {
             return nil
@@ -715,6 +800,62 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
             ?? controller.activeThreadSession?.title
             ?? "Thread"
         return controller.ensureActiveThreadSession(id: threadID, title: title)
+    }
+
+    private func markActivityStarted(id: String) {
+        pendingActivityCompletions[id]?.cancel()
+        pendingActivityCompletions.removeValue(forKey: id)
+        runningActivityStartedAt[id] = now()
+    }
+
+    private func completeActivityWhenVisible(
+        threadID: String?,
+        activityID: String,
+        applyCompletion: @escaping @MainActor (ThreadSession) -> Void
+    ) {
+        let elapsed = runningActivityStartedAt[activityID].map { now().timeIntervalSince($0) }
+            ?? minimumVisibleRunningActivityDuration
+        let remaining = max(0, minimumVisibleRunningActivityDuration - elapsed)
+
+        guard remaining > 0 else {
+            if let session = session(for: threadID) {
+                applyCompletion(session)
+            }
+
+            clearActivityTracking(id: activityID)
+            return
+        }
+
+        pendingActivityCompletions[activityID]?.cancel()
+        pendingActivityCompletions[activityID] = Task { @MainActor [weak self] in
+            guard let self else {
+                return
+            }
+
+            await self.sleep(remaining)
+
+            guard Task.isCancelled == false else {
+                return
+            }
+
+            if let session = self.session(for: threadID) {
+                applyCompletion(session)
+            }
+
+            self.clearActivityTracking(id: activityID)
+        }
+    }
+
+    private func clearActivityTracking(id: String) {
+        pendingActivityCompletions[id]?.cancel()
+        pendingActivityCompletions.removeValue(forKey: id)
+        runningActivityStartedAt.removeValue(forKey: id)
+    }
+
+    private func cancelPendingActivityCompletions() {
+        pendingActivityCompletions.values.forEach { $0.cancel() }
+        pendingActivityCompletions.removeAll()
+        runningActivityStartedAt.removeAll()
     }
 
     private func sendHello() async throws {
@@ -823,6 +964,7 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
     }
 
     private func handleBridgeFailure(message: String) {
+        cancelPendingActivityCompletions()
         receiveTask?.cancel()
         receiveTask = nil
         socketClient?.close()

--- a/AtelierCode/ThreadSession.swift
+++ b/AtelierCode/ThreadSession.swift
@@ -142,6 +142,10 @@ final class ThreadSession {
         turnItems[index].detail = detail
     }
 
+    func hasTurnItem(id: String) -> Bool {
+        turnItems.contains(where: { $0.id == id })
+    }
+
     func appendActivityOutput(id: String, delta: String) {
         guard delta.isEmpty == false,
               let index = turnItems.firstIndex(where: { $0.id == id }) else {

--- a/AtelierCodeTests/AtelierCodeTests.swift
+++ b/AtelierCodeTests/AtelierCodeTests.swift
@@ -32,8 +32,7 @@ struct AppModelTests {
 
         #expect(appModel.recentWorkspaces == snapshot.recentWorkspaces)
         #expect(appModel.codexPathOverride == codexURL.path)
-        #expect(appModel.startupDiagnostics.contains(where: { $0.source == .embeddedBridge }))
-        #expect(appModel.startupDiagnostics.contains(where: { $0.source == .codexOverridePath }))
+        #expect(appModel.startupDiagnostics.isEmpty)
     }
 
     @Test func restoresValidLastSelectedWorkspace() async throws {
@@ -56,7 +55,7 @@ struct AppModelTests {
         #expect(appModel.lastSelectedWorkspacePath == workspaceURL.path)
         #expect(appModel.activeWorkspaceController?.workspace.canonicalPath == workspaceURL.path)
         #expect(appModel.activeWorkspaceController?.connectionStatus == .ready)
-        #expect(appModel.startupDiagnostics.contains(where: { $0.source == .restoredWorkspace && $0.severity == .info }))
+        #expect(appModel.startupDiagnostics.isEmpty)
         #expect(runtimeCoordinator.startCount == 1)
     }
 

--- a/AtelierCodeTests/AtelierCodeTests.swift
+++ b/AtelierCodeTests/AtelierCodeTests.swift
@@ -19,8 +19,7 @@ struct AppModelTests {
         let snapshot = AppPreferencesSnapshot(
             recentWorkspaces: [WorkspaceRecord(url: workspaceURL, lastOpenedAt: .distantPast)],
             lastSelectedWorkspacePath: nil,
-            codexPathOverride: codexURL.path,
-            uiPreferences: UIPreferences(showsStartupDiagnostics: false)
+            codexPathOverride: codexURL.path
         )
         let store = InMemoryAppPreferencesStore(snapshot: snapshot)
         let runtimeCoordinator = TestRuntimeCoordinator()
@@ -33,7 +32,6 @@ struct AppModelTests {
 
         #expect(appModel.recentWorkspaces == snapshot.recentWorkspaces)
         #expect(appModel.codexPathOverride == codexURL.path)
-        #expect(appModel.uiPreferences == UIPreferences(showsStartupDiagnostics: false))
         #expect(appModel.startupDiagnostics.contains(where: { $0.source == .embeddedBridge }))
         #expect(appModel.startupDiagnostics.contains(where: { $0.source == .codexOverridePath }))
     }
@@ -43,8 +41,7 @@ struct AppModelTests {
         let snapshot = AppPreferencesSnapshot(
             recentWorkspaces: [WorkspaceRecord(url: workspaceURL, lastOpenedAt: .now)],
             lastSelectedWorkspacePath: workspaceURL.path,
-            codexPathOverride: nil,
-            uiPreferences: UIPreferences()
+            codexPathOverride: nil
         )
         let store = InMemoryAppPreferencesStore(snapshot: snapshot)
         let runtimeCoordinator = TestRuntimeCoordinator()
@@ -70,8 +67,7 @@ struct AppModelTests {
         let snapshot = AppPreferencesSnapshot(
             recentWorkspaces: [],
             lastSelectedWorkspacePath: workspaceURL.path,
-            codexPathOverride: nil,
-            uiPreferences: UIPreferences()
+            codexPathOverride: nil
         )
         let store = InMemoryAppPreferencesStore(snapshot: snapshot)
 
@@ -110,7 +106,7 @@ struct AppModelTests {
         #expect(Set(appModel.recentWorkspaces.map(\.canonicalPath)).count == appModel.recentWorkspaces.count)
     }
 
-    @Test func roundTripsCodexOverrideAndUIPreferences() async throws {
+    @Test func roundTripsCodexOverride() async throws {
         let store = InMemoryAppPreferencesStore()
         let runtimeCoordinator = TestRuntimeCoordinator()
         let appModel = AppModel(
@@ -122,9 +118,6 @@ struct AppModelTests {
         FileManager.default.createFile(atPath: codexURL.path, contents: Data())
 
         appModel.setCodexPathOverride(codexURL.path)
-        appModel.updateUIPreferences { preferences in
-            preferences.showsStartupDiagnostics = false
-        }
 
         let restoredModel = AppModel(
             preferencesStore: store,
@@ -133,7 +126,6 @@ struct AppModelTests {
         )
 
         #expect(restoredModel.codexPathOverride == codexURL.path)
-        #expect(restoredModel.uiPreferences == UIPreferences(showsStartupDiagnostics: false))
     }
 
     @Test func firstSendCreatesThreadBeforeStartingTurn() async throws {

--- a/AtelierCodeTests/ThreadSessionTests.swift
+++ b/AtelierCodeTests/ThreadSessionTests.swift
@@ -104,7 +104,7 @@ struct ThreadSessionTests {
         #expect(sections.map(\.kind) == [.tools, .fileChanges, .tools])
         #expect(sections.map(\.status) == [.failed, .running, .completed])
         #expect(sections.map(\.hasMixedStatuses) == [true, false, false])
-        #expect(sections.map(\.defaultExpanded) == [false, true, false])
+        #expect(sections.map(\.defaultExpanded) == [false, false, false])
         #expect(sections.map(\.summary) == ["Build failed", "Applying patch", "Finished"])
         #expect(sections.map(\.ordinal) == [1, 1, 2])
         #expect(sections[0].statusCounts.completed == 1)
@@ -138,9 +138,21 @@ struct ThreadSessionTests {
         )
 
         #expect(waitingPresentation.showsAssistantWaitingIndicator)
-        #expect(assistantPresentation.showsAssistantWaitingIndicator == false)
+        #expect(assistantPresentation.showsAssistantWaitingIndicator)
         #expect(activityPresentation.showsAssistantWaitingIndicator == false)
         #expect(completedPresentation.showsAssistantWaitingIndicator == false)
+    }
+
+    @Test func transcriptPresentationShowsAssistantWaitingIndicatorAgainAfterToolFinishes() async throws {
+        let presentation = TranscriptTurnPresentation(
+            turnState: TurnState(phase: .inProgress, failureDescription: nil),
+            turnItems: [
+                makeTurnItem(id: "tool-1", kind: .tool, status: .completed),
+                makeTurnItem(id: "assistant-1", kind: .assistant, text: "Checking the results.")
+            ]
+        )
+
+        #expect(presentation.showsAssistantWaitingIndicator)
     }
 
     @Test func approvalQueueHandlesResolveDuplicateAndStaleCases() async throws {

--- a/AtelierCodeTests/WorkspaceBridgeRuntimeTests.swift
+++ b/AtelierCodeTests/WorkspaceBridgeRuntimeTests.swift
@@ -18,7 +18,7 @@ struct WorkspaceBridgeRuntimeTests {
             rateLimitUpdatedJSON(requestID: "ateliercode-account-read-2"),
             threadListResultJSON(requestID: "ateliercode-thread-list-3", threadTitle: "Bootstrap Thread")
         ])
-        let runtime = WorkspaceBridgeRuntime(
+        let runtime = makeRuntime(
             controller: controller,
             executableLocator: BridgeExecutableLocator(bundle: bundle),
             processLauncher: { _ in processHandle },
@@ -48,7 +48,7 @@ struct WorkspaceBridgeRuntimeTests {
             threadListResultJSON(requestID: "ateliercode-thread-list-3", threadTitle: "Thread")
         ])
         var openedURLs: [URL] = []
-        let runtime = WorkspaceBridgeRuntime(
+        let runtime = makeRuntime(
             controller: controller,
             executableLocator: BridgeExecutableLocator(bundle: bundle),
             processLauncher: { _ in processHandle },
@@ -92,7 +92,7 @@ struct WorkspaceBridgeRuntimeTests {
             rateLimitUpdatedJSON(requestID: "ateliercode-account-read-2"),
             threadListResultJSON(requestID: "ateliercode-thread-list-3", threadTitle: "Thread")
         ])
-        let runtime = WorkspaceBridgeRuntime(
+        let runtime = makeRuntime(
             controller: controller,
             executableLocator: BridgeExecutableLocator(bundle: bundle),
             processLauncher: { _ in processHandle },
@@ -139,7 +139,7 @@ struct WorkspaceBridgeRuntimeTests {
             authChangedJSON(requestID: "ateliercode-account-read-2", state: "signed_out", displayName: nil),
             threadListResultJSON(requestID: "ateliercode-thread-list-3", threadTitle: "Thread")
         ])
-        let runtime = WorkspaceBridgeRuntime(
+        let runtime = makeRuntime(
             controller: controller,
             executableLocator: BridgeExecutableLocator(bundle: bundle),
             processLauncher: { _ in processHandle },
@@ -207,7 +207,7 @@ struct WorkspaceBridgeRuntimeTests {
             authChangedJSON(requestID: "ateliercode-account-read-2", state: "signed_out", displayName: nil),
             threadListResultJSON(requestID: "ateliercode-thread-list-3", threadTitle: "Thread")
         ])
-        let runtime = WorkspaceBridgeRuntime(
+        let runtime = makeRuntime(
             controller: controller,
             executableLocator: BridgeExecutableLocator(bundle: bundle),
             processLauncher: { _ in processHandle },
@@ -299,6 +299,182 @@ struct WorkspaceBridgeRuntimeTests {
         ))
     }
 
+    @Test func activityStartedBeforeTurnStartedRemainsVisible() async throws {
+        let workspace = WorkspaceRecord(url: try temporaryDirectory(named: "runtime-early-activity"), lastOpenedAt: .now)
+        let controller = WorkspaceController(workspace: workspace)
+        let bundle = try bridgeFixtureBundle()
+        let processHandle = FakeBridgeProcessHandle(lines: [startupRecordJSON(port: 4671)])
+        let socketClient = FakeBridgeSocketClient(messages: [
+            welcomeJSON(requestID: "ateliercode-hello-1"),
+            authChangedJSON(requestID: "ateliercode-account-read-2", state: "signed_out", displayName: nil),
+            threadListResultJSON(requestID: "ateliercode-thread-list-3", threadTitle: "Thread")
+        ])
+        let runtime = makeRuntime(
+            controller: controller,
+            executableLocator: BridgeExecutableLocator(bundle: bundle),
+            processLauncher: { _ in processHandle },
+            socketFactory: { _ in socketClient },
+            openURLAction: { _ in }
+        )
+
+        try await runtime.start()
+        try await waitUntil { controller.connectionStatus == .ready }
+
+        let session = controller.openThread(id: "thread-1", title: "Thread")
+
+        try await runtime.startTurn(prompt: "Inspect the early tool state")
+        #expect(session.messages.map(\.text) == ["Inspect the early tool state"])
+        #expect(session.turnState.phase == .inProgress)
+
+        socketClient.enqueue(toolStartedJSON(
+            threadID: "thread-1",
+            turnID: "turn-1",
+            activityID: "tool-1",
+            title: "Read Files",
+            detail: "Scanning the workspace.",
+            command: "rg --files -g '*.swift' .",
+            workingDirectory: workspace.canonicalPath
+        ))
+
+        try await waitUntil {
+            session.turnItems.count == 1 &&
+            session.turnItems[0].id == "tool-1" &&
+            controller.connectionStatus == .streaming &&
+            controller.isAwaitingTurnStart == false
+        }
+
+        #expect(session.turnItems[0].status == .running)
+        #expect(session.turnItems[0].title == "Read Files")
+        #expect(session.turnItems[0].command == "rg --files -g '*.swift' .")
+
+        socketClient.enqueue(turnStartedJSON(requestID: "ateliercode-turn-start-4", threadID: "thread-1", turnID: "turn-1"))
+
+        try await waitUntil {
+            pendingCommandCount(in: runtime) == 0 &&
+            session.turnItems.count == 1 &&
+            session.turnItems[0].id == "tool-1"
+        }
+
+        #expect(session.turnItems[0].status == .running)
+    }
+
+    @Test func toolOutputStartsPlaceholderActivityWhenStartedEventIsMissing() async throws {
+        let workspace = WorkspaceRecord(url: try temporaryDirectory(named: "runtime-tool-output-placeholder"), lastOpenedAt: .now)
+        let controller = WorkspaceController(workspace: workspace)
+        let bundle = try bridgeFixtureBundle()
+        let processHandle = FakeBridgeProcessHandle(lines: [startupRecordJSON(port: 4668)])
+        let socketClient = FakeBridgeSocketClient(messages: [
+            welcomeJSON(requestID: "ateliercode-hello-1"),
+            authChangedJSON(requestID: "ateliercode-account-read-2", state: "signed_out", displayName: nil),
+            threadListResultJSON(requestID: "ateliercode-thread-list-3", threadTitle: "Thread")
+        ])
+        let runtime = makeRuntime(
+            controller: controller,
+            executableLocator: BridgeExecutableLocator(bundle: bundle),
+            processLauncher: { _ in processHandle },
+            socketFactory: { _ in socketClient },
+            openURLAction: { _ in }
+        )
+
+        try await runtime.start()
+        try await waitUntil { controller.connectionStatus == .ready }
+
+        let session = controller.openThread(id: "thread-1", title: "Thread")
+
+        try await runtime.startTurn(prompt: "Inspect output fallback")
+        socketClient.enqueue(turnStartedJSON(requestID: "ateliercode-turn-start-4", threadID: "thread-1", turnID: "turn-1"))
+        socketClient.enqueue(toolOutputJSON(threadID: "thread-1", turnID: "turn-1", activityID: "tool-1", delta: "Streaming...\n"))
+
+        try await waitUntil {
+            session.turnItems.count == 1 &&
+            session.turnItems[0].id == "tool-1" &&
+            session.turnItems[0].status == .running
+        }
+
+        #expect(session.turnItems[0].title == "Tool Call")
+        #expect(session.turnItems[0].output == "Streaming...\n")
+
+        socketClient.enqueue(toolCompletedJSON(
+            threadID: "thread-1",
+            turnID: "turn-1",
+            activityID: "tool-1",
+            status: "completed",
+            detail: "Finished.",
+            exitCode: 0
+        ))
+
+        try await waitUntil {
+            session.turnItems[0].status == .completed && session.turnItems[0].detail == "Finished."
+        }
+
+        #expect(session.turnItems[0].status == .completed)
+        #expect(session.turnItems[0].detail == "Finished.")
+    }
+
+    @Test func fastToolCompletionStaysRunningLongEnoughToRender() async throws {
+        let workspace = WorkspaceRecord(url: try temporaryDirectory(named: "runtime-fast-tool-visible"), lastOpenedAt: .now)
+        let controller = WorkspaceController(workspace: workspace)
+        let bundle = try bridgeFixtureBundle()
+        let processHandle = FakeBridgeProcessHandle(lines: [startupRecordJSON(port: 4669)])
+        let socketClient = FakeBridgeSocketClient(messages: [
+            welcomeJSON(requestID: "ateliercode-hello-1"),
+            authChangedJSON(requestID: "ateliercode-account-read-2", state: "signed_out", displayName: nil),
+            threadListResultJSON(requestID: "ateliercode-thread-list-3", threadTitle: "Thread")
+        ])
+        let sleepGate = SleepGate()
+        let runtime = makeRuntime(
+            controller: controller,
+            executableLocator: BridgeExecutableLocator(bundle: bundle),
+            processLauncher: { _ in processHandle },
+            socketFactory: { _ in socketClient },
+            openURLAction: { _ in },
+            minimumVisibleRunningActivityDuration: 0.2,
+            sleep: { _ in await sleepGate.wait() }
+        )
+
+        try await runtime.start()
+        try await waitUntil { controller.connectionStatus == .ready }
+
+        let session = controller.openThread(id: "thread-1", title: "Thread")
+
+        try await runtime.startTurn(prompt: "Make the spinner visible")
+        socketClient.enqueue(turnStartedJSON(requestID: "ateliercode-turn-start-4", threadID: "thread-1", turnID: "turn-1"))
+        socketClient.enqueue(toolStartedJSON(
+            threadID: "thread-1",
+            turnID: "turn-1",
+            activityID: "tool-1",
+            title: "Read Files",
+            detail: "Scanning the workspace.",
+            command: "rg --files",
+            workingDirectory: workspace.canonicalPath
+        ))
+
+        try await waitUntil {
+            session.turnItems.count == 1 && session.turnItems[0].status == .running
+        }
+
+        socketClient.enqueue(toolCompletedJSON(
+            threadID: "thread-1",
+            turnID: "turn-1",
+            activityID: "tool-1",
+            status: "completed",
+            detail: "Finished reading files.",
+            exitCode: 0
+        ))
+
+        try await Task.sleep(nanoseconds: 20_000_000)
+        #expect(session.turnItems[0].status == .running)
+
+        await sleepGate.open()
+
+        try await waitUntil {
+            session.turnItems[0].status == .completed &&
+            session.turnItems[0].detail == "Finished reading files."
+        }
+
+        #expect(session.turnItems[0].status == .completed)
+    }
+
     @Test func completedTurnArchivesAssistantTranscriptAndCancelledTurnKeepsInlineRows() async throws {
         let workspace = WorkspaceRecord(url: try temporaryDirectory(named: "runtime-inline-turn-terminal"), lastOpenedAt: .now)
         let controller = WorkspaceController(workspace: workspace)
@@ -309,7 +485,7 @@ struct WorkspaceBridgeRuntimeTests {
             authChangedJSON(requestID: "ateliercode-account-read-2", state: "signed_out", displayName: nil),
             threadListResultJSON(requestID: "ateliercode-thread-list-3", threadTitle: "Thread")
         ])
-        let runtime = WorkspaceBridgeRuntime(
+        let runtime = makeRuntime(
             controller: controller,
             executableLocator: BridgeExecutableLocator(bundle: bundle),
             processLauncher: { _ in processHandle },
@@ -380,7 +556,7 @@ struct WorkspaceBridgeRuntimeTests {
             authChangedJSON(requestID: "ateliercode-account-read-2", state: "signed_out", displayName: nil),
             threadListResultJSON(requestID: "ateliercode-thread-list-3", threadTitle: "Thread")
         ])
-        let runtime = WorkspaceBridgeRuntime(
+        let runtime = makeRuntime(
             controller: controller,
             executableLocator: BridgeExecutableLocator(bundle: bundle),
             processLauncher: { _ in processHandle },
@@ -417,7 +593,7 @@ struct WorkspaceBridgeRuntimeTests {
             authChangedJSON(requestID: "ateliercode-account-read-2", state: "signed_out", displayName: nil),
             threadListResultJSON(requestID: "ateliercode-thread-list-3", threadTitle: "Thread")
         ])
-        let runtime = WorkspaceBridgeRuntime(
+        let runtime = makeRuntime(
             controller: controller,
             executableLocator: BridgeExecutableLocator(bundle: bundle),
             processLauncher: { _ in processHandle },
@@ -463,7 +639,7 @@ struct WorkspaceBridgeRuntimeTests {
             authChangedJSON(requestID: "ateliercode-account-read-2", state: "signed_out", displayName: nil),
             threadListResultJSON(requestID: "ateliercode-thread-list-3", threadTitle: "Thread")
         ])
-        let runtime = WorkspaceBridgeRuntime(
+        let runtime = makeRuntime(
             controller: controller,
             executableLocator: BridgeExecutableLocator(bundle: bundle),
             processLauncher: { _ in processHandle },
@@ -500,7 +676,7 @@ struct WorkspaceBridgeRuntimeTests {
             authChangedJSON(requestID: "ateliercode-account-read-2", state: "signed_out", displayName: nil),
             threadListResultJSON(requestID: "ateliercode-thread-list-3", threadTitle: "Thread")
         ])
-        let runtime = WorkspaceBridgeRuntime(
+        let runtime = makeRuntime(
             controller: controller,
             executableLocator: BridgeExecutableLocator(bundle: bundle),
             processLauncher: { _ in processHandle },
@@ -591,6 +767,47 @@ private final class FakeBridgeSocketClient: BridgeSocketClient {
     func enqueue(_ message: String) {
         continuation.yield(message)
     }
+}
+
+private actor SleepGate {
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        let currentWaiters = waiters
+        waiters.removeAll()
+        currentWaiters.forEach { $0.resume() }
+    }
+}
+
+@MainActor
+private func makeRuntime(
+    controller: WorkspaceController,
+    executableLocator: BridgeExecutableLocator? = nil,
+    processLauncher: ((URL) throws -> any BridgeProcessHandle)? = nil,
+    socketFactory: ((URL) -> any BridgeSocketClient)? = nil,
+    openURLAction: ((URL) -> Void)? = nil,
+    appVersion: String? = nil,
+    minimumVisibleRunningActivityDuration: TimeInterval = 0,
+    now: @escaping () -> Date = Date.init,
+    sleep: WorkspaceBridgeRuntime.SleepAction? = nil
+) -> WorkspaceBridgeRuntime {
+    WorkspaceBridgeRuntime(
+        controller: controller,
+        executableLocator: executableLocator,
+        processLauncher: processLauncher,
+        socketFactory: socketFactory,
+        openURLAction: openURLAction,
+        appVersion: appVersion,
+        minimumVisibleRunningActivityDuration: minimumVisibleRunningActivityDuration,
+        now: now,
+        sleep: sleep
+    )
 }
 
 private func bridgeFixtureBundle() throws -> Bundle {

--- a/AtelierCodeUITests/AtelierCodeUITests.swift
+++ b/AtelierCodeUITests/AtelierCodeUITests.swift
@@ -86,9 +86,9 @@ final class AtelierCodeUITests: XCTestCase {
         mixedToolsToggle.click()
         app.buttons["turn-file-changes-section-1-toggle"].click()
 
-        XCTAssertTrue(app.staticTexts["Run tests"].exists)
-        XCTAssertTrue(app.staticTexts["swift test --filter ThreadSessionTests"].exists)
-        XCTAssertTrue(app.staticTexts["Run runtime tests"].exists)
+        XCTAssertTrue(app.staticTexts["Run tests"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.staticTexts["swift test --filter ThreadSessionTests"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.staticTexts["Run runtime tests"].waitForExistence(timeout: 2))
 
         app.buttons["Approve"].click()
 

--- a/AtelierCodeUITests/AtelierCodeUITests.swift
+++ b/AtelierCodeUITests/AtelierCodeUITests.swift
@@ -32,7 +32,8 @@ final class AtelierCodeUITests: XCTestCase {
 
         let readyState = app.staticTexts["Ready"]
         XCTAssertTrue(readyState.waitForExistence(timeout: 5))
-        XCTAssertTrue(app.staticTexts["Start the First Turn"].exists)
+        XCTAssertTrue(app.staticTexts["Start a Thread"].exists)
+        XCTAssertFalse(app.staticTexts["Start the First Turn"].exists)
     }
 
     func testSendingPromptRendersTranscript() throws {
@@ -161,7 +162,7 @@ final class AtelierCodeUITests: XCTestCase {
         let app = try makeApp(scenario: "retry", workspaceName: "RetryWorkspace")
         app.launch()
 
-        let retryButton = app.buttons["retry-connection-button"]
+        let retryButton = app.buttons.matching(identifier: "retry-connection-button").firstMatch
         XCTAssertTrue(retryButton.waitForExistence(timeout: 5))
         XCTAssertTrue(app.staticTexts["Connection Error"].exists)
 


### PR DESCRIPTION
## Summary
- group contiguous tool and file change turn items into transcript sections with derived status, summaries, and stable identifiers
- render grouped sections as collapsed cards in the transcript, while keeping running sections expanded and preserving turn order
- update thread session and UI tests to cover grouping behavior, expand/collapse interactions, and transcript ordering

## Testing
- Not run (not requested)