### PR TITLE
[codex] Improve git status and branch picker interactions

### DIFF
--- a/AtelierCode/AppBootstrap.swift
+++ b/AtelierCode/AppBootstrap.swift
@@ -21,10 +21,30 @@ enum AppBootstrap {
         )
         let coordinator = UITestRuntimeCoordinator(scenario: scenario.kind)
 
+        if scenario.kind == .gitBranchLive {
+            let gitService = WorkspaceGitService(
+                commandRunner: ProcessGitCommandRunner(
+                    executableURL: URL(
+                        fileURLWithPath: "/Applications/Xcode.app/Contents/Developer/usr/bin/git",
+                        isDirectory: false
+                    )
+                )
+            )
+
+            return AppModel(
+                preferencesStore: preferencesStore,
+                bridgeDiagnosticProvider: { .bridgePresent(at: workspaceURL.appendingPathComponent("mock-bridge")) },
+                gitService: gitService,
+                runtimeFactory: { UITestWorkspaceRuntime(controller: $0, coordinator: coordinator) }
+            )
+        }
+
+        let gitService = UITestWorkspaceGitService(scenario: scenario.kind)
+
         return AppModel(
             preferencesStore: preferencesStore,
             bridgeDiagnosticProvider: { .bridgePresent(at: workspaceURL.appendingPathComponent("mock-bridge")) },
-            gitStatusProvider: UITestWorkspaceGitStatusProvider(scenario: scenario.kind),
+            gitService: gitService,
             runtimeFactory: { UITestWorkspaceRuntime(controller: $0, coordinator: coordinator) }
         )
     }
@@ -40,6 +60,8 @@ private struct UITestScenario {
         case refreshOmitsThread = "refresh-omits-thread"
         case repeatedWaiting = "repeated-waiting"
         case gitBranch = "git-branch"
+        case gitBranchError = "git-branch-error"
+        case gitBranchLive = "git-branch-live"
     }
 
     let kind: Kind
@@ -85,16 +107,60 @@ private final class InMemoryBootstrapPreferencesStore: AppPreferencesStore {
     }
 }
 
