### PR TITLE
App server foundation shell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Use this guidance for implementation work related to the new Bun + TypeScript Ap
 - Prefer typed `Result` returns in domain services. Reserve `throw` for exceptional infrastructure failures, and keep domain rule failures distinct from schema and parse failures.
 - Prefer deterministic tests with fakes and fixtures. Add or update tests for lifecycle sequencing, event ordering, approvals, and error handling when behavior changes.
 - Treat generated or vendored Codex contract artifacts as read-only reference inputs. Update them through their generation or import workflow, not by hand.
+- Keep files focused on one clear responsibility; when a file starts mixing concerns or gets hard to scan, extract internal helpers or a sibling module with a clear purpose rather than adding a new abstraction only to make the file smaller.
 
 ## App Server Required Checks
 

--- a/AppServer/appserver.config.example.json
+++ b/AppServer/appserver.config.example.json
@@ -1,0 +1,5 @@
+{
+  "port": 7331,
+  "databasePath": "./var/appserver.sqlite",
+  "logLevel": "info"
+}

--- a/AppServer/biome.json
+++ b/AppServer/biome.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always"
+    }
+  }
+}

--- a/AppServer/bun.lock
+++ b/AppServer/bun.lock
@@ -1,0 +1,46 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "ateliercode-app-server",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.41",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.0.0",
+        "bun-types": "^1.3.11",
+        "typescript": "^5.9.2",
+      },
+    },
+  },
+  "packages": {
+    "@biomejs/biome": ["@biomejs/biome@2.4.11", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.11", "@biomejs/cli-darwin-x64": "2.4.11", "@biomejs/cli-linux-arm64": "2.4.11", "@biomejs/cli-linux-arm64-musl": "2.4.11", "@biomejs/cli-linux-x64": "2.4.11", "@biomejs/cli-linux-x64-musl": "2.4.11", "@biomejs/cli-win32-arm64": "2.4.11", "@biomejs/cli-win32-x64": "2.4.11" }, "bin": { "biome": "bin/biome" } }, "sha512-nWxHX8tf3Opb/qRgZpBbsTOqOodkbrkJ7S+JxJAruxOReaDPPmPuLBAGQ8vigyUgo0QBB+oQltNEAvalLcjggA=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wOt+ed+L2dgZanWyL6i29qlXMc088N11optzpo10peayObBaAshbTcxKUchzEMp9QSY8rh5h6VfAFE3WTS1rqg=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-gZ6zR8XmZlExfi/Pz/PffmdpWOQ8Qhy7oBztgkR8/ylSRyLwfRPSadmiVCV8WQ8PoJ2MWUy2fgID9zmtgUUJmw=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-avdJaEElXrKceK0va9FkJ4P5ci3N01TGkc6ni3P8l3BElqbOz42Wg2IyX3gbh0ZLEd4HVKEIrmuVu/AMuSeFFA=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-+Sbo1OAmlegtdwqFE8iOxFIWLh1B3OEgsuZfBpyyN/kWuqZ8dx9ZEes6zVnDMo+zRHF2wLynRVhoQmV7ohxl2Q=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.11", "", { "os": "linux", "cpu": "x64" }, "sha512-TagWV0iomp5LnEnxWFg4nQO+e52Fow349vaX0Q/PIcX6Zhk4GGBgp3qqZ8PVkpC+cuehRctMf3+6+FgQ8jCEFQ=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.11", "", { "os": "linux", "cpu": "x64" }, "sha512-bexd2IklK7ZgPhrz6jXzpIL6dEAH9MlJU1xGTrypx+FICxrXUp4CqtwfiuoDKse+UlgAlWtzML3jrMqeEAHEhA=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-RJhaTnY8byzxDt4bDVb7AFPHkPcjOPK3xBip4ZRTrN3TEfyhjLRm3r3mqknqydgVTB74XG8l4jMLwEACEeihVg=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.11", "", { "os": "win32", "cpu": "x64" }, "sha512-A8D3JM/00C2KQgUV3oj8Ba15EHEYwebAGCy5Sf9GAjr5Y3+kJIYOiESoqRDeuRZueuMdCsbLZIUqmPhpYXJE9A=="],
+
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
+
+    "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
+
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+  }
+}

--- a/AppServer/package.json
+++ b/AppServer/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "ateliercode-app-server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "bun run ./src/index.ts",
+    "check": "biome check .",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@sinclair/typebox": "^0.34.41"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.0.0",
+    "bun-types": "^1.3.11",
+    "typescript": "^5.9.2"
+  }
+}

--- a/AppServer/src/agents/index.ts
+++ b/AppServer/src/agents/index.ts
@@ -1,0 +1,4 @@
+import { createLifecyclePlaceholder, type LifecycleComponent } from "@/core/shared";
+
+export const createAgentsFeaturePlaceholder = (): LifecycleComponent =>
+  createLifecyclePlaceholder("feature.agents");

