### PR TITLE
Refactor AppServer protocol cleanup and harden edge-case coverage

### DIFF
--- a/AppServer/src/app/config.ts
+++ b/AppServer/src/app/config.ts
@@ -2,7 +2,6 @@ import { readFile } from "node:fs/promises";
 import { isAbsolute, resolve } from "node:path";
 import { type Static, Type } from "@sinclair/typebox";
 import { Value } from "@sinclair/typebox/value";
-import { LOG_LEVELS, type LogLevel } from "@/app/logger";
 import {
   ConfigParseStartupError,
   ConfigReadStartupError,
@@ -161,17 +160,8 @@ const parsePortOverride = (rawPort: string): number => {
 };
 
 const parseLogLevelOverride = (rawLogLevel: string): string => {
-  const normalizedLogLevel = rawLogLevel.trim();
-
-  if (isLogLevel(normalizedLogLevel)) {
-    return normalizedLogLevel;
-  }
-
-  return normalizedLogLevel;
+  return rawLogLevel.trim();
 };
-
-const isLogLevel = (value: string): value is LogLevel =>
-  LOG_LEVELS.some((logLevel) => logLevel === value);
 
 const resolveEnvironment = (env: AppServerEnvironment | undefined): AppServerEnvironment =>
   Object.freeze({

--- a/AppServer/src/app/protocol-harness.test.ts
+++ b/AppServer/src/app/protocol-harness.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { createServer } from "node:net";
 import { createLogger } from "@/app/logger";
 import { APP_SERVER_USER_AGENT } from "@/app/protocol";
 import { type AppServer, createConfiguredAppServer, type SignalRegistrar } from "@/app/server";
+import { getAvailablePort } from "@/test-support/network";
 
 const runningServers: AppServer[] = [];
 
@@ -339,31 +339,3 @@ const createSignalRegistrar = (): SignalRegistrar =>
   Object.freeze({
     subscribe: () => () => {},
   });
-
-const getAvailablePort = async (): Promise<number> => {
-  const server = createServer();
-
-  await new Promise<void>((resolve, reject) => {
-    server.listen(0, "127.0.0.1", () => resolve());
-    server.once("error", reject);
-  });
-
-  const address = server.address();
-
-  if (address === null || typeof address === "string") {
-    throw new Error("Expected a TCP address");
-  }
-
-  await new Promise<void>((resolve, reject) => {
-    server.close((error) => {
-      if (error !== undefined) {
-        reject(error);
-        return;
-      }
-
-      resolve();
-    });
-  });
-
-  return address.port;
-};

--- a/AppServer/src/app/protocol.ts
+++ b/AppServer/src/app/protocol.ts
@@ -6,7 +6,7 @@ import {
   InitializeResultSchema,
 } from "@/core/protocol";
 import { type LifecycleComponent, ok } from "@/core/shared";
-import { createWebSocketServer, type RawTextConnection } from "@/core/transport";
+import { createWebSocketServer, type RawConnectionOpenedEvent } from "@/core/transport";
 
 export const APP_SERVER_USER_AGENT = "AtelierCode App Server/0.1.0";
 
@@ -51,7 +51,7 @@ export const createAppProtocolComponents = (options: {
   const transportComponent = createWebSocketServer({
     logger: transportLogger,
     port: options.config.port,
-    onConnectionOpen: ({ connection }: Readonly<{ connection: RawTextConnection }>) => {
+    onConnectionOpen: ({ connection }: RawConnectionOpenedEvent) => {
       protocol.openConnection({
         connectionId: connection.id,
         sendText: connection.sendText,

--- a/AppServer/src/app/server.test.ts
+++ b/AppServer/src/app/server.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { APP_SERVER_CONFIG_PATH_ENV } from "@/app/config";
@@ -12,6 +11,8 @@ import {
   type SignalHandler,
   type SignalRegistrar,
 } from "@/app/server";
+import { createSilentLogger } from "@/test-support/logger";
+import { getAvailablePort } from "@/test-support/network";
 
 const temporaryDirectories: string[] = [];
 
@@ -316,12 +317,6 @@ const createSignalRegistrar = (): FakeSignalRegistrar => {
   };
 };
 
-const createSilentLogger = () =>
-  createLogger({
-    level: "info",
-    write: () => {},
-  });
-
 const createTestConfig = () =>
   Object.freeze({
     configPath: "/tmp/appserver.config.json",
@@ -359,32 +354,4 @@ const createConfigDirectory = async (port = 7331): Promise<string> => {
   );
 
   return directory;
-};
-
-const getAvailablePort = async (): Promise<number> => {
-  const server = createServer();
-
-  await new Promise<void>((resolve, reject) => {
-    server.listen(0, "127.0.0.1", () => resolve());
-    server.once("error", reject);
-  });
-
-  const address = server.address();
-
-  if (address === null || typeof address === "string") {
-    throw new Error("Expected a TCP address");
-  }
-
-  await new Promise<void>((resolve, reject) => {
-    server.close((error) => {
-      if (error !== undefined) {
-        reject(error);
-        return;
-      }
-
-      resolve();
-    });
-  });
-
-  return address.port;
 };

--- a/AppServer/src/app/server.ts
+++ b/AppServer/src/app/server.ts
@@ -7,7 +7,7 @@ import {
 import { createLogger, type Logger, type LogWriter } from "@/app/logger";
 import { createAppProtocolComponents } from "@/app/protocol";
 import { createApprovalsFeaturePlaceholder } from "@/approvals";
-import type { LifecycleComponent } from "@/core/shared";
+import { getErrorMessage, type LifecycleComponent } from "@/core/shared";
 import { createStoreBootstrapPlaceholder } from "@/core/store";
 import { createThreadsFeaturePlaceholder } from "@/threads";
 import { createTurnsFeaturePlaceholder } from "@/turns";
@@ -264,18 +264,6 @@ type Deferred = Readonly<{
   promise: Promise<void>;
   resolve: () => void;
 }>;
-
-const getErrorMessage = (error: unknown): string => {
-  if (error instanceof AggregateError) {
-    return error.errors.map(getErrorMessage).join("; ");
-  }
-
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  return String(error);
-};
 
 const createDeferred = (): Deferred => {
   let isResolved = false;

--- a/AppServer/src/core/protocol/engine.test.ts
+++ b/AppServer/src/core/protocol/engine.test.ts
@@ -1,18 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { Type } from "@sinclair/typebox";
-import { createLogger } from "@/app/logger";
 import {
   createProtocolEngine,
   InitializeParamsSchema,
   type ProtocolNotification,
 } from "@/core/protocol";
-import { ok } from "@/core/shared";
-
-const createSilentLogger = () =>
-  createLogger({
-    level: "error",
-    write: () => {},
-  });
+import { createCapturingLogger, createSilentLogger } from "@/test-support/logger";
 
 describe("ProtocolEngine", () => {
   test("maps unexpected handler failures to internal errors with structured data", async () => {
@@ -71,29 +64,7 @@ describe("ProtocolEngine", () => {
   test("serializes outbound notifications for later protocol slices", async () => {
     const outbound: string[] = [];
     const engine = createProtocolEngine({
-      logger: createSilentLogger(),
-    });
-
-    engine.registerMethod({
-      method: "initialize",
-      paramsSchema: InitializeParamsSchema,
-      resultSchema: Type.Object(
-        {
-          userAgent: Type.String(),
-        },
-        { additionalProperties: false },
-      ),
-      handler: ({ session }) => {
-        const initialization = session.markInitialized();
-
-        if (!initialization.ok) {
-          return initialization;
-        }
-
-        return ok({
-          userAgent: "AtelierCode App Server/0.1.0",
-        });
-      },
+      logger: createSilentLogger("error"),
     });
 
     engine.openConnection({
@@ -117,5 +88,151 @@ describe("ProtocolEngine", () => {
     });
 
     expect(JSON.parse(outbound[0] ?? "null")).toEqual(notification);
+  });
+
+  test("swallows send failures during outbound notifications and logs the error", async () => {
+    const { logger, records } = createCapturingLogger();
+    const engine = createProtocolEngine({ logger });
+
+    engine.openConnection({
+      connectionId: "connection-1",
+      sendText: async () => {
+        throw new Error("transport failed");
+      },
+    });
+
+    await expect(
+      engine.sendNotification({
+        connectionId: "connection-1",
+        notification: {
+          method: "thread/status/changed",
+          params: {
+            threadId: "thread-1",
+            status: "idle",
+          },
+        },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        level: "error",
+        message: "Protocol send failed",
+        connectionId: "connection-1",
+        error: "transport failed",
+      }),
+    );
+  });
+
+  test("ignores stale connections after lifecycle stop clears the registry", async () => {
+    const outbound: string[] = [];
+    const { logger, records } = createCapturingLogger();
+    const engine = createProtocolEngine({ logger });
+
+    engine.openConnection({
+      connectionId: "connection-1",
+      sendText: async (text) => {
+        outbound.push(text);
+      },
+    });
+
+    await engine.lifecycle.stop("test-stop");
+
+    await engine.sendNotification({
+      connectionId: "connection-1",
+      notification: {
+        method: "thread/status/changed",
+        params: {
+          threadId: "thread-1",
+          status: "idle",
+        },
+      },
+    });
+
+    await engine.handleIncomingText({
+      connectionId: "connection-1",
+      text: JSON.stringify({
+        id: "req-1",
+        method: "initialize",
+        params: {
+          clientInfo: {
+            name: "AtelierCode Test",
+            version: "0.1.0",
+          },
+        },
+      }),
+    });
+
+    expect(outbound).toEqual([]);
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        level: "warn",
+        message: "Protocol send skipped for unknown connection",
+        connectionId: "connection-1",
+      }),
+    );
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        level: "warn",
+        message: "Protocol received text for an unknown connection",
+        connectionId: "connection-1",
+      }),
+    );
+  });
+
+  test("rejects invalid outbound notifications before writing to the transport", async () => {
+    const outbound: string[] = [];
+    const { logger, records } = createCapturingLogger();
+    const engine = createProtocolEngine({ logger });
+
+    engine.openConnection({
+      connectionId: "connection-1",
+      sendText: async (text) => {
+        outbound.push(text);
+      },
+    });
+
+    await engine.sendNotification({
+      connectionId: "connection-1",
+      notification: {
+        method: "",
+      } as ProtocolNotification,
+    });
+
+    expect(outbound).toEqual([]);
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        level: "error",
+        message: "Protocol notification serialization failed",
+        connectionId: "connection-1",
+      }),
+    );
+  });
+
+  test("ignores inbound text for an unknown connection", async () => {
+    const { logger, records } = createCapturingLogger();
+    const engine = createProtocolEngine({ logger });
+
+    await engine.handleIncomingText({
+      connectionId: "missing-connection",
+      text: JSON.stringify({
+        id: "req-1",
+        method: "initialize",
+        params: {
+          clientInfo: {
+            name: "AtelierCode Test",
+            version: "0.1.0",
+          },
+        },
+      }),
+    });
+
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        level: "warn",
+        message: "Protocol received text for an unknown connection",
+        connectionId: "missing-connection",
+      }),
+    );
   });
 });

--- a/AppServer/src/core/protocol/engine.ts
+++ b/AppServer/src/core/protocol/engine.ts
@@ -27,7 +27,7 @@ import {
   type RequestId,
   RequestIdSchema,
 } from "@/core/protocol/schemas";
-import { type LifecycleComponent, ok, type Result } from "@/core/shared";
+import { getErrorMessage, type LifecycleComponent, ok, type Result } from "@/core/shared";
 
 export type ProtocolSendText = (text: string) => Promise<void>;
 
@@ -50,9 +50,6 @@ export type ProtocolEngine = Readonly<{
   openConnection: (options: Readonly<{ connectionId: string; sendText: ProtocolSendText }>) => void;
   closeConnection: (connectionId: string) => void;
   handleIncomingText: (options: Readonly<{ connectionId: string; text: string }>) => Promise<void>;
-  serializeNotification: (
-    notification: ProtocolNotification,
-  ) => Result<string, ProtocolSerializationError>;
   sendNotification: (
     options: Readonly<{ connectionId: string; notification: ProtocolNotification }>,
   ) => Promise<void>;
@@ -94,9 +91,6 @@ export const createProtocolEngine = (options: CreateProtocolEngineOptions): Prot
 
     logger.info("Protocol connection removed", { connectionId });
   };
-
-  const serializeNotification: ProtocolEngine["serializeNotification"] = (notification) =>
-    serializeWithSchema(ProtocolNotificationSchema, notification);
 
   const sendSerializedText = async (connectionId: string, text: string): Promise<void> => {
     const connection = connections.get(connectionId);
@@ -156,7 +150,7 @@ export const createProtocolEngine = (options: CreateProtocolEngineOptions): Prot
     connectionId,
     notification,
   }) => {
-    const serialized = serializeNotification(notification);
+    const serialized = serializeWithSchema(ProtocolNotificationSchema, notification);
 
     if (!serialized.ok) {
       logger.error("Protocol notification serialization failed", {
@@ -278,11 +272,14 @@ export const createProtocolEngine = (options: CreateProtocolEngineOptions): Prot
     }
 
     if (Value.Check(ProtocolRequestSchema, parsedPayload.data)) {
-      await handleRequest(connectionId, parsedPayload.data as ProtocolRequest, connection);
+      // TypeBox validates at runtime, but TypeScript does not narrow from Value.Check().
+      const request = parsedPayload.data as ProtocolRequest;
+      await handleRequest(connectionId, request, connection);
       return;
     }
 
     if (Value.Check(ProtocolNotificationSchema, parsedPayload.data)) {
+      // TypeBox validates at runtime, but TypeScript does not narrow from Value.Check().
       const notification = parsedPayload.data as ProtocolNotification;
 
       logger.debug("Ignoring inbound client notification", {
@@ -308,7 +305,6 @@ export const createProtocolEngine = (options: CreateProtocolEngineOptions): Prot
     openConnection,
     closeConnection,
     handleIncomingText,
-    serializeNotification,
     sendNotification,
   });
 };
@@ -377,11 +373,3 @@ const extractResponseId = (candidate: unknown): RequestId | null => {
 
 const isRecord = (candidate: unknown): candidate is Record<string, unknown> =>
   typeof candidate === "object" && candidate !== null && !Array.isArray(candidate);
-
-const getErrorMessage = (error: unknown): string => {
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  return String(error);
-};

--- a/AppServer/src/core/shared/get-error-message.ts
+++ b/AppServer/src/core/shared/get-error-message.ts
@@ -1,0 +1,11 @@
+export const getErrorMessage = (error: unknown): string => {
+  if (error instanceof AggregateError) {
+    return error.errors.map(getErrorMessage).join("; ");
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+};

--- a/AppServer/src/core/shared/index.ts
+++ b/AppServer/src/core/shared/index.ts
@@ -1,3 +1,4 @@
+export * from "@/core/shared/get-error-message";
 export * from "@/core/shared/lifecycle";
 export * from "@/core/shared/result";
 export * from "@/core/shared/startup-errors";

--- a/AppServer/src/core/transport/websocket-server.ts
+++ b/AppServer/src/core/transport/websocket-server.ts
@@ -1,6 +1,6 @@
 import type { Server, ServerWebSocket } from "bun";
 import type { Logger } from "@/app/logger";
-import type { LifecycleComponent } from "@/core/shared";
+import { getErrorMessage, type LifecycleComponent } from "@/core/shared";
 
 type WebSocketConnectionData = Readonly<{
   connectionId: string;
@@ -74,6 +74,7 @@ export const createWebSocketServer = (
         return new Response("WebSocket upgrade failed", { status: 400 });
       },
       websocket: {
+        // Bun requires a default shape here even though upgrade() replaces it per socket.
         data: {} as WebSocketConnectionData,
         open: async (socket) => {
           const connection = createRawTextConnection(socket);
@@ -196,14 +197,6 @@ export const assertWebSocketSendSucceeded = (sendStatus: number): void => {
   }
 
   throw new Error("WebSocket message was dropped");
-};
-
-const getErrorMessage = (error: unknown): string => {
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  return String(error);
 };
 
 type TimeoutHandle = ReturnType<typeof setTimeout>;

--- a/AppServer/src/test-support/logger.ts
+++ b/AppServer/src/test-support/logger.ts
@@ -1,0 +1,38 @@
+import { createLogger, type Logger, type LogLevel } from "@/app/logger";
+
+type CapturedLogRecord = Readonly<Record<string, unknown>>;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+export const createSilentLogger = (level: LogLevel = "info"): Logger =>
+  createLogger({
+    level,
+    write: () => {},
+  });
+
+export const createCapturingLogger = (
+  level: LogLevel = "debug",
+): Readonly<{
+  logger: Logger;
+  records: CapturedLogRecord[];
+}> => {
+  const records: CapturedLogRecord[] = [];
+  const logger = createLogger({
+    level,
+    write: (line) => {
+      const parsed = JSON.parse(line) as unknown;
+
+      if (!isRecord(parsed)) {
+        throw new Error("Expected structured log output");
+      }
+
+      records.push(Object.freeze({ ...parsed }));
+    },
+  });
+
+  return Object.freeze({
+    logger,
+    records,
+  });
+};

--- a/AppServer/src/test-support/network.ts
+++ b/AppServer/src/test-support/network.ts
@@ -1,0 +1,29 @@
+import { createServer } from "node:net";
+
+export const getAvailablePort = async (): Promise<number> => {
+  const server = createServer();
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+    server.once("error", reject);
+  });
+
+  const address = server.address();
+
+  if (address === null || typeof address === "string") {
+    throw new Error("Expected a TCP address");
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error !== undefined) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+
+  return address.port;
+};

--- a/AppServer/tsconfig.json
+++ b/AppServer/tsconfig.json
@@ -5,7 +5,6 @@
     "moduleResolution": "Bundler",
     "strict": true,
     "noEmit": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },

--- a/Docs/app-server-design.md
+++ b/Docs/app-server-design.md
@@ -320,7 +320,7 @@ Use a single TypeScript path alias configured in `tsconfig.json` to keep imports
 }
 ```
 
-This covers all directories without requiring a new alias each time a feature is added. Relative imports are fine within a single feature directory; use the `@/` alias for cross-feature and cross-layer imports.
+This covers all directories without requiring a new alias each time a feature is added, and it works without a separate `baseUrl` setting. Relative imports are fine within a single feature directory; use the `@/` alias for cross-feature and cross-layer imports.
 
 
 ### Coding Standards


### PR DESCRIPTION
## Summary
- extract shared AppServer utilities for error-message handling and test support
- simplify config log-level override parsing and tighten transport typing around connection-open events
- make protocol notification serialization internal and add clarifying comments for TypeBox narrowing and Bun websocket data behavior
- extend protocol engine coverage for send failures, invalid outbound notifications, unknown connections, and lifecycle cleanup
- remove deprecated `baseUrl` from the AppServer TypeScript config and align the design doc snippet

## Testing
- `cd AppServer && npx biome check . ../Docs/app-server-design.md`
- `cd AppServer && npx tsc --noEmit`
- `bun test AppServer/src/core/protocol/engine.test.ts`
- `bun test AppServer/src/app/server.test.ts`
- `bun test AppServer/src/app/protocol-harness.test.ts`
- `cd AppServer && bun test`