### PR TITLE
Add App Server store bootstrap and workspace open flow

### DIFF
--- a/AppServer/bun.lock
+++ b/AppServer/bun.lock
@@ -6,10 +6,12 @@
       "name": "ateliercode-app-server",
       "dependencies": {
         "@sinclair/typebox": "^0.34.41",
+        "drizzle-orm": "^0.45.2",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.0.0",
         "bun-types": "^1.3.11",
+        "drizzle-kit": "^0.31.10",
         "typescript": "^5.9.2",
       },
     },
@@ -33,14 +35,192 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.11", "", { "os": "win32", "cpu": "x64" }, "sha512-A8D3JM/00C2KQgUV3oj8Ba15EHEYwebAGCy5Sf9GAjr5Y3+kJIYOiESoqRDeuRZueuMdCsbLZIUqmPhpYXJE9A=="],
 
+    "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
+
+    "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
+
+    "@esbuild-kit/esm-loader": ["@esbuild-kit/esm-loader@2.6.5", "", { "dependencies": { "@esbuild-kit/core-utils": "^3.3.2", "get-tsconfig": "^4.7.0" } }, "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
     "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
 
     "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "drizzle-kit": ["drizzle-kit@0.31.10", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "tsx": "^4.21.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw=="],
+
+    "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
+
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
+
+    "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
+
+    "tsx/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.18.20", "", { "os": "android", "cpu": "arm64" }, "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.18.20", "", { "os": "android", "cpu": "x64" }, "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.18.20", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.18.20", "", { "os": "darwin", "cpu": "x64" }, "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.18.20", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.18.20", "", { "os": "freebsd", "cpu": "x64" }, "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.18.20", "", { "os": "linux", "cpu": "arm" }, "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.18.20", "", { "os": "linux", "cpu": "arm64" }, "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.18.20", "", { "os": "linux", "cpu": "ia32" }, "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.18.20", "", { "os": "linux", "cpu": "ppc64" }, "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.18.20", "", { "os": "linux", "cpu": "s390x" }, "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.18.20", "", { "os": "linux", "cpu": "x64" }, "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.18.20", "", { "os": "none", "cpu": "x64" }, "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.18.20", "", { "os": "openbsd", "cpu": "x64" }, "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.18.20", "", { "os": "sunos", "cpu": "x64" }, "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.18.20", "", { "os": "win32", "cpu": "arm64" }, "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
+    "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "tsx/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "tsx/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "tsx/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "tsx/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "tsx/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "tsx/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "tsx/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "tsx/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "tsx/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "tsx/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "tsx/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "tsx/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "tsx/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "tsx/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "tsx/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "tsx/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "tsx/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "tsx/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "tsx/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "tsx/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "tsx/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "tsx/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "tsx/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
   }
 }

--- a/AppServer/drizzle.config.ts
+++ b/AppServer/drizzle.config.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "drizzle-kit";
+
+const ROOT_DIRECTORY = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_CONFIG_PATH = resolve(ROOT_DIRECTORY, "appserver.config.example.json");
+
+type AppServerConfigFile = Readonly<{
+  databasePath?: unknown;
+}>;
+
+const resolveConfigPath = (): string => {
+  const rawPath = process.env.APP_SERVER_CONFIG_PATH?.trim() || DEFAULT_CONFIG_PATH;
+
+  return isAbsolute(rawPath) ? rawPath : resolve(process.cwd(), rawPath);
+};
+
+const resolveDatabasePath = (): string => {
+  const configPath = resolveConfigPath();
+  const rawConfig = JSON.parse(readFileSync(configPath, "utf8")) as AppServerConfigFile;
+
+  if (typeof rawConfig.databasePath !== "string" || rawConfig.databasePath.trim() === "") {
+    throw new Error(`App Server drizzle config is missing a databasePath in ${configPath}`);
+  }
+
+  const trimmedDatabasePath = rawConfig.databasePath.trim();
+
+  return isAbsolute(trimmedDatabasePath)
+    ? trimmedDatabasePath
+    : resolve(dirname(configPath), trimmedDatabasePath);
+};
+
+export default defineConfig({
+  dialect: "sqlite",
+  schema: "./src/**/store.ts",
+  out: "./drizzle",
+  dbCredentials: {
+    url: resolveDatabasePath(),
+  },
+});

