### PR TITLE
Add App Server foundation shell and server-owned lifecycle API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Use this guidance for implementation work related to the new Bun + TypeScript Ap
 - Use Bun's built-in test runner (`bun:test`) for App Server tests.
 - Keep TypeScript strict. Do not use `any`; prefer `unknown`, explicit narrowing, and discriminated unions.
 - Treat protocol schemas and typed contracts as the source of truth at ingress and egress.
+- Prefer specific naming: use `Agent`, `App Server`, and `WebSocket Server`; avoid generic `runtime` terminology in `AppServer/`.
 - Keep Bun-specific APIs at the edges. Domain logic must stay transport-agnostic and runtime-agnostic.
 - Preserve stable IDs and typed event models for `Thread`, `Turn`, `Item`, and approval flows.
 - Model reasoning, plan, diff, and approval events as first-class typed variants even when an early phase only passes them through or stubs part of the behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,11 +14,17 @@ Use this guidance for implementation work related to the new Bun + TypeScript Ap
 - Use Bun's built-in test runner (`bun:test`) for App Server tests.
 - Keep TypeScript strict. Do not use `any`; prefer `unknown`, explicit narrowing, and discriminated unions.
 - Treat protocol schemas and typed contracts as the source of truth at ingress and egress.
+- Use TypeBox as the canonical schema and runtime validation library for App Server protocol and persistence-adjacent schemas.
+- Keep validation layers distinct: JSON-RPC envelope validation, method and event payload validation, and domain execution-rule validation.
 - Prefer specific naming: use `Agent`, `App Server`, and `WebSocket Server`; avoid generic `runtime` terminology in `AppServer/`.
+- Keep shared App Server code provider-neutral. Use `Codex` only in adapter-specific code under `src/agents/` or for literal provider and model values.
 - Keep Bun-specific APIs at the edges. Domain logic must stay transport-agnostic and runtime-agnostic.
+- Preserve App / Core / Features boundaries. Feature code must stay transport-blind, and only `src/app/` composes `core/` and feature modules.
+- Within a feature, only `store.ts` should touch the database handle or Drizzle APIs directly. Services should depend on store functions or store-shaped capabilities.
 - Preserve stable IDs and typed event models for `Thread`, `Turn`, `Item`, and approval flows.
 - Model reasoning, plan, diff, and approval events as first-class typed variants even when an early phase only passes them through or stubs part of the behavior.
 - Keep side effects out of domain logic. Prefer injected interfaces and small pure mapping functions.
+- Prefer typed `Result` returns in domain services. Reserve `throw` for exceptional infrastructure failures, and keep domain rule failures distinct from schema and parse failures.
 - Prefer deterministic tests with fakes and fixtures. Add or update tests for lifecycle sequencing, event ordering, approvals, and error handling when behavior changes.
 - Treat generated or vendored Codex contract artifacts as read-only reference inputs. Update them through their generation or import workflow, not by hand.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,13 @@
 # AGENTS.md
 
 This file guides AI coding agents working on the new `AppServer/` effort.
-It complements [Docs/app-server-design.md](/Users/jeremytondo/Projects/AtelierCode/Docs/app-server-design.md) and [issue #45](https://github.com/jeremytondo/atelier-code/issues/45); it does not replace them.
+It complements [app-server-design.md](/Docs/app-server-design.md).
 
 ## Scope
 
 Use this guidance for implementation work related to the new Bun + TypeScript App Server foundation.
 
-## AppServer Standards
+## App Server Standards
 
 - Use Bun and TypeScript with ECMAScript modules (`import` / `export`) only.
 - Use Biome as the single formatter and linter for `AppServer/`.
@@ -22,7 +22,7 @@ Use this guidance for implementation work related to the new Bun + TypeScript Ap
 - Prefer deterministic tests with fakes and fixtures. Add or update tests for lifecycle sequencing, event ordering, approvals, and error handling when behavior changes.
 - Treat generated or vendored Codex contract artifacts as read-only reference inputs. Update them through their generation or import workflow, not by hand.
 
-## Required Checks
+## App Server Required Checks
 
 Before considering App Server work complete:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+This file guides AI coding agents working on the new `AppServer/` effort.
+It complements [Docs/app-server-design.md](/Users/jeremytondo/Projects/AtelierCode/Docs/app-server-design.md) and [issue #45](https://github.com/jeremytondo/atelier-code/issues/45); it does not replace them.
+
+## Scope
+
+Use this guidance for implementation work related to the new Bun + TypeScript App Server foundation.
+
+## AppServer Standards
+
+- Use Bun and TypeScript with ECMAScript modules (`import` / `export`) only.
+- Use Biome as the single formatter and linter for `AppServer/`.
+- Use Bun's built-in test runner (`bun:test`) for App Server tests.
+- Keep TypeScript strict. Do not use `any`; prefer `unknown`, explicit narrowing, and discriminated unions.
+- Treat protocol schemas and typed contracts as the source of truth at ingress and egress.
+- Keep Bun-specific APIs at the edges. Domain logic must stay transport-agnostic and runtime-agnostic.
+- Preserve stable IDs and typed event models for `Thread`, `Turn`, `Item`, and approval flows.
+- Model reasoning, plan, diff, and approval events as first-class typed variants even when an early phase only passes them through or stubs part of the behavior.
+- Keep side effects out of domain logic. Prefer injected interfaces and small pure mapping functions.
+- Prefer deterministic tests with fakes and fixtures. Add or update tests for lifecycle sequencing, event ordering, approvals, and error handling when behavior changes.
+- Treat generated or vendored Codex contract artifacts as read-only reference inputs. Update them through their generation or import workflow, not by hand.
+
+## Required Checks
+
+Before considering App Server work complete:
+
+- Run `biome format` or `biome check` as appropriate.
+- Run `tsc --noEmit`.
+- Run targeted `bun test` coverage for the touched area.
+- Add or update `bun:test` coverage when changing contract, domain, adapter, or persistence behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Use this guidance for implementation work related to the new Bun + TypeScript Ap
 - Prefer typed `Result` returns in domain services. Reserve `throw` for exceptional infrastructure failures, and keep domain rule failures distinct from schema and parse failures.
 - Prefer deterministic tests with fakes and fixtures. Add or update tests for lifecycle sequencing, event ordering, approvals, and error handling when behavior changes.
 - Treat generated or vendored Codex contract artifacts as read-only reference inputs. Update them through their generation or import workflow, not by hand.
+- Keep files focused on one clear responsibility; when a file starts mixing concerns or gets hard to scan, extract internal helpers or a sibling module with a clear purpose rather than adding a new abstraction only to make the file smaller.
 
 ## App Server Required Checks
 

--- a/AppServer/appserver.config.example.json
+++ b/AppServer/appserver.config.example.json
@@ -1,0 +1,5 @@
+{
+  "port": 7331,
+  "databasePath": "./var/appserver.sqlite",
+  "logLevel": "info"
+}

--- a/AppServer/biome.json
+++ b/AppServer/biome.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always"
+    }
+  }
+}

--- a/AppServer/bun.lock
+++ b/AppServer/bun.lock
@@ -1,0 +1,46 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "ateliercode-app-server",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.41",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.0.0",
+        "bun-types": "^1.3.11",
+        "typescript": "^5.9.2",
+      },
+    },
+  },
+  "packages": {
+    "@biomejs/biome": ["@biomejs/biome@2.4.11", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.11", "@biomejs/cli-darwin-x64": "2.4.11", "@biomejs/cli-linux-arm64": "2.4.11", "@biomejs/cli-linux-arm64-musl": "2.4.11", "@biomejs/cli-linux-x64": "2.4.11", "@biomejs/cli-linux-x64-musl": "2.4.11", "@biomejs/cli-win32-arm64": "2.4.11", "@biomejs/cli-win32-x64": "2.4.11" }, "bin": { "biome": "bin/biome" } }, "sha512-nWxHX8tf3Opb/qRgZpBbsTOqOodkbrkJ7S+JxJAruxOReaDPPmPuLBAGQ8vigyUgo0QBB+oQltNEAvalLcjggA=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wOt+ed+L2dgZanWyL6i29qlXMc088N11optzpo10peayObBaAshbTcxKUchzEMp9QSY8rh5h6VfAFE3WTS1rqg=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-gZ6zR8XmZlExfi/Pz/PffmdpWOQ8Qhy7oBztgkR8/ylSRyLwfRPSadmiVCV8WQ8PoJ2MWUy2fgID9zmtgUUJmw=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-avdJaEElXrKceK0va9FkJ4P5ci3N01TGkc6ni3P8l3BElqbOz42Wg2IyX3gbh0ZLEd4HVKEIrmuVu/AMuSeFFA=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-+Sbo1OAmlegtdwqFE8iOxFIWLh1B3OEgsuZfBpyyN/kWuqZ8dx9ZEes6zVnDMo+zRHF2wLynRVhoQmV7ohxl2Q=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.11", "", { "os": "linux", "cpu": "x64" }, "sha512-TagWV0iomp5LnEnxWFg4nQO+e52Fow349vaX0Q/PIcX6Zhk4GGBgp3qqZ8PVkpC+cuehRctMf3+6+FgQ8jCEFQ=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.11", "", { "os": "linux", "cpu": "x64" }, "sha512-bexd2IklK7ZgPhrz6jXzpIL6dEAH9MlJU1xGTrypx+FICxrXUp4CqtwfiuoDKse+UlgAlWtzML3jrMqeEAHEhA=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-RJhaTnY8byzxDt4bDVb7AFPHkPcjOPK3xBip4ZRTrN3TEfyhjLRm3r3mqknqydgVTB74XG8l4jMLwEACEeihVg=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.11", "", { "os": "win32", "cpu": "x64" }, "sha512-A8D3JM/00C2KQgUV3oj8Ba15EHEYwebAGCy5Sf9GAjr5Y3+kJIYOiESoqRDeuRZueuMdCsbLZIUqmPhpYXJE9A=="],
+
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
+
+    "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
+
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+  }
+}

--- a/AppServer/package.json
+++ b/AppServer/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "ateliercode-app-server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "bun run ./src/index.ts",
+    "check": "biome check .",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@sinclair/typebox": "^0.34.41"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.0.0",
+    "bun-types": "^1.3.11",
+    "typescript": "^5.9.2"
+  }
+}

--- a/AppServer/src/agents/index.ts
+++ b/AppServer/src/agents/index.ts
@@ -1,0 +1,4 @@
+import { createLifecyclePlaceholder, type LifecycleComponent } from "@/core/shared";
+
+export const createAgentsFeaturePlaceholder = (): LifecycleComponent =>
+  createLifecyclePlaceholder("feature.agents");

--- a/AppServer/src/app/config.test.ts
+++ b/AppServer/src/app/config.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  APP_SERVER_CONFIG_PATH_ENV,
+  APP_SERVER_DATABASE_PATH_ENV,
+  APP_SERVER_LOG_LEVEL_ENV,
+  APP_SERVER_PORT_ENV,
+  loadAppServerConfig,
+} from "@/app/config";
+import { ConfigParseStartupError, ConfigValidationStartupError } from "@/core/shared";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  while (temporaryDirectories.length > 0) {
+    const directory = temporaryDirectories.pop();
+
+    if (directory !== undefined) {
+      await rm(directory, { force: true, recursive: true });
+    }
+  }
+});
+
+describe("loadAppServerConfig", () => {
+  test("loads a valid configuration file", async () => {
+    const tempDirectory = await createTempDirectory();
+    const configPath = join(tempDirectory, "appserver.config.json");
+
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        port: 7331,
+        databasePath: "./var/test.sqlite",
+        logLevel: "info",
+      }),
+    );
+
+    const config = await loadAppServerConfig({
+      cwd: tempDirectory,
+      env: {
+        [APP_SERVER_CONFIG_PATH_ENV]: "appserver.config.json",
+      },
+    });
+
+    expect(config).toEqual({
+      configPath,
+      port: 7331,
+      databasePath: "./var/test.sqlite",
+      logLevel: "info",
+    });
+  });
+
+  test("applies supported environment overrides after reading the file", async () => {
+    const tempDirectory = await createTempDirectory();
+    const configPath = join(tempDirectory, "appserver.config.json");
+
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        port: 7000,
+        databasePath: "./var/original.sqlite",
+        logLevel: "info",
+      }),
+    );
+
+    const config = await loadAppServerConfig({
+      cwd: tempDirectory,
+      env: {
+        [APP_SERVER_CONFIG_PATH_ENV]: "appserver.config.json",
+        [APP_SERVER_PORT_ENV]: "9000",
+        [APP_SERVER_DATABASE_PATH_ENV]: "./var/override.sqlite",
+        [APP_SERVER_LOG_LEVEL_ENV]: "debug",
+      },
+    });
+
+    expect(config).toEqual({
+      configPath,
+      port: 9000,
+      databasePath: "./var/override.sqlite",
+      logLevel: "debug",
+    });
+  });
+
+  test("fails with a parse startup error for malformed JSON", async () => {
+    const tempDirectory = await createTempDirectory();
+    const configPath = join(tempDirectory, "appserver.config.json");
+
+    await writeFile(configPath, "{");
+
+    await expect(
+      loadAppServerConfig({
+        cwd: tempDirectory,
+        env: {
+          [APP_SERVER_CONFIG_PATH_ENV]: "appserver.config.json",
+        },
+      }),
+    ).rejects.toBeInstanceOf(ConfigParseStartupError);
+  });
+
+  test("fails with a validation startup error for schema-invalid config", async () => {
+    const tempDirectory = await createTempDirectory();
+    const configPath = join(tempDirectory, "appserver.config.json");
+
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        port: 0,
+        databasePath: "",
+        logLevel: "loud",
+      }),
+    );
+
+    await expect(
+      loadAppServerConfig({
+        cwd: tempDirectory,
+        env: {
+          [APP_SERVER_CONFIG_PATH_ENV]: "appserver.config.json",
+        },
+      }),
+    ).rejects.toBeInstanceOf(ConfigValidationStartupError);
+  });
+});
+
+const createTempDirectory = async (): Promise<string> => {
+  const directory = await mkdtemp(join(tmpdir(), "atelier-appserver-config-"));
+  temporaryDirectories.push(directory);
+
+  return directory;
+};

