### PR TITLE
Add App Server protocol engine and WebSocket transport

### DIFF
--- a/AppServer/src/app/protocol-harness.test.ts
+++ b/AppServer/src/app/protocol-harness.test.ts
@@ -1,0 +1,369 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createServer } from "node:net";
+import { createLogger } from "@/app/logger";
+import { APP_SERVER_USER_AGENT } from "@/app/protocol";
+import { type AppServer, createConfiguredAppServer, type SignalRegistrar } from "@/app/server";
+
+const runningServers: AppServer[] = [];
+
+afterEach(async () => {
+  while (runningServers.length > 0) {
+    const server = runningServers.pop();
+
+    if (server === undefined) {
+      continue;
+    }
+
+    try {
+      await server.stop("test-cleanup");
+    } catch {
+      // Ignore cleanup failures so the original test error stays visible.
+    }
+  }
+});
+
+describe("App Server protocol harness", () => {
+  test("initializes over a real websocket connection without an extra initialized notification", async () => {
+    const harness = await createProtocolHarness();
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      client.sendJson({
+        id: "req-1",
+        method: "initialize",
+        params: {
+          clientInfo: {
+            name: "AtelierCode Test",
+            version: "0.1.0",
+          },
+        },
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-1",
+        result: {
+          userAgent: APP_SERVER_USER_AGENT,
+        },
+      });
+      await expect(client.nextMessage(150)).rejects.toThrow("Timed out waiting for message");
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("maps invalid json to a parse error", async () => {
+    const harness = await createProtocolHarness();
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      client.sendText("{");
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: null,
+        error: {
+          code: -32700,
+          message: "Parse error",
+        },
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("maps invalid envelopes to invalid request", async () => {
+    const harness = await createProtocolHarness();
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      client.sendJson({
+        method: 123,
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: null,
+        error: {
+          code: -32600,
+          message: "Invalid request",
+        },
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("maps unknown methods to method not found", async () => {
+    const harness = await createProtocolHarness();
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      client.sendJson({
+        id: "req-unknown",
+        method: "thread/start",
+        params: {},
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-unknown",
+        error: {
+          code: -32601,
+          message: "Method not found",
+        },
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("maps invalid initialize params to invalid params", async () => {
+    const harness = await createProtocolHarness();
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      client.sendJson({
+        id: "req-invalid-params",
+        method: "initialize",
+        params: {
+          clientInfo: {
+            name: "AtelierCode Test",
+          },
+        },
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-invalid-params",
+        error: {
+          code: -32602,
+          message: "Invalid params",
+        },
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("rejects duplicate initialize requests on the same connection", async () => {
+    const harness = await createProtocolHarness();
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      const initializeRequest = {
+        id: "req-initialize-1",
+        method: "initialize",
+        params: {
+          clientInfo: {
+            name: "AtelierCode Test",
+            version: "0.1.0",
+          },
+        },
+      };
+
+      client.sendJson(initializeRequest);
+      await client.nextMessage();
+
+      client.sendJson({
+        ...initializeRequest,
+        id: "req-initialize-2",
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-initialize-2",
+        error: {
+          code: -33000,
+          message: "Session already initialized",
+          data: {
+            code: "SESSION_ALREADY_INITIALIZED",
+          },
+        },
+      });
+    } finally {
+      await client.close();
+    }
+  });
+});
+
+type ProtocolTestClient = Readonly<{
+  sendText: (text: string) => void;
+  sendJson: (value: unknown) => void;
+  nextMessage: (timeoutMs?: number) => Promise<unknown>;
+  close: () => Promise<void>;
+}>;
+
+const createProtocolHarness = async (): Promise<Readonly<{ port: number }>> => {
+  const port = await getAvailablePort();
+  const server = createConfiguredAppServer({
+    config: {
+      configPath: "/tmp/appserver.config.json",
+      port,
+      databasePath: "./var/test.sqlite",
+      logLevel: "info",
+    },
+    logger: createLogger({
+      level: "error",
+      write: () => {},
+    }),
+    signalRegistrar: createSignalRegistrar(),
+  });
+
+  await server.start();
+  runningServers.push(server);
+
+  return Object.freeze({ port });
+};
+
+const connectProtocolClient = async (port: number): Promise<ProtocolTestClient> => {
+  const socket = new WebSocket(`ws://127.0.0.1:${port}/`);
+  const bufferedMessages: unknown[] = [];
+  const pendingMessages: Array<{
+    resolve: (message: unknown) => void;
+    reject: (error: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }> = [];
+
+  socket.addEventListener("message", (event) => {
+    const text = toMessageText(event.data);
+    const message = JSON.parse(text) as unknown;
+    const nextMessage = pendingMessages.shift();
+
+    if (nextMessage === undefined) {
+      bufferedMessages.push(message);
+      return;
+    }
+
+    clearTimeout(nextMessage.timer);
+    nextMessage.resolve(message);
+  });
+
+  socket.addEventListener("close", () => {
+    while (pendingMessages.length > 0) {
+      const pendingMessage = pendingMessages.shift();
+
+      if (pendingMessage === undefined) {
+        continue;
+      }
+
+      clearTimeout(pendingMessage.timer);
+      pendingMessage.reject(new Error("WebSocket closed before a message arrived"));
+    }
+  });
+
+  await waitForSocketOpen(socket);
+
+  return Object.freeze({
+    sendText: (text) => {
+      socket.send(text);
+    },
+    sendJson: (value) => {
+      socket.send(JSON.stringify(value));
+    },
+    nextMessage: (timeoutMs = 1_000) => {
+      const bufferedMessage = bufferedMessages.shift();
+
+      if (bufferedMessage !== undefined) {
+        return Promise.resolve(bufferedMessage);
+      }
+
+      return new Promise<unknown>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          reject(new Error("Timed out waiting for message"));
+        }, timeoutMs);
+
+        pendingMessages.push({
+          resolve,
+          reject,
+          timer,
+        });
+      });
+    },
+    close: async () => {
+      if (socket.readyState === WebSocket.CLOSED) {
+        return;
+      }
+
+      const closePromise = new Promise<void>((resolve) => {
+        socket.addEventListener(
+          "close",
+          () => {
+            resolve();
+          },
+          { once: true },
+        );
+      });
+
+      socket.close();
+      await closePromise;
+    },
+  });
+};
+
+const waitForSocketOpen = async (socket: WebSocket): Promise<void> => {
+  if (socket.readyState === WebSocket.OPEN) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const onOpen = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = () => {
+      cleanup();
+      reject(new Error("WebSocket failed to open"));
+    };
+    const cleanup = () => {
+      socket.removeEventListener("open", onOpen);
+      socket.removeEventListener("error", onError);
+    };
+
+    socket.addEventListener("open", onOpen, { once: true });
+    socket.addEventListener("error", onError, { once: true });
+  });
+};
+
+const toMessageText = (data: unknown): string => {
+  if (typeof data === "string") {
+    return data;
+  }
+
+  if (data instanceof ArrayBuffer) {
+    return new TextDecoder().decode(data);
+  }
+
+  if (ArrayBuffer.isView(data)) {
+    return new TextDecoder().decode(data);
+  }
+
+  return String(data);
+};
+
+const createSignalRegistrar = (): SignalRegistrar =>
+  Object.freeze({
+    subscribe: () => () => {},
+  });
+
+const getAvailablePort = async (): Promise<number> => {
+  const server = createServer();
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+    server.once("error", reject);
+  });
+
+  const address = server.address();
+
+  if (address === null || typeof address === "string") {
+    throw new Error("Expected a TCP address");
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error !== undefined) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+
+  return address.port;
+};

--- a/AppServer/src/app/protocol.ts
+++ b/AppServer/src/app/protocol.ts
@@ -1,0 +1,74 @@
+import type { AppServerConfig } from "@/app/config";
+import type { Logger } from "@/app/logger";
+import {
+  createProtocolEngine,
+  InitializeParamsSchema,
+  InitializeResultSchema,
+} from "@/core/protocol";
+import { type LifecycleComponent, ok } from "@/core/shared";
+import { createWebSocketServer, type RawTextConnection } from "@/core/transport";
+
+export const APP_SERVER_USER_AGENT = "AtelierCode App Server/0.1.0";
+
+export type AppProtocolComponents = Readonly<{
+  protocolComponent: LifecycleComponent;
+  transportComponent: LifecycleComponent;
+}>;
+
+export const createAppProtocolComponents = (options: {
+  config: AppServerConfig;
+  logger: Logger;
+}): AppProtocolComponents => {
+  const protocolLogger = options.logger.withContext({ component: "core.protocol" });
+  const transportLogger = options.logger.withContext({ component: "core.transport" });
+  const protocol = createProtocolEngine({
+    logger: protocolLogger,
+  });
+
+  protocol.registerMethod({
+    method: "initialize",
+    paramsSchema: InitializeParamsSchema,
+    resultSchema: InitializeResultSchema,
+    handler: ({ connectionId, params, session }) => {
+      const initializationResult = session.markInitialized();
+
+      if (!initializationResult.ok) {
+        return initializationResult;
+      }
+
+      protocolLogger.info("Connection initialized", {
+        connectionId,
+        clientName: params.clientInfo.name,
+        clientVersion: params.clientInfo.version,
+      });
+
+      return ok({
+        userAgent: APP_SERVER_USER_AGENT,
+      });
+    },
+  });
+
+  const transportComponent = createWebSocketServer({
+    logger: transportLogger,
+    port: options.config.port,
+    onConnectionOpen: ({ connection }: Readonly<{ connection: RawTextConnection }>) => {
+      protocol.openConnection({
+        connectionId: connection.id,
+        sendText: connection.sendText,
+      });
+    },
+    onConnectionClose: ({ connectionId }) => {
+      protocol.closeConnection(connectionId);
+    },
+    onTextMessage: ({ connectionId, text }) =>
+      protocol.handleIncomingText({
+        connectionId,
+        text,
+      }),
+  });
+
+  return Object.freeze({
+    protocolComponent: protocol.lifecycle,
+    transportComponent,
+  });
+};

--- a/AppServer/src/app/server.test.ts
+++ b/AppServer/src/app/server.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { APP_SERVER_CONFIG_PATH_ENV } from "@/app/config";
@@ -41,7 +42,8 @@ describe("createAppServer", () => {
   });
 
   test("starts successfully", async () => {
-    const tempDirectory = await createConfigDirectory();
+    const port = await getAvailablePort();
+    const tempDirectory = await createConfigDirectory(port);
     const server = await createAppServer({
       cwd: tempDirectory,
       env: {
@@ -54,7 +56,7 @@ describe("createAppServer", () => {
     await server.start();
 
     expect(server.getState()).toBe("started");
-    expect(server.config.port).toBe(7331);
+    expect(server.config.port).toBe(port);
   });
 
   test("loads config in the high-level constructor while the configured constructor avoids config I/O", async () => {
@@ -323,7 +325,7 @@ const createSilentLogger = () =>
 const createTestConfig = () =>
   Object.freeze({
     configPath: "/tmp/appserver.config.json",
-    port: 7331,
+    port: 0,
     databasePath: "./var/test.sqlite",
     logLevel: "info" as const,
   });
@@ -343,18 +345,46 @@ const createDeferredPromise = <T>() => {
   };
 };
 
-const createConfigDirectory = async (): Promise<string> => {
+const createConfigDirectory = async (port = 7331): Promise<string> => {
   const directory = await mkdtemp(join(tmpdir(), "atelier-appserver-server-"));
   temporaryDirectories.push(directory);
 
   await writeFile(
     join(directory, "appserver.config.json"),
     JSON.stringify({
-      port: 7331,
+      port,
       databasePath: "./var/test.sqlite",
       logLevel: "info",
     }),
   );
 
   return directory;
+};
+
+const getAvailablePort = async (): Promise<number> => {
+  const server = createServer();
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+    server.once("error", reject);
+  });
+
+  const address = server.address();
+
+  if (address === null || typeof address === "string") {
+    throw new Error("Expected a TCP address");
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error !== undefined) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+
+  return address.port;
 };

--- a/AppServer/src/app/server.ts
+++ b/AppServer/src/app/server.ts
@@ -5,11 +5,10 @@ import {
   loadAppServerConfig,
 } from "@/app/config";
 import { createLogger, type Logger, type LogWriter } from "@/app/logger";
+import { createAppProtocolComponents } from "@/app/protocol";
 import { createApprovalsFeaturePlaceholder } from "@/approvals";
-import { createProtocolBootstrapPlaceholder } from "@/core/protocol";
 import type { LifecycleComponent } from "@/core/shared";
 import { createStoreBootstrapPlaceholder } from "@/core/store";
-import { createTransportBootstrapPlaceholder } from "@/core/transport";
 import { createThreadsFeaturePlaceholder } from "@/threads";
 import { createTurnsFeaturePlaceholder } from "@/turns";
 import { createWorkspacesFeaturePlaceholder } from "@/workspaces";
@@ -71,7 +70,7 @@ export const createConfiguredAppServer = (options: CreateConfiguredAppServerOpti
       write: options.writeLog,
     });
   const lifecycleLogger = logger.withContext({ component: "app-server" });
-  const components = [...(options.components ?? createDefaultComponents())];
+  const components = [...(options.components ?? createDefaultComponents(options.config, logger))];
   const signalRegistrar = options.signalRegistrar ?? processSignalRegistrar;
 
   let state: AppServerState = "idle";
@@ -308,14 +307,23 @@ export const processSignalRegistrar: SignalRegistrar = Object.freeze({
   },
 });
 
-const createDefaultComponents = (): readonly LifecycleComponent[] =>
-  Object.freeze([
-    createTransportBootstrapPlaceholder(),
-    createProtocolBootstrapPlaceholder(),
+const createDefaultComponents = (
+  config: AppServerConfig,
+  logger: Logger,
+): readonly LifecycleComponent[] => {
+  const appProtocolComponents = createAppProtocolComponents({
+    config,
+    logger,
+  });
+
+  return Object.freeze([
+    appProtocolComponents.protocolComponent,
     createStoreBootstrapPlaceholder(),
     createAgentsFeaturePlaceholder(),
     createWorkspacesFeaturePlaceholder(),
     createThreadsFeaturePlaceholder(),
     createTurnsFeaturePlaceholder(),
     createApprovalsFeaturePlaceholder(),
+    appProtocolComponents.transportComponent,
   ]);
+};

--- a/AppServer/src/core/protocol/dispatcher.ts
+++ b/AppServer/src/core/protocol/dispatcher.ts
@@ -1,0 +1,68 @@
+import type { Static, TSchema } from "@sinclair/typebox";
+import type { ProtocolMethodError } from "@/core/protocol/errors";
+import type { Result } from "@/core/shared";
+
+export type ProtocolSession = Readonly<{
+  isInitialized: () => boolean;
+  markInitialized: () => Result<void, ProtocolMethodError>;
+}>;
+
+export type ProtocolMethodContext = Readonly<{
+  connectionId: string;
+  session: ProtocolSession;
+}>;
+
+export type ProtocolMethodHandler<TParams, TResult> = (
+  input: ProtocolMethodContext &
+    Readonly<{
+      params: TParams;
+    }>,
+) => Promise<Result<TResult, ProtocolMethodError>> | Result<TResult, ProtocolMethodError>;
+
+export type ProtocolMethodRegistration<
+  TParamsSchema extends TSchema,
+  TResultSchema extends TSchema,
+> = Readonly<{
+  method: string;
+  paramsSchema: TParamsSchema;
+  resultSchema: TResultSchema;
+  handler: ProtocolMethodHandler<Static<TParamsSchema>, Static<TResultSchema>>;
+}>;
+
+export type RegisteredProtocolMethod = Readonly<{
+  method: string;
+  paramsSchema: TSchema;
+  resultSchema: TSchema;
+  handler: ProtocolMethodHandler<unknown, unknown>;
+}>;
+
+export type ProtocolDispatcher = Readonly<{
+  registerMethod: <TParamsSchema extends TSchema, TResultSchema extends TSchema>(
+    registration: ProtocolMethodRegistration<TParamsSchema, TResultSchema>,
+  ) => void;
+  getMethod: (method: string) => RegisteredProtocolMethod | undefined;
+}>;
+
+export const createProtocolDispatcher = (): ProtocolDispatcher => {
+  const methods = new Map<string, RegisteredProtocolMethod>();
+
+  const registerMethod: ProtocolDispatcher["registerMethod"] = (registration) => {
+    if (methods.has(registration.method)) {
+      throw new Error(`Protocol method already registered: ${registration.method}`);
+    }
+
+    const registeredMethod: RegisteredProtocolMethod = Object.freeze({
+      method: registration.method,
+      paramsSchema: registration.paramsSchema,
+      resultSchema: registration.resultSchema,
+      handler: registration.handler as ProtocolMethodHandler<unknown, unknown>,
+    });
+
+    methods.set(registration.method, registeredMethod);
+  };
+
+  return Object.freeze({
+    registerMethod,
+    getMethod: (method) => methods.get(method),
+  });
+};

--- a/AppServer/src/core/protocol/engine.test.ts
+++ b/AppServer/src/core/protocol/engine.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+import { Type } from "@sinclair/typebox";
+import { createLogger } from "@/app/logger";
+import {
+  createProtocolEngine,
+  InitializeParamsSchema,
+  type ProtocolNotification,
+} from "@/core/protocol";
+import { ok } from "@/core/shared";
+
+const createSilentLogger = () =>
+  createLogger({
+    level: "error",
+    write: () => {},
+  });
+
+describe("ProtocolEngine", () => {
+  test("maps unexpected handler failures to internal errors with structured data", async () => {
+    const outbound: string[] = [];
+    const engine = createProtocolEngine({
+      logger: createSilentLogger(),
+    });
+
+    engine.registerMethod({
+      method: "initialize",
+      paramsSchema: InitializeParamsSchema,
+      resultSchema: Type.Object(
+        {
+          userAgent: Type.String(),
+        },
+        { additionalProperties: false },
+      ),
+      handler: () => {
+        throw new Error("boom");
+      },
+    });
+
+    engine.openConnection({
+      connectionId: "connection-1",
+      sendText: async (text) => {
+        outbound.push(text);
+      },
+    });
+
+    await engine.handleIncomingText({
+      connectionId: "connection-1",
+      text: JSON.stringify({
+        id: "req-1",
+        method: "initialize",
+        params: {
+          clientInfo: {
+            name: "AtelierCode Test",
+            version: "0.1.0",
+          },
+        },
+      }),
+    });
+
+    expect(JSON.parse(outbound[0] ?? "null")).toEqual({
+      id: "req-1",
+      error: {
+        code: -32603,
+        message: "Internal error",
+        data: {
+          code: "INTERNAL_ERROR",
+        },
+      },
+    });
+  });
+
+  test("serializes outbound notifications for later protocol slices", async () => {
+    const outbound: string[] = [];
+    const engine = createProtocolEngine({
+      logger: createSilentLogger(),
+    });
+
+    engine.registerMethod({
+      method: "initialize",
+      paramsSchema: InitializeParamsSchema,
+      resultSchema: Type.Object(
+        {
+          userAgent: Type.String(),
+        },
+        { additionalProperties: false },
+      ),
+      handler: ({ session }) => {
+        const initialization = session.markInitialized();
+
+        if (!initialization.ok) {
+          return initialization;
+        }
+
+        return ok({
+          userAgent: "AtelierCode App Server/0.1.0",
+        });
+      },
+    });
+
+    engine.openConnection({
+      connectionId: "connection-1",
+      sendText: async (text) => {
+        outbound.push(text);
+      },
+    });
+
+    const notification: ProtocolNotification = {
+      method: "thread/status/changed",
+      params: {
+        threadId: "thread-1",
+        status: "idle",
+      },
+    };
+
+    await engine.sendNotification({
+      connectionId: "connection-1",
+      notification,
+    });
+
+    expect(JSON.parse(outbound[0] ?? "null")).toEqual(notification);
+  });
+});

--- a/AppServer/src/core/protocol/engine.ts
+++ b/AppServer/src/core/protocol/engine.ts
@@ -1,0 +1,387 @@
+import type { Static, TSchema } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
+import type { Logger } from "@/app/logger";
+import {
+  createProtocolDispatcher,
+  type ProtocolDispatcher,
+  type ProtocolSession,
+} from "@/core/protocol/dispatcher";
+import {
+  createInternalError,
+  createInvalidParamsError,
+  createInvalidRequestError,
+  createMethodNotFoundError,
+  createParseError,
+  createSessionAlreadyInitializedResult,
+  type ProtocolMethodError,
+} from "@/core/protocol/errors";
+import {
+  type ProtocolErrorResponse,
+  ProtocolErrorResponseSchema,
+  type ProtocolNotification,
+  ProtocolNotificationSchema,
+  type ProtocolRequest,
+  ProtocolRequestSchema,
+  type ProtocolSuccessResponse,
+  ProtocolSuccessResponseSchema,
+  type RequestId,
+  RequestIdSchema,
+} from "@/core/protocol/schemas";
+import { type LifecycleComponent, ok, type Result } from "@/core/shared";
+
+export type ProtocolSendText = (text: string) => Promise<void>;
+
+type ProtocolConnectionRecord = {
+  initialized: boolean;
+  sendText: ProtocolSendText;
+};
+
+export type ProtocolSerializationError = Readonly<{
+  message: string;
+}>;
+
+export type CreateProtocolEngineOptions = Readonly<{
+  logger: Logger;
+}>;
+
+export type ProtocolEngine = Readonly<{
+  lifecycle: LifecycleComponent;
+  registerMethod: ProtocolDispatcher["registerMethod"];
+  openConnection: (options: Readonly<{ connectionId: string; sendText: ProtocolSendText }>) => void;
+  closeConnection: (connectionId: string) => void;
+  handleIncomingText: (options: Readonly<{ connectionId: string; text: string }>) => Promise<void>;
+  serializeNotification: (
+    notification: ProtocolNotification,
+  ) => Result<string, ProtocolSerializationError>;
+  sendNotification: (
+    options: Readonly<{ connectionId: string; notification: ProtocolNotification }>,
+  ) => Promise<void>;
+}>;
+
+export const createProtocolEngine = (options: CreateProtocolEngineOptions): ProtocolEngine => {
+  const dispatcher = createProtocolDispatcher();
+  const connections = new Map<string, ProtocolConnectionRecord>();
+  const logger = options.logger;
+
+  const lifecycle: LifecycleComponent = Object.freeze({
+    name: "core.protocol",
+    start: async () => {
+      logger.info("Protocol engine ready");
+    },
+    stop: async () => {
+      connections.clear();
+      logger.info("Protocol engine stopped");
+    },
+  });
+
+  const openConnection = (
+    connection: Readonly<{ connectionId: string; sendText: ProtocolSendText }>,
+  ) => {
+    connections.set(connection.connectionId, {
+      initialized: false,
+      sendText: connection.sendText,
+    });
+
+    logger.info("Protocol connection registered", {
+      connectionId: connection.connectionId,
+    });
+  };
+
+  const closeConnection = (connectionId: string) => {
+    if (!connections.delete(connectionId)) {
+      return;
+    }
+
+    logger.info("Protocol connection removed", { connectionId });
+  };
+
+  const serializeNotification: ProtocolEngine["serializeNotification"] = (notification) =>
+    serializeWithSchema(ProtocolNotificationSchema, notification);
+
+  const sendSerializedText = async (connectionId: string, text: string): Promise<void> => {
+    const connection = connections.get(connectionId);
+
+    if (connection === undefined) {
+      logger.warn("Protocol send skipped for unknown connection", {
+        connectionId,
+      });
+      return;
+    }
+
+    try {
+      await connection.sendText(text);
+    } catch (error) {
+      logger.error("Protocol send failed", {
+        connectionId,
+        error: getErrorMessage(error),
+      });
+    }
+  };
+
+  const sendSuccessResponse = async (
+    connectionId: string,
+    response: ProtocolSuccessResponse,
+  ): Promise<void> => {
+    const serialized = serializeWithSchema(ProtocolSuccessResponseSchema, response);
+
+    if (!serialized.ok) {
+      logger.error("Protocol success response serialization failed", {
+        connectionId,
+        error: serialized.error.message,
+      });
+      return;
+    }
+
+    await sendSerializedText(connectionId, serialized.data);
+  };
+
+  const sendErrorResponse = async (
+    connectionId: string,
+    response: ProtocolErrorResponse,
+  ): Promise<void> => {
+    const serialized = serializeWithSchema(ProtocolErrorResponseSchema, response);
+
+    if (!serialized.ok) {
+      logger.error("Protocol error response serialization failed", {
+        connectionId,
+        error: serialized.error.message,
+      });
+      return;
+    }
+
+    await sendSerializedText(connectionId, serialized.data);
+  };
+
+  const sendNotification: ProtocolEngine["sendNotification"] = async ({
+    connectionId,
+    notification,
+  }) => {
+    const serialized = serializeNotification(notification);
+
+    if (!serialized.ok) {
+      logger.error("Protocol notification serialization failed", {
+        connectionId,
+        error: serialized.error.message,
+      });
+      return;
+    }
+
+    await sendSerializedText(connectionId, serialized.data);
+  };
+
+  const handleRequest = async (
+    connectionId: string,
+    request: ProtocolRequest,
+    connection: ProtocolConnectionRecord,
+  ): Promise<void> => {
+    logger.debug("Protocol request received", {
+      connectionId,
+      method: request.method,
+    });
+
+    const registeredMethod = dispatcher.getMethod(request.method);
+
+    if (registeredMethod === undefined) {
+      await sendErrorResponse(connectionId, {
+        id: request.id,
+        error: createMethodNotFoundError(),
+      });
+      return;
+    }
+
+    if (!Value.Check(registeredMethod.paramsSchema, request.params)) {
+      logger.warn("Protocol params validation failed", {
+        connectionId,
+        method: request.method,
+      });
+
+      await sendErrorResponse(connectionId, {
+        id: request.id,
+        error: createInvalidParamsError(),
+      });
+      return;
+    }
+
+    const session = createProtocolSession(connection);
+
+    try {
+      const methodResult = await registeredMethod.handler({
+        connectionId,
+        params: request.params,
+        session,
+      });
+
+      if (!methodResult.ok) {
+        await sendErrorResponse(connectionId, {
+          id: request.id,
+          error: methodResult.error,
+        });
+        return;
+      }
+
+      if (!Value.Check(registeredMethod.resultSchema, methodResult.data)) {
+        logger.error("Protocol method returned an invalid result", {
+          connectionId,
+          method: request.method,
+        });
+
+        await sendErrorResponse(connectionId, {
+          id: request.id,
+          error: createInternalError(),
+        });
+        return;
+      }
+
+      await sendSuccessResponse(connectionId, {
+        id: request.id,
+        result: methodResult.data,
+      });
+    } catch (error) {
+      logger.error("Protocol method failed unexpectedly", {
+        connectionId,
+        method: request.method,
+        error: getErrorMessage(error),
+      });
+
+      await sendErrorResponse(connectionId, {
+        id: request.id,
+        error: createInternalError(),
+      });
+    }
+  };
+
+  const handleIncomingText: ProtocolEngine["handleIncomingText"] = async ({
+    connectionId,
+    text,
+  }) => {
+    const connection = connections.get(connectionId);
+
+    if (connection === undefined) {
+      logger.warn("Protocol received text for an unknown connection", {
+        connectionId,
+      });
+      return;
+    }
+
+    const parsedPayload = parseIncomingText(text);
+
+    if (!parsedPayload.ok) {
+      logger.warn("Protocol parse error", {
+        connectionId,
+      });
+
+      await sendErrorResponse(connectionId, {
+        id: null,
+        error: createParseError(),
+      });
+      return;
+    }
+
+    if (Value.Check(ProtocolRequestSchema, parsedPayload.data)) {
+      await handleRequest(connectionId, parsedPayload.data as ProtocolRequest, connection);
+      return;
+    }
+
+    if (Value.Check(ProtocolNotificationSchema, parsedPayload.data)) {
+      const notification = parsedPayload.data as ProtocolNotification;
+
+      logger.debug("Ignoring inbound client notification", {
+        connectionId,
+        method: notification.method,
+      });
+      return;
+    }
+
+    logger.warn("Protocol invalid request envelope", {
+      connectionId,
+    });
+
+    await sendErrorResponse(connectionId, {
+      id: extractResponseId(parsedPayload.data),
+      error: createInvalidRequestError(),
+    });
+  };
+
+  return Object.freeze({
+    lifecycle,
+    registerMethod: dispatcher.registerMethod,
+    openConnection,
+    closeConnection,
+    handleIncomingText,
+    serializeNotification,
+    sendNotification,
+  });
+};
+
+const createProtocolSession = (connection: ProtocolConnectionRecord): ProtocolSession =>
+  Object.freeze({
+    isInitialized: () => connection.initialized,
+    markInitialized: () => {
+      if (connection.initialized) {
+        return createSessionAlreadyInitializedResult();
+      }
+
+      connection.initialized = true;
+      return ok(undefined);
+    },
+  });
+
+const parseIncomingText = (text: string): Result<unknown, ProtocolMethodError> => {
+  try {
+    return ok(JSON.parse(text) as unknown);
+  } catch {
+    return {
+      ok: false,
+      error: createParseError(),
+    };
+  }
+};
+
+const serializeWithSchema = <TSchemaValue extends TSchema>(
+  schema: TSchemaValue,
+  candidate: Static<TSchemaValue>,
+): Result<string, ProtocolSerializationError> => {
+  if (!Value.Check(schema, candidate)) {
+    const validationErrors = [...Value.Errors(schema, candidate)].map((issue) => {
+      const path = issue.path || "/";
+      return `${path}: ${issue.message}`;
+    });
+
+    return {
+      ok: false,
+      error: Object.freeze({
+        message: validationErrors.join("; "),
+      }),
+    };
+  }
+
+  try {
+    return ok(JSON.stringify(candidate));
+  } catch (error) {
+    return {
+      ok: false,
+      error: Object.freeze({
+        message: getErrorMessage(error),
+      }),
+    };
+  }
+};
+
+const extractResponseId = (candidate: unknown): RequestId | null => {
+  if (!isRecord(candidate) || !Value.Check(RequestIdSchema, candidate.id)) {
+    return null;
+  }
+
+  return candidate.id as RequestId;
+};
+
+const isRecord = (candidate: unknown): candidate is Record<string, unknown> =>
+  typeof candidate === "object" && candidate !== null && !Array.isArray(candidate);
+
+const getErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+};

--- a/AppServer/src/core/protocol/errors.ts
+++ b/AppServer/src/core/protocol/errors.ts
@@ -1,0 +1,64 @@
+import type { ProtocolErrorData } from "@/core/protocol/schemas";
+import { err, type Result } from "@/core/shared";
+
+export const JSON_RPC_PARSE_ERROR = -32700;
+export const JSON_RPC_INVALID_REQUEST_ERROR = -32600;
+export const JSON_RPC_METHOD_NOT_FOUND_ERROR = -32601;
+export const JSON_RPC_INVALID_PARAMS_ERROR = -32602;
+export const JSON_RPC_INTERNAL_ERROR = -32603;
+
+export const ATELIER_SESSION_ALREADY_INITIALIZED_ERROR = -33000;
+
+export type ProtocolMethodError = Readonly<{
+  code: number;
+  message: string;
+  data?: ProtocolErrorData;
+}>;
+
+export const createProtocolMethodError = (
+  code: number,
+  message: string,
+  data?: ProtocolErrorData,
+): ProtocolMethodError =>
+  Object.freeze(
+    data === undefined
+      ? { code, message }
+      : {
+          code,
+          message,
+          data,
+        },
+  );
+
+export const createParseError = (): ProtocolMethodError =>
+  createProtocolMethodError(JSON_RPC_PARSE_ERROR, "Parse error");
+
+export const createInvalidRequestError = (): ProtocolMethodError =>
+  createProtocolMethodError(JSON_RPC_INVALID_REQUEST_ERROR, "Invalid request");
+
+export const createMethodNotFoundError = (): ProtocolMethodError =>
+  createProtocolMethodError(JSON_RPC_METHOD_NOT_FOUND_ERROR, "Method not found");
+
+export const createInvalidParamsError = (): ProtocolMethodError =>
+  createProtocolMethodError(JSON_RPC_INVALID_PARAMS_ERROR, "Invalid params");
+
+export const createInternalError = (): ProtocolMethodError =>
+  createProtocolMethodError(
+    JSON_RPC_INTERNAL_ERROR,
+    "Internal error",
+    Object.freeze({
+      code: "INTERNAL_ERROR",
+    }),
+  );
+
+export const createSessionAlreadyInitializedError = (): ProtocolMethodError =>
+  createProtocolMethodError(
+    ATELIER_SESSION_ALREADY_INITIALIZED_ERROR,
+    "Session already initialized",
+    Object.freeze({
+      code: "SESSION_ALREADY_INITIALIZED",
+    }),
+  );
+
+export const createSessionAlreadyInitializedResult = (): Result<never, ProtocolMethodError> =>
+  err(createSessionAlreadyInitializedError());

--- a/AppServer/src/core/protocol/index.ts
+++ b/AppServer/src/core/protocol/index.ts
@@ -1,4 +1,4 @@
-import { createLifecyclePlaceholder, type LifecycleComponent } from "@/core/shared";
-
-export const createProtocolBootstrapPlaceholder = (): LifecycleComponent =>
-  createLifecyclePlaceholder("core.protocol");
+export * from "@/core/protocol/dispatcher";
+export * from "@/core/protocol/engine";
+export * from "@/core/protocol/errors";
+export * from "@/core/protocol/schemas";

--- a/AppServer/src/core/protocol/schemas.ts
+++ b/AppServer/src/core/protocol/schemas.ts
@@ -1,0 +1,100 @@
+import { type Static, Type } from "@sinclair/typebox";
+
+export const RequestIdSchema = Type.Union([Type.String(), Type.Number()]);
+export type RequestId = Static<typeof RequestIdSchema>;
+
+export const ResponseIdSchema = Type.Union([RequestIdSchema, Type.Null()]);
+export type ResponseId = Static<typeof ResponseIdSchema>;
+
+export const ProtocolErrorDataSchema = Type.Object(
+  {
+    code: Type.String({ minLength: 1 }),
+  },
+  { additionalProperties: true },
+);
+export type ProtocolErrorData = Static<typeof ProtocolErrorDataSchema>;
+
+export const ProtocolErrorSchema = Type.Object(
+  {
+    code: Type.Integer(),
+    message: Type.String({ minLength: 1 }),
+    data: Type.Optional(ProtocolErrorDataSchema),
+  },
+  { additionalProperties: false },
+);
+export type ProtocolError = Static<typeof ProtocolErrorSchema>;
+
+export const ProtocolRequestSchema = Type.Object(
+  {
+    id: RequestIdSchema,
+    method: Type.String({ minLength: 1 }),
+    params: Type.Optional(Type.Unknown()),
+  },
+  { additionalProperties: false },
+);
+export type ProtocolRequest = Static<typeof ProtocolRequestSchema>;
+
+export const ProtocolSuccessResponseSchema = Type.Object(
+  {
+    id: RequestIdSchema,
+    result: Type.Unknown(),
+  },
+  { additionalProperties: false },
+);
+export type ProtocolSuccessResponse = Static<typeof ProtocolSuccessResponseSchema>;
+
+export const ProtocolErrorResponseSchema = Type.Object(
+  {
+    id: ResponseIdSchema,
+    error: ProtocolErrorSchema,
+  },
+  { additionalProperties: false },
+);
+export type ProtocolErrorResponse = Static<typeof ProtocolErrorResponseSchema>;
+
+export const ProtocolNotificationSchema = Type.Object(
+  {
+    method: Type.String({ minLength: 1 }),
+    params: Type.Optional(Type.Unknown()),
+  },
+  { additionalProperties: false },
+);
+export type ProtocolNotification = Static<typeof ProtocolNotificationSchema>;
+
+export const InitializeCapabilitiesSchema = Type.Object(
+  {
+    experimentalApi: Type.Optional(Type.Boolean()),
+    optOutNotificationMethods: Type.Optional(
+      Type.Union([Type.Array(Type.String({ minLength: 1 })), Type.Null()]),
+    ),
+  },
+  { additionalProperties: false },
+);
+export type InitializeCapabilities = Static<typeof InitializeCapabilitiesSchema>;
+
+export const ClientInfoSchema = Type.Object(
+  {
+    name: Type.String({ minLength: 1 }),
+    title: Type.Optional(Type.Union([Type.String({ minLength: 1 }), Type.Null()])),
+    version: Type.String({ minLength: 1 }),
+  },
+  { additionalProperties: false },
+);
+export type ClientInfo = Static<typeof ClientInfoSchema>;
+
+export const InitializeParamsSchema = Type.Object(
+  {
+    clientInfo: ClientInfoSchema,
+    capabilities: Type.Optional(Type.Union([InitializeCapabilitiesSchema, Type.Null()])),
+  },
+  { additionalProperties: false },
+);
+export type InitializeParams = Static<typeof InitializeParamsSchema>;
+
+export const InitializeResultSchema = Type.Object(
+  {
+    userAgent: Type.String({ minLength: 1 }),
+  },
+  { additionalProperties: false },
+);
+export type InitializeResult = Static<typeof InitializeResultSchema>;

--- a/AppServer/src/core/transport/index.ts
+++ b/AppServer/src/core/transport/index.ts
@@ -1,4 +1,1 @@
-import { createLifecyclePlaceholder, type LifecycleComponent } from "@/core/shared";
-
-export const createTransportBootstrapPlaceholder = (): LifecycleComponent =>
-  createLifecyclePlaceholder("core.transport");
+export * from "@/core/transport/websocket-server";

--- a/AppServer/src/core/transport/websocket-server.test.ts
+++ b/AppServer/src/core/transport/websocket-server.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { assertWebSocketSendSucceeded, waitForShutdown } from "@/core/transport/websocket-server";
+
+describe("WebSocket transport helpers", () => {
+  test("treats Bun backpressure as a queued send rather than a failure", () => {
+    expect(() => {
+      assertWebSocketSendSucceeded(-1);
+    }).not.toThrow();
+    expect(() => {
+      assertWebSocketSendSucceeded(42);
+    }).not.toThrow();
+  });
+
+  test("still fails when Bun reports a dropped frame", () => {
+    expect(() => {
+      assertWebSocketSendSucceeded(0);
+    }).toThrow("WebSocket message was dropped");
+  });
+
+  test("clears the shutdown timeout after the server stops", async () => {
+    let clearedTimer: ReturnType<typeof setTimeout> | null = null;
+    let scheduledTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const didStop = await waitForShutdown(Promise.resolve(), 1_000, {
+      setTimer: (callback, timeoutMs) => {
+        scheduledTimer = setTimeout(callback, timeoutMs);
+        return scheduledTimer;
+      },
+      clearTimer: (timer) => {
+        clearedTimer = timer;
+        clearTimeout(timer);
+      },
+    });
+
+    expect(didStop).toBe(true);
+    expect(clearedTimer).toBe(scheduledTimer);
+  });
+});

--- a/AppServer/src/core/transport/websocket-server.ts
+++ b/AppServer/src/core/transport/websocket-server.ts
@@ -183,22 +183,20 @@ const createRawTextConnection = (
   Object.freeze({
     id: socket.data.connectionId,
     sendText: async (text: string) => {
-      const sendStatus = socket.sendText(text);
-
-      if (sendStatus > 0) {
-        return;
-      }
-
-      if (sendStatus === 0) {
-        throw new Error("WebSocket message was dropped");
-      }
-
-      throw new Error("WebSocket send is backpressured");
+      assertWebSocketSendSucceeded(socket.sendText(text));
     },
     close: (code?: number, reason?: string) => {
       socket.close(code, reason);
     },
   });
+
+export const assertWebSocketSendSucceeded = (sendStatus: number): void => {
+  if (sendStatus !== 0) {
+    return;
+  }
+
+  throw new Error("WebSocket message was dropped");
+};
 
 const getErrorMessage = (error: unknown): string => {
   if (error instanceof Error) {
@@ -208,15 +206,32 @@ const getErrorMessage = (error: unknown): string => {
   return String(error);
 };
 
-const waitForShutdown = async (
+type TimeoutHandle = ReturnType<typeof setTimeout>;
+
+type ShutdownTimerHooks = Readonly<{
+  clearTimer?: (timer: TimeoutHandle) => void;
+  setTimer?: (callback: () => void, timeoutMs: number) => TimeoutHandle;
+}>;
+
+export const waitForShutdown = async (
   shutdownPromise: Promise<void>,
   timeoutMs: number,
+  hooks: ShutdownTimerHooks = {},
 ): Promise<boolean> => {
+  const setTimer = hooks.setTimer ?? ((callback, delay) => setTimeout(callback, delay));
+  const clearTimer = hooks.clearTimer ?? ((timer) => clearTimeout(timer));
   const timeoutResult = Symbol("timeout");
+  let timeoutHandle: TimeoutHandle | null = null;
   const result = await Promise.race<true | typeof timeoutResult>([
-    shutdownPromise.then(() => true),
+    shutdownPromise.then(() => {
+      if (timeoutHandle !== null) {
+        clearTimer(timeoutHandle);
+      }
+
+      return true;
+    }),
     new Promise<typeof timeoutResult>((resolve) => {
-      setTimeout(() => {
+      timeoutHandle = setTimer(() => {
         resolve(timeoutResult);
       }, timeoutMs);
     }),

--- a/AppServer/src/core/transport/websocket-server.ts
+++ b/AppServer/src/core/transport/websocket-server.ts
@@ -1,0 +1,226 @@
+import type { Server, ServerWebSocket } from "bun";
+import type { Logger } from "@/app/logger";
+import type { LifecycleComponent } from "@/core/shared";
+
+type WebSocketConnectionData = Readonly<{
+  connectionId: string;
+}>;
+
+export type RawTextConnection = Readonly<{
+  id: string;
+  sendText: (text: string) => Promise<void>;
+  close: (code?: number, reason?: string) => void;
+}>;
+
+export type RawConnectionOpenedEvent = Readonly<{
+  connection: RawTextConnection;
+}>;
+
+export type RawConnectionClosedEvent = Readonly<{
+  connectionId: string;
+  code: number;
+  reason: string;
+}>;
+
+export type RawTextMessageEvent = Readonly<{
+  connectionId: string;
+  text: string;
+}>;
+
+export type CreateWebSocketServerOptions = Readonly<{
+  logger: Logger;
+  port: number;
+  path?: string;
+  onConnectionOpen?: (event: RawConnectionOpenedEvent) => Promise<void> | void;
+  onConnectionClose?: (event: RawConnectionClosedEvent) => Promise<void> | void;
+  onTextMessage?: (event: RawTextMessageEvent) => Promise<void> | void;
+}>;
+
+export const createWebSocketServer = (
+  options: CreateWebSocketServerOptions,
+): LifecycleComponent => {
+  const logger = options.logger;
+  const path = options.path ?? "/";
+  const sockets = new Map<string, ServerWebSocket<WebSocketConnectionData>>();
+  let server: Server<WebSocketConnectionData> | null = null;
+
+  const start = async (): Promise<void> => {
+    if (server !== null) {
+      return;
+    }
+
+    server = Bun.serve<WebSocketConnectionData>({
+      port: options.port,
+      fetch(request, bunServer) {
+        const url = new URL(request.url);
+
+        if (url.pathname !== path) {
+          return new Response("Not Found", { status: 404 });
+        }
+
+        const connectionId = crypto.randomUUID();
+        const upgraded = bunServer.upgrade(request, {
+          data: { connectionId },
+        });
+
+        if (upgraded) {
+          return;
+        }
+
+        logger.warn("WebSocket upgrade failed", {
+          path: url.pathname,
+        });
+
+        return new Response("WebSocket upgrade failed", { status: 400 });
+      },
+      websocket: {
+        data: {} as WebSocketConnectionData,
+        open: async (socket) => {
+          const connection = createRawTextConnection(socket);
+          sockets.set(connection.id, socket);
+
+          logger.info("WebSocket connection opened", {
+            connectionId: connection.id,
+          });
+
+          try {
+            await options.onConnectionOpen?.({ connection });
+          } catch (error) {
+            logger.error("WebSocket open handler failed", {
+              connectionId: connection.id,
+              error: getErrorMessage(error),
+            });
+            socket.close(1011, "Internal error");
+          }
+        },
+        message: async (socket, message) => {
+          if (typeof message !== "string") {
+            logger.warn("Rejecting non-text WebSocket message", {
+              connectionId: socket.data.connectionId,
+            });
+            socket.close(1003, "Text messages only");
+            return;
+          }
+
+          try {
+            await options.onTextMessage?.({
+              connectionId: socket.data.connectionId,
+              text: message,
+            });
+          } catch (error) {
+            logger.error("WebSocket message handler failed", {
+              connectionId: socket.data.connectionId,
+              error: getErrorMessage(error),
+            });
+            socket.close(1011, "Internal error");
+          }
+        },
+        close: async (socket, code, reason) => {
+          sockets.delete(socket.data.connectionId);
+
+          logger.info("WebSocket connection closed", {
+            connectionId: socket.data.connectionId,
+            code,
+            reason,
+          });
+
+          try {
+            await options.onConnectionClose?.({
+              connectionId: socket.data.connectionId,
+              code,
+              reason,
+            });
+          } catch (error) {
+            logger.error("WebSocket close handler failed", {
+              connectionId: socket.data.connectionId,
+              error: getErrorMessage(error),
+            });
+          }
+        },
+      },
+    });
+
+    logger.info("WebSocket Server started", {
+      port: server.port ?? options.port,
+      path,
+    });
+  };
+
+  const stop = async (reason: string): Promise<void> => {
+    if (server === null) {
+      return;
+    }
+
+    const activeServer = server;
+    server = null;
+
+    logger.info("WebSocket Server stopping", { reason });
+
+    for (const socket of sockets.values()) {
+      socket.close(1001, reason);
+    }
+
+    const didStop = await waitForShutdown(activeServer.stop(true), 1_000);
+    sockets.clear();
+
+    if (!didStop) {
+      logger.warn("WebSocket Server stop timed out", { reason });
+    }
+
+    logger.info("WebSocket Server stopped", { reason });
+  };
+
+  return Object.freeze({
+    name: "core.transport",
+    start,
+    stop,
+  });
+};
+
+const createRawTextConnection = (
+  socket: ServerWebSocket<WebSocketConnectionData>,
+): RawTextConnection =>
+  Object.freeze({
+    id: socket.data.connectionId,
+    sendText: async (text: string) => {
+      const sendStatus = socket.sendText(text);
+
+      if (sendStatus > 0) {
+        return;
+      }
+
+      if (sendStatus === 0) {
+        throw new Error("WebSocket message was dropped");
+      }
+
+      throw new Error("WebSocket send is backpressured");
+    },
+    close: (code?: number, reason?: string) => {
+      socket.close(code, reason);
+    },
+  });
+
+const getErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+};
+
+const waitForShutdown = async (
+  shutdownPromise: Promise<void>,
+  timeoutMs: number,
+): Promise<boolean> => {
+  const timeoutResult = Symbol("timeout");
+  const result = await Promise.race<true | typeof timeoutResult>([
+    shutdownPromise.then(() => true),
+    new Promise<typeof timeoutResult>((resolve) => {
+      setTimeout(() => {
+        resolve(timeoutResult);
+      }, timeoutMs);
+    }),
+  ]);
+
+  return result === true;
+};


### PR DESCRIPTION
## Summary
- add a concrete JSON-RPC protocol engine with TypeBox schemas, request dispatch, response serialization, and error mapping
- add a raw `Bun.serve` WebSocket server for connection lifecycle and text transport
- wire `initialize` through app composition with connection-scoped session state and duplicate-initialize protection
- replace protocol and transport placeholders in App Server startup
- add protocol harness and unit tests covering initialize, parse errors, invalid requests, method-not-found, invalid params, and internal error handling

## Testing
- `./node_modules/.bin/biome check .`
- `./node_modules/.bin/tsc --noEmit`
- `bun test src/core/protocol/engine.test.ts src/app/protocol-harness.test.ts src/app/server.test.ts`