### PR TITLE
Add App Server thread creation and loading support

### DIFF
--- a/AppServer/drizzle/0002_vivid_blizzard.sql
+++ b/AppServer/drizzle/0002_vivid_blizzard.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `workspace_threads` ADD `model` text;
+--> statement-breakpoint
+ALTER TABLE `workspace_threads` ADD `reasoning_effort` text;

--- a/AppServer/drizzle/meta/0002_snapshot.json
+++ b/AppServer/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,141 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "9b61a297-6044-4bfb-9357-4d9cbf8935e9",
+  "prevId": "8e05c6c2-d3ed-45bc-8574-19d0b5b5c192",
+  "tables": {
+    "workspace_threads": {
+      "name": "workspace_threads",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_workspace_path": {
+          "name": "thread_workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_threads_workspace_provider_thread_unique": {
+          "name": "workspace_threads_workspace_provider_thread_unique",
+          "columns": ["workspace_id", "provider", "thread_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspaces": {
+      "name": "workspaces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspaces_workspace_path_unique": {
+          "name": "workspaces_workspace_path_unique",
+          "columns": ["workspace_path"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/AppServer/drizzle/meta/_journal.json
+++ b/AppServer/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1775873148255,
       "tag": "0001_lucky_hellion",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1776110400000,
+      "tag": "0002_vivid_blizzard",
+      "breakpoints": true
     }
   ]
 }

--- a/AppServer/src/agents/codex-adapter/model-mapper.test.ts
+++ b/AppServer/src/agents/codex-adapter/model-mapper.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { mapCodexThread } from "@/agents/codex-adapter/model-mapper";
+
+describe("mapCodexThread", () => {
+  test("rejects negative provider timestamps instead of clamping them", () => {
+    expect(() =>
+      mapCodexThread({
+        id: "thread-1",
+        preview: "Thread preview",
+        createdAt: -1,
+        updatedAt: 1,
+        name: null,
+        status: { type: "idle" },
+        cwd: "/tmp/project",
+      }),
+    ).toThrow("Codex thread createdAt must be a non-negative unix timestamp.");
+  });
+});

--- a/AppServer/src/agents/codex-adapter/model-mapper.ts
+++ b/AppServer/src/agents/codex-adapter/model-mapper.ts
@@ -64,8 +64,8 @@ export const mapCodexThread = (
   Object.freeze({
     id: thread.id,
     preview: thread.preview,
-    createdAt: new Date(Math.max(0, thread.createdAt) * 1_000).toISOString(),
-    updatedAt: new Date(Math.max(0, thread.updatedAt) * 1_000).toISOString(),
+    createdAt: mapUnixTimestampToIso(thread.createdAt, "createdAt"),
+    updatedAt: mapUnixTimestampToIso(thread.updatedAt, "updatedAt"),
     workspacePath: thread.cwd,
     name: thread.name,
     archived: options.archived ?? false,
@@ -108,4 +108,12 @@ const mapAgentThreadSummary = (thread: AgentThread): AgentThreadSummary =>
 
 const assertNever = (value: never): never => {
   throw new Error(`Unhandled Codex mapping variant: ${JSON.stringify(value)}`);
+};
+
+const mapUnixTimestampToIso = (value: number, fieldName: "createdAt" | "updatedAt"): string => {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`Codex thread ${fieldName} must be a non-negative unix timestamp.`);
+  }
+
+  return new Date(value * 1_000).toISOString();
 };

--- a/AppServer/src/agents/codex-adapter/protocol.ts
+++ b/AppServer/src/agents/codex-adapter/protocol.ts
@@ -108,6 +108,15 @@ const CodexThreadResponseSchema = Type.Object(
   { additionalProperties: true },
 );
 
+const CodexConfiguredThreadResponseSchema = Type.Object(
+  {
+    thread: CodexThreadSchema,
+    model: Type.String(),
+    reasoningEffort: Type.Union([CodexReasoningEffortSchema, Type.Null()]),
+  },
+  { additionalProperties: true },
+);
+
 const CodexTurnSchema = Type.Object(
   {
     id: Type.String(),
@@ -211,6 +220,7 @@ export type CodexModelListResponse = Static<typeof CodexModelListResponseSchema>
 export type CodexThreadStatus = Static<typeof CodexThreadStatusSchema>;
 export type CodexThread = Static<typeof CodexThreadSchema>;
 export type CodexThreadListResponse = Static<typeof CodexThreadListResponseSchema>;
+export type CodexConfiguredThreadResponse = Static<typeof CodexConfiguredThreadResponseSchema>;
 export type CodexTurn = Static<typeof CodexTurnSchema>;
 export type CodexInitializeResponse = Static<typeof CodexInitializeResponseSchema>;
 export type CodexTurnPlanUpdatedNotification = Static<
@@ -338,6 +348,15 @@ export const parseCodexThreadListResponse = (candidate: unknown): CodexThreadLis
 
 export const parseCodexThreadResponse = (candidate: unknown): { thread: CodexThread } =>
   validateCodexPayload(CodexThreadResponseSchema, candidate, "thread response");
+
+export const parseCodexConfiguredThreadResponse = (
+  candidate: unknown,
+): CodexConfiguredThreadResponse =>
+  validateCodexPayload(
+    CodexConfiguredThreadResponseSchema,
+    candidate,
+    "configured thread response",
+  );
 
 export const parseCodexTurnResponse = (candidate: unknown): { turn: CodexTurn } =>
   validateCodexPayload(CodexTurnResponseSchema, candidate, "turn response");

--- a/AppServer/src/agents/codex-adapter/session.ts
+++ b/AppServer/src/agents/codex-adapter/session.ts
@@ -28,6 +28,7 @@ import type {
   CodexUserInput,
 } from "@/agents/codex-adapter/protocol";
 import {
+  parseCodexConfiguredThreadResponse,
   parseCodexInitializeResponse,
   parseCodexModelListResponse,
   parseCodexThreadListResponse,
@@ -388,7 +389,7 @@ const createConnectedSession = (options: ConnectedSessionOptions): AgentSession 
     params: AgentThreadStartParams,
   ): Promise<AgentOperationResult<AgentThreadResult>> =>
     runOperation(requestId, async () => {
-      const response = parseCodexThreadResponse(
+      const response = parseCodexConfiguredThreadResponse(
         await options.transport.send({
           id: requestId,
           method: "thread/start",
@@ -398,6 +399,8 @@ const createConnectedSession = (options: ConnectedSessionOptions): AgentSession 
 
       return {
         thread: mapCodexThread(response.thread),
+        model: response.model,
+        reasoningEffort: response.reasoningEffort,
       };
     });
 
@@ -406,7 +409,7 @@ const createConnectedSession = (options: ConnectedSessionOptions): AgentSession 
     params: AgentThreadResumeParams,
   ): Promise<AgentOperationResult<AgentThreadResult>> =>
     runOperation(requestId, async () => {
-      const response = parseCodexThreadResponse(
+      const response = parseCodexConfiguredThreadResponse(
         await options.transport.send({
           id: requestId,
           method: "thread/resume",
@@ -416,6 +419,8 @@ const createConnectedSession = (options: ConnectedSessionOptions): AgentSession 
 
       return {
         thread: mapCodexThread(response.thread),
+        model: response.model,
+        reasoningEffort: response.reasoningEffort,
       };
     });
 

--- a/AppServer/src/agents/contracts.ts
+++ b/AppServer/src/agents/contracts.ts
@@ -315,6 +315,8 @@ export type AgentThreadForkParams = Readonly<{
 
 export type AgentThreadResult = Readonly<{
   thread: AgentThread;
+  model?: string;
+  reasoningEffort?: AgentReasoningEffort | null;
 }>;
 
 export type AgentTurnStartParams = Readonly<{

--- a/AppServer/src/app/protocol-harness.test.ts
+++ b/AppServer/src/app/protocol-harness.test.ts
@@ -13,7 +13,7 @@ import {
 } from "@/app/protocol";
 import { type AppServer, createConfiguredAppServer, type SignalRegistrar } from "@/app/server";
 import { createApprovalsModulePlaceholder } from "@/approvals";
-import { createStoreBootstrap } from "@/core/store";
+import { type AppDatabase, createStoreBootstrap } from "@/core/store";
 import {
   createFakeAgentAdapter,
   createFakeAgentSession,
@@ -21,7 +21,7 @@ import {
   createTestAgentThread,
 } from "@/test-support/agents";
 import { getAvailablePort } from "@/test-support/network";
-import { createSqliteThreadsStore, createThreadsModule } from "@/threads";
+import { createSqliteThreadsStore, createThreadsModule, type ThreadsStore } from "@/threads";
 import { createTurnsModulePlaceholder } from "@/turns";
 import { createSqliteWorkspacesStore, createWorkspacesModule } from "@/workspaces";
 
@@ -811,6 +811,85 @@ describe("App Server protocol harness", () => {
     }
   });
 
+  test("thread/start still succeeds when bookkeeping writes fail and keeps loaded-thread forwarding", async () => {
+    const workspacePath = await createWorkspaceDirectory();
+    const canonicalWorkspacePath = await realpath(workspacePath);
+    const session = createFakeAgentSession({
+      startThread: async () => ({
+        ok: true,
+        data: {
+          thread: createTestAgentThread({
+            id: "thread-best-effort",
+            workspacePath: canonicalWorkspacePath,
+          }),
+          model: "gpt-5.4",
+          reasoningEffort: "medium",
+        },
+      }),
+    });
+    const harness = await createProtocolHarness({
+      agentAdapters: [
+        createFakeAgentAdapter({
+          session,
+        }),
+      ],
+      threadsStoreFactory: (getDatabase) =>
+        createFailingUpsertThreadsStore(createSqliteThreadsStore(getDatabase)),
+    });
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      await initializeClient(client);
+      await openWorkspaceClient(client, workspacePath);
+
+      client.sendJson({
+        id: "req-thread-start",
+        method: "thread/start",
+        params: {},
+      });
+
+      const messages = [await client.nextMessage(), await client.nextMessage()];
+      expect(messages).toContainEqual({
+        id: "req-thread-start",
+        result: {
+          thread: expect.objectContaining({
+            id: "thread-best-effort",
+            model: "gpt-5.4",
+            reasoningEffort: "medium",
+          }),
+        },
+      });
+      expect(messages).toContainEqual({
+        method: "thread/started",
+        params: {
+          thread: expect.objectContaining({
+            id: "thread-best-effort",
+          }),
+        },
+      });
+
+      session.emitNotification(
+        createThreadStatusChangedNotification({
+          threadId: "thread-best-effort",
+          status: { type: "active", activeFlags: ["running"] },
+        }),
+      );
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        method: "thread/status/changed",
+        params: {
+          threadId: "thread-best-effort",
+          status: {
+            type: "active",
+            activeFlags: ["running"],
+          },
+        },
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
   test("thread/read does not subscribe the connection to live thread notifications", async () => {
     const workspacePath = await createWorkspaceDirectory();
     const canonicalWorkspacePath = await realpath(workspacePath);
@@ -1083,6 +1162,67 @@ describe("App Server protocol harness", () => {
             },
           ],
           nextCursor: "cursor-2",
+        },
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("thread/list still succeeds when bookkeeping writes fail", async () => {
+    const workspacePath = await createWorkspaceDirectory();
+    const canonicalWorkspacePath = await realpath(workspacePath);
+    const harness = await createProtocolHarness({
+      agentAdapters: [
+        createFakeProtocolAgentAdapter({
+          listThreadsResult: {
+            ok: true,
+            data: {
+              threads: [
+                createTestAgentThread({
+                  id: "thread-best-effort",
+                  workspacePath: canonicalWorkspacePath,
+                }),
+              ],
+              nextCursor: null,
+            },
+          },
+        }),
+      ],
+      threadsStoreFactory: (getDatabase) =>
+        createFailingUpsertThreadsStore(createSqliteThreadsStore(getDatabase)),
+    });
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      await initializeClient(client);
+      await openWorkspaceClient(client, workspacePath);
+
+      client.sendJson({
+        id: "req-thread-list",
+        method: "thread/list",
+        params: {},
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-thread-list",
+        result: {
+          threads: [
+            {
+              id: "thread-best-effort",
+              preview: "Thread preview",
+              createdAt: "2026-04-10T10:00:00.000Z",
+              updatedAt: "2026-04-10T11:00:00.000Z",
+              name: null,
+              archived: false,
+              model: null,
+              reasoningEffort: null,
+              status: {
+                type: "idle",
+              },
+            },
+          ],
+          nextCursor: null,
         },
       });
     } finally {
@@ -1441,6 +1581,54 @@ describe("App Server protocol harness", () => {
     }
   });
 
+  test("maps malformed thread/list provider payloads to a stable protocol error", async () => {
+    const workspacePath = await createWorkspaceDirectory();
+    const harness = await createProtocolHarness({
+      agentAdapters: [
+        createFakeProtocolAgentAdapter({
+          listThreadsResult: {
+            ok: false,
+            error: {
+              type: "invalidProviderMessage",
+              agentId: "codex",
+              provider: "codex",
+              message: "Malformed thread list payload.",
+            },
+          },
+        }),
+      ],
+    });
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      await initializeClient(client);
+      await openWorkspaceClient(client, workspacePath);
+
+      client.sendJson({
+        id: "req-thread-list",
+        method: "thread/list",
+        params: {},
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-thread-list",
+        error: {
+          code: -33009,
+          message: "Provider returned an invalid payload",
+          data: {
+            code: "INVALID_PROVIDER_PAYLOAD",
+            agentId: "codex",
+            provider: "codex",
+            operation: "thread/list",
+            providerMessage: "Malformed thread list payload.",
+          },
+        },
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
   test("returns a workspace mismatch error when thread/read crosses workspace boundaries", async () => {
     const workspacePath = await createWorkspaceDirectory();
     const harness = await createProtocolHarness({
@@ -1502,6 +1690,7 @@ type ProtocolTestClient = Readonly<{
 const createProtocolHarness = async (
   options: Readonly<{
     agentAdapters?: readonly AgentAdapter[];
+    threadsStoreFactory?: (getDatabase: () => AppDatabase) => ThreadsStore;
   }> = {},
 ): Promise<Readonly<{ port: number }>> => {
   const port = await getAvailablePort();
@@ -1552,7 +1741,9 @@ const createProtocolHarness = async (
     registerMethod: appProtocolRuntime.registerMethod,
     sendNotification: appProtocolRuntime.sendNotification,
     registry: agentsModule.registry,
-    store: createSqliteThreadsStore(storeBootstrap.getDatabase),
+    store:
+      options.threadsStoreFactory?.(storeBootstrap.getDatabase) ??
+      createSqliteThreadsStore(storeBootstrap.getDatabase),
     getOpenedWorkspace: workspacesModule.getOpenedWorkspace,
   });
   const finalizedThreadsModule = threadsModule;
@@ -1598,6 +1789,15 @@ const createTestAgentsConfig = () => ({
     },
   ],
 });
+
+const createFailingUpsertThreadsStore = (store: ThreadsStore): ThreadsStore =>
+  Object.freeze({
+    getWorkspaceThreadLink: store.getWorkspaceThreadLink,
+    listWorkspaceThreadLinks: store.listWorkspaceThreadLinks,
+    upsertWorkspaceThreadLinks: async () => {
+      throw new Error("bookkeeping write failed");
+    },
+  });
 
 const createWorkspaceDirectory = async (): Promise<string> => {
   const rootDirectory = await createTemporaryDirectory("atelier-appserver-workspace-");

--- a/AppServer/src/app/protocol-harness.test.ts
+++ b/AppServer/src/app/protocol-harness.test.ts
@@ -11,7 +11,7 @@ import {
   createAppProtocolRuntime,
   createAppTransportComponent,
 } from "@/app/protocol";
-import { type AppServer, createConfiguredAppServer, type SignalRegistrar } from "@/app/server";
+import { type AppServer, createAppServer, type SignalRegistrar } from "@/app/server";
 import { createApprovalsModulePlaceholder } from "@/approvals";
 import { type AppDatabase, createStoreBootstrap } from "@/core/store";
 import {
@@ -1758,7 +1758,7 @@ const createProtocolHarness = async (
       },
     ],
   });
-  const server = createConfiguredAppServer({
+  const server = await createAppServer({
     config,
     logger,
     signalRegistrar: createSignalRegistrar(),

--- a/AppServer/src/app/protocol-harness.test.ts
+++ b/AppServer/src/app/protocol-harness.test.ts
@@ -130,7 +130,7 @@ describe("App Server protocol harness", () => {
     try {
       client.sendJson({
         id: "req-unknown",
-        method: "thread/start",
+        method: "thread/unknown",
         params: {},
       });
 
@@ -734,6 +734,293 @@ describe("App Server protocol harness", () => {
     }
   });
 
+  test("starts a thread, returns resolved defaults, and emits thread/started", async () => {
+    const workspacePath = await createWorkspaceDirectory();
+    const canonicalWorkspacePath = await realpath(workspacePath);
+    const session = createFakeAgentSession({
+      startThread: async () => ({
+        ok: true,
+        data: {
+          thread: createTestAgentThread({
+            id: "thread-started",
+            workspacePath: canonicalWorkspacePath,
+          }),
+          model: "gpt-5.4",
+          reasoningEffort: "medium",
+        },
+      }),
+    });
+    const harness = await createProtocolHarness({
+      agentAdapters: [
+        createFakeAgentAdapter({
+          session,
+        }),
+      ],
+    });
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      await initializeClient(client);
+      await openWorkspaceClient(client, workspacePath);
+
+      client.sendJson({
+        id: "req-thread-start",
+        method: "thread/start",
+        params: {},
+      });
+
+      const messages = [await client.nextMessage(), await client.nextMessage()];
+      expect(messages).toContainEqual({
+        id: "req-thread-start",
+        result: {
+          thread: {
+            id: "thread-started",
+            preview: "Thread preview",
+            createdAt: "2026-04-10T10:00:00.000Z",
+            updatedAt: "2026-04-10T11:00:00.000Z",
+            name: null,
+            archived: false,
+            model: "gpt-5.4",
+            reasoningEffort: "medium",
+            status: {
+              type: "idle",
+            },
+          },
+        },
+      });
+      expect(messages).toContainEqual({
+        method: "thread/started",
+        params: {
+          thread: {
+            id: "thread-started",
+            preview: "Thread preview",
+            createdAt: "2026-04-10T10:00:00.000Z",
+            updatedAt: "2026-04-10T11:00:00.000Z",
+            name: null,
+            archived: false,
+            model: "gpt-5.4",
+            reasoningEffort: "medium",
+            status: {
+              type: "idle",
+            },
+          },
+        },
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("thread/read does not subscribe the connection to live thread notifications", async () => {
+    const workspacePath = await createWorkspaceDirectory();
+    const canonicalWorkspacePath = await realpath(workspacePath);
+    const session = createFakeAgentSession({
+      readThread: async () => ({
+        ok: true,
+        data: {
+          thread: createTestAgentThread({
+            id: "thread-read-only",
+            workspacePath: canonicalWorkspacePath,
+          }),
+        },
+      }),
+    });
+    const harness = await createProtocolHarness({
+      agentAdapters: [
+        createFakeAgentAdapter({
+          session,
+        }),
+      ],
+    });
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      await initializeClient(client);
+      await openWorkspaceClient(client, workspacePath);
+
+      client.sendJson({
+        id: "req-thread-read",
+        method: "thread/read",
+        params: {
+          threadId: "thread-read-only",
+          includeTurns: false,
+        },
+      });
+      await client.nextMessage();
+
+      session.emitNotification(
+        createThreadStatusChangedNotification({
+          threadId: "thread-read-only",
+          status: { type: "active", activeFlags: ["running"] },
+        }),
+      );
+
+      await expect(client.nextMessage(150)).rejects.toThrow("Timed out waiting for message");
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("fans out loaded-thread status notifications only to subscribed connections and cleans up on close", async () => {
+    const workspacePath = await createWorkspaceDirectory();
+    const canonicalWorkspacePath = await realpath(workspacePath);
+    const session = createFakeAgentSession({
+      resumeThread: async (_requestId, params) => ({
+        ok: true,
+        data: {
+          thread: createTestAgentThread({
+            id: params.threadId,
+            workspacePath: canonicalWorkspacePath,
+          }),
+          model: "gpt-5.4",
+          reasoningEffort: "medium",
+        },
+      }),
+    });
+    const harness = await createProtocolHarness({
+      agentAdapters: [
+        createFakeAgentAdapter({
+          session,
+        }),
+      ],
+    });
+    const clientA = await connectProtocolClient(harness.port);
+    const clientB = await connectProtocolClient(harness.port);
+    const bystander = await connectProtocolClient(harness.port);
+
+    try {
+      await initializeClient(clientA);
+      await initializeClient(clientB);
+      await initializeClient(bystander);
+      await openWorkspaceClient(clientA, workspacePath);
+      await openWorkspaceClient(clientB, workspacePath);
+      await openWorkspaceClient(bystander, workspacePath);
+
+      clientA.sendJson({
+        id: "req-thread-resume-a",
+        method: "thread/resume",
+        params: {
+          threadId: "thread-live",
+        },
+      });
+      clientB.sendJson({
+        id: "req-thread-resume-b",
+        method: "thread/resume",
+        params: {
+          threadId: "thread-live",
+        },
+      });
+
+      await clientA.nextMessage();
+      await clientB.nextMessage();
+
+      session.emitNotification(
+        createThreadStatusChangedNotification({
+          threadId: "thread-live",
+          status: { type: "active", activeFlags: ["running"] },
+        }),
+      );
+
+      await expect(clientA.nextMessage()).resolves.toEqual({
+        method: "thread/status/changed",
+        params: {
+          threadId: "thread-live",
+          status: {
+            type: "active",
+            activeFlags: ["running"],
+          },
+        },
+      });
+      await expect(clientB.nextMessage()).resolves.toEqual({
+        method: "thread/status/changed",
+        params: {
+          threadId: "thread-live",
+          status: {
+            type: "active",
+            activeFlags: ["running"],
+          },
+        },
+      });
+      await expect(bystander.nextMessage(150)).rejects.toThrow("Timed out waiting for message");
+
+      await clientA.close();
+      session.emitNotification(
+        createThreadStatusChangedNotification({
+          threadId: "thread-live",
+          status: { type: "idle" },
+        }),
+      );
+
+      await expect(clientB.nextMessage()).resolves.toEqual({
+        method: "thread/status/changed",
+        params: {
+          threadId: "thread-live",
+          status: {
+            type: "idle",
+          },
+        },
+      });
+      await expect(bystander.nextMessage(150)).rejects.toThrow("Timed out waiting for message");
+    } finally {
+      await clientB.close();
+      await bystander.close();
+    }
+  });
+
+  test("clears loaded-thread subscriptions when the connection switches workspaces", async () => {
+    const firstWorkspacePath = await createWorkspaceDirectory();
+    const secondWorkspacePath = await createWorkspaceDirectory();
+    const canonicalFirstWorkspacePath = await realpath(firstWorkspacePath);
+    const session = createFakeAgentSession({
+      resumeThread: async (_requestId, params) => ({
+        ok: true,
+        data: {
+          thread: createTestAgentThread({
+            id: params.threadId,
+            workspacePath: canonicalFirstWorkspacePath,
+          }),
+          model: "gpt-5.4",
+          reasoningEffort: "medium",
+        },
+      }),
+    });
+    const harness = await createProtocolHarness({
+      agentAdapters: [
+        createFakeAgentAdapter({
+          session,
+        }),
+      ],
+    });
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      await initializeClient(client);
+      await openWorkspaceClient(client, firstWorkspacePath);
+
+      client.sendJson({
+        id: "req-thread-resume",
+        method: "thread/resume",
+        params: {
+          threadId: "thread-live",
+        },
+      });
+      await client.nextMessage();
+
+      await openWorkspaceClient(client, secondWorkspacePath);
+
+      session.emitNotification(
+        createThreadStatusChangedNotification({
+          threadId: "thread-live",
+          status: { type: "active", activeFlags: ["running"] },
+        }),
+      );
+
+      await expect(client.nextMessage(150)).rejects.toThrow("Timed out waiting for message");
+    } finally {
+      await client.close();
+    }
+  });
+
   test("lists threads after initialize and workspace/open", async () => {
     const workspacePath = await createWorkspaceDirectory();
     const canonicalWorkspacePath = await realpath(workspacePath);
@@ -787,6 +1074,8 @@ describe("App Server protocol harness", () => {
               updatedAt: "2026-04-10T11:00:00.000Z",
               name: "Thread browsing",
               archived: false,
+              model: null,
+              reasoningEffort: null,
               status: {
                 type: "active",
                 activeFlags: ["running"],
@@ -931,6 +1220,8 @@ describe("App Server protocol harness", () => {
               updatedAt: "2026-04-10T11:00:00.000Z",
               name: null,
               archived: true,
+              model: null,
+              reasoningEffort: null,
               status: {
                 type: "idle",
               },
@@ -990,6 +1281,8 @@ describe("App Server protocol harness", () => {
             updatedAt: "2026-04-10T11:00:00.000Z",
             name: "Readable thread",
             archived: false,
+            model: null,
+            reasoningEffort: null,
             status: {
               type: "systemError",
               message: "Provider disconnected",
@@ -1231,10 +1524,18 @@ const createProtocolHarness = async (
     config,
     logger: logger.withContext({ component: "core.store" }),
   });
+  let threadsModule: ReturnType<typeof createThreadsModule> | undefined;
   const workspacesModule = createWorkspacesModule({
     logger: logger.withContext({ component: "module.workspaces" }),
     registerMethod: appProtocolRuntime.registerMethod,
     store: createSqliteWorkspacesStore(storeBootstrap.getDatabase),
+    onWorkspaceOpened: ({ connectionId, previousWorkspace, workspace }) => {
+      threadsModule?.handleWorkspaceOpened({
+        connectionId,
+        previousWorkspace,
+        workspace,
+      });
+    },
   });
   const agentsModule = createAgentsModule({
     config: config.agents,
@@ -1246,19 +1547,22 @@ const createProtocolHarness = async (
     ],
     registerMethod: appProtocolRuntime.registerMethod,
   });
-  const threadsModule = createThreadsModule({
+  threadsModule = createThreadsModule({
     logger: logger.withContext({ component: "module.threads" }),
     registerMethod: appProtocolRuntime.registerMethod,
+    sendNotification: appProtocolRuntime.sendNotification,
     registry: agentsModule.registry,
     store: createSqliteThreadsStore(storeBootstrap.getDatabase),
     getOpenedWorkspace: workspacesModule.getOpenedWorkspace,
   });
+  const finalizedThreadsModule = threadsModule;
   const transportComponent = createAppTransportComponent({
     config,
     logger,
     protocol: appProtocolRuntime,
     onConnectionClosed: [
       ({ connectionId }) => {
+        finalizedThreadsModule.handleConnectionClosed(connectionId);
         workspacesModule.handleConnectionClosed(connectionId);
       },
     ],
@@ -1272,7 +1576,7 @@ const createProtocolHarness = async (
       storeBootstrap.lifecycle,
       agentsModule.lifecycle,
       workspacesModule.lifecycle,
-      threadsModule.lifecycle,
+      finalizedThreadsModule.lifecycle,
       createTurnsModulePlaceholder(),
       createApprovalsModulePlaceholder(),
       transportComponent,
@@ -1578,6 +1882,27 @@ const createFakeProtocolAgentAdapter = (options: {
         },
     }),
   });
+
+const createThreadStatusChangedNotification = (input: {
+  threadId: string;
+  status: Readonly<{ type: "idle" }> | Readonly<{ type: "active"; activeFlags: readonly string[] }>;
+}) => ({
+  agentId: "codex",
+  provider: "codex" as const,
+  receivedAt: "2026-04-10T12:00:00.000Z",
+  rawMethod: "thread/status/changed",
+  threadId: input.threadId,
+  type: "thread" as const,
+  event: "statusChanged" as const,
+  thread: {
+    id: input.threadId,
+    preview: "",
+    updatedAt: "2026-04-10T12:00:00.000Z",
+    name: null,
+    archived: false,
+    status: input.status,
+  },
+});
 
 const toMessageText = (data: unknown): string => {
   if (typeof data === "string") {

--- a/AppServer/src/app/protocol.ts
+++ b/AppServer/src/app/protocol.ts
@@ -21,6 +21,7 @@ export type AppProtocolRuntime = Readonly<{
   openConnection: ProtocolEngine["openConnection"];
   closeConnection: ProtocolEngine["closeConnection"];
   handleIncomingText: ProtocolEngine["handleIncomingText"];
+  sendNotification: ProtocolEngine["sendNotification"];
 }>;
 
 export const runConnectionClosedHandlers = async (
@@ -81,6 +82,7 @@ export const createAppProtocolRuntime = (options: { logger: Logger }): AppProtoc
     openConnection: protocol.openConnection,
     closeConnection: protocol.closeConnection,
     handleIncomingText: protocol.handleIncomingText,
+    sendNotification: protocol.sendNotification,
   });
 };
 

--- a/AppServer/src/app/server.test.ts
+++ b/AppServer/src/app/server.test.ts
@@ -6,7 +6,6 @@ import { APP_SERVER_CONFIG_PATH_ENV } from "@/app/config";
 import { createLogger } from "@/app/logger";
 import {
   createAppServer,
-  createConfiguredAppServer,
   type ShutdownSignal,
   type SignalHandler,
   type SignalRegistrar,
@@ -62,7 +61,7 @@ describe("createAppServer", () => {
 
   test("starts even when the configured codex executable is unavailable", async () => {
     const port = await getAvailablePort();
-    const server = createConfiguredAppServer({
+    const server = await createAppServer({
       config: Object.freeze({
         ...createTestConfig(port),
         agents: {
@@ -84,7 +83,7 @@ describe("createAppServer", () => {
     await server.stop("test-stop");
   });
 
-  test("loads config in the high-level constructor while the configured constructor avoids config I/O", async () => {
+  test("loads config when needed and skips config I/O when config is provided", async () => {
     let readCount = 0;
 
     const bootstrappedServer = await createAppServer({
@@ -106,7 +105,7 @@ describe("createAppServer", () => {
       signalRegistrar: createSignalRegistrar(),
     });
 
-    const configuredServer = createConfiguredAppServer({
+    const configuredServer = await createAppServer({
       config: Object.freeze({
         configPath: "/tmp/appserver.config.json",
         port: 7444,
@@ -130,7 +129,7 @@ describe("createAppServer", () => {
 
 describe("AppServer lifecycle", () => {
   test("stops cleanly", async () => {
-    const server = createConfiguredAppServer({
+    const server = await createAppServer({
       config: createTestConfig(),
       logger: createSilentLogger(),
       signalRegistrar: createSignalRegistrar(),
@@ -144,7 +143,7 @@ describe("AppServer lifecycle", () => {
 
   test("makes stop idempotent", async () => {
     let stopCount = 0;
-    const server = createConfiguredAppServer({
+    const server = await createAppServer({
       config: createTestConfig(),
       logger: createSilentLogger(),
       signalRegistrar: createSignalRegistrar(),
@@ -169,7 +168,7 @@ describe("AppServer lifecycle", () => {
   test("routes shutdown signals through the server lifecycle", async () => {
     let stopReason: string | undefined;
     const signalRegistrar = createSignalRegistrar();
-    const server = createConfiguredAppServer({
+    const server = await createAppServer({
       config: createTestConfig(),
       logger: createSilentLogger(),
       signalRegistrar,
@@ -195,7 +194,7 @@ describe("AppServer lifecycle", () => {
   test("finishes shutdown when stop is requested during startup", async () => {
     const events: string[] = [];
     const slowStart = createDeferredPromise<void>();
-    const server = createConfiguredAppServer({
+    const server = await createAppServer({
       config: createTestConfig(),
       logger: createSilentLogger(),
       signalRegistrar: createSignalRegistrar(),
@@ -237,7 +236,7 @@ describe("AppServer lifecycle", () => {
 
   test("reaches a terminal state when component stop fails", async () => {
     const signalRegistrar = createSignalRegistrar();
-    const server = createConfiguredAppServer({
+    const server = await createAppServer({
       config: createTestConfig(),
       logger: createSilentLogger(),
       signalRegistrar,
@@ -261,7 +260,7 @@ describe("AppServer lifecycle", () => {
 
   test("rolls back started components when startup fails partway through", async () => {
     const events: string[] = [];
-    const server = createConfiguredAppServer({
+    const server = await createAppServer({
       config: createTestConfig(),
       logger: createSilentLogger(),
       signalRegistrar: createSignalRegistrar(),
@@ -295,7 +294,7 @@ describe("AppServer lifecycle", () => {
   });
 
   test("resolves waitForStop after shutdown", async () => {
-    const server = createConfiguredAppServer({
+    const server = await createAppServer({
       config: createTestConfig(),
       logger: createSilentLogger(),
       signalRegistrar: createSignalRegistrar(),

--- a/AppServer/src/app/server.ts
+++ b/AppServer/src/app/server.ts
@@ -307,10 +307,18 @@ const createDefaultComponents = (
   const appProtocolRuntime = createAppProtocolRuntime({
     logger,
   });
+  let threadsModule: ReturnType<typeof createThreadsModule> | undefined;
   const workspacesModule = createWorkspacesModule({
     logger: logger.withContext({ component: "module.workspaces" }),
     registerMethod: appProtocolRuntime.registerMethod,
     store: createSqliteWorkspacesStore(storeBootstrap.getDatabase),
+    onWorkspaceOpened: ({ connectionId, previousWorkspace, workspace }) => {
+      threadsModule?.handleWorkspaceOpened({
+        connectionId,
+        previousWorkspace,
+        workspace,
+      });
+    },
   });
   const agentsModule = createAgentsModule({
     config: config.agents,
@@ -322,19 +330,22 @@ const createDefaultComponents = (
     ],
     registerMethod: appProtocolRuntime.registerMethod,
   });
-  const threadsModule = createThreadsModule({
+  threadsModule = createThreadsModule({
     logger: logger.withContext({ component: "module.threads" }),
     registerMethod: appProtocolRuntime.registerMethod,
+    sendNotification: appProtocolRuntime.sendNotification,
     registry: agentsModule.registry,
     store: createSqliteThreadsStore(storeBootstrap.getDatabase),
     getOpenedWorkspace: workspacesModule.getOpenedWorkspace,
   });
+  const finalizedThreadsModule = threadsModule;
   const transportComponent = createAppTransportComponent({
     config,
     logger,
     protocol: appProtocolRuntime,
     onConnectionClosed: [
       ({ connectionId }) => {
+        finalizedThreadsModule.handleConnectionClosed(connectionId);
         workspacesModule.handleConnectionClosed(connectionId);
       },
     ],
@@ -345,7 +356,7 @@ const createDefaultComponents = (
     storeBootstrap.lifecycle,
     agentsModule.lifecycle,
     workspacesModule.lifecycle,
-    threadsModule.lifecycle,
+    finalizedThreadsModule.lifecycle,
     createTurnsModulePlaceholder(),
     createApprovalsModulePlaceholder(),
     transportComponent,

--- a/AppServer/src/app/server.ts
+++ b/AppServer/src/app/server.ts
@@ -32,8 +32,7 @@ export type AppServer = Readonly<{
   waitForStop: () => Promise<void>;
 }>;
 
-export type CreateConfiguredAppServerOptions = Readonly<{
-  config: AppServerConfig;
+type CreateAppServerSharedOptions = Readonly<{
   logger?: Logger;
   now?: () => string;
   writeLog?: LogWriter;
@@ -41,20 +40,29 @@ export type CreateConfiguredAppServerOptions = Readonly<{
   signalRegistrar?: SignalRegistrar;
 }>;
 
-export type CreateAppServerOptions = Readonly<
-  LoadAppServerConfigOptions & {
-    now?: () => string;
-    writeLog?: LogWriter;
-    components?: readonly LifecycleComponent[];
-    signalRegistrar?: SignalRegistrar;
+type CreateAppServerWithResolvedConfigOptions = Readonly<
+  CreateAppServerSharedOptions & {
+    config: AppServerConfig;
   }
 >;
 
-export const createAppServer = async (options: CreateAppServerOptions = {}): Promise<AppServer> => {
-  const config = await loadAppServerConfig(options);
+type CreateAppServerWithConfigLoadOptions = Readonly<
+  CreateAppServerSharedOptions &
+    LoadAppServerConfigOptions & {
+      config?: undefined;
+    }
+>;
 
-  return createConfiguredAppServer({
+export type CreateAppServerOptions =
+  | CreateAppServerWithResolvedConfigOptions
+  | CreateAppServerWithConfigLoadOptions;
+
+export const createAppServer = async (options: CreateAppServerOptions = {}): Promise<AppServer> => {
+  const config = hasResolvedConfig(options) ? options.config : await loadAppServerConfig(options);
+
+  return buildAppServer({
     config,
+    logger: options.logger,
     now: options.now,
     writeLog: options.writeLog,
     components: options.components,
@@ -62,7 +70,11 @@ export const createAppServer = async (options: CreateAppServerOptions = {}): Pro
   });
 };
 
-export const createConfiguredAppServer = (options: CreateConfiguredAppServerOptions): AppServer => {
+const hasResolvedConfig = (
+  options: CreateAppServerOptions,
+): options is CreateAppServerWithResolvedConfigOptions => options.config !== undefined;
+
+const buildAppServer = (options: CreateAppServerWithResolvedConfigOptions): AppServer => {
   const logger =
     options.logger ??
     createLogger({

--- a/AppServer/src/core/protocol/errors.ts
+++ b/AppServer/src/core/protocol/errors.ts
@@ -19,12 +19,17 @@ export const ATELIER_PROVIDER_ERROR = -33005;
 export const ATELIER_WORKSPACE_NOT_OPENED_ERROR = -33006;
 export const ATELIER_THREAD_READ_INCLUDE_TURNS_UNSUPPORTED_ERROR = -33007;
 export const ATELIER_THREAD_WORKSPACE_MISMATCH_ERROR = -33008;
+export const ATELIER_INVALID_PROVIDER_PAYLOAD_ERROR = -33009;
+
+const PROTOCOL_METHOD_ERROR_BRAND = Symbol("ProtocolMethodError");
 
 export type ProtocolMethodError = Readonly<{
   code: number;
   message: string;
   data?: ProtocolErrorData;
-}>;
+}> & {
+  readonly [PROTOCOL_METHOD_ERROR_BRAND]: true;
+};
 
 export const createProtocolMethodError = (
   code: number,
@@ -32,14 +37,14 @@ export const createProtocolMethodError = (
   data?: ProtocolErrorData,
 ): ProtocolMethodError =>
   Object.freeze(
-    data === undefined
-      ? { code, message }
-      : {
-          code,
-          message,
-          data,
-        },
+    brandProtocolMethodError(data === undefined ? { code, message } : { code, message, data }),
   );
+
+export const isProtocolMethodError = (error: unknown): error is ProtocolMethodError =>
+  typeof error === "object" &&
+  error !== null &&
+  PROTOCOL_METHOD_ERROR_BRAND in error &&
+  (error as { [PROTOCOL_METHOD_ERROR_BRAND]?: unknown })[PROTOCOL_METHOD_ERROR_BRAND] === true;
 
 export const createParseError = (): ProtocolMethodError =>
   createProtocolMethodError(JSON_RPC_PARSE_ERROR, "Parse error");
@@ -162,3 +167,34 @@ export const createThreadWorkspaceMismatchResult = (
   threadWorkspacePath: string,
 ): Result<never, ProtocolMethodError> =>
   err(createThreadWorkspaceMismatchError(threadId, openedWorkspacePath, threadWorkspacePath));
+
+export const createInvalidProviderPayloadError = (
+  input: Readonly<{
+    agentId: string;
+    provider: string;
+    operation: string;
+    providerMessage: string;
+  }>,
+): ProtocolMethodError =>
+  createProtocolMethodError(
+    ATELIER_INVALID_PROVIDER_PAYLOAD_ERROR,
+    "Provider returned an invalid payload",
+    Object.freeze({
+      code: "INVALID_PROVIDER_PAYLOAD",
+      agentId: input.agentId,
+      provider: input.provider,
+      operation: input.operation,
+      providerMessage: input.providerMessage,
+    }),
+  );
+
+const brandProtocolMethodError = <T extends { code: number; message: string }>(
+  error: T,
+): T & { readonly [PROTOCOL_METHOD_ERROR_BRAND]: true } => {
+  Object.defineProperty(error, PROTOCOL_METHOD_ERROR_BRAND, {
+    value: true,
+    enumerable: false,
+  });
+
+  return error as T & { readonly [PROTOCOL_METHOD_ERROR_BRAND]: true };
+};

--- a/AppServer/src/test-support/agents.ts
+++ b/AppServer/src/test-support/agents.ts
@@ -6,6 +6,7 @@ import type {
   AgentListThreadsResult,
   AgentNotification,
   AgentOperationResult,
+  AgentReasoningEffort,
   AgentRequestId,
   AgentSession,
   AgentSessionLookupError,
@@ -18,6 +19,7 @@ import type { AgentRegistry } from "@/agents/registry";
 
 export type FakeAgentSession = AgentSession &
   Readonly<{
+    emitNotification: (notification: AgentNotification) => void;
     listModelsCalls: readonly Readonly<{
       requestId: AgentRequestId;
       params: AgentListModelsParams;
@@ -25,6 +27,28 @@ export type FakeAgentSession = AgentSession &
     listThreadsCalls: readonly Readonly<{
       requestId: AgentRequestId;
       params: AgentListThreadsParams;
+    }>[];
+    startThreadCalls: readonly Readonly<{
+      requestId: AgentRequestId;
+      params: Readonly<{
+        workspacePath: string;
+        title?: string;
+        model?: string;
+        reasoningEffort?: AgentReasoningEffort;
+        approvalPolicy?: string;
+        sandbox?: unknown;
+      }>;
+    }>[];
+    resumeThreadCalls: readonly Readonly<{
+      requestId: AgentRequestId;
+      params: Readonly<{
+        threadId: string;
+        workspacePath: string;
+        model?: string;
+        reasoningEffort?: AgentReasoningEffort;
+        approvalPolicy?: string;
+        sandbox?: unknown;
+      }>;
     }>[];
     readThreadCalls: readonly Readonly<{
       requestId: AgentRequestId;
@@ -43,6 +67,28 @@ export type CreateFakeAgentSessionOptions = Readonly<{
     requestId: AgentRequestId,
     params: AgentListThreadsParams,
   ) => Promise<AgentOperationResult<AgentListThreadsResult>>;
+  startThread?: (
+    requestId: AgentRequestId,
+    params: Readonly<{
+      workspacePath: string;
+      title?: string;
+      model?: string;
+      reasoningEffort?: AgentReasoningEffort;
+      approvalPolicy?: string;
+      sandbox?: unknown;
+    }>,
+  ) => Promise<AgentOperationResult<AgentThreadResult>>;
+  resumeThread?: (
+    requestId: AgentRequestId,
+    params: Readonly<{
+      threadId: string;
+      workspacePath: string;
+      model?: string;
+      reasoningEffort?: AgentReasoningEffort;
+      approvalPolicy?: string;
+      sandbox?: unknown;
+    }>,
+  ) => Promise<AgentOperationResult<AgentThreadResult>>;
   readThread?: (
     requestId: AgentRequestId,
     params: AgentThreadReadParams,
@@ -53,6 +99,7 @@ export const createFakeAgentSession = (
   options: CreateFakeAgentSessionOptions = {},
 ): FakeAgentSession => {
   let state = options.state ?? "ready";
+  const listeners = new Set<(notification: AgentNotification) => void>();
   const listModelsCalls: Array<
     Readonly<{
       requestId: AgentRequestId;
@@ -63,6 +110,32 @@ export const createFakeAgentSession = (
     Readonly<{
       requestId: AgentRequestId;
       params: AgentListThreadsParams;
+    }>
+  > = [];
+  const startThreadCalls: Array<
+    Readonly<{
+      requestId: AgentRequestId;
+      params: Readonly<{
+        workspacePath: string;
+        title?: string;
+        model?: string;
+        reasoningEffort?: AgentReasoningEffort;
+        approvalPolicy?: string;
+        sandbox?: unknown;
+      }>;
+    }>
+  > = [];
+  const resumeThreadCalls: Array<
+    Readonly<{
+      requestId: AgentRequestId;
+      params: Readonly<{
+        threadId: string;
+        workspacePath: string;
+        model?: string;
+        reasoningEffort?: AgentReasoningEffort;
+        approvalPolicy?: string;
+        sandbox?: unknown;
+      }>;
     }>
   > = [];
   const readThreadCalls: Array<
@@ -76,7 +149,13 @@ export const createFakeAgentSession = (
     agentId: options.agentId ?? "codex",
     provider: "codex",
     getState: () => state,
-    subscribe: (_listener: (notification: AgentNotification) => void) => () => {},
+    subscribe: (listener: (notification: AgentNotification) => void) => {
+      listeners.add(listener);
+
+      return () => {
+        listeners.delete(listener);
+      };
+    },
     listModels: async (requestId, params) => {
       listModelsCalls.push(
         Object.freeze({
@@ -113,11 +192,48 @@ export const createFakeAgentSession = (
         }
       );
     },
-    startThread: async () => {
-      throw new Error("startThread should not be called in this test.");
+    startThread: async (requestId, params) => {
+      startThreadCalls.push(
+        Object.freeze({
+          requestId,
+          params,
+        }),
+      );
+
+      return (
+        (await options.startThread?.(requestId, params)) ?? {
+          ok: true,
+          data: {
+            thread: createTestAgentThread({
+              workspacePath: params.workspacePath,
+            }),
+            model: params.model ?? "gpt-5.4",
+            reasoningEffort: params.reasoningEffort ?? "medium",
+          },
+        }
+      );
     },
-    resumeThread: async () => {
-      throw new Error("resumeThread should not be called in this test.");
+    resumeThread: async (requestId, params) => {
+      resumeThreadCalls.push(
+        Object.freeze({
+          requestId,
+          params,
+        }),
+      );
+
+      return (
+        (await options.resumeThread?.(requestId, params)) ?? {
+          ok: true,
+          data: {
+            thread: createTestAgentThread({
+              id: params.threadId,
+              workspacePath: params.workspacePath,
+            }),
+            model: params.model ?? "gpt-5.4",
+            reasoningEffort: params.reasoningEffort ?? "medium",
+          },
+        }
+      );
     },
     readThread: async (requestId, params) => {
       readThreadCalls.push(
@@ -154,8 +270,15 @@ export const createFakeAgentSession = (
     disconnect: async () => {
       state = "disconnected";
     },
+    emitNotification: (notification) => {
+      for (const listener of listeners) {
+        listener(notification);
+      }
+    },
     listModelsCalls,
     listThreadsCalls,
+    startThreadCalls,
+    resumeThreadCalls,
     readThreadCalls,
   };
 };

--- a/AppServer/src/threads/index.ts
+++ b/AppServer/src/threads/index.ts
@@ -1,3 +1,4 @@
+export * from "@/threads/loaded-thread-registry";
 export * from "@/threads/schemas";
 export * from "@/threads/service";
 export * from "@/threads/store";

--- a/AppServer/src/threads/loaded-thread-registry.ts
+++ b/AppServer/src/threads/loaded-thread-registry.ts
@@ -1,0 +1,86 @@
+export type LoadedThreadRegistry = Readonly<{
+  markLoaded: (
+    input: Readonly<{
+      connectionId: string;
+      workspaceId: string;
+      threadId: string;
+    }>,
+  ) => void;
+  listSubscribers: (threadId: string) => readonly string[];
+  clearThread: (threadId: string) => readonly string[];
+  clearConnection: (connectionId: string) => readonly string[];
+  clearAll: () => void;
+}>;
+
+export const createLoadedThreadRegistry = (): LoadedThreadRegistry => {
+  const threadIdsByConnectionId = new Map<string, Map<string, string>>();
+  const connectionIdsByThreadId = new Map<string, Set<string>>();
+
+  const clearThreadSubscription = (connectionId: string, threadId: string): void => {
+    const threadIds = threadIdsByConnectionId.get(connectionId);
+    threadIds?.delete(threadId);
+
+    if (threadIds?.size === 0) {
+      threadIdsByConnectionId.delete(connectionId);
+    }
+
+    const connectionIds = connectionIdsByThreadId.get(threadId);
+    connectionIds?.delete(connectionId);
+
+    if (connectionIds?.size === 0) {
+      connectionIdsByThreadId.delete(threadId);
+    }
+  };
+
+  return Object.freeze({
+    markLoaded: ({ connectionId, workspaceId, threadId }) => {
+      const existingThreadIds = threadIdsByConnectionId.get(connectionId);
+
+      if (existingThreadIds !== undefined) {
+        for (const [loadedThreadId, loadedWorkspaceId] of existingThreadIds.entries()) {
+          if (loadedWorkspaceId !== workspaceId) {
+            clearThreadSubscription(connectionId, loadedThreadId);
+          }
+        }
+      }
+
+      const threadIds = threadIdsByConnectionId.get(connectionId) ?? new Map<string, string>();
+      threadIds.set(threadId, workspaceId);
+      threadIdsByConnectionId.set(connectionId, threadIds);
+
+      const connectionIds = connectionIdsByThreadId.get(threadId) ?? new Set<string>();
+      connectionIds.add(connectionId);
+      connectionIdsByThreadId.set(threadId, connectionIds);
+    },
+    listSubscribers: (threadId) => [
+      ...(connectionIdsByThreadId.get(threadId) ?? new Set<string>()),
+    ],
+    clearThread: (threadId) => {
+      const connectionIds = [...(connectionIdsByThreadId.get(threadId) ?? new Set<string>())];
+
+      for (const connectionId of connectionIds) {
+        clearThreadSubscription(connectionId, threadId);
+      }
+
+      return connectionIds;
+    },
+    clearConnection: (connectionId) => {
+      const threadIds = threadIdsByConnectionId.get(connectionId);
+
+      if (threadIds === undefined) {
+        return [];
+      }
+
+      const clearedThreadIds = [...threadIds.keys()];
+      for (const threadId of clearedThreadIds) {
+        clearThreadSubscription(connectionId, threadId);
+      }
+
+      return clearedThreadIds;
+    },
+    clearAll: () => {
+      threadIdsByConnectionId.clear();
+      connectionIdsByThreadId.clear();
+    },
+  });
+};

--- a/AppServer/src/threads/schemas.ts
+++ b/AppServer/src/threads/schemas.ts
@@ -1,4 +1,5 @@
 import { type Static, Type } from "@sinclair/typebox";
+import { ModelReasoningEffortSchema } from "@/agents/schemas";
 
 export const ThreadExecutionStatusSchema = Type.Union([
   Type.Object(
@@ -38,6 +39,8 @@ export const ThreadSchema = Type.Object(
     updatedAt: Type.String({ minLength: 1 }),
     name: Type.Union([Type.String({ minLength: 1 }), Type.Null()]),
     archived: Type.Boolean(),
+    model: Type.Union([Type.String({ minLength: 1 }), Type.Null()]),
+    reasoningEffort: Type.Union([ModelReasoningEffortSchema, Type.Null()]),
     status: ThreadExecutionStatusSchema,
   },
   { additionalProperties: false },
@@ -72,6 +75,15 @@ export const ThreadReadParamsSchema = Type.Object(
 );
 export type ThreadReadParams = Static<typeof ThreadReadParamsSchema>;
 
+export const ThreadStartParamsSchema = Type.Object(
+  {
+    model: Type.Optional(Type.String({ minLength: 1 })),
+    reasoningEffort: Type.Optional(ModelReasoningEffortSchema),
+  },
+  { additionalProperties: false },
+);
+export type ThreadStartParams = Static<typeof ThreadStartParamsSchema>;
+
 export const ThreadReadResultSchema = Type.Object(
   {
     thread: ThreadSchema,
@@ -79,3 +91,46 @@ export const ThreadReadResultSchema = Type.Object(
   { additionalProperties: false },
 );
 export type ThreadReadResult = Static<typeof ThreadReadResultSchema>;
+
+export const ThreadStartResultSchema = ThreadReadResultSchema;
+export type ThreadStartResult = ThreadReadResult;
+
+export const ThreadResumeParamsSchema = Type.Object(
+  {
+    threadId: Type.String({ minLength: 1 }),
+    model: Type.Optional(Type.String({ minLength: 1 })),
+    reasoningEffort: Type.Optional(ModelReasoningEffortSchema),
+  },
+  { additionalProperties: false },
+);
+export type ThreadResumeParams = Static<typeof ThreadResumeParamsSchema>;
+
+export const ThreadResumeResultSchema = ThreadReadResultSchema;
+export type ThreadResumeResult = ThreadReadResult;
+
+export const ThreadStartedNotificationParamsSchema = Type.Object(
+  {
+    thread: ThreadSchema,
+  },
+  { additionalProperties: false },
+);
+export type ThreadStartedNotificationParams = Static<typeof ThreadStartedNotificationParamsSchema>;
+
+export const ThreadStatusChangedNotificationParamsSchema = Type.Object(
+  {
+    threadId: Type.String({ minLength: 1 }),
+    status: ThreadExecutionStatusSchema,
+  },
+  { additionalProperties: false },
+);
+export type ThreadStatusChangedNotificationParams = Static<
+  typeof ThreadStatusChangedNotificationParamsSchema
+>;
+
+export const ThreadClosedNotificationParamsSchema = Type.Object(
+  {
+    threadId: Type.String({ minLength: 1 }),
+  },
+  { additionalProperties: false },
+);
+export type ThreadClosedNotificationParams = Static<typeof ThreadClosedNotificationParamsSchema>;

--- a/AppServer/src/threads/service.test.ts
+++ b/AppServer/src/threads/service.test.ts
@@ -16,7 +16,7 @@ const workspace = Object.freeze({
 });
 
 describe("createThreadsService", () => {
-  test("scopes thread/list to the opened workspace and maps public thread metadata", async () => {
+  test("scopes thread/list to the opened workspace and surfaces stored defaults", async () => {
     const session = createFakeAgentSession({
       listThreads: async () => ({
         ok: true,
@@ -37,7 +37,19 @@ describe("createThreadsService", () => {
         },
       }),
     });
-    const store = createInMemoryThreadsStore();
+    const store = createInMemoryThreadsStore([
+      {
+        workspaceId: "workspace-1",
+        provider: "codex",
+        threadId: "thread-1",
+        threadWorkspacePath: "/tmp/project",
+        archived: false,
+        model: "gpt-5.4",
+        reasoningEffort: "medium",
+        firstSeenAt: "2026-04-10T09:30:00.000Z",
+        lastSeenAt: "2026-04-10T09:30:00.000Z",
+      },
+    ]);
     const service = createThreadsService({
       logger: createSilentLogger("error"),
       registry: createFakeAgentRegistry(session),
@@ -61,6 +73,8 @@ describe("createThreadsService", () => {
             updatedAt: "2026-04-10T11:00:00.000Z",
             name: "Thread browsing",
             archived: false,
+            model: "gpt-5.4",
+            reasoningEffort: "medium",
             status: { type: "active", activeFlags: ["running"] },
           },
         ],
@@ -77,22 +91,206 @@ describe("createThreadsService", () => {
         },
       },
     ]);
+  });
+
+  test("starts a thread, persists resolved defaults, and returns the public thread shape", async () => {
+    const session = createFakeAgentSession({
+      startThread: async () => ({
+        ok: true,
+        data: {
+          thread: createTestAgentThread({
+            id: "thread-2",
+            workspacePath: "/tmp/project",
+            status: { type: "idle" },
+          }),
+          model: "gpt-5.4",
+          reasoningEffort: "high",
+        },
+      }),
+    });
+    const store = createInMemoryThreadsStore();
+    const service = createThreadsService({
+      logger: createSilentLogger("error"),
+      registry: createFakeAgentRegistry(session),
+      store,
+      now: () => "2026-04-10T12:00:00.000Z",
+    });
+
+    const result = await service.startThread("req-start", workspace, {
+      reasoningEffort: "high",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        thread: {
+          id: "thread-2",
+          preview: "Thread preview",
+          createdAt: "2026-04-10T10:00:00.000Z",
+          updatedAt: "2026-04-10T11:00:00.000Z",
+          name: null,
+          archived: false,
+          model: "gpt-5.4",
+          reasoningEffort: "high",
+          status: { type: "idle" },
+        },
+      },
+    });
+    expect(session.startThreadCalls).toEqual([
+      {
+        requestId: "req-start",
+        params: {
+          workspacePath: "/tmp/project",
+          reasoningEffort: "high",
+        },
+      },
+    ]);
     await expect(
-      store.listWorkspaceThreadLinks({
+      store.getWorkspaceThreadLink({
         workspaceId: "workspace-1",
         provider: "codex",
+        threadId: "thread-2",
       }),
-    ).resolves.toEqual([
+    ).resolves.toMatchObject({
+      model: "gpt-5.4",
+      reasoningEffort: "high",
+    });
+  });
+
+  test("resumes a thread using stored defaults when the request omits overrides", async () => {
+    const store = createInMemoryThreadsStore([
+      {
+        workspaceId: "workspace-1",
+        provider: "codex",
+        threadId: "thread-1",
+        threadWorkspacePath: "/tmp/project",
+        archived: true,
+        model: "gpt-5.4-mini",
+        reasoningEffort: "low",
+        firstSeenAt: "2026-04-10T09:30:00.000Z",
+        lastSeenAt: "2026-04-10T09:30:00.000Z",
+      },
+    ]);
+    const session = createFakeAgentSession({
+      resumeThread: async () => ({
+        ok: true,
+        data: {
+          thread: createTestAgentThread({
+            id: "thread-1",
+            workspacePath: "/tmp/project",
+            archived: true,
+            status: { type: "idle" },
+          }),
+          model: "gpt-5.4-mini",
+          reasoningEffort: "low",
+        },
+      }),
+    });
+    const service = createThreadsService({
+      logger: createSilentLogger("error"),
+      registry: createFakeAgentRegistry(session),
+      store,
+      now: () => "2026-04-10T12:00:00.000Z",
+    });
+
+    const result = await service.resumeThread("req-resume", workspace, {
+      threadId: "thread-1",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        thread: {
+          id: "thread-1",
+          preview: "Thread preview",
+          createdAt: "2026-04-10T10:00:00.000Z",
+          updatedAt: "2026-04-10T11:00:00.000Z",
+          name: null,
+          archived: true,
+          model: "gpt-5.4-mini",
+          reasoningEffort: "low",
+          status: { type: "idle" },
+        },
+      },
+    });
+    expect(session.resumeThreadCalls).toEqual([
+      {
+        requestId: "req-resume",
+        params: {
+          threadId: "thread-1",
+          workspacePath: "/tmp/project",
+          model: "gpt-5.4-mini",
+          reasoningEffort: "low",
+        },
+      },
+    ]);
+  });
+
+  test("lets explicit resume overrides win over stored defaults", async () => {
+    const store = createInMemoryThreadsStore([
       {
         workspaceId: "workspace-1",
         provider: "codex",
         threadId: "thread-1",
         threadWorkspacePath: "/tmp/project",
         archived: false,
-        firstSeenAt: "2026-04-10T12:00:00.000Z",
-        lastSeenAt: "2026-04-10T12:00:00.000Z",
+        model: "gpt-5.4-mini",
+        reasoningEffort: "low",
+        firstSeenAt: "2026-04-10T09:30:00.000Z",
+        lastSeenAt: "2026-04-10T09:30:00.000Z",
       },
     ]);
+    const session = createFakeAgentSession({
+      resumeThread: async () => ({
+        ok: true,
+        data: {
+          thread: createTestAgentThread({
+            id: "thread-1",
+            workspacePath: "/tmp/project",
+          }),
+          model: "gpt-5.4",
+          reasoningEffort: null,
+        },
+      }),
+    });
+    const service = createThreadsService({
+      logger: createSilentLogger("error"),
+      registry: createFakeAgentRegistry(session),
+      store,
+      now: () => "2026-04-10T12:00:00.000Z",
+    });
+
+    const result = await service.resumeThread("req-resume", workspace, {
+      threadId: "thread-1",
+      model: "gpt-5.4",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        thread: {
+          id: "thread-1",
+          preview: "Thread preview",
+          createdAt: "2026-04-10T10:00:00.000Z",
+          updatedAt: "2026-04-10T11:00:00.000Z",
+          name: null,
+          archived: false,
+          model: "gpt-5.4",
+          reasoningEffort: "low",
+          status: { type: "idle" },
+        },
+      },
+    });
+    await expect(
+      store.getWorkspaceThreadLink({
+        workspaceId: "workspace-1",
+        provider: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      model: "gpt-5.4",
+      reasoningEffort: "low",
+    });
   });
 
   test("returns an explicit domain error when thread/read requests turns", async () => {
@@ -119,47 +317,10 @@ describe("createThreadsService", () => {
       },
     });
     expect(session.readThreadCalls).toEqual([]);
+    expect(session.resumeThreadCalls).toEqual([]);
   });
 
-  test("returns a workspace mismatch error when provider metadata does not match the opened workspace", async () => {
-    const session = createFakeAgentSession({
-      readThread: async () => ({
-        ok: true,
-        data: {
-          thread: createTestAgentThread({
-            id: "thread-9",
-            workspacePath: "/tmp/other-project",
-          }),
-        },
-      }),
-    });
-    const service = createThreadsService({
-      logger: createSilentLogger("error"),
-      registry: createFakeAgentRegistry(session),
-      store: createInMemoryThreadsStore(),
-    });
-
-    const result = await service.readThread("req-1", workspace, {
-      threadId: "thread-9",
-      includeTurns: false,
-    });
-
-    expect(result).toMatchObject({
-      ok: false,
-      error: {
-        code: -33008,
-        message: "Thread does not belong to the opened workspace",
-        data: {
-          code: "THREAD_WORKSPACE_MISMATCH",
-          threadId: "thread-9",
-          openedWorkspacePath: "/tmp/project",
-          threadWorkspacePath: "/tmp/other-project",
-        },
-      },
-    });
-  });
-
-  test("reuses stored archive linkage as a read hint and keeps linkage idempotent", async () => {
+  test("thread/read stays point-in-time and surfaces stored defaults", async () => {
     const store = createInMemoryThreadsStore([
       {
         workspaceId: "workspace-1",
@@ -167,6 +328,8 @@ describe("createThreadsService", () => {
         threadId: "thread-1",
         threadWorkspacePath: "/tmp/project",
         archived: true,
+        model: "gpt-5.4",
+        reasoningEffort: null,
         firstSeenAt: "2026-04-10T09:30:00.000Z",
         lastSeenAt: "2026-04-10T09:30:00.000Z",
       },
@@ -190,7 +353,7 @@ describe("createThreadsService", () => {
       now: () => "2026-04-10T12:00:00.000Z",
     });
 
-    const result = await service.readThread("req-2", workspace, {
+    const result = await service.readThread("req-read", workspace, {
       threadId: "thread-1",
       includeTurns: false,
     });
@@ -205,13 +368,15 @@ describe("createThreadsService", () => {
           updatedAt: "2026-04-10T11:00:00.000Z",
           name: null,
           archived: true,
+          model: "gpt-5.4",
+          reasoningEffort: null,
           status: { type: "idle" },
         },
       },
     });
     expect(session.readThreadCalls).toEqual([
       {
-        requestId: "req-2",
+        requestId: "req-read",
         params: {
           threadId: "thread-1",
           includeTurns: false,
@@ -219,21 +384,45 @@ describe("createThreadsService", () => {
         },
       },
     ]);
-    await expect(
-      store.listWorkspaceThreadLinks({
-        workspaceId: "workspace-1",
-        provider: "codex",
+    expect(session.resumeThreadCalls).toEqual([]);
+  });
+
+  test("returns a workspace mismatch error when provider metadata does not match the opened workspace", async () => {
+    const session = createFakeAgentSession({
+      resumeThread: async () => ({
+        ok: true,
+        data: {
+          thread: createTestAgentThread({
+            id: "thread-9",
+            workspacePath: "/tmp/other-project",
+          }),
+          model: "gpt-5.4",
+          reasoningEffort: "medium",
+        },
       }),
-    ).resolves.toEqual([
-      {
-        workspaceId: "workspace-1",
-        provider: "codex",
-        threadId: "thread-1",
-        threadWorkspacePath: "/tmp/project",
-        archived: true,
-        firstSeenAt: "2026-04-10T09:30:00.000Z",
-        lastSeenAt: "2026-04-10T12:00:00.000Z",
+    });
+    const service = createThreadsService({
+      logger: createSilentLogger("error"),
+      registry: createFakeAgentRegistry(session),
+      store: createInMemoryThreadsStore(),
+    });
+
+    const result = await service.resumeThread("req-1", workspace, {
+      threadId: "thread-9",
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: -33008,
+        message: "Thread does not belong to the opened workspace",
+        data: {
+          code: "THREAD_WORKSPACE_MISMATCH",
+          threadId: "thread-9",
+          openedWorkspacePath: "/tmp/project",
+          threadWorkspacePath: "/tmp/other-project",
+        },
       },
-    ]);
+    });
   });
 });

--- a/AppServer/src/threads/service.test.ts
+++ b/AppServer/src/threads/service.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, realpath, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   createFakeAgentRegistry,
   createFakeAgentSession,
   createTestAgentThread,
 } from "@/test-support/agents";
-import { createSilentLogger } from "@/test-support/logger";
+import { createCapturingLogger, createSilentLogger } from "@/test-support/logger";
 import { createThreadsService } from "@/threads/service";
-import { createInMemoryThreadsStore } from "@/threads/store";
+import { createInMemoryThreadsStore, type ThreadsStore } from "@/threads/store";
 
 const workspace = Object.freeze({
   id: "workspace-1",
@@ -93,6 +96,48 @@ describe("createThreadsService", () => {
     ]);
   });
 
+  test("thread/list still succeeds when linkage persistence fails", async () => {
+    const { logger, records } = createCapturingLogger();
+    const session = createFakeAgentSession({
+      listThreads: async () => ({
+        ok: true,
+        data: {
+          threads: [
+            createTestAgentThread({
+              id: "thread-1",
+              workspacePath: "/tmp/project",
+            }),
+          ],
+          nextCursor: null,
+        },
+      }),
+    });
+    const service = createThreadsService({
+      logger,
+      registry: createFakeAgentRegistry(session),
+      store: createFailingUpsertStore(createInMemoryThreadsStore()),
+      now: () => "2026-04-10T12:00:00.000Z",
+    });
+
+    await expect(service.listThreads("req-list", workspace, {})).resolves.toMatchObject({
+      ok: true,
+      data: {
+        threads: [
+          {
+            id: "thread-1",
+          },
+        ],
+      },
+    });
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        level: "warn",
+        message: "Failed to persist thread linkage metadata",
+        operation: "thread/list",
+      }),
+    );
+  });
+
   test("starts a thread, persists resolved defaults, and returns the public thread shape", async () => {
     const session = createFakeAgentSession({
       startThread: async () => ({
@@ -136,15 +181,6 @@ describe("createThreadsService", () => {
         },
       },
     });
-    expect(session.startThreadCalls).toEqual([
-      {
-        requestId: "req-start",
-        params: {
-          workspacePath: "/tmp/project",
-          reasoningEffort: "high",
-        },
-      },
-    ]);
     await expect(
       store.getWorkspaceThreadLink({
         workspaceId: "workspace-1",
@@ -155,6 +191,47 @@ describe("createThreadsService", () => {
       model: "gpt-5.4",
       reasoningEffort: "high",
     });
+  });
+
+  test("thread/start still succeeds when linkage persistence fails", async () => {
+    const { logger, records } = createCapturingLogger();
+    const session = createFakeAgentSession({
+      startThread: async () => ({
+        ok: true,
+        data: {
+          thread: createTestAgentThread({
+            id: "thread-start",
+            workspacePath: "/tmp/project",
+          }),
+          model: "gpt-5.4",
+          reasoningEffort: "medium",
+        },
+      }),
+    });
+    const service = createThreadsService({
+      logger,
+      registry: createFakeAgentRegistry(session),
+      store: createFailingUpsertStore(createInMemoryThreadsStore()),
+      now: () => "2026-04-10T12:00:00.000Z",
+    });
+
+    await expect(service.startThread("req-start", workspace, {})).resolves.toMatchObject({
+      ok: true,
+      data: {
+        thread: {
+          id: "thread-start",
+          model: "gpt-5.4",
+          reasoningEffort: "medium",
+        },
+      },
+    });
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        level: "warn",
+        message: "Failed to persist thread linkage metadata",
+        operation: "thread/start",
+      }),
+    );
   });
 
   test("resumes a thread using stored defaults when the request omits overrides", async () => {
@@ -226,7 +303,7 @@ describe("createThreadsService", () => {
     ]);
   });
 
-  test("lets explicit resume overrides win over stored defaults", async () => {
+  test("lets explicit resume overrides win over stored defaults while preserving stored fallbacks", async () => {
     const store = createInMemoryThreadsStore([
       {
         workspaceId: "workspace-1",
@@ -248,8 +325,8 @@ describe("createThreadsService", () => {
             id: "thread-1",
             workspacePath: "/tmp/project",
           }),
-          model: "gpt-5.4",
-          reasoningEffort: null,
+          model: "provider-model",
+          reasoningEffort: "medium",
         },
       }),
     });
@@ -262,7 +339,7 @@ describe("createThreadsService", () => {
 
     const result = await service.resumeThread("req-resume", workspace, {
       threadId: "thread-1",
-      model: "gpt-5.4",
+      model: "request-model",
     });
 
     expect(result).toEqual({
@@ -275,22 +352,193 @@ describe("createThreadsService", () => {
           updatedAt: "2026-04-10T11:00:00.000Z",
           name: null,
           archived: false,
-          model: "gpt-5.4",
+          model: "request-model",
           reasoningEffort: "low",
           status: { type: "idle" },
         },
       },
     });
+  });
+
+  test("thread/resume still succeeds when linkage persistence fails", async () => {
+    const { logger, records } = createCapturingLogger();
+    const session = createFakeAgentSession({
+      resumeThread: async (_requestId, params) => ({
+        ok: true,
+        data: {
+          thread: createTestAgentThread({
+            id: params.threadId,
+            workspacePath: "/tmp/project",
+          }),
+          model: "gpt-5.4",
+          reasoningEffort: "medium",
+        },
+      }),
+    });
+    const service = createThreadsService({
+      logger,
+      registry: createFakeAgentRegistry(session),
+      store: createFailingUpsertStore(
+        createInMemoryThreadsStore([
+          {
+            workspaceId: "workspace-1",
+            provider: "codex",
+            threadId: "thread-1",
+            threadWorkspacePath: "/tmp/project",
+            archived: false,
+            model: "gpt-5.4",
+            reasoningEffort: "medium",
+            firstSeenAt: "2026-04-10T09:30:00.000Z",
+            lastSeenAt: "2026-04-10T09:30:00.000Z",
+          },
+        ]),
+      ),
+      now: () => "2026-04-10T12:00:00.000Z",
+    });
+
     await expect(
-      store.getWorkspaceThreadLink({
-        workspaceId: "workspace-1",
-        provider: "codex",
+      service.resumeThread("req-resume", workspace, {
         threadId: "thread-1",
       }),
     ).resolves.toMatchObject({
-      model: "gpt-5.4",
-      reasoningEffort: "low",
+      ok: true,
+      data: {
+        thread: {
+          id: "thread-1",
+        },
+      },
     });
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        level: "warn",
+        message: "Failed to persist thread linkage metadata",
+        operation: "thread/resume",
+      }),
+    );
+  });
+
+  test("filters cross-workspace provider list results and does not persist them", async () => {
+    const { logger, records } = createCapturingLogger();
+    const store = createInMemoryThreadsStore();
+    const session = createFakeAgentSession({
+      listThreads: async () => ({
+        ok: true,
+        data: {
+          threads: [
+            createTestAgentThread({
+              id: "thread-ok",
+              workspacePath: "/tmp/project",
+            }),
+            createTestAgentThread({
+              id: "thread-other",
+              workspacePath: "/tmp/other-project",
+            }),
+          ],
+          nextCursor: "cursor-2",
+        },
+      }),
+    });
+    const service = createThreadsService({
+      logger,
+      registry: createFakeAgentRegistry(session),
+      store,
+      now: () => "2026-04-10T12:00:00.000Z",
+    });
+
+    const result = await service.listThreads("req-list", workspace, {});
+
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        threads: [
+          {
+            id: "thread-ok",
+            preview: "Thread preview",
+            createdAt: "2026-04-10T10:00:00.000Z",
+            updatedAt: "2026-04-10T11:00:00.000Z",
+            name: null,
+            archived: false,
+            model: null,
+            reasoningEffort: null,
+            status: { type: "idle" },
+          },
+        ],
+        nextCursor: "cursor-2",
+      },
+    });
+    await expect(
+      store.listWorkspaceThreadLinks({
+        workspaceId: "workspace-1",
+        provider: "codex",
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        threadId: "thread-ok",
+      }),
+    ]);
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        level: "warn",
+        message: "Filtered cross-workspace thread from provider list",
+        threadId: "thread-other",
+      }),
+    );
+  });
+
+  test("normalizes equivalent workspace paths when filtering thread/list", async () => {
+    const rootDirectory = await mkdtemp(join(tmpdir(), "atelier-threads-service-"));
+    const workspaceDirectory = join(rootDirectory, "workspace");
+    const aliasPath = join(rootDirectory, "workspace-alias");
+
+    await mkdir(workspaceDirectory, { recursive: true });
+    await symlink(workspaceDirectory, aliasPath);
+
+    const canonicalWorkspacePath = await realpath(workspaceDirectory);
+    const service = createThreadsService({
+      logger: createSilentLogger("error"),
+      registry: createFakeAgentRegistry(
+        createFakeAgentSession({
+          listThreads: async () => ({
+            ok: true,
+            data: {
+              threads: [
+                createTestAgentThread({
+                  id: "thread-symlink",
+                  workspacePath: aliasPath,
+                }),
+              ],
+              nextCursor: null,
+            },
+          }),
+        }),
+      ),
+      store: createInMemoryThreadsStore(),
+      now: () => "2026-04-10T12:00:00.000Z",
+    });
+
+    try {
+      await expect(
+        service.listThreads(
+          "req-list",
+          {
+            ...workspace,
+            workspacePath: canonicalWorkspacePath,
+          },
+          {},
+        ),
+      ).resolves.toMatchObject({
+        ok: true,
+        data: {
+          threads: [
+            {
+              id: "thread-symlink",
+            },
+          ],
+        },
+      });
+    } finally {
+      await rm(rootDirectory, { force: true, recursive: true });
+    }
   });
 
   test("returns an explicit domain error when thread/read requests turns", async () => {
@@ -317,10 +565,9 @@ describe("createThreadsService", () => {
       },
     });
     expect(session.readThreadCalls).toEqual([]);
-    expect(session.resumeThreadCalls).toEqual([]);
   });
 
-  test("thread/read stays point-in-time and surfaces stored defaults", async () => {
+  test("thread/read returns provider-authoritative archived and does not pass cached archived back upstream", async () => {
     const store = createInMemoryThreadsStore([
       {
         workspaceId: "workspace-1",
@@ -341,7 +588,7 @@ describe("createThreadsService", () => {
           thread: createTestAgentThread({
             id: "thread-1",
             workspacePath: "/tmp/project",
-            archived: true,
+            archived: false,
           }),
         },
       }),
@@ -367,7 +614,7 @@ describe("createThreadsService", () => {
           createdAt: "2026-04-10T10:00:00.000Z",
           updatedAt: "2026-04-10T11:00:00.000Z",
           name: null,
-          archived: true,
+          archived: false,
           model: "gpt-5.4",
           reasoningEffort: null,
           status: { type: "idle" },
@@ -380,11 +627,58 @@ describe("createThreadsService", () => {
         params: {
           threadId: "thread-1",
           includeTurns: false,
-          archived: true,
         },
       },
     ]);
-    expect(session.resumeThreadCalls).toEqual([]);
+  });
+
+  test("warns when provider defaults differ from Atelier-resolved defaults without changing behavior", async () => {
+    const { logger, records } = createCapturingLogger();
+    const session = createFakeAgentSession({
+      startThread: async () => ({
+        ok: true,
+        data: {
+          thread: createTestAgentThread({
+            id: "thread-started",
+            workspacePath: "/tmp/project",
+          }),
+          model: "provider-model",
+          reasoningEffort: "medium",
+        },
+      }),
+    });
+    const service = createThreadsService({
+      logger,
+      registry: createFakeAgentRegistry(session),
+      store: createInMemoryThreadsStore(),
+      now: () => "2026-04-10T12:00:00.000Z",
+    });
+
+    const result = await service.startThread("req-start", workspace, {
+      model: "request-model",
+      reasoningEffort: "high",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        thread: expect.objectContaining({
+          id: "thread-started",
+          model: "request-model",
+          reasoningEffort: "high",
+        }),
+      },
+    });
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        level: "warn",
+        message: "Resolved thread defaults differ from provider response",
+        operation: "thread/start",
+        threadId: "thread-started",
+        resolvedModel: "request-model",
+        providerModel: "provider-model",
+      }),
+    );
   });
 
   test("returns a workspace mismatch error when provider metadata does not match the opened workspace", async () => {
@@ -426,3 +720,12 @@ describe("createThreadsService", () => {
     });
   });
 });
+
+const createFailingUpsertStore = (store: ThreadsStore): ThreadsStore =>
+  Object.freeze({
+    getWorkspaceThreadLink: store.getWorkspaceThreadLink,
+    listWorkspaceThreadLinks: store.listWorkspaceThreadLinks,
+    upsertWorkspaceThreadLinks: async () => {
+      throw new Error("bookkeeping write failed");
+    },
+  });

--- a/AppServer/src/threads/service.ts
+++ b/AppServer/src/threads/service.ts
@@ -1,7 +1,9 @@
 import type {
   AgentInvalidMessageError,
+  AgentReasoningEffort,
   AgentRemoteError,
   AgentRequestId,
+  AgentSession,
   AgentSessionUnavailableError,
   AgentThread,
 } from "@/agents/contracts";
@@ -20,8 +22,12 @@ import type {
   ThreadListResult,
   ThreadReadParams,
   ThreadReadResult,
+  ThreadResumeParams,
+  ThreadResumeResult,
+  ThreadStartParams,
+  ThreadStartResult,
 } from "@/threads/schemas";
-import type { ThreadsStore } from "@/threads/store";
+import type { ThreadsStore, WorkspaceThreadLink } from "@/threads/store";
 import type { Workspace } from "@/workspaces/schemas";
 
 export type ThreadsServiceError =
@@ -35,6 +41,16 @@ export type ThreadsService = Readonly<{
     workspace: Workspace,
     params: ThreadListParams,
   ) => Promise<Result<ThreadListResult, ThreadsServiceError>>;
+  startThread: (
+    requestId: AgentRequestId,
+    workspace: Workspace,
+    params: ThreadStartParams,
+  ) => Promise<Result<ThreadStartResult, ThreadsServiceError>>;
+  resumeThread: (
+    requestId: AgentRequestId,
+    workspace: Workspace,
+    params: ThreadResumeParams,
+  ) => Promise<Result<ThreadResumeResult, ThreadsServiceError>>;
   readThread: (
     requestId: AgentRequestId,
     workspace: Workspace,
@@ -47,6 +63,11 @@ export type CreateThreadsServiceOptions = Readonly<{
   registry: AgentRegistry;
   store: ThreadsStore;
   now?: () => string;
+}>;
+
+type ThreadDefaults = Readonly<{
+  model: string | null;
+  reasoningEffort: AgentReasoningEffort | null;
 }>;
 
 export const createThreadsService = (options: CreateThreadsServiceOptions): ThreadsService => {
@@ -63,6 +84,14 @@ export const createThreadsService = (options: CreateThreadsServiceOptions): Thre
 
         throw new Error(sessionResult.error.message);
       }
+
+      const existingLinks = await options.store.listWorkspaceThreadLinks({
+        workspaceId: workspace.id,
+        provider: sessionResult.data.provider,
+      });
+      const defaultsByThreadId = new Map(
+        existingLinks.map((link) => [link.threadId, link] as const),
+      );
 
       const listResult = await sessionResult.data.listThreads(requestId, {
         cursor: params.cursor,
@@ -97,8 +126,118 @@ export const createThreadsService = (options: CreateThreadsServiceOptions): Thre
       });
 
       return ok({
-        threads: listResult.data.threads.map(mapPublicThread),
+        threads: listResult.data.threads.map((thread) =>
+          mapPublicThread(thread, getThreadDefaults(defaultsByThreadId.get(thread.id))),
+        ),
         nextCursor: listResult.data.nextCursor,
+      });
+    },
+    startThread: async (requestId, workspace, params) => {
+      const sessionResult = await options.registry.getSession();
+
+      if (!sessionResult.ok) {
+        if (sessionResult.error.type === "sessionUnavailable") {
+          return err(sessionResult.error);
+        }
+
+        throw new Error(sessionResult.error.message);
+      }
+
+      const startResult = await sessionResult.data.startThread(requestId, {
+        workspacePath: workspace.workspacePath,
+        ...(params.model ? { model: params.model } : {}),
+        ...(params.reasoningEffort ? { reasoningEffort: params.reasoningEffort } : {}),
+      });
+
+      if (!startResult.ok) {
+        switch (startResult.error.type) {
+          case "sessionUnavailable":
+          case "remoteError":
+            return err(startResult.error);
+          case "invalidProviderMessage":
+            return throwInvalidProviderMessage(options.logger, startResult.error);
+          default:
+            return assertNever(startResult.error, "Unhandled thread/start error");
+        }
+      }
+
+      if (startResult.data.thread.workspacePath !== workspace.workspacePath) {
+        return createThreadWorkspaceMismatchResult(
+          startResult.data.thread.id,
+          workspace.workspacePath,
+          startResult.data.thread.workspacePath,
+        );
+      }
+
+      const defaults = resolveThreadDefaults(startResult.data, params);
+      await persistThreadLink(options.store, {
+        workspace,
+        session: sessionResult.data,
+        seenAt: now(),
+        thread: startResult.data.thread,
+        defaults,
+      });
+
+      return ok({
+        thread: mapPublicThread(startResult.data.thread, defaults),
+      });
+    },
+    resumeThread: async (requestId, workspace, params) => {
+      const sessionResult = await options.registry.getSession();
+
+      if (!sessionResult.ok) {
+        if (sessionResult.error.type === "sessionUnavailable") {
+          return err(sessionResult.error);
+        }
+
+        throw new Error(sessionResult.error.message);
+      }
+
+      const existingLink = await options.store.getWorkspaceThreadLink({
+        workspaceId: workspace.id,
+        provider: sessionResult.data.provider,
+        threadId: params.threadId,
+      });
+      const resolvedModel = params.model ?? existingLink?.model;
+      const resolvedReasoningEffort = params.reasoningEffort ?? existingLink?.reasoningEffort;
+      const resumeResult = await sessionResult.data.resumeThread(requestId, {
+        threadId: params.threadId,
+        workspacePath: workspace.workspacePath,
+        ...(resolvedModel ? { model: resolvedModel } : {}),
+        ...(resolvedReasoningEffort ? { reasoningEffort: resolvedReasoningEffort } : {}),
+      });
+
+      if (!resumeResult.ok) {
+        switch (resumeResult.error.type) {
+          case "sessionUnavailable":
+          case "remoteError":
+            return err(resumeResult.error);
+          case "invalidProviderMessage":
+            return throwInvalidProviderMessage(options.logger, resumeResult.error);
+          default:
+            return assertNever(resumeResult.error, "Unhandled thread/resume error");
+        }
+      }
+
+      if (resumeResult.data.thread.workspacePath !== workspace.workspacePath) {
+        return createThreadWorkspaceMismatchResult(
+          resumeResult.data.thread.id,
+          workspace.workspacePath,
+          resumeResult.data.thread.workspacePath,
+        );
+      }
+
+      const defaults = resolveThreadDefaults(resumeResult.data, params, existingLink);
+      await persistThreadLink(options.store, {
+        workspace,
+        session: sessionResult.data,
+        seenAt: now(),
+        thread: resumeResult.data.thread,
+        defaults,
+      });
+
+      return ok({
+        thread: mapPublicThread(resumeResult.data.thread, defaults),
       });
     },
     readThread: async (requestId, workspace, params) => {
@@ -161,13 +300,56 @@ export const createThreadsService = (options: CreateThreadsServiceOptions): Thre
       });
 
       return ok({
-        thread: mapPublicThread(readResult.data.thread),
+        thread: mapPublicThread(readResult.data.thread, getThreadDefaults(existingLink)),
       });
     },
   });
 };
 
-const mapPublicThread = (thread: AgentThread): Thread =>
+const resolveThreadDefaults = (
+  result: Readonly<{
+    model?: string;
+    reasoningEffort?: AgentReasoningEffort | null;
+  }>,
+  params: Readonly<{
+    model?: string;
+    reasoningEffort?: AgentReasoningEffort;
+  }>,
+  existingLink?: WorkspaceThreadLink,
+): ThreadDefaults =>
+  Object.freeze({
+    model: params.model ?? existingLink?.model ?? result.model ?? null,
+    reasoningEffort:
+      params.reasoningEffort ?? existingLink?.reasoningEffort ?? result.reasoningEffort ?? null,
+  });
+
+const persistThreadLink = async (
+  store: ThreadsStore,
+  input: Readonly<{
+    workspace: Workspace;
+    session: AgentSession;
+    seenAt: string;
+    thread: AgentThread;
+    defaults: ThreadDefaults;
+  }>,
+): Promise<void> => {
+  await store.upsertWorkspaceThreadLinks({
+    workspaceId: input.workspace.id,
+    provider: input.session.provider,
+    seenAt: input.seenAt,
+    links: [
+      Object.freeze({
+        threadId: input.thread.id,
+        threadWorkspacePath: input.thread.workspacePath,
+        archived: input.thread.archived,
+        model: input.defaults.model,
+        reasoningEffort: input.defaults.reasoningEffort,
+      }),
+    ],
+  });
+};
+
+const mapPublicThread = (thread: AgentThread, defaults: ThreadDefaults): Thread =>
   Object.freeze({
     id: thread.id,
     preview: thread.preview,
@@ -175,7 +357,15 @@ const mapPublicThread = (thread: AgentThread): Thread =>
     updatedAt: thread.updatedAt,
     name: thread.name,
     archived: thread.archived,
+    model: defaults.model,
+    reasoningEffort: defaults.reasoningEffort,
     status: mapPublicThreadStatus(thread.status),
+  });
+
+const getThreadDefaults = (link: WorkspaceThreadLink | undefined): ThreadDefaults =>
+  Object.freeze({
+    model: link?.model ?? null,
+    reasoningEffort: link?.reasoningEffort ?? null,
   });
 
 const mapPublicThreadStatus = (status: AgentThread["status"]): ThreadExecutionStatus => {
@@ -200,7 +390,7 @@ const mapPublicThreadStatus = (status: AgentThread["status"]): ThreadExecutionSt
 };
 
 const throwInvalidProviderMessage = (logger: Logger, error: AgentInvalidMessageError): never => {
-  logger.error("Thread browsing returned an invalid provider message", {
+  logger.error("Thread operation returned an invalid provider message", {
     agentId: error.agentId,
     provider: error.provider,
     message: error.message,

--- a/AppServer/src/threads/service.ts
+++ b/AppServer/src/threads/service.ts
@@ -1,20 +1,21 @@
 import type {
   AgentInvalidMessageError,
+  AgentProvider,
   AgentReasoningEffort,
   AgentRemoteError,
   AgentRequestId,
-  AgentSession,
   AgentSessionUnavailableError,
   AgentThread,
 } from "@/agents/contracts";
 import type { AgentRegistry } from "@/agents/registry";
 import type { Logger } from "@/app/logger";
 import {
+  createInvalidProviderPayloadError,
   createThreadReadIncludeTurnsUnsupportedResult,
   createThreadWorkspaceMismatchResult,
   type ProtocolMethodError,
 } from "@/core/protocol/errors";
-import { assertNever, err, ok, type Result } from "@/core/shared";
+import { assertNever, err, getErrorMessage, ok, type Result } from "@/core/shared";
 import type {
   Thread,
   ThreadExecutionStatus,
@@ -28,11 +29,24 @@ import type {
   ThreadStartResult,
 } from "@/threads/schemas";
 import type { ThreadsStore, WorkspaceThreadLink } from "@/threads/store";
+import { normalizeWorkspacePath, type WorkspacePathNormalizer } from "@/workspaces/path";
 import type { Workspace } from "@/workspaces/schemas";
+
+type ThreadOperation = "thread/list" | "thread/start" | "thread/resume" | "thread/read";
+
+export type InvalidProviderPayloadError = Readonly<{
+  type: "invalidProviderPayload";
+  agentId: string;
+  provider: AgentProvider;
+  operation: ThreadOperation;
+  message: string;
+  detail?: Record<string, unknown>;
+}>;
 
 export type ThreadsServiceError =
   | AgentSessionUnavailableError
   | AgentRemoteError
+  | InvalidProviderPayloadError
   | ProtocolMethodError;
 
 export type ThreadsService = Readonly<{
@@ -63,6 +77,7 @@ export type CreateThreadsServiceOptions = Readonly<{
   registry: AgentRegistry;
   store: ThreadsStore;
   now?: () => string;
+  normalizeWorkspacePath?: WorkspacePathNormalizer;
 }>;
 
 type ThreadDefaults = Readonly<{
@@ -72,6 +87,7 @@ type ThreadDefaults = Readonly<{
 
 export const createThreadsService = (options: CreateThreadsServiceOptions): ThreadsService => {
   const now = options.now ?? (() => new Date().toISOString());
+  const normalizePath = options.normalizeWorkspacePath ?? normalizeWorkspacePath;
 
   return Object.freeze({
     listThreads: async (requestId, workspace, params) => {
@@ -85,6 +101,7 @@ export const createThreadsService = (options: CreateThreadsServiceOptions): Thre
         throw new Error(sessionResult.error.message);
       }
 
+      const normalizedWorkspacePath = await normalizePath(workspace.workspacePath);
       const existingLinks = await options.store.listWorkspaceThreadLinks({
         workspaceId: workspace.id,
         provider: sessionResult.data.provider,
@@ -97,7 +114,7 @@ export const createThreadsService = (options: CreateThreadsServiceOptions): Thre
         cursor: params.cursor,
         limit: params.limit,
         archived: params.archived,
-        workspacePath: workspace.workspacePath,
+        workspacePath: normalizedWorkspacePath,
       });
 
       if (!listResult.ok) {
@@ -106,17 +123,39 @@ export const createThreadsService = (options: CreateThreadsServiceOptions): Thre
           case "remoteError":
             return err(listResult.error);
           case "invalidProviderMessage":
-            return throwInvalidProviderMessage(options.logger, listResult.error);
+            return err(createInvalidProviderPayloadServiceError("thread/list", listResult.error));
           default:
             return assertNever(listResult.error, "Unhandled thread/list error");
         }
       }
 
-      await options.store.upsertWorkspaceThreadLinks({
-        workspaceId: workspace.id,
+      const threads = (
+        await Promise.all(
+          listResult.data.threads.map(async (thread) => {
+            if (!(await threadBelongsToWorkspace(thread, normalizedWorkspacePath, normalizePath))) {
+              options.logger.warn("Filtered cross-workspace thread from provider list", {
+                threadId: thread.id,
+                workspaceId: workspace.id,
+                openedWorkspacePath: workspace.workspacePath,
+                threadWorkspacePath: thread.workspacePath,
+                provider: sessionResult.data.provider,
+              });
+              return undefined;
+            }
+
+            return thread;
+          }),
+        )
+      ).filter(
+        (thread): thread is (typeof listResult.data.threads)[number] => thread !== undefined,
+      );
+
+      await persistThreadLinksBestEffort(options, {
+        operation: "thread/list",
+        workspace,
         provider: sessionResult.data.provider,
         seenAt: now(),
-        links: listResult.data.threads.map((thread) =>
+        links: threads.map((thread) =>
           Object.freeze({
             threadId: thread.id,
             threadWorkspacePath: thread.workspacePath,
@@ -126,7 +165,7 @@ export const createThreadsService = (options: CreateThreadsServiceOptions): Thre
       });
 
       return ok({
-        threads: listResult.data.threads.map((thread) =>
+        threads: threads.map((thread) =>
           mapPublicThread(thread, getThreadDefaults(defaultsByThreadId.get(thread.id))),
         ),
         nextCursor: listResult.data.nextCursor,
@@ -143,8 +182,9 @@ export const createThreadsService = (options: CreateThreadsServiceOptions): Thre
         throw new Error(sessionResult.error.message);
       }
 
+      const normalizedWorkspacePath = await normalizePath(workspace.workspacePath);
       const startResult = await sessionResult.data.startThread(requestId, {
-        workspacePath: workspace.workspacePath,
+        workspacePath: normalizedWorkspacePath,
         ...(params.model ? { model: params.model } : {}),
         ...(params.reasoningEffort ? { reasoningEffort: params.reasoningEffort } : {}),
       });
@@ -155,13 +195,19 @@ export const createThreadsService = (options: CreateThreadsServiceOptions): Thre
           case "remoteError":
             return err(startResult.error);
           case "invalidProviderMessage":
-            return throwInvalidProviderMessage(options.logger, startResult.error);
+            return err(createInvalidProviderPayloadServiceError("thread/start", startResult.error));
           default:
             return assertNever(startResult.error, "Unhandled thread/start error");
         }
       }
 
-      if (startResult.data.thread.workspacePath !== workspace.workspacePath) {
+      if (
+        !(await threadBelongsToWorkspace(
+          startResult.data.thread,
+          normalizedWorkspacePath,
+          normalizePath,
+        ))
+      ) {
         return createThreadWorkspaceMismatchResult(
           startResult.data.thread.id,
           workspace.workspacePath,
@@ -170,12 +216,28 @@ export const createThreadsService = (options: CreateThreadsServiceOptions): Thre
       }
 
       const defaults = resolveThreadDefaults(startResult.data, params);
-      await persistThreadLink(options.store, {
+      warnOnThreadDefaultsMismatch(options.logger, {
+        operation: "thread/start",
         workspace,
-        session: sessionResult.data,
-        seenAt: now(),
-        thread: startResult.data.thread,
+        threadId: startResult.data.thread.id,
+        providerModel: startResult.data.model,
+        providerReasoningEffort: startResult.data.reasoningEffort,
         defaults,
+      });
+      await persistThreadLinksBestEffort(options, {
+        operation: "thread/start",
+        workspace,
+        provider: sessionResult.data.provider,
+        seenAt: now(),
+        links: [
+          Object.freeze({
+            threadId: startResult.data.thread.id,
+            threadWorkspacePath: startResult.data.thread.workspacePath,
+            archived: startResult.data.thread.archived,
+            model: defaults.model,
+            reasoningEffort: defaults.reasoningEffort,
+          }),
+        ],
       });
 
       return ok({
@@ -193,6 +255,7 @@ export const createThreadsService = (options: CreateThreadsServiceOptions): Thre
         throw new Error(sessionResult.error.message);
       }
 
+      const normalizedWorkspacePath = await normalizePath(workspace.workspacePath);
       const existingLink = await options.store.getWorkspaceThreadLink({
         workspaceId: workspace.id,
         provider: sessionResult.data.provider,
@@ -202,7 +265,7 @@ export const createThreadsService = (options: CreateThreadsServiceOptions): Thre
       const resolvedReasoningEffort = params.reasoningEffort ?? existingLink?.reasoningEffort;
       const resumeResult = await sessionResult.data.resumeThread(requestId, {
         threadId: params.threadId,
-        workspacePath: workspace.workspacePath,
+        workspacePath: normalizedWorkspacePath,
         ...(resolvedModel ? { model: resolvedModel } : {}),
         ...(resolvedReasoningEffort ? { reasoningEffort: resolvedReasoningEffort } : {}),
       });
@@ -213,13 +276,21 @@ export const createThreadsService = (options: CreateThreadsServiceOptions): Thre
           case "remoteError":
             return err(resumeResult.error);
           case "invalidProviderMessage":
-            return throwInvalidProviderMessage(options.logger, resumeResult.error);
+            return err(
+              createInvalidProviderPayloadServiceError("thread/resume", resumeResult.error),
+            );
           default:
             return assertNever(resumeResult.error, "Unhandled thread/resume error");
         }
       }
 
-      if (resumeResult.data.thread.workspacePath !== workspace.workspacePath) {
+      if (
+        !(await threadBelongsToWorkspace(
+          resumeResult.data.thread,
+          normalizedWorkspacePath,
+          normalizePath,
+        ))
+      ) {
         return createThreadWorkspaceMismatchResult(
           resumeResult.data.thread.id,
           workspace.workspacePath,
@@ -228,12 +299,28 @@ export const createThreadsService = (options: CreateThreadsServiceOptions): Thre
       }
 
       const defaults = resolveThreadDefaults(resumeResult.data, params, existingLink);
-      await persistThreadLink(options.store, {
+      warnOnThreadDefaultsMismatch(options.logger, {
+        operation: "thread/resume",
         workspace,
-        session: sessionResult.data,
-        seenAt: now(),
-        thread: resumeResult.data.thread,
+        threadId: resumeResult.data.thread.id,
+        providerModel: resumeResult.data.model,
+        providerReasoningEffort: resumeResult.data.reasoningEffort,
         defaults,
+      });
+      await persistThreadLinksBestEffort(options, {
+        operation: "thread/resume",
+        workspace,
+        provider: sessionResult.data.provider,
+        seenAt: now(),
+        links: [
+          Object.freeze({
+            threadId: resumeResult.data.thread.id,
+            threadWorkspacePath: resumeResult.data.thread.workspacePath,
+            archived: resumeResult.data.thread.archived,
+            model: defaults.model,
+            reasoningEffort: defaults.reasoningEffort,
+          }),
+        ],
       });
 
       return ok({
@@ -255,6 +342,7 @@ export const createThreadsService = (options: CreateThreadsServiceOptions): Thre
         throw new Error(sessionResult.error.message);
       }
 
+      const normalizedWorkspacePath = await normalizePath(workspace.workspacePath);
       const existingLink = await options.store.getWorkspaceThreadLink({
         workspaceId: workspace.id,
         provider: sessionResult.data.provider,
@@ -263,7 +351,6 @@ export const createThreadsService = (options: CreateThreadsServiceOptions): Thre
       const readResult = await sessionResult.data.readThread(requestId, {
         threadId: params.threadId,
         includeTurns: false,
-        archived: existingLink?.archived,
       });
 
       if (!readResult.ok) {
@@ -272,13 +359,19 @@ export const createThreadsService = (options: CreateThreadsServiceOptions): Thre
           case "remoteError":
             return err(readResult.error);
           case "invalidProviderMessage":
-            return throwInvalidProviderMessage(options.logger, readResult.error);
+            return err(createInvalidProviderPayloadServiceError("thread/read", readResult.error));
           default:
             return assertNever(readResult.error, "Unhandled thread/read error");
         }
       }
 
-      if (readResult.data.thread.workspacePath !== workspace.workspacePath) {
+      if (
+        !(await threadBelongsToWorkspace(
+          readResult.data.thread,
+          normalizedWorkspacePath,
+          normalizePath,
+        ))
+      ) {
         return createThreadWorkspaceMismatchResult(
           readResult.data.thread.id,
           workspace.workspacePath,
@@ -323,31 +416,100 @@ const resolveThreadDefaults = (
       params.reasoningEffort ?? existingLink?.reasoningEffort ?? result.reasoningEffort ?? null,
   });
 
-const persistThreadLink = async (
-  store: ThreadsStore,
+const persistThreadLinksBestEffort = async (
+  options: CreateThreadsServiceOptions,
   input: Readonly<{
+    operation: ThreadOperation;
     workspace: Workspace;
-    session: AgentSession;
+    provider: AgentProvider;
     seenAt: string;
-    thread: AgentThread;
-    defaults: ThreadDefaults;
+    links: readonly Readonly<{
+      threadId: string;
+      threadWorkspacePath: string;
+      archived: boolean;
+      model?: string | null;
+      reasoningEffort?: AgentReasoningEffort | null;
+    }>[];
   }>,
 ): Promise<void> => {
-  await store.upsertWorkspaceThreadLinks({
+  try {
+    await options.store.upsertWorkspaceThreadLinks({
+      workspaceId: input.workspace.id,
+      provider: input.provider,
+      seenAt: input.seenAt,
+      links: input.links,
+    });
+  } catch (error) {
+    options.logger.warn("Failed to persist thread linkage metadata", {
+      operation: input.operation,
+      workspaceId: input.workspace.id,
+      workspacePath: input.workspace.workspacePath,
+      provider: input.provider,
+      threadCount: input.links.length,
+      threadIds: input.links.map((link) => link.threadId).join(","),
+      error: getErrorMessage(error),
+    });
+  }
+};
+
+const threadBelongsToWorkspace = async (
+  thread: AgentThread,
+  normalizedWorkspacePath: string,
+  normalizePath: WorkspacePathNormalizer,
+): Promise<boolean> => (await normalizePath(thread.workspacePath)) === normalizedWorkspacePath;
+
+const warnOnThreadDefaultsMismatch = (
+  logger: Logger,
+  input: Readonly<{
+    operation: ThreadOperation;
+    workspace: Workspace;
+    threadId: string;
+    providerModel?: string;
+    providerReasoningEffort?: AgentReasoningEffort | null;
+    defaults: ThreadDefaults;
+  }>,
+): void => {
+  if (
+    input.defaults.model === (input.providerModel ?? null) &&
+    input.defaults.reasoningEffort === (input.providerReasoningEffort ?? null)
+  ) {
+    return;
+  }
+
+  logger.warn("Resolved thread defaults differ from provider response", {
+    operation: input.operation,
     workspaceId: input.workspace.id,
-    provider: input.session.provider,
-    seenAt: input.seenAt,
-    links: [
-      Object.freeze({
-        threadId: input.thread.id,
-        threadWorkspacePath: input.thread.workspacePath,
-        archived: input.thread.archived,
-        model: input.defaults.model,
-        reasoningEffort: input.defaults.reasoningEffort,
-      }),
-    ],
+    workspacePath: input.workspace.workspacePath,
+    threadId: input.threadId,
+    resolvedModel: input.defaults.model,
+    providerModel: input.providerModel ?? null,
+    resolvedReasoningEffort: input.defaults.reasoningEffort,
+    providerReasoningEffort: input.providerReasoningEffort ?? null,
   });
 };
+
+const createInvalidProviderPayloadServiceError = (
+  operation: ThreadOperation,
+  error: AgentInvalidMessageError,
+): InvalidProviderPayloadError =>
+  Object.freeze({
+    type: "invalidProviderPayload",
+    agentId: error.agentId,
+    provider: error.provider,
+    operation,
+    message: error.message,
+    ...(error.detail ? { detail: error.detail } : {}),
+  });
+
+export const mapInvalidProviderPayloadToProtocolError = (
+  error: InvalidProviderPayloadError,
+): ProtocolMethodError =>
+  createInvalidProviderPayloadError({
+    agentId: error.agentId,
+    provider: error.provider,
+    operation: error.operation,
+    providerMessage: error.message,
+  });
 
 const mapPublicThread = (thread: AgentThread, defaults: ThreadDefaults): Thread =>
   Object.freeze({
@@ -387,15 +549,4 @@ const mapPublicThreadStatus = (status: AgentThread["status"]): ThreadExecutionSt
     default:
       return assertNever(status, "Unhandled public thread status");
   }
-};
-
-const throwInvalidProviderMessage = (logger: Logger, error: AgentInvalidMessageError): never => {
-  logger.error("Thread operation returned an invalid provider message", {
-    agentId: error.agentId,
-    provider: error.provider,
-    message: error.message,
-    ...(error.detail ? { detail: JSON.stringify(error.detail) } : {}),
-  });
-
-  throw new Error(error.message, { cause: error });
 };

--- a/AppServer/src/threads/store.test.ts
+++ b/AppServer/src/threads/store.test.ts
@@ -21,7 +21,7 @@ describe("threads store", () => {
   ] as const;
 
   for (const storeFactory of storeFactories) {
-    test(`${storeFactory.name} inserts workspace-thread links`, async () => {
+    test(`${storeFactory.name} inserts workspace-thread links with nullable defaults`, async () => {
       const store = await storeFactory.createStore();
 
       await store.upsertWorkspaceThreadLinks({
@@ -49,12 +49,14 @@ describe("threads store", () => {
         threadId: "thread-1",
         threadWorkspacePath: "/tmp/project",
         archived: false,
+        model: null,
+        reasoningEffort: null,
         firstSeenAt: "2026-04-10T10:00:00.000Z",
         lastSeenAt: "2026-04-10T10:00:00.000Z",
       });
     });
 
-    test(`${storeFactory.name} performs idempotent upserts for repeated sightings`, async () => {
+    test(`${storeFactory.name} preserves stored defaults when later sightings omit them`, async () => {
       const store = await storeFactory.createStore();
 
       await store.upsertWorkspaceThreadLinks({
@@ -66,6 +68,8 @@ describe("threads store", () => {
             threadId: "thread-1",
             threadWorkspacePath: "/tmp/project",
             archived: false,
+            model: "gpt-5.4",
+            reasoningEffort: "high",
           },
         ],
       });
@@ -94,10 +98,63 @@ describe("threads store", () => {
           threadId: "thread-1",
           threadWorkspacePath: "/tmp/project",
           archived: true,
+          model: "gpt-5.4",
+          reasoningEffort: "high",
           firstSeenAt: "2026-04-10T10:00:00.000Z",
           lastSeenAt: "2026-04-10T11:00:00.000Z",
         },
       ]);
+    });
+
+    test(`${storeFactory.name} can explicitly clear nullable defaults`, async () => {
+      const store = await storeFactory.createStore();
+
+      await store.upsertWorkspaceThreadLinks({
+        workspaceId: "workspace-1",
+        provider: "codex",
+        seenAt: "2026-04-10T10:00:00.000Z",
+        links: [
+          {
+            threadId: "thread-1",
+            threadWorkspacePath: "/tmp/project",
+            archived: false,
+            model: "gpt-5.4",
+            reasoningEffort: "medium",
+          },
+        ],
+      });
+      await store.upsertWorkspaceThreadLinks({
+        workspaceId: "workspace-1",
+        provider: "codex",
+        seenAt: "2026-04-10T11:00:00.000Z",
+        links: [
+          {
+            threadId: "thread-1",
+            threadWorkspacePath: "/tmp/project",
+            archived: false,
+            model: null,
+            reasoningEffort: null,
+          },
+        ],
+      });
+
+      await expect(
+        store.getWorkspaceThreadLink({
+          workspaceId: "workspace-1",
+          provider: "codex",
+          threadId: "thread-1",
+        }),
+      ).resolves.toEqual({
+        workspaceId: "workspace-1",
+        provider: "codex",
+        threadId: "thread-1",
+        threadWorkspacePath: "/tmp/project",
+        archived: false,
+        model: null,
+        reasoningEffort: null,
+        firstSeenAt: "2026-04-10T10:00:00.000Z",
+        lastSeenAt: "2026-04-10T11:00:00.000Z",
+      });
     });
 
     test(`${storeFactory.name} keeps associations separate per workspace`, async () => {
@@ -112,6 +169,8 @@ describe("threads store", () => {
             threadId: "thread-1",
             threadWorkspacePath: "/tmp/project-a",
             archived: false,
+            model: "gpt-5.4",
+            reasoningEffort: "medium",
           },
         ],
       });
@@ -124,6 +183,8 @@ describe("threads store", () => {
             threadId: "thread-1",
             threadWorkspacePath: "/tmp/project-b",
             archived: false,
+            model: "gpt-5.4-mini",
+            reasoningEffort: null,
           },
         ],
       });
@@ -140,6 +201,8 @@ describe("threads store", () => {
           threadId: "thread-1",
           threadWorkspacePath: "/tmp/project-a",
           archived: false,
+          model: "gpt-5.4",
+          reasoningEffort: "medium",
           firstSeenAt: "2026-04-10T10:00:00.000Z",
           lastSeenAt: "2026-04-10T10:00:00.000Z",
         },
@@ -156,6 +219,8 @@ describe("threads store", () => {
           threadId: "thread-1",
           threadWorkspacePath: "/tmp/project-b",
           archived: false,
+          model: "gpt-5.4-mini",
+          reasoningEffort: null,
           firstSeenAt: "2026-04-10T10:30:00.000Z",
           lastSeenAt: "2026-04-10T10:30:00.000Z",
         },

--- a/AppServer/src/threads/store.test.ts
+++ b/AppServer/src/threads/store.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, test } from "bun:test";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import { migrate } from "drizzle-orm/bun-sqlite/migrator";
 import { type AppDatabase, DEFAULT_MIGRATIONS_FOLDER } from "@/core/store";
-import { createInMemoryThreadsStore, createSqliteThreadsStore } from "@/threads/store";
+import {
+  createInMemoryThreadsStore,
+  createSqliteThreadsStore,
+  mapWorkspaceThreadRow,
+} from "@/threads/store";
 
 describe("threads store", () => {
   const storeFactories = [
@@ -227,6 +231,70 @@ describe("threads store", () => {
       ]);
     });
   }
+
+  test("sqlite upserts are applied transactionally", async () => {
+    const database = createMigratedInMemoryDatabase();
+    const store = createSqliteThreadsStore(() => database);
+
+    await expect(
+      store.upsertWorkspaceThreadLinks({
+        workspaceId: "workspace-1",
+        provider: "codex",
+        seenAt: "2026-04-10T10:00:00.000Z",
+        links: [
+          {
+            threadId: "thread-ok",
+            threadWorkspacePath: "/tmp/project",
+            archived: false,
+          },
+          {
+            threadId: "thread-bad",
+            threadWorkspacePath: null as never,
+            archived: false,
+          },
+        ],
+      }),
+    ).rejects.toThrow();
+
+    await expect(
+      store.listWorkspaceThreadLinks({
+        workspaceId: "workspace-1",
+        provider: "codex",
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  test("rejects invalid persisted provider values deterministically", () => {
+    expect(() =>
+      mapWorkspaceThreadRow({
+        workspaceId: "workspace-1",
+        provider: "other" as never,
+        threadId: "thread-1",
+        threadWorkspacePath: "/tmp/project",
+        archived: false,
+        model: null,
+        reasoningEffort: null,
+        firstSeenAt: "2026-04-10T10:00:00.000Z",
+        lastSeenAt: "2026-04-10T10:00:00.000Z",
+      }),
+    ).toThrow("Invalid workspace thread provider: other");
+  });
+
+  test("rejects invalid persisted reasoning effort values deterministically", () => {
+    expect(() =>
+      mapWorkspaceThreadRow({
+        workspaceId: "workspace-1",
+        provider: "codex",
+        threadId: "thread-1",
+        threadWorkspacePath: "/tmp/project",
+        archived: false,
+        model: null,
+        reasoningEffort: "turbo" as never,
+        firstSeenAt: "2026-04-10T10:00:00.000Z",
+        lastSeenAt: "2026-04-10T10:00:00.000Z",
+      }),
+    ).toThrow("Invalid workspace thread reasoning effort: turbo");
+  });
 });
 
 const createMigratedInMemoryDatabase = (): AppDatabase => {

--- a/AppServer/src/threads/store.ts
+++ b/AppServer/src/threads/store.ts
@@ -1,6 +1,9 @@
+import { Type } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
 import { and, asc, eq } from "drizzle-orm";
 import { integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
 import type { AgentProvider, AgentReasoningEffort } from "@/agents/contracts";
+import { ModelReasoningEffortSchema } from "@/agents/schemas";
 import type { AppDatabase } from "@/core/store";
 
 export const workspaceThreadsTable = sqliteTable(
@@ -77,6 +80,9 @@ export type ThreadsStore = Readonly<{
 
 type AppDatabaseProvider = () => AppDatabase;
 
+const AgentProviderSchema = Type.Literal("codex");
+const NullableReasoningEffortSchema = Type.Union([ModelReasoningEffortSchema, Type.Null()]);
+
 export const createSqliteThreadsStore = (getDatabase: AppDatabaseProvider): ThreadsStore => {
   const getWorkspaceThreadLink: ThreadsStore["getWorkspaceThreadLink"] = async (lookup) => {
     const database = getDatabase();
@@ -114,20 +120,19 @@ export const createSqliteThreadsStore = (getDatabase: AppDatabaseProvider): Thre
 
   const upsertWorkspaceThreadLinks: ThreadsStore["upsertWorkspaceThreadLinks"] = async (input) => {
     const database = getDatabase();
+    const sqliteHandle = database.$client;
 
-    for (const link of input.links) {
-      const existing = await getWorkspaceThreadLink({
-        workspaceId: input.workspaceId,
-        provider: input.provider,
-        threadId: link.threadId,
-      });
+    sqliteHandle.exec("BEGIN");
 
-      if (existing === undefined) {
-        insertWorkspaceThreadLink(database, input, link);
-        continue;
+    try {
+      for (const link of input.links) {
+        upsertWorkspaceThreadLink(database, input, link);
       }
 
-      updateWorkspaceThreadLink(database, input, link, existing.firstSeenAt);
+      sqliteHandle.exec("COMMIT");
+    } catch (error) {
+      sqliteHandle.exec("ROLLBACK");
+      throw error;
     }
   };
 
@@ -152,15 +157,17 @@ export const createInMemoryThreadsStore = (
         .filter((link) => link.workspaceId === workspaceId && link.provider === provider)
         .sort((left, right) => left.threadId.localeCompare(right.threadId)),
     upsertWorkspaceThreadLinks: async (input) => {
+      const nextLinksByKey = new Map(linksByKey);
+
       for (const link of input.links) {
         const key = toWorkspaceThreadKey({
           workspaceId: input.workspaceId,
           provider: input.provider,
           threadId: link.threadId,
         });
-        const existing = linksByKey.get(key);
+        const existing = nextLinksByKey.get(key);
 
-        linksByKey.set(
+        nextLinksByKey.set(
           key,
           Object.freeze({
             workspaceId: input.workspaceId,
@@ -178,11 +185,17 @@ export const createInMemoryThreadsStore = (
           }),
         );
       }
+
+      linksByKey.clear();
+
+      for (const [key, link] of nextLinksByKey) {
+        linksByKey.set(key, link);
+      }
     },
   });
 };
 
-const insertWorkspaceThreadLink = (
+const upsertWorkspaceThreadLink = (
   database: AppDatabase,
   input: UpsertWorkspaceThreadLinksInput,
   link: WorkspaceThreadLinkRecord,
@@ -195,52 +208,49 @@ const insertWorkspaceThreadLink = (
       threadId: link.threadId,
       threadWorkspacePath: link.threadWorkspacePath,
       archived: link.archived,
-      model: link.model ?? null,
-      reasoningEffort: link.reasoningEffort ?? null,
+      ...(link.model !== undefined ? { model: link.model } : {}),
+      ...(link.reasoningEffort !== undefined ? { reasoningEffort: link.reasoningEffort } : {}),
       firstSeenAt: input.seenAt,
       lastSeenAt: input.seenAt,
     })
-    .run();
-};
-
-const updateWorkspaceThreadLink = (
-  database: AppDatabase,
-  input: UpsertWorkspaceThreadLinksInput,
-  link: WorkspaceThreadLinkRecord,
-  firstSeenAt: string,
-): void => {
-  database
-    .update(workspaceThreadsTable)
-    .set({
-      threadWorkspacePath: link.threadWorkspacePath,
-      archived: link.archived,
-      ...(link.model !== undefined ? { model: link.model } : {}),
-      ...(link.reasoningEffort !== undefined ? { reasoningEffort: link.reasoningEffort } : {}),
-      firstSeenAt,
-      lastSeenAt: input.seenAt,
+    .onConflictDoUpdate({
+      target: [
+        workspaceThreadsTable.workspaceId,
+        workspaceThreadsTable.provider,
+        workspaceThreadsTable.threadId,
+      ],
+      set: {
+        threadWorkspacePath: link.threadWorkspacePath,
+        archived: link.archived,
+        ...(link.model !== undefined ? { model: link.model } : {}),
+        ...(link.reasoningEffort !== undefined ? { reasoningEffort: link.reasoningEffort } : {}),
+        lastSeenAt: input.seenAt,
+      },
     })
-    .where(
-      and(
-        eq(workspaceThreadsTable.workspaceId, input.workspaceId),
-        eq(workspaceThreadsTable.provider, input.provider),
-        eq(workspaceThreadsTable.threadId, link.threadId),
-      ),
-    )
     .run();
 };
 
-const mapWorkspaceThreadRow = (row: WorkspaceThreadRow): WorkspaceThreadLink =>
-  Object.freeze({
+export const mapWorkspaceThreadRow = (row: WorkspaceThreadRow): WorkspaceThreadLink => {
+  if (!Value.Check(AgentProviderSchema, row.provider)) {
+    throw new Error(`Invalid workspace thread provider: ${String(row.provider)}`);
+  }
+
+  if (!Value.Check(NullableReasoningEffortSchema, row.reasoningEffort)) {
+    throw new Error(`Invalid workspace thread reasoning effort: ${String(row.reasoningEffort)}`);
+  }
+
+  return Object.freeze({
     workspaceId: row.workspaceId,
     provider: row.provider as AgentProvider,
     threadId: row.threadId,
     threadWorkspacePath: row.threadWorkspacePath,
     archived: row.archived,
     model: row.model,
-    reasoningEffort: (row.reasoningEffort as AgentReasoningEffort | null) ?? null,
+    reasoningEffort: row.reasoningEffort,
     firstSeenAt: row.firstSeenAt,
     lastSeenAt: row.lastSeenAt,
   });
+};
 
 const toWorkspaceThreadKey = (lookup: WorkspaceThreadLinkLookup): string =>
   `${lookup.workspaceId}:${lookup.provider}:${lookup.threadId}`;

--- a/AppServer/src/threads/store.ts
+++ b/AppServer/src/threads/store.ts
@@ -1,6 +1,6 @@
 import { and, asc, eq } from "drizzle-orm";
 import { integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
-import type { AgentProvider } from "@/agents/contracts";
+import type { AgentProvider, AgentReasoningEffort } from "@/agents/contracts";
 import type { AppDatabase } from "@/core/store";
 
 export const workspaceThreadsTable = sqliteTable(
@@ -11,6 +11,8 @@ export const workspaceThreadsTable = sqliteTable(
     threadId: text("thread_id").notNull(),
     threadWorkspacePath: text("thread_workspace_path").notNull(),
     archived: integer("archived", { mode: "boolean" }).notNull(),
+    model: text("model"),
+    reasoningEffort: text("reasoning_effort"),
     firstSeenAt: text("first_seen_at").notNull(),
     lastSeenAt: text("last_seen_at").notNull(),
   },
@@ -31,6 +33,8 @@ export type WorkspaceThreadLink = Readonly<{
   threadId: string;
   threadWorkspacePath: string;
   archived: boolean;
+  model: string | null;
+  reasoningEffort: AgentReasoningEffort | null;
   firstSeenAt: string;
   lastSeenAt: string;
 }>;
@@ -45,6 +49,8 @@ export type WorkspaceThreadLinkRecord = Readonly<{
   threadId: string;
   threadWorkspacePath: string;
   archived: boolean;
+  model?: string | null;
+  reasoningEffort?: AgentReasoningEffort | null;
 }>;
 
 export type UpsertWorkspaceThreadLinksInput = Readonly<{
@@ -162,6 +168,11 @@ export const createInMemoryThreadsStore = (
             threadId: link.threadId,
             threadWorkspacePath: link.threadWorkspacePath,
             archived: link.archived,
+            model: link.model !== undefined ? link.model : (existing?.model ?? null),
+            reasoningEffort:
+              link.reasoningEffort !== undefined
+                ? link.reasoningEffort
+                : (existing?.reasoningEffort ?? null),
             firstSeenAt: existing?.firstSeenAt ?? input.seenAt,
             lastSeenAt: input.seenAt,
           }),
@@ -184,6 +195,8 @@ const insertWorkspaceThreadLink = (
       threadId: link.threadId,
       threadWorkspacePath: link.threadWorkspacePath,
       archived: link.archived,
+      model: link.model ?? null,
+      reasoningEffort: link.reasoningEffort ?? null,
       firstSeenAt: input.seenAt,
       lastSeenAt: input.seenAt,
     })
@@ -201,6 +214,8 @@ const updateWorkspaceThreadLink = (
     .set({
       threadWorkspacePath: link.threadWorkspacePath,
       archived: link.archived,
+      ...(link.model !== undefined ? { model: link.model } : {}),
+      ...(link.reasoningEffort !== undefined ? { reasoningEffort: link.reasoningEffort } : {}),
       firstSeenAt,
       lastSeenAt: input.seenAt,
     })
@@ -221,6 +236,8 @@ const mapWorkspaceThreadRow = (row: WorkspaceThreadRow): WorkspaceThreadLink =>
     threadId: row.threadId,
     threadWorkspacePath: row.threadWorkspacePath,
     archived: row.archived,
+    model: row.model,
+    reasoningEffort: (row.reasoningEffort as AgentReasoningEffort | null) ?? null,
     firstSeenAt: row.firstSeenAt,
     lastSeenAt: row.lastSeenAt,
   });

--- a/AppServer/src/threads/thread.handlers.ts
+++ b/AppServer/src/threads/thread.handlers.ts
@@ -1,32 +1,49 @@
+import type { AgentNotification, AgentSession, AgentSessionLookupError } from "@/agents/contracts";
 import { createAgentSessionUnavailableError, createProviderError } from "@/agents/protocol-errors";
 import type { AgentRegistry } from "@/agents/registry";
 import { createAgentRequestId } from "@/agents/request-id";
 import type { Logger } from "@/app/logger";
-import type { ProtocolDispatcher } from "@/core/protocol";
+import type { ProtocolDispatcher, ProtocolEngine, ProtocolNotification } from "@/core/protocol";
 import {
   createSessionNotInitializedResult,
   createWorkspaceNotOpenedResult,
   type ProtocolMethodError,
 } from "@/core/protocol/errors";
-import { assertNever, type LifecycleComponent, ok } from "@/core/shared";
+import { assertNever, err, type LifecycleComponent, ok, type Result } from "@/core/shared";
+import { createLoadedThreadRegistry } from "@/threads/loaded-thread-registry";
 import {
   ThreadListParamsSchema,
   ThreadListResultSchema,
   type ThreadReadParams,
   ThreadReadParamsSchema,
   ThreadReadResultSchema,
+  type ThreadResumeParams,
+  ThreadResumeParamsSchema,
+  ThreadResumeResultSchema,
+  type ThreadStartParams,
+  ThreadStartParamsSchema,
+  ThreadStartResultSchema,
 } from "@/threads/schemas";
-import { createThreadsService } from "@/threads/service";
+import { createThreadsService, type ThreadsServiceError } from "@/threads/service";
 import type { ThreadsStore } from "@/threads/store";
 import type { Workspace } from "@/workspaces/schemas";
 
 export type ThreadsModule = Readonly<{
   lifecycle: LifecycleComponent;
+  handleConnectionClosed: (connectionId: string) => void;
+  handleWorkspaceOpened: (
+    input: Readonly<{
+      connectionId: string;
+      previousWorkspace: Workspace | undefined;
+      workspace: Workspace;
+    }>,
+  ) => void;
 }>;
 
 export type CreateThreadsModuleOptions = Readonly<{
   logger: Logger;
   registerMethod: ProtocolDispatcher["registerMethod"];
+  sendNotification: ProtocolEngine["sendNotification"];
   registry: AgentRegistry;
   store: ThreadsStore;
   getOpenedWorkspace: (connectionId: string) => Workspace | undefined;
@@ -40,6 +57,111 @@ export const createThreadsModule = (options: CreateThreadsModuleOptions): Thread
     store: options.store,
     now: options.now,
   });
+  const loadedThreads = createLoadedThreadRegistry();
+  let subscribedSession: AgentSession | undefined;
+  let unsubscribeFromSession: (() => void) | undefined;
+
+  const resetSessionSubscription = (): void => {
+    unsubscribeFromSession?.();
+    unsubscribeFromSession = undefined;
+    subscribedSession = undefined;
+  };
+
+  const sendThreadNotification = async (
+    connectionId: string,
+    notification: ProtocolNotification,
+  ): Promise<void> => {
+    await options.sendNotification({
+      connectionId,
+      notification,
+    });
+  };
+
+  const fanOutThreadNotification = async (
+    threadId: string,
+    notification: ProtocolNotification,
+    clearThreadAfterSend = false,
+  ): Promise<void> => {
+    const connectionIds = loadedThreads.listSubscribers(threadId);
+    if (connectionIds.length === 0) {
+      if (clearThreadAfterSend) {
+        loadedThreads.clearThread(threadId);
+      }
+      return;
+    }
+
+    await Promise.all(
+      connectionIds.map((connectionId) => sendThreadNotification(connectionId, notification)),
+    );
+
+    if (clearThreadAfterSend) {
+      loadedThreads.clearThread(threadId);
+    }
+  };
+
+  const forwardAgentNotification = async (notification: AgentNotification): Promise<void> => {
+    if (notification.type === "disconnect") {
+      loadedThreads.clearAll();
+      resetSessionSubscription();
+      return;
+    }
+
+    if (notification.type !== "thread" || notification.threadId === undefined) {
+      return;
+    }
+
+    switch (notification.event) {
+      case "statusChanged":
+        await fanOutThreadNotification(notification.threadId, {
+          method: "thread/status/changed",
+          params: {
+            threadId: notification.threadId,
+            status: notification.thread.status,
+          },
+        });
+        return;
+      case "closed":
+        await fanOutThreadNotification(
+          notification.threadId,
+          {
+            method: "thread/closed",
+            params: {
+              threadId: notification.threadId,
+            },
+          },
+          true,
+        );
+        return;
+      case "started":
+      case "archived":
+      case "unarchived":
+        return;
+      default:
+        return;
+    }
+  };
+
+  const ensureSessionNotificationBinding = async (): Promise<
+    Result<void, AgentSessionLookupError>
+  > => {
+    const sessionResult = await options.registry.getSession();
+
+    if (!sessionResult.ok) {
+      return err(sessionResult.error);
+    }
+
+    if (subscribedSession === sessionResult.data) {
+      return ok(undefined);
+    }
+
+    resetSessionSubscription();
+    subscribedSession = sessionResult.data;
+    unsubscribeFromSession = sessionResult.data.subscribe((notification) => {
+      void forwardAgentNotification(notification);
+    });
+
+    return ok(undefined);
+  };
 
   options.registerMethod({
     method: "thread/list",
@@ -62,30 +184,101 @@ export const createThreadsModule = (options: CreateThreadsModuleOptions): Thread
         requestId,
       });
       const result = await service.listThreads(agentRequestId, workspace, params);
+      return mapThreadServiceResult(result, "thread/list");
+    },
+  });
+
+  options.registerMethod({
+    method: "thread/start",
+    paramsSchema: ThreadStartParamsSchema,
+    resultSchema: ThreadStartResultSchema,
+    handler: async ({ connectionId, params, requestId, session }) => {
+      if (!session.isInitialized()) {
+        return createSessionNotInitializedResult();
+      }
+
+      const workspace = options.getOpenedWorkspace(connectionId);
+
+      if (workspace === undefined) {
+        return createWorkspaceNotOpenedResult();
+      }
+
+      const bindResult = await ensureSessionNotificationBinding();
+      if (!bindResult.ok) {
+        return mapSessionLookupError(bindResult.error);
+      }
+
+      const agentRequestId = createAgentRequestId({
+        connectionId,
+        method: "thread/start",
+        requestId,
+      });
+      const result = await service.startThread(
+        agentRequestId,
+        workspace,
+        normalizeThreadStartParams(params),
+      );
 
       if (!result.ok) {
-        if (isProtocolMethodError(result.error)) {
-          return {
-            ok: false,
-            error: result.error,
-          };
-        }
-
-        switch (result.error.type) {
-          case "sessionUnavailable":
-            return {
-              ok: false,
-              error: createAgentSessionUnavailableError(result.error),
-            };
-          case "remoteError":
-            return {
-              ok: false,
-              error: createProviderError(result.error),
-            };
-          default:
-            return assertNever(result.error, "Unhandled thread/list protocol error");
-        }
+        return mapThreadServiceResult(result, "thread/start");
       }
+
+      loadedThreads.markLoaded({
+        connectionId,
+        workspaceId: workspace.id,
+        threadId: result.data.thread.id,
+      });
+      void sendThreadNotification(connectionId, {
+        method: "thread/started",
+        params: {
+          thread: result.data.thread,
+        },
+      });
+
+      return ok(result.data);
+    },
+  });
+
+  options.registerMethod({
+    method: "thread/resume",
+    paramsSchema: ThreadResumeParamsSchema,
+    resultSchema: ThreadResumeResultSchema,
+    handler: async ({ connectionId, params, requestId, session }) => {
+      if (!session.isInitialized()) {
+        return createSessionNotInitializedResult();
+      }
+
+      const workspace = options.getOpenedWorkspace(connectionId);
+
+      if (workspace === undefined) {
+        return createWorkspaceNotOpenedResult();
+      }
+
+      const bindResult = await ensureSessionNotificationBinding();
+      if (!bindResult.ok) {
+        return mapSessionLookupError(bindResult.error);
+      }
+
+      const agentRequestId = createAgentRequestId({
+        connectionId,
+        method: "thread/resume",
+        requestId,
+      });
+      const result = await service.resumeThread(
+        agentRequestId,
+        workspace,
+        normalizeThreadResumeParams(params),
+      );
+
+      if (!result.ok) {
+        return mapThreadServiceResult(result, "thread/resume");
+      }
+
+      loadedThreads.markLoaded({
+        connectionId,
+        workspaceId: workspace.id,
+        threadId: result.data.thread.id,
+      });
 
       return ok(result.data);
     },
@@ -116,32 +309,7 @@ export const createThreadsModule = (options: CreateThreadsModuleOptions): Thread
         workspace,
         normalizeThreadReadParams(params),
       );
-
-      if (!result.ok) {
-        if (isProtocolMethodError(result.error)) {
-          return {
-            ok: false,
-            error: result.error,
-          };
-        }
-
-        switch (result.error.type) {
-          case "sessionUnavailable":
-            return {
-              ok: false,
-              error: createAgentSessionUnavailableError(result.error),
-            };
-          case "remoteError":
-            return {
-              ok: false,
-              error: createProviderError(result.error),
-            };
-          default:
-            return assertNever(result.error, "Unhandled thread/read protocol error");
-        }
-      }
-
-      return ok(result.data);
+      return mapThreadServiceResult(result, "thread/read");
     },
   });
 
@@ -152,17 +320,89 @@ export const createThreadsModule = (options: CreateThreadsModuleOptions): Thread
         options.logger.info("Threads module ready");
       },
       stop: async (reason: string) => {
+        loadedThreads.clearAll();
+        resetSessionSubscription();
         options.logger.info("Threads module stopped", { reason });
       },
     }),
+    handleConnectionClosed: (connectionId) => {
+      loadedThreads.clearConnection(connectionId);
+    },
+    handleWorkspaceOpened: ({ connectionId, previousWorkspace, workspace }) => {
+      if (previousWorkspace?.id === workspace.id) {
+        return;
+      }
+
+      loadedThreads.clearConnection(connectionId);
+    },
   });
 };
+
+const normalizeThreadStartParams = (params: ThreadStartParams): ThreadStartParams =>
+  Object.freeze({
+    ...(params.model ? { model: params.model } : {}),
+    ...(params.reasoningEffort ? { reasoningEffort: params.reasoningEffort } : {}),
+  });
+
+const normalizeThreadResumeParams = (params: ThreadResumeParams): ThreadResumeParams =>
+  Object.freeze({
+    threadId: params.threadId,
+    ...(params.model ? { model: params.model } : {}),
+    ...(params.reasoningEffort ? { reasoningEffort: params.reasoningEffort } : {}),
+  });
 
 const normalizeThreadReadParams = (params: ThreadReadParams): ThreadReadParams =>
   Object.freeze({
     threadId: params.threadId,
     includeTurns: params.includeTurns ?? false,
   });
+
+const mapThreadServiceResult = <TResult>(
+  result: Result<TResult, ThreadsServiceError>,
+  method: string,
+): Result<TResult, ProtocolMethodError> => {
+  if (result.ok) {
+    return ok(result.data);
+  }
+
+  if (isProtocolMethodError(result.error)) {
+    return {
+      ok: false,
+      error: result.error,
+    };
+  }
+
+  switch (result.error.type) {
+    case "sessionUnavailable":
+      return {
+        ok: false,
+        error: createAgentSessionUnavailableError(result.error),
+      };
+    case "remoteError":
+      return {
+        ok: false,
+        error: createProviderError(result.error),
+      };
+    default:
+      return assertNever(result.error, `Unhandled ${method} protocol error`);
+  }
+};
+
+const mapSessionLookupError = (
+  error: AgentSessionLookupError,
+): Result<never, ProtocolMethodError> => {
+  switch (error.type) {
+    case "sessionUnavailable":
+      return {
+        ok: false,
+        error: createAgentSessionUnavailableError(error),
+      };
+    case "agentNotFound":
+      throw new Error(error.message);
+    default:
+      return assertNever(error, "Unhandled agent session lookup error");
+  }
+};
 
 const isProtocolMethodError = (error: unknown): error is ProtocolMethodError =>
   typeof error === "object" &&

--- a/AppServer/src/threads/thread.handlers.ts
+++ b/AppServer/src/threads/thread.handlers.ts
@@ -7,9 +7,17 @@ import type { ProtocolDispatcher, ProtocolEngine, ProtocolNotification } from "@
 import {
   createSessionNotInitializedResult,
   createWorkspaceNotOpenedResult,
+  isProtocolMethodError,
   type ProtocolMethodError,
 } from "@/core/protocol/errors";
-import { assertNever, err, type LifecycleComponent, ok, type Result } from "@/core/shared";
+import {
+  assertNever,
+  err,
+  getErrorMessage,
+  type LifecycleComponent,
+  ok,
+  type Result,
+} from "@/core/shared";
 import { createLoadedThreadRegistry } from "@/threads/loaded-thread-registry";
 import {
   ThreadListParamsSchema,
@@ -24,7 +32,11 @@ import {
   ThreadStartParamsSchema,
   ThreadStartResultSchema,
 } from "@/threads/schemas";
-import { createThreadsService, type ThreadsServiceError } from "@/threads/service";
+import {
+  createThreadsService,
+  mapInvalidProviderPayloadToProtocolError,
+  type ThreadsServiceError,
+} from "@/threads/service";
 import type { ThreadsStore } from "@/threads/store";
 import type { Workspace } from "@/workspaces/schemas";
 
@@ -69,12 +81,22 @@ export const createThreadsModule = (options: CreateThreadsModuleOptions): Thread
 
   const sendThreadNotification = async (
     connectionId: string,
+    threadId: string | undefined,
     notification: ProtocolNotification,
   ): Promise<void> => {
-    await options.sendNotification({
-      connectionId,
-      notification,
-    });
+    try {
+      await options.sendNotification({
+        connectionId,
+        notification,
+      });
+    } catch (error) {
+      options.logger.warn("Failed to send thread notification", {
+        connectionId,
+        threadId: threadId ?? null,
+        method: notification.method,
+        error: getErrorMessage(error),
+      });
+    }
   };
 
   const fanOutThreadNotification = async (
@@ -91,7 +113,9 @@ export const createThreadsModule = (options: CreateThreadsModuleOptions): Thread
     }
 
     await Promise.all(
-      connectionIds.map((connectionId) => sendThreadNotification(connectionId, notification)),
+      connectionIds.map((connectionId) =>
+        sendThreadNotification(connectionId, threadId, notification),
+      ),
     );
 
     if (clearThreadAfterSend) {
@@ -184,7 +208,7 @@ export const createThreadsModule = (options: CreateThreadsModuleOptions): Thread
         requestId,
       });
       const result = await service.listThreads(agentRequestId, workspace, params);
-      return mapThreadServiceResult(result, "thread/list");
+      return mapThreadResult(result, "thread/list");
     },
   });
 
@@ -205,7 +229,7 @@ export const createThreadsModule = (options: CreateThreadsModuleOptions): Thread
 
       const bindResult = await ensureSessionNotificationBinding();
       if (!bindResult.ok) {
-        return mapSessionLookupError(bindResult.error);
+        return err(mapThreadError(bindResult.error, "thread/start"));
       }
 
       const agentRequestId = createAgentRequestId({
@@ -220,7 +244,7 @@ export const createThreadsModule = (options: CreateThreadsModuleOptions): Thread
       );
 
       if (!result.ok) {
-        return mapThreadServiceResult(result, "thread/start");
+        return mapThreadResult(result, "thread/start");
       }
 
       loadedThreads.markLoaded({
@@ -228,7 +252,7 @@ export const createThreadsModule = (options: CreateThreadsModuleOptions): Thread
         workspaceId: workspace.id,
         threadId: result.data.thread.id,
       });
-      void sendThreadNotification(connectionId, {
+      void sendThreadNotification(connectionId, result.data.thread.id, {
         method: "thread/started",
         params: {
           thread: result.data.thread,
@@ -256,7 +280,7 @@ export const createThreadsModule = (options: CreateThreadsModuleOptions): Thread
 
       const bindResult = await ensureSessionNotificationBinding();
       if (!bindResult.ok) {
-        return mapSessionLookupError(bindResult.error);
+        return err(mapThreadError(bindResult.error, "thread/resume"));
       }
 
       const agentRequestId = createAgentRequestId({
@@ -271,7 +295,7 @@ export const createThreadsModule = (options: CreateThreadsModuleOptions): Thread
       );
 
       if (!result.ok) {
-        return mapThreadServiceResult(result, "thread/resume");
+        return mapThreadResult(result, "thread/resume");
       }
 
       loadedThreads.markLoaded({
@@ -309,7 +333,7 @@ export const createThreadsModule = (options: CreateThreadsModuleOptions): Thread
         workspace,
         normalizeThreadReadParams(params),
       );
-      return mapThreadServiceResult(result, "thread/read");
+      return mapThreadResult(result, "thread/read");
     },
   });
 
@@ -357,56 +381,35 @@ const normalizeThreadReadParams = (params: ThreadReadParams): ThreadReadParams =
     includeTurns: params.includeTurns ?? false,
   });
 
-const mapThreadServiceResult = <TResult>(
-  result: Result<TResult, ThreadsServiceError>,
+const mapThreadResult = <TResult>(
+  result: Result<TResult, AgentSessionLookupError | ThreadsServiceError>,
   method: string,
 ): Result<TResult, ProtocolMethodError> => {
   if (result.ok) {
     return ok(result.data);
   }
 
-  if (isProtocolMethodError(result.error)) {
-    return {
-      ok: false,
-      error: result.error,
-    };
-  }
-
-  switch (result.error.type) {
-    case "sessionUnavailable":
-      return {
-        ok: false,
-        error: createAgentSessionUnavailableError(result.error),
-      };
-    case "remoteError":
-      return {
-        ok: false,
-        error: createProviderError(result.error),
-      };
-    default:
-      return assertNever(result.error, `Unhandled ${method} protocol error`);
-  }
+  return err(mapThreadError(result.error, method));
 };
 
-const mapSessionLookupError = (
-  error: AgentSessionLookupError,
-): Result<never, ProtocolMethodError> => {
+const mapThreadError = (
+  error: AgentSessionLookupError | ThreadsServiceError,
+  method: string,
+): ProtocolMethodError => {
+  if (isProtocolMethodError(error)) {
+    return error;
+  }
+
   switch (error.type) {
     case "sessionUnavailable":
-      return {
-        ok: false,
-        error: createAgentSessionUnavailableError(error),
-      };
+      return createAgentSessionUnavailableError(error);
+    case "remoteError":
+      return createProviderError(error);
+    case "invalidProviderPayload":
+      return mapInvalidProviderPayloadToProtocolError(error);
     case "agentNotFound":
       throw new Error(error.message);
     default:
-      return assertNever(error, "Unhandled agent session lookup error");
+      return assertNever(error, `Unhandled ${method} protocol error`);
   }
 };
-
-const isProtocolMethodError = (error: unknown): error is ProtocolMethodError =>
-  typeof error === "object" &&
-  error !== null &&
-  !("type" in error) &&
-  "code" in error &&
-  typeof (error as { code: unknown }).code === "number";

--- a/AppServer/src/workspaces/path.ts
+++ b/AppServer/src/workspaces/path.ts
@@ -1,0 +1,12 @@
+import { realpath } from "node:fs/promises";
+import { resolve } from "node:path";
+
+export type WorkspacePathNormalizer = (workspacePath: string) => Promise<string>;
+
+export const normalizeWorkspacePath: WorkspacePathNormalizer = async (workspacePath) => {
+  try {
+    return await realpath(workspacePath);
+  } catch {
+    return resolve(workspacePath);
+  }
+};

--- a/AppServer/src/workspaces/workspace.handlers.ts
+++ b/AppServer/src/workspaces/workspace.handlers.ts
@@ -19,6 +19,13 @@ export type CreateWorkspacesModuleOptions = Readonly<
   {
     logger: Logger;
     registerMethod: ProtocolDispatcher["registerMethod"];
+    onWorkspaceOpened?: (
+      input: Readonly<{
+        connectionId: string;
+        previousWorkspace: Workspace | undefined;
+        workspace: Workspace;
+      }>,
+    ) => void;
   } & CreateWorkspacesServiceOptions
 >;
 
@@ -43,7 +50,13 @@ export const createWorkspacesModule = (
         return workspaceResult;
       }
 
+      const previousWorkspace = openedWorkspacesByConnectionId.get(connectionId);
       openedWorkspacesByConnectionId.set(connectionId, workspaceResult.data);
+      options.onWorkspaceOpened?.({
+        connectionId,
+        previousWorkspace,
+        workspace: workspaceResult.data,
+      });
 
       options.logger.info("Workspace opened", {
         connectionId,


### PR DESCRIPTION
## Summary
- implement `thread/start` and `thread/resume` for the App Server thread-loading phase
- persist per-thread `model` and `reasoningEffort` defaults in thread linkage storage, including the new SQLite migration
- add loaded-thread tracking and connection-scoped fanout for `thread/started`, `thread/status/changed`, and `thread/closed`
- keep `thread/read` point-in-time only and clear loaded-thread subscriptions on connection close and workspace switches
- update the Codex adapter and imported upstream contracts to parse configured thread responses and support the new lifecycle wiring

## Testing
- `bun run check`
- `bun run typecheck`
- `bun test src/threads/store.test.ts src/threads/service.test.ts src/app/protocol-harness.test.ts`