### PR TITLE
Add App Server model list support through the agents feature

### DIFF
--- a/AppServer/src/agents/codex-adapter/model-mapper.ts
+++ b/AppServer/src/agents/codex-adapter/model-mapper.ts
@@ -27,7 +27,7 @@ export const mapCodexModelSummary = (model: CodexModel): AgentModelSummary =>
     ),
     inputModalities: model.inputModalities ? [...model.inputModalities] : undefined,
     supportsPersonality: model.supportsPersonality,
-    isDefault: model.isDefault,
+    isDefault: model.isDefault === true,
   });
 
 export const mapCodexThreadStatus = (status: CodexThreadStatus): AgentThreadExecutionStatus => {

--- a/AppServer/src/agents/codex-adapter/session.test.ts
+++ b/AppServer/src/agents/codex-adapter/session.test.ts
@@ -57,8 +57,28 @@ describe("createCodexAgentSession", () => {
         nextCursor: null,
       },
       {
-        data: [],
-        nextCursor: null,
+        data: [
+          {
+            id: "gpt-5.4-hidden",
+            model: "gpt-5.4-hidden",
+            upgrade: null,
+            upgradeInfo: null,
+            availabilityNux: null,
+            displayName: "GPT-5.4 Hidden",
+            description: "Hidden model",
+            hidden: true,
+            supportedReasoningEfforts: [
+              {
+                reasoningEffort: "high",
+                description: "More reasoning",
+              },
+            ],
+            defaultReasoningEffort: "high",
+            inputModalities: ["text"],
+            supportsPersonality: false,
+          },
+        ],
+        nextCursor: "cursor-2",
       },
     ]);
 
@@ -89,7 +109,9 @@ describe("createCodexAgentSession", () => {
       limit: 20,
       includeHidden: false,
     });