--- a/AppServer/src/app/config.test.ts
+++ b/AppServer/src/app/config.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  APP_SERVER_CONFIG_PATH_ENV,
+  APP_SERVER_DATABASE_PATH_ENV,
+  APP_SERVER_LOG_LEVEL_ENV,
+  APP_SERVER_PORT_ENV,
+  loadAppServerConfig,
+} from "@/app/config";
+import { ConfigParseStartupError, ConfigValidationStartupError } from "@/core/shared";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  while (temporaryDirectories.length > 0) {
+    const directory = temporaryDirectories.pop();
+
+    if (directory !== undefined) {
+      await rm(directory, { force: true, recursive: true });
+    }
+  }
+});
+
+describe("loadAppServerConfig", () => {
+  test("loads a valid configuration file", async () => {
+    const tempDirectory = await createTempDirectory();
+    const configPath = join(tempDirectory, "appserver.config.json");
+
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        port: 7331,
+        databasePath: "./var/test.sqlite",
+        logLevel: "info",
+      }),
+    );
+
+    const config = await loadAppServerConfig({
+      cwd: tempDirectory,
+      env: {
+        [APP_SERVER_CONFIG_PATH_ENV]: "appserver.config.json",
+      },
+    });
+
+    expect(config).toEqual({
+      configPath,
+      port: 7331,
+      databasePath: "./var/test.sqlite",
+      logLevel: "info",
+    });
+  });
+
+  test("applies supported environment overrides after reading the file", async () => {
+    const tempDirectory = await createTempDirectory();
+    const configPath = join(tempDirectory, "appserver.config.json");
+
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        port: 7000,
+        databasePath: "./var/original.sqlite",
+        logLevel: "info",
+      }),
+    );
+
+    const config = await loadAppServerConfig({
+      cwd: tempDirectory,
+      env: {
+        [APP_SERVER_CONFIG_PATH_ENV]: "appserver.config.json",
+        [APP_SERVER_PORT_ENV]: "9000",
+        [APP_SERVER_DATABASE_PATH_ENV]: "./var/override.sqlite",
+        [APP_SERVER_LOG_LEVEL_ENV]: "debug",
+      },
+    });
+
+    expect(config).toEqual({
+      configPath,
+      port: 9000,
+      databasePath: "./var/override.sqlite",
+      logLevel: "debug",
+    });
+  });
+
+  test("fails with a parse startup error for malformed JSON", async () => {
+    const tempDirectory = await createTempDirectory();
+    const configPath = join(tempDirectory, "appserver.config.json");
+
+    await writeFile(configPath, "{");
+
+    await expect(
+      loadAppServerConfig({
+        cwd: tempDirectory,
+        env: {
+          [APP_SERVER_CONFIG_PATH_ENV]: "appserver.config.json",
+        },
+      }),
+    ).rejects.toBeInstanceOf(ConfigParseStartupError);
+  });
+
+  test("fails with a validation startup error for schema-invalid config", async () => {
+    const tempDirectory = await createTempDirectory();
+    const configPath = join(tempDirectory, "appserver.config.json");
+
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        port: 0,
+        databasePath: "",
+        logLevel: "loud",
+      }),
+    );
+
+    await expect(
+      loadAppServerConfig({
+        cwd: tempDirectory,
+        env: {
+          [APP_SERVER_CONFIG_PATH_ENV]: "appserver.config.json",
+        },
+      }),
+    ).rejects.toBeInstanceOf(ConfigValidationStartupError);
+  });
+});
+
+const createTempDirectory = async (): Promise<string> => {
+  const directory = await mkdtemp(join(tmpdir(), "atelier-appserver-config-"));
+  temporaryDirectories.push(directory);
+
+  return directory;
+};

--- a/AppServer/src/app/config.ts
+++ b/AppServer/src/app/config.ts
@@ -1,0 +1,188 @@
+import { readFile } from "node:fs/promises";
+import { isAbsolute, resolve } from "node:path";
+import { type Static, Type } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
+import { LOG_LEVELS, type LogLevel } from "@/app/logger";
+import {
+  ConfigParseStartupError,
+  ConfigReadStartupError,
+  ConfigValidationStartupError,
+} from "@/core/shared";
+
+export const APP_SERVER_CONFIG_PATH_ENV = "APP_SERVER_CONFIG_PATH";
+export const APP_SERVER_PORT_ENV = "APP_SERVER_PORT";
+export const APP_SERVER_DATABASE_PATH_ENV = "APP_SERVER_DATABASE_PATH";
+export const APP_SERVER_LOG_LEVEL_ENV = "APP_SERVER_LOG_LEVEL";
+
+export const DEFAULT_APP_SERVER_CONFIG_PATH = "appserver.config.example.json";
+
+const AppServerConfigFileSchema = Type.Object(
+  {
+    port: Type.Integer({ minimum: 1, maximum: 65535 }),
+    databasePath: Type.String({ minLength: 1 }),
+    logLevel: Type.Union([
+      Type.Literal("debug"),
+      Type.Literal("info"),
+      Type.Literal("warn"),
+      Type.Literal("error"),
+    ]),
+  },
+  { additionalProperties: false },
+);
+
+type AppServerConfigFile = Static<typeof AppServerConfigFileSchema>;
+
+export type AppServerEnvironment = Readonly<
+  Partial<
+    Record<
+      | typeof APP_SERVER_CONFIG_PATH_ENV
+      | typeof APP_SERVER_PORT_ENV
+      | typeof APP_SERVER_DATABASE_PATH_ENV
+      | typeof APP_SERVER_LOG_LEVEL_ENV,
+      string | undefined
+    >
+  >
+>;
+
+export type AppServerConfig = Readonly<
+  AppServerConfigFile & {
+    readonly configPath: string;
+  }
+>;
+
+export type LoadAppServerConfigOptions = Readonly<{
+  cwd?: string;
+  env?: AppServerEnvironment;
+  readTextFile?: (path: string) => Promise<string>;
+}>;
+
+export const loadAppServerConfig = async (
+  options: LoadAppServerConfigOptions = {},
+): Promise<AppServerConfig> => {
+  const cwd = options.cwd ?? process.cwd();
+  const env = resolveEnvironment(options.env);
+  const configPath = resolveConfigPath(cwd, env[APP_SERVER_CONFIG_PATH_ENV]);
+  const readTextFile = options.readTextFile ?? readTextFileFromDisk;
+
+  const rawConfigText = await readConfigText(configPath, readTextFile);
+  const parsedConfig = parseConfigText(rawConfigText, configPath);
+  const configFromFile = validateConfig(parsedConfig, configPath, "configuration file");
+  const resolvedConfig = applyEnvironmentOverrides(configFromFile, env, configPath);
+
+  return Object.freeze({
+    configPath,
+    ...resolvedConfig,
+  });
+};
+
+const resolveConfigPath = (cwd: string, configPathOverride: string | undefined): string => {
+  const rawPath = configPathOverride?.trim() || DEFAULT_APP_SERVER_CONFIG_PATH;
+
+  return isAbsolute(rawPath) ? rawPath : resolve(cwd, rawPath);
+};
+
+const readConfigText = async (
+  configPath: string,
+  readTextFile: (path: string) => Promise<string>,
+): Promise<string> => {
+  try {
+    return await readTextFile(configPath);
+  } catch (error) {
+    throw new ConfigReadStartupError(configPath, error);
+  }
+};
+
+const parseConfigText = (rawConfigText: string, configPath: string): unknown => {
+  try {
+    return JSON.parse(rawConfigText) as unknown;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Invalid JSON";
+    throw new ConfigParseStartupError(configPath, message);
+  }
+};
+
+const validateConfig = (
+  candidate: unknown,
+  configPath: string,
+  source: string,
+): AppServerConfigFile => {
+  if (!Value.Check(AppServerConfigFileSchema, candidate)) {
+    const issues = [...Value.Errors(AppServerConfigFileSchema, candidate)].map(
+      (validationError) => {
+        const path = validationError.path || "/";
+        return `${source} ${path}: ${validationError.message}`;
+      },
+    );
+
+    throw new ConfigValidationStartupError(configPath, issues);
+  }
+
+  const validatedConfig = candidate as AppServerConfigFile;
+
+  return Object.freeze({
+    port: validatedConfig.port,
+    databasePath: validatedConfig.databasePath,
+    logLevel: validatedConfig.logLevel,
+  });
+};
+
+const applyEnvironmentOverrides = (
+  config: AppServerConfigFile,
+  env: AppServerEnvironment,
+  configPath: string,
+): AppServerConfigFile => {
+  const candidate: Record<string, unknown> = {
+    ...config,
+  };
+
+  if (env[APP_SERVER_PORT_ENV] !== undefined) {
+    candidate.port = parsePortOverride(env[APP_SERVER_PORT_ENV]);
+  }
+
+  if (env[APP_SERVER_DATABASE_PATH_ENV] !== undefined) {
+    candidate.databasePath = env[APP_SERVER_DATABASE_PATH_ENV].trim();
+  }
+
+  if (env[APP_SERVER_LOG_LEVEL_ENV] !== undefined) {
+    candidate.logLevel = parseLogLevelOverride(env[APP_SERVER_LOG_LEVEL_ENV]);
+  }
+
+  return validateConfig(candidate, configPath, "resolved configuration");
+};
+
+const parsePortOverride = (rawPort: string): number => {
+  const trimmedPort = rawPort.trim();
+
+  if (!/^\d+$/.test(trimmedPort)) {
+    return Number.NaN;
+  }
+
+  return Number.parseInt(trimmedPort, 10);
+};
+
+const parseLogLevelOverride = (rawLogLevel: string): string => {
+  const normalizedLogLevel = rawLogLevel.trim();
+
+  if (isLogLevel(normalizedLogLevel)) {
+    return normalizedLogLevel;
+  }
+
+  return normalizedLogLevel;
+};
+
+const isLogLevel = (value: string): value is LogLevel =>
+  LOG_LEVELS.some((logLevel) => logLevel === value);
+
+const resolveEnvironment = (env: AppServerEnvironment | undefined): AppServerEnvironment =>
+  Object.freeze({
+    [APP_SERVER_CONFIG_PATH_ENV]:
+      env?.[APP_SERVER_CONFIG_PATH_ENV] ?? process.env[APP_SERVER_CONFIG_PATH_ENV],
+    [APP_SERVER_PORT_ENV]: env?.[APP_SERVER_PORT_ENV] ?? process.env[APP_SERVER_PORT_ENV],
+    [APP_SERVER_DATABASE_PATH_ENV]:
+      env?.[APP_SERVER_DATABASE_PATH_ENV] ?? process.env[APP_SERVER_DATABASE_PATH_ENV],
+    [APP_SERVER_LOG_LEVEL_ENV]:
+      env?.[APP_SERVER_LOG_LEVEL_ENV] ?? process.env[APP_SERVER_LOG_LEVEL_ENV],
+  });
+
+const readTextFileFromDisk = async (path: string): Promise<string> =>
+  readFile(path, { encoding: "utf8" });

