### PR TITLE
Polish sidebar thread management and launch loading

### DIFF
--- a/AgentBridge/src/codex/codex-client.test.ts
+++ b/AgentBridge/src/codex/codex-client.test.ts
@@ -75,6 +75,54 @@ describe("CodexClient", () => {
     ]);
   });
 
+  test("renames a thread and rereads it for the updated summary", async () => {
+    const transport = new FakeTransport([
+      { userAgent: "Codex/Test" },
+      {},
+      {
+        thread: {
+          id: "thread-1",
+          preview: "Renamed preview",
+          updatedAt: 1_700_000_010,
+          name: "Renamed Thread",
+        },
+      },
+    ]);
+    const client = new CodexClient(transport);
+
+    await client.connect();
+    const result = await client.renameThread("req-rename", "thread-1", {
+      title: "  Renamed Thread  ",
+    });
+
+    expect(result.thread).toEqual({
+      id: "thread-1",
+      preview: "Renamed preview",
+      updatedAt: 1_700_000_010,
+      name: "Renamed Thread",
+      status: undefined,
+      turns: [],
+      archived: false,
+    });
+    expect(transport.sent.slice(1)).toEqual([
+      {
+        id: "req-rename:set-name",
+        method: "thread/name/set",
+        params: {
+          threadId: "thread-1",
+          name: "Renamed Thread",
+        },
+      },
+      {
+        id: "req-rename",
+        method: "thread/read",
+        params: {
+          threadId: "thread-1",
+        },
+      },
+    ]);
+  });
+
   test("maps turn interruption approval resolution and account reads", async () => {
     const transport = new FakeTransport([
       { userAgent: "Codex/Test" },

--- a/AgentBridge/src/codex/codex-client.ts
+++ b/AgentBridge/src/codex/codex-client.ts
@@ -6,6 +6,7 @@ import type {
   ThreadArchivePayload,
   ThreadForkPayload,
   ThreadListPayload,
+  ThreadRenamePayload,
   ThreadReadPayload,
   ThreadRollbackPayload,
   ThreadResumePayload,
@@ -51,6 +52,10 @@ export interface CodexThreadReadResult {
 }
 
 export interface CodexThreadForkResult {
+  thread: CodexThread;
+}
+
+export interface CodexThreadRenameResult {
   thread: CodexThread;
 }
 
@@ -121,6 +126,11 @@ export interface CodexClientAdapter {
     threadID: string,
     payload: ThreadForkPayload,
   ): Promise<CodexThreadForkResult>;
+  renameThread(
+    requestID: CodexTransportRequestID,
+    threadID: string,
+    payload: ThreadRenamePayload,
+  ): Promise<CodexThreadRenameResult>;
   archiveThread(
     requestID: CodexTransportRequestID,
     threadID: string,
@@ -292,6 +302,35 @@ export class CodexClient implements CodexClientAdapter {
         threadId: threadID,
       },
     });
+  }
+
+  async renameThread(
+    requestID: CodexTransportRequestID,
+    threadID: string,
+    payload: ThreadRenamePayload,
+  ): Promise<CodexThreadRenameResult> {
+    const title = payload.title.trim();
+
+    await this.transport.send({
+      id: `${String(requestID)}:set-name`,
+      method: "thread/name/set",
+      params: {
+        threadId: threadID,
+        name: title,
+      },
+    });
+
+    const response = await this.transport.send<{ thread: unknown }>({
+      id: requestID,
+      method: "thread/read",
+      params: {
+        threadId: threadID,
+      },
+    });
+
+    return {
+      thread: toCodexThread(response.thread),
+    };
   }
 
   async unarchiveThread(

--- a/AgentBridge/src/index.test.ts
+++ b/AgentBridge/src/index.test.ts
@@ -7,6 +7,7 @@ import type {
   ThreadArchivePayload,
   ThreadForkPayload,
   ThreadListPayload,
+  ThreadRenamePayload,
   ThreadReadPayload,
   ThreadRollbackPayload,
   ThreadResumePayload,
@@ -21,6 +22,7 @@ import type {
   CodexLoginResult,
   CodexThreadForkResult,
   CodexThreadListResult,
+  CodexThreadRenameResult,
   CodexThreadReadResult,
   CodexThreadResumeResult,
   CodexThreadRollbackResult,
@@ -171,6 +173,30 @@ describe("executeBridgeCommand", () => {
         type: "thread.started",
         requestID: "req-unarchive",
         threadID: "thread-1",
+      }),
+    ]);
+
+    const renameEvents = await executeBridgeCommand(client, {
+      id: "req-rename",
+      type: "thread.rename",
+      timestamp: new Date().toISOString(),
+      provider: "codex",
+      threadID: "thread-1",
+      payload: {
+        title: "Renamed Thread",
+      },
+    });
+
+    expect(renameEvents).toEqual([
+      expect.objectContaining({
+        type: "thread.started",
+        requestID: "req-rename",
+        threadID: "thread-1",
+        payload: expect.objectContaining({
+          thread: expect.objectContaining({
+            title: "Renamed Thread",
+          }),
+        }),
       }),
     ]);
   });
@@ -330,6 +356,23 @@ class FakeCodexClient implements CodexClientAdapter {
     _threadID: string,
     _payload: ThreadArchivePayload,
   ): Promise<void> {}
+
+  async renameThread(
+    _requestID: string,
+    threadID: string,
+    payload: ThreadRenamePayload,
+  ): Promise<CodexThreadRenameResult> {
+    return {
+      thread: {
+        id: threadID,
+        preview: "Renamed preview",
+        updatedAt: 1_700_000_005,
+        name: payload.title,
+        status: { type: "idle" },
+        turns: [],
+      },
+    };
+  }
 
   async unarchiveThread(
     _requestID: string,

--- a/AgentBridge/src/index.ts
+++ b/AgentBridge/src/index.ts
@@ -649,6 +649,10 @@ export async function executeBridgeCommand(
         const result = await client.forkThread(command.id, command.threadID, command.payload);
         return [buildThreadStartedEvent(command.id, result.thread)];
       }
+      case "thread.rename": {
+        const result = await client.renameThread(command.id, command.threadID, command.payload);
+        return [buildThreadStartedEvent(command.id, result.thread)];
+      }
       case "thread.archive":
         await client.archiveThread(command.id, command.threadID, command.payload);
         return [buildThreadArchivedEvent(command.threadID, command.id)];

--- a/AgentBridge/src/protocol/types.ts
+++ b/AgentBridge/src/protocol/types.ts
@@ -17,6 +17,7 @@ export type BridgeCommandType =
   | "thread.list"
   | "thread.read"
   | "thread.fork"
+  | "thread.rename"
   | "thread.archive"
   | "thread.unarchive"
   | "thread.rollback"
@@ -213,6 +214,10 @@ export interface ThreadForkPayload {
   workspacePath: string;
 }
 
+export interface ThreadRenamePayload {
+  title: string;
+}
+
 export interface ThreadArchivePayload {}
 
 export interface ThreadUnarchivePayload {}
@@ -265,6 +270,10 @@ export interface ThreadForkCommand extends BridgeCommandEnvelope<"thread.fork", 
   threadID: string;
 }
 
+export interface ThreadRenameCommand extends BridgeCommandEnvelope<"thread.rename", ThreadRenamePayload> {
+  threadID: string;
+}
+
 export interface ThreadArchiveCommand extends BridgeCommandEnvelope<"thread.archive", ThreadArchivePayload> {
   threadID: string;
 }
@@ -305,6 +314,7 @@ export type BridgeCommand =
   | ThreadListCommand
   | ThreadReadCommand
   | ThreadForkCommand
+  | ThreadRenameCommand
   | ThreadArchiveCommand
   | ThreadUnarchiveCommand
   | ThreadRollbackCommand

--- a/AtelierCode/AppBootstrap.swift
+++ b/AtelierCode/AppBootstrap.swift
@@ -33,6 +33,7 @@ private struct UITestScenario {
         case ready
         case retry
         case phase2
+        case refreshOmitsThread = "refresh-omits-thread"
         case repeatedWaiting = "repeated-waiting"
     }
 
@@ -132,10 +133,14 @@ private final class UITestWorkspaceRuntime: WorkspaceConversationRuntime {
 
     func listThreads(archived: Bool) async throws {
         controller.setShowingArchivedThreads(archived)
+
+        if coordinator.scenario == .refreshOmitsThread {
+            controller.replaceThreadList([], archived: archived)
+        }
     }
 
     func startThreadAndWait(title: String?) async throws -> ThreadSession {
-        controller.openThread(id: "ui-test-thread", title: title ?? "New Conversation")
+        controller.openThread(id: "ui-test-thread", title: title ?? "New Conversation", isVisibleInSidebar: false)
     }
 
     func resumeThreadAndWait(id: String) async throws -> ThreadSession {
@@ -187,7 +192,8 @@ private final class UITestWorkspaceRuntime: WorkspaceConversationRuntime {
     }
 
     func startTurn(threadID: String, prompt: String, configuration: BridgeTurnStartConfiguration?) async throws {
-        let session = controller.threadSession(id: threadID) ?? controller.openThread(id: threadID, title: "New Conversation")
+        let session = controller.threadSession(id: threadID)
+            ?? controller.openThread(id: threadID, title: "New Conversation", isVisibleInSidebar: false)
         let turnNumber = coordinator.nextTurnCount()
 
         session.beginTurn(userPrompt: prompt)

--- a/AtelierCode/AppBootstrap.swift
+++ b/AtelierCode/AppBootstrap.swift
@@ -160,6 +160,13 @@ private final class UITestWorkspaceRuntime: WorkspaceConversationRuntime {
         )
     }
 
+    func renameThread(id: String, title: String) async throws {
+        controller.updateThreadSummary(id: id) { summary in
+            summary.title = title
+        }
+        controller.threadSession(id: id)?.updateThreadIdentity(id: id, title: title)
+    }
+
     func archiveThread(id: String) async throws {
         controller.setThreadArchived(true, for: id)
     }

--- a/AtelierCode/AppModel.swift
+++ b/AtelierCode/AppModel.swift
@@ -299,8 +299,18 @@ final class AppModel {
     func forkSelectedThread() async -> Bool {
         guard let controller = selectedWorkspaceController,
               let selectedRoute,
-              let threadID = selectedRoute.threadID,
-              let runtime = runtime(for: controller.workspace.canonicalPath) else {
+              let threadID = selectedRoute.threadID else {
+            return false
+        }
+
+        return await forkThread(workspacePath: controller.workspace.canonicalPath, threadID: threadID)
+    }
+
+    @discardableResult
+    func forkThread(workspacePath: String, threadID: String) async -> Bool {
+        let canonicalPath = WorkspaceRecord.canonicalizedPath(for: workspacePath)
+        guard let controller = workspaceController(for: canonicalPath),
+              let runtime = runtime(for: canonicalPath) else {
             return false
         }
 
@@ -308,9 +318,10 @@ final class AppModel {
             let session = try await runtime.forkThreadAndWait(id: threadID)
             controller.markThreadSelected(session.threadID)
             self.selectedRoute = WorkspaceThreadRoute(
-                workspacePath: controller.workspace.canonicalPath,
+                workspacePath: canonicalPath,
                 threadID: session.threadID
             )
+            lastSelectedWorkspacePath = canonicalPath
             persistPreferences()
             return true
         } catch is CancellationError {
@@ -325,8 +336,18 @@ final class AppModel {
     func archiveSelectedThread() async -> Bool {
         guard let controller = selectedWorkspaceController,
               let selectedRoute,
-              let threadID = selectedRoute.threadID,
-              let runtime = runtime(for: controller.workspace.canonicalPath) else {
+              let threadID = selectedRoute.threadID else {
+            return false
+        }
+
+        return await archiveThread(workspacePath: controller.workspace.canonicalPath, threadID: threadID)
+    }
+
+    @discardableResult
+    func archiveThread(workspacePath: String, threadID: String) async -> Bool {
+        let canonicalPath = WorkspaceRecord.canonicalizedPath(for: workspacePath)
+        guard let controller = workspaceController(for: canonicalPath),
+              let runtime = runtime(for: canonicalPath) else {
             return false
         }
 
@@ -339,10 +360,10 @@ final class AppModel {
                 isRunning: false,
                 hasUnreadActivity: false
             )
-            if controller.isShowingArchivedThreads {
+            if selectedRoute?.workspacePath == canonicalPath, selectedRoute?.threadID == threadID, controller.isShowingArchivedThreads {
                 controller.markThreadSelected(threadID)
-            } else {
-                selectWorkspace(path: controller.workspace.canonicalPath)
+            } else if selectedRoute?.workspacePath == canonicalPath, selectedRoute?.threadID == threadID {
+                selectWorkspace(path: canonicalPath)
             }
             return true
         } catch is CancellationError {
@@ -357,8 +378,18 @@ final class AppModel {
     func unarchiveSelectedThread() async -> Bool {
         guard let controller = selectedWorkspaceController,
               let selectedRoute,
-              let threadID = selectedRoute.threadID,
-              let runtime = runtime(for: controller.workspace.canonicalPath) else {
+              let threadID = selectedRoute.threadID else {
+            return false
+        }
+
+        return await unarchiveThread(workspacePath: controller.workspace.canonicalPath, threadID: threadID)
+    }
+
+    @discardableResult
+    func unarchiveThread(workspacePath: String, threadID: String) async -> Bool {
+        let canonicalPath = WorkspaceRecord.canonicalizedPath(for: workspacePath)
+        guard let controller = workspaceController(for: canonicalPath),
+              let runtime = runtime(for: canonicalPath) else {
             return false
         }
 
@@ -366,10 +397,36 @@ final class AppModel {
             let session = try await runtime.unarchiveThreadAndWait(id: threadID)
             controller.markThreadSelected(session.threadID)
             self.selectedRoute = WorkspaceThreadRoute(
-                workspacePath: controller.workspace.canonicalPath,
+                workspacePath: canonicalPath,
                 threadID: session.threadID
             )
+            lastSelectedWorkspacePath = canonicalPath
             persistPreferences()
+            return true
+        } catch is CancellationError {
+            return false
+        } catch {
+            controller.setConnectionStatus(.error(message: error.localizedDescription))
+            return false
+        }
+    }
+
+    @discardableResult
+    func renameThread(workspacePath: String, threadID: String, title: String) async -> Bool {
+        let canonicalPath = WorkspaceRecord.canonicalizedPath(for: workspacePath)
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let resolvedTitle = trimmedTitle.nilIfEmpty,
+              let controller = workspaceController(for: canonicalPath),
+              let runtime = runtime(for: canonicalPath) else {
+            return false
+        }
+
+        do {
+            try await runtime.renameThread(id: threadID, title: resolvedTitle)
+            controller.updateThreadSummary(id: threadID) { summary in
+                summary.title = resolvedTitle
+            }
+            controller.threadSession(id: threadID)?.updateThreadIdentity(id: threadID, title: resolvedTitle)
             return true
         } catch is CancellationError {
             return false

--- a/AtelierCode/AppModel.swift
+++ b/AtelierCode/AppModel.swift
@@ -271,28 +271,19 @@ final class AppModel {
 
     @discardableResult
     func createThread() async -> Bool {
-        guard let controller = selectedWorkspaceController,
-              await ensureRuntimeReady(for: controller.workspace.canonicalPath),
-              let runtime = runtime(for: controller.workspace.canonicalPath) else {
+        guard let controller = selectedWorkspaceController else {
             return false
         }
 
-        do {
-            let session = try await runtime.startThreadAndWait(title: nil)
-            controller.markThreadSelected(session.threadID)
-            selectedRoute = WorkspaceThreadRoute(
-                workspacePath: controller.workspace.canonicalPath,
-                threadID: session.threadID
-            )
-            lastSelectedWorkspacePath = controller.workspace.canonicalPath
-            persistPreferences()
-            return true
-        } catch is CancellationError {
-            return false
-        } catch {
-            controller.setConnectionStatus(.error(message: error.localizedDescription))
-            return false
-        }
+        controller.clearActiveThreadSession()
+        selectedRoute = WorkspaceThreadRoute(
+            workspacePath: controller.workspace.canonicalPath,
+            threadID: nil
+        )
+        lastSelectedWorkspacePath = controller.workspace.canonicalPath
+        startWorkspaceRuntimeIfNeeded(for: controller.workspace.canonicalPath)
+        persistPreferences()
+        return true
     }
 
     @discardableResult
@@ -576,6 +567,20 @@ final class AppModel {
                 persistPreferences()
             }
 
+            controller.setThreadSidebarVisibility(true, for: threadID)
+            controller.markThreadActivity(
+                id: threadID,
+                at: now(),
+                previewText: trimmedPrompt,
+                hasUnreadActivity: false,
+                lastErrorMessage: nil
+            )
+            controller.updateThreadSummary(id: threadID) { summary in
+                let trimmedTitle = summary.title.trimmingCharacters(in: .whitespacesAndNewlines)
+                if trimmedTitle.isEmpty || trimmedTitle == summary.id || trimmedTitle == "New Conversation" || trimmedTitle == "Thread" {
+                    summary.title = Self.defaultDraftThreadTitle(from: trimmedPrompt)
+                }
+            }
             controller.setAwaitingTurnStart(true, for: threadID)
             try await runtime.startTurn(
                 threadID: threadID,
@@ -837,6 +842,16 @@ final class AppModel {
             workspacePath: workspacePath,
             threadID: controller.visibleThreadSummaries.first?.id
         )
+    }
+
+    private static func defaultDraftThreadTitle(from prompt: String) -> String {
+        let firstLine = prompt
+            .split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: true)
+            .first
+            .map(String.init)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return firstLine?.isEmpty == false ? firstLine! : "New Conversation"
     }
 
     private static func normalizeRecentWorkspaces(_ workspaces: [WorkspaceRecord]) -> [WorkspaceRecord] {

--- a/AtelierCode/AppModel.swift
+++ b/AtelierCode/AppModel.swift
@@ -90,6 +90,7 @@ final class AppModel {
         }
 
         startInitiallySelectedWorkspaceRuntime()
+        preloadInitiallyExpandedWorkspaceThreadLists()
     }
 
     var activeWorkspaceController: WorkspaceController? {
@@ -666,6 +667,26 @@ final class AppModel {
         }
 
         startWorkspaceRuntimeIfNeeded(for: workspacePath)
+    }
+
+    private func preloadInitiallyExpandedWorkspaceThreadLists() {
+        let selectedWorkspacePath = selectedRoute?.workspacePath ?? lastSelectedWorkspacePath
+        let workspacePathsToPreload = workspaceControllers
+            .filter { controller in
+                controller.isExpanded &&
+                controller.workspace.canonicalPath != selectedWorkspacePath
+            }
+            .map(\.workspace.canonicalPath)
+
+        for workspacePath in workspacePathsToPreload {
+            Task { @MainActor [weak self] in
+                guard let self else {
+                    return
+                }
+
+                _ = await prepareWorkspaceForBrowsing(path: workspacePath)
+            }
+        }
     }
 
     private func startRuntime(_ runtime: any WorkspaceConversationRuntime, workspacePath: String) async {

--- a/AtelierCode/AppStateTypes.swift
+++ b/AtelierCode/AppStateTypes.swift
@@ -179,6 +179,7 @@ struct ThreadSummary: Equatable, Sendable, Identifiable {
     var title: String
     var previewText: String
     var updatedAt: Date
+    var isVisibleInSidebar: Bool
     var isArchived: Bool
     var isRunning: Bool
     var hasUnreadActivity: Bool
@@ -189,6 +190,7 @@ struct ThreadSummary: Equatable, Sendable, Identifiable {
         title: String,
         previewText: String,
         updatedAt: Date,
+        isVisibleInSidebar: Bool = true,
         isArchived: Bool = false,
         isRunning: Bool = false,
         hasUnreadActivity: Bool = false,
@@ -198,6 +200,7 @@ struct ThreadSummary: Equatable, Sendable, Identifiable {
         self.title = title
         self.previewText = previewText
         self.updatedAt = updatedAt
+        self.isVisibleInSidebar = isVisibleInSidebar
         self.isArchived = isArchived
         self.isRunning = isRunning
         self.hasUnreadActivity = hasUnreadActivity

--- a/AtelierCode/ContentView.swift
+++ b/AtelierCode/ContentView.swift
@@ -824,6 +824,8 @@ private struct ConversationSurface: View {
                     appModel: appModel,
                     session: appModel.selectedThreadSession,
                     hasSelectedThread: appModel.selectedThreadSummary != nil,
+                    isDraftingNewThread: appModel.selectedRoute?.workspacePath == controller.workspace.canonicalPath &&
+                        appModel.selectedRoute?.threadID == nil,
                     hasVisibleThreads: controller.visibleThreadSummaries.isEmpty == false,
                     bottomInset: bottomInset
                 )
@@ -852,6 +854,7 @@ private struct ConversationTranscript: View {
     let appModel: AppModel
     let session: ThreadSession?
     let hasSelectedThread: Bool
+    let isDraftingNewThread: Bool
     let hasVisibleThreads: Bool
     let bottomInset: CGFloat
 
@@ -867,6 +870,15 @@ private struct ConversationTranscript: View {
             .padding(.bottom, bottomInset)
             .frame(maxWidth: .infinity, minHeight: 420)
             .accessibilityIdentifier("conversation-loading-empty-state")
+        } else if isDraftingNewThread || hasVisibleThreads == false {
+            ContentUnavailableView {
+                Label("Start a Thread", systemImage: "square.and.pencil")
+            } description: {
+                Text("Send your first prompt below to create a new thread for this workspace.")
+            }
+            .padding(.bottom, bottomInset)
+            .frame(maxWidth: .infinity, minHeight: 420)
+            .accessibilityIdentifier("conversation-ready-empty-state")
         } else if hasVisibleThreads {
             ContentUnavailableView {
                 Label("Select a Thread", systemImage: "text.bubble")
@@ -876,15 +888,6 @@ private struct ConversationTranscript: View {
             .padding(.bottom, bottomInset)
             .frame(maxWidth: .infinity, minHeight: 420)
             .accessibilityIdentifier("conversation-select-thread-state")
-        } else {
-            ContentUnavailableView {
-                Label("Start a Thread", systemImage: "square.and.pencil")
-            } description: {
-                Text("Send your first prompt below to create a new thread for this workspace.")
-            }
-            .padding(.bottom, bottomInset)
-            .frame(maxWidth: .infinity, minHeight: 420)
-            .accessibilityIdentifier("conversation-ready-empty-state")
         }
     }
 }
@@ -2095,7 +2098,7 @@ private final class PreviewWorkspaceRuntime: WorkspaceConversationRuntime {
     }
 
     func startThreadAndWait(title: String?) async throws -> ThreadSession {
-        controller.openThread(id: UUID().uuidString, title: title ?? "Preview Thread")
+        controller.openThread(id: UUID().uuidString, title: title ?? "Preview Thread", isVisibleInSidebar: false)
     }
 
     func resumeThreadAndWait(id: String) async throws -> ThreadSession {
@@ -2132,7 +2135,8 @@ private final class PreviewWorkspaceRuntime: WorkspaceConversationRuntime {
     }
 
     func startTurn(threadID: String, prompt: String, configuration: BridgeTurnStartConfiguration?) async throws {
-        let session = controller.threadSession(id: threadID) ?? controller.openThread(id: threadID, title: "Preview Thread")
+        let session = controller.threadSession(id: threadID)
+            ?? controller.openThread(id: threadID, title: "Preview Thread", isVisibleInSidebar: false)
         session.beginTurn(userPrompt: prompt)
         controller.setAwaitingTurnStart(false, for: threadID)
         controller.setCurrentTurnID("preview-turn", for: threadID)

--- a/AtelierCode/ContentView.swift
+++ b/AtelierCode/ContentView.swift
@@ -124,7 +124,7 @@ private struct WorkspaceTreeRow: View {
             )
 
             if controller.isExpanded {
-                VStack(alignment: .leading, spacing: 8) {
+                VStack(alignment: .leading, spacing: 2) {
                     if controller.visibleThreadSummaries.isEmpty {
                         Text("No active threads yet.")
                             .font(.caption)
@@ -357,36 +357,156 @@ private struct WorkspaceThreadRow: View {
     let appModel: AppModel
     let workspacePath: String
     let threadSummary: ThreadSummary
+    @State private var isHovering = false
+    @State private var isRenaming = false
+    @State private var draftTitle = ""
+    @FocusState private var isRenameFieldFocused: Bool
 
     private var isSelected: Bool {
         appModel.selectedRoute?.workspacePath == workspacePath && appModel.selectedRoute?.threadID == threadSummary.id
     }
 
-    var body: some View {
-        Button {
-            Task {
-                _ = await appModel.openThread(
-                    workspacePath: workspacePath,
-                    threadID: threadSummary.id
-                )
-            }
-        } label: {
-            HStack(alignment: .center, spacing: 10) {
-                ZStack {
-                    Circle()
-                        .fill(threadSummary.hasUnreadActivity ? Color.accentColor : Color.clear)
-                        .frame(width: 8, height: 8)
-                }
-                .frame(width: 24, height: 24)
+    private var showsHoverActions: Bool {
+        isHovering || isSelected || isRenaming
+    }
 
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack(alignment: .center, spacing: 8) {
+    private var rowBackgroundColor: Color {
+        if isSelected {
+            return Color.accentColor.opacity(0.14)
+        }
+
+        if isHovering || isRenaming {
+            return Color.secondary.opacity(0.08)
+        }
+
+        return .clear
+    }
+
+    private var rowBorderColor: Color {
+        if isSelected {
+            return Color.accentColor.opacity(0.2)
+        }
+
+        if isHovering || isRenaming {
+            return Color(nsColor: .separatorColor).opacity(0.24)
+        }
+
+        return .clear
+    }
+
+    private var renameCandidate: String {
+        draftTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var canCommitRename: Bool {
+        renameCandidate.isEmpty == false && renameCandidate != threadSummary.title
+    }
+
+    private var showsStatusBadges: Bool {
+        threadSummary.isRunning || threadSummary.lastErrorMessage != nil || threadSummary.isArchived
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 8) {
+            if isRenaming {
+                rowContent
+            } else {
+                Button(action: openThread) {
+                    rowContent
+                }
+                .buttonStyle(.plain)
+            }
+
+            Menu {
+                threadActionMenuItems
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(showsHoverActions ? Color.secondary : Color.clear)
+                    .frame(width: 28, height: 28)
+                    .background(
+                        (isHovering || isRenaming) ? Color.primary.opacity(0.06) : Color.clear,
+                        in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    )
+                    .contentShape(Rectangle())
+            }
+            .menuStyle(BorderlessButtonMenuStyle())
+            .menuIndicator(.hidden)
+            .accessibilityIdentifier("thread-menu-\(threadSummary.id)")
+            .help("Thread options")
+            .opacity(showsHoverActions ? 1 : 0)
+            .allowsHitTesting(showsHoverActions)
+            .animation(.easeInOut(duration: 0.16), value: showsHoverActions)
+        }
+        .padding(.trailing, 6)
+        .background(
+            rowBackgroundColor,
+            in: RoundedRectangle(cornerRadius: 12, style: .continuous)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(rowBorderColor, lineWidth: 1)
+        }
+        .shadow(color: isHovering ? Color.black.opacity(0.04) : .clear, radius: 6, y: 2)
+        .onAppear {
+            draftTitle = threadSummary.title
+        }
+        .onChange(of: threadSummary.title) { _, newValue in
+            if isRenaming == false {
+                draftTitle = newValue
+            }
+        }
+        .onHover { isHovering = $0 }
+        .contextMenu {
+            threadActionMenuItems
+        }
+        .accessibilityIdentifier("thread-row-\(threadSummary.id)")
+    }
+
+    private var rowContent: some View {
+        HStack(alignment: .center, spacing: 10) {
+            ZStack {
+                Circle()
+                    .fill(threadSummary.hasUnreadActivity ? Color.accentColor : Color.clear)
+                    .frame(width: 8, height: 8)
+            }
+            .frame(width: 24, height: 24)
+
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(alignment: .center, spacing: 8) {
+                    if isRenaming {
+                        HStack(spacing: 8) {
+                            TextField("Thread title", text: $draftTitle)
+                                .textFieldStyle(.plain)
+                                .font(.subheadline.weight(.semibold))
+                                .focused($isRenameFieldFocused)
+                                .onSubmit(commitRename)
+                                .onExitCommand(perform: cancelRename)
+
+                            Button(action: commitRename) {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundStyle(canCommitRename ? Color.accentColor : Color.secondary.opacity(0.6))
+                            }
+                            .buttonStyle(.plain)
+                            .disabled(canCommitRename == false)
+                            .help("Save thread title")
+
+                            Button(action: cancelRename) {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundStyle(Color.secondary)
+                            }
+                            .buttonStyle(.plain)
+                            .help("Cancel renaming")
+                        }
+                    } else {
                         Text(threadSummary.title)
                             .font(.subheadline.weight(.semibold))
                             .foregroundStyle(.primary)
                             .lineLimit(1)
                     }
+                }
 
+                if showsStatusBadges {
                     HStack(spacing: 6) {
                         if threadSummary.isRunning {
                             SidebarThreadBadge(text: "Running", color: .blue)
@@ -402,17 +522,86 @@ private struct WorkspaceThreadRow: View {
                     }
                 }
             }
-            .padding(.vertical, 8)
-            .padding(.trailing, 10)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                isSelected ? Color.accentColor.opacity(0.12) : Color.clear,
-                in: RoundedRectangle(cornerRadius: 12, style: .continuous)
-            )
-            .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
-        .accessibilityIdentifier("thread-row-\(threadSummary.id)")
+        .padding(.vertical, 3)
+        .padding(.leading, 2)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+    }
+
+    @ViewBuilder
+    private var threadActionMenuItems: some View {
+        Button(threadSummary.isArchived ? "Unarchive" : "Archive") {
+            if threadSummary.isArchived {
+                Task {
+                    _ = await appModel.unarchiveThread(workspacePath: workspacePath, threadID: threadSummary.id)
+                }
+            } else {
+                Task {
+                    _ = await appModel.archiveThread(workspacePath: workspacePath, threadID: threadSummary.id)
+                }
+            }
+        }
+
+        Button("Rename") {
+            beginRename()
+        }
+
+        Button("Fork") {
+            Task {
+                _ = await appModel.forkThread(workspacePath: workspacePath, threadID: threadSummary.id)
+            }
+        }
+    }
+
+    private func beginRename() {
+        draftTitle = threadSummary.title
+        isRenaming = true
+
+        Task { @MainActor in
+            isRenameFieldFocused = true
+        }
+    }
+
+    private func cancelRename() {
+        draftTitle = threadSummary.title
+        isRenaming = false
+        isRenameFieldFocused = false
+    }
+
+    private func commitRename() {
+        guard canCommitRename else {
+            cancelRename()
+            return
+        }
+
+        let nextTitle = renameCandidate
+        Task {
+            let succeeded = await appModel.renameThread(
+                workspacePath: workspacePath,
+                threadID: threadSummary.id,
+                title: nextTitle
+            )
+
+            await MainActor.run {
+                if succeeded {
+                    draftTitle = nextTitle
+                    isRenaming = false
+                    isRenameFieldFocused = false
+                } else {
+                    isRenameFieldFocused = true
+                }
+            }
+        }
+    }
+
+    private func openThread() {
+        Task {
+            _ = await appModel.openThread(
+                workspacePath: workspacePath,
+                threadID: threadSummary.id
+            )
+        }
     }
 }
 
@@ -1919,6 +2108,13 @@ private final class PreviewWorkspaceRuntime: WorkspaceConversationRuntime {
 
     func forkThreadAndWait(id: String) async throws -> ThreadSession {
         controller.resumeThread(id: "\(id)-fork", title: "Preview Thread")
+    }
+
+    func renameThread(id: String, title: String) async throws {
+        controller.updateThreadSummary(id: id) { summary in
+            summary.title = title
+        }
+        controller.threadSession(id: id)?.updateThreadIdentity(id: id, title: title)
     }
 
     func archiveThread(id: String) async throws {

--- a/AtelierCode/Runtime/BridgeProtocol.swift
+++ b/AtelierCode/Runtime/BridgeProtocol.swift
@@ -11,6 +11,7 @@ enum BridgeCommandType: String, Encodable, Sendable {
     case threadList = "thread.list"
     case threadRead = "thread.read"
     case threadFork = "thread.fork"
+    case threadRename = "thread.rename"
     case threadArchive = "thread.archive"
     case threadUnarchive = "thread.unarchive"
     case threadRollback = "thread.rollback"
@@ -188,6 +189,10 @@ struct BridgeThreadReadPayload: Encodable, Sendable {
 
 struct BridgeThreadForkPayload: Encodable, Sendable {
     let workspacePath: String
+}
+
+struct BridgeThreadRenamePayload: Encodable, Sendable {
+    let title: String
 }
 
 struct BridgeThreadArchivePayload: Encodable, Sendable {}

--- a/AtelierCode/Runtime/WorkspaceBridgeRuntime.swift
+++ b/AtelierCode/Runtime/WorkspaceBridgeRuntime.swift
@@ -62,6 +62,11 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
         case accountLogout
     }
 
+    private struct PendingThreadListRequest {
+        let archived: Bool
+        var summariesByID: [String: ThreadSummary]
+    }
+
     private static let encoder = JSONEncoder()
     private static let decoder = JSONDecoder()
     private static let clientName = "AtelierCode"
@@ -85,6 +90,7 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
     private var pendingThreadSessions: [String: CheckedContinuation<ThreadSession, Error>] = [:]
     private var pendingVoidResponses: [String: CheckedContinuation<Void, Error>] = [:]
     private var pendingApprovalResolutions: [String: CheckedContinuation<Void, Error>] = [:]
+    private var pendingThreadListsByRequestID: [String: PendingThreadListRequest] = [:]
     private var abandonedThreadRequestIDs: Set<String> = []
     private var requestCounter = 0
     private var runningActivityStartedAt: [String: Date] = [:]
@@ -194,6 +200,7 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
         self.pendingVoidResponses.removeAll()
         let pendingApprovalResolutions = self.pendingApprovalResolutions
         self.pendingApprovalResolutions.removeAll()
+        pendingThreadListsByRequestID.removeAll()
         abandonedThreadRequestIDs.removeAll()
         for summary in controller.threadSummaries {
             controller.setCurrentTurnID(nil, for: summary.id)
@@ -218,17 +225,10 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
     }
 
     func listThreads(archived: Bool) async throws {
-        let requestID = nextRequestID(prefix: archived ? "thread-list-archived" : "thread-list")
-        pendingCommands[requestID] = .threadList(archived: archived)
-        try await sendCommand(
-            id: requestID,
-            type: .threadList,
-            payload: BridgeThreadListPayload(
-                workspacePath: controller.workspace.canonicalPath,
-                cursor: nil,
-                limit: nil,
-                archived: archived ? .only : .exclude
-            )
+        try await sendThreadListRequest(
+            archived: archived,
+            cursor: nil,
+            accumulatedSummariesByID: [:]
         )
     }
 
@@ -568,7 +568,7 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
                 case .welcome:
                     continue
                 case .event(let event):
-                    handleEvent(event)
+                    await handleEvent(event)
                 }
             }
         } catch is CancellationError {
@@ -582,7 +582,7 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
         }
     }
 
-    private func handleEvent(_ event: BridgeEventEnvelope) {
+    private func handleEvent(_ event: BridgeEventEnvelope) async {
         adoptTurnContextIfNeeded(from: event)
 
         switch event.payload {
@@ -836,16 +836,7 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
         case .turnCompleted(let payload):
             handleTurnCompleted(payload, event: event)
         case .threadListResult(let payload):
-            let archived: Bool
-            if let requestID = event.requestID,
-               let pendingCommand = pendingCommands.removeValue(forKey: requestID),
-               case .threadList(let requestArchived) = pendingCommand {
-                archived = requestArchived
-            } else {
-                archived = false
-            }
-
-            controller.replaceThreadList(payload.threads.map { $0.toThreadSummary() }, archived: archived)
+            await handleThreadListResult(payload, requestID: event.requestID)
         case .accountLoginResult(let payload):
             if let requestID = event.requestID {
                 pendingCommands.removeValue(forKey: requestID)
@@ -869,7 +860,14 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
     }
 
     private func handleThreadStarted(_ payload: BridgeThreadStartedPayload, requestID: String?) {
-        let summary = payload.thread.toThreadSummary()
+        let pendingCommand = requestID.flatMap { pendingCommands[$0] }
+        var summary = payload.thread.toThreadSummary()
+
+        if case .threadStart? = pendingCommand,
+           payload.thread.messages?.isEmpty != false {
+            summary.isVisibleInSidebar = controller.threadSummary(id: summary.id)?.isVisibleInSidebar ?? false
+        }
+
         controller.upsertThreadSummary(summary)
 
         if let requestID, abandonedThreadRequestIDs.remove(requestID) != nil {
@@ -896,7 +894,11 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
                         messages: messages.map { $0.toConversationMessage() }
                     )
                 } else {
-                    session = controller.openThread(id: summary.id, title: summary.title)
+                    session = controller.openThread(
+                        id: summary.id,
+                        title: summary.title,
+                        isVisibleInSidebar: summary.isVisibleInSidebar
+                    )
                 }
             case .threadRename(let threadID):
                 if let session = controller.threadSession(id: threadID) {
@@ -915,6 +917,42 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
         }
 
         _ = controller.ensureThreadSession(id: summary.id, title: summary.title, markSelected: false)
+    }
+
+    private func handleThreadListResult(_ payload: BridgeThreadListResultPayload, requestID: String?) async {
+        let archived: Bool
+        let requestState: PendingThreadListRequest?
+
+        if let requestID,
+           let pendingCommand = pendingCommands.removeValue(forKey: requestID),
+           case .threadList(let requestArchived) = pendingCommand {
+            archived = requestArchived
+            requestState = pendingThreadListsByRequestID.removeValue(forKey: requestID)
+        } else {
+            archived = false
+            requestState = requestID.flatMap { pendingThreadListsByRequestID.removeValue(forKey: $0) }
+        }
+
+        var accumulatedSummariesByID = requestState?.summariesByID ?? [:]
+        for summary in payload.threads.map({ $0.toThreadSummary() }) {
+            accumulatedSummariesByID[summary.id] = summary
+        }
+
+        if let nextCursor = payload.nextCursor,
+           nextCursor.isEmpty == false {
+            do {
+                try await sendThreadListRequest(
+                    archived: archived,
+                    cursor: nextCursor,
+                    accumulatedSummariesByID: accumulatedSummariesByID
+                )
+            } catch {
+                handleBridgeFailure(message: error.localizedDescription)
+            }
+            return
+        }
+
+        controller.replaceThreadList(Array(accumulatedSummariesByID.values), archived: archived)
     }
 
     private func handleThreadArchived(_ payload: BridgeThreadArchivedPayload, requestID: String?) {
@@ -966,6 +1004,7 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
 
         controller.setCurrentTurnID(event.turnID, for: threadID)
         controller.setAwaitingTurnStart(false, for: threadID)
+        controller.setThreadSidebarVisibility(true, for: threadID)
         controller.markThreadActivity(
             id: threadID,
             at: bridgeDate(from: event.timestamp) ?? now(),
@@ -1076,6 +1115,8 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
                 pendingThreadSessions.removeValue(forKey: requestID)?.resume(
                     throwing: RuntimeBridgeError.requestFailed(message: payload.message)
                 )
+            case .threadList:
+                pendingThreadListsByRequestID.removeValue(forKey: requestID)
             case .threadRename:
                 pendingVoidResponses.removeValue(forKey: requestID)?.resume(
                     throwing: RuntimeBridgeError.requestFailed(message: payload.message)
@@ -1140,6 +1181,7 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
 
         controller.setCurrentTurnID(turnID, for: threadID)
         controller.setAwaitingTurnStart(false, for: threadID)
+        controller.setThreadSidebarVisibility(true, for: threadID)
         controller.markThreadActivity(
             id: threadID,
             at: bridgeDate(from: event.timestamp) ?? now(),
@@ -1222,6 +1264,29 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
         pendingActivityCompletions.values.forEach { $0.cancel() }
         pendingActivityCompletions.removeAll()
         runningActivityStartedAt.removeAll()
+    }
+
+    private func sendThreadListRequest(
+        archived: Bool,
+        cursor: String?,
+        accumulatedSummariesByID: [String: ThreadSummary]
+    ) async throws {
+        let requestID = nextRequestID(prefix: archived ? "thread-list-archived" : "thread-list")
+        pendingCommands[requestID] = .threadList(archived: archived)
+        pendingThreadListsByRequestID[requestID] = PendingThreadListRequest(
+            archived: archived,
+            summariesByID: accumulatedSummariesByID
+        )
+        try await sendCommand(
+            id: requestID,
+            type: .threadList,
+            payload: BridgeThreadListPayload(
+                workspacePath: controller.workspace.canonicalPath,
+                cursor: cursor,
+                limit: nil,
+                archived: archived ? .only : .exclude
+            )
+        )
     }
 
     private func sendHello() async throws {
@@ -1345,6 +1410,7 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
         self.pendingVoidResponses.removeAll()
         let pendingApprovalResolutions = self.pendingApprovalResolutions
         self.pendingApprovalResolutions.removeAll()
+        pendingThreadListsByRequestID.removeAll()
         abandonedThreadRequestIDs.removeAll()
         controller.setBridgeLifecycleState(.idle)
 

--- a/AtelierCode/Runtime/WorkspaceBridgeRuntime.swift
+++ b/AtelierCode/Runtime/WorkspaceBridgeRuntime.swift
@@ -49,6 +49,7 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
         case threadResume
         case threadRead
         case threadFork
+        case threadRename(threadID: String)
         case threadArchive(threadID: String)
         case threadUnarchive
         case threadRollback
@@ -355,6 +356,24 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
                 type: .threadFork,
                 threadID: id,
                 payload: BridgeThreadForkPayload(workspacePath: self.controller.workspace.canonicalPath)
+            )
+        }
+    }
+
+    func renameThread(id: String, title: String) async throws {
+        let requestID = nextRequestID(prefix: "thread-rename")
+        pendingCommands[requestID] = .threadRename(threadID: id)
+
+        try await awaitVoidResponse(requestID: requestID) { [weak self] in
+            guard let self else {
+                throw CancellationError()
+            }
+
+            try await self.sendCommand(
+                id: requestID,
+                type: .threadRename,
+                threadID: id,
+                payload: BridgeThreadRenamePayload(title: title)
             )
         }
     }
@@ -879,6 +898,12 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
                 } else {
                     session = controller.openThread(id: summary.id, title: summary.title)
                 }
+            case .threadRename(let threadID):
+                if let session = controller.threadSession(id: threadID) {
+                    session.updateThreadIdentity(id: summary.id, title: summary.title)
+                }
+                pendingVoidResponses.removeValue(forKey: requestID)?.resume()
+                return
             default:
                 session = controller.ensureThreadSession(id: summary.id, title: summary.title, markSelected: false)
             }
@@ -1049,6 +1074,10 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
             switch pendingCommand {
             case .threadStart, .threadResume, .threadRead, .threadFork, .threadUnarchive, .threadRollback:
                 pendingThreadSessions.removeValue(forKey: requestID)?.resume(
+                    throwing: RuntimeBridgeError.requestFailed(message: payload.message)
+                )
+            case .threadRename:
+                pendingVoidResponses.removeValue(forKey: requestID)?.resume(
                     throwing: RuntimeBridgeError.requestFailed(message: payload.message)
                 )
             case .threadArchive(let threadID):

--- a/AtelierCode/Runtime/WorkspaceConversationRuntime.swift
+++ b/AtelierCode/Runtime/WorkspaceConversationRuntime.swift
@@ -9,6 +9,7 @@ protocol WorkspaceConversationRuntime: AnyObject {
     func resumeThreadAndWait(id: String) async throws -> ThreadSession
     func readThreadAndWait(id: String, includeTurns: Bool) async throws -> ThreadSession
     func forkThreadAndWait(id: String) async throws -> ThreadSession
+    func renameThread(id: String, title: String) async throws
     func archiveThread(id: String) async throws
     func unarchiveThreadAndWait(id: String) async throws -> ThreadSession
     func rollbackThreadAndWait(id: String, numTurns: Int) async throws -> ThreadSession

--- a/AtelierCode/WorkspaceController.swift
+++ b/AtelierCode/WorkspaceController.swift
@@ -21,6 +21,7 @@ final class WorkspaceController {
 
     @ObservationIgnored private var awaitingTurnStartThreadIDs: Set<String>
     @ObservationIgnored private var currentTurnIDsByThreadID: [String: String]
+    @ObservationIgnored private var pinnedSidebarThreadSummariesByID: [String: ThreadSummary]
 
     init(workspace: WorkspaceRecord) {
         self.workspace = workspace
@@ -37,6 +38,7 @@ final class WorkspaceController {
         self.isShowingAllVisibleThreads = false
         self.awaitingTurnStartThreadIDs = []
         self.currentTurnIDsByThreadID = [:]
+        self.pinnedSidebarThreadSummariesByID = [:]
     }
 
     var activeThreadSession: ThreadSession? {
@@ -57,7 +59,7 @@ final class WorkspaceController {
 
     var visibleThreadSummaries: [ThreadSummary] {
         threadSummaries.filter { summary in
-            isShowingArchivedThreads || summary.isArchived == false
+            summary.isVisibleInSidebar && (isShowingArchivedThreads || summary.isArchived == false)
         }
     }
 
@@ -100,6 +102,7 @@ final class WorkspaceController {
         isShowingAllVisibleThreads = false
         awaitingTurnStartThreadIDs.removeAll()
         currentTurnIDsByThreadID.removeAll()
+        pinnedSidebarThreadSummariesByID.removeAll()
     }
 
     func setBridgeLifecycleState(_ state: BridgeLifecycleState) {
@@ -140,22 +143,20 @@ final class WorkspaceController {
 
     func replaceThreadList(_ threadSummaries: [ThreadSummary], archived: Bool = false) {
         let existingByID = Dictionary(uniqueKeysWithValues: self.threadSummaries.map { ($0.id, $0) })
+        let incomingIDs = Set(threadSummaries.map(\.id))
         var merged = self.threadSummaries.filter { $0.isArchived != archived }
+        let mergedIDs = Set(merged.map(\.id))
+        merged.append(
+            contentsOf: pinnedSidebarThreadSummariesByID.values.filter { summary in
+                summary.isArchived == archived &&
+                incomingIDs.contains(summary.id) == false &&
+                mergedIDs.contains(summary.id) == false
+            }
+        )
 
         for summary in threadSummaries {
             let existing = existingByID[summary.id]
-            merged.append(
-                ThreadSummary(
-                    id: summary.id,
-                    title: summary.title,
-                    previewText: summary.previewText,
-                    updatedAt: summary.updatedAt,
-                    isArchived: archived,
-                    isRunning: summary.isRunning || existing?.isRunning == true,
-                    hasUnreadActivity: existing?.hasUnreadActivity ?? false,
-                    lastErrorMessage: summary.lastErrorMessage ?? existing?.lastErrorMessage
-                )
-            )
+            merged.append(Self.mergeRefreshedThreadSummary(summary, existing: existing, archived: archived))
         }
 
         self.threadSummaries = Self.sortedThreadSummaries(merged)
@@ -168,6 +169,7 @@ final class WorkspaceController {
             threadSummaries.append(threadSummary)
         }
 
+        syncPinnedSidebarThreadSummary(id: threadSummary.id)
         threadSummaries = Self.sortedThreadSummaries(threadSummaries)
     }
 
@@ -177,6 +179,7 @@ final class WorkspaceController {
         }
 
         mutate(&threadSummaries[index])
+        syncPinnedSidebarThreadSummary(id: id)
         threadSummaries = Self.sortedThreadSummaries(threadSummaries)
     }
 
@@ -194,6 +197,7 @@ final class WorkspaceController {
         updateThreadSummary(id: id) { summary in
             summary.hasUnreadActivity = false
         }
+        pinThreadSummaryInSidebar(threadID: id)
     }
 
     func threadSession(id: String) -> ThreadSession? {
@@ -201,24 +205,25 @@ final class WorkspaceController {
     }
 
     @discardableResult
-    func openThread(id: String, title: String) -> ThreadSession {
+    func openThread(id: String, title: String, isVisibleInSidebar: Bool = true) -> ThreadSession {
         let existingSummary = threadSummary(id: id)
         let session = threadSessionsByID[id] ?? ThreadSession(threadID: id, title: title)
         session.startThread(id: id, title: title)
         threadSessionsByID[id] = session
-        markThreadSelected(id)
         upsertThreadSummary(
             ThreadSummary(
                 id: id,
                 title: title,
                 previewText: existingSummary?.previewText ?? "",
                 updatedAt: existingSummary?.updatedAt ?? .now,
+                isVisibleInSidebar: existingSummary?.isVisibleInSidebar ?? isVisibleInSidebar,
                 isArchived: existingSummary?.isArchived ?? false,
                 isRunning: existingSummary?.isRunning ?? false,
                 hasUnreadActivity: false,
                 lastErrorMessage: existingSummary?.lastErrorMessage
             )
         )
+        markThreadSelected(id)
         return session
     }
 
@@ -232,19 +237,20 @@ final class WorkspaceController {
         let session = threadSessionsByID[id] ?? ThreadSession(threadID: id, title: title)
         session.resumeThread(id: id, title: title, messages: messages)
         threadSessionsByID[id] = session
-        markThreadSelected(id)
         upsertThreadSummary(
             ThreadSummary(
                 id: id,
                 title: title,
                 previewText: messages.last?.text ?? existingSummary?.previewText ?? "",
                 updatedAt: existingSummary?.updatedAt ?? .now,
+                isVisibleInSidebar: existingSummary?.isVisibleInSidebar ?? true,
                 isArchived: existingSummary?.isArchived ?? false,
                 isRunning: existingSummary?.isRunning ?? false,
                 hasUnreadActivity: false,
                 lastErrorMessage: existingSummary?.lastErrorMessage
             )
         )
+        markThreadSelected(id)
         return session
     }
 
@@ -342,6 +348,32 @@ final class WorkspaceController {
         }
     }
 
+    func setThreadSidebarVisibility(_ isVisibleInSidebar: Bool, for threadID: String) {
+        if threadSummary(id: threadID) == nil,
+           isVisibleInSidebar {
+            let fallbackTitle = threadSession(id: threadID)?.title ?? "New Conversation"
+            upsertThreadSummary(
+                ThreadSummary(
+                    id: threadID,
+                    title: fallbackTitle,
+                    previewText: "",
+                    updatedAt: .now,
+                    isVisibleInSidebar: true
+                )
+            )
+        }
+
+        updateThreadSummary(id: threadID) { summary in
+            summary.isVisibleInSidebar = isVisibleInSidebar
+        }
+
+        if isVisibleInSidebar {
+            pinThreadSummaryInSidebar(threadID: threadID)
+        } else {
+            pinnedSidebarThreadSummariesByID.removeValue(forKey: threadID)
+        }
+    }
+
     func markThreadActivity(
         id: String,
         at date: Date = .now,
@@ -378,13 +410,114 @@ final class WorkspaceController {
     private static func mergeThreadSummary(_ incoming: ThreadSummary, existing: ThreadSummary) -> ThreadSummary {
         ThreadSummary(
             id: incoming.id,
-            title: incoming.title,
-            previewText: incoming.previewText,
-            updatedAt: incoming.updatedAt,
+            title: preferredThreadTitle(incoming: incoming.title, existing: existing.title, threadID: incoming.id),
+            previewText: preferredThreadPreview(
+                incoming: incoming.previewText,
+                existing: existing.previewText,
+                preferExisting: incoming.updatedAt < existing.updatedAt
+            ),
+            updatedAt: preferredThreadUpdatedAt(incoming: incoming.updatedAt, existing: existing.updatedAt),
+            isVisibleInSidebar: incoming.isVisibleInSidebar || existing.isVisibleInSidebar,
             isArchived: incoming.isArchived,
             isRunning: incoming.isRunning || existing.isRunning,
             hasUnreadActivity: incoming.hasUnreadActivity || existing.hasUnreadActivity,
             lastErrorMessage: incoming.lastErrorMessage ?? existing.lastErrorMessage
         )
+    }
+
+    private static func mergeRefreshedThreadSummary(
+        _ incoming: ThreadSummary,
+        existing: ThreadSummary?,
+        archived: Bool
+    ) -> ThreadSummary {
+        let shouldPreferExistingActivity = existing.map { $0.updatedAt > incoming.updatedAt } ?? false
+
+        return ThreadSummary(
+            id: incoming.id,
+            title: preferredThreadTitle(incoming: incoming.title, existing: existing?.title, threadID: incoming.id),
+            previewText: preferredThreadPreview(
+                incoming: incoming.previewText,
+                existing: existing?.previewText,
+                preferExisting: shouldPreferExistingActivity
+            ),
+            updatedAt: preferredThreadUpdatedAt(incoming: incoming.updatedAt, existing: existing?.updatedAt),
+            isVisibleInSidebar: incoming.isVisibleInSidebar || existing?.isVisibleInSidebar == true,
+            isArchived: archived,
+            isRunning: incoming.isRunning || existing?.isRunning == true,
+            hasUnreadActivity: existing?.hasUnreadActivity ?? false,
+            lastErrorMessage: incoming.lastErrorMessage ?? existing?.lastErrorMessage
+        )
+    }
+
+    private func pinThreadSummaryInSidebar(threadID: String) {
+        guard let summary = threadSummary(id: threadID) else {
+            return
+        }
+
+        pinnedSidebarThreadSummariesByID[threadID] = summary
+    }
+
+    private func syncPinnedSidebarThreadSummary(id: String) {
+        guard pinnedSidebarThreadSummariesByID[id] != nil else {
+            return
+        }
+
+        if let summary = threadSummary(id: id) {
+            pinnedSidebarThreadSummariesByID[id] = summary
+        } else {
+            pinnedSidebarThreadSummariesByID.removeValue(forKey: id)
+        }
+    }
+
+    private static func preferredThreadTitle(incoming: String, existing: String?, threadID: String) -> String {
+        guard let existing else {
+            return incoming
+        }
+
+        let normalizedIncoming = incoming.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedExisting = existing.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard normalizedExisting.isEmpty == false else {
+            return incoming
+        }
+
+        if isPlaceholderThreadTitle(normalizedIncoming, threadID: threadID) &&
+            isPlaceholderThreadTitle(normalizedExisting, threadID: threadID) == false {
+            return existing
+        }
+
+        return incoming
+    }
+
+    private static func preferredThreadPreview(incoming: String, existing: String?, preferExisting: Bool) -> String {
+        guard let existing else {
+            return incoming
+        }
+
+        let normalizedIncoming = incoming.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedExisting = existing.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if preferExisting, normalizedExisting.isEmpty == false {
+            return existing
+        }
+
+        if normalizedIncoming.isEmpty, normalizedExisting.isEmpty == false {
+            return existing
+        }
+
+        return incoming
+    }
+
+    private static func preferredThreadUpdatedAt(incoming: Date, existing: Date?) -> Date {
+        guard let existing else {
+            return incoming
+        }
+
+        return max(incoming, existing)
+    }
+
+    private static func isPlaceholderThreadTitle(_ title: String, threadID: String) -> Bool {
+        let normalized = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalized.isEmpty || normalized == threadID || normalized == "Thread" || normalized == "New Conversation"
     }
 }

--- a/AtelierCodeTests/AtelierCodeTests.swift
+++ b/AtelierCodeTests/AtelierCodeTests.swift
@@ -149,6 +149,71 @@ struct AppModelTests {
         #expect(appModel.activeWorkspaceController?.connectionStatus == .streaming)
     }
 
+    @Test func draftThreadsStayHiddenUntilFirstPromptStartsConversation() async throws {
+        let store = InMemoryAppPreferencesStore()
+        let runtimeCoordinator = TestRuntimeCoordinator()
+        let appModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
+            runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
+        )
+        let workspaceURL = try temporaryDirectory(named: "conversation-draft-thread")
+
+        appModel.activateWorkspace(at: workspaceURL)
+        try await waitUntil { appModel.activeWorkspaceController?.connectionStatus == .ready }
+
+        let didCreateThread = await appModel.createThread()
+        let controller = try #require(appModel.activeWorkspaceController)
+
+        #expect(didCreateThread)
+        #expect(runtimeCoordinator.startThreadCount == 0)
+        #expect(appModel.selectedRoute?.threadID == nil)
+        #expect(controller.lastActiveThreadID == nil)
+        #expect(controller.visibleThreadSummaries.isEmpty)
+
+        let didSend = await appModel.sendPrompt("Start the real conversation.")
+        let threadID = try #require(controller.lastActiveThreadID)
+
+        #expect(didSend)
+        #expect(controller.threadSummary(id: threadID)?.isVisibleInSidebar == true)
+        #expect(controller.visibleThreadSummaries.map(\.id) == [threadID])
+        #expect(controller.threadSummary(id: threadID)?.title == "Start the real conversation.")
+
+        controller.replaceThreadList([])
+
+        #expect(controller.visibleThreadSummaries.map(\.id) == [threadID])
+    }
+
+    @Test func startedThreadsSurviveWorkspaceRefreshWhenRuntimeOmitsThem() async throws {
+        let store = InMemoryAppPreferencesStore()
+        let runtimeCoordinator = TestRuntimeCoordinator()
+        let appModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
+            runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
+        )
+        let workspaceURL = try temporaryDirectory(named: "conversation-refresh-survival")
+
+        appModel.activateWorkspace(at: workspaceURL)
+        try await waitUntil { appModel.activeWorkspaceController?.connectionStatus == .ready }
+
+        let didCreateThread = await appModel.createThread()
+        let didSend = await appModel.sendPrompt("Keep this in the sidebar.")
+        let controller = try #require(appModel.activeWorkspaceController)
+        let threadID = try #require(controller.lastActiveThreadID)
+
+        #expect(didCreateThread)
+        #expect(didSend)
+        #expect(controller.visibleThreadSummaries.map(\.id) == [threadID])
+
+        runtimeCoordinator.queuedThreadListResponses = [[]]
+        let prepared = await appModel.prepareWorkspaceForBrowsing(path: workspaceURL.path)
+
+        #expect(prepared)
+        #expect(controller.visibleThreadSummaries.map(\.id) == [threadID])
+        #expect(controller.threadSummary(id: threadID)?.title == "Keep this in the sidebar.")
+    }
+
     @Test func sendAndCancelGatingTracksWorkspaceState() async throws {
         let store = InMemoryAppPreferencesStore()
         let runtimeCoordinator = TestRuntimeCoordinator()
@@ -358,7 +423,7 @@ struct AppModelTests {
                 runtimeCoordinator.records(for: secondWorkspaceURL.path).last?.isRunning == true
         }
 
-        #expect(runtimeCoordinator.records(for: firstWorkspaceURL.path).isEmpty)
+        #expect(runtimeCoordinator.records(for: firstWorkspaceURL.path).allSatisfy { $0.isRunning == false })
         #expect(runtimeCoordinator.records(for: secondWorkspaceURL.path).count == 1)
 
         appModel.selectWorkspace(path: firstWorkspaceURL.path)
@@ -495,6 +560,7 @@ private final class TestRuntimeCoordinator {
     var startTurnConfigurations: [BridgeTurnStartConfiguration?] = []
     var cancelCount = 0
     var resolveApprovalCalls: [(String, ApprovalResolution)] = []
+    var queuedThreadListResponses: [[ThreadSummary]] = []
     var shouldDelayTurnStart = false
     var shouldDelayApprovalResolution = false
     private var pendingDelayedTurnStarts: [CheckedContinuation<Void, Never>] = []
@@ -555,13 +621,17 @@ private final class TestWorkspaceRuntime: WorkspaceConversationRuntime {
 
     func listThreads(archived: Bool) async throws {
         controller.setShowingArchivedThreads(archived)
+        if coordinator.queuedThreadListResponses.isEmpty == false {
+            controller.replaceThreadList(coordinator.queuedThreadListResponses.removeFirst(), archived: archived)
+        }
     }
 
     func startThreadAndWait(title: String?) async throws -> ThreadSession {
         coordinator.startThreadCount += 1
         return controller.openThread(
             id: "thread-\(coordinator.startThreadCount)",
-            title: title ?? "New Conversation"
+            title: title ?? "New Conversation",
+            isVisibleInSidebar: false
         )
     }
 
@@ -613,7 +683,8 @@ private final class TestWorkspaceRuntime: WorkspaceConversationRuntime {
             }
         }
 
-        let session = controller.threadSession(id: threadID) ?? controller.openThread(id: threadID, title: "New Conversation")
+        let session = controller.threadSession(id: threadID)
+            ?? controller.openThread(id: threadID, title: "New Conversation", isVisibleInSidebar: false)
         session.beginTurn(userPrompt: prompt)
         controller.setAwaitingTurnStart(false, for: threadID)
         controller.setCurrentTurnID("test-turn", for: threadID)
@@ -722,7 +793,7 @@ private final class LifecycleProbeRuntime: WorkspaceConversationRuntime {
     }
 
     func startThreadAndWait(title: String?) async throws -> ThreadSession {
-        controller.openThread(id: UUID().uuidString, title: title ?? "New Conversation")
+        controller.openThread(id: UUID().uuidString, title: title ?? "New Conversation", isVisibleInSidebar: false)
     }
 
     func resumeThreadAndWait(id: String) async throws -> ThreadSession {
@@ -759,7 +830,8 @@ private final class LifecycleProbeRuntime: WorkspaceConversationRuntime {
     }
 
     func startTurn(threadID: String, prompt: String, configuration: BridgeTurnStartConfiguration?) async throws {
-        let session = controller.threadSession(id: threadID) ?? controller.openThread(id: threadID, title: "New Conversation")
+        let session = controller.threadSession(id: threadID)
+            ?? controller.openThread(id: threadID, title: "New Conversation", isVisibleInSidebar: false)
         session.beginTurn(userPrompt: prompt)
         controller.setAwaitingTurnStart(false, for: threadID)
         controller.setCurrentTurnID("probe-turn", for: threadID)

--- a/AtelierCodeTests/AtelierCodeTests.swift
+++ b/AtelierCodeTests/AtelierCodeTests.swift
@@ -398,7 +398,7 @@ struct AppModelTests {
         #expect(appModel.activeWorkspaceController?.activeThreadSession?.messages.map(\.text) == ["Ship the first turn"])
     }
 
-    @Test func restoresOnlySelectedWorkspaceRuntimeUntilAnotherWorkspaceIsChosen() async throws {
+    @Test func restoredExpandedWorkspacesPreloadThreadsWithoutChangingSelection() async throws {
         let firstWorkspaceURL = try temporaryDirectory(named: "restored-runtime-a")
         let secondWorkspaceURL = try temporaryDirectory(named: "restored-runtime-b")
         let snapshot = AppPreferencesSnapshot(
@@ -423,17 +423,14 @@ struct AppModelTests {
                 runtimeCoordinator.records(for: secondWorkspaceURL.path).last?.isRunning == true
         }
 
-        #expect(runtimeCoordinator.records(for: firstWorkspaceURL.path).allSatisfy { $0.isRunning == false })
-        #expect(runtimeCoordinator.records(for: secondWorkspaceURL.path).count == 1)
-
-        appModel.selectWorkspace(path: firstWorkspaceURL.path)
-
         try await waitUntil {
-            appModel.activeWorkspaceController?.workspace.canonicalPath == firstWorkspaceURL.path &&
-                runtimeCoordinator.records(for: firstWorkspaceURL.path).last?.isRunning == true
+            runtimeCoordinator.records(for: firstWorkspaceURL.path).last?.isRunning == true &&
+                runtimeCoordinator.records(for: firstWorkspaceURL.path).last?.listThreadsCalls == 1
         }
 
+        #expect(appModel.activeWorkspaceController?.workspace.canonicalPath == secondWorkspaceURL.path)
         #expect(runtimeCoordinator.records(for: firstWorkspaceURL.path).count == 1)
+        #expect(runtimeCoordinator.records(for: firstWorkspaceURL.path).last?.listThreadsArchivedValues == [false])
         #expect(runtimeCoordinator.records(for: secondWorkspaceURL.path).count == 1)
     }
 
@@ -464,7 +461,7 @@ struct AppModelTests {
         #expect(runtimeCoordinator.records(for: secondWorkspaceURL.path).last?.stopCount == 0)
     }
 
-    @Test func expandingWorkspaceStartsRuntimeAndLoadsThreadsWithoutChangingSelection() async throws {
+    @Test func preparingWorkspaceForBrowsingReloadsThreadsWithoutChangingSelection() async throws {
         let firstWorkspaceURL = try temporaryDirectory(named: "expand-runtime-a")
         let secondWorkspaceURL = try temporaryDirectory(named: "expand-runtime-b")
         let snapshot = AppPreferencesSnapshot(
@@ -488,17 +485,22 @@ struct AppModelTests {
                 runtimeCoordinator.records(for: secondWorkspaceURL.path).last?.isRunning == true
         }
 
+        try await waitUntil {
+            runtimeCoordinator.records(for: firstWorkspaceURL.path).last?.isRunning == true &&
+                runtimeCoordinator.records(for: firstWorkspaceURL.path).last?.listThreadsCalls == 1
+        }
+
         let prepared = await appModel.prepareWorkspaceForBrowsing(path: firstWorkspaceURL.path)
 
         #expect(prepared)
 
         try await waitUntil {
             runtimeCoordinator.records(for: firstWorkspaceURL.path).last?.isRunning == true &&
-                runtimeCoordinator.records(for: firstWorkspaceURL.path).last?.listThreadsCalls == 1
+                runtimeCoordinator.records(for: firstWorkspaceURL.path).last?.listThreadsCalls == 2
         }
 
         #expect(appModel.activeWorkspaceController?.workspace.canonicalPath == secondWorkspaceURL.path)
-        #expect(runtimeCoordinator.records(for: firstWorkspaceURL.path).last?.listThreadsArchivedValues == [false])
+        #expect(runtimeCoordinator.records(for: firstWorkspaceURL.path).last?.listThreadsArchivedValues == [false, false])
     }
 
     @Test func retryKeepsOnlyNewestRuntimeRunning() async throws {

--- a/AtelierCodeTests/AtelierCodeTests.swift
+++ b/AtelierCodeTests/AtelierCodeTests.swift
@@ -582,6 +582,13 @@ private final class TestWorkspaceRuntime: WorkspaceConversationRuntime {
         )
     }
 
+    func renameThread(id: String, title: String) async throws {
+        controller.updateThreadSummary(id: id) { summary in
+            summary.title = title
+        }
+        controller.threadSession(id: id)?.updateThreadIdentity(id: id, title: title)
+    }
+
     func archiveThread(id: String) async throws {
         controller.setThreadArchived(true, for: id)
     }
@@ -728,6 +735,13 @@ private final class LifecycleProbeRuntime: WorkspaceConversationRuntime {
 
     func forkThreadAndWait(id: String) async throws -> ThreadSession {
         controller.resumeThread(id: "\(id)-fork", title: "Recovered Conversation")
+    }
+
+    func renameThread(id: String, title: String) async throws {
+        controller.updateThreadSummary(id: id) { summary in
+            summary.title = title
+        }
+        controller.threadSession(id: id)?.updateThreadIdentity(id: id, title: title)
     }
 
     func archiveThread(id: String) async throws {

--- a/AtelierCodeTests/WorkspaceBridgeRuntimeTests.swift
+++ b/AtelierCodeTests/WorkspaceBridgeRuntimeTests.swift
@@ -619,6 +619,62 @@ struct WorkspaceBridgeRuntimeTests {
         #expect(controller.activeThreadSession?.threadID == "thread-42")
     }
 
+    @Test func paginatedThreadListAccumulatesAcrossPagesBeforeReplacingSidebarState() async throws {
+        let workspace = WorkspaceRecord(url: try temporaryDirectory(named: "runtime-thread-pages"), lastOpenedAt: .now)
+        let controller = WorkspaceController(workspace: workspace)
+        let bundle = try bridgeFixtureBundle()
+        let processHandle = FakeBridgeProcessHandle(lines: [startupRecordJSON(port: 4746)])
+        let socketClient = FakeBridgeSocketClient(messages: [
+            welcomeJSON(requestID: "ateliercode-hello-1"),
+            authChangedJSON(requestID: "ateliercode-account-read-2", state: "signed_out", displayName: nil),
+            threadListResultJSON(requestID: "ateliercode-thread-list-3", threadTitle: "Bootstrap")
+        ])
+        let runtime = makeRuntime(
+            controller: controller,
+            executableLocator: BridgeExecutableLocator(bundle: bundle),
+            processLauncher: { _ in processHandle },
+            socketFactory: { _ in socketClient },
+            openURLAction: { _ in }
+        )
+
+        try await runtime.start()
+        try await waitUntil { controller.connectionStatus == .ready }
+
+        try await runtime.listThreads(archived: false)
+        try await waitUntil { pendingCommandCount(in: runtime) == 1 }
+
+        socketClient.enqueue(
+            threadListResultJSON(
+                requestID: "ateliercode-thread-list-4",
+                threads: [
+                    (id: "thread-10", title: "First Page", previewText: "Preview 1", updatedAt: "2026-03-24T10:00:10Z")
+                ],
+                nextCursor: "cursor-2"
+            )
+        )
+
+        try await waitUntil {
+            pendingCommandCount(in: runtime) == 1 &&
+                commandPayload(from: socketClient.sentTexts.last)?["cursor"] as? String == "cursor-2"
+        }
+
+        socketClient.enqueue(
+            threadListResultJSON(
+                requestID: "ateliercode-thread-list-5",
+                threads: [
+                    (id: "thread-11", title: "Second Page", previewText: "Preview 2", updatedAt: "2026-03-24T10:00:11Z")
+                ]
+            )
+        )
+
+        try await waitUntil {
+            pendingCommandCount(in: runtime) == 0 &&
+                Set(controller.threadSummaries.map(\.id)) == Set(["thread-10", "thread-11"])
+        }
+
+        #expect(Set(controller.threadSummaries.map(\.id)) == Set(["thread-10", "thread-11"]))
+    }
+
     @Test func renameThreadSendsCommandAndUpdatesLoadedSession() async throws {
         let workspace = WorkspaceRecord(url: try temporaryDirectory(named: "runtime-thread-rename"), lastOpenedAt: .now)
         let controller = WorkspaceController(workspace: workspace)
@@ -943,6 +999,23 @@ private func rateLimitUpdatedJSON(requestID: String) -> String {
 private func threadListResultJSON(requestID: String, threadTitle: String) -> String {
     """
     {"type":"thread.list.result","timestamp":"2026-03-24T10:00:04Z","requestID":"\(requestID)","payload":{"threads":[{"id":"thread-1","title":"\(threadTitle)","previewText":"Preview","updatedAt":"2026-03-24T10:00:04Z"}],"nextCursor":null}}
+    """
+}
+
+private func threadListResultJSON(
+    requestID: String,
+    threads: [(id: String, title: String, previewText: String, updatedAt: String)],
+    nextCursor: String? = nil
+) -> String {
+    let threadsJSON = threads.map { thread in
+        """
+        {"id":"\(thread.id)","title":"\(jsonEscaped(thread.title))","previewText":"\(jsonEscaped(thread.previewText))","updatedAt":"\(thread.updatedAt)"}
+        """
+    }.joined(separator: ",")
+    let nextCursorJSON = nextCursor.map { "\"\(jsonEscaped($0))\"" } ?? "null"
+
+    return """
+    {"type":"thread.list.result","timestamp":"2026-03-24T10:00:04Z","requestID":"\(requestID)","payload":{"threads":[\(threadsJSON)],"nextCursor":\(nextCursorJSON)}}
     """
 }
 

--- a/AtelierCodeTests/WorkspaceBridgeRuntimeTests.swift
+++ b/AtelierCodeTests/WorkspaceBridgeRuntimeTests.swift
@@ -619,6 +619,56 @@ struct WorkspaceBridgeRuntimeTests {
         #expect(controller.activeThreadSession?.threadID == "thread-42")
     }
 
+    @Test func renameThreadSendsCommandAndUpdatesLoadedSession() async throws {
+        let workspace = WorkspaceRecord(url: try temporaryDirectory(named: "runtime-thread-rename"), lastOpenedAt: .now)
+        let controller = WorkspaceController(workspace: workspace)
+        let bundle = try bridgeFixtureBundle()
+        let processHandle = FakeBridgeProcessHandle(lines: [startupRecordJSON(port: 4749)])
+        let socketClient = FakeBridgeSocketClient(messages: [
+            welcomeJSON(requestID: "ateliercode-hello-1"),
+            authChangedJSON(requestID: "ateliercode-account-read-2", state: "signed_out", displayName: nil),
+            threadListResultJSON(requestID: "ateliercode-thread-list-3", threadTitle: "Thread")
+        ])
+        let runtime = makeRuntime(
+            controller: controller,
+            executableLocator: BridgeExecutableLocator(bundle: bundle),
+            processLauncher: { _ in processHandle },
+            socketFactory: { _ in socketClient },
+            openURLAction: { _ in }
+        )
+
+        try await runtime.start()
+        try await waitUntil { controller.connectionStatus == .ready }
+
+        let session = controller.openThread(id: "thread-1", title: "Thread")
+        let renameTask = Task {
+            try await runtime.renameThread(id: "thread-1", title: "Renamed Thread")
+        }
+
+        try await waitUntil {
+            pendingCommandCount(in: runtime) == 1 &&
+            commandObject(from: socketClient.sentTexts.last ?? "")?["type"] as? String == "thread.rename"
+        }
+
+        #expect(commandPayload(from: socketClient.sentTexts.last)?["title"] as? String == "Renamed Thread")
+
+        socketClient.enqueue(threadStartedJSON(
+            requestID: "ateliercode-thread-rename-4",
+            threadID: "thread-1",
+            threadTitle: "Renamed Thread"
+        ))
+
+        try await renameTask.value
+        try await waitUntil {
+            controller.threadSummary(id: "thread-1")?.title == "Renamed Thread" &&
+            session.title == "Renamed Thread" &&
+            pendingCommandCount(in: runtime) == 0
+        }
+
+        #expect(controller.threadSummary(id: "thread-1")?.title == "Renamed Thread")
+        #expect(session.title == "Renamed Thread")
+    }
+
     @Test func cancelledStartThreadAndWaitIgnoresLateThreadStartedEvent() async throws {
         let workspace = WorkspaceRecord(url: try temporaryDirectory(named: "runtime-thread-cancel"), lastOpenedAt: .now)
         let controller = WorkspaceController(workspace: workspace)

--- a/AtelierCodeTests/WorkspaceControllerTests.swift
+++ b/AtelierCodeTests/WorkspaceControllerTests.swift
@@ -63,7 +63,7 @@ struct WorkspaceControllerTests {
         let session = controller.openThread(id: "thread-2", title: "Second")
         controller.clearActiveThreadSession()
 
-        #expect(controller.threadSummaries == threadSummaries)
+        #expect(Set(controller.threadSummaries.map(\.id)) == Set(threadSummaries.map(\.id)))
         #expect(session.threadID == "thread-2")
         #expect(controller.activeThreadSession == nil)
     }
@@ -124,5 +124,92 @@ struct WorkspaceControllerTests {
 
         #expect(controller.displayedThreadSummaries.count == WorkspaceController.collapsedVisibleThreadLimit)
         #expect(controller.displayedThreadSummaries.map(\.id) == Array(threadSummaries.prefix(WorkspaceController.collapsedVisibleThreadLimit)).map(\.id))
+    }
+
+    @Test func promotedThreadsSurviveListRefresh() async throws {
+        let workspace = WorkspaceRecord(url: try temporaryDirectory(named: "workspace-draft-thread"), lastOpenedAt: .now)
+        let controller = WorkspaceController(workspace: workspace)
+
+        controller.openThread(id: "draft-thread", title: "Draft", isVisibleInSidebar: false)
+
+        #expect(controller.threadSummary(id: "draft-thread")?.isVisibleInSidebar == false)
+        #expect(controller.visibleThreadSummaries.isEmpty)
+
+        controller.setThreadSidebarVisibility(true, for: "draft-thread")
+        controller.replaceThreadList([])
+
+        #expect(controller.threadSummary(id: "draft-thread")?.isVisibleInSidebar == true)
+        #expect(controller.visibleThreadSummaries.map(\.id) == ["draft-thread"])
+    }
+
+    @Test func refreshKeepsExistingHumanTitleWhenIncomingTitleFallsBackToThreadID() async throws {
+        let workspace = WorkspaceRecord(url: try temporaryDirectory(named: "workspace-refresh-title"), lastOpenedAt: .now)
+        let controller = WorkspaceController(workspace: workspace)
+
+        controller.openThread(id: "thread-123", title: "Start the real conversation.", isVisibleInSidebar: true)
+        controller.replaceThreadList([
+            ThreadSummary(id: "thread-123", title: "thread-123", previewText: "Preview", updatedAt: .now)
+        ])
+
+        #expect(controller.threadSummary(id: "thread-123")?.title == "Start the real conversation.")
+        #expect(controller.visibleThreadSummaries.map(\.id) == ["thread-123"])
+    }
+
+    @Test func pinnedSidebarThreadSurvivesRefreshEvenIfSessionIsCleared() async throws {
+        let workspace = WorkspaceRecord(url: try temporaryDirectory(named: "workspace-pinned-thread"), lastOpenedAt: .now)
+        let controller = WorkspaceController(workspace: workspace)
+
+        controller.openThread(id: "thread-keep", title: "Keep Me", isVisibleInSidebar: true)
+        controller.setThreadSidebarVisibility(true, for: "thread-keep")
+        controller.clearThreadSession(id: "thread-keep")
+        controller.replaceThreadList([])
+
+        #expect(controller.threadSummary(id: "thread-keep")?.title == "Keep Me")
+        #expect(controller.visibleThreadSummaries.map(\.id) == ["thread-keep"])
+    }
+
+    @Test func selectedThreadSurvivesRefreshWhenBridgeOmitsIt() async throws {
+        let workspace = WorkspaceRecord(url: try temporaryDirectory(named: "workspace-selected-thread"), lastOpenedAt: .now)
+        let controller = WorkspaceController(workspace: workspace)
+
+        controller.replaceThreadList([
+            ThreadSummary(id: "thread-active", title: "Active", previewText: "Current", updatedAt: .now),
+            ThreadSummary(id: "thread-other", title: "Other", previewText: "Other", updatedAt: .distantPast)
+        ])
+        controller.markThreadSelected("thread-active")
+        controller.replaceThreadList([])
+
+        #expect(controller.threadSummary(id: "thread-active")?.title == "Active")
+        #expect(controller.visibleThreadSummaries.map(\.id) == ["thread-active"])
+    }
+
+    @Test func staleRefreshKeepsNewestLocalActivityVisible() async throws {
+        let workspace = WorkspaceRecord(url: try temporaryDirectory(named: "workspace-stale-refresh"), lastOpenedAt: .now)
+        let controller = WorkspaceController(workspace: workspace)
+        let baseline = Date(timeIntervalSince1970: 1_710_000_000)
+        let promotedDate = baseline.addingTimeInterval(120)
+
+        controller.replaceThreadList((0..<6).map { index in
+            ThreadSummary(
+                id: "thread-\(index)",
+                title: "Thread \(index)",
+                previewText: "Preview \(index)",
+                updatedAt: baseline.addingTimeInterval(TimeInterval(-index))
+            )
+        })
+        controller.markThreadActivity(id: "thread-5", at: promotedDate, previewText: "Fresh local work")
+
+        controller.replaceThreadList((0..<6).map { index in
+            ThreadSummary(
+                id: "thread-\(index)",
+                title: "Thread \(index)",
+                previewText: index == 5 ? "Stale bridge preview" : "Preview \(index)",
+                updatedAt: baseline.addingTimeInterval(TimeInterval(-index))
+            )
+        })
+
+        #expect(controller.displayedThreadSummaries.first?.id == "thread-5")
+        #expect(controller.threadSummary(id: "thread-5")?.previewText == "Fresh local work")
+        #expect(controller.threadSummary(id: "thread-5")?.updatedAt == promotedDate)
     }
 }

--- a/AtelierCodeUITests/AtelierCodeUITests.swift
+++ b/AtelierCodeUITests/AtelierCodeUITests.swift
@@ -52,6 +52,27 @@ final class AtelierCodeUITests: XCTestCase {
         XCTAssertFalse(app.staticTexts["Activity"].exists)
     }
 
+    func testStartedThreadSurvivesCollapseAndRefreshOmission() throws {
+        let app = try makeApp(scenario: "refresh-omits-thread", workspaceName: "RefreshOmission")
+        app.launch()
+
+        let composer = app.textViews["conversation-composer"]
+        XCTAssertTrue(composer.waitForExistence(timeout: 5))
+        composer.click()
+        composer.typeText("Keep this thread visible")
+
+        app.buttons["conversation-send-button"].click()
+
+        let threadRow = app.descendants(matching: .any)["thread-row-ui-test-thread"]
+        XCTAssertTrue(threadRow.waitForExistence(timeout: 5))
+
+        let workspaceButton = app.buttons["recent-workspace-RefreshOmission"]
+        workspaceButton.click()
+        workspaceButton.click()
+
+        XCTAssertTrue(threadRow.waitForExistence(timeout: 5))
+    }
+
     func testPhase2TurnShowsCollapsedGroupedSectionsAndApproveKeepsCompletedTurnVisible() throws {
         let app = try makeApp(scenario: "phase2", workspaceName: "Phase2ApproveWorkspace")
         app.launch()


### PR DESCRIPTION
## Summary
- add thread rename support and tighten sidebar thread presentation
- preserve sidebar threads across workspace refreshes and omissions from bridge refreshes
- preload expanded workspaces on launch so restored thread lists populate immediately

## Testing
- xcodebuild test -project AtelierCode.xcodeproj -scheme AtelierCode -destination 'platform=macOS' -only-testing:AtelierCodeTests/AppModelTests