-    const secondModels = await sessionResult.data.listModels("req-models-2", {});
+    const secondModels = await sessionResult.data.listModels("req-models-2", {
+      includeHidden: true,
+    });
 
     expect(transport.connectCount).toBe(1);
     expect(transport.sent).toEqual([
@@ -120,7 +142,7 @@ describe("createCodexAgentSession", () => {
         method: "model/list",
         params: {
           limit: undefined,
-          includeHidden: undefined,
+          includeHidden: true,
         },
       },
     ]);
@@ -152,8 +174,25 @@ describe("createCodexAgentSession", () => {
     expect(secondModels).toEqual({
       ok: true,
       data: {
-        models: [],
-        nextCursor: null,
+        models: [
+          {
+            id: "gpt-5.4-hidden",
+            model: "gpt-5.4-hidden",
+            displayName: "GPT-5.4 Hidden",
+            hidden: true,
+            defaultReasoningEffort: "high",
+            supportedReasoningEfforts: [
+              {
+                reasoningEffort: "high",
+                description: "More reasoning",
+              },
+            ],
+            inputModalities: ["text"],
+            supportsPersonality: false,
+            isDefault: false,
+          },
+        ],
+        nextCursor: "cursor-2",
       },
     });
   });

--- a/AppServer/src/agents/contracts.ts
+++ b/AppServer/src/agents/contracts.ts
@@ -50,7 +50,7 @@ export type AgentModelSummary = Readonly<{
   supportedReasoningEfforts: readonly AgentModelReasoningEffort[];
   inputModalities?: readonly string[];
   supportsPersonality?: boolean;
-  isDefault?: boolean;
+  isDefault: boolean;
 }>;
 
 export type AgentThreadExecutionStatus =

--- a/AppServer/src/agents/feature.ts
+++ b/AppServer/src/agents/feature.ts
@@ -1,8 +1,11 @@
 import type { AgentAdapter } from "@/agents/adapter";
 import type { AgentsConfig } from "@/agents/config";
 import type { AgentSessionLookupError } from "@/agents/contracts";
+import { registerModelListMethod } from "@/agents/model-list.handlers";
 import { type AgentRegistry, createAgentRegistry } from "@/agents/registry";
+import { createAgentsService } from "@/agents/service";
 import type { Logger } from "@/app/logger";
+import type { ProtocolDispatcher } from "@/core/protocol";
 import type { LifecycleComponent } from "@/core/shared";
 import { err } from "@/core/shared";
 
@@ -15,6 +18,7 @@ export type CreateAgentsFeatureOptions = Readonly<{
   config: AgentsConfig;
   logger: Logger;
   adapters: readonly AgentAdapter[];
+  registerMethod: ProtocolDispatcher["registerMethod"];
 }>;
 
 export const createAgentsFeature = (options: CreateAgentsFeatureOptions): AgentsFeature => {
@@ -44,6 +48,15 @@ export const createAgentsFeature = (options: CreateAgentsFeatureOptions): Agents
     defaultAgentId: options.config.defaultAgent,
     agents: options.config.enabled,
     createSession,
+  });
+  const service = createAgentsService({
+    logger: options.logger,
+    registry,
+  });
+
+  registerModelListMethod({
+    registerMethod: options.registerMethod,
+    service,
   });
 
   return Object.freeze({

--- a/AppServer/src/agents/index.ts
+++ b/AppServer/src/agents/index.ts
@@ -4,4 +4,8 @@ export * from "@/agents/contracts";
 export * from "@/agents/environment";
 export * from "@/agents/executable-discovery";
 export * from "@/agents/feature";
+export * from "@/agents/model-list.handlers";
+export * from "@/agents/protocol-errors";
 export * from "@/agents/registry";
+export * from "@/agents/schemas";
+export * from "@/agents/service";

--- a/AppServer/src/agents/index.ts
+++ b/AppServer/src/agents/index.ts
@@ -7,5 +7,6 @@ export * from "@/agents/feature";
 export * from "@/agents/model-list.handlers";
 export * from "@/agents/protocol-errors";
 export * from "@/agents/registry";
+export * from "@/agents/request-id";
 export * from "@/agents/schemas";
 export * from "@/agents/service";

--- a/AppServer/src/agents/model-list.handlers.ts
+++ b/AppServer/src/agents/model-list.handlers.ts
@@ -1,0 +1,43 @@
+import { createAgentSessionUnavailableError, createProviderError } from "@/agents/protocol-errors";
+import { ModelListParamsSchema, ModelListResultSchema } from "@/agents/schemas";
+import type { AgentsService } from "@/agents/service";
+import type { ProtocolDispatcher } from "@/core/protocol";
+import { createSessionNotInitializedResult } from "@/core/protocol/errors";
+import { ok } from "@/core/shared";
+
+export type RegisterModelListMethodOptions = Readonly<{
+  registerMethod: ProtocolDispatcher["registerMethod"];
+  service: AgentsService;
+}>;
+
+export const registerModelListMethod = (options: RegisterModelListMethodOptions): void => {
+  options.registerMethod({
+    method: "model/list",
+    paramsSchema: ModelListParamsSchema,
+    resultSchema: ModelListResultSchema,
+    handler: async ({ params, requestId, session }) => {
+      if (!session.isInitialized()) {
+        return createSessionNotInitializedResult();
+      }
+
+      const modelsResult = await options.service.listModels(requestId, params);
+
+      if (!modelsResult.ok) {
+        switch (modelsResult.error.type) {
+          case "sessionUnavailable":
+            return {
+              ok: false,
+              error: createAgentSessionUnavailableError(modelsResult.error),
+            };
+          case "remoteError":
+            return {
+              ok: false,
+              error: createProviderError(modelsResult.error),
+            };
+        }
+      }
+
+      return ok(modelsResult.data);
+    },
+  });
+};

--- a/AppServer/src/agents/model-list.handlers.ts
+++ b/AppServer/src/agents/model-list.handlers.ts
@@ -1,9 +1,10 @@
 import { createAgentSessionUnavailableError, createProviderError } from "@/agents/protocol-errors";
+import { createAgentRequestId } from "@/agents/request-id";
 import { ModelListParamsSchema, ModelListResultSchema } from "@/agents/schemas";
 import type { AgentsService } from "@/agents/service";
 import type { ProtocolDispatcher } from "@/core/protocol";
 import { createSessionNotInitializedResult } from "@/core/protocol/errors";
-import { ok } from "@/core/shared";
+import { assertNever, ok } from "@/core/shared";
 
 export type RegisterModelListMethodOptions = Readonly<{
   registerMethod: ProtocolDispatcher["registerMethod"];
@@ -15,12 +16,17 @@ export const registerModelListMethod = (options: RegisterModelListMethodOptions)
     method: "model/list",
     paramsSchema: ModelListParamsSchema,
     resultSchema: ModelListResultSchema,
-    handler: async ({ params, requestId, session }) => {
+    handler: async ({ connectionId, params, requestId, session }) => {
       if (!session.isInitialized()) {
         return createSessionNotInitializedResult();
       }
 
-      const modelsResult = await options.service.listModels(requestId, params);
+      const agentRequestId = createAgentRequestId({
+        connectionId,
+        method: "model/list",
+        requestId,
+      });
+      const modelsResult = await options.service.listModels(agentRequestId, params);
 
       if (!modelsResult.ok) {
         switch (modelsResult.error.type) {
@@ -34,6 +40,8 @@ export const registerModelListMethod = (options: RegisterModelListMethodOptions)
               ok: false,
               error: createProviderError(modelsResult.error),
             };
+          default:
+            return assertNever(modelsResult.error, "Unhandled model/list protocol error");
         }
       }
 

--- a/AppServer/src/agents/protocol-errors.ts
+++ b/AppServer/src/agents/protocol-errors.ts
@@ -1,8 +1,10 @@
 import type { AgentRemoteError, AgentSessionUnavailableError } from "@/agents/contracts";
-import { createProtocolMethodError, type ProtocolMethodError } from "@/core/protocol/errors";
-
-export const ATELIER_AGENT_SESSION_UNAVAILABLE_ERROR = -33004;
-export const ATELIER_PROVIDER_ERROR = -33005;
+import {
+  ATELIER_AGENT_SESSION_UNAVAILABLE_ERROR,
+  ATELIER_PROVIDER_ERROR,
+  createProtocolMethodError,
+  type ProtocolMethodError,
+} from "@/core/protocol/errors";
 
 export const createAgentSessionUnavailableError = (
   error: AgentSessionUnavailableError,

--- a/AppServer/src/agents/protocol-errors.ts
+++ b/AppServer/src/agents/protocol-errors.ts
@@ -1,0 +1,33 @@
+import type { AgentRemoteError, AgentSessionUnavailableError } from "@/agents/contracts";
+import { createProtocolMethodError, type ProtocolMethodError } from "@/core/protocol/errors";
+
+export const ATELIER_AGENT_SESSION_UNAVAILABLE_ERROR = -33004;
+export const ATELIER_PROVIDER_ERROR = -33005;
+
+export const createAgentSessionUnavailableError = (
+  error: AgentSessionUnavailableError,
+): ProtocolMethodError =>
+  createProtocolMethodError(
+    ATELIER_AGENT_SESSION_UNAVAILABLE_ERROR,
+    "Agent session unavailable",
+    Object.freeze({
+      code: "AGENT_SESSION_UNAVAILABLE",
+      agentId: error.agentId,
+      provider: error.provider,
+      reason: error.code,
+      message: error.message,
+    }),
+  );
+
+export const createProviderError = (error: AgentRemoteError): ProtocolMethodError =>
+  createProtocolMethodError(
+    ATELIER_PROVIDER_ERROR,
+    "Provider error",
+    Object.freeze({
+      code: "PROVIDER_ERROR",
+      agentId: error.agentId,
+      provider: error.provider,
+      providerCode: String(error.code),
+      providerMessage: error.message,
+    }),
+  );

--- a/AppServer/src/agents/request-id.ts
+++ b/AppServer/src/agents/request-id.ts
@@ -1,0 +1,15 @@
+import type { AgentRequestId } from "@/agents/contracts";
+import type { RequestId } from "@/core/protocol";
+
+export type CreateAgentRequestIdOptions = Readonly<{
+  connectionId: string;
+  method: string;
+  requestId: RequestId;
+}>;
+
+export const createAgentRequestId = ({
+  connectionId,
+  method,
+  requestId,
+}: CreateAgentRequestIdOptions): AgentRequestId =>
+  `atelier-appserver:${method}:${connectionId}:${String(requestId)}`;

--- a/AppServer/src/agents/schemas.ts
+++ b/AppServer/src/agents/schemas.ts
@@ -1,0 +1,54 @@
+import { type Static, Type } from "@sinclair/typebox";
+
+export const ModelReasoningEffortSchema = Type.Union([
+  Type.Literal("none"),
+  Type.Literal("minimal"),
+  Type.Literal("low"),
+  Type.Literal("medium"),
+  Type.Literal("high"),
+  Type.Literal("xhigh"),
+]);
+export type ModelReasoningEffort = Static<typeof ModelReasoningEffortSchema>;
+
+export const ModelReasoningEffortSummarySchema = Type.Object(
+  {
+    reasoningEffort: ModelReasoningEffortSchema,
+    description: Type.Optional(Type.String({ minLength: 1 })),
+  },
+  { additionalProperties: false },
+);
+export type ModelReasoningEffortSummary = Static<typeof ModelReasoningEffortSummarySchema>;
+
+export const ModelSummarySchema = Type.Object(
+  {
+    id: Type.String({ minLength: 1 }),
+    model: Type.String({ minLength: 1 }),
+    displayName: Type.String({ minLength: 1 }),
+    hidden: Type.Boolean(),
+    defaultReasoningEffort: Type.Optional(ModelReasoningEffortSchema),
+    supportedReasoningEfforts: Type.Array(ModelReasoningEffortSummarySchema),
+    inputModalities: Type.Optional(Type.Array(Type.String({ minLength: 1 }))),
+    supportsPersonality: Type.Optional(Type.Boolean()),
+    isDefault: Type.Boolean(),
+  },
+  { additionalProperties: false },
+);
+export type ModelSummary = Static<typeof ModelSummarySchema>;
+
+export const ModelListParamsSchema = Type.Object(
+  {
+    limit: Type.Optional(Type.Integer({ minimum: 0 })),
+    includeHidden: Type.Optional(Type.Boolean()),
+  },
+  { additionalProperties: false },
+);
+export type ModelListParams = Static<typeof ModelListParamsSchema>;
+
+export const ModelListResultSchema = Type.Object(
+  {
+    models: Type.Array(ModelSummarySchema),
+    nextCursor: Type.Union([Type.String({ minLength: 1 }), Type.Null()]),
+  },
+  { additionalProperties: false },
+);
+export type ModelListResult = Static<typeof ModelListResultSchema>;

--- a/AppServer/src/agents/service.test.ts
+++ b/AppServer/src/agents/service.test.ts
@@ -1,22 +1,20 @@
 import { describe, expect, test } from "bun:test";
-import type {
-  AgentListModelsParams,
-  AgentListModelsResult,
-  AgentNotification,
-  AgentSession,
-} from "@/agents/contracts";
-import type { AgentRegistry } from "@/agents/registry";
 import { createAgentsService } from "@/agents/service";
+import {
+  createFakeAgentRegistry,
+  createFakeAgentSession,
+  createTestAgentModel,
+} from "@/test-support/agents";
 import { createSilentLogger } from "@/test-support/logger";
 
 describe("createAgentsService", () => {
   test("looks up the default agent session and forwards params while preserving nextCursor", async () => {
-    const session = createFakeSession({
+    const session = createFakeAgentSession({
       listModels: async () => ({
         ok: true,
         data: {
           models: [
-            createVisibleModel({
+            createTestAgentModel({
               id: "gpt-5.4",
               model: "gpt-5.4",
               displayName: "GPT-5.4",
@@ -27,7 +25,7 @@ describe("createAgentsService", () => {
         },
       }),
     });
-    const registry = createFakeRegistry(session);
+    const registry = createFakeAgentRegistry(session);
     const service = createAgentsService({
       logger: createSilentLogger(),
       registry,
@@ -77,12 +75,22 @@ describe("createAgentsService", () => {
   test("filters hidden models when includeHidden is omitted", async () => {
     const service = createAgentsService({
       logger: createSilentLogger(),
-      registry: createFakeRegistry(
-        createFakeSession({
+      registry: createFakeAgentRegistry(
+        createFakeAgentSession({
           listModels: async () => ({
             ok: true,
             data: {
-              models: [createVisibleModel(), createHiddenModel()],
+              models: [
+                createTestAgentModel(),
+                createTestAgentModel({
+                  id: "gpt-5.4-hidden",
+                  model: "gpt-5.4-hidden",
+                  displayName: "GPT-5.4 Hidden",
+                  hidden: true,
+                  defaultReasoningEffort: "high",
+                  supportsPersonality: false,
+                }),
+              ],
               nextCursor: null,
             },
           }),
@@ -95,21 +103,29 @@ describe("createAgentsService", () => {
     expect(result).toEqual({
       ok: true,
       data: {
-        models: [createVisibleModel()],
+        models: [createTestAgentModel()],
         nextCursor: null,
       },
     });
   });
 
   test("includes hidden models when includeHidden is true", async () => {
+    const hiddenModel = createTestAgentModel({
+      id: "gpt-5.4-hidden",
+      model: "gpt-5.4-hidden",
+      displayName: "GPT-5.4 Hidden",
+      hidden: true,
+      defaultReasoningEffort: "high",
+      supportsPersonality: false,
+    });
     const service = createAgentsService({
       logger: createSilentLogger(),
-      registry: createFakeRegistry(
-        createFakeSession({
+      registry: createFakeAgentRegistry(
+        createFakeAgentSession({
           listModels: async () => ({
             ok: true,
             data: {
-              models: [createVisibleModel(), createHiddenModel()],
+              models: [createTestAgentModel(), hiddenModel],
               nextCursor: null,
             },
           }),
@@ -124,7 +140,7 @@ describe("createAgentsService", () => {
     expect(result).toEqual({
       ok: true,
       data: {
-        models: [createVisibleModel(), createHiddenModel()],
+        models: [createTestAgentModel(), hiddenModel],
         nextCursor: null,
       },
     });
@@ -133,8 +149,8 @@ describe("createAgentsService", () => {
   test("treats invalid provider payloads as infrastructure failures", async () => {
     const service = createAgentsService({
       logger: createSilentLogger(),
-      registry: createFakeRegistry(
-        createFakeSession({
+      registry: createFakeAgentRegistry(
+        createFakeAgentSession({
           listModels: async () => ({
             ok: false,
             error: {
@@ -153,159 +169,3 @@ describe("createAgentsService", () => {
     );
   });
 });
-
-const createFakeRegistry = (
-  session: AgentSession,
-): AgentRegistry & {
-  requestedAgentIds: Array<string | undefined>;
-} => {
-  const requestedAgentIds: Array<string | undefined> = [];
-
-  return {
-    requestedAgentIds,
-    getDefaultAgentId: () => "codex",
-    listAgents: () => [
-      {
-        id: "codex",
-        provider: "codex",
-      },
-    ],
-    getAgent: (agentId) =>
-      agentId === "codex"
-        ? {
-            id: "codex",
-            provider: "codex",
-          }
-        : undefined,
-    getSession: async (agentId) => {
-      requestedAgentIds.push(agentId);
-      return {
-        ok: true,
-        data: session,
-      };
-    },
-    disconnectAll: async () => {},
-  };
-};
-
-const createFakeSession = (options: {
-  listModels: (
-    requestId: string | number,
-    params: AgentListModelsParams,
-  ) => Promise<
-    | Readonly<{
-        ok: true;
-        data: AgentListModelsResult;
-      }>
-    | Readonly<{
-        ok: false;
-        error: {
-          type: "invalidProviderMessage";
-          agentId: string;
-          provider: "codex";
-          message: string;
-          detail?: Record<string, unknown>;
-        };
-      }>
-  >;
-}): AgentSession & {
-  listModelsCalls: Array<
-    Readonly<{
-      requestId: string | number;
-      params: AgentListModelsParams;
-    }>
-  >;
-} => {
-  const listModelsCalls: Array<
-    Readonly<{
-      requestId: string | number;
-      params: AgentListModelsParams;
-    }>
-  > = [];
-
-  return {
-    agentId: "codex",
-    provider: "codex",
-    getState: () => "ready",
-    subscribe: (_listener: (notification: AgentNotification) => void) => () => {},
-    listModels: async (requestId, params) => {
-      listModelsCalls.push({
-        requestId,
-        params,
-      });
-
-      return options.listModels(requestId, params);
-    },
-    startThread: async () => {
-      throw new Error("startThread should not be called in this test.");
-    },
-    resumeThread: async () => {
-      throw new Error("resumeThread should not be called in this test.");
-    },
-    readThread: async () => {
-      throw new Error("readThread should not be called in this test.");
-    },
-    forkThread: async () => {
-      throw new Error("forkThread should not be called in this test.");
-    },
-    startTurn: async () => {
-      throw new Error("startTurn should not be called in this test.");
-    },
-    steerTurn: async () => {
-      throw new Error("steerTurn should not be called in this test.");
-    },
-    interruptTurn: async () => {
-      throw new Error("interruptTurn should not be called in this test.");
-    },
-    resolveApproval: async () => {
-      throw new Error("resolveApproval should not be called in this test.");
-    },
-    disconnect: async () => {},
-    listModelsCalls,
-  };
-};
-
-const createVisibleModel = (
-  overrides: Partial<
-    Readonly<{
-      id: string;
-      model: string;
-      displayName: string;
-      isDefault: boolean;
-    }>
-  > = {},
-) =>
-  Object.freeze({
-    id: overrides.id ?? "gpt-5.4",
-    model: overrides.model ?? "gpt-5.4",
-    displayName: overrides.displayName ?? "GPT-5.4",
-    hidden: false,
-    defaultReasoningEffort: "medium" as const,
-    supportedReasoningEfforts: [
-      {
-        reasoningEffort: "medium" as const,
-        description: "Balanced",
-      },
-    ],
-    inputModalities: ["text"],
-    supportsPersonality: true,
-    isDefault: overrides.isDefault ?? false,
-  });
-
-const createHiddenModel = () =>
-  Object.freeze({
-    id: "gpt-5.4-hidden",
-    model: "gpt-5.4-hidden",
-    displayName: "GPT-5.4 Hidden",
-    hidden: true,
-    defaultReasoningEffort: "high" as const,
-    supportedReasoningEfforts: [
-      {
-        reasoningEffort: "high" as const,
-        description: "Deeper reasoning",
-      },
-    ],
-    inputModalities: ["text"],
-    supportsPersonality: false,
-    isDefault: false,
-  });

--- a/AppServer/src/agents/service.test.ts
+++ b/AppServer/src/agents/service.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  AgentListModelsParams,
+  AgentListModelsResult,
+  AgentNotification,
+  AgentSession,
+} from "@/agents/contracts";
+import type { AgentRegistry } from "@/agents/registry";
+import { createAgentsService } from "@/agents/service";
+import { createSilentLogger } from "@/test-support/logger";
+
+describe("createAgentsService", () => {
+  test("looks up the default agent session and forwards params while preserving nextCursor", async () => {
+    const session = createFakeSession({
+      listModels: async () => ({
+        ok: true,
+        data: {
+          models: [
+            createVisibleModel({
+              id: "gpt-5.4",
+              model: "gpt-5.4",
+              displayName: "GPT-5.4",
+              isDefault: true,
+            }),
+          ],
+          nextCursor: "cursor-2",
+        },
+      }),
+    });
+    const registry = createFakeRegistry(session);
+    const service = createAgentsService({
+      logger: createSilentLogger(),
+      registry,
+    });
+
+    const result = await service.listModels("req-model-list", {
+      limit: 25,
+      includeHidden: true,
+    });
+
+    expect(registry.requestedAgentIds).toEqual([undefined]);
+    expect(session.listModelsCalls).toEqual([
+      {
+        requestId: "req-model-list",
+        params: {
+          limit: 25,
+          includeHidden: true,
+        },
+      },
+    ]);
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        models: [
+          {
+            id: "gpt-5.4",
+            model: "gpt-5.4",
+            displayName: "GPT-5.4",
+            hidden: false,
+            defaultReasoningEffort: "medium",
+            supportedReasoningEfforts: [
+              {
+                reasoningEffort: "medium",
+                description: "Balanced",
+              },
+            ],
+            inputModalities: ["text"],
+            supportsPersonality: true,
+            isDefault: true,
+          },
+        ],
+        nextCursor: "cursor-2",
+      },
+    });
+  });
+
+  test("filters hidden models when includeHidden is omitted", async () => {
+    const service = createAgentsService({
+      logger: createSilentLogger(),
+      registry: createFakeRegistry(
+        createFakeSession({
+          listModels: async () => ({
+            ok: true,
+            data: {
+              models: [createVisibleModel(), createHiddenModel()],
+              nextCursor: null,
+            },
+          }),
+        }),
+      ),
+    });
+
+    const result = await service.listModels("req-model-list", {});
+
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        models: [createVisibleModel()],
+        nextCursor: null,
+      },
+    });
+  });
+
+  test("includes hidden models when includeHidden is true", async () => {
+    const service = createAgentsService({
+      logger: createSilentLogger(),
+      registry: createFakeRegistry(
+        createFakeSession({
+          listModels: async () => ({
+            ok: true,
+            data: {
+              models: [createVisibleModel(), createHiddenModel()],
+              nextCursor: null,
+            },
+          }),
+        }),
+      ),
+    });
+
+    const result = await service.listModels("req-model-list", {
+      includeHidden: true,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        models: [createVisibleModel(), createHiddenModel()],
+        nextCursor: null,
+      },
+    });
+  });
+
+  test("treats invalid provider payloads as infrastructure failures", async () => {
+    const service = createAgentsService({
+      logger: createSilentLogger(),
+      registry: createFakeRegistry(
+        createFakeSession({
+          listModels: async () => ({
+            ok: false,
+            error: {
+              type: "invalidProviderMessage",
+              agentId: "codex",
+              provider: "codex",
+              message: "Malformed provider payload.",
+            },
+          }),
+        }),
+      ),
+    });
+
+    await expect(service.listModels("req-model-list", {})).rejects.toThrow(
+      "Malformed provider payload.",
+    );
+  });
+});
+
+const createFakeRegistry = (
+  session: AgentSession,
+): AgentRegistry & {
+  requestedAgentIds: Array<string | undefined>;
+} => {
+  const requestedAgentIds: Array<string | undefined> = [];
+
+  return {
+    requestedAgentIds,
+    getDefaultAgentId: () => "codex",
+    listAgents: () => [
+      {
+        id: "codex",
+        provider: "codex",
+      },
+    ],
+    getAgent: (agentId) =>
+      agentId === "codex"
+        ? {
+            id: "codex",
+            provider: "codex",
+          }
+        : undefined,
+    getSession: async (agentId) => {
+      requestedAgentIds.push(agentId);
+      return {
+        ok: true,
+        data: session,
+      };
+    },
+    disconnectAll: async () => {},
+  };
+};
+
+const createFakeSession = (options: {
+  listModels: (
+    requestId: string | number,
+    params: AgentListModelsParams,
+  ) => Promise<
+    | Readonly<{
+        ok: true;
+        data: AgentListModelsResult;
+      }>
+    | Readonly<{
+        ok: false;
+        error: {
+          type: "invalidProviderMessage";
+          agentId: string;
+          provider: "codex";
+          message: string;
+          detail?: Record<string, unknown>;
+        };
+      }>
+  >;
+}): AgentSession & {
+  listModelsCalls: Array<
+    Readonly<{
+      requestId: string | number;
+      params: AgentListModelsParams;
+    }>
+  >;
+} => {
+  const listModelsCalls: Array<
+    Readonly<{
+      requestId: string | number;
+      params: AgentListModelsParams;
+    }>
+  > = [];
+
+  return {
+    agentId: "codex",
+    provider: "codex",
+    getState: () => "ready",
+    subscribe: (_listener: (notification: AgentNotification) => void) => () => {},
+    listModels: async (requestId, params) => {
+      listModelsCalls.push({
+        requestId,
+        params,
+      });
+
+      return options.listModels(requestId, params);
+    },
+    startThread: async () => {
+      throw new Error("startThread should not be called in this test.");
+    },
+    resumeThread: async () => {
+      throw new Error("resumeThread should not be called in this test.");
+    },
+    readThread: async () => {
+      throw new Error("readThread should not be called in this test.");
+    },
+    forkThread: async () => {
+      throw new Error("forkThread should not be called in this test.");
+    },
+    startTurn: async () => {
+      throw new Error("startTurn should not be called in this test.");
+    },
+    steerTurn: async () => {
+      throw new Error("steerTurn should not be called in this test.");
+    },
+    interruptTurn: async () => {
+      throw new Error("interruptTurn should not be called in this test.");
+    },
+    resolveApproval: async () => {
+      throw new Error("resolveApproval should not be called in this test.");
+    },
+    disconnect: async () => {},
+    listModelsCalls,
+  };
+};
+
+const createVisibleModel = (
+  overrides: Partial<
+    Readonly<{
+      id: string;
+      model: string;
+      displayName: string;
+      isDefault: boolean;
+    }>
+  > = {},
+) =>
+  Object.freeze({
+    id: overrides.id ?? "gpt-5.4",
+    model: overrides.model ?? "gpt-5.4",
+    displayName: overrides.displayName ?? "GPT-5.4",
+    hidden: false,
+    defaultReasoningEffort: "medium" as const,
+    supportedReasoningEfforts: [
+      {
+        reasoningEffort: "medium" as const,
+        description: "Balanced",
+      },
+    ],
+    inputModalities: ["text"],
+    supportsPersonality: true,
+    isDefault: overrides.isDefault ?? false,
+  });
+
+const createHiddenModel = () =>
+  Object.freeze({
+    id: "gpt-5.4-hidden",
+    model: "gpt-5.4-hidden",
+    displayName: "GPT-5.4 Hidden",
+    hidden: true,
+    defaultReasoningEffort: "high" as const,
+    supportedReasoningEfforts: [
+      {
+        reasoningEffort: "high" as const,
+        description: "Deeper reasoning",
+      },
+    ],
+    inputModalities: ["text"],
+    supportsPersonality: false,
+    isDefault: false,
+  });

--- a/AppServer/src/agents/service.ts
+++ b/AppServer/src/agents/service.ts
@@ -1,0 +1,97 @@
+import type {
+  AgentInvalidMessageError,
+  AgentModelSummary,
+  AgentRemoteError,
+  AgentRequestId,
+  AgentSessionUnavailableError,
+} from "@/agents/contracts";
+import type { AgentRegistry } from "@/agents/registry";
+import type { ModelListParams, ModelListResult, ModelSummary } from "@/agents/schemas";
+import type { Logger } from "@/app/logger";
+import { err, ok, type Result } from "@/core/shared";
+
+export type AgentsServiceError = AgentSessionUnavailableError | AgentRemoteError;
+
+export type AgentsService = Readonly<{
+  listModels: (
+    requestId: AgentRequestId,
+    params: ModelListParams,
+  ) => Promise<Result<ModelListResult, AgentsServiceError>>;
+}>;
+
+export type CreateAgentsServiceOptions = Readonly<{
+  logger: Logger;
+  registry: AgentRegistry;
+}>;
+
+export const createAgentsService = (options: CreateAgentsServiceOptions): AgentsService =>
+  Object.freeze({
+    listModels: async (requestId, params) => {
+      const sessionResult = await options.registry.getSession();
+
+      if (!sessionResult.ok) {
+        if (sessionResult.error.type === "sessionUnavailable") {
+          return err(sessionResult.error);
+        }
+
+        throw new Error(sessionResult.error.message);
+      }
+
+      const modelsResult = await sessionResult.data.listModels(requestId, params);
+
+      if (!modelsResult.ok) {
+        switch (modelsResult.error.type) {
+          case "sessionUnavailable":
+          case "remoteError":
+            return err(modelsResult.error);
+          case "invalidProviderMessage":
+            throwInvalidProviderMessage(options.logger, modelsResult.error);
+        }
+
+        throw new Error("Unhandled agent model/list error.");
+      }
+
+      const models =
+        params.includeHidden === true
+          ? modelsResult.data.models.map(mapModelSummary)
+          : modelsResult.data.models
+              .filter((model: AgentModelSummary) => !model.hidden)
+              .map(mapModelSummary);
+
+      return ok({
+        models,
+        nextCursor: modelsResult.data.nextCursor,
+      });
+    },
+  });
+
+const mapModelSummary = (model: AgentModelSummary): ModelSummary =>
+  Object.freeze({
+    id: model.id,
+    model: model.model,
+    displayName: model.displayName,
+    hidden: model.hidden,
+    defaultReasoningEffort: model.defaultReasoningEffort,
+    supportedReasoningEfforts: model.supportedReasoningEfforts.map((effort) =>
+      Object.freeze({
+        reasoningEffort: effort.reasoningEffort,
+        ...(effort.description ? { description: effort.description } : {}),
+      }),
+    ),
+    ...(model.inputModalities ? { inputModalities: [...model.inputModalities] } : {}),
+    ...(model.supportsPersonality !== undefined
+      ? { supportsPersonality: model.supportsPersonality }
+      : {}),
+    isDefault: model.isDefault,
+  });
+
+const throwInvalidProviderMessage = (logger: Logger, error: AgentInvalidMessageError): never => {
+  logger.error("Agent operation returned an invalid provider message", {
+    agentId: error.agentId,
+    provider: error.provider,
+    message: error.message,
+    ...(error.detail ? { detail: JSON.stringify(error.detail) } : {}),
+  });
+
+  throw new Error(error.message, { cause: error });
+};

--- a/AppServer/src/agents/service.ts
+++ b/AppServer/src/agents/service.ts
@@ -8,7 +8,7 @@ import type {
 import type { AgentRegistry } from "@/agents/registry";
 import type { ModelListParams, ModelListResult, ModelSummary } from "@/agents/schemas";
 import type { Logger } from "@/app/logger";
-import { err, ok, type Result } from "@/core/shared";
+import { assertNever, err, ok, type Result } from "@/core/shared";
 
 export type AgentsServiceError = AgentSessionUnavailableError | AgentRemoteError;
 
@@ -45,12 +45,15 @@ export const createAgentsService = (options: CreateAgentsServiceOptions): Agents
           case "remoteError":
             return err(modelsResult.error);
           case "invalidProviderMessage":
-            throwInvalidProviderMessage(options.logger, modelsResult.error);
+            return throwInvalidProviderMessage(options.logger, modelsResult.error);
+          default:
+            return assertNever(modelsResult.error, "Unhandled agent model/list error");
         }
-
-        throw new Error("Unhandled agent model/list error.");
       }
 
+      // The service enforces the public App Server contract even if an adapter
+      // forgets to hide models by default. Adapters can still honor
+      // `includeHidden` to reduce upstream payload size.
       const models =
         params.includeHidden === true
           ? modelsResult.data.models.map(mapModelSummary)

--- a/AppServer/src/app/protocol-harness.test.ts
+++ b/AppServer/src/app/protocol-harness.test.ts
@@ -2,10 +2,22 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { AgentAdapter } from "@/agents";
+import { createAgentsFeature } from "@/agents";
+import { createCodexAgentAdapter } from "@/agents/codex-adapter";
 import { createLogger } from "@/app/logger";
-import { APP_SERVER_USER_AGENT } from "@/app/protocol";
+import {
+  APP_SERVER_USER_AGENT,
+  createAppProtocolRuntime,
+  createAppTransportComponent,
+} from "@/app/protocol";
 import { type AppServer, createConfiguredAppServer, type SignalRegistrar } from "@/app/server";
+import { createApprovalsFeaturePlaceholder } from "@/approvals";
+import { createStoreBootstrap } from "@/core/store";
 import { getAvailablePort } from "@/test-support/network";
+import { createThreadsFeaturePlaceholder } from "@/threads";
+import { createTurnsFeaturePlaceholder } from "@/turns";
+import { createSqliteWorkspacesStore, createWorkspacesFeature } from "@/workspaces";
 
 const runningServers: AppServer[] = [];
 const temporaryDirectories: string[] = [];
@@ -194,6 +206,293 @@ describe("App Server protocol harness", () => {
     }
   });
 
+  test("returns models after initialize", async () => {
+    const harness = await createProtocolHarness({
+      agentAdapters: [
+        createFakeProtocolAgentAdapter({
+          listModelsResult: {
+            ok: true,
+            data: {
+              models: [
+                createProtocolModel({
+                  id: "gpt-5.4",
+                  model: "gpt-5.4",
+                  displayName: "GPT-5.4",
+                  isDefault: true,
+                }),
+              ],
+              nextCursor: "cursor-2",
+            },
+          },
+        }),
+      ],
+    });
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      await initializeClient(client);
+
+      client.sendJson({
+        id: "req-model-list",
+        method: "model/list",
+        params: {
+          limit: 20,
+        },
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-model-list",
+        result: {
+          models: [
+            {
+              id: "gpt-5.4",
+              model: "gpt-5.4",
+              displayName: "GPT-5.4",
+              hidden: false,
+              defaultReasoningEffort: "medium",
+              supportedReasoningEfforts: [
+                {
+                  reasoningEffort: "medium",
+                  description: "Balanced",
+                },
+              ],
+              inputModalities: ["text"],
+              supportsPersonality: true,
+              isDefault: true,
+            },
+          ],
+          nextCursor: "cursor-2",
+        },
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("rejects model/list before initialize", async () => {
+    const harness = await createProtocolHarness();
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      client.sendJson({
+        id: "req-model-list",
+        method: "model/list",
+        params: {},
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-model-list",
+        error: {
+          code: -33001,
+          message: "Session not initialized",
+          data: {
+            code: "SESSION_NOT_INITIALIZED",
+          },
+        },
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("maps malformed model/list params to invalid params", async () => {
+    const harness = await createProtocolHarness();
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      await initializeClient(client);
+
+      client.sendJson({
+        id: "req-model-list",
+        method: "model/list",
+        params: {
+          limit: "twenty",
+        },
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-model-list",
+        error: {
+          code: -32602,
+          message: "Invalid params",
+        },
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("filters hidden models by default", async () => {
+    const harness = await createProtocolHarness({
+      agentAdapters: [
+        createFakeProtocolAgentAdapter({
+          listModelsResult: {
+            ok: true,
+            data: {
+              models: [createProtocolModel(), createProtocolHiddenModel()],
+              nextCursor: null,
+            },
+          },
+        }),
+      ],
+    });
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      await initializeClient(client);
+
+      client.sendJson({
+        id: "req-model-list",
+        method: "model/list",
+        params: {},
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-model-list",
+        result: {
+          models: [createProtocolModel()],
+          nextCursor: null,
+        },
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("includes hidden models when requested", async () => {
+    const harness = await createProtocolHarness({
+      agentAdapters: [
+        createFakeProtocolAgentAdapter({
+          listModelsResult: {
+            ok: true,
+            data: {
+              models: [createProtocolModel(), createProtocolHiddenModel()],
+              nextCursor: null,
+            },
+          },
+        }),
+      ],
+    });
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      await initializeClient(client);
+
+      client.sendJson({
+        id: "req-model-list",
+        method: "model/list",
+        params: {
+          includeHidden: true,
+        },
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-model-list",
+        result: {
+          models: [createProtocolModel(), createProtocolHiddenModel()],
+          nextCursor: null,
+        },
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("maps agent session startup failures to agent session unavailable", async () => {
+    const harness = await createProtocolHarness({
+      agentAdapters: [
+        createFakeProtocolAgentAdapter({
+          createSessionResult: {
+            ok: false,
+            error: {
+              type: "sessionUnavailable",
+              agentId: "codex",
+              provider: "codex",
+              code: "startupFailed",
+              message: "Codex failed to start.",
+            },
+          },
+        }),
+      ],
+    });
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      await initializeClient(client);
+
+      client.sendJson({
+        id: "req-model-list",
+        method: "model/list",
+        params: {},
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-model-list",
+        error: {
+          code: -33004,
+          message: "Agent session unavailable",
+          data: {
+            code: "AGENT_SESSION_UNAVAILABLE",
+            agentId: "codex",
+            provider: "codex",
+            reason: "startupFailed",
+            message: "Codex failed to start.",
+          },
+        },
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("maps provider remote errors to provider error", async () => {
+    const harness = await createProtocolHarness({
+      agentAdapters: [
+        createFakeProtocolAgentAdapter({
+          listModelsResult: {
+            ok: false,
+            error: {
+              type: "remoteError",
+              agentId: "codex",
+              provider: "codex",
+              requestId: "req-model-list",
+              code: 418,
+              message: "Provider said no.",
+            },
+          },
+        }),
+      ],
+    });
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      await initializeClient(client);
+
+      client.sendJson({
+        id: "req-model-list",
+        method: "model/list",
+        params: {},
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-model-list",
+        error: {
+          code: -33005,
+          message: "Provider error",
+          data: {
+            code: "PROVIDER_ERROR",
+            agentId: "codex",
+            provider: "codex",
+            providerCode: "418",
+            providerMessage: "Provider said no.",
+          },
+        },
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
   test("opens a workspace after initialize", async () => {
     const harness = await createProtocolHarness();
     const client = await connectProtocolClient(harness.port);
@@ -367,22 +666,70 @@ type ProtocolTestClient = Readonly<{
   close: () => Promise<void>;
 }>;
 
-const createProtocolHarness = async (): Promise<Readonly<{ port: number }>> => {
+const createProtocolHarness = async (
+  options: Readonly<{
+    agentAdapters?: readonly AgentAdapter[];
+  }> = {},
+): Promise<Readonly<{ port: number }>> => {
   const port = await getAvailablePort();
   const configDirectory = await createTemporaryDirectory("atelier-appserver-protocol-");
+  const config = {
+    configPath: join(configDirectory, "appserver.config.json"),
+    port,
+    databasePath: "./var/test.sqlite",
+    logLevel: "info" as const,
+    agents: createTestAgentsConfig(),
+  };
+  const logger = createLogger({
+    level: "error",
+    write: () => {},
+  });
+  const appProtocolRuntime = createAppProtocolRuntime({
+    logger,
+  });
+  const storeBootstrap = createStoreBootstrap({
+    config,
+    logger: logger.withContext({ component: "core.store" }),
+  });
+  const workspacesFeature = createWorkspacesFeature({
+    logger: logger.withContext({ component: "feature.workspaces" }),
+    registerMethod: appProtocolRuntime.registerMethod,
+    store: createSqliteWorkspacesStore(storeBootstrap.getDatabase),
+  });
+  const agentsFeature = createAgentsFeature({
+    config: config.agents,
+    logger: logger.withContext({ component: "feature.agents" }),
+    adapters: options.agentAdapters ?? [
+      createCodexAgentAdapter({
+        logger: logger.withContext({ component: "agents.codex" }),
+      }),
+    ],
+    registerMethod: appProtocolRuntime.registerMethod,
+  });
+  const transportComponent = createAppTransportComponent({
+    config,
+    logger,
+    protocol: appProtocolRuntime,
+    onConnectionClosed: [
+      ({ connectionId }) => {
+        workspacesFeature.handleConnectionClosed(connectionId);
+      },
+    ],
+  });
   const server = createConfiguredAppServer({
-    config: {
-      configPath: join(configDirectory, "appserver.config.json"),
-      port,
-      databasePath: "./var/test.sqlite",
-      logLevel: "info",
-      agents: createTestAgentsConfig(),
-    },
-    logger: createLogger({
-      level: "error",
-      write: () => {},
-    }),
+    config,
+    logger,
     signalRegistrar: createSignalRegistrar(),
+    components: [
+      appProtocolRuntime.protocolComponent,
+      storeBootstrap.lifecycle,
+      agentsFeature.lifecycle,
+      workspacesFeature.lifecycle,
+      createThreadsFeaturePlaceholder(),
+      createTurnsFeaturePlaceholder(),
+      createApprovalsFeaturePlaceholder(),
+      transportComponent,
+    ],
   });
 
   await server.start();
@@ -408,6 +755,26 @@ const createWorkspaceDirectory = async (): Promise<string> => {
   await mkdir(workspacePath, { recursive: true });
 
   return workspacePath;
+};
+
+const initializeClient = async (client: ProtocolTestClient): Promise<void> => {
+  client.sendJson({
+    id: "req-initialize",
+    method: "initialize",
+    params: {
+      clientInfo: {
+        name: "AtelierCode Test",
+        version: "0.1.0",
+      },
+    },
+  });
+
+  await expect(client.nextMessage()).resolves.toEqual({
+    id: "req-initialize",
+    result: {
+      userAgent: APP_SERVER_USER_AGENT,
+    },
+  });
 };
 
 const connectProtocolClient = async (port: number): Promise<ProtocolTestClient> => {
@@ -518,6 +885,161 @@ const waitForSocketOpen = async (socket: WebSocket): Promise<void> => {
     socket.addEventListener("error", onError, { once: true });
   });
 };
+
+const createFakeProtocolAgentAdapter = (options: {
+  createSessionResult?:
+    | Readonly<{
+        ok: true;
+        data: ReturnType<typeof createFakeProtocolAgentSession>;
+      }>
+    | Readonly<{
+        ok: false;
+        error: {
+          type: "sessionUnavailable";
+          agentId: string;
+          provider: "codex";
+          code: "executableMissing" | "startupFailed" | "disconnected";
+          message: string;
+        };
+      }>;
+  listModelsResult?:
+    | Readonly<{
+        ok: true;
+        data: {
+          models: readonly ReturnType<typeof createProtocolModel>[];
+          nextCursor: string | null;
+        };
+      }>
+    | Readonly<{
+        ok: false;
+        error:
+          | Readonly<{
+              type: "remoteError";
+              agentId: string;
+              provider: "codex";
+              requestId: string | number;
+              code: number;
+              message: string;
+            }>
+          | Readonly<{
+              type: "invalidProviderMessage";
+              agentId: string;
+              provider: "codex";
+              message: string;
+            }>;
+      }>;
+}): AgentAdapter => ({
+  provider: "codex",
+  createSession: async () =>
+    options.createSessionResult ?? {
+      ok: true,
+      data: createFakeProtocolAgentSession({
+        listModelsResult: options.listModelsResult ?? {
+          ok: true,
+          data: {
+            models: [createProtocolModel()],
+            nextCursor: null,
+          },
+        },
+      }),
+    },
+});
+
+const createFakeProtocolAgentSession = (options: {
+  listModelsResult:
+    | Readonly<{
+        ok: true;
+        data: {
+          models: readonly ReturnType<typeof createProtocolModel>[];
+          nextCursor: string | null;
+        };
+      }>
+    | Readonly<{
+        ok: false;
+        error:
+          | Readonly<{
+              type: "remoteError";
+              agentId: string;
+              provider: "codex";
+              requestId: string | number;
+              code: number;
+              message: string;
+            }>
+          | Readonly<{
+              type: "invalidProviderMessage";
+              agentId: string;
+              provider: "codex";
+              message: string;
+            }>;
+      }>;
+}) => ({
+  agentId: "codex",
+  provider: "codex" as const,
+  getState: () => "ready" as const,
+  subscribe: () => () => {},
+  listModels: async () => options.listModelsResult,
+  startThread: async () => {
+    throw new Error("startThread should not be called in this test.");
+  },
+  resumeThread: async () => {
+    throw new Error("resumeThread should not be called in this test.");
+  },
+  readThread: async () => {
+    throw new Error("readThread should not be called in this test.");
+  },
+  forkThread: async () => {
+    throw new Error("forkThread should not be called in this test.");
+  },
+  startTurn: async () => {
+    throw new Error("startTurn should not be called in this test.");
+  },
+  steerTurn: async () => {
+    throw new Error("steerTurn should not be called in this test.");
+  },
+  interruptTurn: async () => {
+    throw new Error("interruptTurn should not be called in this test.");
+  },
+  resolveApproval: async () => {
+    throw new Error("resolveApproval should not be called in this test.");
+  },
+  disconnect: async () => {},
+});
+
+const createProtocolModel = (
+  overrides: Partial<
+    Readonly<{
+      id: string;
+      model: string;
+      displayName: string;
+      hidden: boolean;
+      isDefault: boolean;
+    }>
+  > = {},
+) =>
+  Object.freeze({
+    id: overrides.id ?? "gpt-5.4",
+    model: overrides.model ?? "gpt-5.4",
+    displayName: overrides.displayName ?? "GPT-5.4",
+    hidden: overrides.hidden ?? false,
+    defaultReasoningEffort: "medium" as const,
+    supportedReasoningEfforts: [
+      {
+        reasoningEffort: "medium" as const,
+        description: "Balanced",
+      },
+    ],
+    inputModalities: ["text"],
+    supportsPersonality: true,
+    isDefault: overrides.isDefault ?? false,
+  });
+
+const createProtocolHiddenModel = () =>
+  createProtocolModel({
+    id: "gpt-5.4-hidden",
+    model: "gpt-5.4-hidden",
+    displayName: "GPT-5.4 Hidden",
+    hidden: true,
+  });
 
 const toMessageText = (data: unknown): string => {
   if (typeof data === "string") {

--- a/AppServer/src/app/protocol-harness.test.ts
+++ b/AppServer/src/app/protocol-harness.test.ts
@@ -14,6 +14,11 @@ import {
 import { type AppServer, createConfiguredAppServer, type SignalRegistrar } from "@/app/server";
 import { createApprovalsFeaturePlaceholder } from "@/approvals";
 import { createStoreBootstrap } from "@/core/store";
+import {
+  createFakeAgentAdapter,
+  createFakeAgentSession,
+  createTestAgentModel,
+} from "@/test-support/agents";
 import { getAvailablePort } from "@/test-support/network";
 import { createThreadsFeaturePlaceholder } from "@/threads";
 import { createTurnsFeaturePlaceholder } from "@/turns";
@@ -214,7 +219,7 @@ describe("App Server protocol harness", () => {
             ok: true,
             data: {
               models: [
-                createProtocolModel({
+                createTestAgentModel({
                   id: "gpt-5.4",
                   model: "gpt-5.4",
                   displayName: "GPT-5.4",
@@ -264,6 +269,46 @@ describe("App Server protocol harness", () => {
           nextCursor: "cursor-2",
         },
       });
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("maps protocol request IDs to agent request IDs before calling the adapter", async () => {
+    const session = createFakeAgentSession({
+      listModels: async () => ({
+        ok: true,
+        data: {
+          models: [createTestAgentModel()],
+          nextCursor: null,
+        },
+      }),
+    });
+    const harness = await createProtocolHarness({
+      agentAdapters: [
+        createFakeAgentAdapter({
+          session,
+        }),
+      ],
+    });
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      await initializeClient(client);
+
+      client.sendJson({
+        id: "req-model-list",
+        method: "model/list",
+        params: {},
+      });
+
+      await client.nextMessage();
+
+      expect(session.listModelsCalls).toHaveLength(1);
+      expect(session.listModelsCalls[0]?.requestId).not.toBe("req-model-list");
+      expect(session.listModelsCalls[0]?.requestId).toEqual(
+        expect.stringMatching(/^atelier-appserver:model\/list:.*:req-model-list$/),
+      );
     } finally {
       await client.close();
     }
@@ -329,7 +374,17 @@ describe("App Server protocol harness", () => {
           listModelsResult: {
             ok: true,
             data: {
-              models: [createProtocolModel(), createProtocolHiddenModel()],
+              models: [
+                createTestAgentModel(),
+                createTestAgentModel({
+                  id: "gpt-5.4-hidden",
+                  model: "gpt-5.4-hidden",
+                  displayName: "GPT-5.4 Hidden",
+                  hidden: true,
+                  defaultReasoningEffort: "high",
+                  supportsPersonality: false,
+                }),
+              ],
               nextCursor: null,
             },
           },
@@ -350,7 +405,7 @@ describe("App Server protocol harness", () => {
       await expect(client.nextMessage()).resolves.toEqual({
         id: "req-model-list",
         result: {
-          models: [createProtocolModel()],
+          models: [createTestAgentModel()],
           nextCursor: null,
         },
       });
@@ -366,7 +421,17 @@ describe("App Server protocol harness", () => {
           listModelsResult: {
             ok: true,
             data: {
-              models: [createProtocolModel(), createProtocolHiddenModel()],
+              models: [
+                createTestAgentModel(),
+                createTestAgentModel({
+                  id: "gpt-5.4-hidden",
+                  model: "gpt-5.4-hidden",
+                  displayName: "GPT-5.4 Hidden",
+                  hidden: true,
+                  defaultReasoningEffort: "high",
+                  supportsPersonality: false,
+                }),
+              ],
               nextCursor: null,
             },
           },
@@ -389,7 +454,17 @@ describe("App Server protocol harness", () => {
       await expect(client.nextMessage()).resolves.toEqual({
         id: "req-model-list",
         result: {
-          models: [createProtocolModel(), createProtocolHiddenModel()],
+          models: [
+            createTestAgentModel(),
+            createTestAgentModel({
+              id: "gpt-5.4-hidden",
+              model: "gpt-5.4-hidden",
+              displayName: "GPT-5.4 Hidden",
+              hidden: true,
+              defaultReasoningEffort: "high",
+              supportsPersonality: false,
+            }),
+          ],
           nextCursor: null,
         },
       });
@@ -890,7 +965,7 @@ const createFakeProtocolAgentAdapter = (options: {
   createSessionResult?:
     | Readonly<{
         ok: true;
-        data: ReturnType<typeof createFakeProtocolAgentSession>;
+        data: ReturnType<typeof createFakeAgentSession>;
       }>
     | Readonly<{
         ok: false;
@@ -906,7 +981,7 @@ const createFakeProtocolAgentAdapter = (options: {
     | Readonly<{
         ok: true;
         data: {
-          models: readonly ReturnType<typeof createProtocolModel>[];
+          models: readonly ReturnType<typeof createTestAgentModel>[];
           nextCursor: string | null;
         };
       }>
@@ -928,117 +1003,19 @@ const createFakeProtocolAgentAdapter = (options: {
               message: string;
             }>;
       }>;
-}): AgentAdapter => ({
-  provider: "codex",
-  createSession: async () =>
-    options.createSessionResult ?? {
-      ok: true,
-      data: createFakeProtocolAgentSession({
-        listModelsResult: options.listModelsResult ?? {
+}): AgentAdapter =>
+  createFakeAgentAdapter({
+    createSessionResult: options.createSessionResult,
+    session: createFakeAgentSession({
+      listModels: async () =>
+        options.listModelsResult ?? {
           ok: true,
           data: {
-            models: [createProtocolModel()],
+            models: [createTestAgentModel()],
             nextCursor: null,
           },
         },
-      }),
-    },
-});
-
-const createFakeProtocolAgentSession = (options: {
-  listModelsResult:
-    | Readonly<{
-        ok: true;
-        data: {
-          models: readonly ReturnType<typeof createProtocolModel>[];
-          nextCursor: string | null;
-        };
-      }>
-    | Readonly<{
-        ok: false;
-        error:
-          | Readonly<{
-              type: "remoteError";
-              agentId: string;
-              provider: "codex";
-              requestId: string | number;
-              code: number;
-              message: string;
-            }>
-          | Readonly<{
-              type: "invalidProviderMessage";
-              agentId: string;
-              provider: "codex";
-              message: string;
-            }>;
-      }>;
-}) => ({
-  agentId: "codex",
-  provider: "codex" as const,
-  getState: () => "ready" as const,
-  subscribe: () => () => {},
-  listModels: async () => options.listModelsResult,
-  startThread: async () => {
-    throw new Error("startThread should not be called in this test.");
-  },
-  resumeThread: async () => {
-    throw new Error("resumeThread should not be called in this test.");
-  },
-  readThread: async () => {
-    throw new Error("readThread should not be called in this test.");
-  },
-  forkThread: async () => {
-    throw new Error("forkThread should not be called in this test.");
-  },
-  startTurn: async () => {
-    throw new Error("startTurn should not be called in this test.");
-  },
-  steerTurn: async () => {
-    throw new Error("steerTurn should not be called in this test.");
-  },
-  interruptTurn: async () => {
-    throw new Error("interruptTurn should not be called in this test.");
-  },
-  resolveApproval: async () => {
-    throw new Error("resolveApproval should not be called in this test.");
-  },
-  disconnect: async () => {},
-});
-
-const createProtocolModel = (
-  overrides: Partial<
-    Readonly<{
-      id: string;
-      model: string;
-      displayName: string;
-      hidden: boolean;
-      isDefault: boolean;
-    }>
-  > = {},
-) =>
-  Object.freeze({
-    id: overrides.id ?? "gpt-5.4",
-    model: overrides.model ?? "gpt-5.4",
-    displayName: overrides.displayName ?? "GPT-5.4",
-    hidden: overrides.hidden ?? false,
-    defaultReasoningEffort: "medium" as const,
-    supportedReasoningEfforts: [
-      {
-        reasoningEffort: "medium" as const,
-        description: "Balanced",
-      },
-    ],
-    inputModalities: ["text"],
-    supportsPersonality: true,
-    isDefault: overrides.isDefault ?? false,
-  });
-
-const createProtocolHiddenModel = () =>
-  createProtocolModel({
-    id: "gpt-5.4-hidden",
-    model: "gpt-5.4-hidden",
-    displayName: "GPT-5.4 Hidden",
-    hidden: true,
+    }),
   });
 
 const toMessageText = (data: unknown): string => {

--- a/AppServer/src/app/server.ts
+++ b/AppServer/src/app/server.ts
@@ -320,6 +320,7 @@ const createDefaultComponents = (
         logger: logger.withContext({ component: "agents.codex" }),
       }),
     ],
+    registerMethod: appProtocolRuntime.registerMethod,
   });
   const transportComponent = createAppTransportComponent({
     config,

--- a/AppServer/src/core/protocol/dispatcher.ts
+++ b/AppServer/src/core/protocol/dispatcher.ts
@@ -1,5 +1,6 @@
 import type { Static, TSchema } from "@sinclair/typebox";
 import type { ProtocolMethodError } from "@/core/protocol/errors";
+import type { RequestId } from "@/core/protocol/schemas";
 import type { Result } from "@/core/shared";
 
 export type ProtocolSession = Readonly<{
@@ -9,6 +10,7 @@ export type ProtocolSession = Readonly<{
 
 export type ProtocolMethodContext = Readonly<{
   connectionId: string;
+  requestId: RequestId;
   session: ProtocolSession;
 }>;
 

--- a/AppServer/src/core/protocol/engine.ts
+++ b/AppServer/src/core/protocol/engine.ts
@@ -201,6 +201,7 @@ export const createProtocolEngine = (options: CreateProtocolEngineOptions): Prot
     try {
       const methodResult = await registeredMethod.handler({
         connectionId,
+        requestId: request.id,
         params: request.params,
         session,
       });

--- a/AppServer/src/core/protocol/errors.ts
+++ b/AppServer/src/core/protocol/errors.ts
@@ -7,10 +7,15 @@ export const JSON_RPC_METHOD_NOT_FOUND_ERROR = -32601;
 export const JSON_RPC_INVALID_PARAMS_ERROR = -32602;
 export const JSON_RPC_INTERNAL_ERROR = -32603;
 
+// Atelier-owned protocol errors reserve the `-33000` to `-33099` range.
+// Keep the registry centralized in this module to avoid collisions as more
+// feature methods add domain-specific protocol failures.
 export const ATELIER_SESSION_ALREADY_INITIALIZED_ERROR = -33000;
 export const ATELIER_SESSION_NOT_INITIALIZED_ERROR = -33001;
 export const ATELIER_WORKSPACE_PATH_NOT_FOUND_ERROR = -33002;
 export const ATELIER_WORKSPACE_PATH_NOT_DIRECTORY_ERROR = -33003;
+export const ATELIER_AGENT_SESSION_UNAVAILABLE_ERROR = -33004;
+export const ATELIER_PROVIDER_ERROR = -33005;
 
 export type ProtocolMethodError = Readonly<{
   code: number;

--- a/AppServer/src/core/shared/assert-never.ts
+++ b/AppServer/src/core/shared/assert-never.ts
@@ -1,0 +1,6 @@
+export const assertNever = (
+  value: never,
+  message = "Unhandled discriminated union member",
+): never => {
+  throw new Error(`${message}: ${JSON.stringify(value)}`);
+};

--- a/AppServer/src/core/shared/index.ts
+++ b/AppServer/src/core/shared/index.ts
@@ -1,3 +1,4 @@
+export * from "@/core/shared/assert-never";
 export * from "@/core/shared/get-error-message";
 export * from "@/core/shared/lifecycle";
 export * from "@/core/shared/result";

--- a/AppServer/src/test-support/agents.ts
+++ b/AppServer/src/test-support/agents.ts
@@ -1,0 +1,186 @@
+import type { AgentAdapter } from "@/agents/adapter";
+import type {
+  AgentListModelsParams,
+  AgentListModelsResult,
+  AgentNotification,
+  AgentOperationResult,
+  AgentRequestId,
+  AgentSession,
+  AgentSessionLookupError,
+  AgentSessionState,
+} from "@/agents/contracts";
+import type { AgentRegistry } from "@/agents/registry";
+
+export type FakeAgentSession = AgentSession &
+  Readonly<{
+    listModelsCalls: readonly Readonly<{
+      requestId: AgentRequestId;
+      params: AgentListModelsParams;
+    }>[];
+  }>;
+
+export type CreateFakeAgentSessionOptions = Readonly<{
+  agentId?: string;
+  state?: AgentSessionState;
+  listModels?: (
+    requestId: AgentRequestId,
+    params: AgentListModelsParams,
+  ) => Promise<AgentOperationResult<AgentListModelsResult>>;
+}>;
+
+export const createFakeAgentSession = (
+  options: CreateFakeAgentSessionOptions = {},
+): FakeAgentSession => {
+  let state = options.state ?? "ready";
+  const listModelsCalls: Array<
+    Readonly<{
+      requestId: AgentRequestId;
+      params: AgentListModelsParams;
+    }>
+  > = [];
+
+  return {
+    agentId: options.agentId ?? "codex",
+    provider: "codex",
+    getState: () => state,
+    subscribe: (_listener: (notification: AgentNotification) => void) => () => {},
+    listModels: async (requestId, params) => {
+      listModelsCalls.push(
+        Object.freeze({
+          requestId,
+          params,
+        }),
+      );
+
+      return (
+        (await options.listModels?.(requestId, params)) ?? {
+          ok: true,
+          data: {
+            models: [],
+            nextCursor: null,
+          },
+        }
+      );
+    },
+    startThread: async () => {
+      throw new Error("startThread should not be called in this test.");
+    },
+    resumeThread: async () => {
+      throw new Error("resumeThread should not be called in this test.");
+    },
+    readThread: async () => {
+      throw new Error("readThread should not be called in this test.");
+    },
+    forkThread: async () => {
+      throw new Error("forkThread should not be called in this test.");
+    },
+    startTurn: async () => {
+      throw new Error("startTurn should not be called in this test.");
+    },
+    steerTurn: async () => {
+      throw new Error("steerTurn should not be called in this test.");
+    },
+    interruptTurn: async () => {
+      throw new Error("interruptTurn should not be called in this test.");
+    },
+    resolveApproval: async () => {
+      throw new Error("resolveApproval should not be called in this test.");
+    },
+    disconnect: async () => {
+      state = "disconnected";
+    },
+    listModelsCalls,
+  };
+};
+
+export const createFakeAgentRegistry = (
+  session: AgentSession,
+): AgentRegistry &
+  Readonly<{
+    requestedAgentIds: readonly (string | undefined)[];
+  }> => {
+  const requestedAgentIds: Array<string | undefined> = [];
+
+  return {
+    requestedAgentIds,
+    getDefaultAgentId: () => "codex",
+    listAgents: () => [
+      {
+        id: "codex",
+        provider: "codex",
+      },
+    ],
+    getAgent: (agentId) =>
+      agentId === "codex"
+        ? {
+            id: "codex",
+            provider: "codex",
+          }
+        : undefined,
+    getSession: async (agentId) => {
+      requestedAgentIds.push(agentId);
+      return {
+        ok: true,
+        data: session,
+      };
+    },
+    disconnectAll: async () => {},
+  };
+};
+
+export type CreateFakeAgentAdapterOptions = Readonly<{
+  createSessionResult?:
+    | Readonly<{
+        ok: true;
+        data: AgentSession;
+      }>
+    | Readonly<{
+        ok: false;
+        error: AgentSessionLookupError;
+      }>;
+  session?: AgentSession;
+}>;
+
+export const createFakeAgentAdapter = (
+  options: CreateFakeAgentAdapterOptions = {},
+): AgentAdapter => ({
+  provider: "codex",
+  createSession: async () =>
+    options.createSessionResult ?? {
+      ok: true,
+      data: options.session ?? createFakeAgentSession(),
+    },
+});
+
+export const createTestAgentModel = (
+  overrides: Partial<
+    Readonly<{
+      id: string;
+      model: string;
+      displayName: string;
+      hidden: boolean;
+      isDefault: boolean;
+      defaultReasoningEffort: "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
+      supportsPersonality: boolean;
+    }>
+  > = {},
+) =>
+  Object.freeze({
+    id: overrides.id ?? "gpt-5.4",
+    model: overrides.model ?? "gpt-5.4",
+    displayName: overrides.displayName ?? "GPT-5.4",
+    hidden: overrides.hidden ?? false,
+    defaultReasoningEffort: overrides.defaultReasoningEffort ?? ("medium" as const),
+    supportedReasoningEfforts: [
+      {
+        reasoningEffort: overrides.defaultReasoningEffort ?? ("medium" as const),
+        description:
+          (overrides.defaultReasoningEffort ?? "medium") === "high"
+            ? "Deeper reasoning"
+            : "Balanced",
+      },
+    ],
+    inputModalities: ["text"],
+    supportsPersonality: overrides.supportsPersonality ?? true,
+    isDefault: overrides.isDefault ?? false,
+  });


### PR DESCRIPTION
## Summary
- add the first agent-backed `model/list` App Server method with provider-neutral schemas, service flow, and handler registration
- map agent session startup failures and upstream provider errors to explicit Atelier protocol errors
- preserve `nextCursor`, filter hidden models by default, and normalize Codex model metadata for the public contract
- extend protocol harness, agents service, and Codex adapter seam tests for `model/list`
- include the related App Server foundation and Codex contract import updates needed for this phase

## Testing
- `bun run check`
- `bun run typecheck`
- `bun test src/agents/service.test.ts src/app/protocol-harness.test.ts src/agents/codex-adapter/session.test.ts`