--- a/AppServer/drizzle/0000_unknown_roughhouse.sql
+++ b/AppServer/drizzle/0000_unknown_roughhouse.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `workspaces` (
+	`id` text PRIMARY KEY NOT NULL,
+	`workspace_path` text NOT NULL,
+	`created_at` text NOT NULL,
+	`last_opened_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `workspaces_workspace_path_unique` ON `workspaces` (`workspace_path`);

--- a/AppServer/drizzle/meta/0000_snapshot.json
+++ b/AppServer/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,62 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "80b6c35f-3809-46aa-a198-0ef5813a8184",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_workspace_path_unique": {
+          "name": "workspaces_workspace_path_unique",
+          "columns": ["workspace_path"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/AppServer/drizzle/meta/_journal.json
+++ b/AppServer/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1775820312603,
+      "tag": "0000_unknown_roughhouse",
+      "breakpoints": true
+    }
+  ]
+}

--- a/AppServer/package.json
+++ b/AppServer/package.json
@@ -5,16 +5,19 @@
   "type": "module",
   "scripts": {
     "start": "bun run ./src/index.ts",
+    "db:generate": "drizzle-kit generate",
     "check": "biome check .",
     "typecheck": "tsc --noEmit",
     "test": "bun test"
   },
   "dependencies": {
-    "@sinclair/typebox": "^0.34.41"
+    "@sinclair/typebox": "^0.34.41",
+    "drizzle-orm": "^0.45.2"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.0",
     "bun-types": "^1.3.11",
+    "drizzle-kit": "^0.31.10",
     "typescript": "^5.9.2"
   }
 }

--- a/AppServer/src/app/protocol-harness.test.ts
+++ b/AppServer/src/app/protocol-harness.test.ts
@@ -1,10 +1,14 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { createLogger } from "@/app/logger";
 import { APP_SERVER_USER_AGENT } from "@/app/protocol";
 import { type AppServer, createConfiguredAppServer, type SignalRegistrar } from "@/app/server";
 import { getAvailablePort } from "@/test-support/network";
 
 const runningServers: AppServer[] = [];
+const temporaryDirectories: string[] = [];
 
 afterEach(async () => {
   while (runningServers.length > 0) {
@@ -19,6 +23,16 @@ afterEach(async () => {
     } catch {
       // Ignore cleanup failures so the original test error stays visible.
     }
+  }
+
+  while (temporaryDirectories.length > 0) {
+    const directory = temporaryDirectories.pop();
+
+    if (directory === undefined) {
+      continue;
+    }
+
+    await rm(directory, { force: true, recursive: true });
   }
 });
 
@@ -179,6 +193,171 @@ describe("App Server protocol harness", () => {
       await client.close();
     }
   });
+
+  test("opens a workspace after initialize", async () => {
+    const harness = await createProtocolHarness();
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      const workspacePath = await createWorkspaceDirectory();
+      const canonicalWorkspacePath = await realpath(workspacePath);
+
+      client.sendJson({
+        id: "req-initialize",
+        method: "initialize",
+        params: {
+          clientInfo: {
+            name: "AtelierCode Test",
+            version: "0.1.0",
+          },
+        },
+      });
+      await client.nextMessage();
+
+      client.sendJson({
+        id: "req-workspace-open",
+        method: "workspace/open",
+        params: {
+          workspacePath,
+        },
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-workspace-open",
+        result: {
+          workspace: {
+            id: expect.any(String),
+            workspacePath: canonicalWorkspacePath,
+            createdAt: expect.any(String),
+            lastOpenedAt: expect.any(String),
+          },
+        },
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("rejects workspace/open before initialize", async () => {
+    const harness = await createProtocolHarness();
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      const workspacePath = await createWorkspaceDirectory();
+
+      client.sendJson({
+        id: "req-workspace-open",
+        method: "workspace/open",
+        params: {
+          workspacePath,
+        },
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-workspace-open",
+        error: {
+          code: -33001,
+          message: "Session not initialized",
+          data: {
+            code: "SESSION_NOT_INITIALIZED",
+          },
+        },
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("maps malformed workspace/open params to invalid params", async () => {
+    const harness = await createProtocolHarness();
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      client.sendJson({
+        id: "req-initialize",
+        method: "initialize",
+        params: {
+          clientInfo: {
+            name: "AtelierCode Test",
+            version: "0.1.0",
+          },
+        },
+      });
+      await client.nextMessage();
+
+      client.sendJson({
+        id: "req-workspace-open",
+        method: "workspace/open",
+        params: {
+          workspacePath: 123,
+        },
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-workspace-open",
+        error: {
+          code: -32602,
+          message: "Invalid params",
+        },
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("returns the same workspace identity for repeat opens of the same canonical directory", async () => {
+    const harness = await createProtocolHarness();
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      const workspacePath = await createWorkspaceDirectory();
+      const canonicalWorkspacePath = await realpath(workspacePath);
+      const aliasWorkspacePath = join(workspacePath, ".");
+
+      client.sendJson({
+        id: "req-initialize",
+        method: "initialize",
+        params: {
+          clientInfo: {
+            name: "AtelierCode Test",
+            version: "0.1.0",
+          },
+        },
+      });
+      await client.nextMessage();
+
+      client.sendJson({
+        id: "req-workspace-open-1",
+        method: "workspace/open",
+        params: {
+          workspacePath,
+        },
+      });
+      const firstResponse = (await client.nextMessage()) as {
+        readonly result: {
+          readonly workspace: {
+            readonly id: string;
+            readonly workspacePath: string;
+          };
+        };
+      };
+
+      client.sendJson({
+        id: "req-workspace-open-2",
+        method: "workspace/open",
+        params: {
+          workspacePath: aliasWorkspacePath,
+        },
+      });
+      const secondResponse = (await client.nextMessage()) as typeof firstResponse;
+
+      expect(firstResponse.result.workspace.workspacePath).toBe(canonicalWorkspacePath);
+      expect(secondResponse.result.workspace.workspacePath).toBe(canonicalWorkspacePath);
+      expect(secondResponse.result.workspace.id).toBe(firstResponse.result.workspace.id);
+    } finally {
+      await client.close();
+    }
+  });
 });
 
 type ProtocolTestClient = Readonly<{
@@ -190,9 +369,10 @@ type ProtocolTestClient = Readonly<{
 
 const createProtocolHarness = async (): Promise<Readonly<{ port: number }>> => {
   const port = await getAvailablePort();
+  const configDirectory = await createTemporaryDirectory("atelier-appserver-protocol-");
   const server = createConfiguredAppServer({
     config: {
-      configPath: "/tmp/appserver.config.json",
+      configPath: join(configDirectory, "appserver.config.json"),
       port,
       databasePath: "./var/test.sqlite",
       logLevel: "info",
@@ -208,6 +388,15 @@ const createProtocolHarness = async (): Promise<Readonly<{ port: number }>> => {
   runningServers.push(server);
 
   return Object.freeze({ port });
+};
+
+const createWorkspaceDirectory = async (): Promise<string> => {
+  const rootDirectory = await createTemporaryDirectory("atelier-appserver-workspace-");
+  const workspacePath = join(rootDirectory, "workspace");
+
+  await mkdir(workspacePath, { recursive: true });
+
+  return workspacePath;
 };
 
 const connectProtocolClient = async (port: number): Promise<ProtocolTestClient> => {
@@ -339,3 +528,9 @@ const createSignalRegistrar = (): SignalRegistrar =>
   Object.freeze({
     subscribe: () => () => {},
   });
+
+const createTemporaryDirectory = async (prefix: string): Promise<string> => {
+  const directory = await mkdtemp(join(tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+};

--- a/AppServer/src/app/protocol.test.ts
+++ b/AppServer/src/app/protocol.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { runConnectionClosedHandlers } from "@/app/protocol";
+
+describe("runConnectionClosedHandlers", () => {
+  test("runs every handler and aggregates failures after all handlers complete", async () => {
+    const events: string[] = [];
+
+    await expect(
+      runConnectionClosedHandlers(
+        [
+          ({ connectionId }) => {
+            events.push(`first:${connectionId}`);
+            throw new Error("first failed");
+          },
+          ({ connectionId }) => {
+            events.push(`second:${connectionId}`);
+          },
+          async ({ connectionId }) => {
+            events.push(`third:${connectionId}`);
+            throw new Error("third failed");
+          },
+        ],
+        "connection-1",
+      ),
+    ).rejects.toThrow("Connection close handlers failed");
+
+    expect(events).toEqual(["first:connection-1", "second:connection-1", "third:connection-1"]);
+  });
+
+  test("rethrows a single failure without wrapping it", async () => {
+    await expect(
+      runConnectionClosedHandlers(
+        [
+          () => {
+            throw new Error("single failed");
+          },
+        ],
+        "connection-1",
+      ),
+    ).rejects.toThrow("single failed");
+  });
+});

--- a/AppServer/src/app/protocol.ts
+++ b/AppServer/src/app/protocol.ts
@@ -23,6 +23,29 @@ export type AppProtocolRuntime = Readonly<{
   handleIncomingText: ProtocolEngine["handleIncomingText"];
 }>;
 
+export const runConnectionClosedHandlers = async (
+  handlers: readonly ConnectionClosedHandler[],
+  connectionId: string,
+): Promise<void> => {
+  const closeErrors: unknown[] = [];
+
+  for (const handleConnectionClosed of handlers) {
+    try {
+      await handleConnectionClosed({ connectionId });
+    } catch (error) {
+      closeErrors.push(error);
+    }
+  }
+
+  if (closeErrors.length === 1) {
+    throw closeErrors[0];
+  }
+
+  if (closeErrors.length > 1) {
+    throw new AggregateError(closeErrors, "Connection close handlers failed");
+  }
+};
+
 export const createAppProtocolRuntime = (options: { logger: Logger }): AppProtocolRuntime => {
   const protocolLogger = options.logger.withContext({ component: "core.protocol" });
   const protocol = createProtocolEngine({
@@ -78,9 +101,7 @@ export const createAppTransportComponent = (options: {
     },
     onConnectionClose: async ({ connectionId }) => {
       try {
-        for (const handleConnectionClosed of options.onConnectionClosed ?? []) {
-          await handleConnectionClosed({ connectionId });
-        }
+        await runConnectionClosedHandlers(options.onConnectionClosed ?? [], connectionId);
       } finally {
         options.protocol.closeConnection(connectionId);
       }

--- a/AppServer/src/app/protocol.ts
+++ b/AppServer/src/app/protocol.ts
@@ -4,20 +4,27 @@ import {
   createProtocolEngine,
   InitializeParamsSchema,
   InitializeResultSchema,
+  type ProtocolEngine,
 } from "@/core/protocol";
 import { type LifecycleComponent, ok } from "@/core/shared";
 import { createWebSocketServer, type RawConnectionOpenedEvent } from "@/core/transport";
 
 export const APP_SERVER_USER_AGENT = "AtelierCode App Server/0.1.0";
 
+export type ConnectionClosedHandler = (
+  options: Readonly<{ connectionId: string }>,
+) => Promise<void> | void;
+
 export type AppProtocolComponents = Readonly<{
   protocolComponent: LifecycleComponent;
   transportComponent: LifecycleComponent;
+  registerMethod: ProtocolEngine["registerMethod"];
 }>;
 
 export const createAppProtocolComponents = (options: {
   config: AppServerConfig;
   logger: Logger;
+  onConnectionClosed?: readonly ConnectionClosedHandler[];
 }): AppProtocolComponents => {
   const protocolLogger = options.logger.withContext({ component: "core.protocol" });
   const transportLogger = options.logger.withContext({ component: "core.transport" });
@@ -57,8 +64,14 @@ export const createAppProtocolComponents = (options: {
         sendText: connection.sendText,
       });
     },
-    onConnectionClose: ({ connectionId }) => {
-      protocol.closeConnection(connectionId);
+    onConnectionClose: async ({ connectionId }) => {
+      try {
+        for (const handleConnectionClosed of options.onConnectionClosed ?? []) {
+          await handleConnectionClosed({ connectionId });
+        }
+      } finally {
+        protocol.closeConnection(connectionId);
+      }
     },
     onTextMessage: ({ connectionId, text }) =>
       protocol.handleIncomingText({
@@ -70,5 +83,6 @@ export const createAppProtocolComponents = (options: {
   return Object.freeze({
     protocolComponent: protocol.lifecycle,
     transportComponent,
+    registerMethod: protocol.registerMethod,
   });
 };

--- a/AppServer/src/app/protocol.ts
+++ b/AppServer/src/app/protocol.ts
@@ -6,7 +6,7 @@ import {
   InitializeResultSchema,
   type ProtocolEngine,
 } from "@/core/protocol";
-import { type LifecycleComponent, ok } from "@/core/shared";
+import { ok } from "@/core/shared";
 import { createWebSocketServer, type RawConnectionOpenedEvent } from "@/core/transport";
 
 export const APP_SERVER_USER_AGENT = "AtelierCode App Server/0.1.0";
@@ -15,19 +15,16 @@ export type ConnectionClosedHandler = (
   options: Readonly<{ connectionId: string }>,
 ) => Promise<void> | void;
 
-export type AppProtocolComponents = Readonly<{
-  protocolComponent: LifecycleComponent;
-  transportComponent: LifecycleComponent;
+export type AppProtocolRuntime = Readonly<{
+  protocolComponent: ProtocolEngine["lifecycle"];
   registerMethod: ProtocolEngine["registerMethod"];
+  openConnection: ProtocolEngine["openConnection"];
+  closeConnection: ProtocolEngine["closeConnection"];
+  handleIncomingText: ProtocolEngine["handleIncomingText"];
 }>;
 
-export const createAppProtocolComponents = (options: {
-  config: AppServerConfig;
-  logger: Logger;
-  onConnectionClosed?: readonly ConnectionClosedHandler[];
-}): AppProtocolComponents => {
+export const createAppProtocolRuntime = (options: { logger: Logger }): AppProtocolRuntime => {
   const protocolLogger = options.logger.withContext({ component: "core.protocol" });
-  const transportLogger = options.logger.withContext({ component: "core.transport" });
   const protocol = createProtocolEngine({
     logger: protocolLogger,
   });
@@ -55,11 +52,26 @@ export const createAppProtocolComponents = (options: {
     },
   });
 
-  const transportComponent = createWebSocketServer({
-    logger: transportLogger,
+  return Object.freeze({
+    protocolComponent: protocol.lifecycle,
+    registerMethod: protocol.registerMethod,
+    openConnection: protocol.openConnection,
+    closeConnection: protocol.closeConnection,
+    handleIncomingText: protocol.handleIncomingText,
+  });
+};
+
+export const createAppTransportComponent = (options: {
+  config: AppServerConfig;
+  logger: Logger;
+  protocol: Pick<AppProtocolRuntime, "openConnection" | "closeConnection" | "handleIncomingText">;
+  onConnectionClosed?: readonly ConnectionClosedHandler[];
+}) =>
+  createWebSocketServer({
+    logger: options.logger.withContext({ component: "core.transport" }),
     port: options.config.port,
     onConnectionOpen: ({ connection }: RawConnectionOpenedEvent) => {
-      protocol.openConnection({
+      options.protocol.openConnection({
         connectionId: connection.id,
         sendText: connection.sendText,
       });
@@ -70,19 +82,12 @@ export const createAppProtocolComponents = (options: {
           await handleConnectionClosed({ connectionId });
         }
       } finally {
-        protocol.closeConnection(connectionId);
+        options.protocol.closeConnection(connectionId);
       }
     },
     onTextMessage: ({ connectionId, text }) =>
-      protocol.handleIncomingText({
+      options.protocol.handleIncomingText({
         connectionId,
         text,
       }),
   });
-
-  return Object.freeze({
-    protocolComponent: protocol.lifecycle,
-    transportComponent,
-    registerMethod: protocol.registerMethod,
-  });
-};

--- a/AppServer/src/app/server.test.ts
+++ b/AppServer/src/app/server.test.ts
@@ -317,13 +317,17 @@ const createSignalRegistrar = (): FakeSignalRegistrar => {
   };
 };
 
-const createTestConfig = () =>
-  Object.freeze({
-    configPath: "/tmp/appserver.config.json",
+const createTestConfig = () => {
+  const rootDirectory = join(tmpdir(), `atelier-appserver-server-${crypto.randomUUID()}`);
+  temporaryDirectories.push(rootDirectory);
+
+  return Object.freeze({
+    configPath: join(rootDirectory, "appserver.config.json"),
     port: 0,
     databasePath: "./var/test.sqlite",
     logLevel: "info" as const,
   });
+};
 
 const createDeferredPromise = <T>() => {
   let resolvePromise: (value: T | PromiseLike<T>) => void = () => {};

--- a/AppServer/src/app/server.ts
+++ b/AppServer/src/app/server.ts
@@ -8,10 +8,10 @@ import { createLogger, type Logger, type LogWriter } from "@/app/logger";
 import { createAppProtocolComponents } from "@/app/protocol";
 import { createApprovalsFeaturePlaceholder } from "@/approvals";
 import { getErrorMessage, type LifecycleComponent } from "@/core/shared";
-import { createStoreBootstrapPlaceholder } from "@/core/store";
+import { createStoreBootstrap } from "@/core/store";
 import { createThreadsFeaturePlaceholder } from "@/threads";
 import { createTurnsFeaturePlaceholder } from "@/turns";
-import { createWorkspacesFeaturePlaceholder } from "@/workspaces";
+import { createSqliteWorkspacesStore, createWorkspacesFeature } from "@/workspaces";
 
 export type AppServerState = "idle" | "starting" | "started" | "stopping" | "stopped";
 export type ShutdownSignal = "SIGINT" | "SIGTERM";
@@ -299,16 +299,33 @@ const createDefaultComponents = (
   config: AppServerConfig,
   logger: Logger,
 ): readonly LifecycleComponent[] => {
+  const storeBootstrap = createStoreBootstrap({
+    config,
+    logger: logger.withContext({ component: "core.store" }),
+  });
+  let handleWorkspaceConnectionClosed = (_connectionId: string) => {};
   const appProtocolComponents = createAppProtocolComponents({
     config,
     logger,
+    onConnectionClosed: [
+      ({ connectionId }) => {
+        handleWorkspaceConnectionClosed(connectionId);
+      },
+    ],
   });
+  const workspacesFeature = createWorkspacesFeature({
+    logger: logger.withContext({ component: "feature.workspaces" }),
+    registerMethod: appProtocolComponents.registerMethod,
+    store: createSqliteWorkspacesStore(storeBootstrap.getDatabase),
+  });
+
+  handleWorkspaceConnectionClosed = workspacesFeature.handleConnectionClosed;
 
   return Object.freeze([
     appProtocolComponents.protocolComponent,
-    createStoreBootstrapPlaceholder(),
+    storeBootstrap.lifecycle,
     createAgentsFeaturePlaceholder(),
-    createWorkspacesFeaturePlaceholder(),
+    workspacesFeature.lifecycle,
     createThreadsFeaturePlaceholder(),
     createTurnsFeaturePlaceholder(),
     createApprovalsFeaturePlaceholder(),

--- a/AppServer/src/app/server.ts
+++ b/AppServer/src/app/server.ts
@@ -5,7 +5,7 @@ import {
   loadAppServerConfig,
 } from "@/app/config";
 import { createLogger, type Logger, type LogWriter } from "@/app/logger";
-import { createAppProtocolComponents } from "@/app/protocol";
+import { createAppProtocolRuntime, createAppTransportComponent } from "@/app/protocol";
 import { createApprovalsFeaturePlaceholder } from "@/approvals";
 import { getErrorMessage, type LifecycleComponent } from "@/core/shared";
 import { createStoreBootstrap } from "@/core/store";
@@ -303,32 +303,33 @@ const createDefaultComponents = (
     config,
     logger: logger.withContext({ component: "core.store" }),
   });
-  let handleWorkspaceConnectionClosed = (_connectionId: string) => {};
-  const appProtocolComponents = createAppProtocolComponents({
-    config,
+  const appProtocolRuntime = createAppProtocolRuntime({
     logger,
-    onConnectionClosed: [
-      ({ connectionId }) => {
-        handleWorkspaceConnectionClosed(connectionId);
-      },
-    ],
   });
   const workspacesFeature = createWorkspacesFeature({
     logger: logger.withContext({ component: "feature.workspaces" }),
-    registerMethod: appProtocolComponents.registerMethod,
+    registerMethod: appProtocolRuntime.registerMethod,
     store: createSqliteWorkspacesStore(storeBootstrap.getDatabase),
   });
-
-  handleWorkspaceConnectionClosed = workspacesFeature.handleConnectionClosed;
+  const transportComponent = createAppTransportComponent({
+    config,
+    logger,
+    protocol: appProtocolRuntime,
+    onConnectionClosed: [
+      ({ connectionId }) => {
+        workspacesFeature.handleConnectionClosed(connectionId);
+      },
+    ],
+  });
 
   return Object.freeze([
-    appProtocolComponents.protocolComponent,
+    appProtocolRuntime.protocolComponent,
     storeBootstrap.lifecycle,
     createAgentsFeaturePlaceholder(),
     workspacesFeature.lifecycle,
     createThreadsFeaturePlaceholder(),
     createTurnsFeaturePlaceholder(),
     createApprovalsFeaturePlaceholder(),
-    appProtocolComponents.transportComponent,
+    transportComponent,
   ]);
 };

--- a/AppServer/src/core/protocol/errors.ts
+++ b/AppServer/src/core/protocol/errors.ts
@@ -8,6 +8,9 @@ export const JSON_RPC_INVALID_PARAMS_ERROR = -32602;
 export const JSON_RPC_INTERNAL_ERROR = -32603;
 
 export const ATELIER_SESSION_ALREADY_INITIALIZED_ERROR = -33000;
+export const ATELIER_SESSION_NOT_INITIALIZED_ERROR = -33001;
+export const ATELIER_WORKSPACE_PATH_NOT_FOUND_ERROR = -33002;
+export const ATELIER_WORKSPACE_PATH_NOT_DIRECTORY_ERROR = -33003;
 
 export type ProtocolMethodError = Readonly<{
   code: number;
@@ -62,3 +65,43 @@ export const createSessionAlreadyInitializedError = (): ProtocolMethodError =>
 
 export const createSessionAlreadyInitializedResult = (): Result<never, ProtocolMethodError> =>
   err(createSessionAlreadyInitializedError());
+
+export const createSessionNotInitializedError = (): ProtocolMethodError =>
+  createProtocolMethodError(
+    ATELIER_SESSION_NOT_INITIALIZED_ERROR,
+    "Session not initialized",
+    Object.freeze({
+      code: "SESSION_NOT_INITIALIZED",
+    }),
+  );
+
+export const createSessionNotInitializedResult = (): Result<never, ProtocolMethodError> =>
+  err(createSessionNotInitializedError());
+
+export const createWorkspacePathNotFoundError = (workspacePath: string): ProtocolMethodError =>
+  createProtocolMethodError(
+    ATELIER_WORKSPACE_PATH_NOT_FOUND_ERROR,
+    "Workspace path does not exist",
+    Object.freeze({
+      code: "WORKSPACE_PATH_NOT_FOUND",
+      workspacePath,
+    }),
+  );
+
+export const createWorkspacePathNotFoundResult = (
+  workspacePath: string,
+): Result<never, ProtocolMethodError> => err(createWorkspacePathNotFoundError(workspacePath));
+
+export const createWorkspacePathNotDirectoryError = (workspacePath: string): ProtocolMethodError =>
+  createProtocolMethodError(
+    ATELIER_WORKSPACE_PATH_NOT_DIRECTORY_ERROR,
+    "Workspace path is not a directory",
+    Object.freeze({
+      code: "WORKSPACE_PATH_NOT_DIRECTORY",
+      workspacePath,
+    }),
+  );
+
+export const createWorkspacePathNotDirectoryResult = (
+  workspacePath: string,
+): Result<never, ProtocolMethodError> => err(createWorkspacePathNotDirectoryError(workspacePath));

--- a/AppServer/src/core/store/index.test.ts
+++ b/AppServer/src/core/store/index.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createStoreBootstrap, resolveDatabasePath } from "@/core/store";
+import { createSilentLogger } from "@/test-support/logger";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  while (temporaryDirectories.length > 0) {
+    const directory = temporaryDirectories.pop();
+
+    if (directory === undefined) {
+      continue;
+    }
+
+    await rm(directory, { force: true, recursive: true });
+  }
+});
+
+describe("resolveDatabasePath", () => {
+  test("resolves relative database paths from the config file directory", () => {
+    expect(
+      resolveDatabasePath({
+        configPath: "/tmp/config/appserver.config.json",
+        port: 7331,
+        databasePath: "./var/appserver.sqlite",
+        logLevel: "info",
+      }),
+    ).toBe("/tmp/config/var/appserver.sqlite");
+  });
+});
+
+describe("createStoreBootstrap", () => {
+  test("applies migrations for a fresh database", async () => {
+    const config = await createTestConfig();
+    const bootstrap = createStoreBootstrap({
+      config,
+      logger: createSilentLogger(),
+    });
+
+    await bootstrap.lifecycle.start();
+
+    const databaseFile = await readFile(bootstrap.getDatabasePath(), "utf8");
+    const workspacesTable = bootstrap
+      .getSqliteHandle()
+      .query("select name from sqlite_master where type = 'table' and name = 'workspaces' limit 1")
+      .get() as { readonly name: string } | undefined;
+
+    expect(databaseFile.length).toBeGreaterThan(0);
+    expect(workspacesTable).toEqual({ name: "workspaces" });
+  });
+
+  test("starts cleanly when the database is already migrated", async () => {
+    const config = await createTestConfig();
+    const bootstrap = createStoreBootstrap({
+      config,
+      logger: createSilentLogger(),
+    });
+
+    await bootstrap.lifecycle.start();
+    await bootstrap.lifecycle.stop("first-stop");
+    await expect(bootstrap.lifecycle.start()).resolves.toBeUndefined();
+  });
+
+  test("closes the database handle during shutdown", async () => {
+    const config = await createTestConfig();
+    const bootstrap = createStoreBootstrap({
+      config,
+      logger: createSilentLogger(),
+    });
+
+    await bootstrap.lifecycle.start();
+    const sqliteHandle = bootstrap.getSqliteHandle();
+
+    await bootstrap.lifecycle.stop("test-stop");
+
+    expect(() => sqliteHandle.query("select 1").get()).toThrow();
+    expect(() => bootstrap.getSqliteHandle()).toThrow("App Server SQLite handle is not started");
+  });
+
+  test("fails startup cleanly when migrations are invalid", async () => {
+    const config = await createTestConfig();
+    const migrationsFolder = await createBrokenMigrationsFolder();
+    const bootstrap = createStoreBootstrap({
+      config,
+      logger: createSilentLogger(),
+      migrationsFolder,
+    });
+
+    await expect(bootstrap.lifecycle.start()).rejects.toThrow();
+    expect(() => bootstrap.getSqliteHandle()).toThrow("App Server SQLite handle is not started");
+  });
+});
+
+const createBrokenMigrationsFolder = async (): Promise<string> => {
+  const directory = await createTemporaryDirectory("atelier-appserver-store-bad-migrations-");
+  const metaDirectory = join(directory, "meta");
+
+  await mkdir(metaDirectory, { recursive: true });
+  await writeFile(
+    join(metaDirectory, "_journal.json"),
+    JSON.stringify({
+      version: "7",
+      dialect: "sqlite",
+      entries: [
+        {
+          idx: 0,
+          version: "7",
+          when: 1_744_322_400_000,
+          tag: "0000_broken",
+          breakpoints: true,
+        },
+      ],
+    }),
+  );
+  await writeFile(join(directory, "0000_broken.sql"), "this is not valid sql;");
+
+  return directory;
+};
+
+const createTestConfig = async () => {
+  const configDirectory = await createTemporaryDirectory("atelier-appserver-store-config-");
+
+  return Object.freeze({
+    configPath: join(configDirectory, "appserver.config.json"),
+    port: 0,
+    databasePath: "./var/test.sqlite",
+    logLevel: "info" as const,
+  });
+};
+
+const createTemporaryDirectory = async (prefix: string): Promise<string> => {
+  const directory = await mkdtemp(join(tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+};

--- a/AppServer/src/core/store/index.ts
+++ b/AppServer/src/core/store/index.ts
@@ -1,4 +1,112 @@
-import { createLifecyclePlaceholder, type LifecycleComponent } from "@/core/shared";
+import { Database } from "bun:sqlite";
+import { mkdir } from "node:fs/promises";
+import { dirname, isAbsolute, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { type BunSQLiteDatabase, drizzle } from "drizzle-orm/bun-sqlite";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import type { AppServerConfig } from "@/app/config";
+import type { Logger } from "@/app/logger";
+import type { LifecycleComponent } from "@/core/shared";
 
-export const createStoreBootstrapPlaceholder = (): LifecycleComponent =>
-  createLifecyclePlaceholder("core.store");
+const STORE_DIRECTORY = dirname(fileURLToPath(import.meta.url));
+
+export const DEFAULT_MIGRATIONS_FOLDER = resolve(STORE_DIRECTORY, "../../../drizzle");
+
+export type AppDatabase = BunSQLiteDatabase<Record<string, never>> & {
+  readonly $client: Database;
+};
+
+export type StoreBootstrap = Readonly<{
+  lifecycle: LifecycleComponent;
+  getDatabase: () => AppDatabase;
+  getDatabasePath: () => string;
+  getSqliteHandle: () => Database;
+}>;
+
+export type CreateStoreBootstrapOptions = Readonly<{
+  config: AppServerConfig;
+  logger: Logger;
+  migrationsFolder?: string;
+}>;
+
+export const createStoreBootstrap = (options: CreateStoreBootstrapOptions): StoreBootstrap => {
+  const databasePath = resolveDatabasePath(options.config);
+  const migrationsFolder = options.migrationsFolder ?? DEFAULT_MIGRATIONS_FOLDER;
+  const logger = options.logger;
+  let database: AppDatabase | null = null;
+  let sqliteHandle: Database | null = null;
+
+  const lifecycle: LifecycleComponent = Object.freeze({
+    name: "core.store",
+    start: async () => {
+      if (database !== null && sqliteHandle !== null) {
+        return;
+      }
+
+      await mkdir(dirname(databasePath), { recursive: true });
+
+      const openedSqliteHandle = new Database(databasePath, {
+        create: true,
+        strict: true,
+      });
+
+      try {
+        openedSqliteHandle.exec("PRAGMA journal_mode = WAL;");
+        const openedDatabase = drizzle(openedSqliteHandle);
+
+        migrate(openedDatabase, {
+          migrationsFolder,
+        });
+
+        sqliteHandle = openedSqliteHandle;
+        database = openedDatabase;
+
+        logger.info("Store bootstrap completed", {
+          databasePath,
+          migrationsFolder,
+        });
+      } catch (error) {
+        openedSqliteHandle.close(false);
+        throw error;
+      }
+    },
+    stop: async (reason) => {
+      if (sqliteHandle === null) {
+        return;
+      }
+
+      sqliteHandle.close(false);
+      sqliteHandle = null;
+      database = null;
+
+      logger.info("Store bootstrap stopped", {
+        databasePath,
+        reason,
+      });
+    },
+  });
+
+  return Object.freeze({
+    lifecycle,
+    getDatabase: () => {
+      if (database === null) {
+        throw new Error("App Server database is not started");
+      }
+
+      return database;
+    },
+    getDatabasePath: () => databasePath,
+    getSqliteHandle: () => {
+      if (sqliteHandle === null) {
+        throw new Error("App Server SQLite handle is not started");
+      }
+
+      return sqliteHandle;
+    },
+  });
+};
+
+export const resolveDatabasePath = (config: AppServerConfig): string =>
+  isAbsolute(config.databasePath)
+    ? config.databasePath
+    : resolve(dirname(config.configPath), config.databasePath);

--- a/AppServer/src/workspaces/index.ts
+++ b/AppServer/src/workspaces/index.ts
@@ -1,4 +1,4 @@
-import { createLifecyclePlaceholder, type LifecycleComponent } from "@/core/shared";
-
-export const createWorkspacesFeaturePlaceholder = (): LifecycleComponent =>
-  createLifecyclePlaceholder("feature.workspaces");
+export * from "@/workspaces/schemas";
+export * from "@/workspaces/service";
+export * from "@/workspaces/store";
+export * from "@/workspaces/workspace.handlers";

--- a/AppServer/src/workspaces/schemas.ts
+++ b/AppServer/src/workspaces/schemas.ts
@@ -1,0 +1,28 @@
+import { type Static, Type } from "@sinclair/typebox";
+
+export const WorkspaceSchema = Type.Object(
+  {
+    id: Type.String({ minLength: 1 }),
+    workspacePath: Type.String({ minLength: 1 }),
+    createdAt: Type.String({ minLength: 1 }),
+    lastOpenedAt: Type.String({ minLength: 1 }),
+  },
+  { additionalProperties: false },
+);
+export type Workspace = Static<typeof WorkspaceSchema>;
+
+export const WorkspaceOpenParamsSchema = Type.Object(
+  {
+    workspacePath: Type.String({ minLength: 1 }),
+  },
+  { additionalProperties: false },
+);
+export type WorkspaceOpenParams = Static<typeof WorkspaceOpenParamsSchema>;
+
+export const WorkspaceOpenResultSchema = Type.Object(
+  {
+    workspace: WorkspaceSchema,
+  },
+  { additionalProperties: false },
+);
+export type WorkspaceOpenResult = Static<typeof WorkspaceOpenResultSchema>;

--- a/AppServer/src/workspaces/service.test.ts
+++ b/AppServer/src/workspaces/service.test.ts
@@ -62,6 +62,31 @@ describe("createWorkspacesService", () => {
     });
   });
 
+  test("only generates a workspace id when a new workspace is created", async () => {
+    const tempDirectory = await createTemporaryDirectory("atelier-appserver-workspaces-service-");
+    const workspaceDirectory = join(tempDirectory, "workspace");
+    let createWorkspaceIdCallCount = 0;
+    const service = createWorkspacesService({
+      store: createInMemoryWorkspacesStore(),
+      createWorkspaceId: () => {
+        createWorkspaceIdCallCount += 1;
+        return "workspace-1";
+      },
+      now: createTimestampSequence(["2026-04-10T10:00:00.000Z", "2026-04-10T11:00:00.000Z"]),
+    });
+
+    await mkdir(workspaceDirectory, { recursive: true });
+
+    await service.openWorkspace({
+      workspacePath: workspaceDirectory,
+    });
+    await service.openWorkspace({
+      workspacePath: workspaceDirectory,
+    });
+
+    expect(createWorkspaceIdCallCount).toBe(1);
+  });
+
   test("returns a domain error when the workspace path does not exist", async () => {
     const service = createWorkspacesService({
       store: createInMemoryWorkspacesStore(),

--- a/AppServer/src/workspaces/service.test.ts
+++ b/AppServer/src/workspaces/service.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createWorkspacesService } from "@/workspaces/service";
+import { createInMemoryWorkspacesStore } from "@/workspaces/store";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  while (temporaryDirectories.length > 0) {
+    const directory = temporaryDirectories.pop();
+
+    if (directory === undefined) {
+      continue;
+    }
+
+    await rm(directory, { force: true, recursive: true });
+  }
+});
+
+describe("createWorkspacesService", () => {
+  test("treats canonical paths as the same workspace", async () => {
+    const tempDirectory = await createTemporaryDirectory("atelier-appserver-workspaces-service-");
+    const workspaceDirectory = join(tempDirectory, "workspace");
+    const symlinkPath = join(tempDirectory, "workspace-link");
+    const store = createInMemoryWorkspacesStore();
+    const service = createWorkspacesService({
+      store,
+      createWorkspaceId: createIncrementingWorkspaceId(),
+      now: createTimestampSequence(["2026-04-10T10:00:00.000Z", "2026-04-10T11:00:00.000Z"]),
+    });
+
+    await mkdir(workspaceDirectory, { recursive: true });
+    await symlink(workspaceDirectory, symlinkPath);
+    const canonicalWorkspacePath = await realpath(workspaceDirectory);
+
+    const firstOpen = await service.openWorkspace({
+      workspacePath: workspaceDirectory,
+    });
+    const secondOpen = await service.openWorkspace({
+      workspacePath: symlinkPath,
+    });
+
+    expect(firstOpen).toEqual({
+      ok: true,
+      data: {
+        id: "workspace-1",
+        workspacePath: canonicalWorkspacePath,
+        createdAt: "2026-04-10T10:00:00.000Z",
+        lastOpenedAt: "2026-04-10T10:00:00.000Z",
+      },
+    });
+    expect(secondOpen).toEqual({
+      ok: true,
+      data: {
+        id: "workspace-1",
+        workspacePath: canonicalWorkspacePath,
+        createdAt: "2026-04-10T10:00:00.000Z",
+        lastOpenedAt: "2026-04-10T11:00:00.000Z",
+      },
+    });
+  });
+
+  test("returns a domain error when the workspace path does not exist", async () => {
+    const service = createWorkspacesService({
+      store: createInMemoryWorkspacesStore(),
+    });
+
+    const result = await service.openWorkspace({
+      workspacePath: "/definitely/missing/workspace",
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: -33002,
+        message: "Workspace path does not exist",
+        data: {
+          code: "WORKSPACE_PATH_NOT_FOUND",
+          workspacePath: "/definitely/missing/workspace",
+        },
+      },
+    });
+  });
+
+  test("returns a domain error when the workspace path points to a file", async () => {
+    const tempDirectory = await createTemporaryDirectory("atelier-appserver-workspaces-service-");
+    const workspaceFile = join(tempDirectory, "workspace.txt");
+    const service = createWorkspacesService({
+      store: createInMemoryWorkspacesStore(),
+    });
+
+    await writeFile(workspaceFile, "hello");
+    const canonicalWorkspaceFile = await realpath(workspaceFile);
+
+    const result = await service.openWorkspace({
+      workspacePath: workspaceFile,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: -33003,
+        message: "Workspace path is not a directory",
+        data: {
+          code: "WORKSPACE_PATH_NOT_DIRECTORY",
+          workspacePath: canonicalWorkspaceFile,
+        },
+      },
+    });
+  });
+});
+
+const createTimestampSequence = (timestamps: readonly string[]) => {
+  let index = 0;
+
+  return () => {
+    const timestamp = timestamps[index] ?? timestamps[timestamps.length - 1];
+    index += 1;
+    return timestamp;
+  };
+};
+
+const createIncrementingWorkspaceId = () => {
+  let nextId = 1;
+
+  return () => {
+    const workspaceId = `workspace-${nextId}`;
+    nextId += 1;
+    return workspaceId;
+  };
+};
+
+const createTemporaryDirectory = async (prefix: string): Promise<string> => {
+  const directory = await mkdtemp(join(tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+};

--- a/AppServer/src/workspaces/service.ts
+++ b/AppServer/src/workspaces/service.ts
@@ -1,0 +1,79 @@
+import { realpath, stat } from "node:fs/promises";
+import {
+  createWorkspacePathNotDirectoryResult,
+  createWorkspacePathNotFoundResult,
+  type ProtocolMethodError,
+} from "@/core/protocol/errors";
+import { ok, type Result } from "@/core/shared";
+import type { Workspace, WorkspaceOpenParams } from "@/workspaces/schemas";
+import type { WorkspacesStore } from "@/workspaces/store";
+
+export type WorkspacesService = Readonly<{
+  openWorkspace: (params: WorkspaceOpenParams) => Promise<Result<Workspace, ProtocolMethodError>>;
+}>;
+
+export type CreateWorkspacesServiceOptions = Readonly<{
+  store: WorkspacesStore;
+  createWorkspaceId?: () => string;
+  now?: () => string;
+  realpathPath?: typeof realpath;
+  statPath?: typeof stat;
+}>;
+
+export const createWorkspacesService = (
+  options: CreateWorkspacesServiceOptions,
+): WorkspacesService => {
+  const createWorkspaceId = options.createWorkspaceId ?? (() => crypto.randomUUID());
+  const now = options.now ?? (() => new Date().toISOString());
+  const resolveRealPath = options.realpathPath ?? realpath;
+  const readPathStats = options.statPath ?? stat;
+
+  return Object.freeze({
+    openWorkspace: async (params) => {
+      const canonicalWorkspacePath = await canonicalizeWorkspacePath(
+        params.workspacePath,
+        resolveRealPath,
+        readPathStats,
+      );
+
+      if (!canonicalWorkspacePath.ok) {
+        return canonicalWorkspacePath;
+      }
+
+      const openedAt = now();
+      const workspace = await options.store.openWorkspace({
+        workspaceId: createWorkspaceId(),
+        workspacePath: canonicalWorkspacePath.data,
+        openedAt,
+      });
+
+      return ok(workspace);
+    },
+  });
+};
+
+const canonicalizeWorkspacePath = async (
+  workspacePath: string,
+  resolveRealPath: typeof realpath,
+  readPathStats: typeof stat,
+): Promise<Result<string, ProtocolMethodError>> => {
+  let canonicalWorkspacePath: string;
+
+  try {
+    canonicalWorkspacePath = await resolveRealPath(workspacePath);
+  } catch {
+    return createWorkspacePathNotFoundResult(workspacePath);
+  }
+
+  try {
+    const pathStats = await readPathStats(canonicalWorkspacePath);
+
+    if (!pathStats.isDirectory()) {
+      return createWorkspacePathNotDirectoryResult(canonicalWorkspacePath);
+    }
+  } catch {
+    return createWorkspacePathNotFoundResult(workspacePath);
+  }
+
+  return ok(canonicalWorkspacePath);
+};

--- a/AppServer/src/workspaces/service.ts
+++ b/AppServer/src/workspaces/service.ts
@@ -42,9 +42,9 @@ export const createWorkspacesService = (
 
       const openedAt = now();
       const workspace = await options.store.openWorkspace({
-        workspaceId: createWorkspaceId(),
         workspacePath: canonicalWorkspacePath.data,
         openedAt,
+        createWorkspaceId,
       });
 
       return ok(workspace);

--- a/AppServer/src/workspaces/store.test.ts
+++ b/AppServer/src/workspaces/store.test.ts
@@ -23,16 +23,24 @@ describe("workspaces store", () => {
   for (const storeFactory of storeFactories) {
     test(`${storeFactory.name} creates and reopens a workspace by canonical path`, async () => {
       const store = await storeFactory.createStore();
+      let nextWorkspaceId = 1;
+      let createWorkspaceIdCallCount = 0;
+      const createWorkspaceId = () => {
+        createWorkspaceIdCallCount += 1;
+        const workspaceId = `workspace-${nextWorkspaceId}`;
+        nextWorkspaceId += 1;
+        return workspaceId;
+      };
 
       const firstOpen = await store.openWorkspace({
-        workspaceId: "workspace-1",
         workspacePath: "/tmp/project",
         openedAt: "2026-04-10T10:00:00.000Z",
+        createWorkspaceId,
       });
       const secondOpen = await store.openWorkspace({
-        workspaceId: "workspace-2",
         workspacePath: "/tmp/project",
         openedAt: "2026-04-10T11:00:00.000Z",
+        createWorkspaceId,
       });
 
       expect(firstOpen).toEqual({
@@ -47,6 +55,7 @@ describe("workspaces store", () => {
         createdAt: "2026-04-10T10:00:00.000Z",
         lastOpenedAt: "2026-04-10T11:00:00.000Z",
       });
+      expect(createWorkspaceIdCallCount).toBe(1);
     });
   }
 });

--- a/AppServer/src/workspaces/store.test.ts
+++ b/AppServer/src/workspaces/store.test.ts
@@ -1,0 +1,63 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import { type AppDatabase, DEFAULT_MIGRATIONS_FOLDER } from "@/core/store";
+import { createInMemoryWorkspacesStore, createSqliteWorkspacesStore } from "@/workspaces/store";
+
+describe("workspaces store", () => {
+  const storeFactories = [
+    {
+      name: "sqlite",
+      createStore: async () => {
+        const database = createMigratedInMemoryDatabase();
+        return createSqliteWorkspacesStore(() => database);
+      },
+    },
+    {
+      name: "in-memory",
+      createStore: async () => createInMemoryWorkspacesStore(),
+    },
+  ] as const;
+
+  for (const storeFactory of storeFactories) {
+    test(`${storeFactory.name} creates and reopens a workspace by canonical path`, async () => {
+      const store = await storeFactory.createStore();
+
+      const firstOpen = await store.openWorkspace({
+        workspaceId: "workspace-1",
+        workspacePath: "/tmp/project",
+        openedAt: "2026-04-10T10:00:00.000Z",
+      });
+      const secondOpen = await store.openWorkspace({
+        workspaceId: "workspace-2",
+        workspacePath: "/tmp/project",
+        openedAt: "2026-04-10T11:00:00.000Z",
+      });
+
+      expect(firstOpen).toEqual({
+        id: "workspace-1",
+        workspacePath: "/tmp/project",
+        createdAt: "2026-04-10T10:00:00.000Z",
+        lastOpenedAt: "2026-04-10T10:00:00.000Z",
+      });
+      expect(secondOpen).toEqual({
+        id: "workspace-1",
+        workspacePath: "/tmp/project",
+        createdAt: "2026-04-10T10:00:00.000Z",
+        lastOpenedAt: "2026-04-10T11:00:00.000Z",
+      });
+    });
+  }
+});
+
+const createMigratedInMemoryDatabase = (): AppDatabase => {
+  const sqliteHandle = new Database(":memory:", { strict: true });
+  const database = drizzle(sqliteHandle);
+
+  migrate(database, {
+    migrationsFolder: DEFAULT_MIGRATIONS_FOLDER,
+  });
+
+  return database;
+};

--- a/AppServer/src/workspaces/store.ts
+++ b/AppServer/src/workspaces/store.ts
@@ -1,0 +1,155 @@
+import { eq } from "drizzle-orm";
+import { sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
+import type { AppDatabase } from "@/core/store";
+import type { Workspace } from "@/workspaces/schemas";
+
+export const workspacesTable = sqliteTable(
+  "workspaces",
+  {
+    id: text("id").primaryKey(),
+    workspacePath: text("workspace_path").notNull(),
+    createdAt: text("created_at").notNull(),
+    lastOpenedAt: text("last_opened_at").notNull(),
+  },
+  (table) => [uniqueIndex("workspaces_workspace_path_unique").on(table.workspacePath)],
+);
+
+type WorkspaceRow = typeof workspacesTable.$inferSelect;
+
+export type OpenWorkspaceStoreInput = Readonly<{
+  workspaceId: string;
+  workspacePath: string;
+  openedAt: string;
+}>;
+
+export type WorkspacesStore = Readonly<{
+  openWorkspace: (input: OpenWorkspaceStoreInput) => Promise<Workspace>;
+}>;
+
+type AppDatabaseProvider = () => AppDatabase;
+
+export const createSqliteWorkspacesStore = (getDatabase: AppDatabaseProvider): WorkspacesStore => {
+  const openWorkspace: WorkspacesStore["openWorkspace"] = async (input) => {
+    const database = getDatabase();
+    const existingWorkspace = findWorkspaceByPath(database, input.workspacePath);
+
+    if (existingWorkspace !== undefined) {
+      return reopenWorkspace(database, existingWorkspace, input.openedAt);
+    }
+
+    try {
+      insertWorkspace(database, input);
+      return Object.freeze({
+        id: input.workspaceId,
+        workspacePath: input.workspacePath,
+        createdAt: input.openedAt,
+        lastOpenedAt: input.openedAt,
+      });
+    } catch (error) {
+      const concurrentWorkspace = findWorkspaceByPath(database, input.workspacePath);
+
+      if (concurrentWorkspace === undefined) {
+        throw error;
+      }
+
+      return reopenWorkspace(database, concurrentWorkspace, input.openedAt);
+    }
+  };
+
+  return Object.freeze({
+    openWorkspace,
+  });
+};
+
+export const createInMemoryWorkspacesStore = (
+  initialWorkspaces: readonly Workspace[] = [],
+): WorkspacesStore => {
+  const workspacesByPath = new Map<string, Workspace>(
+    initialWorkspaces.map((workspace) => [
+      workspace.workspacePath,
+      Object.freeze({ ...workspace }),
+    ]),
+  );
+
+  return Object.freeze({
+    openWorkspace: async (input) => {
+      const existingWorkspace = workspacesByPath.get(input.workspacePath);
+
+      if (existingWorkspace !== undefined) {
+        const reopenedWorkspace = Object.freeze({
+          ...existingWorkspace,
+          lastOpenedAt: input.openedAt,
+        });
+
+        workspacesByPath.set(input.workspacePath, reopenedWorkspace);
+        return reopenedWorkspace;
+      }
+
+      const createdWorkspace = Object.freeze({
+        id: input.workspaceId,
+        workspacePath: input.workspacePath,
+        createdAt: input.openedAt,
+        lastOpenedAt: input.openedAt,
+      });
+
+      workspacesByPath.set(input.workspacePath, createdWorkspace);
+      return createdWorkspace;
+    },
+  });
+};
+
+const findWorkspaceByPath = (
+  database: AppDatabase,
+  workspacePath: string,
+): Workspace | undefined => {
+  const workspaceRow = database
+    .select()
+    .from(workspacesTable)
+    .where(eq(workspacesTable.workspacePath, workspacePath))
+    .get();
+
+  if (workspaceRow === undefined) {
+    return undefined;
+  }
+
+  return mapWorkspaceRow(workspaceRow);
+};
+
+const insertWorkspace = (database: AppDatabase, input: OpenWorkspaceStoreInput): void => {
+  database
+    .insert(workspacesTable)
+    .values({
+      id: input.workspaceId,
+      workspacePath: input.workspacePath,
+      createdAt: input.openedAt,
+      lastOpenedAt: input.openedAt,
+    })
+    .run();
+};
+
+const reopenWorkspace = (
+  database: AppDatabase,
+  workspace: Workspace,
+  openedAt: string,
+): Workspace => {
+  database
+    .update(workspacesTable)
+    .set({
+      lastOpenedAt: openedAt,
+    })
+    .where(eq(workspacesTable.id, workspace.id))
+    .run();
+
+  return Object.freeze({
+    ...workspace,
+    lastOpenedAt: openedAt,
+  });
+};
+
+const mapWorkspaceRow = (workspaceRow: WorkspaceRow): Workspace =>
+  Object.freeze({
+    id: workspaceRow.id,
+    workspacePath: workspaceRow.workspacePath,
+    createdAt: workspaceRow.createdAt,
+    lastOpenedAt: workspaceRow.lastOpenedAt,
+  });

--- a/AppServer/src/workspaces/store.ts
+++ b/AppServer/src/workspaces/store.ts
@@ -15,11 +15,16 @@ export const workspacesTable = sqliteTable(
 );
 
 type WorkspaceRow = typeof workspacesTable.$inferSelect;
-
-export type OpenWorkspaceStoreInput = Readonly<{
+type CreateWorkspaceStoreInput = Readonly<{
   workspaceId: string;
   workspacePath: string;
   openedAt: string;
+}>;
+
+export type OpenWorkspaceStoreInput = Readonly<{
+  workspacePath: string;
+  openedAt: string;
+  createWorkspaceId: () => string;
 }>;
 
 export type WorkspacesStore = Readonly<{
@@ -38,9 +43,14 @@ export const createSqliteWorkspacesStore = (getDatabase: AppDatabaseProvider): W
     }
 
     try {
-      insertWorkspace(database, input);
+      const workspaceId = input.createWorkspaceId();
+
+      insertWorkspace(database, {
+        ...input,
+        workspaceId,
+      });
       return Object.freeze({
-        id: input.workspaceId,
+        id: workspaceId,
         workspacePath: input.workspacePath,
         createdAt: input.openedAt,
         lastOpenedAt: input.openedAt,
@@ -85,8 +95,9 @@ export const createInMemoryWorkspacesStore = (
         return reopenedWorkspace;
       }
 
+      const workspaceId = input.createWorkspaceId();
       const createdWorkspace = Object.freeze({
-        id: input.workspaceId,
+        id: workspaceId,
         workspacePath: input.workspacePath,
         createdAt: input.openedAt,
         lastOpenedAt: input.openedAt,
@@ -115,7 +126,7 @@ const findWorkspaceByPath = (
   return mapWorkspaceRow(workspaceRow);
 };
 
-const insertWorkspace = (database: AppDatabase, input: OpenWorkspaceStoreInput): void => {
+const insertWorkspace = (database: AppDatabase, input: CreateWorkspaceStoreInput): void => {
   database
     .insert(workspacesTable)
     .values({

--- a/AppServer/src/workspaces/workspace.handlers.ts
+++ b/AppServer/src/workspaces/workspace.handlers.ts
@@ -1,0 +1,76 @@
+import type { Logger } from "@/app/logger";
+import type { ProtocolDispatcher } from "@/core/protocol";
+import { createSessionNotInitializedResult } from "@/core/protocol/errors";
+import { type LifecycleComponent, ok } from "@/core/shared";
+import {
+  type Workspace,
+  WorkspaceOpenParamsSchema,
+  WorkspaceOpenResultSchema,
+} from "@/workspaces/schemas";
+import { type CreateWorkspacesServiceOptions, createWorkspacesService } from "@/workspaces/service";
+
+export type WorkspacesFeature = Readonly<{
+  lifecycle: LifecycleComponent;
+  getOpenedWorkspace: (connectionId: string) => Workspace | undefined;
+  handleConnectionClosed: (connectionId: string) => void;
+}>;
+
+export type CreateWorkspacesFeatureOptions = Readonly<
+  {
+    logger: Logger;
+    registerMethod: ProtocolDispatcher["registerMethod"];
+  } & CreateWorkspacesServiceOptions
+>;
+
+export const createWorkspacesFeature = (
+  options: CreateWorkspacesFeatureOptions,
+): WorkspacesFeature => {
+  const service = createWorkspacesService(options);
+  const openedWorkspacesByConnectionId = new Map<string, Workspace>();
+
+  options.registerMethod({
+    method: "workspace/open",
+    paramsSchema: WorkspaceOpenParamsSchema,
+    resultSchema: WorkspaceOpenResultSchema,
+    handler: async ({ connectionId, params, session }) => {
+      if (!session.isInitialized()) {
+        return createSessionNotInitializedResult();
+      }
+
+      const workspaceResult = await service.openWorkspace(params);
+
+      if (!workspaceResult.ok) {
+        return workspaceResult;
+      }
+
+      openedWorkspacesByConnectionId.set(connectionId, workspaceResult.data);
+
+      options.logger.info("Workspace opened", {
+        connectionId,
+        workspaceId: workspaceResult.data.id,
+        workspacePath: workspaceResult.data.workspacePath,
+      });
+
+      return ok({
+        workspace: workspaceResult.data,
+      });
+    },
+  });
+
+  return Object.freeze({
+    lifecycle: Object.freeze({
+      name: "feature.workspaces",
+      start: async () => {
+        options.logger.info("Workspaces feature ready");
+      },
+      stop: async (reason: string) => {
+        openedWorkspacesByConnectionId.clear();
+        options.logger.info("Workspaces feature stopped", { reason });
+      },
+    }),
+    getOpenedWorkspace: (connectionId) => openedWorkspacesByConnectionId.get(connectionId),
+    handleConnectionClosed: (connectionId) => {
+      openedWorkspacesByConnectionId.delete(connectionId);
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- add SQLite + Drizzle bootstrap for `AppServer/`, including config-based database path resolution, startup migrations, and clean shutdown handling
- check in the initial Drizzle migration and wire migration generation tooling into the package
- implement the first real `workspaces` feature vertical with TypeBox schemas, store/service/handler layers, and per-connection opened-workspace state
- register `workspace/open` after `initialize`, enforce initialize-before-use, and return explicit Atelier domain errors for invalid workspace paths
- make `workspace/open` idempotent by canonical workspace path and persist only Atelier-owned workspace metadata for this phase
- expand protocol, store, and service coverage for workspace open, migration bootstrap, and connection lifecycle behavior

## Testing
- `bun run check`
- `bun run typecheck`
- `bun test`