--- a/AppServer/src/app/logger.test.ts
+++ b/AppServer/src/app/logger.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { createLogger } from "@/app/logger";
+
+describe("createLogger", () => {
+  test("emits structured JSON log lines", () => {
+    const lines: string[] = [];
+    const logger = createLogger({
+      level: "info",
+      now: () => "2026-04-09T00:00:00.000Z",
+      write: (line) => {
+        lines.push(line);
+      },
+    });
+
+    logger.info("hello");
+
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0])).toEqual({
+      timestamp: "2026-04-09T00:00:00.000Z",
+      level: "info",
+      message: "hello",
+    });
+  });
+
+  test("merges base context with per-call context", () => {
+    const lines: string[] = [];
+    const logger = createLogger({
+      level: "debug",
+      context: { connectionId: "conn-1" },
+      now: () => "2026-04-09T00:00:00.000Z",
+      write: (line) => {
+        lines.push(line);
+      },
+    });
+
+    logger.info("context", { threadId: "thread-1" });
+
+    expect(JSON.parse(lines[0])).toEqual({
+      timestamp: "2026-04-09T00:00:00.000Z",
+      level: "info",
+      message: "context",
+      connectionId: "conn-1",
+      threadId: "thread-1",
+    });
+  });
+
+  test("withContext creates a derived logger without mutating the parent logger", () => {
+    const lines: string[] = [];
+    const logger = createLogger({
+      level: "info",
+      context: { connectionId: "conn-1" },
+      now: () => "2026-04-09T00:00:00.000Z",
+      write: (line) => {
+        lines.push(line);
+      },
+    });
+    const childLogger = logger.withContext({ threadId: "thread-1" });
+
+    logger.info("parent");
+    childLogger.info("child");
+
+    expect(JSON.parse(lines[0])).toEqual({
+      timestamp: "2026-04-09T00:00:00.000Z",
+      level: "info",
+      message: "parent",
+      connectionId: "conn-1",
+    });
+    expect(JSON.parse(lines[1])).toEqual({
+      timestamp: "2026-04-09T00:00:00.000Z",
+      level: "info",
+      message: "child",
+      connectionId: "conn-1",
+      threadId: "thread-1",
+    });
+  });
+});

--- a/AppServer/src/app/logger.ts
+++ b/AppServer/src/app/logger.ts
@@ -1,0 +1,86 @@
+export const LOG_LEVELS = ["debug", "info", "warn", "error"] as const;
+
+export type LogLevel = (typeof LOG_LEVELS)[number];
+export type LogValue = string | number | boolean | null;
+export type LogContext = Readonly<Record<string, LogValue>>;
+export type LogWriter = (line: string) => void;
+
+export type Logger = Readonly<{
+  level: LogLevel;
+  debug: (message: string, context?: LogContext) => void;
+  info: (message: string, context?: LogContext) => void;
+  warn: (message: string, context?: LogContext) => void;
+  error: (message: string, context?: LogContext) => void;
+  withContext: (context: LogContext) => Logger;
+}>;
+
+export type CreateLoggerOptions = Readonly<{
+  level: LogLevel;
+  context?: LogContext;
+  now?: () => string;
+  write?: LogWriter;
+}>;
+
+type LogRecord = Readonly<
+  {
+    timestamp: string;
+    level: LogLevel;
+    message: string;
+  } & Record<string, LogValue>
+>;
+
+const LOG_LEVEL_PRIORITY: Readonly<Record<LogLevel, number>> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+export const createLogger = (options: CreateLoggerOptions): Logger => {
+  const baseContext = Object.freeze({ ...(options.context ?? {}) });
+  const now = options.now ?? defaultNow;
+  const write = options.write ?? defaultWrite;
+
+  const shouldLog = (level: LogLevel): boolean =>
+    LOG_LEVEL_PRIORITY[level] >= LOG_LEVEL_PRIORITY[options.level];
+
+  const emit = (level: LogLevel, message: string, context?: LogContext): void => {
+    if (!shouldLog(level)) {
+      return;
+    }
+
+    const record: LogRecord = {
+      timestamp: now(),
+      level,
+      message,
+      ...baseContext,
+      ...(context ?? {}),
+    };
+
+    write(JSON.stringify(record));
+  };
+
+  return Object.freeze({
+    level: options.level,
+    debug: (message, context) => emit("debug", message, context),
+    info: (message, context) => emit("info", message, context),
+    warn: (message, context) => emit("warn", message, context),
+    error: (message, context) => emit("error", message, context),
+    withContext: (context) =>
+      createLogger({
+        level: options.level,
+        now,
+        write,
+        context: {
+          ...baseContext,
+          ...context,
+        },
+      }),
+  });
+};
+
+const defaultNow = (): string => new Date().toISOString();
+
+const defaultWrite = (line: string): void => {
+  console.log(line);
+};

