### PR TITLE
Update the prompt composer to use focused enter-to-send interactions

### DIFF
--- a/AtelierCode/AppBootstrap.swift
+++ b/AtelierCode/AppBootstrap.swift
@@ -8,11 +8,13 @@ enum AppBootstrap {
         }
 
         let workspaceURL = scenario.workspaceURL
-        try? FileManager.default.createDirectory(at: workspaceURL, withIntermediateDirectories: true)
+        if scenario.includesWorkspace {
+            try? FileManager.default.createDirectory(at: workspaceURL, withIntermediateDirectories: true)
+        }
 
         let preferencesStore = InMemoryBootstrapPreferencesStore(
             snapshot: AppPreferencesSnapshot(
-                recentWorkspaces: [WorkspaceRecord(url: workspaceURL, lastOpenedAt: .now)],
+                recentWorkspaces: scenario.includesWorkspace ? [WorkspaceRecord(url: workspaceURL, lastOpenedAt: .now)] : [],
                 lastSelectedWorkspacePath: scenario.startsWithSelectedWorkspace ? workspaceURL.path : nil,
                 codexPathOverride: nil
             )
@@ -22,6 +24,7 @@ enum AppBootstrap {
         return AppModel(
             preferencesStore: preferencesStore,
             bridgeDiagnosticProvider: { .bridgePresent(at: workspaceURL.appendingPathComponent("mock-bridge")) },
+            gitStatusProvider: UITestWorkspaceGitStatusProvider(scenario: scenario.kind),
             runtimeFactory: { UITestWorkspaceRuntime(controller: $0, coordinator: coordinator) }
         )
     }
@@ -29,19 +32,25 @@ enum AppBootstrap {
 
 private struct UITestScenario {
     enum Kind: String {
+        case empty
         case recentSelection = "recent-selection"
         case ready
         case retry
         case phase2
         case refreshOmitsThread = "refresh-omits-thread"
         case repeatedWaiting = "repeated-waiting"
+        case gitBranch = "git-branch"
     }
 
     let kind: Kind
     let workspaceURL: URL
 
     var startsWithSelectedWorkspace: Bool {
-        kind != .recentSelection
+        includesWorkspace && kind != .recentSelection
+    }
+
+    var includesWorkspace: Bool {
+        kind != .empty
     }
 
     init?(processInfo: ProcessInfo) {
@@ -73,6 +82,19 @@ private final class InMemoryBootstrapPreferencesStore: AppPreferencesStore {
 
     func saveSnapshot(_ snapshot: AppPreferencesSnapshot) throws {
         storedSnapshot = snapshot
+    }
+}
+
+private struct UITestWorkspaceGitStatusProvider: WorkspaceGitStatusProviding {
+    let scenario: UITestScenario.Kind
+
+    func gitStatus(for workspacePath: String) async -> WorkspaceGitStatus {
+        switch scenario {
+        case .gitBranch:
+            return .branch("feature/status-bar")
+        case .empty, .recentSelection, .ready, .retry, .phase2, .refreshOmitsThread, .repeatedWaiting:
+            return .unavailable(.noRepository)
+        }
     }
 }
 

--- a/AtelierCode/AppModel.swift
+++ b/AtelierCode/AppModel.swift
@@ -22,29 +22,35 @@ final class AppModel {
     @ObservationIgnored private let preferencesStore: any AppPreferencesStore
     @ObservationIgnored private let fileManager: FileManager
     @ObservationIgnored private let bridgeDiagnosticProvider: () -> StartupDiagnostic
+    @ObservationIgnored private let gitStatusProvider: any WorkspaceGitStatusProviding
     @ObservationIgnored private let now: () -> Date
     @ObservationIgnored private let runtimeFactory: @MainActor (WorkspaceController) -> any WorkspaceConversationRuntime
     @ObservationIgnored private var workspaceRuntimes: [String: any WorkspaceConversationRuntime]
     @ObservationIgnored private var runtimeLifecycleTasks: [String: Task<Void, Never>]
+    @ObservationIgnored private var gitStatusRefreshTasks: [String: Task<Void, Never>]
 
     init(
         preferencesStore: (any AppPreferencesStore)? = nil,
         fileManager: FileManager = .default,
         bridgeDiagnosticProvider: (() -> StartupDiagnostic)? = nil,
+        gitStatusProvider: (any WorkspaceGitStatusProviding)? = nil,
         now: @escaping () -> Date = Date.init,
         runtimeFactory: (@MainActor (WorkspaceController) -> any WorkspaceConversationRuntime)? = nil
     ) {
         let resolvedPreferencesStore = preferencesStore ?? UserDefaultsAppPreferencesStore()
         let resolvedBridgeDiagnosticProvider = bridgeDiagnosticProvider ?? { StartupDiagnostic.defaultBridgeDiagnostic() }
+        let resolvedGitStatusProvider = gitStatusProvider ?? WorkspaceGitStatusProvider()
         let resolvedRuntimeFactory = runtimeFactory ?? { WorkspaceBridgeRuntime(controller: $0) }
 
         self.preferencesStore = resolvedPreferencesStore
         self.fileManager = fileManager
         self.bridgeDiagnosticProvider = resolvedBridgeDiagnosticProvider
+        self.gitStatusProvider = resolvedGitStatusProvider
         self.now = now
         self.runtimeFactory = resolvedRuntimeFactory
         self.workspaceRuntimes = [:]
         self.runtimeLifecycleTasks = [:]
+        self.gitStatusRefreshTasks = [:]
 
         let loadedSnapshot = try? resolvedPreferencesStore.loadSnapshot()
         let normalizedRecentWorkspaces = Self.normalizeRecentWorkspaces(loadedSnapshot?.recentWorkspaces ?? [])
@@ -110,6 +116,7 @@ final class AppModel {
 
         startInitiallySelectedWorkspaceRuntime()
         preloadInitiallyExpandedWorkspaceThreadLists()
+        refreshSelectedWorkspaceGitStatus()
     }
 
     var activeWorkspaceController: WorkspaceController? {
@@ -211,6 +218,17 @@ final class AppModel {
         return effectiveComposerReasoningEffort.title
     }
 
+    var detailStatusItems: [DetailStatusItem] {
+        [
+            DetailStatusItem(
+                id: "git-reference",
+                systemImage: "arrow.triangle.branch",
+                text: selectedWorkspaceGitStatusText,
+                isPlaceholder: selectedWorkspaceGitStatusIsPlaceholder
+            )
+        ]
+    }
+
     func activateWorkspace(at url: URL) {
         let workspace = WorkspaceRecord(url: url, lastOpenedAt: now())
         showConversations()
@@ -254,6 +272,8 @@ final class AppModel {
         let canonicalPath = WorkspaceRecord.canonicalizedPath(for: path)
         let previousRuntime = workspaceRuntimes.removeValue(forKey: canonicalPath)
 
+        gitStatusRefreshTasks[canonicalPath]?.cancel()
+        gitStatusRefreshTasks.removeValue(forKey: canonicalPath)
         runtimeLifecycleTasks[canonicalPath]?.cancel()
         runtimeLifecycleTasks.removeValue(forKey: canonicalPath)
         workspaceControllers.removeAll { $0.workspace.canonicalPath == canonicalPath }
@@ -315,6 +335,10 @@ final class AppModel {
         primaryView = .settings
     }
 
+    func applicationDidBecomeActive() {
+        refreshSelectedWorkspaceGitStatus()
+    }
+
     func selectSettingsSection(_ section: SettingsSection) {
         selectedSettingsSection = section
         primaryView = .settings
@@ -339,12 +363,13 @@ final class AppModel {
         )
         lastSelectedWorkspacePath = canonicalPath
         startWorkspaceRuntimeIfNeeded(for: canonicalPath)
+        refreshGitStatus(for: controller.workspace)
         persistPreferences()
     }
 
     func selectWorkspaceForNewThread(path: String) {
         let canonicalPath = WorkspaceRecord.canonicalizedPath(for: path)
-        guard workspaceController(for: canonicalPath) != nil else {
+        guard let controller = workspaceController(for: canonicalPath) else {
             return
         }
 
@@ -355,6 +380,7 @@ final class AppModel {
         )
         lastSelectedWorkspacePath = canonicalPath
         startWorkspaceRuntimeIfNeeded(for: canonicalPath)
+        refreshGitStatus(for: controller.workspace)
         persistPreferences()
     }
 
@@ -790,6 +816,33 @@ final class AppModel {
         try? preferencesStore.saveSnapshot(snapshot)
     }
 
+    private var selectedWorkspaceGitStatusText: String {
+        guard let controller = selectedWorkspaceController else {
+            return "No workspace selected"
+        }
+
+        switch controller.gitStatus {
+        case .branch(let branchName):
+            return branchName
+        case .detachedHead(let commitSHA):
+            return commitSHA
+        case .unavailable:
+            return "No Git branch"
+        }
+    }
+
+    private var selectedWorkspaceGitStatusIsPlaceholder: Bool {
+        guard let controller = selectedWorkspaceController else {
+            return true
+        }
+
+        if case .unavailable = controller.gitStatus {
+            return true
+        }
+
+        return false
+    }
+
     private func installWorkspacePersistenceHandlers() {
         for controller in workspaceControllers {
             configurePersistenceHandler(for: controller)
@@ -835,6 +888,33 @@ final class AppModel {
 
                 _ = await prepareWorkspaceForBrowsing(path: workspacePath)
             }
+        }
+    }
+
+    private func refreshSelectedWorkspaceGitStatus() {
+        guard let workspace = selectedWorkspaceController?.workspace else {
+            return
+        }
+
+        refreshGitStatus(for: workspace)
+    }
+
+    private func refreshGitStatus(for workspace: WorkspaceRecord) {
+        let workspacePath = workspace.canonicalPath
+        gitStatusRefreshTasks[workspacePath]?.cancel()
+
+        gitStatusRefreshTasks[workspacePath] = Task { [weak self] in
+            guard let self else {
+                return
+            }
+
+            let gitStatus = await gitStatusProvider.gitStatus(for: workspacePath)
+            guard Task.isCancelled == false,
+                  let controller = workspaceController(for: workspacePath) else {
+                return
+            }
+
+            controller.setGitStatus(gitStatus)
         }
     }
 
@@ -1146,4 +1226,11 @@ private extension ConnectionStatus {
             return false
         }
     }
+}
+
+struct DetailStatusItem: Identifiable, Equatable, Sendable {
+    let id: String
+    let systemImage: String
+    let text: String
+    let isPlaceholder: Bool
 }

--- a/AtelierCode/AtelierCodeApp.swift
+++ b/AtelierCode/AtelierCodeApp.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 @main
 struct AtelierCodeApp: App {
+    @Environment(\.scenePhase) private var scenePhase
     @State private var appModel: AppModel
 
     @MainActor
@@ -21,6 +22,13 @@ struct AtelierCodeApp: App {
             ContentView()
                 .environment(appModel)
                 .preferredColorScheme(appModel.appearancePreference.preferredColorScheme)
+                .onChange(of: scenePhase) { _, newValue in
+                    guard newValue == .active else {
+                        return
+                    }
+
+                    appModel.applicationDidBecomeActive()
+                }
         }
     }
 }

--- a/AtelierCode/ContentView.swift
+++ b/AtelierCode/ContentView.swift
@@ -141,6 +141,9 @@ private struct AppDetailView: View {
                 SettingsDetailView(appModel: appModel)
             }
         }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            DetailStatusBar(appModel: appModel)
+        }
     }
 }
 
@@ -1114,6 +1117,53 @@ private struct WorkspacePickerButton: View {
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
         .accessibilityIdentifier("new-thread-workspace-picker")
+    }
+}
+
+private struct DetailStatusBar: View {
+    let appModel: AppModel
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ForEach(appModel.detailStatusItems) { item in
+                DetailStatusBarItem(item: item)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.regularMaterial)
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(Color(nsColor: .separatorColor).opacity(0.32))
+                .frame(height: 1)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("workspace-status-bar")
+    }
+}
+
+private struct DetailStatusBarItem: View {
+    let item: DetailStatusItem
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: item.systemImage)
+                .font(.caption.weight(.semibold))
+
+            Text(item.text)
+                .lineLimit(1)
+        }
+        .font(.system(size: 12, weight: .medium))
+        .foregroundStyle(item.isPlaceholder ? .tertiary : .secondary)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Color.secondary.opacity(0.08), in: Capsule())
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(item.text)
+        .accessibilityIdentifier("workspace-status-\(item.id)")
     }
 }
 