--- a/AppServer/src/app/config.ts
+++ b/AppServer/src/app/config.ts
@@ -1,0 +1,188 @@
+import { readFile } from "node:fs/promises";
+import { isAbsolute, resolve } from "node:path";
+import { type Static, Type } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
+import { LOG_LEVELS, type LogLevel } from "@/app/logger";
+import {
+  ConfigParseStartupError,
+  ConfigReadStartupError,
+  ConfigValidationStartupError,
+} from "@/core/shared";
+
+export const APP_SERVER_CONFIG_PATH_ENV = "APP_SERVER_CONFIG_PATH";
+export const APP_SERVER_PORT_ENV = "APP_SERVER_PORT";
+export const APP_SERVER_DATABASE_PATH_ENV = "APP_SERVER_DATABASE_PATH";
+export const APP_SERVER_LOG_LEVEL_ENV = "APP_SERVER_LOG_LEVEL";
+
+export const DEFAULT_APP_SERVER_CONFIG_PATH = "appserver.config.example.json";
+
+const AppServerConfigFileSchema = Type.Object(
+  {
+    port: Type.Integer({ minimum: 1, maximum: 65535 }),
+    databasePath: Type.String({ minLength: 1 }),
+    logLevel: Type.Union([
+      Type.Literal("debug"),
+      Type.Literal("info"),
+      Type.Literal("warn"),
+      Type.Literal("error"),
+    ]),
+  },
+  { additionalProperties: false },
+);
+
+type AppServerConfigFile = Static<typeof AppServerConfigFileSchema>;
+
+export type AppServerEnvironment = Readonly<
+  Partial<
+    Record<
+      | typeof APP_SERVER_CONFIG_PATH_ENV
+      | typeof APP_SERVER_PORT_ENV
+      | typeof APP_SERVER_DATABASE_PATH_ENV
+      | typeof APP_SERVER_LOG_LEVEL_ENV,
+      string | undefined
+    >
+  >
+>;
+
+export type AppServerConfig = Readonly<
+  AppServerConfigFile & {
+    readonly configPath: string;
+  }
+>;
+
+export type LoadAppServerConfigOptions = Readonly<{
+  cwd?: string;
+  env?: AppServerEnvironment;
+  readTextFile?: (path: string) => Promise<string>;
+}>;
+
+export const loadAppServerConfig = async (
+  options: LoadAppServerConfigOptions = {},
+): Promise<AppServerConfig> => {
+  const cwd = options.cwd ?? process.cwd();
+  const env = resolveEnvironment(options.env);
+  const configPath = resolveConfigPath(cwd, env[APP_SERVER_CONFIG_PATH_ENV]);
+  const readTextFile = options.readTextFile ?? readTextFileFromDisk;
+
+  const rawConfigText = await readConfigText(configPath, readTextFile);
+  const parsedConfig = parseConfigText(rawConfigText, configPath);
+  const configFromFile = validateConfig(parsedConfig, configPath, "configuration file");
+  const resolvedConfig = applyEnvironmentOverrides(configFromFile, env, configPath);
+
+  return Object.freeze({
+    configPath,
+    ...resolvedConfig,
+  });
+};
+
+const resolveConfigPath = (cwd: string, configPathOverride: string | undefined): string => {
+  const rawPath = configPathOverride?.trim() || DEFAULT_APP_SERVER_CONFIG_PATH;
+
+  return isAbsolute(rawPath) ? rawPath : resolve(cwd, rawPath);
+};
+
+const readConfigText = async (
+  configPath: string,
+  readTextFile: (path: string) => Promise<string>,
+): Promise<string> => {
+  try {
+    return await readTextFile(configPath);
+  } catch (error) {
+    throw new ConfigReadStartupError(configPath, error);
+  }
+};
+
+const parseConfigText = (rawConfigText: string, configPath: string): unknown => {
+  try {
+    return JSON.parse(rawConfigText) as unknown;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Invalid JSON";
+    throw new ConfigParseStartupError(configPath, message);
+  }
+};
+
+const validateConfig = (
+  candidate: unknown,
+  configPath: string,
+  source: string,
+): AppServerConfigFile => {
+  if (!Value.Check(AppServerConfigFileSchema, candidate)) {
+    const issues = [...Value.Errors(AppServerConfigFileSchema, candidate)].map(
+      (validationError) => {
+        const path = validationError.path || "/";
+        return `${source} ${path}: ${validationError.message}`;
+      },
+    );
+
+    throw new ConfigValidationStartupError(configPath, issues);
+  }
+
+  const validatedConfig = candidate as AppServerConfigFile;
+
+  return Object.freeze({
+    port: validatedConfig.port,
+    databasePath: validatedConfig.databasePath,
+    logLevel: validatedConfig.logLevel,
+  });
+};
+
+const applyEnvironmentOverrides = (
+  config: AppServerConfigFile,
+  env: AppServerEnvironment,
+  configPath: string,
+): AppServerConfigFile => {
+  const candidate: Record<string, unknown> = {
+    ...config,
+  };
+
+  if (env[APP_SERVER_PORT_ENV] !== undefined) {
+    candidate.port = parsePortOverride(env[APP_SERVER_PORT_ENV]);
+  }
+
+  if (env[APP_SERVER_DATABASE_PATH_ENV] !== undefined) {
+    candidate.databasePath = env[APP_SERVER_DATABASE_PATH_ENV].trim();
+  }
+
+  if (env[APP_SERVER_LOG_LEVEL_ENV] !== undefined) {
+    candidate.logLevel = parseLogLevelOverride(env[APP_SERVER_LOG_LEVEL_ENV]);
+  }
+
+  return validateConfig(candidate, configPath, "resolved configuration");
+};
+
+const parsePortOverride = (rawPort: string): number => {
+  const trimmedPort = rawPort.trim();
+
+  if (!/^\d+$/.test(trimmedPort)) {
+    return Number.NaN;
+  }
+
+  return Number.parseInt(trimmedPort, 10);
+};
+
+const parseLogLevelOverride = (rawLogLevel: string): string => {
+  const normalizedLogLevel = rawLogLevel.trim();
+
+  if (isLogLevel(normalizedLogLevel)) {
+    return normalizedLogLevel;
+  }
+
+  return normalizedLogLevel;
+};
+
+const isLogLevel = (value: string): value is LogLevel =>
+  LOG_LEVELS.some((logLevel) => logLevel === value);
+
+const resolveEnvironment = (env: AppServerEnvironment | undefined): AppServerEnvironment =>
+  Object.freeze({
+    [APP_SERVER_CONFIG_PATH_ENV]:
+      env?.[APP_SERVER_CONFIG_PATH_ENV] ?? process.env[APP_SERVER_CONFIG_PATH_ENV],
+    [APP_SERVER_PORT_ENV]: env?.[APP_SERVER_PORT_ENV] ?? process.env[APP_SERVER_PORT_ENV],
+    [APP_SERVER_DATABASE_PATH_ENV]:
+      env?.[APP_SERVER_DATABASE_PATH_ENV] ?? process.env[APP_SERVER_DATABASE_PATH_ENV],
+    [APP_SERVER_LOG_LEVEL_ENV]:
+      env?.[APP_SERVER_LOG_LEVEL_ENV] ?? process.env[APP_SERVER_LOG_LEVEL_ENV],
+  });
+
+const readTextFileFromDisk = async (path: string): Promise<string> =>
+  readFile(path, { encoding: "utf8" });

--- a/AppServer/src/app/logger.test.ts
+++ b/AppServer/src/app/logger.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { createLogger } from "@/app/logger";
+
+describe("createLogger", () => {
+  test("emits structured JSON log lines", () => {
+    const lines: string[] = [];
+    const logger = createLogger({
+      level: "info",
+      now: () => "2026-04-09T00:00:00.000Z",
+      write: (line) => {
+        lines.push(line);
+      },
+    });
+
+    logger.info("hello");
+
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0])).toEqual({
+      timestamp: "2026-04-09T00:00:00.000Z",
+      level: "info",
+      message: "hello",
+    });
+  });
+
+  test("merges base context with per-call context", () => {
+    const lines: string[] = [];
+    const logger = createLogger({
+      level: "debug",
+      context: { connectionId: "conn-1" },
+      now: () => "2026-04-09T00:00:00.000Z",
+      write: (line) => {
+        lines.push(line);
+      },
+    });
+
+    logger.info("context", { threadId: "thread-1" });
+
+    expect(JSON.parse(lines[0])).toEqual({
+      timestamp: "2026-04-09T00:00:00.000Z",
+      level: "info",
+      message: "context",
+      connectionId: "conn-1",
+      threadId: "thread-1",
+    });
+  });
+
+  test("withContext creates a derived logger without mutating the parent logger", () => {
+    const lines: string[] = [];
+    const logger = createLogger({
+      level: "info",
+      context: { connectionId: "conn-1" },
+      now: () => "2026-04-09T00:00:00.000Z",
+      write: (line) => {
+        lines.push(line);
+      },
+    });
+    const childLogger = logger.withContext({ threadId: "thread-1" });
+
+    logger.info("parent");
+    childLogger.info("child");
+
+    expect(JSON.parse(lines[0])).toEqual({
+      timestamp: "2026-04-09T00:00:00.000Z",
+      level: "info",
+      message: "parent",
+      connectionId: "conn-1",
+    });
+    expect(JSON.parse(lines[1])).toEqual({
+      timestamp: "2026-04-09T00:00:00.000Z",
+      level: "info",
+      message: "child",
+      connectionId: "conn-1",
+      threadId: "thread-1",
+    });
+  });
+});

--- a/AppServer/src/app/logger.ts
+++ b/AppServer/src/app/logger.ts
@@ -1,0 +1,86 @@
+export const LOG_LEVELS = ["debug", "info", "warn", "error"] as const;
+
+export type LogLevel = (typeof LOG_LEVELS)[number];
+export type LogValue = string | number | boolean | null;
+export type LogContext = Readonly<Record<string, LogValue>>;
+export type LogWriter = (line: string) => void;
+
+export type Logger = Readonly<{
+  level: LogLevel;
+  debug: (message: string, context?: LogContext) => void;
+  info: (message: string, context?: LogContext) => void;
+  warn: (message: string, context?: LogContext) => void;
+  error: (message: string, context?: LogContext) => void;
+  withContext: (context: LogContext) => Logger;
+}>;
+
+export type CreateLoggerOptions = Readonly<{
+  level: LogLevel;
+  context?: LogContext;
+  now?: () => string;
+  write?: LogWriter;
+}>;
+
+type LogRecord = Readonly<
+  {
+    timestamp: string;
+    level: LogLevel;
+    message: string;
+  } & Record<string, LogValue>
+>;
+
+const LOG_LEVEL_PRIORITY: Readonly<Record<LogLevel, number>> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+export const createLogger = (options: CreateLoggerOptions): Logger => {
+  const baseContext = Object.freeze({ ...(options.context ?? {}) });
+  const now = options.now ?? defaultNow;
+  const write = options.write ?? defaultWrite;
+
+  const shouldLog = (level: LogLevel): boolean =>
+    LOG_LEVEL_PRIORITY[level] >= LOG_LEVEL_PRIORITY[options.level];
+
+  const emit = (level: LogLevel, message: string, context?: LogContext): void => {
+    if (!shouldLog(level)) {
+      return;
+    }
+
+    const record: LogRecord = {
+      timestamp: now(),
+      level,
+      message,
+      ...baseContext,
+      ...(context ?? {}),
+    };
+
+    write(JSON.stringify(record));
+  };
+
+  return Object.freeze({
+    level: options.level,
+    debug: (message, context) => emit("debug", message, context),
+    info: (message, context) => emit("info", message, context),
+    warn: (message, context) => emit("warn", message, context),
+    error: (message, context) => emit("error", message, context),
+    withContext: (context) =>
+      createLogger({
+        level: options.level,
+        now,
+        write,
+        context: {
+          ...baseContext,
+          ...context,
+        },
+      }),
+  });
+};
+
+const defaultNow = (): string => new Date().toISOString();
+
+const defaultWrite = (line: string): void => {
+  console.log(line);
+};

--- a/AppServer/src/app/server.test.ts
+++ b/AppServer/src/app/server.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { APP_SERVER_CONFIG_PATH_ENV } from "@/app/config";
+import { createLogger } from "@/app/logger";
+import {
+  createAppServer,
+  createConfiguredAppServer,
+  type ShutdownSignal,
+  type SignalHandler,
+  type SignalRegistrar,
+} from "@/app/server";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  while (temporaryDirectories.length > 0) {
+    const directory = temporaryDirectories.pop();
+
+    if (directory !== undefined) {
+      await rm(directory, { force: true, recursive: true });
+    }
+  }
+});
+
+describe("createAppServer", () => {
+  test("bootstraps from the config file into an idle server", async () => {
+    const tempDirectory = await createConfigDirectory();
+    const server = await createAppServer({
+      cwd: tempDirectory,
+      env: {
+        [APP_SERVER_CONFIG_PATH_ENV]: "appserver.config.json",
+      },
+      writeLog: () => {},
+      signalRegistrar: createSignalRegistrar(),
+    });
+
+    expect(server.getState()).toBe("idle");
+    expect(server.config.port).toBe(7331);
+  });
+
+  test("starts successfully", async () => {
+    const tempDirectory = await createConfigDirectory();
+    const server = await createAppServer({
+      cwd: tempDirectory,
+      env: {
+        [APP_SERVER_CONFIG_PATH_ENV]: "appserver.config.json",
+      },
+      writeLog: () => {},
+      signalRegistrar: createSignalRegistrar(),
+    });
+
+    await server.start();
+
+    expect(server.getState()).toBe("started");
+    expect(server.config.port).toBe(7331);
+  });
+
+  test("loads config in the high-level constructor while the configured constructor avoids config I/O", async () => {
+    let readCount = 0;
+
+    const bootstrappedServer = await createAppServer({
+      cwd: "/unused",
+      env: {
+        [APP_SERVER_CONFIG_PATH_ENV]: "appserver.config.json",
+      },
+      readTextFile: async () => {
+        readCount += 1;
+
+        return JSON.stringify({
+          port: 7331,
+          databasePath: "./var/test.sqlite",
+          logLevel: "info",
+        });
+      },
+      writeLog: () => {},
+      signalRegistrar: createSignalRegistrar(),
+    });
+
+    const configuredServer = createConfiguredAppServer({
+      config: Object.freeze({
+        configPath: "/tmp/appserver.config.json",
+        port: 7444,
+        databasePath: "./var/configured.sqlite",
+        logLevel: "info",
+      }),
+      logger: createLogger({
+        level: "info",
+        write: () => {},
+      }),
+      signalRegistrar: createSignalRegistrar(),
+    });
+
+    expect(readCount).toBe(1);
+    expect(bootstrappedServer.config.configPath).toBe("/unused/appserver.config.json");
+    expect(configuredServer.config.port).toBe(7444);
+    expect(configuredServer.getState()).toBe("idle");
+  });
+});
+
+describe("AppServer lifecycle", () => {
+  test("stops cleanly", async () => {
+    const server = createConfiguredAppServer({
+      config: createTestConfig(),
+      logger: createSilentLogger(),
+      signalRegistrar: createSignalRegistrar(),
+    });
+
+    await server.start();
+    await server.stop("test-stop");
+
+    expect(server.getState()).toBe("stopped");
+  });
+
+  test("makes stop idempotent", async () => {
+    let stopCount = 0;
+    const server = createConfiguredAppServer({
+      config: createTestConfig(),
+      logger: createSilentLogger(),
+      signalRegistrar: createSignalRegistrar(),
+      components: [
+        {
+          name: "fake-component",
+          start: async () => {},
+          stop: async () => {
+            stopCount += 1;
+          },
+        },
+      ],
+    });
+
+    await server.start();
+    await Promise.all([server.stop("first"), server.stop("second")]);
+
+    expect(stopCount).toBe(1);
+    expect(server.getState()).toBe("stopped");
+  });
+
+  test("routes shutdown signals through the server lifecycle", async () => {
+    let stopReason: string | undefined;
+    const signalRegistrar = createSignalRegistrar();
+    const server = createConfiguredAppServer({
+      config: createTestConfig(),
+      logger: createSilentLogger(),
+      signalRegistrar,
+      components: [
+        {
+          name: "fake-component",
+          start: async () => {},
+          stop: async (reason) => {
+            stopReason = reason;
+          },
+        },
+      ],
+    });
+
+    await server.start();
+    signalRegistrar.emit("SIGTERM");
+    await server.waitForStop();
+
+    expect(stopReason).toBe("SIGTERM");
+    expect(server.getState()).toBe("stopped");
+  });
+
+  test("resolves waitForStop after shutdown", async () => {
+    const server = createConfiguredAppServer({
+      config: createTestConfig(),
+      logger: createSilentLogger(),
+      signalRegistrar: createSignalRegistrar(),
+    });
+    let didResolve = false;
+
+    await server.start();
+    const waitForStop = server.waitForStop().then(() => {
+      didResolve = true;
+    });
+
+    expect(didResolve).toBe(false);
+
+    await server.stop("wait-for-stop");
+    await waitForStop;
+
+    expect(didResolve).toBe(true);
+  });
+});
+
+type FakeSignalRegistrar = SignalRegistrar &
+  Readonly<{
+    emit: (signal: ShutdownSignal) => void;
+  }>;
+
+const createSignalRegistrar = (): FakeSignalRegistrar => {
+  const handlers: Record<ShutdownSignal, SignalHandler[]> = {
+    SIGINT: [],
+    SIGTERM: [],
+  };
+
+  return {
+    subscribe: (signal, handler) => {
+      handlers[signal].push(handler);
+
+      return () => {
+        handlers[signal] = handlers[signal].filter((candidate) => candidate !== handler);
+      };
+    },
+    emit: (signal) => {
+      for (const handler of handlers[signal]) {
+        handler();
+      }
+    },
+  };
+};
+
+const createSilentLogger = () =>
+  createLogger({
+    level: "info",
+    write: () => {},
+  });
+
+const createTestConfig = () =>
+  Object.freeze({
+    configPath: "/tmp/appserver.config.json",
+    port: 7331,
+    databasePath: "./var/test.sqlite",
+    logLevel: "info" as const,
+  });
+
+const createConfigDirectory = async (): Promise<string> => {
+  const directory = await mkdtemp(join(tmpdir(), "atelier-appserver-server-"));
+  temporaryDirectories.push(directory);
+
+  await writeFile(
+    join(directory, "appserver.config.json"),
+    JSON.stringify({
+      port: 7331,
+      databasePath: "./var/test.sqlite",
+      logLevel: "info",
+    }),
+  );
+
+  return directory;
+};