--- a/AppServer/src/app/server.test.ts
+++ b/AppServer/src/app/server.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { APP_SERVER_CONFIG_PATH_ENV } from "@/app/config";
+import { createLogger } from "@/app/logger";
+import {
+  createAppServer,
+  createConfiguredAppServer,
+  type ShutdownSignal,
+  type SignalHandler,
+  type SignalRegistrar,
+} from "@/app/server";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  while (temporaryDirectories.length > 0) {
+    const directory = temporaryDirectories.pop();
+
+    if (directory !== undefined) {
+      await rm(directory, { force: true, recursive: true });
+    }
+  }
+});
+
+describe("createAppServer", () => {
+  test("bootstraps from the config file into an idle server", async () => {
+    const tempDirectory = await createConfigDirectory();
+    const server = await createAppServer({
+      cwd: tempDirectory,
+      env: {
+        [APP_SERVER_CONFIG_PATH_ENV]: "appserver.config.json",
+      },
+      writeLog: () => {},
+      signalRegistrar: createSignalRegistrar(),
+    });
+
+    expect(server.getState()).toBe("idle");
+    expect(server.config.port).toBe(7331);
+  });
+
+  test("starts successfully", async () => {
+    const tempDirectory = await createConfigDirectory();
+    const server = await createAppServer({
+      cwd: tempDirectory,
+      env: {
+        [APP_SERVER_CONFIG_PATH_ENV]: "appserver.config.json",
+      },
+      writeLog: () => {},
+      signalRegistrar: createSignalRegistrar(),
+    });
+
+    await server.start();
+
+    expect(server.getState()).toBe("started");
+    expect(server.config.port).toBe(7331);
+  });
+
+  test("loads config in the high-level constructor while the configured constructor avoids config I/O", async () => {
+    let readCount = 0;
+
+    const bootstrappedServer = await createAppServer({
+      cwd: "/unused",
+      env: {
+        [APP_SERVER_CONFIG_PATH_ENV]: "appserver.config.json",
+      },
+      readTextFile: async () => {
+        readCount += 1;
+
+        return JSON.stringify({
+          port: 7331,
+          databasePath: "./var/test.sqlite",
+          logLevel: "info",
+        });
+      },
+      writeLog: () => {},
+      signalRegistrar: createSignalRegistrar(),
+    });
+
+    const configuredServer = createConfiguredAppServer({
+      config: Object.freeze({
+        configPath: "/tmp/appserver.config.json",
+        port: 7444,
+        databasePath: "./var/configured.sqlite",
+        logLevel: "info",
+      }),
+      logger: createLogger({
+        level: "info",
+        write: () => {},
+      }),
+      signalRegistrar: createSignalRegistrar(),
+    });
+
+    expect(readCount).toBe(1);
+    expect(bootstrappedServer.config.configPath).toBe("/unused/appserver.config.json");
+    expect(configuredServer.config.port).toBe(7444);
+    expect(configuredServer.getState()).toBe("idle");
+  });
+});
+
+describe("AppServer lifecycle", () => {
+  test("stops cleanly", async () => {
+    const server = createConfiguredAppServer({
+      config: createTestConfig(),
+      logger: createSilentLogger(),
+      signalRegistrar: createSignalRegistrar(),
+    });
+
+    await server.start();
+    await server.stop("test-stop");
+
+    expect(server.getState()).toBe("stopped");
+  });
+
+  test("makes stop idempotent", async () => {
+    let stopCount = 0;
+    const server = createConfiguredAppServer({
+      config: createTestConfig(),
+      logger: createSilentLogger(),
+      signalRegistrar: createSignalRegistrar(),
+      components: [
+        {
+          name: "fake-component",
+          start: async () => {},
+          stop: async () => {
+            stopCount += 1;
+          },
+        },
+      ],
+    });
+
+    await server.start();
+    await Promise.all([server.stop("first"), server.stop("second")]);
+
+    expect(stopCount).toBe(1);
+    expect(server.getState()).toBe("stopped");
+  });
+
+  test("routes shutdown signals through the server lifecycle", async () => {
+    let stopReason: string | undefined;
+    const signalRegistrar = createSignalRegistrar();
+    const server = createConfiguredAppServer({
+      config: createTestConfig(),
+      logger: createSilentLogger(),
+      signalRegistrar,
+      components: [
+        {
+          name: "fake-component",
+          start: async () => {},
+          stop: async (reason) => {
+            stopReason = reason;
+          },
+        },
+      ],
+    });
+
+    await server.start();
+    signalRegistrar.emit("SIGTERM");
+    await server.waitForStop();
+
+    expect(stopReason).toBe("SIGTERM");
+    expect(server.getState()).toBe("stopped");
+  });
+
+  test("resolves waitForStop after shutdown", async () => {
+    const server = createConfiguredAppServer({
+      config: createTestConfig(),
+      logger: createSilentLogger(),
+      signalRegistrar: createSignalRegistrar(),
+    });
+    let didResolve = false;
+
+    await server.start();
+    const waitForStop = server.waitForStop().then(() => {
+      didResolve = true;
+    });
+
+    expect(didResolve).toBe(false);
+
+    await server.stop("wait-for-stop");
+    await waitForStop;
+
+    expect(didResolve).toBe(true);
+  });
+});
+
+type FakeSignalRegistrar = SignalRegistrar &
+  Readonly<{
+    emit: (signal: ShutdownSignal) => void;
+  }>;
+
+const createSignalRegistrar = (): FakeSignalRegistrar => {
+  const handlers: Record<ShutdownSignal, SignalHandler[]> = {
+    SIGINT: [],
+    SIGTERM: [],
+  };
+
+  return {
+    subscribe: (signal, handler) => {
+      handlers[signal].push(handler);
+
+      return () => {
+        handlers[signal] = handlers[signal].filter((candidate) => candidate !== handler);
+      };
+    },
+    emit: (signal) => {
+      for (const handler of handlers[signal]) {
+        handler();
+      }
+    },
+  };
+};
+
+const createSilentLogger = () =>
+  createLogger({
+    level: "info",
+    write: () => {},
+  });
+
+const createTestConfig = () =>
+  Object.freeze({
+    configPath: "/tmp/appserver.config.json",
+    port: 7331,
+    databasePath: "./var/test.sqlite",
+    logLevel: "info" as const,
+  });
+
+const createConfigDirectory = async (): Promise<string> => {
+  const directory = await mkdtemp(join(tmpdir(), "atelier-appserver-server-"));
+  temporaryDirectories.push(directory);
+
+  await writeFile(
+    join(directory, "appserver.config.json"),
+    JSON.stringify({
+      port: 7331,
+      databasePath: "./var/test.sqlite",
+      logLevel: "info",
+    }),
+  );
+
+  return directory;
+};