-private struct UITestWorkspaceGitStatusProvider: WorkspaceGitStatusProviding {
+private actor UITestWorkspaceGitService: WorkspaceGitServing {
     let scenario: UITestScenario.Kind
+    private var localBranches: [String]
+    private var currentStatus: WorkspaceGitStatus
 
-    func gitStatus(for workspacePath: String) async -> WorkspaceGitStatus {
+    init(scenario: UITestScenario.Kind) {
+        self.scenario = scenario
+
         switch scenario {
         case .gitBranch:
-            return .branch("feature/status-bar")
-        case .empty, .recentSelection, .ready, .retry, .phase2, .refreshOmitsThread, .repeatedWaiting:
-            return .unavailable(.noRepository)
+            localBranches = ["main", "feature/status-bar", "release"]
+            currentStatus = .branch("feature/status-bar")
+        case .gitBranchError:
+            localBranches = ["main", "feature/status-bar", "release"]
+            currentStatus = .branch("feature/status-bar")
+        case .empty, .recentSelection, .ready, .retry, .phase2, .refreshOmitsThread, .repeatedWaiting, .gitBranchLive:
+            localBranches = []
+            currentStatus = .unavailable(.noRepository)
         }
+    }
+
+    func snapshot(for workspacePath: String) async -> WorkspaceGitSnapshot {
+        WorkspaceGitSnapshot(status: currentStatus, localBranches: localBranches)
+    }
+
+    func switchToBranch(named branchName: String, for workspacePath: String) async throws -> WorkspaceGitSnapshot {
+        if scenario == .gitBranchError {
+            throw WorkspaceGitBranchManagerError.gitRejected(
+                "error: Your local changes to the following files would be overwritten by switch."
+            )
+        }
+
+        guard localBranches.contains(branchName) else {
+            throw WorkspaceGitBranchManagerError.gitRejected("error: pathspec '\(branchName)' did not match any branch.")
+        }
+
+        currentStatus = .branch(branchName)
+        return WorkspaceGitSnapshot(status: currentStatus, localBranches: localBranches)
+    }
+
+    func createAndSwitchToBranch(named branchName: String, for workspacePath: String) async throws -> WorkspaceGitSnapshot {
+        if scenario == .gitBranchError {
+            throw WorkspaceGitBranchManagerError.gitRejected("error: cannot lock ref 'refs/heads/\(branchName)'")
+        }
+
+        guard localBranches.contains(branchName) == false else {
+            currentStatus = .branch(branchName)
+            return WorkspaceGitSnapshot(status: currentStatus, localBranches: localBranches)
+        }
+
+        localBranches.append(branchName)
+        localBranches.sort()
+        currentStatus = .branch(branchName)
+        return WorkspaceGitSnapshot(status: currentStatus, localBranches: localBranches)
     }
 }
 

--- a/AtelierCode/AppModel.swift
+++ b/AtelierCode/AppModel.swift
@@ -339,6 +339,10 @@ final class AppModel {
         refreshSelectedWorkspaceGitStatus()
     }
 
+    func applicationWindowDidBecomeKey() {
+        refreshSelectedWorkspaceGitStatus()
+    }
+
     func selectSettingsSection(_ section: SettingsSection) {
         selectedSettingsSection = section
         primaryView = .settings
@@ -357,13 +361,8 @@ final class AppModel {
         showConversations()
         let threadID = preferredThreadID(for: controller)
         controller.markThreadSelected(threadID)
-        selectedRoute = WorkspaceThreadRoute(
-            workspacePath: canonicalPath,
-            threadID: threadID
-        )
-        lastSelectedWorkspacePath = canonicalPath
+        updateSelectedRoute(workspacePath: canonicalPath, threadID: threadID)
         startWorkspaceRuntimeIfNeeded(for: canonicalPath)
-        refreshGitStatus(for: controller.workspace)
         persistPreferences()
     }
 
@@ -374,13 +373,8 @@ final class AppModel {
         }
 
         showConversations()
-        selectedRoute = WorkspaceThreadRoute(
-            workspacePath: canonicalPath,
-            threadID: nil
-        )
-        lastSelectedWorkspacePath = canonicalPath
+        updateSelectedRoute(workspacePath: canonicalPath, threadID: nil)
         startWorkspaceRuntimeIfNeeded(for: canonicalPath)
-        refreshGitStatus(for: controller.workspace)
         persistPreferences()
     }
 
@@ -428,8 +422,7 @@ final class AppModel {
             }
 
             controller.markThreadSelected(threadID)
-            selectedRoute = WorkspaceThreadRoute(workspacePath: canonicalPath, threadID: threadID)
-            lastSelectedWorkspacePath = canonicalPath
+            updateSelectedRoute(workspacePath: canonicalPath, threadID: threadID)
             persistPreferences()
             return true
         } catch is CancellationError {
@@ -448,11 +441,7 @@ final class AppModel {
 
         showConversations()
         controller.clearActiveThreadSession()
-        selectedRoute = WorkspaceThreadRoute(
-            workspacePath: controller.workspace.canonicalPath,
-            threadID: nil
-        )
-        lastSelectedWorkspacePath = controller.workspace.canonicalPath
+        updateSelectedRoute(workspacePath: controller.workspace.canonicalPath, threadID: nil)
         startWorkspaceRuntimeIfNeeded(for: controller.workspace.canonicalPath)
         persistPreferences()
         return true
@@ -480,11 +469,7 @@ final class AppModel {
         do {
             let session = try await runtime.forkThreadAndWait(id: threadID)
             controller.markThreadSelected(session.threadID)
-            self.selectedRoute = WorkspaceThreadRoute(
-                workspacePath: canonicalPath,
-                threadID: session.threadID
-            )
-            lastSelectedWorkspacePath = canonicalPath
+            updateSelectedRoute(workspacePath: canonicalPath, threadID: session.threadID)
             persistPreferences()
             return true
         } catch is CancellationError {
@@ -559,11 +544,7 @@ final class AppModel {
         do {
             let session = try await runtime.unarchiveThreadAndWait(id: threadID)
             controller.markThreadSelected(session.threadID)
-            self.selectedRoute = WorkspaceThreadRoute(
-                workspacePath: canonicalPath,
-                threadID: session.threadID
-            )
-            lastSelectedWorkspacePath = canonicalPath
+            updateSelectedRoute(workspacePath: canonicalPath, threadID: session.threadID)
             persistPreferences()
             return true
         } catch is CancellationError {
@@ -611,10 +592,7 @@ final class AppModel {
         do {
             let session = try await runtime.rollbackThreadAndWait(id: threadID, numTurns: 1)
             controller.markThreadSelected(session.threadID)
-            self.selectedRoute = WorkspaceThreadRoute(
-                workspacePath: controller.workspace.canonicalPath,
-                threadID: session.threadID
-            )
+            updateSelectedRoute(workspacePath: controller.workspace.canonicalPath, threadID: session.threadID)
             persistPreferences()
             return true
         } catch is CancellationError {
@@ -724,10 +702,7 @@ final class AppModel {
                 let session = try await runtime.startThreadAndWait(title: nil)
                 threadID = session.threadID
                 controller.markThreadSelected(threadID)
-                selectedRoute = WorkspaceThreadRoute(
-                    workspacePath: controller.workspace.canonicalPath,
-                    threadID: threadID
-                )
+                updateSelectedRoute(workspacePath: controller.workspace.canonicalPath, threadID: threadID)
                 persistPreferences()
             }
 
@@ -897,6 +872,17 @@ final class AppModel {
         }
 
         refreshGitStatus(for: workspace)
+    }
+
+    private func updateSelectedRoute(workspacePath: String, threadID: String?) {
+        selectedRoute = WorkspaceThreadRoute(workspacePath: workspacePath, threadID: threadID)
+        lastSelectedWorkspacePath = workspacePath
+
+        guard let controller = workspaceController(for: workspacePath) else {
+            return
+        }
+
+        refreshGitStatus(for: controller.workspace)
     }
 
     private func refreshGitStatus(for workspace: WorkspaceRecord) {

--- a/AtelierCode/AppModel.swift
+++ b/AtelierCode/AppModel.swift
@@ -18,39 +18,43 @@ final class AppModel {
     private(set) var selectedRoute: WorkspaceThreadRoute?
     private(set) var primaryView: AppPrimaryView
     private(set) var selectedSettingsSection: SettingsSection
+    private(set) var branchPickerState: WorkspaceBranchPickerState?
 
     @ObservationIgnored private let preferencesStore: any AppPreferencesStore
     @ObservationIgnored private let fileManager: FileManager
     @ObservationIgnored private let bridgeDiagnosticProvider: () -> StartupDiagnostic
-    @ObservationIgnored private let gitStatusProvider: any WorkspaceGitStatusProviding
+    @ObservationIgnored private let gitService: any WorkspaceGitServing
     @ObservationIgnored private let now: () -> Date
     @ObservationIgnored private let runtimeFactory: @MainActor (WorkspaceController) -> any WorkspaceConversationRuntime
     @ObservationIgnored private var workspaceRuntimes: [String: any WorkspaceConversationRuntime]
     @ObservationIgnored private var runtimeLifecycleTasks: [String: Task<Void, Never>]
     @ObservationIgnored private var gitStatusRefreshTasks: [String: Task<Void, Never>]
+    @ObservationIgnored private var branchPickerRefreshTask: Task<Void, Never>?
 
     init(
         preferencesStore: (any AppPreferencesStore)? = nil,
         fileManager: FileManager = .default,
         bridgeDiagnosticProvider: (() -> StartupDiagnostic)? = nil,
-        gitStatusProvider: (any WorkspaceGitStatusProviding)? = nil,
+        gitService: (any WorkspaceGitServing)? = nil,
         now: @escaping () -> Date = Date.init,
         runtimeFactory: (@MainActor (WorkspaceController) -> any WorkspaceConversationRuntime)? = nil
     ) {
         let resolvedPreferencesStore = preferencesStore ?? UserDefaultsAppPreferencesStore()
         let resolvedBridgeDiagnosticProvider = bridgeDiagnosticProvider ?? { StartupDiagnostic.defaultBridgeDiagnostic() }
-        let resolvedGitStatusProvider = gitStatusProvider ?? WorkspaceGitStatusProvider()
+        let resolvedGitService = gitService ?? WorkspaceGitService()
         let resolvedRuntimeFactory = runtimeFactory ?? { WorkspaceBridgeRuntime(controller: $0) }
 
         self.preferencesStore = resolvedPreferencesStore
         self.fileManager = fileManager
         self.bridgeDiagnosticProvider = resolvedBridgeDiagnosticProvider
-        self.gitStatusProvider = resolvedGitStatusProvider
+        self.gitService = resolvedGitService
         self.now = now
         self.runtimeFactory = resolvedRuntimeFactory
         self.workspaceRuntimes = [:]
         self.runtimeLifecycleTasks = [:]
         self.gitStatusRefreshTasks = [:]
+        self.branchPickerRefreshTask = nil
+        self.branchPickerState = nil
 
         let loadedSnapshot = try? resolvedPreferencesStore.loadSnapshot()
         let normalizedRecentWorkspaces = Self.normalizeRecentWorkspaces(loadedSnapshot?.recentWorkspaces ?? [])
@@ -72,6 +76,7 @@ final class AppModel {
         selectedRoute = nil
         primaryView = .conversations
         selectedSettingsSection = .general
+        branchPickerState = nil
 
         if let codexOverridePath {
             appendStartupDiagnostic(Self.codexOverrideDiagnostic(path: codexOverridePath, fileManager: fileManager))
@@ -224,9 +229,170 @@ final class AppModel {
                 id: "git-reference",
                 systemImage: "arrow.triangle.branch",
                 text: selectedWorkspaceGitStatusText,
-                isPlaceholder: selectedWorkspaceGitStatusIsPlaceholder
+                isPlaceholder: selectedWorkspaceGitStatusIsPlaceholder,
+                isInteractive: selectedWorkspaceGitStatusIsInteractive
             )
         ]
+    }
+
+    var isSelectedWorkspaceBranchPickerPresented: Bool {
+        guard let workspacePath = selectedWorkspaceController?.workspace.canonicalPath else {
+            return false
+        }
+
+        return branchPickerState?.workspacePath == workspacePath
+    }
+
+    var selectedWorkspaceBranchPickerFilterText: String {
+        guard isSelectedWorkspaceBranchPickerPresented else {
+            return ""
+        }
+
+        return branchPickerState?.filterText ?? ""
+    }
+
+    var selectedWorkspaceBranchPickerFilteredBranches: [String] {
+        guard isSelectedWorkspaceBranchPickerPresented else {
+            return []
+        }
+
+        return branchPickerState?.filteredBranches ?? []
+    }
+
+    var selectedWorkspaceBranchPickerCurrentBranchName: String? {
+        return branchPickerState?.currentBranchName
+    }
+
+    var selectedWorkspaceBranchPickerErrorMessage: String? {
+        guard isSelectedWorkspaceBranchPickerPresented else {
+            return nil
+        }
+
+        return branchPickerState?.errorMessage
+    }
+
+    var isSelectedWorkspaceBranchPickerLoading: Bool {
+        guard isSelectedWorkspaceBranchPickerPresented else {
+            return false
+        }
+
+        return branchPickerState?.isLoading ?? false
+    }
+
+    var isSelectedWorkspaceBranchPickerPerformingAction: Bool {
+        guard isSelectedWorkspaceBranchPickerPresented else {
+            return false
+        }
+
+        return branchPickerState?.isPerformingAction ?? false
+    }
+
+    var canCreateSelectedWorkspaceBranchFromPicker: Bool {
+        guard isSelectedWorkspaceBranchPickerPresented else {
+            return false
+        }
+
+        guard let branchPickerState else {
+            return false
+        }
+
+        return branchPickerState.isLoading == false &&
+            branchPickerState.isPerformingAction == false &&
+            branchPickerState.submittedBranchName.isEmpty == false &&
+            branchPickerState.exactMatchName == nil
+    }
+
+    var selectedWorkspaceBranchPickerCreateButtonTitle: String {
+        guard let branchPickerState,
+              branchPickerState.submittedBranchName.isEmpty == false,
+              branchPickerState.exactMatchName == nil else {
+            return "Create and check out new branch..."
+        }
+
+        return "Create and check out \"\(branchPickerState.submittedBranchName)\""
+    }
+
+    func showSelectedWorkspaceBranchPicker() {
+        guard selectedWorkspaceGitStatusIsInteractive else {
+            return
+        }
+
+        guard isSelectedWorkspaceBranchPickerPresented == false else {
+            return
+        }
+
+        presentSelectedWorkspaceBranchPicker()
+    }
+
+    func toggleSelectedWorkspaceBranchPicker() {
+        if isSelectedWorkspaceBranchPickerPresented {
+            dismissSelectedWorkspaceBranchPicker()
+            return
+        }
+
+        showSelectedWorkspaceBranchPicker()
+    }
+
+    func dismissSelectedWorkspaceBranchPicker() {
+        branchPickerRefreshTask?.cancel()
+        branchPickerRefreshTask = nil
+        branchPickerState = nil
+    }
+
+    func setSelectedWorkspaceBranchPickerFilterText(_ filterText: String) {
+        guard isSelectedWorkspaceBranchPickerPresented else {
+            return
+        }
+
+        guard var branchPickerState else {
+            return
+        }
+
+        branchPickerState.filterText = filterText
+        branchPickerState.errorMessage = nil
+        self.branchPickerState = branchPickerState
+    }
+
+    func selectBranchFromPicker(_ branchName: String) async {
+        guard let branchPickerState,
+              isSelectedWorkspaceBranchPickerPresented,
+              branchPickerState.isLoading == false,
+              branchPickerState.isPerformingAction == false else {
+            return
+        }
+
+        if selectedWorkspaceBranchPickerCurrentBranchName == branchName {
+            dismissSelectedWorkspaceBranchPicker()
+            return
+        }
+
+        await performBranchPickerAction(named: branchName, createIfNeeded: false)
+    }
+
+    func submitSelectedWorkspaceBranchPicker() async {
+        guard let exactMatchName = selectedWorkspaceBranchPickerExactMatchName else {
+            await createSelectedWorkspaceBranchFromPicker()
+            return
+        }
+
+        await performBranchPickerAction(named: exactMatchName, createIfNeeded: false)
+    }
+
+    func createSelectedWorkspaceBranchFromPicker() async {
+        guard let branchPickerState else {
+            return
+        }
+
+        let branchName = branchPickerState.submittedBranchName
+        guard branchName.isEmpty == false else {
+            return
+        }
+
+        guard branchPickerState.exactMatchName == nil else {
+            return
+        }
+
+        await performBranchPickerAction(named: branchName, createIfNeeded: true)
     }
 
     func activateWorkspace(at url: URL) {
@@ -265,6 +431,7 @@ final class AppModel {
         showConversations()
         selectedRoute = nil
         lastSelectedWorkspacePath = nil
+        dismissSelectedWorkspaceBranchPicker()
         persistPreferences()
     }
 
@@ -287,6 +454,10 @@ final class AppModel {
                 preferExistingThreadSelection: true
             )
             lastSelectedWorkspacePath = selectedRoute?.workspacePath
+        }
+
+        if branchPickerState?.workspacePath == canonicalPath {
+            resetBranchPickerState(for: selectedRoute?.workspacePath)
         }
 
         persistPreferences()
@@ -368,7 +539,7 @@ final class AppModel {
 
     func selectWorkspaceForNewThread(path: String) {
         let canonicalPath = WorkspaceRecord.canonicalizedPath(for: path)
-        guard let controller = workspaceController(for: canonicalPath) else {
+        guard workspaceController(for: canonicalPath) != nil else {
             return
         }
 
@@ -818,6 +989,23 @@ final class AppModel {
         return false
     }
 
+    private var selectedWorkspaceGitStatusIsInteractive: Bool {
+        guard let controller = selectedWorkspaceController else {
+            return false
+        }
+
+        switch controller.gitStatus {
+        case .branch, .detachedHead:
+            return true
+        case .unavailable:
+            return false
+        }
+    }
+
+    private var selectedWorkspaceBranchPickerExactMatchName: String? {
+        branchPickerState?.exactMatchName
+    }
+
     private func installWorkspacePersistenceHandlers() {
         for controller in workspaceControllers {
             configurePersistenceHandler(for: controller)
@@ -871,10 +1059,11 @@ final class AppModel {
             return
         }
 
-        refreshGitStatus(for: workspace)
+        refreshGitSnapshot(for: workspace)
     }
 
     private func updateSelectedRoute(workspacePath: String, threadID: String?) {
+        resetBranchPickerState(for: workspacePath)
         selectedRoute = WorkspaceThreadRoute(workspacePath: workspacePath, threadID: threadID)
         lastSelectedWorkspacePath = workspacePath
 
@@ -882,10 +1071,10 @@ final class AppModel {
             return
         }
 
-        refreshGitStatus(for: controller.workspace)
+        refreshGitSnapshot(for: controller.workspace)
     }
 
-    private func refreshGitStatus(for workspace: WorkspaceRecord) {
+    private func refreshGitSnapshot(for workspace: WorkspaceRecord) {
         let workspacePath = workspace.canonicalPath
         gitStatusRefreshTasks[workspacePath]?.cancel()
 
@@ -894,14 +1083,156 @@ final class AppModel {
                 return
             }
 
-            let gitStatus = await gitStatusProvider.gitStatus(for: workspacePath)
+            let snapshot = await gitService.snapshot(for: workspacePath)
             guard Task.isCancelled == false,
                   let controller = workspaceController(for: workspacePath) else {
                 return
             }
 
-            controller.setGitStatus(gitStatus)
+            controller.setGitSnapshot(snapshot)
+
+        if case .unavailable = snapshot.status,
+               branchPickerState?.workspacePath == workspacePath {
+                dismissSelectedWorkspaceBranchPicker()
+            }
         }
+    }
+
+    private func presentSelectedWorkspaceBranchPicker() {
+        guard let controller = selectedWorkspaceController,
+              selectedWorkspaceGitStatusIsInteractive else {
+            return
+        }
+
+        let workspacePath = controller.workspace.canonicalPath
+        let currentBranchName = Self.currentBranchName(from: controller.gitStatus)
+        branchPickerState = WorkspaceBranchPickerState(
+            workspacePath: workspacePath,
+            sessionID: UUID(),
+            branchNames: Self.normalizedBranchNames(
+                controller.localGitBranches,
+                currentBranchName: currentBranchName
+            ),
+            currentBranchName: currentBranchName,
+            filterText: "",
+            errorMessage: nil,
+            isLoading: controller.localGitBranches.isEmpty,
+            isPerformingAction: false
+        )
+
+        reloadSelectedWorkspaceBranchPicker()
+    }
+
+    private func reloadSelectedWorkspaceBranchPicker() {
+        guard let branchPickerState else {
+            return
+        }
+
+        let workspacePath = branchPickerState.workspacePath
+        let sessionID = branchPickerState.sessionID
+
+        branchPickerRefreshTask?.cancel()
+        branchPickerRefreshTask = Task { [weak self] in
+            guard let self else {
+                return
+            }
+
+            let snapshot = await gitService.snapshot(for: workspacePath)
+            guard Task.isCancelled == false,
+                  let controller = workspaceController(for: workspacePath),
+                  var currentBranchPickerState = self.branchPickerState,
+                  currentBranchPickerState.sessionID == sessionID,
+                  currentBranchPickerState.workspacePath == workspacePath else {
+                return
+            }
+
+            controller.setGitSnapshot(snapshot)
+
+            if case .unavailable = snapshot.status {
+                dismissSelectedWorkspaceBranchPicker()
+                return
+            }
+
+            currentBranchPickerState.branchNames = Self.normalizedBranchNames(
+                snapshot.localBranches,
+                currentBranchName: Self.currentBranchName(from: snapshot.status)
+            )
+            currentBranchPickerState.currentBranchName = Self.currentBranchName(from: snapshot.status)
+            currentBranchPickerState.isLoading = false
+            self.branchPickerState = currentBranchPickerState
+        }
+    }
+
+    private func performBranchPickerAction(named branchName: String, createIfNeeded: Bool) async {
+        guard let controller = selectedWorkspaceController,
+              var currentBranchPickerState = branchPickerState,
+              currentBranchPickerState.workspacePath == controller.workspace.canonicalPath,
+              currentBranchPickerState.isLoading == false,
+              currentBranchPickerState.isPerformingAction == false else {
+            return
+        }
+
+        let workspacePath = currentBranchPickerState.workspacePath
+        let sessionID = currentBranchPickerState.sessionID
+        currentBranchPickerState.errorMessage = nil
+        currentBranchPickerState.isPerformingAction = true
+        self.branchPickerState = currentBranchPickerState
+
+        do {
+            let snapshot: WorkspaceGitSnapshot
+            if createIfNeeded {
+                snapshot = try await gitService.createAndSwitchToBranch(named: branchName, for: workspacePath)
+            } else {
+                snapshot = try await gitService.switchToBranch(named: branchName, for: workspacePath)
+            }
+
+            guard let refreshedController = workspaceController(for: workspacePath),
+                  var currentBranchPickerState = self.branchPickerState,
+                  currentBranchPickerState.sessionID == sessionID,
+                  currentBranchPickerState.workspacePath == workspacePath else {
+                dismissSelectedWorkspaceBranchPicker()
+                return
+            }
+
+            refreshedController.setGitSnapshot(snapshot)
+            currentBranchPickerState.branchNames = Self.normalizedBranchNames(
+                snapshot.localBranches,
+                currentBranchName: Self.currentBranchName(from: snapshot.status)
+            )
+            currentBranchPickerState.currentBranchName = Self.currentBranchName(from: snapshot.status)
+            currentBranchPickerState.isPerformingAction = false
+            self.branchPickerState = currentBranchPickerState
+            dismissSelectedWorkspaceBranchPicker()
+            refreshGitSnapshot(for: refreshedController.workspace)
+        } catch let error as WorkspaceGitBranchManagerError {
+            guard var currentBranchPickerState = self.branchPickerState,
+                  currentBranchPickerState.sessionID == sessionID,
+                  currentBranchPickerState.workspacePath == workspacePath else {
+                return
+            }
+
+            currentBranchPickerState.isPerformingAction = false
+            currentBranchPickerState.errorMessage = error.message
+            self.branchPickerState = currentBranchPickerState
+        } catch {
+            guard var currentBranchPickerState = self.branchPickerState,
+                  currentBranchPickerState.sessionID == sessionID,
+                  currentBranchPickerState.workspacePath == workspacePath else {
+                return
+            }
+
+            currentBranchPickerState.isPerformingAction = false
+            currentBranchPickerState.errorMessage = error.localizedDescription
+            self.branchPickerState = currentBranchPickerState
+        }
+    }
+
+    private func resetBranchPickerState(for workspacePath: String?) {
+        guard branchPickerState?.workspacePath != workspacePath else {
+            return
+        }
+
+        dismissSelectedWorkspaceBranchPicker()
     }
 
     private func startRuntime(_ runtime: any WorkspaceConversationRuntime, workspacePath: String) async {
@@ -1120,6 +1451,34 @@ final class AppModel {
         return uniqueWorkspaces
     }
 
+    private static func normalizedBranchNames(_ branchNames: [String], currentBranchName: String?) -> [String] {
+        var seenBranchNames = Set<String>()
+        var normalizedBranchNames = branchNames
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { $0.isEmpty == false }
+            .filter { seenBranchNames.insert($0).inserted }
+
+        if let currentBranchName = currentBranchName?.trimmingCharacters(in: .whitespacesAndNewlines),
+           currentBranchName.isEmpty == false,
+           seenBranchNames.insert(currentBranchName).inserted {
+            normalizedBranchNames.append(currentBranchName)
+        }
+
+        normalizedBranchNames.sort { lhs, rhs in
+            lhs.localizedCaseInsensitiveCompare(rhs) == .orderedAscending
+        }
+
+        return normalizedBranchNames
+    }
+
+    private static func currentBranchName(from status: WorkspaceGitStatus) -> String? {
+        guard case .branch(let branchName) = status else {
+            return nil
+        }
+
+        return branchName
+    }
+
     private static func normalizeWorkspaceStates(
         _ workspaceStates: [PersistedWorkspaceState]
     ) -> [String: PersistedWorkspaceState] {
@@ -1185,6 +1544,47 @@ final class AppModel {
     }
 }
 
+struct WorkspaceBranchPickerState: Equatable, Sendable {
+    let workspacePath: String
+    let sessionID: UUID
+    var branchNames: [String]
+    var currentBranchName: String?
+    var filterText: String
+    var errorMessage: String?
+    var isLoading: Bool
+    var isPerformingAction: Bool
+
+    var normalizedFilterText: String {
+        filterText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var submittedBranchName: String {
+        normalizedFilterText
+    }
+
+    var exactMatchName: String? {
+        let branchName = normalizedFilterText
+        guard branchName.isEmpty == false else {
+            return nil
+        }
+
+        return branchNames.first { candidate in
+            candidate == branchName
+        }
+    }
+
+    var filteredBranches: [String] {
+        let filterText = normalizedFilterText
+        guard filterText.isEmpty == false else {
+            return branchNames
+        }
+
+        return branchNames.filter { branchName in
+            branchName.localizedCaseInsensitiveContains(filterText)
+        }
+    }
+}
+
 private extension String {
     var nilIfEmpty: String? {
         isEmpty ? nil : self
@@ -1219,4 +1619,5 @@ struct DetailStatusItem: Identifiable, Equatable, Sendable {
     let systemImage: String
     let text: String
     let isPlaceholder: Bool
+    let isInteractive: Bool
 }

--- a/AtelierCode/AppModel.swift
+++ b/AtelierCode/AppModel.swift
@@ -259,6 +259,22 @@ final class AppModel {
         return branchPickerState?.filteredBranches ?? []
     }
 
+    var selectedWorkspaceBranchPickerItems: [WorkspaceBranchPickerItem] {
+        guard isSelectedWorkspaceBranchPickerPresented else {
+            return []
+        }
+
+        return branchPickerState?.items ?? []
+    }
+
+    var selectedWorkspaceBranchPickerSelectedItemID: WorkspaceBranchPickerItem.ID? {
+        guard isSelectedWorkspaceBranchPickerPresented else {
+            return nil
+        }
+
+        return branchPickerState?.selectedItemID
+    }
+
     var selectedWorkspaceBranchPickerCurrentBranchName: String? {
         return branchPickerState?.currentBranchName
     }
@@ -296,20 +312,7 @@ final class AppModel {
             return false
         }
 
-        return branchPickerState.isLoading == false &&
-            branchPickerState.isPerformingAction == false &&
-            branchPickerState.submittedBranchName.isEmpty == false &&
-            branchPickerState.exactMatchName == nil
-    }
-
-    var selectedWorkspaceBranchPickerCreateButtonTitle: String {
-        guard let branchPickerState,
-              branchPickerState.submittedBranchName.isEmpty == false,
-              branchPickerState.exactMatchName == nil else {
-            return "Create and check out new branch..."
-        }
-
-        return "Create and check out \"\(branchPickerState.submittedBranchName)\""
+        return branchPickerState.canCreateBranch
     }
 
     func showSelectedWorkspaceBranchPicker() {
@@ -348,8 +351,17 @@ final class AppModel {
             return
         }
 
-        branchPickerState.filterText = filterText
-        branchPickerState.errorMessage = nil
+        branchPickerState.setFilterText(filterText)
+        self.branchPickerState = branchPickerState
+    }
+
+    func moveSelectedWorkspaceBranchPickerSelection(_ direction: WorkspaceBranchPickerSelectionDirection) {
+        guard isSelectedWorkspaceBranchPickerPresented,
+              var branchPickerState else {
+            return
+        }
+
+        branchPickerState.moveSelection(direction)
         self.branchPickerState = branchPickerState
     }
 
@@ -370,12 +382,16 @@ final class AppModel {
     }
 
     func submitSelectedWorkspaceBranchPicker() async {
-        guard let exactMatchName = selectedWorkspaceBranchPickerExactMatchName else {
-            await createSelectedWorkspaceBranchFromPicker()
+        guard let selectedItem = branchPickerState?.selectedItem else {
             return
         }
 
-        await performBranchPickerAction(named: exactMatchName, createIfNeeded: false)
+        switch selectedItem {
+        case .branch(let branchName):
+            await selectBranchFromPicker(branchName)
+        case .create(let branchName):
+            await performBranchPickerAction(named: branchName, createIfNeeded: true)
+        }
     }
 
     func createSelectedWorkspaceBranchFromPicker() async {
@@ -1002,10 +1018,6 @@ final class AppModel {
         }
     }
 
-    private var selectedWorkspaceBranchPickerExactMatchName: String? {
-        branchPickerState?.exactMatchName
-    }
-
     private func installWorkspacePersistenceHandlers() {
         for controller in workspaceControllers {
             configurePersistenceHandler(for: controller)
@@ -1115,10 +1127,13 @@ final class AppModel {
             ),
             currentBranchName: currentBranchName,
             filterText: "",
+            selectedItemID: nil,
             errorMessage: nil,
             isLoading: controller.localGitBranches.isEmpty,
             isPerformingAction: false
         )
+
+        branchPickerState?.selectDefaultItem()
 
         reloadSelectedWorkspaceBranchPicker()
     }
@@ -1159,6 +1174,7 @@ final class AppModel {
             )
             currentBranchPickerState.currentBranchName = Self.currentBranchName(from: snapshot.status)
             currentBranchPickerState.isLoading = false
+            currentBranchPickerState.syncSelection()
             self.branchPickerState = currentBranchPickerState
         }
     }
@@ -1550,6 +1566,7 @@ struct WorkspaceBranchPickerState: Equatable, Sendable {
     var branchNames: [String]
     var currentBranchName: String?
     var filterText: String
+    var selectedItemID: WorkspaceBranchPickerItem.ID?
     var errorMessage: String?
     var isLoading: Bool
     var isPerformingAction: Bool
@@ -1581,6 +1598,119 @@ struct WorkspaceBranchPickerState: Equatable, Sendable {
 
         return branchNames.filter { branchName in
             branchName.localizedCaseInsensitiveContains(filterText)
+        }
+    }
+
+    var canCreateBranch: Bool {
+        isLoading == false &&
+        isPerformingAction == false &&
+        submittedBranchName.isEmpty == false &&
+        exactMatchName == nil
+    }
+
+    var items: [WorkspaceBranchPickerItem] {
+        var items = filteredBranches.map(WorkspaceBranchPickerItem.branch)
+
+        if canCreateBranch {
+            items.append(.create(submittedBranchName))
+        }
+
+        return items
+    }
+
+    var selectedItem: WorkspaceBranchPickerItem? {
+        guard let selectedItemID else {
+            return items.first(where: { $0.id == defaultSelectedItemID })
+        }
+
+        return items.first(where: { $0.id == selectedItemID })
+    }
+
+    mutating func setFilterText(_ filterText: String) {
+        self.filterText = filterText
+        errorMessage = nil
+        selectDefaultItem()
+    }
+
+    mutating func moveSelection(_ direction: WorkspaceBranchPickerSelectionDirection) {
+        let items = items
+        guard items.isEmpty == false else {
+            selectedItemID = nil
+            return
+        }
+
+        guard let selectedItemID,
+              let selectedIndex = items.firstIndex(where: { $0.id == selectedItemID }) else {
+            self.selectedItemID = defaultSelectedItemID
+            return
+        }
+
+        let nextIndex: Int
+        switch direction {
+        case .up:
+            nextIndex = max(selectedIndex - 1, 0)
+        case .down:
+            nextIndex = min(selectedIndex + 1, items.count - 1)
+        }
+
+        self.selectedItemID = items[nextIndex].id
+    }
+
+    mutating func selectDefaultItem() {
+        selectedItemID = defaultSelectedItemID
+    }
+
+    mutating func syncSelection() {
+        let items = items
+        guard items.isEmpty == false else {
+            selectedItemID = nil
+            return
+        }
+
+        guard let selectedItemID,
+              items.contains(where: { $0.id == selectedItemID }) else {
+            self.selectedItemID = defaultSelectedItemID
+            return
+        }
+    }
+
+    private var defaultSelectedItemID: WorkspaceBranchPickerItem.ID? {
+        let items = items
+        guard items.isEmpty == false else {
+            return nil
+        }
+
+        if normalizedFilterText.isEmpty,
+           let currentBranchName,
+           let currentBranchItem = items.first(where: {
+               if case .branch(let branchName) = $0 {
+                   return branchName == currentBranchName
+               }
+
+               return false
+           }) {
+            return currentBranchItem.id
+        }
+
+        return items.first?.id
+    }
+}
+
+enum WorkspaceBranchPickerSelectionDirection: Sendable {
+    case up
+    case down
+}
+
+enum WorkspaceBranchPickerItem: Identifiable, Equatable, Sendable {
+    case branch(String)
+    case create(String)
+
+    var id: String {
+        switch self {
+        case .branch(let branchName):
+            return "branch:\(branchName)"
+        case .create(let branchName):
+            return "create:\(branchName)"
         }
     }
 }

--- a/AtelierCode/AtelierCodeApp.swift
+++ b/AtelierCode/AtelierCodeApp.swift
@@ -6,10 +6,10 @@
 //
 
 import SwiftUI
+import AppKit
 
 @main
 struct AtelierCodeApp: App {
-    @Environment(\.scenePhase) private var scenePhase
     @State private var appModel: AppModel
 
     @MainActor
@@ -22,12 +22,11 @@ struct AtelierCodeApp: App {
             ContentView()
                 .environment(appModel)
                 .preferredColorScheme(appModel.appearancePreference.preferredColorScheme)
-                .onChange(of: scenePhase) { _, newValue in
-                    guard newValue == .active else {
-                        return
-                    }
-
+                .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
                     appModel.applicationDidBecomeActive()
+                }
+                .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { _ in
+                    appModel.applicationWindowDidBecomeKey()
                 }
         }
     }

--- a/AtelierCode/ContentView.swift
+++ b/AtelierCode/ContentView.swift
@@ -1205,6 +1205,7 @@ private struct DetailStatusBarItem: View {
 
 private struct BranchPickerPopover: View {
     let appModel: AppModel
+    @FocusState private var isFilterFieldFocused: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -1212,8 +1213,9 @@ private struct BranchPickerPopover: View {
                 Image(systemName: "magnifyingglass")
                     .foregroundStyle(.secondary)
 
-                TextField("Search branches", text: filterTextBinding)
+                TextField("Search or create branch", text: filterTextBinding)
                     .textFieldStyle(.plain)
+                    .focused($isFilterFieldFocused)
                     .onSubmit {
                         Task {
                             await appModel.submitSelectedWorkspaceBranchPicker()
@@ -1226,10 +1228,10 @@ private struct BranchPickerPopover: View {
             .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
 
             Text("Branches")
-                .font(.caption.weight(.semibold))
+                .font(.caption.weight(.medium))
                 .foregroundStyle(.secondary)
                 .textCase(.uppercase)
-                .tracking(0.8)
+                .tracking(0.5)
 
             if appModel.isSelectedWorkspaceBranchPickerLoading &&
                 appModel.selectedWorkspaceBranchPickerFilteredBranches.isEmpty {
@@ -1255,35 +1257,27 @@ private struct BranchPickerPopover: View {
                     .fixedSize(horizontal: false, vertical: true)
                     .accessibilityIdentifier("branch-picker-error")
             }
-
-            Divider()
-
-            Button {
-                Task {
-                    await appModel.createSelectedWorkspaceBranchFromPicker()
-                }
-            } label: {
-                HStack(spacing: 12) {
-                    Image(systemName: "plus")
-                        .font(.system(size: 18, weight: .medium))
-
-                    Text(appModel.selectedWorkspaceBranchPickerCreateButtonTitle)
-                        .font(.headline)
-
-                    Spacer(minLength: 0)
-                }
-                .padding(.horizontal, 6)
-                .padding(.vertical, 4)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .buttonStyle(.plain)
-            .disabled(appModel.canCreateSelectedWorkspaceBranchFromPicker == false)
-            .accessibilityIdentifier("branch-picker-create-action")
         }
         .padding(16)
         .frame(width: 360)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("branch-picker-popover")
+        .onAppear {
+            isFilterFieldFocused = true
+        }
+        .onMoveCommand { direction in
+            switch direction {
+            case .up:
+                appModel.moveSelectedWorkspaceBranchPickerSelection(.up)
+            case .down:
+                appModel.moveSelectedWorkspaceBranchPickerSelection(.down)
+            default:
+                break
+            }
+        }
+        .onExitCommand {
+            appModel.dismissSelectedWorkspaceBranchPicker()
+        }
     }
 
     private var filterTextBinding: Binding<String> {
@@ -1298,30 +1292,43 @@ private struct BranchPickerBranchList: View {
     let appModel: AppModel
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 4) {
-                if appModel.selectedWorkspaceBranchPickerFilteredBranches.isEmpty {
-                    Text(emptyStateText)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.vertical, 12)
-                        .accessibilityIdentifier("branch-picker-empty-state")
-                } else {
-                    ForEach(appModel.selectedWorkspaceBranchPickerFilteredBranches, id: \.self) { branchName in
-                        BranchPickerRow(
-                            branchName: branchName,
-                            isCurrentBranch: appModel.selectedWorkspaceBranchPickerCurrentBranchName == branchName,
-                            isDisabled: appModel.isSelectedWorkspaceBranchPickerPerformingAction
-                        ) {
-                            Task {
-                                await appModel.selectBranchFromPicker(branchName)
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 4) {
+                    if appModel.selectedWorkspaceBranchPickerItems.isEmpty {
+                        Text(emptyStateText)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.vertical, 12)
+                            .accessibilityIdentifier("branch-picker-empty-state")
+                    } else {
+                        ForEach(appModel.selectedWorkspaceBranchPickerItems) { item in
+                            BranchPickerRow(
+                                item: item,
+                                isCurrentBranch: currentBranchName(for: item) == appModel.selectedWorkspaceBranchPickerCurrentBranchName,
+                                isSelected: appModel.selectedWorkspaceBranchPickerSelectedItemID == item.id,
+                                isDisabled: appModel.isSelectedWorkspaceBranchPickerPerformingAction
+                            ) {
+                                Task {
+                                    await performAction(for: item)
+                                }
                             }
+                            .id(item.id)
                         }
                     }
                 }
+                .padding(2)
             }
-            .padding(2)
+            .onChange(of: appModel.selectedWorkspaceBranchPickerSelectedItemID) { _, selectedItemID in
+                guard let selectedItemID else {
+                    return
+                }
+
+                withAnimation(.easeInOut(duration: 0.12)) {
+                    proxy.scrollTo(selectedItemID, anchor: .center)
+                }
+            }
         }
         .frame(minHeight: 140, maxHeight: 220)
         .background(Color.secondary.opacity(0.03), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
@@ -1339,52 +1346,127 @@ private struct BranchPickerBranchList: View {
             return "No local branches found."
         }
 
-        if appModel.canCreateSelectedWorkspaceBranchFromPicker {
-            return "No branches match \"\(filterText)\". Press Return to create and check out this branch."
+        return "No branches match \"\(filterText)\"."
+    }
+
+    private func currentBranchName(for item: WorkspaceBranchPickerItem) -> String? {
+        guard case .branch(let branchName) = item else {
+            return nil
         }
 
-        return "No branches match \"\(filterText)\"."
+        return branchName
+    }
+
+    private func performAction(for item: WorkspaceBranchPickerItem) async {
+        switch item {
+        case .branch(let branchName):
+            await appModel.selectBranchFromPicker(branchName)
+        case .create:
+            await appModel.createSelectedWorkspaceBranchFromPicker()
+        }
     }
 }
 
 private struct BranchPickerRow: View {
-    let branchName: String
+    let item: WorkspaceBranchPickerItem
     let isCurrentBranch: Bool
+    let isSelected: Bool
     let isDisabled: Bool
     let action: () -> Void
 
     var body: some View {
         Button(action: action) {
             HStack(spacing: 12) {
-                Image(systemName: "arrow.triangle.branch")
-                    .font(.system(size: 14, weight: .medium))
+                Image(systemName: iconName)
+                    .font(.system(size: 13, weight: .medium))
                     .foregroundStyle(.secondary)
 
-                Text(branchName)
-                    .font(.headline)
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.system(size: 13, weight: .regular))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+
+                    if let subtitle {
+                        Text(subtitle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
 
                 Spacer(minLength: 0)
 
                 if isCurrentBranch {
                     Image(systemName: "checkmark")
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundStyle(.primary)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(isSelected ? Color.accentColor : Color.primary)
                 }
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 9)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(backgroundColor, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .stroke(borderColor, lineWidth: isSelected ? 1 : 0)
+            }
         }
         .buttonStyle(.plain)
         .disabled(isDisabled)
-        .accessibilityIdentifier("branch-picker-item-\(branchName)")
+        .accessibilityIdentifier(accessibilityIdentifier)
     }
 
     private var backgroundColor: Color {
-        isCurrentBranch ? Color.accentColor.opacity(0.12) : Color.clear
+        if isSelected {
+            return Color.accentColor.opacity(0.14)
+        }
+
+        if isCurrentBranch {
+            return Color.accentColor.opacity(0.07)
+        }
+
+        return Color.clear
+    }
+
+    private var borderColor: Color {
+        isSelected ? Color.accentColor.opacity(0.4) : .clear
+    }
+
+    private var iconName: String {
+        switch item {
+        case .branch:
+            return "arrow.triangle.branch"
+        case .create:
+            return "plus"
+        }
+    }
+
+    private var title: String {
+        switch item {
+        case .branch(let branchName):
+            return branchName
+        case .create:
+            return "Create and check out branch"
+        }
+    }
+
+    private var subtitle: String? {
+        switch item {
+        case .branch:
+            return nil
+        case .create(let branchName):
+            return branchName
+        }
+    }
+
+    private var accessibilityIdentifier: String {
+        switch item {
+        case .branch(let branchName):
+            return "branch-picker-item-\(branchName)"
+        case .create:
+            return "branch-picker-create-item"
+        }
     }
 }
 

--- a/AtelierCode/ContentView.swift
+++ b/AtelierCode/ContentView.swift
@@ -1126,7 +1126,7 @@ private struct DetailStatusBar: View {
     var body: some View {
         HStack(spacing: 12) {
             ForEach(appModel.detailStatusItems) { item in
-                DetailStatusBarItem(item: item)
+                DetailStatusBarItem(appModel: appModel, item: item)
             }
 
             Spacer(minLength: 0)
@@ -1146,9 +1146,36 @@ private struct DetailStatusBar: View {
 }
 
 private struct DetailStatusBarItem: View {
+    let appModel: AppModel
     let item: DetailStatusItem
 
     var body: some View {
+        ZStack {
+            if item.isInteractive && item.id == "git-reference" {
+                Button {
+                    appModel.toggleSelectedWorkspaceBranchPicker()
+                } label: {
+                    content
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("workspace-status-\(item.id)")
+                .accessibilityLabel(item.text)
+            } else {
+                content
+                    .accessibilityIdentifier("workspace-status-\(item.id)")
+                    .accessibilityLabel(item.text)
+            }
+        }
+        .popover(
+            isPresented: item.id == "git-reference" ? branchPickerPresentation : .constant(false),
+            attachmentAnchor: .rect(.bounds),
+            arrowEdge: .bottom
+        ) {
+            BranchPickerPopover(appModel: appModel)
+        }
+    }
+
+    private var content: some View {
         HStack(spacing: 8) {
             Image(systemName: item.systemImage)
                 .font(.caption.weight(.semibold))
@@ -1162,8 +1189,202 @@ private struct DetailStatusBarItem: View {
         .padding(.vertical, 6)
         .background(Color.secondary.opacity(0.08), in: Capsule())
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel(item.text)
-        .accessibilityIdentifier("workspace-status-\(item.id)")
+    }
+
+    private var branchPickerPresentation: Binding<Bool> {
+        Binding(
+            get: { appModel.isSelectedWorkspaceBranchPickerPresented },
+            set: { isPresented in
+                if isPresented == false {
+                    appModel.dismissSelectedWorkspaceBranchPicker()
+                }
+            }
+        )
+    }
+}
+
+private struct BranchPickerPopover: View {
+    let appModel: AppModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(spacing: 10) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+
+                TextField("Search branches", text: filterTextBinding)
+                    .textFieldStyle(.plain)
+                    .onSubmit {
+                        Task {
+                            await appModel.submitSelectedWorkspaceBranchPicker()
+                        }
+                    }
+                    .accessibilityIdentifier("branch-picker-filter")
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+
+            Text("Branches")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+                .tracking(0.8)
+
+            if appModel.isSelectedWorkspaceBranchPickerLoading &&
+                appModel.selectedWorkspaceBranchPickerFilteredBranches.isEmpty {
+                HStack(spacing: 10) {
+                    ProgressView()
+                        .controlSize(.small)
+
+                    Text("Loading local branches…")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 12)
+            } else {
+                BranchPickerBranchList(appModel: appModel)
+            }
+
+            if let errorMessage = appModel.selectedWorkspaceBranchPickerErrorMessage,
+               errorMessage.isEmpty == false {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("branch-picker-error")
+            }
+
+            Divider()
+
+            Button {
+                Task {
+                    await appModel.createSelectedWorkspaceBranchFromPicker()
+                }
+            } label: {
+                HStack(spacing: 12) {
+                    Image(systemName: "plus")
+                        .font(.system(size: 18, weight: .medium))
+
+                    Text(appModel.selectedWorkspaceBranchPickerCreateButtonTitle)
+                        .font(.headline)
+
+                    Spacer(minLength: 0)
+                }
+                .padding(.horizontal, 6)
+                .padding(.vertical, 4)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .buttonStyle(.plain)
+            .disabled(appModel.canCreateSelectedWorkspaceBranchFromPicker == false)
+            .accessibilityIdentifier("branch-picker-create-action")
+        }
+        .padding(16)
+        .frame(width: 360)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("branch-picker-popover")
+    }
+
+    private var filterTextBinding: Binding<String> {
+        Binding(
+            get: { appModel.selectedWorkspaceBranchPickerFilterText },
+            set: { appModel.setSelectedWorkspaceBranchPickerFilterText($0) }
+        )
+    }
+}
+
+private struct BranchPickerBranchList: View {
+    let appModel: AppModel
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 4) {
+                if appModel.selectedWorkspaceBranchPickerFilteredBranches.isEmpty {
+                    Text(emptyStateText)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.vertical, 12)
+                        .accessibilityIdentifier("branch-picker-empty-state")
+                } else {
+                    ForEach(appModel.selectedWorkspaceBranchPickerFilteredBranches, id: \.self) { branchName in
+                        BranchPickerRow(
+                            branchName: branchName,
+                            isCurrentBranch: appModel.selectedWorkspaceBranchPickerCurrentBranchName == branchName,
+                            isDisabled: appModel.isSelectedWorkspaceBranchPickerPerformingAction
+                        ) {
+                            Task {
+                                await appModel.selectBranchFromPicker(branchName)
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(2)
+        }
+        .frame(minHeight: 140, maxHeight: 220)
+        .background(Color.secondary.opacity(0.03), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(Color(nsColor: .separatorColor).opacity(0.22), lineWidth: 1)
+        }
+    }
+
+    private var emptyStateText: String {
+        let filterText = appModel.selectedWorkspaceBranchPickerFilterText
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if filterText.isEmpty {
+            return "No local branches found."
+        }
+
+        if appModel.canCreateSelectedWorkspaceBranchFromPicker {
+            return "No branches match \"\(filterText)\". Press Return to create and check out this branch."
+        }
+
+        return "No branches match \"\(filterText)\"."
+    }
+}
+
+private struct BranchPickerRow: View {
+    let branchName: String
+    let isCurrentBranch: Bool
+    let isDisabled: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: "arrow.triangle.branch")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.secondary)
+
+                Text(branchName)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+
+                Spacer(minLength: 0)
+
+                if isCurrentBranch {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(.primary)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 9)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(backgroundColor, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled)
+        .accessibilityIdentifier("branch-picker-item-\(branchName)")
+    }
+
+    private var backgroundColor: Color {
+        isCurrentBranch ? Color.accentColor.opacity(0.12) : Color.clear
     }
 }
 

--- a/AtelierCode/WorkspaceController.swift
+++ b/AtelierCode/WorkspaceController.swift
@@ -27,6 +27,7 @@ final class WorkspaceController {
     private(set) var rateLimitState: RateLimitState?
     private(set) var availableModels: [ComposerModelOption]
     private(set) var gitStatus: WorkspaceGitStatus
+    private(set) var localGitBranches: [String]
     private(set) var threadSessionsByID: [String: ThreadSession]
     private(set) var lastActiveThreadID: String? {
         didSet {
@@ -64,6 +65,7 @@ final class WorkspaceController {
         self.rateLimitState = nil
         self.availableModels = []
         self.gitStatus = .unavailable(.lookupFailed)
+        self.localGitBranches = []
         self.threadSessionsByID = [:]
         self.lastActiveThreadID = nil
         self.isShowingArchivedThreads = false
@@ -148,6 +150,8 @@ final class WorkspaceController {
         pendingLogin = nil
         rateLimitState = nil
         availableModels = []
+        gitStatus = .unavailable(.lookupFailed)
+        localGitBranches = []
         threadSessionsByID.removeAll()
         lastActiveThreadID = nil
         isShowingArchivedThreads = false
@@ -196,6 +200,15 @@ final class WorkspaceController {
 
     func setGitStatus(_ gitStatus: WorkspaceGitStatus) {
         self.gitStatus = gitStatus
+    }
+
+    func setLocalGitBranches(_ localGitBranches: [String]) {
+        self.localGitBranches = localGitBranches
+    }
+
+    func setGitSnapshot(_ snapshot: WorkspaceGitSnapshot) {
+        gitStatus = snapshot.status
+        localGitBranches = snapshot.localBranches
     }
 
     func setShowingArchivedThreads(_ isShowingArchivedThreads: Bool) {

--- a/AtelierCode/WorkspaceGitStatus.swift
+++ b/AtelierCode/WorkspaceGitStatus.swift
@@ -12,48 +12,153 @@ enum WorkspaceGitStatus: Equatable, Sendable {
     case unavailable(WorkspaceGitStatusUnavailableReason)
 }
 
-protocol WorkspaceGitStatusProviding: Sendable {
-    func gitStatus(for workspacePath: String) async -> WorkspaceGitStatus
+struct WorkspaceGitSnapshot: Equatable, Sendable {
+    let status: WorkspaceGitStatus
+    let localBranches: [String]
 }
 
-struct WorkspaceGitStatusProvider: WorkspaceGitStatusProviding {
+enum WorkspaceGitBranchManagerError: Error, Equatable, Sendable {
+    case gitUnavailable
+    case gitRejected(String)
+
+    var message: String {
+        switch self {
+        case .gitUnavailable:
+            return "Git is not available."
+        case .gitRejected(let message):
+            return message
+        }
+    }
+}
+
+protocol WorkspaceGitServing: Sendable {
+    func snapshot(for workspacePath: String) async -> WorkspaceGitSnapshot
+    func switchToBranch(named branchName: String, for workspacePath: String) async throws -> WorkspaceGitSnapshot
+    func createAndSwitchToBranch(named branchName: String, for workspacePath: String) async throws -> WorkspaceGitSnapshot
+}
+
+struct WorkspaceGitService: WorkspaceGitServing {
     private let commandRunner: any GitCommandRunning
 
     init(commandRunner: (any GitCommandRunning)? = nil) {
         self.commandRunner = commandRunner ?? ProcessGitCommandRunner()
     }
 
-    func gitStatus(for workspacePath: String) async -> WorkspaceGitStatus {
+    func snapshot(for workspacePath: String) async -> WorkspaceGitSnapshot {
+        await loadSnapshot(for: workspacePath)
+    }
+
+    func switchToBranch(named branchName: String, for workspacePath: String) async throws -> WorkspaceGitSnapshot {
+        _ = try await run(arguments: ["-C", workspacePath, "switch", branchName])
+        let snapshot = await loadSnapshot(for: workspacePath)
+
+        return snapshot.withFallbackBranchName(branchName)
+    }
+
+    func createAndSwitchToBranch(named branchName: String, for workspacePath: String) async throws -> WorkspaceGitSnapshot {
+        _ = try await run(arguments: ["-C", workspacePath, "switch", "-c", branchName])
+        let snapshot = await loadSnapshot(for: workspacePath)
+
+        return snapshot.withFallbackBranchName(branchName)
+    }
+
+    private func loadSnapshot(for workspacePath: String) async -> WorkspaceGitSnapshot {
         do {
             let repositoryCheck = try await commandRunner.run(
                 arguments: ["-C", workspacePath, "rev-parse", "--is-inside-work-tree"]
             )
             guard repositoryCheck.exitCode == 0 else {
-                return .unavailable(.noRepository)
+                return WorkspaceGitSnapshot(status: .unavailable(.noRepository), localBranches: [])
             }
 
-            let symbolicReference = try await commandRunner.run(
-                arguments: ["-C", workspacePath, "symbolic-ref", "--quiet", "--short", "HEAD"]
+            let status = try await resolveStatus(for: workspacePath)
+            let localBranches = try await resolveLocalBranches(
+                for: workspacePath,
+                currentBranchName: status.currentBranchName
             )
-            if symbolicReference.exitCode == 0,
-               let branchName = symbolicReference.stdout.trimmedGitOutput.nilIfEmpty {
-                return .branch(branchName)
-            }
 
-            let commitReference = try await commandRunner.run(
-                arguments: ["-C", workspacePath, "rev-parse", "--short", "HEAD"]
+            return WorkspaceGitSnapshot(
+                status: status,
+                localBranches: localBranches
             )
-            if commitReference.exitCode == 0,
-               let commitSHA = commitReference.stdout.trimmedGitOutput.nilIfEmpty {
-                return .detachedHead(commitSHA)
-            }
-
-            return .unavailable(.lookupFailed)
         } catch GitCommandRunnerError.executableUnavailable {
-            return .unavailable(.gitUnavailable)
+            return WorkspaceGitSnapshot(status: .unavailable(.gitUnavailable), localBranches: [])
         } catch {
-            return .unavailable(.lookupFailed)
+            return WorkspaceGitSnapshot(status: .unavailable(.lookupFailed), localBranches: [])
         }
+    }
+
+    private func resolveStatus(for workspacePath: String) async throws -> WorkspaceGitStatus {
+        let symbolicReference = try await commandRunner.run(
+            arguments: ["-C", workspacePath, "symbolic-ref", "--quiet", "--short", "HEAD"]
+        )
+        if symbolicReference.exitCode == 0,
+           let branchName = symbolicReference.stdout.trimmedGitOutput.nilIfEmpty {
+            return .branch(branchName)
+        }
+
+        let commitReference = try await commandRunner.run(
+            arguments: ["-C", workspacePath, "rev-parse", "--short", "HEAD"]
+        )
+        if commitReference.exitCode == 0,
+           let commitSHA = commitReference.stdout.trimmedGitOutput.nilIfEmpty {
+            return .detachedHead(commitSHA)
+        }
+
+        return .unavailable(.lookupFailed)
+    }
+
+    private func resolveLocalBranches(for workspacePath: String, currentBranchName: String?) async throws -> [String] {
+        let result = try await commandRunner.run(
+            arguments: ["-C", workspacePath, "for-each-ref", "--format=%(refname:short)", "refs/heads"]
+        )
+
+        guard result.exitCode == 0 else {
+            return Self.normalizeLocalBranches([], currentBranchName: currentBranchName)
+        }
+
+        let localBranches = result.stdout
+            .split(whereSeparator: \.isNewline)
+            .map(String.init)
+
+        return Self.normalizeLocalBranches(localBranches, currentBranchName: currentBranchName)
+    }
+
+    private func run(arguments: [String]) async throws -> GitCommandResult {
+        do {
+            let result = try await commandRunner.run(arguments: arguments)
+            guard result.exitCode == 0 else {
+                throw WorkspaceGitBranchManagerError.gitRejected(result.failureMessage)
+            }
+
+            return result
+        } catch GitCommandRunnerError.executableUnavailable {
+            throw WorkspaceGitBranchManagerError.gitUnavailable
+        } catch let error as WorkspaceGitBranchManagerError {
+            throw error
+        } catch {
+            throw WorkspaceGitBranchManagerError.gitRejected(error.localizedDescription)
+        }
+    }
+
+    fileprivate static func normalizeLocalBranches(_ branchNames: [String], currentBranchName: String?) -> [String] {
+        var seenBranches = Set<String>()
+        var normalizedBranches = branchNames
+            .map(\.trimmedGitOutput)
+            .filter { $0.isEmpty == false }
+            .filter { seenBranches.insert($0).inserted }
+
+        if let currentBranchName = currentBranchName?.trimmedGitOutput,
+           currentBranchName.isEmpty == false,
+           seenBranches.insert(currentBranchName).inserted {
+            normalizedBranches.append(currentBranchName)
+        }
+
+        normalizedBranches.sort { lhs, rhs in
+            lhs.localizedCaseInsensitiveCompare(rhs) == .orderedAscending
+        }
+
+        return normalizedBranches
     }
 }
 
@@ -74,8 +179,8 @@ protocol GitCommandRunning: Sendable {
 struct ProcessGitCommandRunner: GitCommandRunning {
     private let executableURL: URL
 
-    init(executableURL: URL = URL(fileURLWithPath: "/usr/bin/git", isDirectory: false)) {
-        self.executableURL = executableURL
+    init(executableURL: URL? = nil, fileManager: FileManager = .default) {
+        self.executableURL = executableURL ?? Self.defaultExecutableURL(fileManager: fileManager)
     }
 
     func run(arguments: [String]) async throws -> GitCommandResult {
@@ -117,6 +222,44 @@ struct ProcessGitCommandRunner: GitCommandRunning {
             )
         }.value
     }
+
+    private static func defaultExecutableURL(fileManager: FileManager) -> URL {
+        for path in candidateExecutablePaths where fileManager.isExecutableFile(atPath: path) {
+            return URL(fileURLWithPath: path, isDirectory: false)
+        }
+
+        return URL(fileURLWithPath: "/usr/bin/git", isDirectory: false)
+    }
+
+    private static let candidateExecutablePaths: [String] = [
+        "/Applications/Xcode.app/Contents/Developer/usr/bin/git",
+        "/opt/homebrew/bin/git",
+        "/usr/local/bin/git",
+        "/usr/bin/git"
+    ]
+}
+
+private extension WorkspaceGitSnapshot {
+    func withFallbackBranchName(_ branchName: String) -> WorkspaceGitSnapshot {
+        guard status.currentBranchName == nil else {
+            return self
+        }
+
+        return WorkspaceGitSnapshot(
+            status: .branch(branchName),
+            localBranches: WorkspaceGitService.normalizeLocalBranches(localBranches, currentBranchName: branchName)
+        )
+    }
+}
+
+private extension WorkspaceGitStatus {
+    var currentBranchName: String? {
+        guard case .branch(let branchName) = self else {
+            return nil
+        }
+
+        return branchName
+    }
 }
 
 private extension String {
@@ -126,5 +269,13 @@ private extension String {
 
     var nilIfEmpty: String? {
         isEmpty ? nil : self
+    }
+}
+
+private extension GitCommandResult {
+    var failureMessage: String {
+        stderr.trimmedGitOutput.nilIfEmpty
+            ?? stdout.trimmedGitOutput.nilIfEmpty
+            ?? "Git command failed."
     }
 }

--- a/AtelierCodeTests/AtelierCodeTests.swift
+++ b/AtelierCodeTests/AtelierCodeTests.swift
@@ -461,6 +461,73 @@ struct AppModelTests {
         #expect(await gitService.requestedWorkspacePaths() == [workspaceURL.path, workspaceURL.path, workspaceURL.path])
     }
 
+    @Test func submittingCreateSelectionCreatesAndSwitchesToNewBranch() async throws {
+        let store = InMemoryAppPreferencesStore()
+        let runtimeCoordinator = TestRuntimeCoordinator()
+        let gitService = TestWorkspaceGitService()
+        let appModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
+            gitService: gitService,
+            runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
+        )
+        let workspaceURL = try temporaryDirectory(named: "branch-picker-create-selection")
+
+        await gitService.enqueueStatuses([.branch("main"), .branch("main"), .branch("feature/new-work")], for: workspaceURL.path)
+        await gitService.setLocalBranches(["main", "release"], for: workspaceURL.path)
+        appModel.activateWorkspace(at: workspaceURL)
+        try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .branch("main") }
+
+        appModel.showSelectedWorkspaceBranchPicker()
+        try await waitUntil { appModel.selectedWorkspaceBranchPickerFilteredBranches == ["main", "release"] }
+
+        appModel.setSelectedWorkspaceBranchPickerFilterText("feature/new-work")
+
+        #expect(appModel.selectedWorkspaceBranchPickerItems == [.create("feature/new-work")])
+        #expect(appModel.selectedWorkspaceBranchPickerSelectedItemID == WorkspaceBranchPickerItem.create("feature/new-work").id)
+
+        await appModel.submitSelectedWorkspaceBranchPicker()
+        try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .branch("feature/new-work") }
+
+        #expect(appModel.isSelectedWorkspaceBranchPickerPresented == false)
+        #expect(await gitService.createdBranches(for: workspaceURL.path) == ["feature/new-work"])
+        #expect(await gitService.switchedBranches(for: workspaceURL.path).isEmpty)
+    }
+
+    @Test func movingBranchPickerSelectionUpdatesHighlightedItem() async throws {
+        let store = InMemoryAppPreferencesStore()
+        let runtimeCoordinator = TestRuntimeCoordinator()
+        let gitService = TestWorkspaceGitService()
+        let appModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
+            gitService: gitService,
+            runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
+        )
+        let workspaceURL = try temporaryDirectory(named: "branch-picker-keyboard-selection")
+
+        await gitService.enqueueStatuses([.branch("main"), .branch("main")], for: workspaceURL.path)
+        await gitService.setLocalBranches(["main", "release"], for: workspaceURL.path)
+        appModel.activateWorkspace(at: workspaceURL)
+        try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .branch("main") }
+
+        appModel.showSelectedWorkspaceBranchPicker()
+        try await waitUntil { appModel.selectedWorkspaceBranchPickerItems == [.branch("main"), .branch("release")] }
+
+        #expect(appModel.selectedWorkspaceBranchPickerSelectedItemID == WorkspaceBranchPickerItem.branch("main").id)
+
+        appModel.moveSelectedWorkspaceBranchPickerSelection(.down)
+        #expect(appModel.selectedWorkspaceBranchPickerSelectedItemID == WorkspaceBranchPickerItem.branch("release").id)
+
+        appModel.setSelectedWorkspaceBranchPickerFilterText("release-")
+        #expect(
+            appModel.selectedWorkspaceBranchPickerItems == [
+                .create("release-")
+            ]
+        )
+        #expect(appModel.selectedWorkspaceBranchPickerSelectedItemID == WorkspaceBranchPickerItem.create("release-").id)
+    }
+
     @Test func failedBranchSwitchKeepsPickerOpenWithoutChangingWorkspaceRuntimeState() async throws {
         let store = InMemoryAppPreferencesStore()
         let runtimeCoordinator = TestRuntimeCoordinator()

--- a/AtelierCodeTests/AtelierCodeTests.swift
+++ b/AtelierCodeTests/AtelierCodeTests.swift
@@ -174,16 +174,16 @@ struct AppModelTests {
     @Test func selectingWorkspaceReturnsFromSettingsToConversationView() async throws {
         let store = InMemoryAppPreferencesStore()
         let runtimeCoordinator = TestRuntimeCoordinator()
-        let gitStatusProvider = TestWorkspaceGitStatusProvider()
+        let gitService = TestWorkspaceGitService()
         let appModel = AppModel(
             preferencesStore: store,
             bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
-            gitStatusProvider: gitStatusProvider,
+            gitService: gitService,
             runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
         )
         let workspaceURL = try temporaryDirectory(named: "settings-navigation")
 
-        await gitStatusProvider.enqueueStatuses([.branch("main")], for: workspaceURL.path)
+        await gitService.enqueueStatuses([.branch("main")], for: workspaceURL.path)
         appModel.activateWorkspace(at: workspaceURL)
         try await waitUntil { appModel.activeWorkspaceController?.connectionStatus == .ready }
 
@@ -199,25 +199,25 @@ struct AppModelTests {
     @Test func selectingDifferentWorkspaceRefreshesGitStatusForNewSelection() async throws {
         let store = InMemoryAppPreferencesStore()
         let runtimeCoordinator = TestRuntimeCoordinator()
-        let gitStatusProvider = TestWorkspaceGitStatusProvider()
+        let gitService = TestWorkspaceGitService()
         let appModel = AppModel(
             preferencesStore: store,
             bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
-            gitStatusProvider: gitStatusProvider,
+            gitService: gitService,
             runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
         )
         let firstWorkspaceURL = try temporaryDirectory(named: "git-status-first")
         let secondWorkspaceURL = try temporaryDirectory(named: "git-status-second")
 
-        await gitStatusProvider.enqueueStatuses([.branch("main")], for: firstWorkspaceURL.path)
+        await gitService.enqueueStatuses([.branch("main")], for: firstWorkspaceURL.path)
         appModel.activateWorkspace(at: firstWorkspaceURL)
         try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .branch("main") }
 
-        await gitStatusProvider.enqueueStatuses([.detachedHead("abc1234")], for: secondWorkspaceURL.path)
+        await gitService.enqueueStatuses([.detachedHead("abc1234")], for: secondWorkspaceURL.path)
         appModel.activateWorkspace(at: secondWorkspaceURL)
         try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .detachedHead("abc1234") }
 
-        #expect(await gitStatusProvider.requestedWorkspacePaths() == [firstWorkspaceURL.path, secondWorkspaceURL.path])
+        #expect(await gitService.requestedWorkspacePaths() == [firstWorkspaceURL.path, secondWorkspaceURL.path])
         #expect(appModel.activeWorkspaceController?.workspace.canonicalPath == secondWorkspaceURL.path)
         #expect(appModel.activeWorkspaceController?.gitStatus == .detachedHead("abc1234"))
     }
@@ -225,64 +225,64 @@ struct AppModelTests {
     @Test func appActivationRefreshesSelectedWorkspaceGitStatusAgain() async throws {
         let store = InMemoryAppPreferencesStore()
         let runtimeCoordinator = TestRuntimeCoordinator()
-        let gitStatusProvider = TestWorkspaceGitStatusProvider()
+        let gitService = TestWorkspaceGitService()
         let appModel = AppModel(
             preferencesStore: store,
             bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
-            gitStatusProvider: gitStatusProvider,
+            gitService: gitService,
             runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
         )
         let workspaceURL = try temporaryDirectory(named: "git-status-reactivation")
 
-        await gitStatusProvider.enqueueStatuses([.branch("main"), .detachedHead("abc1234")], for: workspaceURL.path)
+        await gitService.enqueueStatuses([.branch("main"), .detachedHead("abc1234")], for: workspaceURL.path)
         appModel.activateWorkspace(at: workspaceURL)
         try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .branch("main") }
 
         appModel.applicationDidBecomeActive()
         try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .detachedHead("abc1234") }
 
-        #expect(await gitStatusProvider.requestedWorkspacePaths() == [workspaceURL.path, workspaceURL.path])
+        #expect(await gitService.requestedWorkspacePaths() == [workspaceURL.path, workspaceURL.path])
         #expect(appModel.activeWorkspaceController?.gitStatus == .detachedHead("abc1234"))
     }
 
     @Test func keyWindowActivationRefreshesSelectedWorkspaceGitStatusAgain() async throws {
         let store = InMemoryAppPreferencesStore()
         let runtimeCoordinator = TestRuntimeCoordinator()
-        let gitStatusProvider = TestWorkspaceGitStatusProvider()
+        let gitService = TestWorkspaceGitService()
         let appModel = AppModel(
             preferencesStore: store,
             bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
-            gitStatusProvider: gitStatusProvider,
+            gitService: gitService,
             runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
         )
         let workspaceURL = try temporaryDirectory(named: "git-status-window-key")
 
-        await gitStatusProvider.enqueueStatuses([.branch("main"), .branch("feature/window-key")], for: workspaceURL.path)
+        await gitService.enqueueStatuses([.branch("main"), .branch("feature/window-key")], for: workspaceURL.path)
         appModel.activateWorkspace(at: workspaceURL)
         try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .branch("main") }
 
         appModel.applicationWindowDidBecomeKey()
         try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .branch("feature/window-key") }
 
-        #expect(await gitStatusProvider.requestedWorkspacePaths() == [workspaceURL.path, workspaceURL.path])
+        #expect(await gitService.requestedWorkspacePaths() == [workspaceURL.path, workspaceURL.path])
         #expect(appModel.activeWorkspaceController?.gitStatus == .branch("feature/window-key"))
     }
 
     @Test func openingThreadInAnotherWorkspaceRefreshesGitStatusForThatWorkspace() async throws {
         let store = InMemoryAppPreferencesStore()
         let runtimeCoordinator = TestRuntimeCoordinator()
-        let gitStatusProvider = TestWorkspaceGitStatusProvider()
+        let gitService = TestWorkspaceGitService()
         let appModel = AppModel(
             preferencesStore: store,
             bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
-            gitStatusProvider: gitStatusProvider,
+            gitService: gitService,
             runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
         )
         let firstWorkspaceURL = try temporaryDirectory(named: "git-status-thread-open-first")
         let secondWorkspaceURL = try temporaryDirectory(named: "git-status-thread-open-second")
 
-        await gitStatusProvider.enqueueStatuses([.branch("main"), .branch("main")], for: firstWorkspaceURL.path)
-        await gitStatusProvider.enqueueStatuses([.branch("feature/initial"), .detachedHead("abc1234")], for: secondWorkspaceURL.path)
+        await gitService.enqueueStatuses([.branch("main"), .branch("main")], for: firstWorkspaceURL.path)
+        await gitService.enqueueStatuses([.branch("feature/initial"), .detachedHead("abc1234")], for: secondWorkspaceURL.path)
 
         appModel.activateWorkspace(at: firstWorkspaceURL)
         try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .branch("main") }
@@ -312,12 +312,188 @@ struct AppModelTests {
                 appModel.activeWorkspaceController?.gitStatus == .detachedHead("abc1234")
         }
 
-        #expect(await gitStatusProvider.requestedWorkspacePaths() == [
+        #expect(await gitService.requestedWorkspacePaths() == [
             firstWorkspaceURL.path,
             secondWorkspaceURL.path,
             firstWorkspaceURL.path,
             secondWorkspaceURL.path,
         ])
+    }
+
+    @Test func openingBranchPickerLoadsBranchesAndResetsWhenWorkspaceChanges() async throws {
+        let store = InMemoryAppPreferencesStore()
+        let runtimeCoordinator = TestRuntimeCoordinator()
+        let gitService = TestWorkspaceGitService()
+        let appModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
+            gitService: gitService,
+            runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
+        )
+        let firstWorkspaceURL = try temporaryDirectory(named: "branch-picker-first")
+        let secondWorkspaceURL = try temporaryDirectory(named: "branch-picker-second")
+
+        await gitService.enqueueStatuses([.branch("main"), .branch("main")], for: firstWorkspaceURL.path)
+        await gitService.setLocalBranches(["main", "release"], for: firstWorkspaceURL.path)
+        appModel.activateWorkspace(at: firstWorkspaceURL)
+        try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .branch("main") }
+
+        appModel.showSelectedWorkspaceBranchPicker()
+        try await waitUntil {
+            appModel.isSelectedWorkspaceBranchPickerPresented &&
+                appModel.selectedWorkspaceBranchPickerFilteredBranches == ["main", "release"]
+        }
+
+        await gitService.enqueueStatuses([.branch("feature/detached-work")], for: secondWorkspaceURL.path)
+        appModel.activateWorkspace(at: secondWorkspaceURL)
+        try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .branch("feature/detached-work") }
+
+        #expect(appModel.isSelectedWorkspaceBranchPickerPresented == false)
+    }
+
+    @Test func dismissingAndReopeningBranchPickerStartsFreshSession() async throws {
+        let store = InMemoryAppPreferencesStore()
+        let runtimeCoordinator = TestRuntimeCoordinator()
+        let gitService = TestWorkspaceGitService()
+        let appModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
+            gitService: gitService,
+            runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
+        )
+        let workspaceURL = try temporaryDirectory(named: "branch-picker-reopen")
+
+        await gitService.enqueueStatuses([.branch("main"), .branch("main"), .branch("main")], for: workspaceURL.path)
+        await gitService.setLocalBranches(["git-branches", "main"], for: workspaceURL.path)
+        appModel.activateWorkspace(at: workspaceURL)
+        try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .branch("main") }
+
+        appModel.showSelectedWorkspaceBranchPicker()
+        try await waitUntil { appModel.selectedWorkspaceBranchPickerFilteredBranches == ["git-branches", "main"] }
+
+        appModel.dismissSelectedWorkspaceBranchPicker()
+        #expect(appModel.isSelectedWorkspaceBranchPickerPresented == false)
+
+        appModel.showSelectedWorkspaceBranchPicker()
+        try await waitUntil { appModel.selectedWorkspaceBranchPickerFilteredBranches == ["git-branches", "main"] }
+
+        #expect(appModel.selectedWorkspaceBranchPickerFilterText.isEmpty)
+    }
+
+    @Test func openingBranchPickerShowsCurrentBranchWhenBranchCacheIsEmpty() async throws {
+        let store = InMemoryAppPreferencesStore()
+        let runtimeCoordinator = TestRuntimeCoordinator()
+        let gitService = TestWorkspaceGitService()
+        let appModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
+            gitService: gitService,
+            runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
+        )
+        let workspaceURL = try temporaryDirectory(named: "branch-picker-current-branch-fallback")
+
+        await gitService.enqueueStatuses([.branch("git-branches"), .branch("git-branches")], for: workspaceURL.path)
+        await gitService.setLocalBranches([], for: workspaceURL.path)
+        appModel.activateWorkspace(at: workspaceURL)
+        try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .branch("git-branches") }
+
+        appModel.showSelectedWorkspaceBranchPicker()
+        try await waitUntil {
+            appModel.isSelectedWorkspaceBranchPickerPresented &&
+                appModel.selectedWorkspaceBranchPickerFilteredBranches == ["git-branches"]
+        }
+
+        #expect(appModel.selectedWorkspaceBranchPickerCurrentBranchName == "git-branches")
+    }
+
+    @Test func openingBranchPickerRefreshesFromCurrentBranchToFullLocalBranchList() async throws {
+        let store = InMemoryAppPreferencesStore()
+        let runtimeCoordinator = TestRuntimeCoordinator()
+        let gitService = TestWorkspaceGitService()
+        let appModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
+            gitService: gitService,
+            runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
+        )
+        let workspaceURL = try temporaryDirectory(named: "branch-picker-refreshes-full-list")
+
+        await gitService.enqueueStatuses([.branch("git-branches"), .branch("git-branches")], for: workspaceURL.path)
+        await gitService.setLocalBranches([], for: workspaceURL.path)
+        appModel.activateWorkspace(at: workspaceURL)
+        try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .branch("git-branches") }
+
+        await gitService.setLocalBranches(["git-branches", "main"], for: workspaceURL.path)
+        appModel.showSelectedWorkspaceBranchPicker()
+
+        try await waitUntil {
+            appModel.selectedWorkspaceBranchPickerFilteredBranches == ["git-branches", "main"]
+        }
+    }
+
+    @Test func submittingExistingBranchSwitchesAndRefreshesSelectedWorkspaceStatus() async throws {
+        let store = InMemoryAppPreferencesStore()
+        let runtimeCoordinator = TestRuntimeCoordinator()
+        let gitService = TestWorkspaceGitService()
+        let appModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
+            gitService: gitService,
+            runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
+        )
+        let workspaceURL = try temporaryDirectory(named: "branch-picker-switch")
+
+        await gitService.enqueueStatuses([.branch("main"), .branch("main"), .branch("release")], for: workspaceURL.path)
+        await gitService.setLocalBranches(["main", "release"], for: workspaceURL.path)
+        appModel.activateWorkspace(at: workspaceURL)
+        try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .branch("main") }
+
+        appModel.showSelectedWorkspaceBranchPicker()
+        try await waitUntil { appModel.selectedWorkspaceBranchPickerFilteredBranches == ["main", "release"] }
+
+        appModel.setSelectedWorkspaceBranchPickerFilterText("release")
+        await appModel.submitSelectedWorkspaceBranchPicker()
+        try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .branch("release") }
+
+        #expect(appModel.isSelectedWorkspaceBranchPickerPresented == false)
+        #expect(await gitService.switchedBranches(for: workspaceURL.path) == ["release"])
+        #expect(await gitService.createdBranches(for: workspaceURL.path).isEmpty)
+        #expect(await gitService.requestedWorkspacePaths() == [workspaceURL.path, workspaceURL.path, workspaceURL.path])
+    }
+
+    @Test func failedBranchSwitchKeepsPickerOpenWithoutChangingWorkspaceRuntimeState() async throws {
+        let store = InMemoryAppPreferencesStore()
+        let runtimeCoordinator = TestRuntimeCoordinator()
+        let gitService = TestWorkspaceGitService()
+        let appModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
+            gitService: gitService,
+            runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
+        )
+        let workspaceURL = try temporaryDirectory(named: "branch-picker-failure")
+
+        await gitService.enqueueStatuses([.branch("main"), .branch("main")], for: workspaceURL.path)
+        await gitService.setLocalBranches(["main", "release"], for: workspaceURL.path)
+        await gitService.failSwitch(
+            to: "release",
+            error: .gitRejected("error: Your local changes would be overwritten by checkout."),
+            for: workspaceURL.path
+        )
+        appModel.activateWorkspace(at: workspaceURL)
+        try await waitUntil { appModel.activeWorkspaceController?.connectionStatus == .ready }
+        try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .branch("main") }
+
+        appModel.showSelectedWorkspaceBranchPicker()
+        try await waitUntil { appModel.selectedWorkspaceBranchPickerFilteredBranches == ["main", "release"] }
+
+        appModel.setSelectedWorkspaceBranchPickerFilterText("release")
+        await appModel.submitSelectedWorkspaceBranchPicker()
+
+        #expect(appModel.isSelectedWorkspaceBranchPickerPresented)
+        #expect(appModel.selectedWorkspaceBranchPickerErrorMessage == "error: Your local changes would be overwritten by checkout.")
+        #expect(appModel.activeWorkspaceController?.gitStatus == .branch("main"))
+        #expect(appModel.activeWorkspaceController?.connectionStatus == .ready)
     }
 
     @Test func firstSendCreatesThreadBeforeStartingTurn() async throws {
@@ -1100,26 +1276,81 @@ private final class TestWorkspaceRuntime: WorkspaceConversationRuntime {
     }
 }
 
-private actor TestWorkspaceGitStatusProvider: WorkspaceGitStatusProviding {
+private actor TestWorkspaceGitService: WorkspaceGitServing {
     private var queuedStatusesByWorkspacePath: [String: [WorkspaceGitStatus]] = [:]
+    private var localBranchesByWorkspacePath: [String: [String]] = [:]
     private var requestedPaths: [String] = []
+    private var switchFailuresByWorkspacePath: [String: [String: WorkspaceGitBranchManagerError]] = [:]
+    private var switchedBranchesByWorkspacePath: [String: [String]] = [:]
+    private var createdBranchesByWorkspacePath: [String: [String]] = [:]
 
     func enqueueStatuses(_ statuses: [WorkspaceGitStatus], for workspacePath: String) {
         queuedStatusesByWorkspacePath[workspacePath, default: []].append(contentsOf: statuses)
+    }
+
+    func setLocalBranches(_ branches: [String], for workspacePath: String) {
+        localBranchesByWorkspacePath[workspacePath] = branches
+    }
+
+    func failSwitch(to branchName: String, error: WorkspaceGitBranchManagerError, for workspacePath: String) {
+        switchFailuresByWorkspacePath[workspacePath, default: [:]][branchName] = error
     }
 
     func requestedWorkspacePaths() -> [String] {
         requestedPaths
     }
 
-    func gitStatus(for workspacePath: String) async -> WorkspaceGitStatus {
+    func switchedBranches(for workspacePath: String) -> [String] {
+        switchedBranchesByWorkspacePath[workspacePath] ?? []
+    }
+
+    func createdBranches(for workspacePath: String) -> [String] {
+        createdBranchesByWorkspacePath[workspacePath] ?? []
+    }
+
+    func snapshot(for workspacePath: String) async -> WorkspaceGitSnapshot {
         requestedPaths.append(workspacePath)
 
+        let localBranches = localBranchesByWorkspacePath[workspacePath] ?? []
         if queuedStatusesByWorkspacePath[workspacePath]?.isEmpty == false {
-            return queuedStatusesByWorkspacePath[workspacePath]!.removeFirst()
+            return WorkspaceGitSnapshot(
+                status: queuedStatusesByWorkspacePath[workspacePath]!.removeFirst(),
+                localBranches: localBranches
+            )
         }
 
-        return .unavailable(.lookupFailed)
+        return WorkspaceGitSnapshot(
+            status: .unavailable(.lookupFailed),
+            localBranches: localBranches
+        )
+    }
+
+    func switchToBranch(named branchName: String, for workspacePath: String) async throws -> WorkspaceGitSnapshot {
+        if let error = switchFailuresByWorkspacePath[workspacePath]?[branchName] {
+            throw error
+        }
+
+        switchedBranchesByWorkspacePath[workspacePath, default: []].append(branchName)
+        let localBranches = localBranchesByWorkspacePath[workspacePath] ?? []
+        return WorkspaceGitSnapshot(
+            status: .branch(branchName),
+            localBranches: localBranches.isEmpty ? [branchName] : localBranches
+        )
+    }
+
+    func createAndSwitchToBranch(named branchName: String, for workspacePath: String) async throws -> WorkspaceGitSnapshot {
+        createdBranchesByWorkspacePath[workspacePath, default: []].append(branchName)
+        if localBranchesByWorkspacePath[workspacePath]?.contains(branchName) != true {
+            localBranchesByWorkspacePath[workspacePath, default: []].append(branchName)
+        }
+
+        let localBranches = localBranchesByWorkspacePath[workspacePath] ?? [branchName]
+        return WorkspaceGitSnapshot(
+            status: .branch(branchName),
+            localBranches: localBranches.sorted { lhs, rhs in
+                lhs.localizedCaseInsensitiveCompare(rhs) == .orderedAscending
+            }
+        )
     }
 }
 

--- a/AtelierCodeTests/AtelierCodeTests.swift
+++ b/AtelierCodeTests/AtelierCodeTests.swift
@@ -245,6 +245,81 @@ struct AppModelTests {
         #expect(appModel.activeWorkspaceController?.gitStatus == .detachedHead("abc1234"))
     }
 
+    @Test func keyWindowActivationRefreshesSelectedWorkspaceGitStatusAgain() async throws {
+        let store = InMemoryAppPreferencesStore()
+        let runtimeCoordinator = TestRuntimeCoordinator()
+        let gitStatusProvider = TestWorkspaceGitStatusProvider()
+        let appModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
+            gitStatusProvider: gitStatusProvider,
+            runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
+        )
+        let workspaceURL = try temporaryDirectory(named: "git-status-window-key")
+
+        await gitStatusProvider.enqueueStatuses([.branch("main"), .branch("feature/window-key")], for: workspaceURL.path)
+        appModel.activateWorkspace(at: workspaceURL)
+        try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .branch("main") }
+
+        appModel.applicationWindowDidBecomeKey()
+        try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .branch("feature/window-key") }
+
+        #expect(await gitStatusProvider.requestedWorkspacePaths() == [workspaceURL.path, workspaceURL.path])
+        #expect(appModel.activeWorkspaceController?.gitStatus == .branch("feature/window-key"))
+    }
+
+    @Test func openingThreadInAnotherWorkspaceRefreshesGitStatusForThatWorkspace() async throws {
+        let store = InMemoryAppPreferencesStore()
+        let runtimeCoordinator = TestRuntimeCoordinator()
+        let gitStatusProvider = TestWorkspaceGitStatusProvider()
+        let appModel = AppModel(
+            preferencesStore: store,
+            bridgeDiagnosticProvider: { .bridgePresent(at: URL(fileURLWithPath: "/tmp/bridge")) },
+            gitStatusProvider: gitStatusProvider,
+            runtimeFactory: { TestWorkspaceRuntime(controller: $0, coordinator: runtimeCoordinator) }
+        )
+        let firstWorkspaceURL = try temporaryDirectory(named: "git-status-thread-open-first")
+        let secondWorkspaceURL = try temporaryDirectory(named: "git-status-thread-open-second")
+
+        await gitStatusProvider.enqueueStatuses([.branch("main"), .branch("main")], for: firstWorkspaceURL.path)
+        await gitStatusProvider.enqueueStatuses([.branch("feature/initial"), .detachedHead("abc1234")], for: secondWorkspaceURL.path)
+
+        appModel.activateWorkspace(at: firstWorkspaceURL)
+        try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .branch("main") }
+
+        appModel.activateWorkspace(at: secondWorkspaceURL)
+        try await waitUntil { appModel.activeWorkspaceController?.gitStatus == .branch("feature/initial") }
+        appModel.activeWorkspaceController?.upsertThreadSummary(
+            ThreadSummary(
+                id: "thread-2",
+                title: "Second Workspace Thread",
+                previewText: "Open me",
+                updatedAt: .now
+            )
+        )
+
+        appModel.selectWorkspace(path: firstWorkspaceURL.path)
+        try await waitUntil {
+            appModel.activeWorkspaceController?.workspace.canonicalPath == firstWorkspaceURL.path &&
+                appModel.activeWorkspaceController?.gitStatus == .branch("main")
+        }
+
+        let didOpen = await appModel.openThread(workspacePath: secondWorkspaceURL.path, threadID: "thread-2")
+
+        #expect(didOpen)
+        try await waitUntil {
+            appModel.activeWorkspaceController?.workspace.canonicalPath == secondWorkspaceURL.path &&
+                appModel.activeWorkspaceController?.gitStatus == .detachedHead("abc1234")
+        }
+
+        #expect(await gitStatusProvider.requestedWorkspacePaths() == [
+            firstWorkspaceURL.path,
+            secondWorkspaceURL.path,
+            firstWorkspaceURL.path,
+            secondWorkspaceURL.path,
+        ])
+    }
+
     @Test func firstSendCreatesThreadBeforeStartingTurn() async throws {
         let store = InMemoryAppPreferencesStore()
         let runtimeCoordinator = TestRuntimeCoordinator()

--- a/AtelierCodeTests/WorkspaceGitStatusProviderTests.swift
+++ b/AtelierCodeTests/WorkspaceGitStatusProviderTests.swift
@@ -3,28 +3,32 @@ import Testing
 @testable import AtelierCode
 
 @MainActor
-struct WorkspaceGitStatusProviderTests {
-    @Test func resolvesNamedBranch() async throws {
+struct WorkspaceGitServiceTests {
+    @Test func resolvesNamedBranchSnapshot() async throws {
         let workspacePath = "/tmp/branch-workspace"
-        let provider = WorkspaceGitStatusProvider(
+        let service = WorkspaceGitService(
             commandRunner: StubGitCommandRunner(results: [
                 ["-C", workspacePath, "rev-parse", "--is-inside-work-tree"]: .success(
                     GitCommandResult(exitCode: 0, stdout: "true\n", stderr: "")
                 ),
                 ["-C", workspacePath, "symbolic-ref", "--quiet", "--short", "HEAD"]: .success(
                     GitCommandResult(exitCode: 0, stdout: "main\n", stderr: "")
+                ),
+                ["-C", workspacePath, "for-each-ref", "--format=%(refname:short)", "refs/heads"]: .success(
+                    GitCommandResult(exitCode: 0, stdout: "feature/status-bar\nmain\n", stderr: "")
                 )
             ])
         )
 
-        let gitStatus = await provider.gitStatus(for: workspacePath)
+        let snapshot = await service.snapshot(for: workspacePath)
 
-        #expect(gitStatus == .branch("main"))
+        #expect(snapshot.status == .branch("main"))
+        #expect(snapshot.localBranches == ["feature/status-bar", "main"])
     }
 
     @Test func resolvesDetachedHeadWhenSymbolicRefFails() async throws {
         let workspacePath = "/tmp/detached-workspace"
-        let provider = WorkspaceGitStatusProvider(
+        let service = WorkspaceGitService(
             commandRunner: StubGitCommandRunner(results: [
                 ["-C", workspacePath, "rev-parse", "--is-inside-work-tree"]: .success(
                     GitCommandResult(exitCode: 0, stdout: "true\n", stderr: "")
@@ -34,18 +38,22 @@ struct WorkspaceGitStatusProviderTests {
                 ),
                 ["-C", workspacePath, "rev-parse", "--short", "HEAD"]: .success(
                     GitCommandResult(exitCode: 0, stdout: "abc1234\n", stderr: "")
+                ),
+                ["-C", workspacePath, "for-each-ref", "--format=%(refname:short)", "refs/heads"]: .success(
+                    GitCommandResult(exitCode: 0, stdout: "main\nrelease\n", stderr: "")
                 )
             ])
         )
 
-        let gitStatus = await provider.gitStatus(for: workspacePath)
+        let snapshot = await service.snapshot(for: workspacePath)
 
-        #expect(gitStatus == .detachedHead("abc1234"))
+        #expect(snapshot.status == .detachedHead("abc1234"))
+        #expect(snapshot.localBranches == ["main", "release"])
     }
 
     @Test func reportsNonRepositoryWhenRepositoryCheckFails() async throws {
         let workspacePath = "/tmp/non-repo-workspace"
-        let provider = WorkspaceGitStatusProvider(
+        let service = WorkspaceGitService(
             commandRunner: StubGitCommandRunner(results: [
                 ["-C", workspacePath, "rev-parse", "--is-inside-work-tree"]: .success(
                     GitCommandResult(exitCode: 128, stdout: "", stderr: "fatal: not a git repository\n")
@@ -53,14 +61,14 @@ struct WorkspaceGitStatusProviderTests {
             ])
         )
 
-        let gitStatus = await provider.gitStatus(for: workspacePath)
+        let snapshot = await service.snapshot(for: workspacePath)
 
-        #expect(gitStatus == .unavailable(.noRepository))
+        #expect(snapshot == WorkspaceGitSnapshot(status: .unavailable(.noRepository), localBranches: []))
     }
 
     @Test func reportsMissingGitExecutable() async throws {
         let workspacePath = "/tmp/missing-git-workspace"
-        let provider = WorkspaceGitStatusProvider(
+        let service = WorkspaceGitService(
             commandRunner: StubGitCommandRunner(results: [
                 ["-C", workspacePath, "rev-parse", "--is-inside-work-tree"]: .failure(
                     GitCommandRunnerError.executableUnavailable
@@ -68,9 +76,115 @@ struct WorkspaceGitStatusProviderTests {
             ])
         )
 
-        let gitStatus = await provider.gitStatus(for: workspacePath)
+        let snapshot = await service.snapshot(for: workspacePath)
 
-        #expect(gitStatus == .unavailable(.gitUnavailable))
+        #expect(snapshot == WorkspaceGitSnapshot(status: .unavailable(.gitUnavailable), localBranches: []))
+    }
+
+    @Test func includesCurrentBranchWhenBranchListingOmitsIt() async throws {
+        let workspacePath = "/tmp/current-branch-fallback"
+        let service = WorkspaceGitService(
+            commandRunner: StubGitCommandRunner(results: [
+                ["-C", workspacePath, "rev-parse", "--is-inside-work-tree"]: .success(
+                    GitCommandResult(exitCode: 0, stdout: "true\n", stderr: "")
+                ),
+                ["-C", workspacePath, "symbolic-ref", "--quiet", "--short", "HEAD"]: .success(
+                    GitCommandResult(exitCode: 0, stdout: "git-branches\n", stderr: "")
+                ),
+                ["-C", workspacePath, "for-each-ref", "--format=%(refname:short)", "refs/heads"]: .success(
+                    GitCommandResult(exitCode: 0, stdout: "main\n", stderr: "")
+                )
+            ])
+        )
+
+        let snapshot = await service.snapshot(for: workspacePath)
+
+        #expect(snapshot.status == .branch("git-branches"))
+        #expect(snapshot.localBranches == ["git-branches", "main"])
+    }
+
+    @Test func switchesToExistingLocalBranch() async throws {
+        let workspacePath = "/tmp/switch-branch-workspace"
+        let service = WorkspaceGitService(
+            commandRunner: StubGitCommandRunner(results: [
+                ["-C", workspacePath, "switch", "release"]: .success(
+                    GitCommandResult(exitCode: 0, stdout: "", stderr: "")
+                ),
+                ["-C", workspacePath, "rev-parse", "--is-inside-work-tree"]: .success(
+                    GitCommandResult(exitCode: 0, stdout: "true\n", stderr: "")
+                ),
+                ["-C", workspacePath, "symbolic-ref", "--quiet", "--short", "HEAD"]: .success(
+                    GitCommandResult(exitCode: 0, stdout: "release\n", stderr: "")
+                ),
+                ["-C", workspacePath, "for-each-ref", "--format=%(refname:short)", "refs/heads"]: .success(
+                    GitCommandResult(exitCode: 0, stdout: "main\nrelease\n", stderr: "")
+                )
+            ])
+        )
+
+        let snapshot = try await service.switchToBranch(named: "release", for: workspacePath)
+
+        #expect(snapshot.status == .branch("release"))
+        #expect(snapshot.localBranches == ["main", "release"])
+    }
+
+    @Test func createsAndSwitchesToNewLocalBranch() async throws {
+        let workspacePath = "/tmp/create-branch-workspace"
+        let service = WorkspaceGitService(
+            commandRunner: StubGitCommandRunner(results: [
+                ["-C", workspacePath, "switch", "-c", "feature/new-branch"]: .success(
+                    GitCommandResult(exitCode: 0, stdout: "", stderr: "")
+                ),
+                ["-C", workspacePath, "rev-parse", "--is-inside-work-tree"]: .success(
+                    GitCommandResult(exitCode: 0, stdout: "true\n", stderr: "")
+                ),
+                ["-C", workspacePath, "symbolic-ref", "--quiet", "--short", "HEAD"]: .success(
+                    GitCommandResult(exitCode: 0, stdout: "feature/new-branch\n", stderr: "")
+                ),
+                ["-C", workspacePath, "for-each-ref", "--format=%(refname:short)", "refs/heads"]: .success(
+                    GitCommandResult(exitCode: 0, stdout: "feature/new-branch\nmain\n", stderr: "")
+                )
+            ])
+        )
+
+        let snapshot = try await service.createAndSwitchToBranch(named: "feature/new-branch", for: workspacePath)
+
+        #expect(snapshot.status == .branch("feature/new-branch"))
+        #expect(snapshot.localBranches == ["feature/new-branch", "main"])
+    }
+
+    @Test func propagatesGitCheckoutFailures() async throws {
+        let workspacePath = "/tmp/error-branch-workspace"
+        let service = WorkspaceGitService(
+            commandRunner: StubGitCommandRunner(results: [
+                ["-C", workspacePath, "switch", "release"]: .success(
+                    GitCommandResult(
+                        exitCode: 1,
+                        stdout: "",
+                        stderr: "error: Your local changes to the following files would be overwritten by switch.\n"
+                    )
+                )
+            ])
+        )
+
+        await #expect(throws: WorkspaceGitBranchManagerError.gitRejected(
+            "error: Your local changes to the following files would be overwritten by switch."
+        )) {
+            try await service.switchToBranch(named: "release", for: workspacePath)
+        }
+    }
+
+    @Test func realRepositorySnapshotIncludesCurrentAndMainBranches() async throws {
+        let repositoryURL = try makeGitRepository(named: "workspace-git-snapshot")
+        try writeFile(named: "README.md", contents: "hello\n", in: repositoryURL)
+        try runGit(arguments: ["add", "README.md"], in: repositoryURL)
+        try runGit(arguments: ["commit", "-m", "Initial commit"], in: repositoryURL)
+        try runGit(arguments: ["switch", "-c", "git-branches"], in: repositoryURL)
+
+        let snapshot = await WorkspaceGitService().snapshot(for: repositoryURL.path)
+
+        #expect(snapshot.status == .branch("git-branches"))
+        #expect(snapshot.localBranches == ["git-branches", "main"])
     }
 }
 
@@ -94,4 +208,58 @@ private struct StubGitCommandRunner: GitCommandRunning {
 
 private enum StubError: Error {
     case unexpectedCommand
+}
+
+private func makeGitRepository(named name: String) throws -> URL {
+    let repositoryURL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("\(name)-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: repositoryURL, withIntermediateDirectories: true)
+    try runGit(arguments: ["init", "-b", "main"], in: repositoryURL)
+    try runGit(arguments: ["config", "user.name", "AtelierCode Tests"], in: repositoryURL)
+    try runGit(arguments: ["config", "user.email", "tests@example.com"], in: repositoryURL)
+    return repositoryURL
+}
+
+private func writeFile(named name: String, contents: String, in directoryURL: URL) throws {
+    let fileURL = directoryURL.appendingPathComponent(name, isDirectory: false)
+    guard let data = contents.data(using: .utf8) else {
+        throw GitFixtureError.commandFailed("Failed to encode fixture contents.")
+    }
+
+    try data.write(to: fileURL)
+}
+
+@discardableResult
+private func runGit(arguments: [String], in directoryURL: URL) throws -> String {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/git", isDirectory: false)
+    process.arguments = ["-C", directoryURL.path] + arguments
+
+    let stdoutPipe = Pipe()
+    let stderrPipe = Pipe()
+    process.standardOutput = stdoutPipe
+    process.standardError = stderrPipe
+
+    try process.run()
+    process.waitUntilExit()
+
+    let stdout = String(decoding: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    let stderr = String(decoding: stderrPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+
+    guard process.terminationStatus == 0 else {
+        throw GitFixtureError.commandFailed(stderr.isEmpty ? stdout : stderr)
+    }
+
+    return stdout
+}
+
+private enum GitFixtureError: Error, CustomStringConvertible {
+    case commandFailed(String)
+
+    var description: String {
+        switch self {
+        case .commandFailed(let message):
+            return message
+        }
+    }
 }

--- a/AtelierCodeUITests/AtelierCodeUITests.swift
+++ b/AtelierCodeUITests/AtelierCodeUITests.swift
@@ -284,13 +284,34 @@ final class AtelierCodeUITests: XCTestCase {
         filterField.click()
         filterField.typeText("feature/new-work")
 
-        let createAction = app.buttons["branch-picker-create-action"]
-        XCTAssertTrue(createAction.exists)
-        XCTAssertEqual(createAction.label, "Create and check out \"feature/new-work\"")
-        createAction.click()
+        let createAction = app.buttons["branch-picker-create-item"]
+        XCTAssertTrue(createAction.waitForExistence(timeout: 1))
+        XCTAssertFalse(app.buttons["branch-picker-create-action"].exists)
+
+        app.typeKey(.return, modifierFlags: [])
 
         XCTAssertFalse(app.textFields["branch-picker-filter"].waitForExistence(timeout: 1))
         XCTAssertEqual(statusItem.label, "feature/new-work")
+    }
+
+    func testBranchPickerKeyboardNavigationSwitchesHighlightedBranch() throws {
+        let app = try makeApp(scenario: "git-branch", workspaceName: "BranchKeyboardWorkspace")
+        app.launch()
+
+        let statusItem = app.buttons["workspace-status-git-reference"]
+        XCTAssertTrue(statusItem.waitForExistence(timeout: 5))
+
+        statusItem.click()
+
+        let filterField = app.textFields["branch-picker-filter"]
+        XCTAssertTrue(filterField.waitForExistence(timeout: 5))
+        filterField.click()
+
+        app.typeKey(.downArrow, modifierFlags: [])
+        app.typeKey(.return, modifierFlags: [])
+
+        XCTAssertFalse(app.textFields["branch-picker-filter"].waitForExistence(timeout: 1))
+        XCTAssertEqual(statusItem.label, "main")
     }
 
     func testLiveBranchPickerShowsCurrentAndMainBranch() throws {

--- a/AtelierCodeUITests/AtelierCodeUITests.swift
+++ b/AtelierCodeUITests/AtelierCodeUITests.swift
@@ -5,6 +5,7 @@
 //  Created by Jeremy Margaritondo on 3/23/26.
 //
 
+import Foundation
 import XCTest
 
 final class AtelierCodeUITests: XCTestCase {
@@ -231,9 +232,107 @@ final class AtelierCodeUITests: XCTestCase {
         let app = try makeApp(scenario: "git-branch", workspaceName: "BranchWorkspace")
         app.launch()
 
-        let statusItem = app.otherElements["workspace-status-git-reference"]
+        let statusItem = app.buttons["workspace-status-git-reference"]
         XCTAssertTrue(statusItem.waitForExistence(timeout: 5))
         XCTAssertEqual(statusItem.label, "feature/status-bar")
+    }
+
+    func testBranchStatusItemOpensPickerForGitWorkspace() throws {
+        let app = try makeApp(scenario: "git-branch", workspaceName: "BranchPickerWorkspace")
+        app.launch()
+
+        let statusItem = app.buttons["workspace-status-git-reference"]
+        XCTAssertTrue(statusItem.waitForExistence(timeout: 5))
+
+        statusItem.click()
+
+        let filterField = app.textFields["branch-picker-filter"]
+        XCTAssertTrue(filterField.waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["branch-picker-item-main"].exists)
+        XCTAssertTrue(app.buttons["branch-picker-item-feature/status-bar"].exists)
+        XCTAssertTrue(app.buttons["branch-picker-item-release"].exists)
+    }
+
+    func testBranchPickerSwitchesToExistingLocalBranch() throws {
+        let app = try makeApp(scenario: "git-branch", workspaceName: "BranchSwitchWorkspace")
+        app.launch()
+
+        let statusItem = app.buttons["workspace-status-git-reference"]
+        XCTAssertTrue(statusItem.waitForExistence(timeout: 5))
+
+        statusItem.click()
+
+        let releaseBranch = app.buttons["branch-picker-item-release"]
+        XCTAssertTrue(releaseBranch.waitForExistence(timeout: 5))
+        releaseBranch.click()
+
+        XCTAssertFalse(app.textFields["branch-picker-filter"].waitForExistence(timeout: 1))
+        XCTAssertEqual(statusItem.label, "release")
+    }
+
+    func testBranchPickerCreatesAndSwitchesToNewBranch() throws {
+        let app = try makeApp(scenario: "git-branch", workspaceName: "BranchCreateWorkspace")
+        app.launch()
+
+        let statusItem = app.buttons["workspace-status-git-reference"]
+        XCTAssertTrue(statusItem.waitForExistence(timeout: 5))
+
+        statusItem.click()
+
+        let filterField = app.textFields["branch-picker-filter"]
+        XCTAssertTrue(filterField.waitForExistence(timeout: 5))
+        filterField.click()
+        filterField.typeText("feature/new-work")
+
+        let createAction = app.buttons["branch-picker-create-action"]
+        XCTAssertTrue(createAction.exists)
+        XCTAssertEqual(createAction.label, "Create and check out \"feature/new-work\"")
+        createAction.click()
+
+        XCTAssertFalse(app.textFields["branch-picker-filter"].waitForExistence(timeout: 1))
+        XCTAssertEqual(statusItem.label, "feature/new-work")
+    }
+
+    func testLiveBranchPickerShowsCurrentAndMainBranch() throws {
+        let workspaceURL = try makeGitRepositoryWorkspace(named: "LiveBranchPickerWorkspace")
+        let app = makeApp(scenario: "git-branch-live", workspaceURL: workspaceURL)
+        app.launch()
+
+        let statusItem = app.buttons["workspace-status-git-reference"]
+        XCTAssertTrue(statusItem.waitForExistence(timeout: 5))
+        XCTAssertEqual(statusItem.label, "git-branches")
+
+        statusItem.click()
+
+        XCTAssertTrue(app.buttons["branch-picker-item-git-branches"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["branch-picker-item-main"].exists)
+    }
+
+    func testLiveBranchPickerCanReopenWithoutCrashing() throws {
+        let workspaceURL = try makeGitRepositoryWorkspace(named: "LiveBranchPickerReopenWorkspace")
+        let app = makeApp(scenario: "git-branch-live", workspaceURL: workspaceURL)
+        app.launch()
+
+        let statusItem = app.buttons["workspace-status-git-reference"]
+        XCTAssertTrue(statusItem.waitForExistence(timeout: 5))
+
+        for _ in 0..<3 {
+            statusItem.click()
+            XCTAssertTrue(app.textFields["branch-picker-filter"].waitForExistence(timeout: 5))
+            dismissBranchPicker(in: app)
+            XCTAssertFalse(app.textFields["branch-picker-filter"].waitForExistence(timeout: 1))
+            XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2))
+        }
+    }
+
+    func testNoGitBranchPlaceholderStaysNonInteractive() throws {
+        let app = try makeApp(scenario: "ready", workspaceName: "NoBranchNonInteractiveWorkspace")
+        app.launch()
+
+        XCTAssertFalse(app.buttons["workspace-status-git-reference"].exists)
+        let placeholder = app.otherElements["workspace-status-git-reference"]
+        XCTAssertTrue(placeholder.waitForExistence(timeout: 5))
+        XCTAssertEqual(placeholder.label, "No Git branch")
     }
 
     func testLaunchPerformance() throws {
@@ -247,6 +346,10 @@ final class AtelierCodeUITests: XCTestCase {
         let workspaceURL = FileManager.default.temporaryDirectory.appendingPathComponent(workspaceName, isDirectory: true)
         try FileManager.default.createDirectory(at: workspaceURL, withIntermediateDirectories: true)
 
+        return makeApp(scenario: scenario, workspaceURL: workspaceURL)
+    }
+
+    private func makeApp(scenario: String, workspaceURL: URL) -> XCUIApplication {
         let app = XCUIApplication()
         app.launchEnvironment["ATELIERCODE_UI_TEST_SCENARIO"] = scenario
         app.launchEnvironment["ATELIERCODE_UI_TEST_WORKSPACE"] = workspaceURL.path
@@ -257,5 +360,63 @@ final class AtelierCodeUITests: XCTestCase {
         for _ in 0..<maxSwipes where element.exists == false {
             scrollView.swipeUp()
         }
+    }
+
+    private func dismissBranchPicker(in app: XCUIApplication) {
+        let statusItem = app.buttons["workspace-status-git-reference"]
+        if statusItem.exists {
+            statusItem.click()
+        }
+
+        if app.textFields["branch-picker-filter"].exists {
+            app.typeKey(.escape, modifierFlags: [])
+        }
+    }
+
+    private func makeGitRepositoryWorkspace(named name: String) throws -> URL {
+        let workspaceURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(name)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: workspaceURL, withIntermediateDirectories: true)
+
+        try runGit(arguments: ["init", "-b", "main"], in: workspaceURL)
+        try runGit(arguments: ["config", "user.name", "AtelierCode UI Tests"], in: workspaceURL)
+        try runGit(arguments: ["config", "user.email", "ui-tests@example.com"], in: workspaceURL)
+        guard let data = "hello\n".data(using: .utf8) else {
+            throw NSError(domain: "AtelierCodeUITests", code: 1)
+        }
+
+        try data.write(to: workspaceURL.appendingPathComponent("README.md", isDirectory: false))
+        try runGit(arguments: ["add", "README.md"], in: workspaceURL)
+        try runGit(arguments: ["commit", "-m", "Initial commit"], in: workspaceURL)
+        try runGit(arguments: ["switch", "-c", "git-branches"], in: workspaceURL)
+        return workspaceURL
+    }
+
+    @discardableResult
+    private func runGit(arguments: [String], in directoryURL: URL) throws -> String {
+        let process = Process()
+        process.executableURL = URL(
+            fileURLWithPath: "/Applications/Xcode.app/Contents/Developer/usr/bin/git",
+            isDirectory: false
+        )
+        process.arguments = ["-C", directoryURL.path] + arguments
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let stdout = String(decoding: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        let stderr = String(decoding: stderrPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+
+        guard process.terminationStatus == 0 else {
+            XCTFail(stderr.isEmpty ? stdout : stderr)
+            throw NSError(domain: "AtelierCodeUITests", code: Int(process.terminationStatus))
+        }
+
+        return stdout
     }
 }


### PR DESCRIPTION
## Summary
- add richer git branch state and actions in the app model so branch switching and creation are first-class flows
- refresh workspace git status on focus and route changes so the selected workspace branch stays current
- rework the branch picker into a clearer command-palette style UI with inline create-and-checkout, lighter typography, and keyboard navigation
- extend unit and UI coverage around git status refresh and branch picker behavior

## Why
The branch picker path for creating a branch was hard to discover, and the selected workspace git status could become stale when returning to the app or moving between workspace routes. This branch makes the branch workflow more explicit and keeps the status indicator more trustworthy.

## Impact
Users can switch or create branches directly from the status item with keyboard support, and the branch label updates more reliably across workspace navigation and app focus changes.

## Validation
- `xcodebuild test -project AtelierCode.xcodeproj -scheme AtelierCode -destination 'platform=macOS' -only-testing:AtelierCodeTests/AtelierCodeTests`
- A full run including `AtelierCodeUITests` compiled, but the macOS UI runner timed out while enabling automation mode in this environment.