### PR TITLE
Refactor the prompt composer layout and enter-to-send behavior

### DIFF
--- a/AgentBridge/src/codex/codex-client.test.ts
+++ b/AgentBridge/src/codex/codex-client.test.ts
@@ -9,6 +9,76 @@ import type {
 } from "./codex-transport";
 
 describe("CodexClient", () => {
+  test("lists models and preserves server capabilities", async () => {
+    const transport = new FakeTransport([
+      { userAgent: "Codex/Test" },
+      {
+        data: [
+          {
+            id: "gpt-5.4",
+            model: "gpt-5.4",
+            displayName: "GPT-5.4",
+            hidden: false,
+            defaultReasoningEffort: "medium",
+            supportedReasoningEfforts: [
+              {
+                reasoningEffort: "low",
+                description: "Lower latency",
+              },
+              {
+                reasoningEffort: "high",
+                description: "More reasoning",
+              },
+            ],
+            inputModalities: ["text", "image"],
+            supportsPersonality: true,
+            isDefault: true,
+          },
+        ],
+      },
+    ]);
+    const client = new CodexClient(transport);
+
+    await client.connect();
+    const result = await client.listModels("req-models", {
+      limit: 20,
+      includeHidden: false,
+    });
+
+    expect(result).toEqual({
+      models: [
+        {
+          id: "gpt-5.4",
+          model: "gpt-5.4",
+          displayName: "GPT-5.4",
+          hidden: false,
+          defaultReasoningEffort: "medium",
+          supportedReasoningEfforts: [
+            {
+              reasoningEffort: "low",
+              description: "Lower latency",
+            },
+            {
+              reasoningEffort: "high",
+              description: "More reasoning",
+            },
+          ],
+          inputModalities: ["text", "image"],
+          supportsPersonality: true,
+          isDefault: true,
+        },
+      ],
+    });
+    expect(transport.sent[1]).toEqual({
+      id: "req-models",
+      method: "model/list",
+      params: {
+        limit: 20,
+        includeHidden: undefined,
+      },
+    });
+  });
+
   test("initializes once and maps thread start plus naming", async () => {
     const transport = new FakeTransport([
       { userAgent: "Codex/Test" },

--- a/AgentBridge/src/codex/codex-client.ts
+++ b/AgentBridge/src/codex/codex-client.ts
@@ -2,6 +2,8 @@ import type {
   AccountReadPayload,
   AccountLoginPayload,
   ApprovalResolvePayload,
+  ModelListPayload,
+  ReasoningEffort,
   ThreadArchiveFilter,
   ThreadArchivePayload,
   ThreadForkPayload,
@@ -32,6 +34,27 @@ export interface CodexThread {
   status?: unknown;
   turns?: unknown[];
   archived?: boolean;
+}
+
+export interface CodexModelReasoningEffort {
+  reasoningEffort: ReasoningEffort;
+  description?: string;
+}
+
+export interface CodexModelSummary {
+  id: string;
+  model: string;
+  displayName: string;
+  hidden: boolean;
+  defaultReasoningEffort?: ReasoningEffort;
+  supportedReasoningEfforts: CodexModelReasoningEffort[];
+  inputModalities?: string[];
+  supportsPersonality?: boolean;
+  isDefault?: boolean;
+}
+
+export interface CodexModelListResult {
+  models: CodexModelSummary[];
 }
 
 export interface CodexThreadListResult {
@@ -110,6 +133,10 @@ export interface CodexLoginResult {
 export interface CodexClientAdapter {
   connect(): Promise<void>;
   disconnect(): Promise<void>;
+  listModels(
+    requestID: CodexTransportRequestID,
+    payload: ModelListPayload,
+  ): Promise<CodexModelListResult>;
   startThread(requestID: CodexTransportRequestID, payload: ThreadStartPayload): Promise<CodexThreadStartResult>;
   resumeThread(
     requestID: CodexTransportRequestID,
@@ -230,6 +257,24 @@ export class CodexClient implements CodexClientAdapter {
     }
 
     return { thread };
+  }
+
+  async listModels(
+    requestID: CodexTransportRequestID,
+    payload: ModelListPayload,
+  ): Promise<CodexModelListResult> {
+    const response = await this.transport.send<{ data: unknown[] }>({
+      id: requestID,
+      method: "model/list",
+      params: {
+        limit: payload.limit,
+        includeHidden: payload.includeHidden === true ? true : undefined,
+      },
+    });
+
+    return {
+      models: Array.isArray(response.data) ? response.data.map((model) => toCodexModelSummary(model)) : [],
+    };
   }
 
   async resumeThread(
@@ -531,6 +576,21 @@ function mapArchiveFilter(filter: ThreadArchiveFilter | undefined): boolean | un
   }
 }
 
+function mapSupportedReasoningEffort(value: unknown): ReasoningEffort | undefined {
+  if (
+    value === "none" ||
+    value === "minimal" ||
+    value === "low" ||
+    value === "medium" ||
+    value === "high" ||
+    value === "xhigh"
+  ) {
+    return value;
+  }
+
+  return undefined;
+}
+
 function mapApprovalPolicy(value: string | undefined): string | undefined {
   if (
     value === "untrusted" ||
@@ -695,6 +755,49 @@ function toCodexAccount(value: unknown): CodexAccount | null {
   }
 
   return null;
+}
+
+function toCodexModelSummary(value: unknown): CodexModelSummary {
+  if (
+    !isPlainObject(value) ||
+    typeof value.id !== "string" ||
+    typeof value.model !== "string" ||
+    typeof value.displayName !== "string"
+  ) {
+    throw new Error("Codex model/list payload is malformed.");
+  }
+
+  const supportedReasoningEfforts = Array.isArray(value.supportedReasoningEfforts)
+    ? value.supportedReasoningEfforts.flatMap((effort) => {
+        if (!isPlainObject(effort)) {
+          return [];
+        }
+
+        const reasoningEffort = mapSupportedReasoningEffort(effort.reasoningEffort);
+        if (!reasoningEffort) {
+          return [];
+        }
+
+        return [{
+          reasoningEffort,
+          description: typeof effort.description === "string" ? effort.description : undefined,
+        }];
+      })
+    : [];
+
+  return {
+    id: value.id,
+    model: value.model,
+    displayName: value.displayName,
+    hidden: value.hidden === true,
+    defaultReasoningEffort: mapSupportedReasoningEffort(value.defaultReasoningEffort),
+    supportedReasoningEfforts,
+    inputModalities: Array.isArray(value.inputModalities)
+      ? value.inputModalities.filter((modality): modality is string => typeof modality === "string")
+      : undefined,
+    supportsPersonality: value.supportsPersonality === true,
+    isDefault: value.isDefault === true,
+  };
 }
 
 function toCodexRateLimitSnapshot(value: unknown): CodexRateLimitSnapshot | null {

--- a/AgentBridge/src/index.test.ts
+++ b/AgentBridge/src/index.test.ts
@@ -5,6 +5,7 @@ import type {
   AccountReadPayload,
   ApprovalResolvePayload,
   BridgeEnvironmentDiagnostics,
+  ModelListPayload,
   ThreadArchivePayload,
   ThreadForkPayload,
   ThreadListPayload,
@@ -25,6 +26,7 @@ import type {
   CodexAccountReadResult,
   CodexClientAdapter,
   CodexLoginResult,
+  CodexModelListResult,
   CodexThreadForkResult,
   CodexThreadListResult,
   CodexThreadRenameResult,
@@ -103,6 +105,37 @@ describe("executeBridgeCommand", () => {
       expect.objectContaining({
         type: "rateLimit.updated",
         requestID: "req-account",
+      }),
+    ]);
+  });
+
+  test("emits a model list result event for model discovery", async () => {
+    const client = new FakeCodexClient();
+
+    const events = await executeBridgeCommand(client, {
+      id: "req-models",
+      type: "model.list",
+      timestamp: new Date().toISOString(),
+      provider: "codex",
+      payload: {
+        limit: 20,
+        includeHidden: false,
+      },
+    });
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "model.list.result",
+        requestID: "req-models",
+        payload: {
+          models: [
+            expect.objectContaining({
+              id: "gpt-5.4",
+              displayName: "GPT-5.4",
+              isDefault: true,
+            }),
+          ],
+        },
       }),
     ]);
   });
@@ -371,6 +404,28 @@ class FakeCodexClient implements CodexClientAdapter {
   async connect(): Promise<void> {}
 
   async disconnect(): Promise<void> {}
+
+  async listModels(_requestID: string, _payload: ModelListPayload): Promise<CodexModelListResult> {
+    return {
+      models: [
+        {
+          id: "gpt-5.4",
+          model: "gpt-5.4",
+          displayName: "GPT-5.4",
+          hidden: false,
+          defaultReasoningEffort: "medium",
+          supportedReasoningEfforts: [
+            { reasoningEffort: "low", description: "Lower latency" },
+            { reasoningEffort: "medium", description: "Balanced" },
+            { reasoningEffort: "high", description: "More reasoning" },
+          ],
+          inputModalities: ["text", "image"],
+          supportsPersonality: true,
+          isDefault: true,
+        },
+      ],
+    };
+  }
 
   async startThread(_requestID: string, payload: ThreadStartPayload): Promise<CodexThreadStartResult> {
     return {

--- a/AgentBridge/src/index.ts
+++ b/AgentBridge/src/index.ts
@@ -28,6 +28,7 @@ import type {
   BridgeStartupError,
   ErrorEvent,
   HelloEnvelope,
+  ModelListResultEvent,
   RateLimitUpdatedEvent,
   ProviderHealth,
   ProviderStatusEvent,
@@ -708,6 +709,19 @@ export async function executeBridgeCommand(
 
   try {
     switch (command.type) {
+      case "model.list": {
+        const result = await client.listModels(command.id, command.payload);
+        const event: ModelListResultEvent = {
+          type: "model.list.result",
+          timestamp: new Date().toISOString(),
+          provider: "codex",
+          requestID: command.id,
+          payload: {
+            models: result.models,
+          },
+        };
+        return [event];
+      }
       case "thread.start": {
         const result = await client.startThread(command.id, command.payload);
         return [buildThreadStartedEvent(command.id, result.thread)];

--- a/AgentBridge/src/protocol/types.ts
+++ b/AgentBridge/src/protocol/types.ts
@@ -13,6 +13,7 @@ export type ProviderIdentifier = string;
 export type BridgeTransport = "websocket";
 export type BridgeHandshakeType = "hello" | "welcome";
 export type BridgeCommandType =
+  | "model.list"
   | "thread.start"
   | "thread.resume"
   | "thread.list"
@@ -29,6 +30,7 @@ export type BridgeCommandType =
   | "account.login"
   | "account.logout";
 export type BridgeEventType =
+  | "model.list.result"
   | "thread.started"
   | "thread.archived"
   | "thread.unarchived"
@@ -64,6 +66,7 @@ export type AuthState = "unknown" | "signed_out" | "signed_in";
 export type PlanStepStatus = "pending" | "in_progress" | "completed";
 export type ProviderConnectionStatus = "starting" | "ready" | "degraded" | "disconnected" | "error";
 export type RateLimitBucketKind = "requests" | "tokens" | "other";
+export type ReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
 
 export interface BridgeEnvelopeBase<TType extends BridgeMessageType = BridgeMessageType> {
   type: TType;
@@ -155,6 +158,23 @@ export interface RateLimitBucket {
   detail?: string;
 }
 
+export interface ModelReasoningEffortSummary {
+  reasoningEffort: ReasoningEffort;
+  description?: string;
+}
+
+export interface ModelSummary {
+  id: string;
+  model: string;
+  displayName: string;
+  hidden: boolean;
+  defaultReasoningEffort?: ReasoningEffort;
+  supportedReasoningEfforts: ModelReasoningEffortSummary[];
+  inputModalities?: string[];
+  supportsPersonality?: boolean;
+  isDefault?: boolean;
+}
+
 export interface TurnStartConfiguration {
   cwd?: string;
   model?: string;
@@ -203,6 +223,11 @@ export interface WelcomeEnvelope extends BridgeHandshakeEnvelope<"welcome", Welc
 export interface ThreadStartPayload {
   workspacePath: string;
   title?: string;
+}
+
+export interface ModelListPayload {
+  limit?: number;
+  includeHidden?: boolean;
 }
 
 export interface ThreadResumePayload {
@@ -266,6 +291,8 @@ export interface AccountLogoutPayload {
 
 export interface ThreadStartCommand extends BridgeCommandEnvelope<"thread.start", ThreadStartPayload> {}
 
+export interface ModelListCommand extends BridgeCommandEnvelope<"model.list", ModelListPayload> {}
+
 export interface ThreadResumeCommand extends BridgeCommandEnvelope<"thread.resume", ThreadResumePayload> {
   threadID: string;
 }
@@ -319,6 +346,7 @@ export interface AccountLogoutCommand
   extends BridgeCommandEnvelope<"account.logout", AccountLogoutPayload> {}
 
 export type BridgeCommand =
+  | ModelListCommand
   | ThreadStartCommand
   | ThreadResumeCommand
   | ThreadListCommand
@@ -420,6 +448,10 @@ export interface PlanUpdatedPayload {
 export interface TurnCompletedPayload {
   status: TurnCompletionStatus;
   detail?: string;
+}
+
+export interface ModelListResultPayload {
+  models: ModelSummary[];
 }
 
 export interface ThreadListResultPayload {
@@ -553,6 +585,11 @@ export interface ThreadListResultEvent
   requestID: string;
 }
 
+export interface ModelListResultEvent
+  extends BridgeEventEnvelope<"model.list.result", ModelListResultPayload> {
+  requestID: string;
+}
+
 export interface AccountLoginResultEvent
   extends BridgeEventEnvelope<"account.login.result", AccountLoginResultPayload> {
   requestID: string;
@@ -568,6 +605,7 @@ export interface ErrorEvent extends BridgeEventEnvelope<"error", ErrorPayload> {
 export interface ProviderStatusEvent extends BridgeEventEnvelope<"provider.status", ProviderStatusPayload> {}
 
 export type BridgeEvent =
+  | ModelListResultEvent
   | ThreadStartedEvent
   | ThreadArchivedEvent
   | ThreadUnarchivedEvent

--- a/AtelierCode/AppBootstrap.swift
+++ b/AtelierCode/AppBootstrap.swift
@@ -131,6 +131,10 @@ private final class UITestWorkspaceRuntime: WorkspaceConversationRuntime {
         controller.setConnectionStatus(.disconnected)
     }
 
+    func refreshModels() async throws {
+        controller.setAvailableModels([])
+    }
+
     func listThreads(archived: Bool) async throws {
         controller.setShowingArchivedThreads(archived)
 

--- a/AtelierCode/AppModel.swift
+++ b/AtelierCode/AppModel.swift
@@ -11,6 +11,8 @@ final class AppModel {
     private(set) var lastSelectedWorkspacePath: String?
     private(set) var codexPathOverride: String?
     private(set) var appearancePreference: AppAppearancePreference
+    private(set) var composerModelID: String?
+    private(set) var composerReasoningEffort: ComposerReasoningEffort
     private(set) var startupDiagnostics: [StartupDiagnostic]
     private(set) var workspaceControllers: [WorkspaceController]
     private(set) var selectedRoute: WorkspaceThreadRoute?
@@ -50,11 +52,15 @@ final class AppModel {
         let selectedPath = loadedSnapshot?.lastSelectedWorkspacePath.map(WorkspaceRecord.canonicalizedPath(for:))
         let codexOverridePath = loadedSnapshot?.codexPathOverride
         let appearancePreference = loadedSnapshot?.appearancePreference ?? .system
+        let composerModelID = loadedSnapshot?.composerModelID?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        let composerReasoningEffort = ComposerReasoningEffort(storedValue: loadedSnapshot?.composerReasoningEffort.rawValue)
 
         recentWorkspaces = []
         lastSelectedWorkspacePath = nil
         codexPathOverride = codexOverridePath
         self.appearancePreference = appearancePreference
+        self.composerModelID = composerModelID
+        self.composerReasoningEffort = composerReasoningEffort
         startupDiagnostics = []
         workspaceControllers = []
         selectedRoute = nil
@@ -142,8 +148,30 @@ final class AppModel {
             lastSelectedWorkspacePath: lastSelectedWorkspacePath,
             codexPathOverride: codexPathOverride,
             appearancePreference: appearancePreference,
+            composerModelID: composerModelID,
+            composerReasoningEffort: composerReasoningEffort,
             workspaceStates: workspaceControllers.map(\.persistedState)
         )
+    }
+
+    var availableComposerModels: [ComposerModelOption] {
+        ComposerModelOption.fallbackCatalog
+    }
+
+    var selectedComposerModelOption: ComposerModelOption? {
+        ComposerModelOption.resolvedOption(for: composerModelID)
+    }
+
+    var composerModelTitle: String {
+        selectedComposerModelOption?.title ?? "Default Model"
+    }
+
+    var availableComposerReasoningEfforts: [ComposerReasoningEffort] {
+        ComposerReasoningEffort.allCases
+    }
+
+    var composerReasoningEffortTitle: String {
+        composerReasoningEffort.title
     }
 
     func activateWorkspace(at url: URL) {
@@ -223,6 +251,25 @@ final class AppModel {
         }
 
         appearancePreference = preference
+        persistPreferences()
+    }
+
+    func setComposerModelID(_ modelID: String?) {
+        let normalizedModelID = modelID?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        guard composerModelID != normalizedModelID else {
+            return
+        }
+
+        composerModelID = normalizedModelID
+        persistPreferences()
+    }
+
+    func setComposerReasoningEffort(_ effort: ComposerReasoningEffort) {
+        guard composerReasoningEffort != effort else {
+            return
+        }
+
+        composerReasoningEffort = effort
         persistPreferences()
     }
 
@@ -785,8 +832,8 @@ final class AppModel {
     private func defaultTurnConfiguration(for controller: WorkspaceController) -> BridgeTurnStartConfiguration {
         BridgeTurnStartConfiguration(
             cwd: controller.workspace.canonicalPath,
-            model: nil,
-            reasoningEffort: nil,
+            model: composerModelID,
+            reasoningEffort: composerReasoningEffort.bridgeValue,
             sandboxPolicy: SandboxPolicy.workspaceWrite.rawValue,
             approvalPolicy: ApprovalPolicy.onRequest.rawValue,
             summaryMode: SummaryMode.concise.rawValue,

--- a/AtelierCode/AppModel.swift
+++ b/AtelierCode/AppModel.swift
@@ -155,11 +155,40 @@ final class AppModel {
     }
 
     var availableComposerModels: [ComposerModelOption] {
-        ComposerModelOption.fallbackCatalog
+        selectedWorkspaceController?.availableModels ?? []
+    }
+
+    var defaultComposerModelOption: ComposerModelOption? {
+        availableComposerModels.first(where: \.isDefault) ?? availableComposerModels.first
+    }
+
+    var effectiveComposerModelID: String? {
+        explicitComposerModelOption?.id
+    }
+
+    var effectiveComposerReasoningEffort: ComposerReasoningEffort {
+        guard composerReasoningEffort != .appDefault else {
+            return .appDefault
+        }
+
+        guard let selectedComposerModelOption,
+              selectedComposerModelOption.supportedReasoningEfforts.contains(composerReasoningEffort) else {
+            return .appDefault
+        }
+
+        return composerReasoningEffort
+    }
+
+    private var explicitComposerModelOption: ComposerModelOption? {
+        guard let composerModelID else {
+            return nil
+        }
+
+        return availableComposerModels.first(where: { $0.id == composerModelID })
     }
 
     var selectedComposerModelOption: ComposerModelOption? {
-        ComposerModelOption.resolvedOption(for: composerModelID)
+        explicitComposerModelOption ?? defaultComposerModelOption
     }
 
     var composerModelTitle: String {
@@ -167,11 +196,19 @@ final class AppModel {
     }
 
     var availableComposerReasoningEfforts: [ComposerReasoningEffort] {
-        ComposerReasoningEffort.allCases
+        guard let selectedComposerModelOption else {
+            return [.appDefault]
+        }
+
+        return [.appDefault] + selectedComposerModelOption.supportedReasoningEfforts
     }
 
     var composerReasoningEffortTitle: String {
-        composerReasoningEffort.title
+        if effectiveComposerReasoningEffort == .appDefault {
+            return selectedComposerModelOption?.defaultReasoningEffort?.title ?? composerReasoningEffort.title
+        }
+
+        return effectiveComposerReasoningEffort.title
     }
 
     func activateWorkspace(at url: URL) {
@@ -832,8 +869,8 @@ final class AppModel {
     private func defaultTurnConfiguration(for controller: WorkspaceController) -> BridgeTurnStartConfiguration {
         BridgeTurnStartConfiguration(
             cwd: controller.workspace.canonicalPath,
-            model: composerModelID,
-            reasoningEffort: composerReasoningEffort.bridgeValue,
+            model: effectiveComposerModelID,
+            reasoningEffort: effectiveComposerReasoningEffort.bridgeValue,
             sandboxPolicy: SandboxPolicy.workspaceWrite.rawValue,
             approvalPolicy: ApprovalPolicy.onRequest.rawValue,
             summaryMode: SummaryMode.concise.rawValue,

--- a/AtelierCode/AppPreferencesStore.swift
+++ b/AtelierCode/AppPreferencesStore.swift
@@ -10,6 +10,8 @@ struct AppPreferencesSnapshot: Codable, Equatable, Sendable {
     var lastSelectedWorkspacePath: String?
     var codexPathOverride: String?
     var appearancePreference: AppAppearancePreference
+    var composerModelID: String?
+    var composerReasoningEffort: ComposerReasoningEffort
     var workspaceStates: [PersistedWorkspaceState]
 
     init(
@@ -17,12 +19,16 @@ struct AppPreferencesSnapshot: Codable, Equatable, Sendable {
         lastSelectedWorkspacePath: String?,
         codexPathOverride: String?,
         appearancePreference: AppAppearancePreference = .system,
+        composerModelID: String? = nil,
+        composerReasoningEffort: ComposerReasoningEffort = .appDefault,
         workspaceStates: [PersistedWorkspaceState] = []
     ) {
         self.recentWorkspaces = recentWorkspaces
         self.lastSelectedWorkspacePath = lastSelectedWorkspacePath
         self.codexPathOverride = codexPathOverride
         self.appearancePreference = appearancePreference
+        self.composerModelID = composerModelID
+        self.composerReasoningEffort = composerReasoningEffort
         self.workspaceStates = workspaceStates
     }
 
@@ -31,6 +37,8 @@ struct AppPreferencesSnapshot: Codable, Equatable, Sendable {
         case lastSelectedWorkspacePath
         case codexPathOverride
         case appearancePreference
+        case composerModelID
+        case composerReasoningEffort
         case workspaceStates
     }
 
@@ -40,6 +48,8 @@ struct AppPreferencesSnapshot: Codable, Equatable, Sendable {
         lastSelectedWorkspacePath = try container.decodeIfPresent(String.self, forKey: .lastSelectedWorkspacePath)
         codexPathOverride = try container.decodeIfPresent(String.self, forKey: .codexPathOverride)
         appearancePreference = try container.decodeIfPresent(AppAppearancePreference.self, forKey: .appearancePreference) ?? .system
+        composerModelID = try container.decodeIfPresent(String.self, forKey: .composerModelID)
+        composerReasoningEffort = try container.decodeIfPresent(ComposerReasoningEffort.self, forKey: .composerReasoningEffort) ?? .appDefault
         workspaceStates = try container.decodeIfPresent([PersistedWorkspaceState].self, forKey: .workspaceStates) ?? []
     }
 
@@ -49,6 +59,8 @@ struct AppPreferencesSnapshot: Codable, Equatable, Sendable {
         try container.encodeIfPresent(lastSelectedWorkspacePath, forKey: .lastSelectedWorkspacePath)
         try container.encodeIfPresent(codexPathOverride, forKey: .codexPathOverride)
         try container.encode(appearancePreference, forKey: .appearancePreference)
+        try container.encodeIfPresent(composerModelID, forKey: .composerModelID)
+        try container.encode(composerReasoningEffort, forKey: .composerReasoningEffort)
         try container.encode(workspaceStates, forKey: .workspaceStates)
     }
 }

--- a/AtelierCode/AppStateTypes.swift
+++ b/AtelierCode/AppStateTypes.swift
@@ -544,6 +544,70 @@ enum AppAppearancePreference: String, Codable, Equatable, Sendable, CaseIterable
     }
 }
 
+struct ComposerModelOption: Equatable, Sendable, Identifiable {
+    let id: String
+    let title: String
+
+    static let fallbackCatalog: [Self] = [
+        Self(id: "gpt-5.4", title: "GPT-5.4"),
+        Self(id: "gpt-5.4-mini", title: "GPT-5.4 Mini"),
+        Self(id: "gpt-5.3-codex", title: "GPT-5.3 Codex"),
+        Self(id: "gpt-5.3-codex-spark", title: "GPT-5.3 Codex Spark"),
+        Self(id: "gpt-5.2", title: "GPT-5.2"),
+        Self(id: "gpt-5.2-codex", title: "GPT-5.2 Codex"),
+        Self(id: "gpt-5.1-codex-max", title: "GPT-5.1 Codex Max"),
+        Self(id: "gpt-5.1-codex-mini", title: "GPT-5.1 Codex Mini")
+    ]
+
+    static func resolvedOption(for id: String?) -> Self? {
+        let normalizedID = id?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard normalizedID.isEmpty == false else {
+            return nil
+        }
+
+        return fallbackCatalog.first(where: { $0.id == normalizedID }) ?? Self(id: normalizedID, title: normalizedID)
+    }
+}
+
+enum ComposerReasoningEffort: String, Codable, Equatable, Sendable, CaseIterable, Identifiable {
+    case appDefault = "default"
+    case minimal
+    case low
+    case medium
+    case high
+    case xhigh
+    case none
+
+    var id: String { rawValue }
+
+    var bridgeValue: String? {
+        self == .appDefault ? nil : rawValue
+    }
+
+    var title: String {
+        switch self {
+        case .appDefault:
+            return "Default Effort"
+        case .minimal:
+            return "Minimal"
+        case .low:
+            return "Low"
+        case .medium:
+            return "Medium"
+        case .high:
+            return "High"
+        case .xhigh:
+            return "Extra High"
+        case .none:
+            return "None"
+        }
+    }
+
+    init(storedValue: String?) {
+        self = ComposerReasoningEffort(rawValue: storedValue ?? ComposerReasoningEffort.appDefault.rawValue) ?? .appDefault
+    }
+}
+
 enum ConversationRole: String, Codable, Equatable, Sendable {
     case system
     case user

--- a/AtelierCode/AppStateTypes.swift
+++ b/AtelierCode/AppStateTypes.swift
@@ -547,26 +547,9 @@ enum AppAppearancePreference: String, Codable, Equatable, Sendable, CaseIterable
 struct ComposerModelOption: Equatable, Sendable, Identifiable {
     let id: String
     let title: String
-
-    static let fallbackCatalog: [Self] = [
-        Self(id: "gpt-5.4", title: "GPT-5.4"),
-        Self(id: "gpt-5.4-mini", title: "GPT-5.4 Mini"),
-        Self(id: "gpt-5.3-codex", title: "GPT-5.3 Codex"),
-        Self(id: "gpt-5.3-codex-spark", title: "GPT-5.3 Codex Spark"),
-        Self(id: "gpt-5.2", title: "GPT-5.2"),
-        Self(id: "gpt-5.2-codex", title: "GPT-5.2 Codex"),
-        Self(id: "gpt-5.1-codex-max", title: "GPT-5.1 Codex Max"),
-        Self(id: "gpt-5.1-codex-mini", title: "GPT-5.1 Codex Mini")
-    ]
-
-    static func resolvedOption(for id: String?) -> Self? {
-        let normalizedID = id?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        guard normalizedID.isEmpty == false else {
-            return nil
-        }
-
-        return fallbackCatalog.first(where: { $0.id == normalizedID }) ?? Self(id: normalizedID, title: normalizedID)
-    }
+    let defaultReasoningEffort: ComposerReasoningEffort?
+    let supportedReasoningEfforts: [ComposerReasoningEffort]
+    let isDefault: Bool
 }
 
 enum ComposerReasoningEffort: String, Codable, Equatable, Sendable, CaseIterable, Identifiable {
@@ -579,6 +562,8 @@ enum ComposerReasoningEffort: String, Codable, Equatable, Sendable, CaseIterable
     case none
 
     var id: String { rawValue }
+
+    static let serverSupportedDefaults: [Self] = [.low, .medium, .high, .xhigh]
 
     var bridgeValue: String? {
         self == .appDefault ? nil : rawValue
@@ -605,6 +590,16 @@ enum ComposerReasoningEffort: String, Codable, Equatable, Sendable, CaseIterable
 
     init(storedValue: String?) {
         self = ComposerReasoningEffort(rawValue: storedValue ?? ComposerReasoningEffort.appDefault.rawValue) ?? .appDefault
+    }
+
+    init?(bridgeValue: String?) {
+        guard let bridgeValue,
+              let effort = ComposerReasoningEffort(rawValue: bridgeValue),
+              effort != .appDefault else {
+            return nil
+        }
+
+        self = effort
     }
 }
 

--- a/AtelierCode/ContentView.swift
+++ b/AtelierCode/ContentView.swift
@@ -2098,50 +2098,52 @@ private struct ComposerBar: View {
             }
 
             HStack(alignment: .center, spacing: 8) {
-                Menu {
-                    Button {
-                        appModel.setComposerModelID(nil)
+                if appModel.availableComposerModels.isEmpty == false {
+                    Menu {
+                        Button {
+                            appModel.setComposerModelID(nil)
+                        } label: {
+                            ComposerMenuItemLabel(
+                                title: "Default Model",
+                                isSelected: appModel.effectiveComposerModelID == nil
+                            )
+                        }
+
+                        Divider()
+
+                        ForEach(appModel.availableComposerModels) { option in
+                            Button {
+                                appModel.setComposerModelID(option.id)
+                            } label: {
+                                ComposerMenuItemLabel(
+                                    title: option.title,
+                                    isSelected: appModel.effectiveComposerModelID == option.id
+                                )
+                            }
+                        }
                     } label: {
-                        ComposerMenuItemLabel(
-                            title: "Default Model",
-                            isSelected: appModel.composerModelID == nil
-                        )
+                        ComposerMenuChip(title: appModel.composerModelTitle)
                     }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("composer-model-button")
 
-                    Divider()
-
-                    ForEach(appModel.availableComposerModels) { option in
-                        Button {
-                            appModel.setComposerModelID(option.id)
-                        } label: {
-                            ComposerMenuItemLabel(
-                                title: option.title,
-                                isSelected: appModel.composerModelID == option.id
-                            )
+                    Menu {
+                        ForEach(appModel.availableComposerReasoningEfforts) { effort in
+                            Button {
+                                appModel.setComposerReasoningEffort(effort)
+                            } label: {
+                                ComposerMenuItemLabel(
+                                    title: effort.title,
+                                    isSelected: appModel.effectiveComposerReasoningEffort == effort
+                                )
+                            }
                         }
+                    } label: {
+                        ComposerMenuChip(title: appModel.composerReasoningEffortTitle)
                     }
-                } label: {
-                    ComposerMenuChip(title: appModel.composerModelTitle)
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("composer-reasoning-button")
                 }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier("composer-model-button")
-
-                Menu {
-                    ForEach(appModel.availableComposerReasoningEfforts) { effort in
-                        Button {
-                            appModel.setComposerReasoningEffort(effort)
-                        } label: {
-                            ComposerMenuItemLabel(
-                                title: effort.title,
-                                isSelected: appModel.composerReasoningEffort == effort
-                            )
-                        }
-                    }
-                } label: {
-                    ComposerMenuChip(title: appModel.composerReasoningEffortTitle)
-                }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier("composer-reasoning-button")
 
                 Spacer(minLength: 0)
 
@@ -2498,6 +2500,10 @@ private final class PreviewWorkspaceRuntime: WorkspaceConversationRuntime {
 
     func stop() async {
         controller.setAwaitingTurnStart(false)
+    }
+
+    func refreshModels() async throws {
+        controller.setAvailableModels([])
     }
 
     func listThreads(archived: Bool) async throws {

--- a/AtelierCode/ContentView.swift
+++ b/AtelierCode/ContentView.swift
@@ -2096,11 +2096,56 @@ private struct ComposerBar: View {
                         .allowsHitTesting(false)
                 }
             }
-            
-            if appModel.canCancelTurn {
-                HStack {
-                    Spacer(minLength: 0)
 
+            HStack(alignment: .center, spacing: 8) {
+                Menu {
+                    Button {
+                        appModel.setComposerModelID(nil)
+                    } label: {
+                        ComposerMenuItemLabel(
+                            title: "Default Model",
+                            isSelected: appModel.composerModelID == nil
+                        )
+                    }
+
+                    Divider()
+
+                    ForEach(appModel.availableComposerModels) { option in
+                        Button {
+                            appModel.setComposerModelID(option.id)
+                        } label: {
+                            ComposerMenuItemLabel(
+                                title: option.title,
+                                isSelected: appModel.composerModelID == option.id
+                            )
+                        }
+                    }
+                } label: {
+                    ComposerMenuChip(title: appModel.composerModelTitle)
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("composer-model-button")
+
+                Menu {
+                    ForEach(appModel.availableComposerReasoningEfforts) { effort in
+                        Button {
+                            appModel.setComposerReasoningEffort(effort)
+                        } label: {
+                            ComposerMenuItemLabel(
+                                title: effort.title,
+                                isSelected: appModel.composerReasoningEffort == effort
+                            )
+                        }
+                    }
+                } label: {
+                    ComposerMenuChip(title: appModel.composerReasoningEffortTitle)
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("composer-reasoning-button")
+
+                Spacer(minLength: 0)
+
+                if appModel.canCancelTurn {
                     Button {
                         Task {
                             await appModel.cancelActiveTurn()
@@ -2122,6 +2167,15 @@ private struct ComposerBar: View {
                     .accessibilityIdentifier("conversation-cancel-button")
                 }
             }
+            .padding(.leading, ComposerMetrics.textHorizontalInset)
+
+            if showsDisabledBanner {
+                Text(disabledBannerText)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .padding(.leading, ComposerMetrics.textHorizontalInset)
+                    .accessibilityIdentifier("composer-disabled-banner")
+            }
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 12)
@@ -2134,15 +2188,6 @@ private struct ComposerBar: View {
                 .stroke(editorBorderColor, lineWidth: isFocused ? 1.25 : 1)
         }
         .shadow(color: editorShadowColor, radius: isFocused ? 14 : 6, y: isFocused ? 5 : 2)
-        .overlay(alignment: .bottomLeading) {
-            if showsDisabledBanner {
-                Text(disabledBannerText)
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 12)
-                    .padding(.bottom, 10)
-            }
-        }
     }
 
     private var editorBorderColor: Color {
@@ -2191,6 +2236,41 @@ private struct ComposerBar: View {
         Task {
             if await appModel.sendPrompt(prompt) {
                 composerText = ""
+            }
+        }
+    }
+}
+
+private struct ComposerMenuChip: View {
+    let title: String
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(title)
+                .lineLimit(1)
+        }
+        .font(.footnote.weight(.medium))
+        .foregroundColor(Color(nsColor: .placeholderTextColor).opacity(0.7))
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Color.white.opacity(0.04), in: Capsule())
+        .overlay {
+            Capsule()
+                .stroke(Color.white.opacity(0.06), lineWidth: 1)
+        }
+    }
+}
+
+private struct ComposerMenuItemLabel: View {
+    let title: String
+    let isSelected: Bool
+
+    var body: some View {
+        Group {
+            if isSelected {
+                Label(title, systemImage: "checkmark")
+            } else {
+                Text(title)
             }
         }
     }

--- a/AtelierCode/Runtime/BridgeProtocol.swift
+++ b/AtelierCode/Runtime/BridgeProtocol.swift
@@ -6,6 +6,7 @@ enum BridgeProtocolVersion {
 }
 
 enum BridgeCommandType: String, Encodable, Sendable {
+    case modelList = "model.list"
     case threadStart = "thread.start"
     case threadResume = "thread.resume"
     case threadList = "thread.list"
@@ -24,6 +25,7 @@ enum BridgeCommandType: String, Encodable, Sendable {
 }
 
 enum BridgeEventType: String, Decodable, Sendable {
+    case modelListResult = "model.list.result"
     case threadStarted = "thread.started"
     case threadArchived = "thread.archived"
     case threadUnarchived = "thread.unarchived"
@@ -185,6 +187,11 @@ struct BridgeCommandEnvelope<Payload: Encodable>: Encodable {
 struct BridgeThreadStartPayload: Encodable, Sendable {
     let workspacePath: String
     let title: String?
+}
+
+struct BridgeModelListPayload: Encodable, Sendable {
+    let limit: Int?
+    let includeHidden: Bool?
 }
 
 struct BridgeThreadResumePayload: Encodable, Sendable {
@@ -414,6 +421,27 @@ struct BridgeRateLimitUpdatedPayload: Decodable, Equatable, Sendable {
     let buckets: [BridgeRateLimitBucketDTO]
 }
 
+struct BridgeModelReasoningEffortDTO: Decodable, Equatable, Sendable {
+    let reasoningEffort: String
+    let description: String?
+}
+
+struct BridgeModelSummaryDTO: Decodable, Equatable, Sendable {
+    let id: String
+    let model: String
+    let displayName: String
+    let hidden: Bool
+    let defaultReasoningEffort: String?
+    let supportedReasoningEfforts: [BridgeModelReasoningEffortDTO]
+    let inputModalities: [String]?
+    let supportsPersonality: Bool?
+    let isDefault: Bool?
+}
+
+struct BridgeModelListResultPayload: Decodable, Equatable, Sendable {
+    let models: [BridgeModelSummaryDTO]
+}
+
 enum BridgeJSONValue: Codable, Equatable, Sendable {
     case string(String)
     case number(Double)
@@ -480,6 +508,7 @@ struct BridgeProviderStatusPayload: Decodable, Equatable, Sendable {
 }
 
 enum BridgeEventPayload: Equatable, Sendable {
+    case modelListResult(BridgeModelListResultPayload)
     case threadStarted(BridgeThreadStartedPayload)
     case threadArchived(BridgeThreadArchivedPayload)
     case threadUnarchived(BridgeThreadUnarchivedPayload)
@@ -541,6 +570,8 @@ struct BridgeEventEnvelope: Decodable, Equatable, Sendable {
         activityID = try container.decodeIfPresent(String.self, forKey: .activityID)
 
         switch type {
+        case .modelListResult:
+            payload = .modelListResult(try container.decode(BridgeModelListResultPayload.self, forKey: .payload))
         case .threadStarted:
             payload = .threadStarted(try container.decode(BridgeThreadStartedPayload.self, forKey: .payload))
         case .threadArchived:
@@ -628,6 +659,29 @@ extension BridgeThreadSummaryDTO {
             title: title,
             messages: (messages ?? []).map { $0.toConversationMessage() }
         )
+    }
+}
+
+extension BridgeModelSummaryDTO {
+    var composerModelOption: ComposerModelOption? {
+        let supportedReasoningEfforts = supportedReasoningEfforts.compactMap(\.composerReasoningEffort)
+        let resolvedSupportedReasoningEfforts = supportedReasoningEfforts.isEmpty
+            ? ComposerReasoningEffort.serverSupportedDefaults
+            : supportedReasoningEfforts
+
+        return ComposerModelOption(
+            id: id,
+            title: displayName,
+            defaultReasoningEffort: ComposerReasoningEffort(bridgeValue: defaultReasoningEffort),
+            supportedReasoningEfforts: resolvedSupportedReasoningEfforts,
+            isDefault: isDefault ?? false
+        )
+    }
+}
+
+extension BridgeModelReasoningEffortDTO {
+    var composerReasoningEffort: ComposerReasoningEffort? {
+        ComposerReasoningEffort(bridgeValue: reasoningEffort)
     }
 }
 

--- a/AtelierCode/Runtime/WorkspaceBridgeRuntime.swift
+++ b/AtelierCode/Runtime/WorkspaceBridgeRuntime.swift
@@ -71,6 +71,7 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
     private static let decoder = JSONDecoder()
     private static let clientName = "AtelierCode"
     private static let provider = "codex"
+    private static let modelListRequestID = "ateliercode-model-list"
 
     let controller: WorkspaceController
 
@@ -178,6 +179,7 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
             }
 
             try await refreshAccount()
+            try await refreshModels()
             try await listThreads(archived: false)
         } catch {
             handleBridgeFailure(message: error.localizedDescription)
@@ -226,6 +228,14 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
         controller.setBridgeLifecycleState(.idle)
         controller.setConnectionStatus(.disconnected)
         isStopping = false
+    }
+
+    func refreshModels() async throws {
+        try await sendCommand(
+            id: Self.modelListRequestID,
+            type: .modelList,
+            payload: BridgeModelListPayload(limit: 100, includeHidden: false)
+        )
     }
 
     func listThreads(archived: Bool) async throws {
@@ -597,6 +607,8 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
         adoptTurnContextIfNeeded(from: event)
 
         switch event.payload {
+        case .modelListResult(let payload):
+            handleModelListResult(payload, requestID: event.requestID)
         case .threadStarted(let payload):
             handleThreadStarted(payload, requestID: event.requestID)
         case .threadArchived(let payload):
@@ -934,6 +946,10 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
         _ = controller.ensureThreadSession(id: summary.id, title: summary.title, markSelected: false)
     }
 
+    private func handleModelListResult(_ payload: BridgeModelListResultPayload, requestID: String?) {
+        controller.setAvailableModels(payload.models.compactMap(\.composerModelOption))
+    }
+
     private func handleThreadListResult(
         _ payload: BridgeThreadListResultPayload,
         requestID: String?,
@@ -1128,9 +1144,19 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
             controller.setAuthState(.signedIn(accountDescription: payload.account?.displayName ?? "Signed In"))
             controller.clearPendingLogin()
         }
+
+        Task { @MainActor [weak self] in
+            try? await self?.refreshModels()
+        }
     }
 
     private func handleBridgeError(_ payload: BridgeErrorPayload, requestID: String?) {
+        var shouldUpdateConnectionStatus = true
+
+        if requestID == Self.modelListRequestID {
+            shouldUpdateConnectionStatus = false
+        }
+
         if let requestID,
            let pendingCommand = pendingCommands.removeValue(forKey: requestID) {
             switch pendingCommand {
@@ -1171,7 +1197,9 @@ final class WorkspaceBridgeRuntime: WorkspaceConversationRuntime {
             }
         }
 
-        controller.setConnectionStatus(.error(message: payload.message))
+        if shouldUpdateConnectionStatus {
+            controller.setConnectionStatus(.error(message: payload.message))
+        }
     }
 
     private func handleProviderStatus(_ payload: BridgeProviderStatusPayload) {

--- a/AtelierCode/Runtime/WorkspaceConversationRuntime.swift
+++ b/AtelierCode/Runtime/WorkspaceConversationRuntime.swift
@@ -4,6 +4,7 @@ import Foundation
 protocol WorkspaceConversationRuntime: AnyObject {
     func start() async throws
     func stop() async
+    func refreshModels() async throws
     func listThreads(archived: Bool) async throws
     func startThreadAndWait(title: String?) async throws -> ThreadSession
     func resumeThreadAndWait(id: String) async throws -> ThreadSession

--- a/AtelierCode/WorkspaceController.swift
+++ b/AtelierCode/WorkspaceController.swift
@@ -25,6 +25,7 @@ final class WorkspaceController {
     private(set) var authState: AuthState
     private(set) var pendingLogin: PendingLogin?
     private(set) var rateLimitState: RateLimitState?
+    private(set) var availableModels: [ComposerModelOption]
     private(set) var threadSessionsByID: [String: ThreadSession]
     private(set) var lastActiveThreadID: String? {
         didSet {
@@ -60,6 +61,7 @@ final class WorkspaceController {
         self.authState = .unknown
         self.pendingLogin = nil
         self.rateLimitState = nil
+        self.availableModels = []
         self.threadSessionsByID = [:]
         self.lastActiveThreadID = nil
         self.isShowingArchivedThreads = false
@@ -142,6 +144,7 @@ final class WorkspaceController {
         authState = .unknown
         pendingLogin = nil
         rateLimitState = nil
+        availableModels = []
         threadSessionsByID.removeAll()
         lastActiveThreadID = nil
         isShowingArchivedThreads = false
@@ -182,6 +185,10 @@ final class WorkspaceController {
 
     func setRateLimitState(_ rateLimitState: RateLimitState?) {
         self.rateLimitState = rateLimitState
+    }
+
+    func setAvailableModels(_ availableModels: [ComposerModelOption]) {
+        self.availableModels = availableModels
     }
 
     func setShowingArchivedThreads(_ isShowingArchivedThreads: Bool) {

--- a/AtelierCodeTests/AtelierCodeTests.swift
+++ b/AtelierCodeTests/AtelierCodeTests.swift
@@ -540,6 +540,15 @@ struct AppModelTests {
     @Test func sendPromptUsesSelectedModelAndReasoningEffort() async throws {
         let store = InMemoryAppPreferencesStore()
         let runtimeCoordinator = TestRuntimeCoordinator()
+        runtimeCoordinator.availableModels = [
+            ComposerModelOption(
+                id: "gpt-5.4",
+                title: "GPT-5.4",
+                defaultReasoningEffort: .medium,
+                supportedReasoningEfforts: [.low, .medium, .high, .xhigh],
+                isDefault: true
+            )
+        ]
         let appModel = AppModel(
             preferencesStore: store,
             bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
@@ -556,6 +565,27 @@ struct AppModelTests {
         let configuration = try #require(runtimeCoordinator.startTurnConfigurations.last ?? nil)
         #expect(configuration.model == "gpt-5.4")
         #expect(configuration.reasoningEffort == "high")
+    }
+
+    @Test func sendPromptOmitsUnavailableModelAndReasoningSelections() async throws {
+        let store = InMemoryAppPreferencesStore()
+        let runtimeCoordinator = TestRuntimeCoordinator()
+        let appModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
+            runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
+        )
+        let workspaceURL = try temporaryDirectory(named: "conversation-config-no-model-catalog")
+
+        appModel.setComposerModelID("gpt-5.4")
+        appModel.setComposerReasoningEffort(.high)
+        appModel.activateWorkspace(at: workspaceURL)
+        try await waitUntil { appModel.activeWorkspaceController?.connectionStatus == .ready }
+        _ = await appModel.sendPrompt("Create a README without a model catalog")
+
+        let configuration = try #require(runtimeCoordinator.startTurnConfigurations.last ?? nil)
+        #expect(configuration.model == nil)
+        #expect(configuration.reasoningEffort == nil)
     }
 
     @Test func secondSendIsRejectedWhileWaitingForTurnStartAcknowledgement() async throws {
@@ -788,6 +818,7 @@ private final class TestRuntimeCoordinator {
     var startThreadCount = 0
     var startTurnPrompts: [String] = []
     var startTurnConfigurations: [BridgeTurnStartConfiguration?] = []
+    var availableModels: [ComposerModelOption] = []
     var cancelCount = 0
     var resolveApprovalCalls: [(String, ApprovalResolution)] = []
     var queuedThreadListResponses: [[ThreadSummary]] = []
@@ -839,6 +870,7 @@ private final class TestWorkspaceRuntime: WorkspaceConversationRuntime {
 
     func start() async throws {
         coordinator.startCount += 1
+        controller.setAvailableModels(coordinator.availableModels)
         controller.setBridgeLifecycleState(.idle)
         controller.setConnectionStatus(.ready)
     }
@@ -847,6 +879,10 @@ private final class TestWorkspaceRuntime: WorkspaceConversationRuntime {
         coordinator.stopCount += 1
         controller.setAwaitingTurnStart(false)
         controller.setConnectionStatus(.disconnected)
+    }
+
+    func refreshModels() async throws {
+        controller.setAvailableModels(coordinator.availableModels)
     }
 
     func listThreads(archived: Bool) async throws {
@@ -1015,6 +1051,10 @@ private final class LifecycleProbeRuntime: WorkspaceConversationRuntime {
         controller.setAwaitingTurnStart(false)
         controller.setBridgeLifecycleState(.idle)
         controller.setConnectionStatus(.disconnected)
+    }
+
+    func refreshModels() async throws {
+        controller.setAvailableModels([])
     }
 
     func listThreads(archived: Bool) async throws {

--- a/AtelierCodeTests/AtelierCodeTests.swift
+++ b/AtelierCodeTests/AtelierCodeTests.swift
@@ -149,6 +149,28 @@ struct AppModelTests {
         #expect(restoredModel.appearancePreference == .dark)
     }
 
+    @Test func roundTripsComposerSelections() async throws {
+        let store = InMemoryAppPreferencesStore()
+        let runtimeCoordinator = TestRuntimeCoordinator()
+        let appModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
+            runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
+        )
+
+        appModel.setComposerModelID("gpt-5.4")
+        appModel.setComposerReasoningEffort(.xhigh)
+
+        let restoredModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
+            runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
+        )
+
+        #expect(restoredModel.composerModelID == "gpt-5.4")
+        #expect(restoredModel.composerReasoningEffort == .xhigh)
+    }
+
     @Test func selectingWorkspaceReturnsFromSettingsToConversationView() async throws {
         let store = InMemoryAppPreferencesStore()
         let runtimeCoordinator = TestRuntimeCoordinator()
@@ -513,6 +535,27 @@ struct AppModelTests {
         #expect(configuration.sandboxPolicy == "workspace-write")
         #expect(configuration.approvalPolicy == "on-request")
         #expect(configuration.summaryMode == "concise")
+    }
+
+    @Test func sendPromptUsesSelectedModelAndReasoningEffort() async throws {
+        let store = InMemoryAppPreferencesStore()
+        let runtimeCoordinator = TestRuntimeCoordinator()
+        let appModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
+            runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
+        )
+        let workspaceURL = try temporaryDirectory(named: "conversation-config-model")
+
+        appModel.setComposerModelID("gpt-5.4")
+        appModel.setComposerReasoningEffort(.high)
+        appModel.activateWorkspace(at: workspaceURL)
+        try await waitUntil { appModel.activeWorkspaceController?.connectionStatus == .ready }
+        _ = await appModel.sendPrompt("Create a README with the selected model")
+
+        let configuration = try #require(runtimeCoordinator.startTurnConfigurations.last ?? nil)
+        #expect(configuration.model == "gpt-5.4")
+        #expect(configuration.reasoningEffort == "high")
     }
 
     @Test func secondSendIsRejectedWhileWaitingForTurnStartAcknowledgement() async throws {

--- a/AtelierCodeTests/WorkspaceBridgeRuntimeTests.swift
+++ b/AtelierCodeTests/WorkspaceBridgeRuntimeTests.swift
@@ -15,6 +15,7 @@ struct WorkspaceBridgeRuntimeTests {
         let socketClient = FakeBridgeSocketClient(messages: [
             welcomeJSON(requestID: "ateliercode-hello-1"),
             authChangedJSON(requestID: "ateliercode-account-read-2", state: "signed_in", displayName: "chatgpt (pro)"),
+            modelListResultJSON(requestID: "ateliercode-model-list"),
             rateLimitUpdatedJSON(requestID: "ateliercode-account-read-2"),
             threadListResultJSON(requestID: "ateliercode-thread-list-3", threadTitle: "Bootstrap Thread")
         ])
@@ -34,6 +35,8 @@ struct WorkspaceBridgeRuntimeTests {
         #expect(controller.authState == .signedIn(accountDescription: "chatgpt (pro)"))
         #expect(controller.rateLimitState?.buckets.count == 1)
         #expect(controller.threadSummaries.map(\.title) == ["Bootstrap Thread"])
+        #expect(controller.availableModels.first?.id == "gpt-5.4")
+        #expect(controller.availableModels.first?.defaultReasoningEffort == .medium)
         #expect(controller.bridgeEnvironmentDiagnostics == WorkspaceBridgeEnvironmentDiagnostics(
             source: .loginProbe,
             shellPath: "/bin/zsh",
@@ -41,7 +44,37 @@ struct WorkspaceBridgeRuntimeTests {
             pathDirectoryCount: 5,
             homeDirectory: "/Users/tester"
         ))
-        #expect(sentMessageTypes(from: socketClient.sentTexts) == ["hello", "account.read", "thread.list"])
+        let sentMessageTypes = sentMessageTypes(from: socketClient.sentTexts)
+        #expect(sentMessageTypes.contains("hello"))
+        #expect(sentMessageTypes.contains("account.read"))
+        #expect(sentMessageTypes.contains("model.list"))
+        #expect(sentMessageTypes.contains("thread.list"))
+    }
+
+    @Test func modelListErrorsDoNotPoisonWorkspaceConnection() async throws {
+        let workspace = WorkspaceRecord(url: try temporaryDirectory(named: "runtime-model-list-error"), lastOpenedAt: .now)
+        let controller = WorkspaceController(workspace: workspace)
+        let bundle = try bridgeFixtureBundle()
+        let processHandle = FakeBridgeProcessHandle(lines: [startupRecordJSON(port: 4246)])
+        let socketClient = FakeBridgeSocketClient(messages: [
+            welcomeJSON(requestID: "ateliercode-hello-1"),
+            authChangedJSON(requestID: "ateliercode-account-read-2", state: "signed_out", displayName: nil),
+            modelListErrorJSON(requestID: "ateliercode-model-list", message: "model/list is unavailable"),
+            threadListResultJSON(requestID: "ateliercode-thread-list-3", threadTitle: "Thread")
+        ])
+        let runtime = makeRuntime(
+            controller: controller,
+            executableLocator: BridgeExecutableLocator(bundle: bundle),
+            processLauncher: { _ in processHandle },
+            socketFactory: { _ in socketClient },
+            openURLAction: { _ in }
+        )
+
+        try await runtime.start()
+        try await waitUntil { controller.connectionStatus == .ready && controller.threadSummaries.count == 1 }
+
+        #expect(controller.connectionStatus == .ready)
+        #expect(controller.availableModels.isEmpty)
     }
 
     @Test func providerStatusUpdatesEnvironmentWarningAndExecutablePath() async throws {
@@ -792,10 +825,10 @@ struct WorkspaceBridgeRuntimeTests {
 
         try await waitUntil {
             pendingCommandCount(in: runtime) == 1 &&
-            commandObject(from: socketClient.sentTexts.last ?? "")?["type"] as? String == "thread.rename"
+            latestCommandPayload(ofType: "thread.rename", from: socketClient.sentTexts)?["title"] as? String == "Renamed Thread"
         }
 
-        #expect(commandPayload(from: socketClient.sentTexts.last)?["title"] as? String == "Renamed Thread")
+        #expect(latestCommandPayload(ofType: "thread.rename", from: socketClient.sentTexts)?["title"] as? String == "Renamed Thread")
 
         socketClient.enqueue(threadStartedJSON(
             requestID: "ateliercode-thread-rename-4",
@@ -1108,6 +1141,18 @@ private func rateLimitUpdatedJSON(requestID: String) -> String {
     """
 }
 
+private func modelListResultJSON(requestID: String) -> String {
+    """
+    {"type":"model.list.result","timestamp":"2026-03-24T10:00:03Z","requestID":"\(requestID)","payload":{"models":[{"id":"gpt-5.4","model":"gpt-5.4","displayName":"GPT-5.4","hidden":false,"defaultReasoningEffort":"medium","supportedReasoningEfforts":[{"reasoningEffort":"low","description":"Lower latency"},{"reasoningEffort":"medium","description":"Balanced"},{"reasoningEffort":"high","description":"More reasoning"}],"inputModalities":["text","image"],"supportsPersonality":true,"isDefault":true}]}}
+    """
+}
+
+private func modelListErrorJSON(requestID: String, message: String) -> String {
+    """
+    {"type":"error","timestamp":"2026-03-24T10:00:03Z","requestID":"\(requestID)","payload":{"code":"provider_command_failed","message":"\(jsonEscaped(message))"}}
+    """
+}
+
 private func threadListResultJSON(requestID: String, threadTitle: String) -> String {
     """
     {"type":"thread.list.result","timestamp":"2026-03-24T10:00:04Z","requestID":"\(requestID)","payload":{"threads":[{"id":"thread-1","title":"\(threadTitle)","previewText":"Preview","updatedAt":"2026-03-24T10:00:04Z"}],"nextCursor":null}}
@@ -1311,6 +1356,20 @@ private func commandPayload(from message: String?) -> [String: Any]? {
     }
 
     return payload
+}
+
+private func latestCommandPayload(ofType type: String, from messages: [String]) -> [String: Any]? {
+    for message in messages.reversed() {
+        guard let object = commandObject(from: message),
+              object["type"] as? String == type,
+              let payload = object["payload"] as? [String: Any] else {
+            continue
+        }
+
+        return payload
+    }
+
+    return nil
 }
 
 private func commandObject(from message: String) -> [String: Any]? {


### PR DESCRIPTION
## Summary
- restyle the prompt composer with a unified card treatment, focus state, and disabled banner
- remove the explicit send button in favor of Enter-to-send from the text view
- align composer placeholder/text insets and extract shared layout helpers for composer and sidebar cards
- update UI tests to submit prompts via Return and assert the send button is no longer shown

## Testing
- Not run (not requested)