--- a/AppServer/src/app/server.test.ts
+++ b/AppServer/src/app/server.test.ts
@@ -163,6 +163,108 @@ describe("AppServer lifecycle", () => {
     expect(server.getState()).toBe("stopped");
   });
 
+  test("finishes shutdown when stop is requested during startup", async () => {
+    const events: string[] = [];
+    const slowStart = createDeferredPromise<void>();
+    const server = createConfiguredAppServer({
+      config: createTestConfig(),
+      logger: createSilentLogger(),
+      signalRegistrar: createSignalRegistrar(),
+      components: [
+        {
+          name: "slow-component",
+          start: async () => {
+            events.push("slow:start:begin");
+            await slowStart.promise;
+            events.push("slow:start:end");
+          },
+          stop: async (reason) => {
+            events.push(`slow:stop:${reason}`);
+          },
+        },
+        {
+          name: "second-component",
+          start: async () => {
+            events.push("second:start");
+          },
+          stop: async (reason) => {
+            events.push(`second:stop:${reason}`);
+          },
+        },
+      ],
+    });
+
+    const startPromise = server.start();
+    await Promise.resolve();
+
+    const stopPromise = server.stop("manual");
+    slowStart.resolve();
+
+    await Promise.all([startPromise, stopPromise, server.waitForStop()]);
+
+    expect(server.getState()).toBe("stopped");
+    expect(events).toEqual(["slow:start:begin", "slow:start:end", "slow:stop:manual"]);
+  });
+
+  test("reaches a terminal state when component stop fails", async () => {
+    const signalRegistrar = createSignalRegistrar();
+    const server = createConfiguredAppServer({
+      config: createTestConfig(),
+      logger: createSilentLogger(),
+      signalRegistrar,
+      components: [
+        {
+          name: "failing-stop-component",
+          start: async () => {},
+          stop: async () => {
+            throw new Error("stop failed");
+          },
+        },
+      ],
+    });
+
+    await server.start();
+    await expect(server.stop("manual")).rejects.toThrow("stop failed");
+    await server.waitForStop();
+
+    expect(server.getState()).toBe("stopped");
+  });
+
+  test("rolls back started components when startup fails partway through", async () => {
+    const events: string[] = [];
+    const server = createConfiguredAppServer({
+      config: createTestConfig(),
+      logger: createSilentLogger(),
+      signalRegistrar: createSignalRegistrar(),
+      components: [
+        {
+          name: "first-component",
+          start: async () => {
+            events.push("first:start");
+          },
+          stop: async (reason) => {
+            events.push(`first:stop:${reason}`);
+          },
+        },
+        {
+          name: "failing-start-component",
+          start: async () => {
+            events.push("second:start");
+            throw new Error("start failed");
+          },
+          stop: async () => {
+            events.push("second:stop");
+          },
+        },
+      ],
+    });
+
+    await expect(server.start()).rejects.toThrow("start failed");
+
+    expect(server.getState()).toBe("idle");
+    expect(events).toEqual(["first:start", "second:start", "first:stop:startup-failed"]);
+  });
+
   test("resolves waitForStop after shutdown", async () => {
     const server = createConfiguredAppServer({
       config: createTestConfig(),
@@ -225,6 +327,21 @@ const createTestConfig = () =>
     databasePath: "./var/test.sqlite",
     logLevel: "info" as const,
   });
+
+const createDeferredPromise = <T>() => {
+  let resolvePromise: (value: T | PromiseLike<T>) => void = () => {};
+
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  return {
+    promise,
+    resolve: (value: T) => {
+      resolvePromise(value);
+    },
+  };
+};
 
 const createConfigDirectory = async (): Promise<string> => {
   const directory = await mkdtemp(join(tmpdir(), "atelier-appserver-server-"));

--- a/AppServer/src/app/server.ts
+++ b/AppServer/src/app/server.ts
@@ -77,7 +77,8 @@ export const createConfiguredAppServer = (options: CreateConfiguredAppServerOpti
   let state: AppServerState = "idle";
   let startPromise: Promise<void> | null = null;
   let stopPromise: Promise<void> | null = null;
-  let hasStarted = false;
+  let stopReason: string | null = null;
+  let startedComponents: LifecycleComponent[] = [];
   let signalUnsubscribes: readonly Unsubscribe[] = [];
   const waitForStop = createDeferred();
 
@@ -85,7 +86,12 @@ export const createConfiguredAppServer = (options: CreateConfiguredAppServerOpti
     const subscriptions = (["SIGINT", "SIGTERM"] as const).map((signal) =>
       signalRegistrar.subscribe(signal, () => {
         lifecycleLogger.info("Shutdown signal received", { signal });
-        void stop(signal);
+        void stop(signal).catch((error) => {
+          lifecycleLogger.error("App Server stop failed", {
+            reason: signal,
+            error: getErrorMessage(error),
+          });
+        });
       }),
     );
 
@@ -100,9 +106,35 @@ export const createConfiguredAppServer = (options: CreateConfiguredAppServerOpti
     signalUnsubscribes = Object.freeze([]);
   };
 
+  const stopStartedComponents = async (reason: string): Promise<void> => {
+    const stopErrors: unknown[] = [];
+
+    for (const component of [...startedComponents].reverse()) {
+      try {
+        await component.stop(reason);
+      } catch (error) {
+        stopErrors.push(error);
+      }
+    }
+
+    startedComponents = [];
+
+    if (stopErrors.length === 1) {
+      throw stopErrors[0];
+    }
+
+    if (stopErrors.length > 1) {
+      throw new AggregateError(stopErrors, "App Server shutdown failed");
+    }
+  };
+
   const start = async (): Promise<void> => {
     if (state === "started") {
       return;
+    }
+
+    if (state === "stopping") {
+      return stopPromise ?? Promise.resolve();
     }
 
     if (state === "stopped") {
@@ -121,10 +153,18 @@ export const createConfiguredAppServer = (options: CreateConfiguredAppServerOpti
       });
 
       for (const component of components) {
+        if (stopReason !== null) {
+          return;
+        }
+
         await component.start();
+        startedComponents.push(component);
       }
 
-      hasStarted = true;
+      if (stopReason !== null) {
+        return;
+      }
+
       registerSignalHandlers();
       state = "started";
       lifecycleLogger.info("App Server started", {
@@ -137,7 +177,17 @@ export const createConfiguredAppServer = (options: CreateConfiguredAppServerOpti
       await startPromise;
     } catch (error) {
       unregisterSignalHandlers();
-      state = "idle";
+      try {
+        await stopStartedComponents(stopReason ?? "startup-failed");
+      } catch (rollbackError) {
+        state = stopReason === null ? "idle" : "stopping";
+        throw new AggregateError(
+          [error, rollbackError],
+          "App Server startup failed and rollback failed",
+        );
+      }
+
+      state = stopReason === null ? "idle" : "stopping";
       throw error;
     } finally {
       startPromise = null;
@@ -153,20 +203,45 @@ export const createConfiguredAppServer = (options: CreateConfiguredAppServerOpti
       return stopPromise;
     }
 
+    stopReason = stopReason ?? reason;
     state = "stopping";
     unregisterSignalHandlers();
     stopPromise = (async () => {
-      lifecycleLogger.info("App Server stopping", { reason });
+      lifecycleLogger.info("App Server stopping", { reason: stopReason });
 
-      if (hasStarted) {
-        for (const component of [...components].reverse()) {
-          await component.stop(reason);
+      let stopError: unknown = null;
+
+      if (startPromise !== null) {
+        try {
+          await startPromise;
+        } catch (error) {
+          stopError = error;
+        }
+      }
+
+      if (startedComponents.length > 0) {
+        try {
+          await stopStartedComponents(stopReason);
+        } catch (error) {
+          stopError =
+            stopError === null
+              ? error
+              : new AggregateError([stopError, error], "App Server shutdown failed");
         }
       }
 
       state = "stopped";
-      lifecycleLogger.info("App Server stopped", { reason });
       waitForStop.resolve();
+
+      if (stopError !== null) {
+        lifecycleLogger.error("App Server stopped with errors", {
+          reason: stopReason,
+          error: getErrorMessage(stopError),
+        });
+        throw stopError;
+      }
+
+      lifecycleLogger.info("App Server stopped", { reason: stopReason });
     })();
 
     try {
@@ -190,6 +265,18 @@ type Deferred = Readonly<{
   promise: Promise<void>;
   resolve: () => void;
 }>;
+
+const getErrorMessage = (error: unknown): string => {
+  if (error instanceof AggregateError) {
+    return error.errors.map(getErrorMessage).join("; ");
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+};
 
 const createDeferred = (): Deferred => {
   let isResolved = false;

--- a/AppServer/src/app/server.ts
+++ b/AppServer/src/app/server.ts
@@ -1,0 +1,234 @@
+import { createAgentsFeaturePlaceholder } from "@/agents";
+import {
+  type AppServerConfig,
+  type LoadAppServerConfigOptions,
+  loadAppServerConfig,
+} from "@/app/config";
+import { createLogger, type Logger, type LogWriter } from "@/app/logger";
+import { createApprovalsFeaturePlaceholder } from "@/approvals";
+import { createProtocolBootstrapPlaceholder } from "@/core/protocol";
+import type { LifecycleComponent } from "@/core/shared";
+import { createStoreBootstrapPlaceholder } from "@/core/store";
+import { createTransportBootstrapPlaceholder } from "@/core/transport";
+import { createThreadsFeaturePlaceholder } from "@/threads";
+import { createTurnsFeaturePlaceholder } from "@/turns";
+import { createWorkspacesFeaturePlaceholder } from "@/workspaces";
+
+export type AppServerState = "idle" | "starting" | "started" | "stopping" | "stopped";
+export type ShutdownSignal = "SIGINT" | "SIGTERM";
+export type SignalHandler = () => void;
+export type Unsubscribe = () => void;
+
+export type SignalRegistrar = Readonly<{
+  subscribe: (signal: ShutdownSignal, handler: SignalHandler) => Unsubscribe;
+}>;
+
+export type AppServer = Readonly<{
+  config: AppServerConfig;
+  logger: Logger;
+  getState: () => AppServerState;
+  start: () => Promise<void>;
+  stop: (reason?: string) => Promise<void>;
+  waitForStop: () => Promise<void>;
+}>;
+
+export type CreateConfiguredAppServerOptions = Readonly<{
+  config: AppServerConfig;
+  logger?: Logger;
+  now?: () => string;
+  writeLog?: LogWriter;
+  components?: readonly LifecycleComponent[];
+  signalRegistrar?: SignalRegistrar;
+}>;
+
+export type CreateAppServerOptions = Readonly<
+  LoadAppServerConfigOptions & {
+    now?: () => string;
+    writeLog?: LogWriter;
+    components?: readonly LifecycleComponent[];
+    signalRegistrar?: SignalRegistrar;
+  }
+>;
+
+export const createAppServer = async (options: CreateAppServerOptions = {}): Promise<AppServer> => {
+  const config = await loadAppServerConfig(options);
+
+  return createConfiguredAppServer({
+    config,
+    now: options.now,
+    writeLog: options.writeLog,
+    components: options.components,
+    signalRegistrar: options.signalRegistrar,
+  });
+};
+
+export const createConfiguredAppServer = (options: CreateConfiguredAppServerOptions): AppServer => {
+  const logger =
+    options.logger ??
+    createLogger({
+      level: options.config.logLevel,
+      now: options.now,
+      write: options.writeLog,
+    });
+  const lifecycleLogger = logger.withContext({ component: "app-server" });
+  const components = [...(options.components ?? createDefaultComponents())];
+  const signalRegistrar = options.signalRegistrar ?? processSignalRegistrar;
+
+  let state: AppServerState = "idle";
+  let startPromise: Promise<void> | null = null;
+  let stopPromise: Promise<void> | null = null;
+  let hasStarted = false;
+  let signalUnsubscribes: readonly Unsubscribe[] = [];
+  const waitForStop = createDeferred();
+
+  const registerSignalHandlers = (): void => {
+    const subscriptions = (["SIGINT", "SIGTERM"] as const).map((signal) =>
+      signalRegistrar.subscribe(signal, () => {
+        lifecycleLogger.info("Shutdown signal received", { signal });
+        void stop(signal);
+      }),
+    );
+
+    signalUnsubscribes = Object.freeze(subscriptions);
+  };
+
+  const unregisterSignalHandlers = (): void => {
+    for (const unsubscribe of signalUnsubscribes) {
+      unsubscribe();
+    }
+
+    signalUnsubscribes = Object.freeze([]);
+  };
+
+  const start = async (): Promise<void> => {
+    if (state === "started") {
+      return;
+    }
+
+    if (state === "stopped") {
+      return;
+    }
+
+    if (startPromise !== null) {
+      return startPromise;
+    }
+
+    state = "starting";
+    startPromise = (async () => {
+      lifecycleLogger.info("App Server starting", {
+        port: options.config.port,
+        databasePath: options.config.databasePath,
+      });
+
+      for (const component of components) {
+        await component.start();
+      }
+
+      hasStarted = true;
+      registerSignalHandlers();
+      state = "started";
+      lifecycleLogger.info("App Server started", {
+        port: options.config.port,
+        componentCount: components.length,
+      });
+    })();
+
+    try {
+      await startPromise;
+    } catch (error) {
+      unregisterSignalHandlers();
+      state = "idle";
+      throw error;
+    } finally {
+      startPromise = null;
+    }
+  };
+
+  const stop = async (reason = "requested"): Promise<void> => {
+    if (state === "stopped") {
+      return;
+    }
+
+    if (stopPromise !== null) {
+      return stopPromise;
+    }
+
+    state = "stopping";
+    unregisterSignalHandlers();
+    stopPromise = (async () => {
+      lifecycleLogger.info("App Server stopping", { reason });
+
+      if (hasStarted) {
+        for (const component of [...components].reverse()) {
+          await component.stop(reason);
+        }
+      }
+
+      state = "stopped";
+      lifecycleLogger.info("App Server stopped", { reason });
+      waitForStop.resolve();
+    })();
+
+    try {
+      await stopPromise;
+    } finally {
+      stopPromise = null;
+    }
+  };
+
+  return Object.freeze({
+    config: options.config,
+    logger,
+    getState: () => state,
+    start,
+    stop,
+    waitForStop: () => waitForStop.promise,
+  });
+};
+
+type Deferred = Readonly<{
+  promise: Promise<void>;
+  resolve: () => void;
+}>;
+
+const createDeferred = (): Deferred => {
+  let isResolved = false;
+  let resolvePromise: () => void = () => {};
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = () => {
+      if (isResolved) {
+        return;
+      }
+
+      isResolved = true;
+      resolve();
+    };
+  });
+
+  return {
+    promise,
+    resolve: resolvePromise,
+  };
+};
+
+export const processSignalRegistrar: SignalRegistrar = Object.freeze({
+  subscribe: (signal, handler) => {
+    process.on(signal, handler);
+
+    return () => {
+      process.off(signal, handler);
+    };
+  },
+});
+
+const createDefaultComponents = (): readonly LifecycleComponent[] =>
+  Object.freeze([
+    createTransportBootstrapPlaceholder(),
+    createProtocolBootstrapPlaceholder(),
+    createStoreBootstrapPlaceholder(),
+    createAgentsFeaturePlaceholder(),
+    createWorkspacesFeaturePlaceholder(),
+    createThreadsFeaturePlaceholder(),
+    createTurnsFeaturePlaceholder(),
+    createApprovalsFeaturePlaceholder(),
+  ]);

--- a/AppServer/src/approvals/index.ts
+++ b/AppServer/src/approvals/index.ts
@@ -1,0 +1,4 @@
+import { createLifecyclePlaceholder, type LifecycleComponent } from "@/core/shared";
+
+export const createApprovalsFeaturePlaceholder = (): LifecycleComponent =>
+  createLifecyclePlaceholder("feature.approvals");

--- a/AppServer/src/core/protocol/index.ts
+++ b/AppServer/src/core/protocol/index.ts
@@ -1,0 +1,4 @@
+import { createLifecyclePlaceholder, type LifecycleComponent } from "@/core/shared";
+
+export const createProtocolBootstrapPlaceholder = (): LifecycleComponent =>
+  createLifecyclePlaceholder("core.protocol");

--- a/AppServer/src/core/shared/index.ts
+++ b/AppServer/src/core/shared/index.ts
@@ -1,0 +1,3 @@
+export * from "@/core/shared/lifecycle";
+export * from "@/core/shared/result";
+export * from "@/core/shared/startup-errors";

--- a/AppServer/src/core/shared/lifecycle.ts
+++ b/AppServer/src/core/shared/lifecycle.ts
@@ -1,0 +1,12 @@
+export type LifecycleComponent = Readonly<{
+  name: string;
+  start: () => Promise<void>;
+  stop: (reason: string) => Promise<void>;
+}>;
+
+export const createLifecyclePlaceholder = (name: string): LifecycleComponent =>
+  Object.freeze({
+    name,
+    start: async () => {},
+    stop: async () => {},
+  });

--- a/AppServer/src/core/shared/result.ts
+++ b/AppServer/src/core/shared/result.ts
@@ -1,0 +1,21 @@
+export type Result<T, E> =
+  | Readonly<{
+      ok: true;
+      data: T;
+    }>
+  | Readonly<{
+      ok: false;
+      error: E;
+    }>;
+
+export const ok = <T>(data: T): Result<T, never> =>
+  Object.freeze({
+    ok: true,
+    data,
+  });
+
+export const err = <E>(error: E): Result<never, E> =>
+  Object.freeze({
+    ok: false,
+    error,
+  });

--- a/AppServer/src/core/shared/startup-errors.ts
+++ b/AppServer/src/core/shared/startup-errors.ts
@@ -1,0 +1,46 @@
+export type StartupErrorCode =
+  | "CONFIG_READ_ERROR"
+  | "CONFIG_PARSE_ERROR"
+  | "CONFIG_VALIDATION_ERROR";
+
+export abstract class StartupError extends Error {
+  public readonly code: StartupErrorCode;
+
+  protected constructor(code: StartupErrorCode, message: string, cause?: unknown) {
+    super(message, cause === undefined ? undefined : { cause });
+    this.name = new.target.name;
+    this.code = code;
+  }
+}
+
+export class ConfigReadStartupError extends StartupError {
+  public readonly configPath: string;
+
+  public constructor(configPath: string, cause?: unknown) {
+    super("CONFIG_READ_ERROR", `Failed to read App Server config at ${configPath}`, cause);
+    this.configPath = configPath;
+  }
+}
+
+export class ConfigParseStartupError extends StartupError {
+  public readonly configPath: string;
+
+  public constructor(configPath: string, details: string) {
+    super("CONFIG_PARSE_ERROR", `Failed to parse App Server config at ${configPath}: ${details}`);
+    this.configPath = configPath;
+  }
+}
+
+export class ConfigValidationStartupError extends StartupError {
+  public readonly configPath: string;
+  public readonly issues: readonly string[];
+
+  public constructor(configPath: string, issues: readonly string[]) {
+    super(
+      "CONFIG_VALIDATION_ERROR",
+      `Invalid App Server config at ${configPath}: ${issues.join("; ")}`,
+    );
+    this.configPath = configPath;
+    this.issues = issues;
+  }
+}

--- a/AppServer/src/core/store/index.ts
+++ b/AppServer/src/core/store/index.ts
@@ -1,0 +1,4 @@
+import { createLifecyclePlaceholder, type LifecycleComponent } from "@/core/shared";
+
+export const createStoreBootstrapPlaceholder = (): LifecycleComponent =>
+  createLifecyclePlaceholder("core.store");

--- a/AppServer/src/core/transport/index.ts
+++ b/AppServer/src/core/transport/index.ts
@@ -1,0 +1,4 @@
+import { createLifecyclePlaceholder, type LifecycleComponent } from "@/core/shared";
+
+export const createTransportBootstrapPlaceholder = (): LifecycleComponent =>
+  createLifecyclePlaceholder("core.transport");

--- a/AppServer/src/index.ts
+++ b/AppServer/src/index.ts
@@ -1,0 +1,15 @@
+import { createAppServer } from "@/app/server";
+
+try {
+  const server = await createAppServer();
+  await server.start();
+  await server.waitForStop();
+} catch (error) {
+  if (error instanceof Error) {
+    console.error(error.message);
+  } else {
+    console.error("Unknown App Server startup failure");
+  }
+
+  process.exitCode = 1;
+}

--- a/AppServer/src/threads/index.ts
+++ b/AppServer/src/threads/index.ts
@@ -1,0 +1,4 @@
+import { createLifecyclePlaceholder, type LifecycleComponent } from "@/core/shared";
+
+export const createThreadsFeaturePlaceholder = (): LifecycleComponent =>
+  createLifecyclePlaceholder("feature.threads");

--- a/AppServer/src/turns/index.ts
+++ b/AppServer/src/turns/index.ts
@@ -1,0 +1,4 @@
+import { createLifecyclePlaceholder, type LifecycleComponent } from "@/core/shared";
+
+export const createTurnsFeaturePlaceholder = (): LifecycleComponent =>
+  createLifecyclePlaceholder("feature.turns");

--- a/AppServer/src/workspaces/index.ts
+++ b/AppServer/src/workspaces/index.ts
@@ -1,0 +1,4 @@
+import { createLifecyclePlaceholder, type LifecycleComponent } from "@/core/shared";
+
+export const createWorkspacesFeaturePlaceholder = (): LifecycleComponent =>
+  createLifecyclePlaceholder("feature.workspaces");

--- a/AppServer/tsconfig.json
+++ b/AppServer/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/Docs/app-server-design.md
+++ b/Docs/app-server-design.md
@@ -240,8 +240,8 @@ This layer is generic, reusable plumbing that makes the server run. It is strict
 
 This is the bootstrap layer and the **only** place in the codebase where `core/` and feature directories are allowed to interact.
 
-- **`server.ts`** — The main entry point. It initializes the core transport and protocol engines, registers the feature handlers with the dispatcher, wires parsed events to the transport layer, and starts the listener. It contains zero per-request business logic.
-- **`session.ts`** — Manages process-level lifecycle (startup, shutdown, healthcheck). Session-scoped execution state such as loaded threads, active turns, and pending approvals belongs in the relevant feature directories, not here.
+- **App layer lifecycle** — The app layer owns process-level startup, shutdown, and healthcheck coordination. It initializes the core transport and protocol engines, registers feature handlers with the dispatcher, wires parsed events to the transport layer, and starts the listener. It contains zero per-request business logic.
+- **Feature-owned runtime state** — Loaded threads, active turns, pending approvals, and other execution state live in the relevant feature directories, not in the app lifecycle surface.
 
 #### Import Rules
 
@@ -296,14 +296,14 @@ Configuration is loaded once at startup from a configuration file, with environm
 
 The configuration file is the primary source for settings such as server port, database location, available agents, and feature flags. Environment variables may override specific values when needed but should not be the default mechanism for most settings.
 
-Configuration should be read into a typed, readonly config object during bootstrap in `app/server.ts` and passed explicitly to the subsystems that need it. Feature code should never read environment variables or configuration files directly.
+Configuration should be read into a typed, readonly config object during bootstrap in the app layer and passed explicitly to the subsystems that need it. Feature code should never read environment variables or configuration files directly.
 
 
 ### Graceful Shutdown
 
 The server process should handle `SIGINT` and `SIGTERM` signals and shut down cleanly. Graceful shutdown means: stop accepting new WebSocket connections, interrupt or complete any active turns, flush pending store writes, close the database connection, and then exit.
 
-The shutdown sequence should be coordinated from `app/session.ts`, calling into features and core subsystems in the correct order. If shutdown takes longer than a reasonable timeout, force exit to avoid hanging indefinitely.
+The shutdown sequence should be coordinated from the app layer, calling into features and core subsystems in the correct order. If shutdown takes longer than a reasonable timeout, force exit to avoid hanging indefinitely.
 
 
 ### Path Aliases


### PR DESCRIPTION
## Summary
- add the tracked `AppServer/` Bun + TypeScript package with Biome, strict TypeScript, path aliases, and placeholder app/core/feature modules
- implement typed JSON config loading with TypeBox validation, environment overrides, and startup-specific error types
- add a minimal structured logger plus the App Server bootstrap/lifecycle API with server-owned start, stop, signal handling, and `waitForStop()`
- update the design doc to keep lifecycle coordination in the app layer without prescribing a separate public `session.ts` abstraction

## Testing
- `bun run check`
- `bun run typecheck`
- `bun run test`