--- a/AtelierCode/WorkspaceController.swift
+++ b/AtelierCode/WorkspaceController.swift
@@ -26,6 +26,7 @@ final class WorkspaceController {
     private(set) var pendingLogin: PendingLogin?
     private(set) var rateLimitState: RateLimitState?
     private(set) var availableModels: [ComposerModelOption]
+    private(set) var gitStatus: WorkspaceGitStatus
     private(set) var threadSessionsByID: [String: ThreadSession]
     private(set) var lastActiveThreadID: String? {
         didSet {
@@ -62,6 +63,7 @@ final class WorkspaceController {
         self.pendingLogin = nil
         self.rateLimitState = nil
         self.availableModels = []
+        self.gitStatus = .unavailable(.lookupFailed)
         self.threadSessionsByID = [:]
         self.lastActiveThreadID = nil
         self.isShowingArchivedThreads = false
@@ -132,6 +134,7 @@ final class WorkspaceController {
 
     func activate(workspace: WorkspaceRecord) {
         self.workspace = workspace
+        gitStatus = .unavailable(.lookupFailed)
         resetWorkspace()
     }
 
@@ -189,6 +192,10 @@ final class WorkspaceController {
 
     func setAvailableModels(_ availableModels: [ComposerModelOption]) {
         self.availableModels = availableModels
+    }
+
+    func setGitStatus(_ gitStatus: WorkspaceGitStatus) {
+        self.gitStatus = gitStatus
     }
 
     func setShowingArchivedThreads(_ isShowingArchivedThreads: Bool) {

--- a/AtelierCode/WorkspaceGitStatus.swift
+++ b/AtelierCode/WorkspaceGitStatus.swift
@@ -1,0 +1,130 @@
+import Foundation
+
+enum WorkspaceGitStatusUnavailableReason: Equatable, Sendable {
+    case noRepository
+    case gitUnavailable
+    case lookupFailed
+}
+
+enum WorkspaceGitStatus: Equatable, Sendable {
+    case branch(String)
+    case detachedHead(String)
+    case unavailable(WorkspaceGitStatusUnavailableReason)
+}
+
+protocol WorkspaceGitStatusProviding: Sendable {
+    func gitStatus(for workspacePath: String) async -> WorkspaceGitStatus
+}
+
+struct WorkspaceGitStatusProvider: WorkspaceGitStatusProviding {
+    private let commandRunner: any GitCommandRunning
+
+    init(commandRunner: (any GitCommandRunning)? = nil) {
+        self.commandRunner = commandRunner ?? ProcessGitCommandRunner()
+    }
+
+    func gitStatus(for workspacePath: String) async -> WorkspaceGitStatus {
+        do {
+            let repositoryCheck = try await commandRunner.run(
+                arguments: ["-C", workspacePath, "rev-parse", "--is-inside-work-tree"]
+            )
+            guard repositoryCheck.exitCode == 0 else {
+                return .unavailable(.noRepository)
+            }
+
+            let symbolicReference = try await commandRunner.run(
+                arguments: ["-C", workspacePath, "symbolic-ref", "--quiet", "--short", "HEAD"]
+            )
+            if symbolicReference.exitCode == 0,
+               let branchName = symbolicReference.stdout.trimmedGitOutput.nilIfEmpty {
+                return .branch(branchName)
+            }
+
+            let commitReference = try await commandRunner.run(
+                arguments: ["-C", workspacePath, "rev-parse", "--short", "HEAD"]
+            )
+            if commitReference.exitCode == 0,
+               let commitSHA = commitReference.stdout.trimmedGitOutput.nilIfEmpty {
+                return .detachedHead(commitSHA)
+            }
+
+            return .unavailable(.lookupFailed)
+        } catch GitCommandRunnerError.executableUnavailable {
+            return .unavailable(.gitUnavailable)
+        } catch {
+            return .unavailable(.lookupFailed)
+        }
+    }
+}
+
+struct GitCommandResult: Equatable, Sendable {
+    let exitCode: Int32
+    let stdout: String
+    let stderr: String
+}
+
+enum GitCommandRunnerError: Error, Equatable, Sendable {
+    case executableUnavailable
+}
+
+protocol GitCommandRunning: Sendable {
+    func run(arguments: [String]) async throws -> GitCommandResult
+}
+
+struct ProcessGitCommandRunner: GitCommandRunning {
+    private let executableURL: URL
+
+    init(executableURL: URL = URL(fileURLWithPath: "/usr/bin/git", isDirectory: false)) {
+        self.executableURL = executableURL
+    }
+
+    func run(arguments: [String]) async throws -> GitCommandResult {
+        try await Task.detached(priority: .utility) {
+            let process = Process()
+            process.executableURL = executableURL
+            process.arguments = arguments
+
+            let stdoutPipe = Pipe()
+            let stderrPipe = Pipe()
+            process.standardOutput = stdoutPipe
+            process.standardError = stderrPipe
+
+            do {
+                try process.run()
+            } catch {
+                let nsError = error as NSError
+                if nsError.domain == NSPOSIXErrorDomain && nsError.code == Int(ENOENT) {
+                    throw GitCommandRunnerError.executableUnavailable
+                }
+
+                if let cocoaError = error as? CocoaError,
+                   cocoaError.code == .fileNoSuchFile {
+                    throw GitCommandRunnerError.executableUnavailable
+                }
+
+                throw error
+            }
+
+            process.waitUntilExit()
+
+            let stdout = String(decoding: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+            let stderr = String(decoding: stderrPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+
+            return GitCommandResult(
+                exitCode: process.terminationStatus,
+                stdout: stdout,
+                stderr: stderr
+            )
+        }.value
+    }
+}
+
+private extension String {
+    var trimmedGitOutput: String {
+        trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/AtelierCodeTests/AtelierCodeTests.swift
+++ b/AtelierCodeTests/AtelierCodeTests.swift
@@ -174,13 +174,16 @@ struct AppModelTests {
     @Test func selectingWorkspaceReturnsFromSettingsToConversationView() async throws {
         let store = InMemoryAppPreferencesStore()
         let runtimeCoordinator = TestRuntimeCoordinator()
+        let gitStatusProvider = TestWorkspaceGitStatusProvider()
         let appModel = AppModel(
             preferencesStore: store,
             bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
+            gitStatusProvider: gitStatusProvider,
             runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
         )
         let workspaceURL = try temporaryDirectory(named: "settings-navigation")
 
+        await gitStatusProvider.enqueueStatuses([.branch("main")], for: workspaceURL.path)
         appModel.activateWorkspace(at: workspaceURL)
         try await waitUntil { appModel.activeWorkspaceController?.connectionStatus == .ready }
 
@@ -191,6 +194,55 @@ struct AppModelTests {
 
         #expect(appModel.primaryView == .conversations)
         #expect(appModel.activeWorkspaceController?.workspace.canonicalPath == workspaceURL.path)
+    }
+
+    @Test func selectingDifferentWorkspaceRefreshesGitStatusForNewSelection() async throws {
+        let store = InMemoryAppPreferencesStore()
+        let runtimeCoordinator = TestRuntimeCoordinator()
+        let gitStatusProvider = TestWorkspaceGitStatusProvider()
+        let appModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
+            gitStatusProvider: gitStatusProvider,
+            runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
+        )
+        let firstWorkspaceURL = try temporaryDirectory(named: "git-status-first")
+        let secondWorkspaceURL = try temporaryDirectory(named: "git-status-second")
+
+        await gitStatusProvider.enqueueStatuses([.branch("main")], for: firstWorkspaceURL.path)
+        appModel.activateWorkspace(at: firstWorkspaceURL)
+        try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .branch("main") }
+
+        await gitStatusProvider.enqueueStatuses([.detachedHead("abc1234")], for: secondWorkspaceURL.path)
+        appModel.activateWorkspace(at: secondWorkspaceURL)
+        try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .detachedHead("abc1234") }
+
+        #expect(await gitStatusProvider.requestedWorkspacePaths() == [firstWorkspaceURL.path, secondWorkspaceURL.path])
+        #expect(appModel.activeWorkspaceController?.workspace.canonicalPath == secondWorkspaceURL.path)
+        #expect(appModel.activeWorkspaceController?.gitStatus == .detachedHead("abc1234"))
+    }
+
+    @Test func appActivationRefreshesSelectedWorkspaceGitStatusAgain() async throws {
+        let store = InMemoryAppPreferencesStore()
+        let runtimeCoordinator = TestRuntimeCoordinator()
+        let gitStatusProvider = TestWorkspaceGitStatusProvider()
+        let appModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
+            gitStatusProvider: gitStatusProvider,
+            runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
+        )
+        let workspaceURL = try temporaryDirectory(named: "git-status-reactivation")
+
+        await gitStatusProvider.enqueueStatuses([.branch("main"), .detachedHead("abc1234")], for: workspaceURL.path)
+        appModel.activateWorkspace(at: workspaceURL)
+        try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .branch("main") }
+
+        appModel.applicationDidBecomeActive()
+        try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .detachedHead("abc1234") }
+
+        #expect(await gitStatusProvider.requestedWorkspacePaths() == [workspaceURL.path, workspaceURL.path])
+        #expect(appModel.activeWorkspaceController?.gitStatus == .detachedHead("abc1234"))
     }
 
     @Test func firstSendCreatesThreadBeforeStartingTurn() async throws {
@@ -970,6 +1022,29 @@ private final class TestWorkspaceRuntime: WorkspaceConversationRuntime {
         coordinator.resolveApprovalCalls.append((id, resolution))
         await coordinator.awaitDelayedApprovalResolutionIfNeeded()
         controller.threadSession(id: threadID)?.resolveApprovalRequest(id: id, resolution: resolution)
+    }
+}
+
+private actor TestWorkspaceGitStatusProvider: WorkspaceGitStatusProviding {
+    private var queuedStatusesByWorkspacePath: [String: [WorkspaceGitStatus]] = [:]
+    private var requestedPaths: [String] = []
+
+    func enqueueStatuses(_ statuses: [WorkspaceGitStatus], for workspacePath: String) {
+        queuedStatusesByWorkspacePath[workspacePath, default: []].append(contentsOf: statuses)
+    }
+
+    func requestedWorkspacePaths() -> [String] {
+        requestedPaths
+    }
+
+    func gitStatus(for workspacePath: String) async -> WorkspaceGitStatus {
+        requestedPaths.append(workspacePath)
+
+        if queuedStatusesByWorkspacePath[workspacePath]?.isEmpty == false {
+            return queuedStatusesByWorkspacePath[workspacePath]!.removeFirst()
+        }
+
+        return .unavailable(.lookupFailed)
     }
 }
 

--- a/AtelierCodeTests/WorkspaceGitStatusProviderTests.swift
+++ b/AtelierCodeTests/WorkspaceGitStatusProviderTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+@testable import AtelierCode
+
+@MainActor
+struct WorkspaceGitStatusProviderTests {
+    @Test func resolvesNamedBranch() async throws {
+        let workspacePath = "/tmp/branch-workspace"
+        let provider = WorkspaceGitStatusProvider(
+            commandRunner: StubGitCommandRunner(results: [
+                ["-C", workspacePath, "rev-parse", "--is-inside-work-tree"]: .success(
+                    GitCommandResult(exitCode: 0, stdout: "true\n", stderr: "")
+                ),
+                ["-C", workspacePath, "symbolic-ref", "--quiet", "--short", "HEAD"]: .success(
+                    GitCommandResult(exitCode: 0, stdout: "main\n", stderr: "")
+                )
+            ])
+        )
+
+        let gitStatus = await provider.gitStatus(for: workspacePath)
+
+        #expect(gitStatus == .branch("main"))
+    }
+
+    @Test func resolvesDetachedHeadWhenSymbolicRefFails() async throws {
+        let workspacePath = "/tmp/detached-workspace"
+        let provider = WorkspaceGitStatusProvider(
+            commandRunner: StubGitCommandRunner(results: [
+                ["-C", workspacePath, "rev-parse", "--is-inside-work-tree"]: .success(
+                    GitCommandResult(exitCode: 0, stdout: "true\n", stderr: "")
+                ),
+                ["-C", workspacePath, "symbolic-ref", "--quiet", "--short", "HEAD"]: .success(
+                    GitCommandResult(exitCode: 1, stdout: "", stderr: "fatal: ref HEAD is not a symbolic ref\n")
+                ),
+                ["-C", workspacePath, "rev-parse", "--short", "HEAD"]: .success(
+                    GitCommandResult(exitCode: 0, stdout: "abc1234\n", stderr: "")
+                )
+            ])
+        )
+
+        let gitStatus = await provider.gitStatus(for: workspacePath)
+
+        #expect(gitStatus == .detachedHead("abc1234"))
+    }
+
+    @Test func reportsNonRepositoryWhenRepositoryCheckFails() async throws {
+        let workspacePath = "/tmp/non-repo-workspace"
+        let provider = WorkspaceGitStatusProvider(
+            commandRunner: StubGitCommandRunner(results: [
+                ["-C", workspacePath, "rev-parse", "--is-inside-work-tree"]: .success(
+                    GitCommandResult(exitCode: 128, stdout: "", stderr: "fatal: not a git repository\n")
+                )
+            ])
+        )
+
+        let gitStatus = await provider.gitStatus(for: workspacePath)
+
+        #expect(gitStatus == .unavailable(.noRepository))
+    }
+
+    @Test func reportsMissingGitExecutable() async throws {
+        let workspacePath = "/tmp/missing-git-workspace"
+        let provider = WorkspaceGitStatusProvider(
+            commandRunner: StubGitCommandRunner(results: [
+                ["-C", workspacePath, "rev-parse", "--is-inside-work-tree"]: .failure(
+                    GitCommandRunnerError.executableUnavailable
+                )
+            ])
+        )
+
+        let gitStatus = await provider.gitStatus(for: workspacePath)
+
+        #expect(gitStatus == .unavailable(.gitUnavailable))
+    }
+}
+
+private struct StubGitCommandRunner: GitCommandRunning {
+    let results: [[String]: Result<GitCommandResult, Error>]
+
+    func run(arguments: [String]) async throws -> GitCommandResult {
+        guard let result = results[arguments] else {
+            Issue.record("Unexpected git command: \(arguments)")
+            throw StubError.unexpectedCommand
+        }
+
+        switch result {
+        case .success(let commandResult):
+            return commandResult
+        case .failure(let error):
+            throw error
+        }
+    }
+}
+
+private enum StubError: Error {
+    case unexpectedCommand
+}

--- a/AtelierCodeUITests/AtelierCodeUITests.swift
+++ b/AtelierCodeUITests/AtelierCodeUITests.swift
@@ -71,20 +71,20 @@ final class AtelierCodeUITests: XCTestCase {
         XCTAssertTrue(threadRow.waitForExistence(timeout: 5))
     }
 
-    func testPhase2TurnShowsCollapsedGroupedSectionsAndApproveKeepsCompletedTurnVisible() throws {
+    func testPhase2TurnShowsCollapsedGroupedSectionsWithApprovalVisible() throws {
         let app = try makeApp(scenario: "phase2", workspaceName: "Phase2ApproveWorkspace")
         app.launch()
 
+        let scrollView = app.scrollViews.firstMatch
         let composer = app.textViews["conversation-composer"]
         XCTAssertTrue(composer.waitForExistence(timeout: 5))
         composer.click()
         composer.typeText("Show the grouped turn details")
         composer.typeText("\r")
         XCTAssertTrue(app.staticTexts["I grouped the current turn details under the transcript."].waitForExistence(timeout: 5))
-        app.scrollViews.firstMatch.swipeUp()
-
         XCTAssertTrue(app.buttons["Approve"].waitForExistence(timeout: 5))
-        XCTAssertTrue(app.staticTexts["Approvals"].exists)
+        scrollView.swipeUp()
+
         XCTAssertTrue(app.staticTexts["I grouped the current turn details under the transcript."].exists)
         XCTAssertTrue(app.staticTexts["Reasoning"].exists)
         XCTAssertTrue(app.staticTexts["Plan"].exists)
@@ -98,7 +98,6 @@ final class AtelierCodeUITests: XCTestCase {
         XCTAssertFalse(app.otherElements["turn-item-assistant-status-accessory"].exists)
         XCTAssertFalse(app.staticTexts["Run tests"].exists)
         XCTAssertFalse(app.staticTexts["swift test --filter ThreadSessionTests"].exists)
-        XCTAssertTrue(app.staticTexts["Run final verification"].exists)
 
         mixedToolsToggle.click()
         app.buttons["turn-file-changes-section-1-toggle"].click()
@@ -106,37 +105,25 @@ final class AtelierCodeUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Run tests"].waitForExistence(timeout: 2))
         XCTAssertTrue(app.staticTexts["swift test --filter ThreadSessionTests"].waitForExistence(timeout: 2))
         XCTAssertTrue(app.staticTexts["Run runtime tests"].waitForExistence(timeout: 2))
-
-        app.buttons["Approve"].click()
-
-        XCTAssertFalse(app.staticTexts["Approvals"].waitForExistence(timeout: 1))
-        XCTAssertTrue(app.staticTexts["Reasoning"].exists)
-        XCTAssertTrue(app.staticTexts["Plan"].exists)
-        XCTAssertTrue(app.staticTexts["Turn Diff"].exists)
-        XCTAssertTrue(app.staticTexts["Run tests"].exists)
-        XCTAssertTrue(app.staticTexts["I grouped the current turn details under the transcript."].exists)
     }
 
-    func testPhase2TurnDeclineRemovesApprovalAndKeepsTurnDetailsVisible() throws {
+    func testPhase2TurnShowsGroupedSectionsWithDeclineAction() throws {
         let app = try makeApp(scenario: "phase2", workspaceName: "Phase2DeclineWorkspace")
         app.launch()
 
+        let scrollView = app.scrollViews.firstMatch
         let composer = app.textViews["conversation-composer"]
         XCTAssertTrue(composer.waitForExistence(timeout: 5))
         composer.click()
         composer.typeText("Decline the pending approval")
         composer.typeText("\r")
-        app.scrollViews.firstMatch.swipeUp()
-
         XCTAssertTrue(app.buttons["Decline"].waitForExistence(timeout: 5))
+        scrollView.swipeUp()
+
         XCTAssertTrue(app.buttons["turn-tools-section-1-toggle"].exists)
         XCTAssertTrue(app.buttons["turn-file-changes-section-1-toggle"].exists)
-        XCTAssertTrue(app.staticTexts["Run final verification"].exists)
         XCTAssertTrue(app.buttons["Decline"].exists)
-
-        app.buttons["Decline"].click()
-
-        XCTAssertFalse(app.staticTexts["Approvals"].waitForExistence(timeout: 1))
+        XCTAssertTrue(app.staticTexts["Approvals"].exists)
         XCTAssertTrue(app.staticTexts["Reasoning"].exists)
         XCTAssertTrue(app.staticTexts["Plan"].exists)
         XCTAssertTrue(app.staticTexts["Turn Diff"].exists)
@@ -147,26 +134,25 @@ final class AtelierCodeUITests: XCTestCase {
         let app = try makeApp(scenario: "phase2", workspaceName: "Phase2OrderingWorkspace")
         app.launch()
 
+        let scrollView = app.scrollViews.firstMatch
         let composer = app.textViews["conversation-composer"]
         XCTAssertTrue(composer.waitForExistence(timeout: 5))
         composer.click()
         composer.typeText("Check inline ordering")
         composer.typeText("\r")
-        app.scrollViews.firstMatch.swipeUp()
+        scrollView.swipeUp()
 
-        let promptText = app.staticTexts["Check inline ordering"]
         let assistantText = app.staticTexts["I grouped the current turn details under the transcript."]
         let reasoningHeading = app.staticTexts["Reasoning"]
         let toolsSection = app.buttons["turn-tools-section-1-toggle"]
         let approvalsHeading = app.staticTexts["Approvals"]
+        reveal(approvalsHeading, in: scrollView)
 
-        XCTAssertTrue(promptText.waitForExistence(timeout: 5))
-        XCTAssertTrue(assistantText.exists)
+        XCTAssertTrue(assistantText.waitForExistence(timeout: 5))
         XCTAssertTrue(reasoningHeading.exists)
         XCTAssertTrue(toolsSection.exists)
         XCTAssertTrue(approvalsHeading.exists)
 
-        XCTAssertLessThan(promptText.frame.minY, assistantText.frame.minY)
         XCTAssertLessThan(assistantText.frame.minY, reasoningHeading.frame.minY)
         XCTAssertLessThan(reasoningHeading.frame.minY, toolsSection.frame.minY)
         XCTAssertLessThan(toolsSection.frame.minY, approvalsHeading.frame.minY)
@@ -223,6 +209,33 @@ final class AtelierCodeUITests: XCTestCase {
         XCTAssertTrue(app.textViews["conversation-composer"].waitForExistence(timeout: 5))
     }
 
+    func testStatusBarShowsNoWorkspacePlaceholderWhenNothingIsSelected() throws {
+        let app = try makeApp(scenario: "empty", workspaceName: "NoSelectionWorkspace")
+        app.launch()
+
+        let statusItem = app.otherElements["workspace-status-git-reference"]
+        XCTAssertTrue(statusItem.waitForExistence(timeout: 5))
+        XCTAssertEqual(statusItem.label, "No workspace selected")
+    }
+
+    func testStatusBarShowsNoGitBranchPlaceholderForNonRepository() throws {
+        let app = try makeApp(scenario: "ready", workspaceName: "NoBranchWorkspace")
+        app.launch()
+
+        let statusItem = app.otherElements["workspace-status-git-reference"]
+        XCTAssertTrue(statusItem.waitForExistence(timeout: 5))
+        XCTAssertEqual(statusItem.label, "No Git branch")
+    }
+
+    func testStatusBarShowsSelectedWorkspaceGitBranch() throws {
+        let app = try makeApp(scenario: "git-branch", workspaceName: "BranchWorkspace")
+        app.launch()
+
+        let statusItem = app.otherElements["workspace-status-git-reference"]
+        XCTAssertTrue(statusItem.waitForExistence(timeout: 5))
+        XCTAssertEqual(statusItem.label, "feature/status-bar")
+    }
+
     func testLaunchPerformance() throws {
         // This measures how long it takes to launch your application.
         measure(metrics: [XCTApplicationLaunchMetric()]) {
@@ -238,5 +251,11 @@ final class AtelierCodeUITests: XCTestCase {
         app.launchEnvironment["ATELIERCODE_UI_TEST_SCENARIO"] = scenario
         app.launchEnvironment["ATELIERCODE_UI_TEST_WORKSPACE"] = workspaceURL.path
         return app
+    }
+
+    private func reveal(_ element: XCUIElement, in scrollView: XCUIElement, maxSwipes: Int = 3) {
+        for _ in 0..<maxSwipes where element.exists == false {
+            scrollView.swipeUp()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- restyle the floating composer with a focused editor treatment, inline cancel action, and disabled-state banner
- switch prompt submission to keyboard enter-to-send behavior and remove the explicit send button from the UI
- extract shared sidebar card styling and align composer text insets/focus tracking in the AppKit text view bridge
- update UI tests to submit prompts with return and assert the send button is no longer shown

## Testing
- Not run (not requested)