--- a/AppServer/src/app/server.test.ts
+++ b/AppServer/src/app/server.test.ts
@@ -163,6 +163,108 @@ describe("AppServer lifecycle", () => {
     expect(server.getState()).toBe("stopped");
   });
 
+  test("finishes shutdown when stop is requested during startup", async () => {
+    const events: string[] = [];
+    const slowStart = createDeferredPromise<void>();
+    const server = createConfiguredAppServer({
+      config: createTestConfig(),
+      logger: createSilentLogger(),
+      signalRegistrar: createSignalRegistrar(),
+      components: [
+        {
+          name: "slow-component",
+          start: async () => {
+            events.push("slow:start:begin");
+            await slowStart.promise;
+            events.push("slow:start:end");
+          },
+          stop: async (reason) => {
+            events.push(`slow:stop:${reason}`);
+          },
+        },
+        {
+          name: "second-component",
+          start: async () => {
+            events.push("second:start");
+          },
+          stop: async (reason) => {
+            events.push(`second:stop:${reason}`);
+          },
+        },
+      ],
+    });
+
+    const startPromise = server.start();
+    await Promise.resolve();
+
+    const stopPromise = server.stop("manual");
+    slowStart.resolve();
+
+    await Promise.all([startPromise, stopPromise, server.waitForStop()]);
+
+    expect(server.getState()).toBe("stopped");
+    expect(events).toEqual(["slow:start:begin", "slow:start:end", "slow:stop:manual"]);
+  });
+
+  test("reaches a terminal state when component stop fails", async () => {
+    const signalRegistrar = createSignalRegistrar();
+    const server = createConfiguredAppServer({
+      config: createTestConfig(),
+      logger: createSilentLogger(),
+      signalRegistrar,
+      components: [
+        {
+          name: "failing-stop-component",
+          start: async () => {},
+          stop: async () => {
+            throw new Error("stop failed");
+          },
+        },
+      ],
+    });
+
+    await server.start();
+    await expect(server.stop("manual")).rejects.toThrow("stop failed");
+    await server.waitForStop();
+
+    expect(server.getState()).toBe("stopped");
+  });
+
+  test("rolls back started components when startup fails partway through", async () => {
+    const events: string[] = [];
+    const server = createConfiguredAppServer({
+      config: createTestConfig(),
+      logger: createSilentLogger(),
+      signalRegistrar: createSignalRegistrar(),
+      components: [
+        {
+          name: "first-component",
+          start: async () => {
+            events.push("first:start");
+          },
+          stop: async (reason) => {
+            events.push(`first:stop:${reason}`);
+          },
+        },
+        {
+          name: "failing-start-component",
+          start: async () => {
+            events.push("second:start");
+            throw new Error("start failed");
+          },
+          stop: async () => {
+            events.push("second:stop");
+          },
+        },
+      ],
+    });
+
+    await expect(server.start()).rejects.toThrow("start failed");
+
+    expect(server.getState()).toBe("idle");
+    expect(events).toEqual(["first:start", "second:start", "first:stop:startup-failed"]);
+  });
+
   test("resolves waitForStop after shutdown", async () => {
     const server = createConfiguredAppServer({
       config: createTestConfig(),
@@ -225,6 +327,21 @@ const createTestConfig = () =>
     databasePath: "./var/test.sqlite",
     logLevel: "info" as const,
   });
+
+const createDeferredPromise = <T>() => {
+  let resolvePromise: (value: T | PromiseLike<T>) => void = () => {};
+
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  return {
+    promise,
+    resolve: (value: T) => {
+      resolvePromise(value);
+    },
+  };
+};
 
 const createConfigDirectory = async (): Promise<string> => {
   const directory = await mkdtemp(join(tmpdir(), "atelier-appserver-server-"));

--- a/AppServer/src/app/server.ts
+++ b/AppServer/src/app/server.ts
@@ -77,7 +77,8 @@ export const createConfiguredAppServer = (options: CreateConfiguredAppServerOpti
   let state: AppServerState = "idle";
   let startPromise: Promise<void> | null = null;
   let stopPromise: Promise<void> | null = null;
-  let hasStarted = false;
+  let stopReason: string | null = null;
+  let startedComponents: LifecycleComponent[] = [];
   let signalUnsubscribes: readonly Unsubscribe[] = [];
   const waitForStop = createDeferred();
 
@@ -85,7 +86,12 @@ export const createConfiguredAppServer = (options: CreateConfiguredAppServerOpti
     const subscriptions = (["SIGINT", "SIGTERM"] as const).map((signal) =>
       signalRegistrar.subscribe(signal, () => {
         lifecycleLogger.info("Shutdown signal received", { signal });
-        void stop(signal);
+        void stop(signal).catch((error) => {
+          lifecycleLogger.error("App Server stop failed", {
+            reason: signal,
+            error: getErrorMessage(error),
+          });
+        });
       }),
     );
 
@@ -100,9 +106,35 @@ export const createConfiguredAppServer = (options: CreateConfiguredAppServerOpti
     signalUnsubscribes = Object.freeze([]);
   };
 
+  const stopStartedComponents = async (reason: string): Promise<void> => {
+    const stopErrors: unknown[] = [];
+
+    for (const component of [...startedComponents].reverse()) {
+      try {
+        await component.stop(reason);
+      } catch (error) {
+        stopErrors.push(error);
+      }
+    }
+
+    startedComponents = [];
+
+    if (stopErrors.length === 1) {
+      throw stopErrors[0];
+    }
+
+    if (stopErrors.length > 1) {
+      throw new AggregateError(stopErrors, "App Server shutdown failed");
+    }
+  };
+
   const start = async (): Promise<void> => {
     if (state === "started") {
       return;
+    }
+
+    if (state === "stopping") {
+      return stopPromise ?? Promise.resolve();
     }
 
     if (state === "stopped") {
@@ -121,10 +153,18 @@ export const createConfiguredAppServer = (options: CreateConfiguredAppServerOpti
       });
 
       for (const component of components) {
+        if (stopReason !== null) {
+          return;
+        }
+
         await component.start();
+        startedComponents.push(component);
       }
 
-      hasStarted = true;
+      if (stopReason !== null) {
+        return;
+      }
+
       registerSignalHandlers();
       state = "started";
       lifecycleLogger.info("App Server started", {
@@ -137,7 +177,17 @@ export const createConfiguredAppServer = (options: CreateConfiguredAppServerOpti
       await startPromise;
     } catch (error) {
       unregisterSignalHandlers();
-      state = "idle";
+      try {
+        await stopStartedComponents(stopReason ?? "startup-failed");
+      } catch (rollbackError) {
+        state = stopReason === null ? "idle" : "stopping";
+        throw new AggregateError(
+          [error, rollbackError],
+          "App Server startup failed and rollback failed",
+        );
+      }
+
+      state = stopReason === null ? "idle" : "stopping";
       throw error;
     } finally {
       startPromise = null;
@@ -153,20 +203,45 @@ export const createConfiguredAppServer = (options: CreateConfiguredAppServerOpti
       return stopPromise;
     }
 
+    stopReason = stopReason ?? reason;
     state = "stopping";
     unregisterSignalHandlers();
     stopPromise = (async () => {
-      lifecycleLogger.info("App Server stopping", { reason });
+      lifecycleLogger.info("App Server stopping", { reason: stopReason });
 
-      if (hasStarted) {
-        for (const component of [...components].reverse()) {
-          await component.stop(reason);
+      let stopError: unknown = null;
+
+      if (startPromise !== null) {
+        try {
+          await startPromise;
+        } catch (error) {
+          stopError = error;
+        }
+      }
+
+      if (startedComponents.length > 0) {
+        try {
+          await stopStartedComponents(stopReason);
+        } catch (error) {
+          stopError =
+            stopError === null
+              ? error
+              : new AggregateError([stopError, error], "App Server shutdown failed");
         }
       }
 
       state = "stopped";
-      lifecycleLogger.info("App Server stopped", { reason });
       waitForStop.resolve();
+
+      if (stopError !== null) {
+        lifecycleLogger.error("App Server stopped with errors", {
+          reason: stopReason,
+          error: getErrorMessage(stopError),
+        });
+        throw stopError;
+      }
+
+      lifecycleLogger.info("App Server stopped", { reason: stopReason });
     })();
 
     try {
@@ -190,6 +265,18 @@ type Deferred = Readonly<{
   promise: Promise<void>;
   resolve: () => void;
 }>;
+
+const getErrorMessage = (error: unknown): string => {
+  if (error instanceof AggregateError) {
+    return error.errors.map(getErrorMessage).join("; ");
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+};
 
 const createDeferred = (): Deferred => {
   let isResolved = false;

--- a/AppServer/src/app/server.ts
+++ b/AppServer/src/app/server.ts
@@ -1,0 +1,234 @@
+import { createAgentsFeaturePlaceholder } from "@/agents";
+import {
+  type AppServerConfig,
+  type LoadAppServerConfigOptions,
+  loadAppServerConfig,
+} from "@/app/config";
+import { createLogger, type Logger, type LogWriter } from "@/app/logger";
+import { createApprovalsFeaturePlaceholder } from "@/approvals";
+import { createProtocolBootstrapPlaceholder } from "@/core/protocol";
+import type { LifecycleComponent } from "@/core/shared";
+import { createStoreBootstrapPlaceholder } from "@/core/store";
+import { createTransportBootstrapPlaceholder } from "@/core/transport";
+import { createThreadsFeaturePlaceholder } from "@/threads";
+import { createTurnsFeaturePlaceholder } from "@/turns";
+import { createWorkspacesFeaturePlaceholder } from "@/workspaces";
+
+export type AppServerState = "idle" | "starting" | "started" | "stopping" | "stopped";
+export type ShutdownSignal = "SIGINT" | "SIGTERM";
+export type SignalHandler = () => void;
+export type Unsubscribe = () => void;
+
+export type SignalRegistrar = Readonly<{
+  subscribe: (signal: ShutdownSignal, handler: SignalHandler) => Unsubscribe;
+}>;
+
+export type AppServer = Readonly<{
+  config: AppServerConfig;
+  logger: Logger;
+  getState: () => AppServerState;
+  start: () => Promise<void>;
+  stop: (reason?: string) => Promise<void>;
+  waitForStop: () => Promise<void>;
+}>;
+
+export type CreateConfiguredAppServerOptions = Readonly<{
+  config: AppServerConfig;
+  logger?: Logger;
+  now?: () => string;
+  writeLog?: LogWriter;
+  components?: readonly LifecycleComponent[];
+  signalRegistrar?: SignalRegistrar;
+}>;
+
+export type CreateAppServerOptions = Readonly<
+  LoadAppServerConfigOptions & {
+    now?: () => string;
+    writeLog?: LogWriter;
+    components?: readonly LifecycleComponent[];
+    signalRegistrar?: SignalRegistrar;
+  }
+>;
+
+export const createAppServer = async (options: CreateAppServerOptions = {}): Promise<AppServer> => {
+  const config = await loadAppServerConfig(options);
+
+  return createConfiguredAppServer({
+    config,
+    now: options.now,
+    writeLog: options.writeLog,
+    components: options.components,
+    signalRegistrar: options.signalRegistrar,
+  });
+};
+
+export const createConfiguredAppServer = (options: CreateConfiguredAppServerOptions): AppServer => {
+  const logger =
+    options.logger ??
+    createLogger({
+      level: options.config.logLevel,
+      now: options.now,
+      write: options.writeLog,
+    });
+  const lifecycleLogger = logger.withContext({ component: "app-server" });
+  const components = [...(options.components ?? createDefaultComponents())];
+  const signalRegistrar = options.signalRegistrar ?? processSignalRegistrar;
+
+  let state: AppServerState = "idle";
+  let startPromise: Promise<void> | null = null;
+  let stopPromise: Promise<void> | null = null;
+  let hasStarted = false;
+  let signalUnsubscribes: readonly Unsubscribe[] = [];
+  const waitForStop = createDeferred();
+
+  const registerSignalHandlers = (): void => {
+    const subscriptions = (["SIGINT", "SIGTERM"] as const).map((signal) =>
+      signalRegistrar.subscribe(signal, () => {
+        lifecycleLogger.info("Shutdown signal received", { signal });
+        void stop(signal);
+      }),
+    );
+
+    signalUnsubscribes = Object.freeze(subscriptions);
+  };
+
+  const unregisterSignalHandlers = (): void => {
+    for (const unsubscribe of signalUnsubscribes) {
+      unsubscribe();
+    }
+
+    signalUnsubscribes = Object.freeze([]);
+  };
+
+  const start = async (): Promise<void> => {
+    if (state === "started") {
+      return;
+    }
+
+    if (state === "stopped") {
+      return;
+    }
+
+    if (startPromise !== null) {
+      return startPromise;
+    }
+
+    state = "starting";
+    startPromise = (async () => {
+      lifecycleLogger.info("App Server starting", {
+        port: options.config.port,
+        databasePath: options.config.databasePath,
+      });
+
+      for (const component of components) {
+        await component.start();
+      }
+
+      hasStarted = true;
+      registerSignalHandlers();
+      state = "started";
+      lifecycleLogger.info("App Server started", {
+        port: options.config.port,
+        componentCount: components.length,
+      });
+    })();
+
+    try {
+      await startPromise;
+    } catch (error) {
+      unregisterSignalHandlers();
+      state = "idle";
+      throw error;
+    } finally {
+      startPromise = null;
+    }
+  };
+
+  const stop = async (reason = "requested"): Promise<void> => {
+    if (state === "stopped") {
+      return;
+    }
+
+    if (stopPromise !== null) {
+      return stopPromise;
+    }
+
+    state = "stopping";
+    unregisterSignalHandlers();
+    stopPromise = (async () => {
+      lifecycleLogger.info("App Server stopping", { reason });
+
+      if (hasStarted) {
+        for (const component of [...components].reverse()) {
+          await component.stop(reason);
+        }
+      }
+
+      state = "stopped";
+      lifecycleLogger.info("App Server stopped", { reason });
+      waitForStop.resolve();
+    })();
+
+    try {
+      await stopPromise;
+    } finally {
+      stopPromise = null;
+    }
+  };
+
+  return Object.freeze({
+    config: options.config,
+    logger,
+    getState: () => state,
+    start,
+    stop,
+    waitForStop: () => waitForStop.promise,
+  });
+};
+
+type Deferred = Readonly<{
+  promise: Promise<void>;
+  resolve: () => void;
+}>;
+
+const createDeferred = (): Deferred => {
+  let isResolved = false;
+  let resolvePromise: () => void = () => {};
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = () => {
+      if (isResolved) {
+        return;
+      }
+
+      isResolved = true;
+      resolve();
+    };
+  });
+
+  return {
+    promise,
+    resolve: resolvePromise,
+  };
+};
+
+export const processSignalRegistrar: SignalRegistrar = Object.freeze({
+  subscribe: (signal, handler) => {
+    process.on(signal, handler);
+
+    return () => {
+      process.off(signal, handler);
+    };
+  },
+});
+
+const createDefaultComponents = (): readonly LifecycleComponent[] =>
+  Object.freeze([
+    createTransportBootstrapPlaceholder(),
+    createProtocolBootstrapPlaceholder(),
+    createStoreBootstrapPlaceholder(),
+    createAgentsFeaturePlaceholder(),
+    createWorkspacesFeaturePlaceholder(),
+    createThreadsFeaturePlaceholder(),
+    createTurnsFeaturePlaceholder(),
+    createApprovalsFeaturePlaceholder(),
+  ]);

--- a/AppServer/src/approvals/index.ts
+++ b/AppServer/src/approvals/index.ts
@@ -1,0 +1,4 @@
+import { createLifecyclePlaceholder, type LifecycleComponent } from "@/core/shared";
+
+export const createApprovalsFeaturePlaceholder = (): LifecycleComponent =>
+  createLifecyclePlaceholder("feature.approvals");

--- a/AppServer/src/core/protocol/index.ts
+++ b/AppServer/src/core/protocol/index.ts
@@ -1,0 +1,4 @@
+import { createLifecyclePlaceholder, type LifecycleComponent } from "@/core/shared";
+
+export const createProtocolBootstrapPlaceholder = (): LifecycleComponent =>
+  createLifecyclePlaceholder("core.protocol");

--- a/AppServer/src/core/shared/index.ts
+++ b/AppServer/src/core/shared/index.ts
@@ -1,0 +1,3 @@
+export * from "@/core/shared/lifecycle";
+export * from "@/core/shared/result";
+export * from "@/core/shared/startup-errors";

--- a/AppServer/src/core/shared/lifecycle.ts
+++ b/AppServer/src/core/shared/lifecycle.ts
@@ -1,0 +1,12 @@
+export type LifecycleComponent = Readonly<{
+  name: string;
+  start: () => Promise<void>;
+  stop: (reason: string) => Promise<void>;
+}>;
+
+export const createLifecyclePlaceholder = (name: string): LifecycleComponent =>
+  Object.freeze({
+    name,
+    start: async () => {},
+    stop: async () => {},
+  });

--- a/AppServer/src/core/shared/result.ts
+++ b/AppServer/src/core/shared/result.ts
@@ -1,0 +1,21 @@
+export type Result<T, E> =
+  | Readonly<{
+      ok: true;
+      data: T;
+    }>
+  | Readonly<{
+      ok: false;
+      error: E;
+    }>;
+
+export const ok = <T>(data: T): Result<T, never> =>
+  Object.freeze({
+    ok: true,
+    data,
+  });
+
+export const err = <E>(error: E): Result<never, E> =>
+  Object.freeze({
+    ok: false,
+    error,
+  });

--- a/AppServer/src/core/shared/startup-errors.ts
+++ b/AppServer/src/core/shared/startup-errors.ts
@@ -1,0 +1,46 @@
+export type StartupErrorCode =
+  | "CONFIG_READ_ERROR"
+  | "CONFIG_PARSE_ERROR"
+  | "CONFIG_VALIDATION_ERROR";
+
+export abstract class StartupError extends Error {
+  public readonly code: StartupErrorCode;
+
+  protected constructor(code: StartupErrorCode, message: string, cause?: unknown) {
+    super(message, cause === undefined ? undefined : { cause });
+    this.name = new.target.name;
+    this.code = code;
+  }
+}
+
+export class ConfigReadStartupError extends StartupError {
+  public readonly configPath: string;
+
+  public constructor(configPath: string, cause?: unknown) {
+    super("CONFIG_READ_ERROR", `Failed to read App Server config at ${configPath}`, cause);
+    this.configPath = configPath;
+  }
+}
+
+export class ConfigParseStartupError extends StartupError {
+  public readonly configPath: string;
+
+  public constructor(configPath: string, details: string) {
+    super("CONFIG_PARSE_ERROR", `Failed to parse App Server config at ${configPath}: ${details}`);
+    this.configPath = configPath;
+  }
+}
+
+export class ConfigValidationStartupError extends StartupError {
+  public readonly configPath: string;
+  public readonly issues: readonly string[];
+
+  public constructor(configPath: string, issues: readonly string[]) {
+    super(
+      "CONFIG_VALIDATION_ERROR",
+      `Invalid App Server config at ${configPath}: ${issues.join("; ")}`,
+    );
+    this.configPath = configPath;
+    this.issues = issues;
+  }
+}

--- a/AppServer/src/core/store/index.ts
+++ b/AppServer/src/core/store/index.ts
@@ -1,0 +1,4 @@
+import { createLifecyclePlaceholder, type LifecycleComponent } from "@/core/shared";
+
+export const createStoreBootstrapPlaceholder = (): LifecycleComponent =>
+  createLifecyclePlaceholder("core.store");

--- a/AppServer/src/core/transport/index.ts
+++ b/AppServer/src/core/transport/index.ts
@@ -1,0 +1,4 @@
+import { createLifecyclePlaceholder, type LifecycleComponent } from "@/core/shared";
+
+export const createTransportBootstrapPlaceholder = (): LifecycleComponent =>
+  createLifecyclePlaceholder("core.transport");

--- a/AppServer/src/index.ts
+++ b/AppServer/src/index.ts
@@ -1,0 +1,15 @@
+import { createAppServer } from "@/app/server";
+
+try {
+  const server = await createAppServer();
+  await server.start();
+  await server.waitForStop();
+} catch (error) {
+  if (error instanceof Error) {
+    console.error(error.message);
+  } else {
+    console.error("Unknown App Server startup failure");
+  }
+
+  process.exitCode = 1;
+}

--- a/AppServer/src/threads/index.ts
+++ b/AppServer/src/threads/index.ts
@@ -1,0 +1,4 @@
+import { createLifecyclePlaceholder, type LifecycleComponent } from "@/core/shared";
+
+export const createThreadsFeaturePlaceholder = (): LifecycleComponent =>
+  createLifecyclePlaceholder("feature.threads");

--- a/AppServer/src/turns/index.ts
+++ b/AppServer/src/turns/index.ts
@@ -1,0 +1,4 @@
+import { createLifecyclePlaceholder, type LifecycleComponent } from "@/core/shared";
+
+export const createTurnsFeaturePlaceholder = (): LifecycleComponent =>
+  createLifecyclePlaceholder("feature.turns");

--- a/AppServer/src/workspaces/index.ts
+++ b/AppServer/src/workspaces/index.ts
@@ -1,0 +1,4 @@
+import { createLifecyclePlaceholder, type LifecycleComponent } from "@/core/shared";
+
+export const createWorkspacesFeaturePlaceholder = (): LifecycleComponent =>
+  createLifecyclePlaceholder("feature.workspaces");

--- a/AppServer/tsconfig.json
+++ b/AppServer/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/Docs/app-server-design.md
+++ b/Docs/app-server-design.md
@@ -243,21 +243,21 @@ Use a storage interface boundary from the start, with:
 * **SQLite-backed implementation** as the initial durable target.
 
 Implementation choice:
-* Use **raw Bun SQLite** for the first implementation.
-* Do **not** introduce Drizzle or another typed query layer in the initial rollout.
-* Keep SQL localized behind `store/` repository-style interfaces so a future query layer can be introduced without changing protocol, domain, or adapter code.
+* Use **Drizzle ORM with SQLite** for the first durable implementation.
+* Treat Drizzle as the canonical schema and query layer for App Server metadata persistence.
+* Keep Drizzle usage localized behind `store/` repository-style interfaces so protocol, domain, and adapter code do not depend directly on ORM details.
 
 Migration approach:
-* Store schema migrations as ordered SQL files under the App Server module, for example `AppServer/migrations/0001_initial.sql`.
+* Generate and apply schema migrations using the Drizzle migration workflow for the App Server module.
+* Keep migration files checked into the repository under the App Server module so schema evolution is reviewable and reproducible.
 * Apply migrations at process startup before accepting WebSocket traffic.
-* Track applied migrations in a small metadata table such as `schema_migrations`.
 * Treat failed or partial migrations as startup failures rather than attempting best-effort runtime recovery.
 * Limit the persisted schema in early phases to Atelier-owned metadata and reattachment state, not mirrored thread/turn/item history.
 
 Rationale:
-* Keeps the first persisted version operationally simple and easy to inspect.
-* Avoids committing early to an additional abstraction layer before the metadata schema has stabilized.
-* Preserves a clean upgrade path to a richer persistence layer without forcing Phase 1 and Phase 2 work to wait on ORM decisions.
+* Avoids building a one-off migration system that would likely be replaced later.
+* Keeps schema definition, migrations, and typed queries aligned from the first persisted version.
+* Improves maintainability as the metadata model grows across persistence and restart-reattachment phases.
 
 ### Module Boundaries
 Recommended module boundaries:

--- a/Docs/app-server-design.md
+++ b/Docs/app-server-design.md
@@ -367,10 +367,11 @@ Pass dependencies as function arguments or use a context object. The `app/server
 
 Each file has a single responsibility and explicitly exports its public surface. Each feature exposes one `index.ts` barrel file exporting its public API. Internal helpers stay unexported. Do not chain barrel files across directory levels.
 
-#### Naming: Avoid "Runtime"
-
-The word "runtime" is overloaded — it can mean the server process, an external agent system (Codex, Claude), or an operational status. Use specific terms instead: **agent** for external agent systems, **agent adapter** for agent-specific integration code, **execution status** or **thread status** for operational state, and **server process** for the running App Server.
-
+#### Naming Conventions
+ 
+**Avoid "runtime."** The word is overloaded — it can mean the server process, an external agent system (Codex, Claude), or an operational status. Use specific terms instead: **agent** for external agent systems, **agent adapter** for agent-specific integration code, **execution status** or **thread status** for operational state, and **server process** for the running App Server.
+ 
+**Keep "Codex" out of shared code.** Use "Codex" only in adapter-specific code under `src/agents/` or for literal provider and model values. Everywhere else in the App Server, use generic names. The App Server contract is Codex-shaped, but shared code should not be coupled to a specific agent's name.
 
 ### Testing Strategy
 

--- a/Docs/app-server-design.md
+++ b/Docs/app-server-design.md
@@ -206,102 +206,226 @@ Example approval flow:
 
 The App Server should preserve enough approval state to support active UI rendering, recovery, and auditability, but it should not invent a separate approval system when the runtime already provides the authoritative flow.
 
-## Implementation Foundations
-This section captures the baseline implementation decisions for the App Server. The goal is to keep the server contract explicit and Codex-shaped while introducing only the minimum structure required for reliability and growth.
+## Architecture & Standards
 
-### App Server Foundation
-The App Server should provide:
-* A runnable process with healthcheck and initialize flow.
-* A long-lived WebSocket entrypoint for request, response, and notification traffic.
-* A method dispatcher that maps each incoming `method` to a handler, correlates responses using request `id`, and returns consistent protocol errors for unsupported methods or invalid params.
-* Session-scoped execution state needed to coordinate active work (for example, which thread is loaded, whether a turn is currently active, and whether an approval is pending), without redefining the canonical thread/turn/item records produced by the connected agent runtime.
-* A `Store` interface for Atelier-owned data (such as workspace metadata and thread index data), where domain services call interface methods and concrete implementations (for example, in-memory or SQLite) are swapped underneath without changing WebSocket handlers or protocol message shapes.
+This section defines the module architecture, coding standards, and tooling decisions for the Atelier Code App Server. It complements the core design document and replaces the original Module Boundaries section.
+
+
+### Module Architecture (App / Core / Features)
+
+The App Server strictly separates infrastructure plumbing from domain business logic using a pragmatic **App / Core / Features** architecture. The primary organizational axis is **feature cohesion**: code that changes together lives together. Infrastructure remains generic and stable while domain logic scales with feature growth.
+
+#### Feature Directories — Domain Logic
+
+Feature directories live at the `src/` root alongside `app/` and `core/` (e.g., `src/workspaces/`, `src/threads/`, `src/turns/`, `src/agents/`). This layer contains the business value of Atelier Code. Code here represents features and entities.
+
+**Contents:** TypeBox validation schemas, business logic services, protocol entry points (`*.handlers.ts`), and feature-specific repository interfaces that define what persistence queries the feature requires.
+
+**Rule:** Feature directories are entirely blind to the transport layer. They do not know if a request came from a WebSocket, an HTTP endpoint, or a local CLI. They receive parsed objects, execute logic, and return results.
+
+**Agent adapters** live under `src/agents/`. Adapter logic is domain-meaningful — it defines how Atelier talks to a specific agent like Codex or Claude — not generic plumbing. Adapter interfaces are defined here, with concrete implementations per agent as sub-modules.
+
+**Interdependencies:** Features may depend on each other's public interfaces (turns depend on threads), but only through explicit imports of typed contracts exported from the feature's `index.ts`. Features must not reach into each other's internals.
+
+Each feature exposes a single barrel `index.ts` that exports its public API: handlers, service functions, types, and repository interfaces. Internal helpers remain unexported. Barrel files should not be chained across directory levels — one per feature is the limit.
+
+#### `src/core/` — Infrastructure Engine
+
+This layer is generic, reusable plumbing that makes the server run. It is strictly isolated from domain logic.
+
+- **`transport/`** — Manages raw socket connections (e.g., `websocket-server.ts`). It only emits and receives raw strings. It does not parse JSON or handle business logic.
+- **`protocol/`** — The translation layer. It parses raw strings from the transport layer into JSON-RPC objects and uses a generic `Dispatcher` to route methods to registered feature handlers.
+- **`store/`** — Persistence interfaces and their implementations (in-memory and SQLite via Drizzle). Feature-specific repository interfaces are defined in the features themselves; core store implementations fulfill those interfaces.
+- **`shared/`** — Truly generic utilities used across the application (e.g., custom error classes, ID generators).
+
+#### `src/app/` — Orchestrator
+
+This is the bootstrap layer and the **only** place in the codebase where `core/` and feature directories are allowed to interact.
+
+- **`server.ts`** — The main entry point. It initializes the core transport and protocol engines, registers the feature handlers with the dispatcher, wires parsed events to the transport layer, and starts the listener. It contains zero per-request business logic.
+- **`session.ts`** — Manages process-level lifecycle (startup, shutdown, healthcheck). Session-scoped execution state such as loaded threads, active turns, and pending approvals belongs in the relevant feature directories, not here.
+
+#### Import Rules
+
+- `core/transport/`, `core/protocol/`, and `core/store/` are peers. None imports from another. All three may import from `core/shared/`.
+- Feature directories never import from `core/transport/` or any WebSocket-specific code.
+- `src/app/` is the only place that connects transport, protocol, store, and features.
+
 
 ### Server Framework
-Use **raw `Bun.serve`** for the App Server shell.
 
-Rationale:
-* Keeps protocol ownership explicit at the transport boundary.
-* Minimizes framework-level indirection for long-lived WebSocket lifecycle handling.
-* Aligns with existing Bun + TypeScript tooling already used by the bridge runtime.
-* Reduces risk of framework-imposed patterns drifting from the Codex-shaped contract.
+Use **raw `Bun.serve`** for the App Server shell. No HTTP framework (Hono, Elysia, etc.) is needed.
 
-### Validation Model
-Use a three-layer validation model:
-1. **Envelope validation**: Parse and validate JSON-RPC-shaped message envelopes at ingress.
-2. **Method payload validation**: Validate `params` and event payloads with method-specific schemas.
-3. **Execution rule validation**: Enforce lifecycle and state rules in domain services.
+The App Server exposes a single long-lived WebSocket connection, not a REST API with routing and middleware. The JSON-RPC method dispatcher is the router. This is a small, protocol-critical surface that should be owned directly rather than abstracted behind a framework that provides no value for this use case.
 
-Guidelines:
-* Inbound requests and outbound notifications should both be validated against canonical schemas.
-* Validation failures should map to stable, machine-readable error codes and message shapes.
-* Execution rule violations (for example, steering a non-active turn) should be distinct from schema parse failures.
 
-### Persistence Strategy
-Use a storage interface boundary from the start, with:
-* **In-memory implementation** as the default for iteration and testing.
-* **SQLite-backed implementation** as the initial durable target.
+### Schema & Validation
 
-Implementation choice:
-* Use **Drizzle ORM with SQLite** for the first durable implementation.
-* Treat Drizzle as the canonical schema and query layer for App Server metadata persistence.
-* Keep Drizzle usage localized behind `store/` repository-style interfaces so protocol, domain, and adapter code do not depend directly on ORM details.
+Use **TypeBox** as the schema and runtime validation library.
 
-Migration approach:
-* Generate and apply schema migrations using the Drizzle migration workflow for the App Server module.
-* Keep migration files checked into the repository under the App Server module so schema evolution is reviewable and reproducible.
-* Apply migrations at process startup before accepting WebSocket traffic.
-* Treat failed or partial migrations as startup failures rather than attempting best-effort runtime recovery.
-* Limit the persisted schema in early phases to Atelier-owned metadata and reattachment state, not mirrored thread/turn/item history.
+TypeBox produces JSON Schema natively and supports compiled runtime validation, which fits a protocol-heavy WebSocket server well. Drizzle has first-class TypeBox schema generation support, keeping the persistence and validation layers aligned without a mapping step.
 
-Rationale:
-* Avoids building a one-off migration system that would likely be replaced later.
-* Keeps schema definition, migrations, and typed queries aligned from the first persisted version.
-* Improves maintainability as the metadata model grows across persistence and restart-reattachment phases.
+Validation follows three layers:
 
-### Module Boundaries
-Recommended module boundaries:
-* `transport/` for WebSocket server, connection/session lifecycle, and framing.
-* `protocol/` for envelope parsing, dispatcher, method registry, and response/error mapping.
-* `schema/` for request/response/notification payload schemas.
-* `domain/` for workspace/thread/turn/approval orchestration and invariants.
-* `store/` for persistence interfaces and in-memory implementations.
-* `runtime-adapters/` for Codex adapter and future runtime adapters.
+1. **Envelope validation** — Parse and validate JSON-RPC-shaped message envelopes at ingress.
+2. **Method payload validation** — Validate `params` and event payloads against method-specific TypeBox schemas.
+3. **Execution rule validation** — Enforce lifecycle and state rules in domain services.
 
-Dependency direction:
-* `transport/` may depend on `protocol/` but not on `domain/`, `store/`, or runtime-specific code directly.
-* `protocol/` may depend on `schema/` and `domain/` service interfaces, but should not depend on concrete `store/` or runtime adapter implementations.
-* `schema/` is a leaf for contract definitions and should not depend on transport, domain orchestration, persistence, or adapters.
-* `domain/` owns lifecycle rules and orchestration. It may depend on abstract interfaces implemented by `store/` and `runtime-adapters/`, but must not depend on transport concerns.
-* `store/` implements persistence interfaces owned by the domain boundary and must not depend on `transport/` or WebSocket protocol handling.
-* `runtime-adapters/` implement runtime-facing interfaces owned by the domain boundary and must not depend on `transport/`.
+Inbound requests and outbound notifications should both be validated against canonical schemas. Validation failures map to stable, machine-readable error codes and message shapes. Execution rule violations (e.g., steering a non-active turn) must be distinct from schema parse failures.
 
-In practical terms, dependency flow should point inward toward `domain/` contracts and outward only through injected interfaces. No lower layer should import from a higher layer simply for convenience.
+
+### Error Handling
+
+Domain services return typed `Result` values (see Coding Standards). The protocol layer is responsible for mapping those results to well-formed JSON-RPC responses — either `{ id, result }` for success or `{ id, error }` for failure.
+
+Protocol errors should use standard JSON-RPC error codes (`-32700` parse error, `-32600` invalid request, `-32601` method not found, `-32602` invalid params) for envelope and schema validation failures. Atelier-specific domain errors should use a dedicated code range (e.g., starting at `-33000`) with stable, machine-readable error codes such as `TURN_NOT_ACTIVE` or `THREAD_NOT_FOUND`. Every error response includes a `code`, a human-readable `message`, and an optional `data` field for structured context.
+
+The transport layer should have a catch-all that ensures the client always receives a well-formed error response, even for unhandled failures. No request should result in a silent drop or malformed payload.
+
+
+### Logging & Observability
+
+Use structured logging from day one. Log entries should be JSON-formatted with consistent fields: `timestamp`, `level`, `message`, and contextual correlation IDs (`connectionId`, `threadId`, `turnId`) where applicable.
+
+The logger should be provided through feature-level context created at composition time, not imported as a process-wide global. This keeps feature code testable (swap in a silent or capturing logger in tests) and avoids hidden side effects.
+
+Log levels: `debug` for internal tracing, `info` for lifecycle events (connection opened, thread started, turn completed), `warn` for recoverable issues (validation failure, stale approval), `error` for infrastructure failures (database write failed, WebSocket send failed).
+
+
+### Configuration
+
+Configuration is loaded once at startup from a configuration file, with environment variable overrides for values that vary by deployment context (e.g., port, database path in CI).
+
+The configuration file is the primary source for settings such as server port, database location, available agents, and feature flags. Environment variables may override specific values when needed but should not be the default mechanism for most settings.
+
+Configuration should be read into a typed, readonly config object during bootstrap in `app/server.ts` and passed explicitly to the subsystems that need it. Feature code should never read environment variables or configuration files directly.
+
+
+### Graceful Shutdown
+
+The server process should handle `SIGINT` and `SIGTERM` signals and shut down cleanly. Graceful shutdown means: stop accepting new WebSocket connections, interrupt or complete any active turns, flush pending store writes, close the database connection, and then exit.
+
+The shutdown sequence should be coordinated from `app/session.ts`, calling into features and core subsystems in the correct order. If shutdown takes longer than a reasonable timeout, force exit to avoid hanging indefinitely.
+
+
+### Path Aliases
+
+Use a single TypeScript path alias configured in `tsconfig.json` to keep imports clean across the project:
+
+```json
+{
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}
+```
+
+This covers all directories without requiring a new alias each time a feature is added. Relative imports are fine within a single feature directory; use the `@/` alias for cross-feature and cross-layer imports.
+
+
+### Coding Standards
+
+#### Functions and Data Over Classes
+
+The default unit of composition is a function that takes data and returns data. Services are modules that export functions, not class instances. Classes are reserved for genuinely stateful things — a WebSocket connection, a database handle — not used as namespaces for grouping methods.
+
+#### Colocation Over Premature Abstraction
+
+Keep code close to where it's used until duplication actually causes pain. A schema, its handler, and its service logic living in the same feature directory is the intended outcome of this architecture. Do not extract shared abstractions preemptively.
+
+#### Types as Documentation
+
+With strict TypeScript and TypeBox schemas at boundaries, types replace much of what comments and naming conventions traditionally provided. Discriminated unions for events, branded types for IDs, and `readonly` by default communicate constraints more reliably than prose. If a comment is explaining what a value can be, it should be a better type instead. Comments still have a role for non-obvious intent — protocol design decisions, lifecycle invariants, or "why" context that types alone cannot express.
+
+#### Explicit Over Clever
+
+Prefer `if`/`else` or `switch` over complex ternary chains. Prefer named intermediate variables over long method chains when readability suffers. Prefer early returns over nested conditionals. Code should be traceable linearly without jumping around.
+
+#### Errors as Values
+
+For domain logic, return result types rather than throwing:
+
+```typescript
+type Result<T, E = AppError> =
+  | { ok: true; data: T }
+  | { ok: false; error: E }
+```
+
+This makes error paths visible in the type system and forces callers to handle them. Reserve `throw` for genuinely exceptional infrastructure failures (database unreachable, WebSocket write failure). Domain-level failures such as "turn is not active" or "thread not found" are expected outcomes, not exceptions.
+
+#### Immutability by Default
+
+Use `readonly` on types, `as const` on literals, and avoid mutation in domain logic. When state needs to change, return a new value. Mutable state lives only at the edges — the store, the WebSocket connection — not in domain functions transforming data.
+
+#### Dependency Injection Without Magic
+
+Pass dependencies as function arguments or use a context object. The `app/server.ts` composition root wires things together at startup. No DI containers, decorators, or reflection.
+
+#### Small Files, Explicit Exports
+
+Each file has a single responsibility and explicitly exports its public surface. Each feature exposes one `index.ts` barrel file exporting its public API. Internal helpers stay unexported. Do not chain barrel files across directory levels.
+
+#### Naming: Avoid "Runtime"
+
+The word "runtime" is overloaded — it can mean the server process, an external agent system (Codex, Claude), or an operational status. Use specific terms instead: **agent** for external agent systems, **agent adapter** for agent-specific integration code, **execution status** or **thread status** for operational state, and **server process** for the running App Server.
+
 
 ### Testing Strategy
-The early App Server phases should be covered by three complementary test layers:
-* **Protocol harness tests**: End-to-end WebSocket contract tests that connect to the running server process, send JSON-RPC-shaped requests, and assert response shapes, protocol errors, and notification ordering for happy-path and invalid-sequencing cases.
-* **Domain service tests**: Focused unit tests for thread/turn/approval lifecycle rules using fake stores and fake runtime adapters. These tests should verify invariants such as initialize-before-use, one active turn per thread, approval scoping, and state transition correctness without requiring a live socket.
-* **Persistence tests**: Shared store conformance tests that run against both the in-memory store and the SQLite store. SQLite coverage should include migration application, restart reload, duplicate mapping protection, and failure behavior for missing or stale runtime linkage.
-* **Adapter contract tests**: Tests for the Codex adapter that validate request mapping, response normalization, notification translation, and error handling against pinned Codex contract fixtures where possible.
-* **Live smoke tests**: Environment-gated tests against a real local Codex setup for the minimal lifecycle once the real adapter exists. These should stay small and verify integration seams rather than replace deterministic contract coverage.
 
-Testing guidance:
-* Protocol harness tests are the primary executable check for the public Atelier contract.
-* Domain tests should cover execution-rule failures separately from schema validation failures.
-* Store conformance tests should run against every `Store` implementation to keep behavior aligned across in-memory and SQLite backends.
-* Adapter tests should prefer pinned fixtures for determinism and reserve live runtime tests for smoke coverage only.
+The App Server should be covered by five complementary test layers:
 
-### Deferred Architecture Decisions
-The following decisions are intentionally deferred and should be captured as separate follow-up work rather than left implicit:
-* Client-managed App Server installation, startup, restart, and reconnection behavior across local macOS and future remote-host scenarios.
-* Secure remote connection and discovery details for non-local App Server deployments.
-* Broader multi-runtime selection and capability-gating behavior beyond the initial Codex-only rollout.
+**Protocol harness tests** are the primary executable check for the public Atelier contract. These are end-to-end WebSocket tests that connect to the running server process, send JSON-RPC-shaped requests, and assert response shapes, protocol errors, and notification ordering for both happy-path and invalid-sequencing cases.
 
-### Baseline Readiness Criteria
+**Domain service tests** are focused unit tests for thread, turn, and approval lifecycle rules using fake stores and fake agent adapters. These verify invariants such as initialize-before-use, one active turn per thread, approval scoping, and state transition correctness without requiring a live socket. Domain tests should cover execution-rule failures separately from schema validation failures.
+
+**Store conformance tests** are shared tests that run against every store implementation (in-memory and SQLite) to keep behavior aligned across backends. SQLite coverage should include migration application, restart reload, duplicate mapping protection, and failure behavior for missing or stale linkage.
+
+**Agent adapter contract tests** validate request mapping, response normalization, notification translation, and error handling against pinned Codex contract fixtures where possible. Adapter tests should prefer pinned fixtures for determinism.
+
+**Live smoke tests** are environment-gated tests against a real local Codex setup for the minimal lifecycle once the real adapter exists. These should stay small and verify integration seams rather than replace deterministic contract coverage.
+
+
+### Tooling
+
+| Concern         | Tool              | Notes                                                                 |
+|-----------------|-------------------|-----------------------------------------------------------------------|
+| Execution       | Bun               | Server process, test runner, script execution.                        |
+| Language        | TypeScript (strict) | No `any`. Prefer `unknown`, explicit narrowing, discriminated unions. |
+| Server          | `Bun.serve`       | Raw WebSocket server. No HTTP framework.                              |
+| Validation      | TypeBox           | Runtime validation with native JSON Schema output.                    |
+| Persistence     | Drizzle ORM + SQLite | Behind repository interfaces. In-memory store for testing.         |
+| Formatting      | Biome             | Single formatter and linter for the App Server.                       |
+| Testing         | `bun:test`        | Bun's built-in test runner.                                          |
+
+
+### Persistence Strategy
+
+Use a storage interface boundary from the start, with an in-memory implementation as the default for iteration and testing and a SQLite-backed implementation as the initial durable target.
+
+Use **Drizzle ORM with SQLite** for the first durable implementation. Treat Drizzle as the canonical schema and query layer for App Server metadata persistence. Keep Drizzle usage localized behind repository-style interfaces in `core/store/` so protocol, feature, and adapter code do not depend directly on ORM details.
+
+Generate and apply schema migrations using the Drizzle migration workflow. Keep migration files checked into the repository under the App Server module so schema evolution is reviewable and reproducible. Apply migrations at process startup before accepting WebSocket traffic. Treat failed or partial migrations as startup failures rather than attempting best-effort recovery.
+
+Limit the persisted schema in early phases to Atelier-owned metadata and reattachment state, not mirrored thread/turn/item history.
+
+
+### Deferred Decisions
+
+The following decisions are intentionally deferred and should be captured as separate follow-up work:
+
+- Client-managed App Server installation, startup, restart, and reconnection behavior across local macOS and future remote-host scenarios.
+- Secure remote connection and discovery details for non-local App Server deployments.
+- Broader multi-agent selection and capability-gating behavior beyond the initial Codex-only rollout.
+
+
+### Readiness Criteria
+
 The implementation is ready for broader integration when:
-* The App Server can accept a WebSocket connection, initialize, and route a minimal method set.
-* Thread and turn lifecycle state transitions can be exercised end-to-end in tests.
-* Approval request and resolution flow can be simulated through notifications and decisions.
-* Domain orchestration depends on `Store` interfaces rather than concrete database code.
-* Protocol harness tests can assert contract shape and lifecycle sequencing.
+
+- The App Server can accept a WebSocket connection, initialize, and route a minimal method set.
+- Thread and turn lifecycle state transitions can be exercised end-to-end in tests.
+- Approval request and resolution flow can be simulated through notifications and decisions.
+- Feature code depends on store interfaces rather than concrete database code.
+- Protocol harness tests can assert contract shape and lifecycle sequencing.

--- a/Docs/app-server-design.md
+++ b/Docs/app-server-design.md
@@ -14,21 +14,14 @@ This document is centered on the **Agentic Coding** domain. The other domains ar
 
 ___
 # Agentic Coding
-The Agentic Coding domain defines the system for working with AI agent runtimes. It governs how users do things like create workspaces, conduct conversations, run turns, receive streaming updates, respond to approval requests, and continue work over time.
-
-Its role is to provide a stable product model across one or more agent runtimes while keeping provider-specific behavior contained within runtime adapters.
-
-## Scope
-This document is focused on the Atelier App Server and Agent Adapters for the Agentic Coding domain.
-
-It defines the server contract, adapter responsibilities, and runtime model. Native client architecture and client-specific behaviors are intentionally out of scope and should be defined separately.
+The Agentic Coding domain defines the system and UI for working with AI agents. It governs how users do things like create workspaces, conduct conversations, run turns, receive streaming updates, respond to approval requests, and continue work over time.
 
 ## Core System Components
 The Agentic Coding domain is composed of four primary system components:
 
 - **Client Application**: A native macOS application, with future support for iOS, that delivers the primary end-user experience. 
 - **App Server**: The backend control plane responsible for managing sessions, persistence, approvals, real-time thread updates, and the stable client-facing protocol. It coordinates communication between the client application and supported agent runtimes and owns the Atelier product contract.
-- **Agent Adapters**: A provider-specific integration layer that maps the App Server’s Codex-shaped contract to the native interface exposed by an agent runtime. The Codex adapter should be near pass-through. Other adapters, such as Claude Agent SDK, translate runtime-specific behavior into the Codex-shaped model used by the App Server. Adapters normalize runtime differences upward but do not redefine the platform model.
+- **Agent Adapters**: A provider-specific integration layer that maps the App Server's Codex-shaped contract to the native interface exposed by an agent runtime. The Codex adapter should be near pass-through. Other adapters, such as Claude Agent SDK, translate agent-specific behavior into the Codex-shaped model used by the App Server. Adapters normalize agent differences upward but do not redefine the platform model.
 - **Agent Runtimes**: The external agent systems that perform execution on behalf of the user, including maintaining the agent loop, invoking tools, and producing outputs. Examples include [Codex App Server](https://developers.openai.com/codex/app-server) and [Claude Agent SDK](https://platform.claude.com/docs/en/agent-sdk/overview).
 
 ### Note on the Client Application
@@ -38,12 +31,17 @@ The client is responsible for connecting to the App Server and ensuring that the
 
 The exact installation, startup, restart, and reconnection mechanism is intentionally out of scope for this document. The App Server contract should not depend on those client lifecycle mechanics beyond requiring a long-lived connection model and explicit initialization on each connection.
 
+## Scope
+This document is focused on the Atelier App Server and Agent Adapters for the Agentic Coding domain.
+
+It defines the server contract, adapter responsibilities, and protocol model. Native client architecture and client-specific behaviors are intentionally out of scope and should be defined separately.
+
 ## Design Stance
-The **[Codex App Server](https://developers.openai.com/codex/app-server)** is the reference runtime model for the Atelier Code App Server.
+The **[Codex App Server](https://developers.openai.com/codex/app-server)** is the reference model for the Atelier Code App Server.
 
-The **Atelier Code App Server** should mirror Codex as closely as practical. Atelier Code is not defining a separate orchestration model; it is adopting a Codex-shaped contract and adding only Atelier-owned platform concerns such as workspace metadata, persistence, capability gating, and runtime selection.
+The **Atelier Code App Server** should mirror Codex as closely as practical. Atelier Code is not defining a separate orchestration model; it is adopting a Codex-shaped contract and adding only Atelier-owned platform concerns such as workspace metadata, persistence, capability gating, and agent selection.
 
-The **Codex adapter** should be mostly pass-through. Other adapters, such as **Claude Agent SDK**, should conform to the same Codex-shaped contract. When a runtime cannot fully support that contract, the limitation should be exposed through explicit capabilities rather than weakening the model.
+The **Codex adapter** should be mostly pass-through. Other adapters, such as **Claude Agent SDK**, should conform to the same Codex-shaped contract. When an agent runtime cannot fully support that contract, the limitation should be exposed through explicit capabilities rather than weakening the model.
 
 ### Codex App Server References 
 * [Documentation](https://developers.openai.com/codex/app-server/)
@@ -67,7 +65,7 @@ In compact form:
 Atelier-specific methods should be limited to Atelier-owned concerns such as `Workspace` and related platform metadata.
 
 ## Core Primitives
-The **Agentic Coding** domain is built around one Atelier-owned primitive, **Workspace**, layered on top of a Codex-shaped runtime model built around **Thread**, **Turn**, and **Item**.
+The **Agentic Coding** domain is built around one Atelier-owned primitive, **Workspace**, layered on top of a Codex-shaped model built around **Thread**, **Turn**, and **Item**.
 * **Workspace**: The top-level container for agent work within a specific code environment. It defines where work takes place, including the local or remote environment and working directory, and stores workspace metadata and associated threads.
 * **Thread**: A conversation between the user and an agent. Threads contain turns.
 * **Turn**: A single user request and the agent work that follows. Turns contain items and stream incremental updates.
@@ -106,46 +104,46 @@ The Atelier **App Server** mirrors the core thread and turn operations of the **
 The App Server does not attempt to mirror the full Codex API surface. Codex-specific admin, configuration, plugin, and auxiliary execution APIs remain outside the core Atelier protocol.
 
 ## Models
-The **Atelier App Server** exposes the runtime model catalog through a Codex-aligned model/list method.
+The **Atelier App Server** exposes the model catalog through a Codex-aligned model/list method.
 
-The client only needs visible models, enough metadata to render the model picker, and the reasoning options supported by each model. The response should include the model identifier, display name, supported reasoning efforts, default reasoning effort, and whether the model is the runtime’s recommended default.
+The client only needs visible models, enough metadata to render the model picker, and the reasoning options supported by each model. The response should include the model identifier, display name, supported reasoning efforts, default reasoning effort, and whether the model is the agent runtime's recommended default.
 
-New threads use the runtime default model. The client may change the model and reasoning effort for a thread, and that selection persists for subsequent turns until changed again.
+New threads use the agent runtime default model. The client may change the model and reasoning effort for a thread, and that selection persists for subsequent turns until changed again.
 
 The current model and reasoning effort for a thread should be exposed through thread data, not through model/list.
 
 ## Threads
 A **Thread** is the conversation container for agent work. Threads are started with `thread/start`, resumed for active interaction with `thread/resume`, forked with `thread/fork`, read with `thread/read`, and listed with `thread/list`.
 
-`thread/read` should remain distinct from `thread/resume`. `thread/read` returns stored thread data only. It does not load the thread for active runtime interaction and does not establish a live notification stream.
+`thread/read` should remain distinct from `thread/resume`. `thread/read` returns stored thread data only. It does not load the thread for active interaction and does not establish a live notification stream.
 
-`thread/resume` loads the thread for active runtime interaction. After resume, live execution updates should arrive through notifications rather than through repeated point-in-time reads.
+`thread/resume` loads the thread for active interaction. After resume, live execution updates should arrive through notifications rather than through repeated point-in-time reads.
 
 `thread/list` and `thread/read` support history, navigation, and point-in-time inspection. They should not be treated as the canonical surface for active execution. 
 
-Loaded-thread behavior should be represented through thread runtime status and notifications, not as a separate platform primitive. Thread runtime status should remain Codex-shaped, with states such as `notLoaded`, `idle`, `active`, and `systemError`, while live loaded-thread changes are surfaced through notifications.
+Loaded-thread behavior should be represented through thread execution status and notifications, not as a separate platform primitive. Thread execution status should remain Codex-shaped, with states such as `notLoaded`, `idle`, `active`, and `systemError`, while live loaded-thread changes are surfaced through notifications.
 
 ## Turns
 A **Turn** is a single unit of work within a thread. It begins with user input and includes the agent activity that follows.
 
 Turns are started with turn/start, may be guided further with turn/steer, and may be interrupted with turn/interrupt.
 
-A turn belongs to exactly one thread and is ordered within that thread. Only one turn may be active at a time per thread. A `Turn` is the core execution primitive. An active turn is not a separate concept; it is a turn whose status remains in progress or is awaiting user or runtime input.
+A turn belongs to exactly one thread and is ordered within that thread. Only one turn may be active at a time per thread. A `Turn` is the core execution primitive. An active turn is not a separate concept; it is a turn whose status remains in progress or is awaiting user input.
 
 ### Turn Lifecycle
 * A turn begins when the client issues turn/start.
-* The server forwards the request to the selected runtime and begins streaming updates.
+* The server forwards the request to the selected agent runtime and begins streaming updates.
 * While the turn is active, the server streams lifecycle changes, item events, and any requests for user action such as approvals.
-* The client may send turn/steer to provide additional guidance to the active turn when supported by the runtime.
-* A turn remains active while execution is in progress or awaiting required user or runtime input.
+* The client may send turn/steer to provide additional guidance to the active turn when supported by the agent runtime.
+* A turn remains active while execution is in progress or awaiting required user input.
 * A turn ends when it completes, fails, or is interrupted.
 * The final turn state is emitted through the notification stream.
 
 ### Turn State
-Turn status represents overall execution progress and is distinct from item-level updates. The App Server should stay aligned with the runtime's turn model where practical. An active turn is a turn whose status is still in progress or awaiting input. Any normalization needed for cross-runtime consistency should be handled by the adapter layer.
+Turn status represents overall execution progress and is distinct from item-level updates. The App Server should stay aligned with the agent runtime's turn model where practical. An active turn is a turn whose status is still in progress or awaiting input. Any normalization needed for cross-agent consistency should be handled by the adapter layer.
 
 ## Events
-Events are the live notification stream for thread lifecycle, turn lifecycle, item activity, and user-action requests. Read and list methods return point-in-time state; notifications are the canonical surface for active execution. After a thread is started or resumed, the client receives notifications as runtime state changes.
+Events are the live notification stream for thread lifecycle, turn lifecycle, item activity, and user-action requests. Read and list methods return point-in-time state; notifications are the canonical surface for active execution. After a thread is started or resumed, the client receives notifications as agent runtime state changes.
 
 At a minimum, the event stream should cover:
 * **Thread events** such as status changes, archive state changes, and closure.
@@ -155,9 +153,9 @@ At a minimum, the event stream should cover:
 
 Notifications are the canonical surface for loaded-thread and in-progress turn execution.
 
-`thread/status/changed` should carry runtime thread state for loaded threads. `turn/started` and `turn/completed` should mark turn lifecycle boundaries. `item/started` and `item/completed` should mark item lifecycle boundaries.
+`thread/status/changed` should carry thread execution state for loaded threads. `turn/started` and `turn/completed` should mark turn lifecycle boundaries. `item/started` and `item/completed` should mark item lifecycle boundaries.
 
-When runtime activity pauses for approval or other user input, the App Server should surface the request through the notification stream and emit a resolution event when the request is answered or cleared.
+When agent runtime activity pauses for approval or other user input, the App Server should surface the request through the notification stream and emit a resolution event when the request is answered or cleared.
 
 Example happy-path flow:
 * `initialize`
@@ -174,24 +172,24 @@ Items are the units of input and output within a turn. They should remain Codex-
 
 An item should have a stable identity within the turn, a concrete item type, and a final completed shape that the client can treat as authoritative. Some item types may also produce incremental delta events while work is in progress.
 
-Item deltas may be streamed while work is in progress when the runtime supports them. These deltas improve responsiveness, but the final item/completed payload should remain the authoritative final state for that item.
+Item deltas may be streamed while work is in progress when the agent runtime supports them. These deltas improve responsiveness, but the final item/completed payload should remain the authoritative final state for that item.
 
 The client should render live progress from deltas when available, but should reconcile to the final completed item state. The App Server should not require the client to reconstruct the durable item record solely from deltas.
 
 ## Approvals
-Approvals let the **Atelier App Server** pause execution when the selected runtime requires explicit user consent before continuing.
+Approvals let the **Atelier App Server** pause execution when the selected agent runtime requires explicit user consent before continuing.
 
 Approval requests are surfaced by the server during an active turn and resolved by the client. They are scoped to the relevant **Thread**, **Turn**, and item or request identity, and should be presented as part of the active conversation rather than as a separate workflow.
 
 At minimum, the system should support:
-* **Command execution approvals** when the runtime requires permission before running a command.
-* **File change approvals** when the runtime requires permission before applying edits.
+* **Command execution approvals** when the agent runtime requires permission before running a command.
+* **File change approvals** when the agent runtime requires permission before applying edits.
 * **Tool or connector approvals** when a tool call has side effects or otherwise requires explicit user confirmation.
 
 The App Server should treat approvals as server-initiated requests. The client responds with a user decision, and the server then resumes, declines, or clears the pending work.
 
 The approval lifecycle should remain Codex-shaped:
-* The runtime emits an item that represents the pending action.
+* The agent runtime emits an item that represents the pending action.
 * The server sends an approval request to the client for that item.
 * The client returns a decision.
 * The server emits a resolution event.
@@ -204,11 +202,11 @@ Example approval flow:
 * resolution event is emitted
 * item completes
 
-The App Server should preserve enough approval state to support active UI rendering, recovery, and auditability, but it should not invent a separate approval system when the runtime already provides the authoritative flow.
+The App Server should preserve enough approval state to support active UI rendering, recovery, and auditability, but it should not invent a separate approval system when the agent runtime already provides the authoritative flow.
 
 ## Architecture & Standards
 
-This section defines the module architecture, coding standards, and tooling decisions for the Atelier Code App Server. It complements the core design document and replaces the original Module Boundaries section.
+This section defines the module architecture, coding standards, and tooling decisions for the Atelier Code App Server.
 
 
 ### Module Architecture (App / Core / Features)
@@ -219,7 +217,7 @@ The App Server strictly separates infrastructure plumbing from domain business l
 
 Feature directories live at the `src/` root alongside `app/` and `core/` (e.g., `src/workspaces/`, `src/threads/`, `src/turns/`, `src/agents/`). This layer contains the business value of Atelier Code. Code here represents features and entities.
 
-**Contents:** TypeBox validation schemas, business logic services, protocol entry points (`*.handlers.ts`), and feature-specific repository interfaces that define what persistence queries the feature requires.
+**Contents:** TypeBox validation schemas, business logic services, protocol entry points (`*.handlers.ts`), and persistence logic (`store.ts` with Drizzle table definitions and query functions). Each feature owns its full persistence vertical.
 
 **Rule:** Feature directories are entirely blind to the transport layer. They do not know if a request came from a WebSocket, an HTTP endpoint, or a local CLI. They receive parsed objects, execute logic, and return results.
 
@@ -227,7 +225,7 @@ Feature directories live at the `src/` root alongside `app/` and `core/` (e.g., 
 
 **Interdependencies:** Features may depend on each other's public interfaces (turns depend on threads), but only through explicit imports of typed contracts exported from the feature's `index.ts`. Features must not reach into each other's internals.
 
-Each feature exposes a single barrel `index.ts` that exports its public API: handlers, service functions, types, and repository interfaces. Internal helpers remain unexported. Barrel files should not be chained across directory levels — one per feature is the limit.
+Each feature exposes a single barrel `index.ts` that exports its public API: handlers, service functions, and types. Internal helpers remain unexported. Barrel files should not be chained across directory levels — one per feature is the limit.
 
 #### `src/core/` — Infrastructure Engine
 
@@ -235,7 +233,7 @@ This layer is generic, reusable plumbing that makes the server run. It is strict
 
 - **`transport/`** — Manages raw socket connections (e.g., `websocket-server.ts`). It only emits and receives raw strings. It does not parse JSON or handle business logic.
 - **`protocol/`** — The translation layer. It parses raw strings from the transport layer into JSON-RPC objects and uses a generic `Dispatcher` to route methods to registered feature handlers.
-- **`store/`** — Persistence interfaces and their implementations (in-memory and SQLite via Drizzle). Feature-specific repository interfaces are defined in the features themselves; core store implementations fulfill those interfaces.
+- **`store/`** — Database primitives: the connection handle, migration runner, and shared Drizzle configuration. It does not contain feature-specific table definitions or query logic — those live in each feature's `store.ts`.
 - **`shared/`** — Truly generic utilities used across the application (e.g., custom error classes, ID generators).
 
 #### `src/app/` — Orchestrator
@@ -248,8 +246,8 @@ This is the bootstrap layer and the **only** place in the codebase where `core/`
 #### Import Rules
 
 - `core/transport/`, `core/protocol/`, and `core/store/` are peers. None imports from another. All three may import from `core/shared/`.
-- Feature directories never import from `core/transport/` or any WebSocket-specific code.
-- `src/app/` is the only place that connects transport, protocol, store, and features.
+- Feature directories may import the database connection type from `core/store/` and utilities from `core/shared/`, but never import from `core/transport/` or any WebSocket-specific code. `core/store/` never imports from features.
+- `src/app/` is the only place that connects transport, protocol, store, and features. It creates the database connection from `core/store/` and passes it to each feature's store at startup.
 
 
 ### Server Framework
@@ -278,9 +276,9 @@ Inbound requests and outbound notifications should both be validated against can
 
 Domain services return typed `Result` values (see Coding Standards). The protocol layer is responsible for mapping those results to well-formed JSON-RPC responses — either `{ id, result }` for success or `{ id, error }` for failure.
 
-Protocol errors should use standard JSON-RPC error codes (`-32700` parse error, `-32600` invalid request, `-32601` method not found, `-32602` invalid params) for envelope and schema validation failures. Atelier-specific domain errors should use a dedicated code range (e.g., starting at `-33000`) with stable, machine-readable error codes such as `TURN_NOT_ACTIVE` or `THREAD_NOT_FOUND`. Every error response includes a `code`, a human-readable `message`, and an optional `data` field for structured context.
+The `error` object follows JSON-RPC spec: `code` is always numeric, `message` is a human-readable string, and `data` is an optional object for structured context. Standard JSON-RPC error codes (`-32700` parse error, `-32600` invalid request, `-32601` method not found, `-32602` invalid params) cover envelope and schema validation failures. Atelier-specific errors use a dedicated numeric range starting at `-33000`. Stable, machine-readable symbolic codes such as `TURN_NOT_ACTIVE` or `THREAD_NOT_FOUND` go in `error.data.code`, not in the top-level numeric `error.code` field.
 
-The transport layer should have a catch-all that ensures the client always receives a well-formed error response, even for unhandled failures. No request should result in a silent drop or malformed payload.
+The protocol layer should have a catch-all that ensures the client always receives a well-formed error response, even for unhandled failures. No request should result in a silent drop or malformed payload. Malformed outbound notifications have no response path in JSON-RPC — these should be logged and dropped.
 
 
 ### Logging & Observability
@@ -368,10 +366,11 @@ Pass dependencies as function arguments or use a context object. The `app/server
 Each file has a single responsibility and explicitly exports its public surface. Each feature exposes one `index.ts` barrel file exporting its public API. Internal helpers stay unexported. Do not chain barrel files across directory levels.
 
 #### Naming Conventions
- 
-**Avoid "runtime."** The word is overloaded — it can mean the server process, an external agent system (Codex, Claude), or an operational status. Use specific terms instead: **agent** for external agent systems, **agent adapter** for agent-specific integration code, **execution status** or **thread status** for operational state, and **server process** for the running App Server.
- 
+
+**Qualify "runtime."** The bare word "runtime" is ambiguous — it can mean the server process, an external agent system, or an operational status. Always qualify it: **agent runtime** for external agent systems (Codex, Claude), **agent adapter** for agent-specific integration code, **execution status** or **thread status** for operational state, and **server process** for the running App Server. In code (type names, variable names, module names), prefer **agent** as the short form when context is clear.
+
 **Keep "Codex" out of shared code.** Use "Codex" only in adapter-specific code under `src/agents/` or for literal provider and model values. Everywhere else in the App Server, use generic names. The App Server contract is Codex-shaped, but shared code should not be coupled to a specific agent's name.
+
 
 ### Testing Strategy
 
@@ -381,7 +380,7 @@ The App Server should be covered by five complementary test layers:
 
 **Domain service tests** are focused unit tests for thread, turn, and approval lifecycle rules using fake stores and fake agent adapters. These verify invariants such as initialize-before-use, one active turn per thread, approval scoping, and state transition correctness without requiring a live socket. Domain tests should cover execution-rule failures separately from schema validation failures.
 
-**Store conformance tests** are shared tests that run against every store implementation (in-memory and SQLite) to keep behavior aligned across backends. SQLite coverage should include migration application, restart reload, duplicate mapping protection, and failure behavior for missing or stale linkage.
+**Store tests** verify each feature's persistence logic against both its Drizzle implementation and its in-memory test fake. SQLite coverage should include migration application, restart reload, duplicate mapping protection, and failure behavior for missing or stale linkage.
 
 **Agent adapter contract tests** validate request mapping, response normalization, notification translation, and error handling against pinned Codex contract fixtures where possible. Adapter tests should prefer pinned fixtures for determinism.
 
@@ -396,16 +395,16 @@ The App Server should be covered by five complementary test layers:
 | Language        | TypeScript (strict) | No `any`. Prefer `unknown`, explicit narrowing, discriminated unions. |
 | Server          | `Bun.serve`       | Raw WebSocket server. No HTTP framework.                              |
 | Validation      | TypeBox           | Runtime validation with native JSON Schema output.                    |
-| Persistence     | Drizzle ORM + SQLite | Behind repository interfaces. In-memory store for testing.         |
+| Persistence     | Drizzle ORM + SQLite | Feature-owned stores. In-memory fakes for testing.                 |
 | Formatting      | Biome             | Single formatter and linter for the App Server.                       |
 | Testing         | `bun:test`        | Bun's built-in test runner.                                          |
 
 
 ### Persistence Strategy
 
-Use a storage interface boundary from the start, with an in-memory implementation as the default for iteration and testing and a SQLite-backed implementation as the initial durable target.
+Each feature owns its persistence logic. A feature's `store.ts` contains its Drizzle table definitions and query functions. For testing, in-memory fakes are plain objects that satisfy the same structural type — no separate interface file needed. `core/store/` provides only the database connection, migration runner, and shared Drizzle configuration.
 
-Use **Drizzle ORM with SQLite** for the first durable implementation. Treat Drizzle as the canonical schema and query layer for App Server metadata persistence. Keep Drizzle usage localized behind repository-style interfaces in `core/store/` so protocol, feature, and adapter code do not depend directly on ORM details.
+Use **Drizzle ORM with SQLite** for the first durable implementation. Drizzle's migration tooling can scan table definitions across multiple feature directories.
 
 Generate and apply schema migrations using the Drizzle migration workflow. Keep migration files checked into the repository under the App Server module so schema evolution is reviewable and reproducible. Apply migrations at process startup before accepting WebSocket traffic. Treat failed or partial migrations as startup failures rather than attempting best-effort recovery.
 
@@ -428,5 +427,5 @@ The implementation is ready for broader integration when:
 - The App Server can accept a WebSocket connection, initialize, and route a minimal method set.
 - Thread and turn lifecycle state transitions can be exercised end-to-end in tests.
 - Approval request and resolution flow can be simulated through notifications and decisions.
-- Feature code depends on store interfaces rather than concrete database code.
+- Feature services depend on store parameters rather than direct database access, and can be tested with in-memory fakes.
 - Protocol harness tests can assert contract shape and lifecycle sequencing.

--- a/Docs/app-server-design.md
+++ b/Docs/app-server-design.md
@@ -204,4 +204,61 @@ Example approval flow:
 
 The App Server should preserve enough approval state to support active UI rendering, recovery, and auditability, but it should not invent a separate approval system when the runtime already provides the authoritative flow.
 
+## Implementation Foundations
+This section captures the baseline implementation decisions for the App Server. The goal is to keep the server contract explicit and Codex-shaped while introducing only the minimum structure required for reliability and growth.
+
+### App Server Foundation
+The App Server should provide:
+* A runnable process with healthcheck and initialize flow.
+* A long-lived WebSocket entrypoint for request, response, and notification traffic.
+* A method dispatcher that maps each incoming `method` to a handler, correlates responses using request `id`, and returns consistent protocol errors for unsupported methods or invalid params.
+* Session-scoped execution state needed to coordinate active work (for example, which thread is loaded, whether a turn is currently active, and whether an approval is pending), without redefining the canonical thread/turn/item records produced by the connected agent runtime.
+* A `Store` interface for Atelier-owned data (such as workspace metadata and thread index data), where domain services call interface methods and concrete implementations (for example, in-memory or SQLite) are swapped underneath without changing WebSocket handlers or protocol message shapes.
+
+### Server Framework
+Use **raw `Bun.serve`** for the App Server shell.
+
+Rationale:
+* Keeps protocol ownership explicit at the transport boundary.
+* Minimizes framework-level indirection for long-lived WebSocket lifecycle handling.
+* Aligns with existing Bun + TypeScript tooling already used by the bridge runtime.
+* Reduces risk of framework-imposed patterns drifting from the Codex-shaped contract.
+
+### Validation Model
+Use a three-layer validation model:
+1. **Envelope validation**: Parse and validate JSON-RPC-shaped message envelopes at ingress.
+2. **Method payload validation**: Validate `params` and event payloads with method-specific schemas.
+3. **Execution rule validation**: Enforce lifecycle and state rules in domain services.
+
+Guidelines:
+* Inbound requests and outbound notifications should both be validated against canonical schemas.
+* Validation failures should map to stable, machine-readable error codes and message shapes.
+* Execution rule violations (for example, steering a non-active turn) should be distinct from schema parse failures.
+
+### Persistence Strategy
+Use a storage interface boundary from the start, with:
+* **In-memory implementation** as the default for iteration and testing.
+* **SQLite-backed implementation** as the initial durable target.
+
+Rationale:
+* Keeps protocol and lifecycle work decoupled from migration and database concerns.
+* Preserves a clean upgrade path to durable thread, turn, and approval state.
+
+### Module Boundaries
+Recommended module boundaries:
+* `transport/` for WebSocket server, connection/session lifecycle, and framing.
+* `protocol/` for envelope parsing, dispatcher, method registry, and response/error mapping.
+* `schema/` for request/response/notification payload schemas.
+* `domain/` for workspace/thread/turn/approval orchestration and invariants.
+* `store/` for persistence interfaces and in-memory implementations.
+* `runtime-adapters/` for Codex adapter and future runtime adapters.
+
+### Baseline Readiness Criteria
+The implementation is ready for broader integration when:
+* The App Server can accept a WebSocket connection, initialize, and route a minimal method set.
+* Thread and turn lifecycle state transitions can be exercised end-to-end in tests.
+* Approval request and resolution flow can be simulated through notifications and decisions.
+* Domain orchestration depends on `Store` interfaces rather than concrete database code.
+* Protocol harness tests can assert contract shape and lifecycle sequencing.
+
 #projects/atelier-code

--- a/Docs/app-server-design.md
+++ b/Docs/app-server-design.md
@@ -240,8 +240,8 @@ This layer is generic, reusable plumbing that makes the server run. It is strict
 
 This is the bootstrap layer and the **only** place in the codebase where `core/` and feature directories are allowed to interact.
 
-- **`server.ts`** — The main entry point. It initializes the core transport and protocol engines, registers the feature handlers with the dispatcher, wires parsed events to the transport layer, and starts the listener. It contains zero per-request business logic.
-- **`session.ts`** — Manages process-level lifecycle (startup, shutdown, healthcheck). Session-scoped execution state such as loaded threads, active turns, and pending approvals belongs in the relevant feature directories, not here.
+- **App layer lifecycle** — The app layer owns process-level startup, shutdown, and healthcheck coordination. It initializes the core transport and protocol engines, registers feature handlers with the dispatcher, wires parsed events to the transport layer, and starts the listener. It contains zero per-request business logic.
+- **Feature-owned runtime state** — Loaded threads, active turns, pending approvals, and other execution state live in the relevant feature directories, not in the app lifecycle surface.
 
 #### Import Rules
 
@@ -296,14 +296,14 @@ Configuration is loaded once at startup from a configuration file, with environm
 
 The configuration file is the primary source for settings such as server port, database location, available agents, and feature flags. Environment variables may override specific values when needed but should not be the default mechanism for most settings.
 
-Configuration should be read into a typed, readonly config object during bootstrap in `app/server.ts` and passed explicitly to the subsystems that need it. Feature code should never read environment variables or configuration files directly.
+Configuration should be read into a typed, readonly config object during bootstrap in the app layer and passed explicitly to the subsystems that need it. Feature code should never read environment variables or configuration files directly.
 
 
 ### Graceful Shutdown
 
 The server process should handle `SIGINT` and `SIGTERM` signals and shut down cleanly. Graceful shutdown means: stop accepting new WebSocket connections, interrupt or complete any active turns, flush pending store writes, close the database connection, and then exit.
 
-The shutdown sequence should be coordinated from `app/session.ts`, calling into features and core subsystems in the correct order. If shutdown takes longer than a reasonable timeout, force exit to avoid hanging indefinitely.
+The shutdown sequence should be coordinated from the app layer, calling into features and core subsystems in the correct order. If shutdown takes longer than a reasonable timeout, force exit to avoid hanging indefinitely.
 
 
 ### Path Aliases

--- a/Docs/app-server-design.md
+++ b/Docs/app-server-design.md
@@ -34,7 +34,9 @@ The Agentic Coding domain is composed of four primary system components:
 ### Note on the Client Application
 The client application is out of scope for this document, however this is some context in case it affects decisions made for the App Server and Agent Adapters.
 
-The client is responsible for connecting to the App Server and ensuring that the App Server is installed and running on the local machine or remote development host. On macOS, this likely means local installation when needed, background process launch, and local WebSocket connection. In future remote scenarios, such as iOS clients connecting to a remote development machine, the client may connect to a remote App Server over a secure network such as Tailscale. The exact installation, startup, and reconnection mechanism is still to be determined.
+The client is responsible for connecting to the App Server and ensuring that the App Server is installed and running on the local machine or remote development host. On macOS, this likely means local installation when needed, background process launch, and local WebSocket connection. In future remote scenarios, such as iOS clients connecting to a remote development machine, the client may connect to a remote App Server over a secure network such as Tailscale.
+
+The exact installation, startup, restart, and reconnection mechanism is intentionally out of scope for this document. The App Server contract should not depend on those client lifecycle mechanics beyond requiring a long-lived connection model and explicit initialization on each connection.
 
 ## Design Stance
 The **[Codex App Server](https://developers.openai.com/codex/app-server)** is the reference runtime model for the Atelier Code App Server.
@@ -240,9 +242,22 @@ Use a storage interface boundary from the start, with:
 * **In-memory implementation** as the default for iteration and testing.
 * **SQLite-backed implementation** as the initial durable target.
 
+Implementation choice:
+* Use **raw Bun SQLite** for the first implementation.
+* Do **not** introduce Drizzle or another typed query layer in the initial rollout.
+* Keep SQL localized behind `store/` repository-style interfaces so a future query layer can be introduced without changing protocol, domain, or adapter code.
+
+Migration approach:
+* Store schema migrations as ordered SQL files under the App Server module, for example `AppServer/migrations/0001_initial.sql`.
+* Apply migrations at process startup before accepting WebSocket traffic.
+* Track applied migrations in a small metadata table such as `schema_migrations`.
+* Treat failed or partial migrations as startup failures rather than attempting best-effort runtime recovery.
+* Limit the persisted schema in early phases to Atelier-owned metadata and reattachment state, not mirrored thread/turn/item history.
+
 Rationale:
-* Keeps protocol and lifecycle work decoupled from migration and database concerns.
-* Preserves a clean upgrade path to durable thread, turn, and approval state.
+* Keeps the first persisted version operationally simple and easy to inspect.
+* Avoids committing early to an additional abstraction layer before the metadata schema has stabilized.
+* Preserves a clean upgrade path to a richer persistence layer without forcing Phase 1 and Phase 2 work to wait on ORM decisions.
 
 ### Module Boundaries
 Recommended module boundaries:
@@ -253,6 +268,36 @@ Recommended module boundaries:
 * `store/` for persistence interfaces and in-memory implementations.
 * `runtime-adapters/` for Codex adapter and future runtime adapters.
 
+Dependency direction:
+* `transport/` may depend on `protocol/` but not on `domain/`, `store/`, or runtime-specific code directly.
+* `protocol/` may depend on `schema/` and `domain/` service interfaces, but should not depend on concrete `store/` or runtime adapter implementations.
+* `schema/` is a leaf for contract definitions and should not depend on transport, domain orchestration, persistence, or adapters.
+* `domain/` owns lifecycle rules and orchestration. It may depend on abstract interfaces implemented by `store/` and `runtime-adapters/`, but must not depend on transport concerns.
+* `store/` implements persistence interfaces owned by the domain boundary and must not depend on `transport/` or WebSocket protocol handling.
+* `runtime-adapters/` implement runtime-facing interfaces owned by the domain boundary and must not depend on `transport/`.
+
+In practical terms, dependency flow should point inward toward `domain/` contracts and outward only through injected interfaces. No lower layer should import from a higher layer simply for convenience.
+
+### Testing Strategy
+The early App Server phases should be covered by three complementary test layers:
+* **Protocol harness tests**: End-to-end WebSocket contract tests that connect to the running server process, send JSON-RPC-shaped requests, and assert response shapes, protocol errors, and notification ordering for happy-path and invalid-sequencing cases.
+* **Domain service tests**: Focused unit tests for thread/turn/approval lifecycle rules using fake stores and fake runtime adapters. These tests should verify invariants such as initialize-before-use, one active turn per thread, approval scoping, and state transition correctness without requiring a live socket.
+* **Persistence tests**: Shared store conformance tests that run against both the in-memory store and the SQLite store. SQLite coverage should include migration application, restart reload, duplicate mapping protection, and failure behavior for missing or stale runtime linkage.
+* **Adapter contract tests**: Tests for the Codex adapter that validate request mapping, response normalization, notification translation, and error handling against pinned Codex contract fixtures where possible.
+* **Live smoke tests**: Environment-gated tests against a real local Codex setup for the minimal lifecycle once the real adapter exists. These should stay small and verify integration seams rather than replace deterministic contract coverage.
+
+Testing guidance:
+* Protocol harness tests are the primary executable check for the public Atelier contract.
+* Domain tests should cover execution-rule failures separately from schema validation failures.
+* Store conformance tests should run against every `Store` implementation to keep behavior aligned across in-memory and SQLite backends.
+* Adapter tests should prefer pinned fixtures for determinism and reserve live runtime tests for smoke coverage only.
+
+### Deferred Architecture Decisions
+The following decisions are intentionally deferred and should be captured as separate follow-up work rather than left implicit:
+* Client-managed App Server installation, startup, restart, and reconnection behavior across local macOS and future remote-host scenarios.
+* Secure remote connection and discovery details for non-local App Server deployments.
+* Broader multi-runtime selection and capability-gating behavior beyond the initial Codex-only rollout.
+
 ### Baseline Readiness Criteria
 The implementation is ready for broader integration when:
 * The App Server can accept a WebSocket connection, initialize, and route a minimal method set.
@@ -260,5 +305,3 @@ The implementation is ready for broader integration when:
 * Approval request and resolution flow can be simulated through notifications and decisions.
 * Domain orchestration depends on `Store` interfaces rather than concrete database code.
 * Protocol harness tests can assert contract shape and lifecycle sequencing.
-
-#projects/atelier-code

--- a/Docs/app-server-design.md
+++ b/Docs/app-server-design.md
@@ -1,0 +1,207 @@
+# Atelier Code: Technical Design
+## Mission
+
+Atelier Code delivers an uncompromising, AI-first modern coding experience. It combines the power of AI coding agents with the speed, polish, and ergonomics of a native SwiftUI interface.
+
+## Product Domains
+Atelier Code is organized around three product domains:
+
+- **Agentic Coding**: Write code with AI agents.
+- **Context Management (Future State)**: Create, organize, and manage context using a beautiful native markdown editor. 
+- **Planning (Future State)**: Plan and manage product work, tasks, and execution.
+
+This document is centered on the **Agentic Coding** domain. The other domains are important to the long-term vision, but their internal models remain intentionally high level for now.
+
+___
+# Agentic Coding
+The Agentic Coding domain defines the system for working with AI agent runtimes. It governs how users do things like create workspaces, conduct conversations, run turns, receive streaming updates, respond to approval requests, and continue work over time.
+
+Its role is to provide a stable product model across one or more agent runtimes while keeping provider-specific behavior contained within runtime adapters.
+
+## Scope
+This document is focused on the Atelier App Server and Agent Adapters for the Agentic Coding domain.
+
+It defines the server contract, adapter responsibilities, and runtime model. Native client architecture and client-specific behaviors are intentionally out of scope and should be defined separately.
+
+## Core System Components
+The Agentic Coding domain is composed of four primary system components:
+
+- **Client Application**: A native macOS application, with future support for iOS, that delivers the primary end-user experience. 
+- **App Server**: The backend control plane responsible for managing sessions, persistence, approvals, real-time thread updates, and the stable client-facing protocol. It coordinates communication between the client application and supported agent runtimes and owns the Atelier product contract.
+- **Agent Adapters**: A provider-specific integration layer that maps the App Server’s Codex-shaped contract to the native interface exposed by an agent runtime. The Codex adapter should be near pass-through. Other adapters, such as Claude Agent SDK, translate runtime-specific behavior into the Codex-shaped model used by the App Server. Adapters normalize runtime differences upward but do not redefine the platform model.
+- **Agent Runtimes**: The external agent systems that perform execution on behalf of the user, including maintaining the agent loop, invoking tools, and producing outputs. Examples include [Codex App Server](https://developers.openai.com/codex/app-server) and [Claude Agent SDK](https://platform.claude.com/docs/en/agent-sdk/overview).
+
+### Note on the Client Application
+The client application is out of scope for this document, however this is some context in case it affects decisions made for the App Server and Agent Adapters.
+
+The client is responsible for connecting to the App Server and ensuring that the App Server is installed and running on the local machine or remote development host. On macOS, this likely means local installation when needed, background process launch, and local WebSocket connection. In future remote scenarios, such as iOS clients connecting to a remote development machine, the client may connect to a remote App Server over a secure network such as Tailscale. The exact installation, startup, and reconnection mechanism is still to be determined.
+
+## Design Stance
+The **[Codex App Server](https://developers.openai.com/codex/app-server)** is the reference runtime model for the Atelier Code App Server.
+
+The **Atelier Code App Server** should mirror Codex as closely as practical. Atelier Code is not defining a separate orchestration model; it is adopting a Codex-shaped contract and adding only Atelier-owned platform concerns such as workspace metadata, persistence, capability gating, and runtime selection.
+
+The **Codex adapter** should be mostly pass-through. Other adapters, such as **Claude Agent SDK**, should conform to the same Codex-shaped contract. When a runtime cannot fully support that contract, the limitation should be exposed through explicit capabilities rather than weakening the model.
+
+### Codex App Server References 
+* [Documentation](https://developers.openai.com/codex/app-server/)
+* [Source Code](https://github.com/openai/codex/tree/main/codex-rs/app-server)
+
+## Protocol
+The Atelier **App Server** exposes a long-lived bidirectional **WebSocket** interface to the **Client Application** built around three protocol message types:
+* **Requests**
+* **Responses**
+* **Notifications**
+
+The protocol should remain JSON-RPC-shaped. Requests use `{ id, method, params }`. Responses echo `id` and return either `{ result }` or `{ error }`. Notifications use `{ method, params }` and do not include an `id`.
+
+Method and notification names should remain slash-shaped where practical, using forms such as `thread/start`, `turn/start`, and `turn/started`.
+
+In compact form:
+* Request: `{ id, method, params }`
+* Response: `{ id, result }` or `{ id, error }`
+* Notification: `{ method, params }`
+
+Atelier-specific methods should be limited to Atelier-owned concerns such as `Workspace` and related platform metadata.
+
+## Core Primitives
+The **Agentic Coding** domain is built around one Atelier-owned primitive, **Workspace**, layered on top of a Codex-shaped runtime model built around **Thread**, **Turn**, and **Item**.
+* **Workspace**: The top-level container for agent work within a specific code environment. It defines where work takes place, including the local or remote environment and working directory, and stores workspace metadata and associated threads.
+* **Thread**: A conversation between the user and an agent. Threads contain turns.
+* **Turn**: A single user request and the agent work that follows. Turns contain items and stream incremental updates.
+* **Item**: A unit of input or output within a turn, such as a user message, agent message, command execution, file change, or tool call.
+
+## Lifecycle Overview
+* **Initialize once per connection**: After opening a WebSocket connection to the **Atelier App Server**, the client establishes the session and begins receiving notifications.
+* **Open a workspace**: The client opens or creates a **Workspace** to establish Atelier-owned product context for execution.
+* **Start or resume a thread**: The client starts, resumes, or forks a **Thread** within that workspace.
+* **Begin a turn**: The client starts a **Turn** with user input.
+* **Steer an active turn**: The client may append input to the active turn without creating a new one.
+* **Stream updates**: While a turn is active, the server streams status changes, item updates, and requests for user action.
+* **Read point-in-time state**: `thread/read` and `thread/list` return point-in-time state. Live execution state is surfaced through the notification stream.
+* **Finish the turn**: The server emits the final turn state when execution completes, fails, is interrupted, or pauses for user action.
+
+## Initialization
+After opening a WebSocket connection to the **Atelier App Server**, the **Client Application** initializes the session before issuing other requests.
+
+The Atelier App Server keeps the same general initialize-then-proceed shape as Codex, but uses initialization only for lightweight client/server compatibility, session setup, and readiness rather than broad protocol negotiation.
+
+## API Overview
+The Atelier **App Server** mirrors the core thread and turn operations of the **Codex App Server**. The API surface is centered on:
+* thread/start
+* thread/resume
+* thread/fork
+* thread/read
+* thread/list
+* thread/name/set
+* thread/archive
+* thread/unarchive
+* turn/start
+* turn/steer
+* turn/interrupt
+* model/list
+
+The App Server does not attempt to mirror the full Codex API surface. Codex-specific admin, configuration, plugin, and auxiliary execution APIs remain outside the core Atelier protocol.
+
+## Models
+The **Atelier App Server** exposes the runtime model catalog through a Codex-aligned model/list method.
+
+The client only needs visible models, enough metadata to render the model picker, and the reasoning options supported by each model. The response should include the model identifier, display name, supported reasoning efforts, default reasoning effort, and whether the model is the runtime’s recommended default.
+
+New threads use the runtime default model. The client may change the model and reasoning effort for a thread, and that selection persists for subsequent turns until changed again.
+
+The current model and reasoning effort for a thread should be exposed through thread data, not through model/list.
+
+## Threads
+A **Thread** is the conversation container for agent work. Threads are started with `thread/start`, resumed for active interaction with `thread/resume`, forked with `thread/fork`, read with `thread/read`, and listed with `thread/list`.
+
+`thread/read` should remain distinct from `thread/resume`. `thread/read` returns stored thread data only. It does not load the thread for active runtime interaction and does not establish a live notification stream.
+
+`thread/resume` loads the thread for active runtime interaction. After resume, live execution updates should arrive through notifications rather than through repeated point-in-time reads.
+
+`thread/list` and `thread/read` support history, navigation, and point-in-time inspection. They should not be treated as the canonical surface for active execution. 
+
+Loaded-thread behavior should be represented through thread runtime status and notifications, not as a separate platform primitive. Thread runtime status should remain Codex-shaped, with states such as `notLoaded`, `idle`, `active`, and `systemError`, while live loaded-thread changes are surfaced through notifications.
+
+## Turns
+A **Turn** is a single unit of work within a thread. It begins with user input and includes the agent activity that follows.
+
+Turns are started with turn/start, may be guided further with turn/steer, and may be interrupted with turn/interrupt.
+
+A turn belongs to exactly one thread and is ordered within that thread. Only one turn may be active at a time per thread. A `Turn` is the core execution primitive. An active turn is not a separate concept; it is a turn whose status remains in progress or is awaiting user or runtime input.
+
+### Turn Lifecycle
+* A turn begins when the client issues turn/start.
+* The server forwards the request to the selected runtime and begins streaming updates.
+* While the turn is active, the server streams lifecycle changes, item events, and any requests for user action such as approvals.
+* The client may send turn/steer to provide additional guidance to the active turn when supported by the runtime.
+* A turn remains active while execution is in progress or awaiting required user or runtime input.
+* A turn ends when it completes, fails, or is interrupted.
+* The final turn state is emitted through the notification stream.
+
+### Turn State
+Turn status represents overall execution progress and is distinct from item-level updates. The App Server should stay aligned with the runtime's turn model where practical. An active turn is a turn whose status is still in progress or awaiting input. Any normalization needed for cross-runtime consistency should be handled by the adapter layer.
+
+## Events
+Events are the live notification stream for thread lifecycle, turn lifecycle, item activity, and user-action requests. Read and list methods return point-in-time state; notifications are the canonical surface for active execution. After a thread is started or resumed, the client receives notifications as runtime state changes.
+
+At a minimum, the event stream should cover:
+* **Thread events** such as status changes, archive state changes, and closure.
+* **Turn events** such as turn start, completion, plan updates, and diff updates.
+* **Item events** such as item start, item completion, and item-specific delta streams.
+* **Request resolution events** used to close the loop on approvals and other user-action requests.
+
+Notifications are the canonical surface for loaded-thread and in-progress turn execution.
+
+`thread/status/changed` should carry runtime thread state for loaded threads. `turn/started` and `turn/completed` should mark turn lifecycle boundaries. `item/started` and `item/completed` should mark item lifecycle boundaries.
+
+When runtime activity pauses for approval or other user input, the App Server should surface the request through the notification stream and emit a resolution event when the request is answered or cleared.
+
+Example happy-path flow:
+* `initialize`
+* `workspace/open`
+* `thread/start`
+* `thread/started`
+* `turn/start`
+* `turn/started`
+* item message and item delta notifications
+* `turn/completed`
+
+### Items
+Items are the units of input and output within a turn. They should remain Codex-shaped in the App Server and be surfaced through item lifecycle notifications rather than through a separate platform-specific model.
+
+An item should have a stable identity within the turn, a concrete item type, and a final completed shape that the client can treat as authoritative. Some item types may also produce incremental delta events while work is in progress.
+
+Item deltas may be streamed while work is in progress when the runtime supports them. These deltas improve responsiveness, but the final item/completed payload should remain the authoritative final state for that item.
+
+The client should render live progress from deltas when available, but should reconcile to the final completed item state. The App Server should not require the client to reconstruct the durable item record solely from deltas.
+
+## Approvals
+Approvals let the **Atelier App Server** pause execution when the selected runtime requires explicit user consent before continuing.
+
+Approval requests are surfaced by the server during an active turn and resolved by the client. They are scoped to the relevant **Thread**, **Turn**, and item or request identity, and should be presented as part of the active conversation rather than as a separate workflow.
+
+At minimum, the system should support:
+* **Command execution approvals** when the runtime requires permission before running a command.
+* **File change approvals** when the runtime requires permission before applying edits.
+* **Tool or connector approvals** when a tool call has side effects or otherwise requires explicit user confirmation.
+
+The App Server should treat approvals as server-initiated requests. The client responds with a user decision, and the server then resumes, declines, or clears the pending work.
+
+The approval lifecycle should remain Codex-shaped:
+* The runtime emits an item that represents the pending action.
+* The server sends an approval request to the client for that item.
+* The client returns a decision.
+* The server emits a resolution event.
+* The item completes with its final outcome.
+
+Example approval flow:
+* item begins
+* approval request is emitted
+* client returns decision
+* resolution event is emitted
+* item completes
+
+The App Server should preserve enough approval state to support active UI rendering, recovery, and auditability, but it should not invent a separate approval system when the runtime already provides the authoritative flow.
+
+#projects/atelier-code

--- a/Docs/app-server-design.md
+++ b/Docs/app-server-design.md
@@ -246,7 +246,7 @@ This is the bootstrap layer and the **only** place in the codebase where `core/`
 #### Import Rules
 
 - `core/transport/`, `core/protocol/`, and `core/store/` are peers. None imports from another. All three may import from `core/shared/`.
-- Feature directories may import the database connection type from `core/store/` and utilities from `core/shared/`, but never import from `core/transport/` or any WebSocket-specific code. `core/store/` never imports from features.
+- Feature directories may import the database connection type from `core/store/` and utilities from `core/shared/`, but never import from `core/transport/` or any WebSocket-specific code. Within a feature, only `store.ts` should touch the database connection or Drizzle APIs directly. Feature services should depend on store functions or store-shaped capability objects, not on the database handle itself. `core/store/` never imports from features.
 - `src/app/` is the only place that connects transport, protocol, store, and features. It creates the database connection from `core/store/` and passes it to each feature's store at startup.
 
 
@@ -402,7 +402,7 @@ The App Server should be covered by five complementary test layers:
 
 ### Persistence Strategy
 
-Each feature owns its persistence logic. A feature's `store.ts` contains its Drizzle table definitions and query functions. For testing, in-memory fakes are plain objects that satisfy the same structural type — no separate interface file needed. `core/store/` provides only the database connection, migration runner, and shared Drizzle configuration.
+Each feature owns its persistence logic. A feature's `store.ts` contains its Drizzle table definitions and query functions, and it is the only place in that feature allowed to touch the database handle or Drizzle APIs directly. Feature services consume store functions or store-shaped capability objects so they remain transport-agnostic and testable. For testing, in-memory fakes are plain objects that satisfy the same structural type — no separate interface file needed. `core/store/` provides only the database connection, migration runner, and shared Drizzle configuration.
 
 Use **Drizzle ORM with SQLite** for the first durable implementation. Drizzle's migration tooling can scan table definitions across multiple feature directories.
 
@@ -427,5 +427,5 @@ The implementation is ready for broader integration when:
 - The App Server can accept a WebSocket connection, initialize, and route a minimal method set.
 - Thread and turn lifecycle state transitions can be exercised end-to-end in tests.
 - Approval request and resolution flow can be simulated through notifications and decisions.
-- Feature services depend on store parameters rather than direct database access, and can be tested with in-memory fakes.
+- Feature services depend on store functions or store-shaped capability objects rather than direct database access, and can be tested with in-memory fakes.
 - Protocol harness tests can assert contract shape and lifecycle sequencing.


### PR DESCRIPTION
## Summary
- add the tracked `AppServer/` Bun + TypeScript package with Biome, strict TypeScript, path aliases, and placeholder app/core/feature modules
- implement typed JSON config loading with TypeBox validation, environment overrides, and startup-specific error types
- add a minimal structured logger plus the App Server bootstrap/lifecycle API with server-owned start, stop, signal handling, and `waitForStop()`
- update the design doc to keep lifecycle coordination in the app layer without prescribing a separate public `session.ts` abstraction

## Testing
- `bun run check`
- `bun run typecheck`
- `bun run test`