### PR TITLE
Add App Server turn execution and event stream support

### DIFF
--- a/AppServer/src/agents/codex-adapter/notification-mapper.test.ts
+++ b/AppServer/src/agents/codex-adapter/notification-mapper.test.ts
@@ -4,7 +4,11 @@ import {
   mapCodexTransportNotification,
 } from "@/agents/codex-adapter/notification-mapper";
 import type {
+  CodexAgentMessageDeltaNotification,
+  CodexCommandExecutionOutputDeltaNotification,
   CodexCommandExecutionRequestApprovalParams,
+  CodexMcpToolCallProgressNotification,
+  CodexReasoningSummaryTextDeltaNotification,
   CodexReasoningTextDeltaNotification,
   CodexTurnDiffUpdatedNotification,
   CodexTurnPlanUpdatedNotification,
@@ -247,6 +251,127 @@ describe("mapCodexTransportNotification", () => {
         turnId: "turn-1",
         itemId: "item-1",
         delta: "Thinking...",
+      },
+    ]);
+  });
+
+  test("maps supported item delta fixtures into provider-neutral notifications", () => {
+    const messageFixture: CodexAgentMessageDeltaNotification = {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "item-message",
+      delta: "Working on it...",
+    };
+    const reasoningSummaryFixture: CodexReasoningSummaryTextDeltaNotification = {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "item-reasoning",
+      delta: "Short summary",
+      summaryIndex: 0,
+    };
+    const commandFixture: CodexCommandExecutionOutputDeltaNotification = {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "item-command",
+      delta: "stdout line\n",
+    };
+    const toolFixture: CodexMcpToolCallProgressNotification = {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "item-tool",
+      message: "Fetching results",
+    };
+
+    expect(
+      mapCodexTransportNotification(
+        {
+          method: "item/agentMessage/delta",
+          params: messageFixture,
+        },
+        context,
+      ),
+    ).toEqual([
+      {
+        agentId: "codex",
+        provider: "codex",
+        receivedAt: "2026-04-10T12:00:00.000Z",
+        rawMethod: "item/agentMessage/delta",
+        rawPayload: messageFixture,
+        type: "message",
+        event: "textDelta",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "item-message",
+        delta: "Working on it...",
+      },
+    ]);
+    expect(
+      mapCodexTransportNotification(
+        {
+          method: "item/reasoning/summaryTextDelta",
+          params: reasoningSummaryFixture,
+        },
+        context,
+      ),
+    ).toEqual([
+      {
+        agentId: "codex",
+        provider: "codex",
+        receivedAt: "2026-04-10T12:00:00.000Z",
+        rawMethod: "item/reasoning/summaryTextDelta",
+        rawPayload: reasoningSummaryFixture,
+        type: "reasoning",
+        event: "summaryTextDelta",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "item-reasoning",
+        delta: "Short summary",
+      },
+    ]);
+    expect(
+      mapCodexTransportNotification(
+        {
+          method: "item/commandExecution/outputDelta",
+          params: commandFixture,
+        },
+        context,
+      ),
+    ).toEqual([
+      {
+        agentId: "codex",
+        provider: "codex",
+        receivedAt: "2026-04-10T12:00:00.000Z",
+        rawMethod: "item/commandExecution/outputDelta",
+        rawPayload: commandFixture,
+        type: "command",
+        event: "outputDelta",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "item-command",
+        delta: "stdout line\n",
+      },
+    ]);
+    expect(
+      mapCodexTransportNotification(
+        {
+          method: "item/mcpToolCall/progress",
+          params: toolFixture,
+        },
+        context,
+      ),
+    ).toEqual([
+      {
+        agentId: "codex",
+        provider: "codex",
+        receivedAt: "2026-04-10T12:00:00.000Z",
+        rawMethod: "item/mcpToolCall/progress",
+        rawPayload: toolFixture,
+        type: "tool",
+        event: "progress",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "item-tool",
+        message: "Fetching results",
       },
     ]);
   });

--- a/AppServer/src/agents/codex-adapter/notification-mapper.ts
+++ b/AppServer/src/agents/codex-adapter/notification-mapper.ts
@@ -1,8 +1,16 @@
+import { Value } from "@sinclair/typebox/value";
 import {
   mapCodexThreadStatus,
   mapCodexThreadSummary,
   mapCodexTurnSummary,
 } from "@/agents/codex-adapter/model-mapper";
+import {
+  CodexAgentMessageDeltaNotificationSchema,
+  CodexCommandExecutionOutputDeltaNotificationSchema,
+  CodexMcpToolCallProgressNotificationSchema,
+  CodexReasoningSummaryTextDeltaNotificationSchema,
+  CodexReasoningTextDeltaNotificationSchema,
+} from "@/agents/codex-adapter/protocol";
 import type {
   CodexTransportDisconnectInfo,
   CodexTransportNotification,
@@ -193,25 +201,73 @@ export const mapCodexTransportNotification = (
             },
           ]
         : [buildMalformedMessage(base, notification.method)];
-    case "item/reasoning/summaryTextDelta":
-    case "item/reasoning/textDelta":
-      return params &&
-        typeof params.threadId === "string" &&
-        typeof params.turnId === "string" &&
-        typeof params.itemId === "string" &&
-        typeof params.delta === "string"
+    case "item/agentMessage/delta":
+      return params && Value.Check(CodexAgentMessageDeltaNotificationSchema, params)
         ? [
             {
               ...base,
-              type: "reasoning",
-              event:
-                notification.method === "item/reasoning/summaryTextDelta"
-                  ? "summaryTextDelta"
-                  : "textDelta",
+              type: "message",
+              event: "textDelta",
               threadId: params.threadId,
               turnId: params.turnId,
               itemId: params.itemId,
               delta: params.delta,
+            },
+          ]
+        : [buildMalformedMessage(base, notification.method)];
+    case "item/reasoning/summaryTextDelta":
+      return params && Value.Check(CodexReasoningSummaryTextDeltaNotificationSchema, params)
+        ? [
+            {
+              ...base,
+              type: "reasoning",
+              event: "summaryTextDelta",
+              threadId: params.threadId,
+              turnId: params.turnId,
+              itemId: params.itemId,
+              delta: params.delta,
+            },
+          ]
+        : [buildMalformedMessage(base, notification.method)];
+    case "item/reasoning/textDelta":
+      return params && Value.Check(CodexReasoningTextDeltaNotificationSchema, params)
+        ? [
+            {
+              ...base,
+              type: "reasoning",
+              event: "textDelta",
+              threadId: params.threadId,
+              turnId: params.turnId,
+              itemId: params.itemId,
+              delta: params.delta,
+            },
+          ]
+        : [buildMalformedMessage(base, notification.method)];
+    case "item/commandExecution/outputDelta":
+      return params && Value.Check(CodexCommandExecutionOutputDeltaNotificationSchema, params)
+        ? [
+            {
+              ...base,
+              type: "command",
+              event: "outputDelta",
+              threadId: params.threadId,
+              turnId: params.turnId,
+              itemId: params.itemId,
+              delta: params.delta,
+            },
+          ]
+        : [buildMalformedMessage(base, notification.method)];
+    case "item/mcpToolCall/progress":
+      return params && Value.Check(CodexMcpToolCallProgressNotificationSchema, params)
+        ? [
+            {
+              ...base,
+              type: "tool",
+              event: "progress",
+              threadId: params.threadId,
+              turnId: params.turnId,
+              itemId: params.itemId,
+              message: params.message,
             },
           ]
         : [buildMalformedMessage(base, notification.method)];

--- a/AppServer/src/agents/codex-adapter/protocol.ts
+++ b/AppServer/src/agents/codex-adapter/protocol.ts
@@ -204,6 +204,47 @@ export const CodexReasoningTextDeltaNotificationSchema = Type.Object(
   { additionalProperties: true },
 );
 
+export const CodexAgentMessageDeltaNotificationSchema = Type.Object(
+  {
+    threadId: Type.String(),
+    turnId: Type.String(),
+    itemId: Type.String(),
+    delta: Type.String(),
+  },
+  { additionalProperties: true },
+);
+
+export const CodexReasoningSummaryTextDeltaNotificationSchema = Type.Object(
+  {
+    threadId: Type.String(),
+    turnId: Type.String(),
+    itemId: Type.String(),
+    delta: Type.String(),
+    summaryIndex: Type.Integer(),
+  },
+  { additionalProperties: true },
+);
+
+export const CodexCommandExecutionOutputDeltaNotificationSchema = Type.Object(
+  {
+    threadId: Type.String(),
+    turnId: Type.String(),
+    itemId: Type.String(),
+    delta: Type.String(),
+  },
+  { additionalProperties: true },
+);
+
+export const CodexMcpToolCallProgressNotificationSchema = Type.Object(
+  {
+    threadId: Type.String(),
+    turnId: Type.String(),
+    itemId: Type.String(),
+    message: Type.String(),
+  },
+  { additionalProperties: true },
+);
+
 export const CodexCommandExecutionRequestApprovalParamsSchema = Type.Object(
   {
     threadId: Type.String(),
@@ -233,6 +274,18 @@ export type CodexTurnDiffUpdatedNotification = Static<
 >;
 export type CodexReasoningTextDeltaNotification = Static<
   typeof CodexReasoningTextDeltaNotificationSchema
+>;
+export type CodexAgentMessageDeltaNotification = Static<
+  typeof CodexAgentMessageDeltaNotificationSchema
+>;
+export type CodexReasoningSummaryTextDeltaNotification = Static<
+  typeof CodexReasoningSummaryTextDeltaNotificationSchema
+>;
+export type CodexCommandExecutionOutputDeltaNotification = Static<
+  typeof CodexCommandExecutionOutputDeltaNotificationSchema
+>;
+export type CodexMcpToolCallProgressNotification = Static<
+  typeof CodexMcpToolCallProgressNotificationSchema
 >;
 export type CodexCommandExecutionRequestApprovalParams = Static<
   typeof CodexCommandExecutionRequestApprovalParamsSchema

--- a/AppServer/src/agents/codex-adapter/session.test.ts
+++ b/AppServer/src/agents/codex-adapter/session.test.ts
@@ -638,6 +638,93 @@ describe("createCodexAgentSession", () => {
     });
   });
 
+  test("maps turn/start through the Codex transport contract", async () => {
+    const executablePath = createFakeExecutable();
+    const transport = new FakeTransport([
+      { userAgent: "Codex/Test" },
+      {
+        turn: {
+          id: "turn-1",
+          status: "inProgress",
+          error: null,
+        },
+      },
+    ]);
+    const sessionResult = await createCodexAgentSession({
+      agentId: "codex",
+      config: {
+        id: "codex",
+        provider: "codex",
+      },
+      logger: createSilentLogger(),
+      transport,
+      environmentResolver: new BaseEnvironmentResolver({
+        inheritedEnvironment: {
+          ATELIERCODE_CODEX_PATH: executablePath,
+          PATH: path.dirname(executablePath),
+          HOME: "/Users/tester",
+          SHELL: "/bin/zsh",
+        },
+      }),
+    });
+
+    expect(sessionResult.ok).toBe(true);
+    if (!sessionResult.ok) {
+      throw new Error("Expected the Codex session to be created.");
+    }
+
+    const turnResult = await sessionResult.data.startTurn("req-turn-start", {
+      threadId: "thread-1",
+      prompt: "Ship the turn execution layer",
+      cwd: "/tmp/project",
+    });
+
+    expect(transport.sent).toEqual([
+      {
+        id: "atelier-appserver-initialize",
+        method: "initialize",
+        params: {
+          clientInfo: {
+            name: "AtelierCode App Server",
+            title: null,
+            version: "0.1.0",
+          },
+          capabilities: {
+            experimentalApi: true,
+          },
+        },
+      },
+      {
+        id: "req-turn-start",
+        method: "turn/start",
+        params: {
+          threadId: "thread-1",
+          input: [
+            {
+              type: "text",
+              text: "Ship the turn execution layer",
+              text_elements: [],
+            },
+          ],
+          cwd: "/tmp/project",
+          model: undefined,
+          effort: undefined,
+        },
+      },
+    ]);
+    expect(turnResult).toEqual({
+      ok: true,
+      data: {
+        turn: {
+          id: "turn-1",
+          status: {
+            type: "inProgress",
+          },
+        },
+      },
+    });
+  });
+
   test("translates approval requests and resolves them through provider responses", async () => {
     const executablePath = createFakeExecutable();
     const transport = new FakeTransport([{ userAgent: "Codex/Test" }]);

--- a/AppServer/src/agents/contracts.ts
+++ b/AppServer/src/agents/contracts.ts
@@ -158,12 +158,33 @@ export type AgentItemNotification = AgentNotificationBase &
     }>;
   }>;
 
+export type AgentMessageNotification = AgentNotificationBase &
+  Readonly<{
+    type: "message";
+    event: "textDelta";
+    delta: string;
+  }>;
+
 export type AgentReasoningNotification = AgentNotificationBase &
   Readonly<{
     type: "reasoning";
     event: "summaryTextDelta" | "summaryPartAdded" | "textDelta";
     delta?: string;
     summaryPart?: unknown;
+  }>;
+
+export type AgentCommandNotification = AgentNotificationBase &
+  Readonly<{
+    type: "command";
+    event: "outputDelta";
+    delta: string;
+  }>;
+
+export type AgentToolNotification = AgentNotificationBase &
+  Readonly<{
+    type: "tool";
+    event: "progress";
+    message: string;
   }>;
 
 export type AgentPlanNotification = AgentNotificationBase &
@@ -212,7 +233,10 @@ export type AgentNotification =
   | AgentThreadNotification
   | AgentTurnNotification
   | AgentItemNotification
+  | AgentMessageNotification
   | AgentReasoningNotification
+  | AgentCommandNotification
+  | AgentToolNotification
   | AgentPlanNotification
   | AgentDiffNotification
   | AgentApprovalNotification

--- a/AppServer/src/app/protocol-harness.test.ts
+++ b/AppServer/src/app/protocol-harness.test.ts
@@ -1817,6 +1817,258 @@ describe("App Server protocol harness", () => {
     }
   });
 
+  test("preserves terminal turn status on turn/completed and allows a follow-up turn", async () => {
+    const workspacePath = await createWorkspaceDirectory();
+    const canonicalWorkspacePath = await realpath(workspacePath);
+    let turnCounter = 0;
+    const session = createFakeAgentSession({
+      resumeThread: async (_requestId, params) => ({
+        ok: true,
+        data: {
+          thread: createTestAgentThread({
+            id: params.threadId,
+            workspacePath: canonicalWorkspacePath,
+          }),
+          model: "gpt-5.4",
+          reasoningEffort: "medium",
+        },
+      }),
+      startTurn: async () => {
+        turnCounter += 1;
+
+        return {
+          ok: true,
+          data: {
+            turn: createTestAgentTurn({
+              id: `turn-${turnCounter}`,
+            }),
+          },
+        };
+      },
+    });
+    const harness = await createProtocolHarness({
+      agentAdapters: [
+        createFakeAgentAdapter({
+          session,
+        }),
+      ],
+    });
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      await initializeClient(client);
+      await openWorkspaceClient(client, workspacePath);
+
+      client.sendJson({
+        id: "req-thread-resume",
+        method: "thread/resume",
+        params: {
+          threadId: "thread-live",
+        },
+      });
+      await client.nextMessage();
+
+      client.sendJson({
+        id: "req-turn-start-1",
+        method: "turn/start",
+        params: {
+          threadId: "thread-live",
+          prompt: "Start a turn that will fail",
+        },
+      });
+      await client.nextMessage();
+
+      session.emitNotification(
+        createTurnCompletedNotification({
+          threadId: "thread-live",
+          turnId: "turn-1",
+          status: {
+            type: "failed",
+            message: "provider failed",
+          },
+        }),
+      );
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-live",
+          turn: {
+            id: "turn-1",
+            status: {
+              type: "failed",
+              message: "provider failed",
+            },
+          },
+        },
+      });
+
+      client.sendJson({
+        id: "req-turn-start-2",
+        method: "turn/start",
+        params: {
+          threadId: "thread-live",
+          prompt: "Start the follow-up turn",
+        },
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-turn-start-2",
+        result: {
+          turn: {
+            id: "turn-2",
+            status: {
+              type: "inProgress",
+            },
+          },
+        },
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("preserves pre-response turn notifications during the turn/start reservation window", async () => {
+    const workspacePath = await createWorkspaceDirectory();
+    const canonicalWorkspacePath = await realpath(workspacePath);
+    let session!: ReturnType<typeof createFakeAgentSession>;
+    session = createFakeAgentSession({
+      resumeThread: async (_requestId, params) => ({
+        ok: true,
+        data: {
+          thread: createTestAgentThread({
+            id: params.threadId,
+            workspacePath: canonicalWorkspacePath,
+          }),
+          model: "gpt-5.4",
+          reasoningEffort: "medium",
+        },
+      }),
+      startTurn: async () => {
+        session.emitNotification(
+          createTurnStartedNotification({
+            threadId: "thread-live",
+            turnId: "turn-1",
+          }),
+        );
+        session.emitNotification(
+          createItemStartedNotification({
+            threadId: "thread-live",
+            turnId: "turn-1",
+            itemId: "item-message",
+            kind: "agent_message",
+          }),
+        );
+        session.emitNotification(
+          createMessageDeltaNotification({
+            threadId: "thread-live",
+            turnId: "turn-1",
+            itemId: "item-message",
+            delta: "Working on it...",
+          }),
+        );
+
+        return {
+          ok: true,
+          data: {
+            turn: createTestAgentTurn({
+              id: "turn-1",
+            }),
+          },
+        };
+      },
+    });
+    const harness = await createProtocolHarness({
+      agentAdapters: [
+        createFakeAgentAdapter({
+          session,
+        }),
+      ],
+    });
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      await initializeClient(client);
+      await openWorkspaceClient(client, workspacePath);
+
+      client.sendJson({
+        id: "req-thread-resume",
+        method: "thread/resume",
+        params: {
+          threadId: "thread-live",
+        },
+      });
+      await client.nextMessage();
+
+      client.sendJson({
+        id: "req-turn-start",
+        method: "turn/start",
+        params: {
+          threadId: "thread-live",
+          prompt: "Start a turn",
+        },
+      });
+
+      const messages = await Promise.all([
+        client.nextMessage(),
+        client.nextMessage(),
+        client.nextMessage(),
+        client.nextMessage(),
+      ]);
+
+      expect(messages[0]).toEqual({
+        method: "turn/started",
+        params: {
+          threadId: "thread-live",
+          turn: {
+            id: "turn-1",
+            status: {
+              type: "inProgress",
+            },
+          },
+        },
+      });
+      expect(messages).toContainEqual({
+        method: "item/started",
+        params: {
+          threadId: "thread-live",
+          turnId: "turn-1",
+          item: {
+            id: "item-message",
+            kind: "agent_message",
+            rawItem: {
+              id: "item-message",
+              type: "agent_message",
+              status: "in_progress",
+            },
+          },
+        },
+      });
+      expect(messages).toContainEqual({
+        method: "item/message/textDelta",
+        params: {
+          threadId: "thread-live",
+          turnId: "turn-1",
+          itemId: "item-message",
+          delta: "Working on it...",
+        },
+      });
+      expect(messages).toContainEqual({
+        id: "req-turn-start",
+        result: {
+          turn: {
+            id: "turn-1",
+            status: {
+              type: "inProgress",
+            },
+          },
+        },
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
   test("clears loaded-thread subscriptions when the connection switches workspaces", async () => {
     const firstWorkspacePath = await createWorkspaceDirectory();
     const secondWorkspacePath = await createWorkspaceDirectory();
@@ -3152,7 +3404,15 @@ const createTurnStartedNotification = (input: { threadId: string; turnId: string
   },
 });
 
-const createTurnCompletedNotification = (input: { threadId: string; turnId: string }) => ({
+const createTurnCompletedNotification = (input: {
+  threadId: string;
+  turnId: string;
+  status?:
+    | { type: "completed" }
+    | { type: "failed"; message: string }
+    | { type: "cancelled" }
+    | { type: "interrupted" };
+}) => ({
   agentId: "codex",
   provider: "codex" as const,
   receivedAt: "2026-04-10T12:00:00.000Z",
@@ -3163,7 +3423,7 @@ const createTurnCompletedNotification = (input: { threadId: string; turnId: stri
   event: "completed" as const,
   turn: {
     id: input.turnId,
-    status: { type: "completed" } as const,
+    status: input.status ?? ({ type: "completed" } as const),
   },
 });
 

--- a/AppServer/src/app/protocol-harness.test.ts
+++ b/AppServer/src/app/protocol-harness.test.ts
@@ -19,10 +19,11 @@ import {
   createFakeAgentSession,
   createTestAgentModel,
   createTestAgentThread,
+  createTestAgentTurn,
 } from "@/test-support/agents";
 import { getAvailablePort } from "@/test-support/network";
 import { createSqliteThreadsStore, createThreadsModule, type ThreadsStore } from "@/threads";
-import { createTurnsModulePlaceholder } from "@/turns";
+import { createTurnsModule } from "@/turns";
 import { createSqliteWorkspacesStore, createWorkspacesModule } from "@/workspaces";
 
 const runningServers: AppServer[] = [];
@@ -1237,6 +1238,585 @@ describe("App Server protocol harness", () => {
     }
   });
 
+  test("rejects turn/start when the thread is not loaded for the calling connection", async () => {
+    const workspacePath = await createWorkspaceDirectory();
+    const session = createFakeAgentSession();
+    const harness = await createProtocolHarness({
+      agentAdapters: [
+        createFakeAgentAdapter({
+          session,
+        }),
+      ],
+    });
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      await initializeClient(client);
+      await openWorkspaceClient(client, workspacePath);
+
+      client.sendJson({
+        id: "req-turn-start",
+        method: "turn/start",
+        params: {
+          threadId: "thread-not-loaded",
+          prompt: "Try to start a turn",
+        },
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-turn-start",
+        error: {
+          code: -33010,
+          message: "Thread is not loaded for this connection",
+          data: {
+            code: "THREAD_NOT_LOADED",
+            threadId: "thread-not-loaded",
+          },
+        },
+      });
+      expect(session.startTurnCalls).toHaveLength(0);
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("rejects starting a second active turn on the same thread", async () => {
+    const workspacePath = await createWorkspaceDirectory();
+    const canonicalWorkspacePath = await realpath(workspacePath);
+    let turnCounter = 0;
+    const session = createFakeAgentSession({
+      resumeThread: async (_requestId, params) => ({
+        ok: true,
+        data: {
+          thread: createTestAgentThread({
+            id: params.threadId,
+            workspacePath: canonicalWorkspacePath,
+          }),
+          model: "gpt-5.4",
+          reasoningEffort: "medium",
+        },
+      }),
+      startTurn: async () => {
+        turnCounter += 1;
+
+        return {
+          ok: true,
+          data: {
+            turn: createTestAgentTurn({
+              id: `turn-${turnCounter}`,
+            }),
+          },
+        };
+      },
+    });
+    const harness = await createProtocolHarness({
+      agentAdapters: [
+        createFakeAgentAdapter({
+          session,
+        }),
+      ],
+    });
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      await initializeClient(client);
+      await openWorkspaceClient(client, workspacePath);
+
+      client.sendJson({
+        id: "req-thread-resume",
+        method: "thread/resume",
+        params: {
+          threadId: "thread-live",
+        },
+      });
+      await client.nextMessage();
+
+      client.sendJson({
+        id: "req-turn-start-1",
+        method: "turn/start",
+        params: {
+          threadId: "thread-live",
+          prompt: "Start the first turn",
+        },
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-turn-start-1",
+        result: {
+          turn: {
+            id: "turn-1",
+            status: {
+              type: "inProgress",
+            },
+          },
+        },
+      });
+
+      client.sendJson({
+        id: "req-turn-start-2",
+        method: "turn/start",
+        params: {
+          threadId: "thread-live",
+          prompt: "Start another turn",
+        },
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-turn-start-2",
+        error: {
+          code: -33011,
+          message: "Thread already has an active turn",
+          data: {
+            code: "TURN_ALREADY_ACTIVE",
+            threadId: "thread-live",
+            activeTurnId: "turn-1",
+          },
+        },
+      });
+      expect(session.startTurnCalls).toHaveLength(1);
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("fans out turn and item notifications in order only to subscribed clients and clears active turns on completion", async () => {
+    const workspacePath = await createWorkspaceDirectory();
+    const canonicalWorkspacePath = await realpath(workspacePath);
+    let turnCounter = 0;
+    const session = createFakeAgentSession({
+      resumeThread: async (_requestId, params) => ({
+        ok: true,
+        data: {
+          thread: createTestAgentThread({
+            id: params.threadId,
+            workspacePath: canonicalWorkspacePath,
+          }),
+          model: "gpt-5.4",
+          reasoningEffort: "medium",
+        },
+      }),
+      startTurn: async () => {
+        turnCounter += 1;
+
+        return {
+          ok: true,
+          data: {
+            turn: createTestAgentTurn({
+              id: `turn-${turnCounter}`,
+            }),
+          },
+        };
+      },
+    });
+    const harness = await createProtocolHarness({
+      agentAdapters: [
+        createFakeAgentAdapter({
+          session,
+        }),
+      ],
+    });
+    const clientA = await connectProtocolClient(harness.port);
+    const clientB = await connectProtocolClient(harness.port);
+    const bystander = await connectProtocolClient(harness.port);
+
+    try {
+      await initializeClient(clientA);
+      await initializeClient(clientB);
+      await initializeClient(bystander);
+      await openWorkspaceClient(clientA, workspacePath);
+      await openWorkspaceClient(clientB, workspacePath);
+      await openWorkspaceClient(bystander, workspacePath);
+
+      clientA.sendJson({
+        id: "req-thread-resume-a",
+        method: "thread/resume",
+        params: {
+          threadId: "thread-live",
+        },
+      });
+      clientB.sendJson({
+        id: "req-thread-resume-b",
+        method: "thread/resume",
+        params: {
+          threadId: "thread-live",
+        },
+      });
+
+      await clientA.nextMessage();
+      await clientB.nextMessage();
+
+      clientA.sendJson({
+        id: "req-turn-start",
+        method: "turn/start",
+        params: {
+          threadId: "thread-live",
+          prompt: "Ship the event stream",
+        },
+      });
+
+      await expect(clientA.nextMessage()).resolves.toEqual({
+        id: "req-turn-start",
+        result: {
+          turn: {
+            id: "turn-1",
+            status: {
+              type: "inProgress",
+            },
+          },
+        },
+      });
+
+      const streamedNotifications = [
+        createTurnStartedNotification({
+          threadId: "thread-live",
+          turnId: "turn-1",
+        }),
+        createItemStartedNotification({
+          threadId: "thread-live",
+          turnId: "turn-1",
+          itemId: "item-message",
+          kind: "agent_message",
+        }),
+        createMessageDeltaNotification({
+          threadId: "thread-live",
+          turnId: "turn-1",
+          itemId: "item-message",
+          delta: "Working on it...",
+        }),
+        createItemCompletedNotification({
+          threadId: "thread-live",
+          turnId: "turn-1",
+          itemId: "item-message",
+          kind: "agent_message",
+          rawItem: {
+            id: "item-message",
+            type: "agent_message",
+            status: "completed",
+            text: "Working on it...",
+          },
+        }),
+        createItemStartedNotification({
+          threadId: "thread-live",
+          turnId: "turn-1",
+          itemId: "item-reasoning",
+          kind: "reasoning",
+        }),
+        createReasoningTextDeltaNotification({
+          threadId: "thread-live",
+          turnId: "turn-1",
+          itemId: "item-reasoning",
+          delta: "Thinking...",
+        }),
+        createReasoningSummaryTextDeltaNotification({
+          threadId: "thread-live",
+          turnId: "turn-1",
+          itemId: "item-reasoning",
+          delta: "Short summary",
+        }),
+        createItemCompletedNotification({
+          threadId: "thread-live",
+          turnId: "turn-1",
+          itemId: "item-reasoning",
+          kind: "reasoning",
+          rawItem: {
+            id: "item-reasoning",
+            type: "reasoning",
+            status: "completed",
+          },
+        }),
+        createItemStartedNotification({
+          threadId: "thread-live",
+          turnId: "turn-1",
+          itemId: "item-command",
+          kind: "command_execution",
+        }),
+        createCommandOutputDeltaNotification({
+          threadId: "thread-live",
+          turnId: "turn-1",
+          itemId: "item-command",
+          delta: "stdout line\n",
+        }),
+        createItemCompletedNotification({
+          threadId: "thread-live",
+          turnId: "turn-1",
+          itemId: "item-command",
+          kind: "command_execution",
+          rawItem: {
+            id: "item-command",
+            type: "command_execution",
+            status: "completed",
+          },
+        }),
+        createItemStartedNotification({
+          threadId: "thread-live",
+          turnId: "turn-1",
+          itemId: "item-tool",
+          kind: "mcp_tool_call",
+        }),
+        createToolProgressNotification({
+          threadId: "thread-live",
+          turnId: "turn-1",
+          itemId: "item-tool",
+          message: "Fetching results",
+        }),
+        createItemCompletedNotification({
+          threadId: "thread-live",
+          turnId: "turn-1",
+          itemId: "item-tool",
+          kind: "mcp_tool_call",
+          rawItem: {
+            id: "item-tool",
+            type: "mcp_tool_call",
+            status: "completed",
+          },
+        }),
+        createTurnCompletedNotification({
+          threadId: "thread-live",
+          turnId: "turn-1",
+        }),
+      ] as const;
+
+      for (const notification of streamedNotifications) {
+        session.emitNotification(notification);
+      }
+
+      const clientAMessages = await Promise.all(
+        streamedNotifications.map(() => clientA.nextMessage()),
+      );
+      const clientBMessages = await Promise.all(
+        streamedNotifications.map(() => clientB.nextMessage()),
+      );
+
+      expect(clientAMessages).toEqual([
+        {
+          method: "turn/started",
+          params: {
+            threadId: "thread-live",
+            turn: {
+              id: "turn-1",
+              status: {
+                type: "inProgress",
+              },
+            },
+          },
+        },
+        {
+          method: "item/started",
+          params: {
+            threadId: "thread-live",
+            turnId: "turn-1",
+            item: {
+              id: "item-message",
+              kind: "agent_message",
+              rawItem: {
+                id: "item-message",
+                type: "agent_message",
+                status: "in_progress",
+              },
+            },
+          },
+        },
+        {
+          method: "item/message/textDelta",
+          params: {
+            threadId: "thread-live",
+            turnId: "turn-1",
+            itemId: "item-message",
+            delta: "Working on it...",
+          },
+        },
+        {
+          method: "item/completed",
+          params: {
+            threadId: "thread-live",
+            turnId: "turn-1",
+            item: {
+              id: "item-message",
+              kind: "agent_message",
+              rawItem: {
+                id: "item-message",
+                type: "agent_message",
+                status: "completed",
+                text: "Working on it...",
+              },
+            },
+          },
+        },
+        {
+          method: "item/started",
+          params: {
+            threadId: "thread-live",
+            turnId: "turn-1",
+            item: {
+              id: "item-reasoning",
+              kind: "reasoning",
+              rawItem: {
+                id: "item-reasoning",
+                type: "reasoning",
+                status: "in_progress",
+              },
+            },
+          },
+        },
+        {
+          method: "item/reasoning/textDelta",
+          params: {
+            threadId: "thread-live",
+            turnId: "turn-1",
+            itemId: "item-reasoning",
+            delta: "Thinking...",
+          },
+        },
+        {
+          method: "item/reasoning/summaryTextDelta",
+          params: {
+            threadId: "thread-live",
+            turnId: "turn-1",
+            itemId: "item-reasoning",
+            delta: "Short summary",
+          },
+        },
+        {
+          method: "item/completed",
+          params: {
+            threadId: "thread-live",
+            turnId: "turn-1",
+            item: {
+              id: "item-reasoning",
+              kind: "reasoning",
+              rawItem: {
+                id: "item-reasoning",
+                type: "reasoning",
+                status: "completed",
+              },
+            },
+          },
+        },
+        {
+          method: "item/started",
+          params: {
+            threadId: "thread-live",
+            turnId: "turn-1",
+            item: {
+              id: "item-command",
+              kind: "command_execution",
+              rawItem: {
+                id: "item-command",
+                type: "command_execution",
+                status: "in_progress",
+              },
+            },
+          },
+        },
+        {
+          method: "item/commandExecution/outputDelta",
+          params: {
+            threadId: "thread-live",
+            turnId: "turn-1",
+            itemId: "item-command",
+            delta: "stdout line\n",
+          },
+        },
+        {
+          method: "item/completed",
+          params: {
+            threadId: "thread-live",
+            turnId: "turn-1",
+            item: {
+              id: "item-command",
+              kind: "command_execution",
+              rawItem: {
+                id: "item-command",
+                type: "command_execution",
+                status: "completed",
+              },
+            },
+          },
+        },
+        {
+          method: "item/started",
+          params: {
+            threadId: "thread-live",
+            turnId: "turn-1",
+            item: {
+              id: "item-tool",
+              kind: "mcp_tool_call",
+              rawItem: {
+                id: "item-tool",
+                type: "mcp_tool_call",
+                status: "in_progress",
+              },
+            },
+          },
+        },
+        {
+          method: "item/tool/progress",
+          params: {
+            threadId: "thread-live",
+            turnId: "turn-1",
+            itemId: "item-tool",
+            message: "Fetching results",
+          },
+        },
+        {
+          method: "item/completed",
+          params: {
+            threadId: "thread-live",
+            turnId: "turn-1",
+            item: {
+              id: "item-tool",
+              kind: "mcp_tool_call",
+              rawItem: {
+                id: "item-tool",
+                type: "mcp_tool_call",
+                status: "completed",
+              },
+            },
+          },
+        },
+        {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-live",
+            turn: {
+              id: "turn-1",
+              status: {
+                type: "completed",
+              },
+            },
+          },
+        },
+      ]);
+      expect(clientBMessages).toEqual(clientAMessages);
+      await expect(bystander.nextMessage(150)).rejects.toThrow("Timed out waiting for message");
+
+      clientA.sendJson({
+        id: "req-turn-start-2",
+        method: "turn/start",
+        params: {
+          threadId: "thread-live",
+          prompt: "Start another turn after completion",
+        },
+      });
+
+      await expect(clientA.nextMessage()).resolves.toEqual({
+        id: "req-turn-start-2",
+        result: {
+          turn: {
+            id: "turn-2",
+            status: {
+              type: "inProgress",
+            },
+          },
+        },
+      });
+    } finally {
+      await clientA.close();
+      await clientB.close();
+      await bystander.close();
+    }
+  });
+
   test("clears loaded-thread subscriptions when the connection switches workspaces", async () => {
     const firstWorkspacePath = await createWorkspaceDirectory();
     const secondWorkspacePath = await createWorkspaceDirectory();
@@ -2149,6 +2729,17 @@ const createProtocolHarness = async (
     getOpenedWorkspace: workspacesModule.getOpenedWorkspace,
   });
   const finalizedThreadsModule = threadsModule;
+  const turnsModule = createTurnsModule({
+    logger: logger.withContext({ component: "module.turns" }),
+    registerMethod: appProtocolRuntime.registerMethod,
+    sendNotification: appProtocolRuntime.sendNotification,
+    registry: agentsModule.registry,
+    getOpenedWorkspace: workspacesModule.getOpenedWorkspace,
+    loadedThreads: {
+      isThreadLoadedForConnection: finalizedThreadsModule.isThreadLoadedForConnection,
+      listLoadedThreadSubscribers: finalizedThreadsModule.listLoadedThreadSubscribers,
+    },
+  });
   const transportComponent = createAppTransportComponent({
     config,
     logger,
@@ -2170,7 +2761,7 @@ const createProtocolHarness = async (
       agentsModule.lifecycle,
       workspacesModule.lifecycle,
       finalizedThreadsModule.lifecycle,
-      createTurnsModulePlaceholder(),
+      turnsModule.lifecycle,
       createApprovalsModulePlaceholder(),
       transportComponent,
     ],
@@ -2544,6 +3135,175 @@ const createThreadNameUpdatedNotification = (input: {
     archived: false,
     status: { type: "notLoaded" } as const,
   },
+});
+
+const createTurnStartedNotification = (input: { threadId: string; turnId: string }) => ({
+  agentId: "codex",
+  provider: "codex" as const,
+  receivedAt: "2026-04-10T12:00:00.000Z",
+  rawMethod: "turn/started",
+  threadId: input.threadId,
+  turnId: input.turnId,
+  type: "turn" as const,
+  event: "started" as const,
+  turn: {
+    id: input.turnId,
+    status: { type: "inProgress" } as const,
+  },
+});
+
+const createTurnCompletedNotification = (input: { threadId: string; turnId: string }) => ({
+  agentId: "codex",
+  provider: "codex" as const,
+  receivedAt: "2026-04-10T12:00:00.000Z",
+  rawMethod: "turn/completed",
+  threadId: input.threadId,
+  turnId: input.turnId,
+  type: "turn" as const,
+  event: "completed" as const,
+  turn: {
+    id: input.turnId,
+    status: { type: "completed" } as const,
+  },
+});
+
+const createItemStartedNotification = (input: {
+  threadId: string;
+  turnId: string;
+  itemId: string;
+  kind: string;
+}) => ({
+  agentId: "codex",
+  provider: "codex" as const,
+  receivedAt: "2026-04-10T12:00:00.000Z",
+  rawMethod: "item/started",
+  threadId: input.threadId,
+  turnId: input.turnId,
+  itemId: input.itemId,
+  type: "item" as const,
+  event: "started" as const,
+  item: {
+    id: input.itemId,
+    kind: input.kind,
+    rawItem: {
+      id: input.itemId,
+      type: input.kind,
+      status: "in_progress",
+    },
+  },
+});
+
+const createItemCompletedNotification = (input: {
+  threadId: string;
+  turnId: string;
+  itemId: string;
+  kind: string;
+  rawItem: Record<string, unknown>;
+}) => ({
+  agentId: "codex",
+  provider: "codex" as const,
+  receivedAt: "2026-04-10T12:00:00.000Z",
+  rawMethod: "item/completed",
+  threadId: input.threadId,
+  turnId: input.turnId,
+  itemId: input.itemId,
+  type: "item" as const,
+  event: "completed" as const,
+  item: {
+    id: input.itemId,
+    kind: input.kind,
+    rawItem: input.rawItem,
+  },
+});
+
+const createMessageDeltaNotification = (input: {
+  threadId: string;
+  turnId: string;
+  itemId: string;
+  delta: string;
+}) => ({
+  agentId: "codex",
+  provider: "codex" as const,
+  receivedAt: "2026-04-10T12:00:00.000Z",
+  rawMethod: "item/agentMessage/delta",
+  threadId: input.threadId,
+  turnId: input.turnId,
+  itemId: input.itemId,
+  type: "message" as const,
+  event: "textDelta" as const,
+  delta: input.delta,
+});
+
+const createReasoningTextDeltaNotification = (input: {
+  threadId: string;
+  turnId: string;
+  itemId: string;
+  delta: string;
+}) => ({
+  agentId: "codex",
+  provider: "codex" as const,
+  receivedAt: "2026-04-10T12:00:00.000Z",
+  rawMethod: "item/reasoning/textDelta",
+  threadId: input.threadId,
+  turnId: input.turnId,
+  itemId: input.itemId,
+  type: "reasoning" as const,
+  event: "textDelta" as const,
+  delta: input.delta,
+});
+
+const createReasoningSummaryTextDeltaNotification = (input: {
+  threadId: string;
+  turnId: string;
+  itemId: string;
+  delta: string;
+}) => ({
+  agentId: "codex",
+  provider: "codex" as const,
+  receivedAt: "2026-04-10T12:00:00.000Z",
+  rawMethod: "item/reasoning/summaryTextDelta",
+  threadId: input.threadId,
+  turnId: input.turnId,
+  itemId: input.itemId,
+  type: "reasoning" as const,
+  event: "summaryTextDelta" as const,
+  delta: input.delta,
+});
+
+const createCommandOutputDeltaNotification = (input: {
+  threadId: string;
+  turnId: string;
+  itemId: string;
+  delta: string;
+}) => ({
+  agentId: "codex",
+  provider: "codex" as const,
+  receivedAt: "2026-04-10T12:00:00.000Z",
+  rawMethod: "item/commandExecution/outputDelta",
+  threadId: input.threadId,
+  turnId: input.turnId,
+  itemId: input.itemId,
+  type: "command" as const,
+  event: "outputDelta" as const,
+  delta: input.delta,
+});
+
+const createToolProgressNotification = (input: {
+  threadId: string;
+  turnId: string;
+  itemId: string;
+  message: string;
+}) => ({
+  agentId: "codex",
+  provider: "codex" as const,
+  receivedAt: "2026-04-10T12:00:00.000Z",
+  rawMethod: "item/mcpToolCall/progress",
+  threadId: input.threadId,
+  turnId: input.turnId,
+  itemId: input.itemId,
+  type: "tool" as const,
+  event: "progress" as const,
+  message: input.message,
 });
 
 const toMessageText = (data: unknown): string => {

--- a/AppServer/src/app/server.ts
+++ b/AppServer/src/app/server.ts
@@ -11,7 +11,7 @@ import { createApprovalsModulePlaceholder } from "@/approvals";
 import { getErrorMessage, type LifecycleComponent } from "@/core/shared";
 import { createStoreBootstrap } from "@/core/store";
 import { createSqliteThreadsStore, createThreadsModule } from "@/threads";
-import { createTurnsModulePlaceholder } from "@/turns";
+import { createTurnsModule } from "@/turns";
 import { createSqliteWorkspacesStore, createWorkspacesModule } from "@/workspaces";
 
 export type AppServerState = "idle" | "starting" | "started" | "stopping" | "stopped";
@@ -351,6 +351,17 @@ const createDefaultComponents = (
     getOpenedWorkspace: workspacesModule.getOpenedWorkspace,
   });
   const finalizedThreadsModule = threadsModule;
+  const turnsModule = createTurnsModule({
+    logger: logger.withContext({ component: "module.turns" }),
+    registerMethod: appProtocolRuntime.registerMethod,
+    sendNotification: appProtocolRuntime.sendNotification,
+    registry: agentsModule.registry,
+    getOpenedWorkspace: workspacesModule.getOpenedWorkspace,
+    loadedThreads: {
+      isThreadLoadedForConnection: finalizedThreadsModule.isThreadLoadedForConnection,
+      listLoadedThreadSubscribers: finalizedThreadsModule.listLoadedThreadSubscribers,
+    },
+  });
   const transportComponent = createAppTransportComponent({
     config,
     logger,
@@ -369,7 +380,7 @@ const createDefaultComponents = (
     agentsModule.lifecycle,
     workspacesModule.lifecycle,
     finalizedThreadsModule.lifecycle,
-    createTurnsModulePlaceholder(),
+    turnsModule.lifecycle,
     createApprovalsModulePlaceholder(),
     transportComponent,
   ]);

--- a/AppServer/src/core/protocol/errors.ts
+++ b/AppServer/src/core/protocol/errors.ts
@@ -20,6 +20,8 @@ export const ATELIER_WORKSPACE_NOT_OPENED_ERROR = -33006;
 export const ATELIER_THREAD_READ_INCLUDE_TURNS_UNSUPPORTED_ERROR = -33007;
 export const ATELIER_THREAD_WORKSPACE_MISMATCH_ERROR = -33008;
 export const ATELIER_INVALID_PROVIDER_PAYLOAD_ERROR = -33009;
+export const ATELIER_THREAD_NOT_LOADED_ERROR = -33010;
+export const ATELIER_ACTIVE_TURN_ALREADY_EXISTS_ERROR = -33011;
 
 const PROTOCOL_METHOD_ERROR_BRAND = Symbol("ProtocolMethodError");
 
@@ -187,6 +189,40 @@ export const createInvalidProviderPayloadError = (
       providerMessage: input.providerMessage,
     }),
   );
+
+export const createThreadNotLoadedForConnectionError = (threadId: string): ProtocolMethodError =>
+  createProtocolMethodError(
+    ATELIER_THREAD_NOT_LOADED_ERROR,
+    "Thread is not loaded for this connection",
+    Object.freeze({
+      code: "THREAD_NOT_LOADED",
+      threadId,
+    }),
+  );
+
+export const createThreadNotLoadedForConnectionResult = (
+  threadId: string,
+): Result<never, ProtocolMethodError> => err(createThreadNotLoadedForConnectionError(threadId));
+
+export const createActiveTurnAlreadyExistsError = (
+  threadId: string,
+  activeTurnId?: string,
+): ProtocolMethodError =>
+  createProtocolMethodError(
+    ATELIER_ACTIVE_TURN_ALREADY_EXISTS_ERROR,
+    "Thread already has an active turn",
+    Object.freeze({
+      code: "TURN_ALREADY_ACTIVE",
+      threadId,
+      ...(activeTurnId ? { activeTurnId } : {}),
+    }),
+  );
+
+export const createActiveTurnAlreadyExistsResult = (
+  threadId: string,
+  activeTurnId?: string,
+): Result<never, ProtocolMethodError> =>
+  err(createActiveTurnAlreadyExistsError(threadId, activeTurnId));
 
 const brandProtocolMethodError = <T extends { code: number; message: string }>(
   error: T,

--- a/AppServer/src/test-support/agents.ts
+++ b/AppServer/src/test-support/agents.ts
@@ -19,6 +19,7 @@ import type {
   AgentThreadResult,
   AgentThreadSetNameParams,
   AgentThreadUnarchiveParams,
+  AgentTurnResult,
 } from "@/agents/contracts";
 import type { AgentRegistry } from "@/agents/registry";
 
@@ -75,6 +76,16 @@ export type FakeAgentSession = AgentSession &
       requestId: AgentRequestId;
       params: AgentThreadSetNameParams;
     }>[];
+    startTurnCalls: readonly Readonly<{
+      requestId: AgentRequestId;
+      params: Readonly<{
+        threadId: string;
+        prompt: string;
+        model?: string;
+        reasoningEffort?: AgentReasoningEffort;
+        cwd?: string;
+      }>;
+    }>[];
   }>;
 
 export type CreateFakeAgentSessionOptions = Readonly<{
@@ -130,6 +141,16 @@ export type CreateFakeAgentSessionOptions = Readonly<{
     requestId: AgentRequestId,
     params: AgentThreadSetNameParams,
   ) => Promise<AgentOperationResult<AgentThreadMutationResult>>;
+  startTurn?: (
+    requestId: AgentRequestId,
+    params: Readonly<{
+      threadId: string;
+      prompt: string;
+      model?: string;
+      reasoningEffort?: AgentReasoningEffort;
+      cwd?: string;
+    }>,
+  ) => Promise<AgentOperationResult<AgentTurnResult>>;
 }>;
 
 export const createFakeAgentSession = (
@@ -203,6 +224,18 @@ export const createFakeAgentSession = (
     Readonly<{
       requestId: AgentRequestId;
       params: AgentThreadSetNameParams;
+    }>
+  > = [];
+  const startTurnCalls: Array<
+    Readonly<{
+      requestId: AgentRequestId;
+      params: Readonly<{
+        threadId: string;
+        prompt: string;
+        model?: string;
+        reasoningEffort?: AgentReasoningEffort;
+        cwd?: string;
+      }>;
     }>
   > = [];
 
@@ -384,8 +417,22 @@ export const createFakeAgentSession = (
         }
       );
     },
-    startTurn: async () => {
-      throw new Error("startTurn should not be called in this test.");
+    startTurn: async (requestId, params) => {
+      startTurnCalls.push(
+        Object.freeze({
+          requestId,
+          params,
+        }),
+      );
+
+      return (
+        (await options.startTurn?.(requestId, params)) ?? {
+          ok: true,
+          data: {
+            turn: createTestAgentTurn(),
+          },
+        }
+      );
     },
     steerTurn: async () => {
       throw new Error("steerTurn should not be called in this test.");
@@ -413,6 +460,7 @@ export const createFakeAgentSession = (
     archiveThreadCalls,
     unarchiveThreadCalls,
     setThreadNameCalls,
+    startTurnCalls,
   };
 };
 
@@ -531,4 +579,17 @@ export const createTestAgentThread = (
     name: overrides.name ?? null,
     archived: overrides.archived ?? false,
     status: overrides.status ?? ({ type: "idle" } as const),
+  });
+
+export const createTestAgentTurn = (
+  overrides: Partial<
+    Readonly<{
+      id: string;
+      status: AgentTurnResult["turn"]["status"];
+    }>
+  > = {},
+) =>
+  Object.freeze({
+    id: overrides.id ?? "turn-1",
+    status: overrides.status ?? ({ type: "inProgress" } as const),
   });

--- a/AppServer/src/threads/loaded-thread-registry.ts
+++ b/AppServer/src/threads/loaded-thread-registry.ts
@@ -6,6 +6,7 @@ export type LoadedThreadRegistry = Readonly<{
       threadId: string;
     }>,
   ) => void;
+  isLoaded: (input: Readonly<{ connectionId: string; threadId: string }>) => boolean;
   listSubscribers: (threadId: string) => readonly string[];
   clearThread: (threadId: string) => readonly string[];
   clearConnection: (connectionId: string) => readonly string[];
@@ -52,6 +53,8 @@ export const createLoadedThreadRegistry = (): LoadedThreadRegistry => {
       connectionIds.add(connectionId);
       connectionIdsByThreadId.set(threadId, connectionIds);
     },
+    isLoaded: ({ connectionId, threadId }) =>
+      threadIdsByConnectionId.get(connectionId)?.has(threadId) ?? false,
     listSubscribers: (threadId) => [
       ...(connectionIdsByThreadId.get(threadId) ?? new Set<string>()),
     ],

--- a/AppServer/src/threads/thread.handlers.ts
+++ b/AppServer/src/threads/thread.handlers.ts
@@ -50,6 +50,13 @@ import type { Workspace } from "@/workspaces/schemas";
 
 export type ThreadsModule = Readonly<{
   lifecycle: LifecycleComponent;
+  isThreadLoadedForConnection: (
+    input: Readonly<{
+      connectionId: string;
+      threadId: string;
+    }>,
+  ) => boolean;
+  listLoadedThreadSubscribers: (threadId: string) => readonly string[];
   handleConnectionClosed: (connectionId: string) => void;
   handleWorkspaceOpened: (
     input: Readonly<{
@@ -498,6 +505,9 @@ export const createThreadsModule = (options: CreateThreadsModuleOptions): Thread
         options.logger.info("Threads module stopped", { reason });
       },
     }),
+    isThreadLoadedForConnection: ({ connectionId, threadId }) =>
+      loadedThreads.isLoaded({ connectionId, threadId }),
+    listLoadedThreadSubscribers: (threadId) => loadedThreads.listSubscribers(threadId),
     handleConnectionClosed: (connectionId) => {
       loadedThreads.clearConnection(connectionId);
     },

--- a/AppServer/src/turns/active-turn-registry.test.ts
+++ b/AppServer/src/turns/active-turn-registry.test.ts
@@ -109,4 +109,102 @@ describe("active turn registry", () => {
     });
     expect(registry.getActiveTurn("thread-1")).toBeUndefined();
   });
+
+  test("rejects reserving a second active turn for the same thread", () => {
+    const registry = createActiveTurnRegistry();
+
+    expect(registry.reserveThread("thread-1")).toEqual({
+      ok: true,
+      data: {
+        release: expect.any(Function),
+      },
+    });
+    expect(registry.reserveThread("thread-1")).toEqual({
+      ok: false,
+      error: {
+        type: "activeTurnConflict",
+        threadId: "thread-1",
+        message: "Thread already has an active turn.",
+      },
+    });
+  });
+
+  test("ignores mismatched turn ids instead of clobbering active state", () => {
+    const registry = createActiveTurnRegistry();
+
+    registry.startTurn({
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        status: {
+          type: "inProgress",
+        },
+      },
+    });
+    registry.recordItemStarted({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      item: {
+        id: "item-1",
+        kind: "agent_message",
+        rawItem: {
+          id: "item-1",
+          type: "agent_message",
+          status: "in_progress",
+        },
+      },
+    });
+
+    expect(
+      registry.appendMessageText({
+        threadId: "thread-1",
+        turnId: "turn-2",
+        itemId: "item-2",
+        delta: "late stray",
+      }),
+    ).toBe(false);
+    expect(
+      registry.recordItemCompleted({
+        threadId: "thread-1",
+        turnId: "turn-2",
+        item: {
+          id: "item-2",
+          kind: "agent_message",
+          rawItem: {
+            id: "item-2",
+            type: "agent_message",
+            status: "completed",
+          },
+        },
+      }),
+    ).toBe(false);
+
+    expect(registry.getActiveTurn("thread-1")).toEqual({
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        status: {
+          type: "inProgress",
+        },
+      },
+      items: [
+        {
+          item: {
+            id: "item-1",
+            kind: "agent_message",
+            rawItem: {
+              id: "item-1",
+              type: "agent_message",
+              status: "in_progress",
+            },
+          },
+          messageText: "",
+          reasoningText: "",
+          reasoningSummaryText: "",
+          commandOutput: "",
+          toolProgress: [],
+        },
+      ],
+    });
+  });
 });

--- a/AppServer/src/turns/active-turn-registry.test.ts
+++ b/AppServer/src/turns/active-turn-registry.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import { createActiveTurnRegistry } from "@/turns/active-turn-registry";
+
+describe("active turn registry", () => {
+  test("reconciles streamed item state against the final completed item payload", () => {
+    const registry = createActiveTurnRegistry();
+
+    registry.startTurn({
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        status: {
+          type: "inProgress",
+        },
+      },
+    });
+    registry.recordItemStarted({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      item: {
+        id: "item-1",
+        kind: "agent_message",
+        rawItem: {
+          id: "item-1",
+          type: "agent_message",
+          status: "in_progress",
+        },
+      },
+    });
+    registry.appendMessageText({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "item-1",
+      delta: "Hello",
+    });
+    registry.appendMessageText({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "item-1",
+      delta: " world",
+    });
+    registry.recordItemCompleted({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      item: {
+        id: "item-1",
+        kind: "agent_message",
+        rawItem: {
+          id: "item-1",
+          type: "agent_message",
+          status: "completed",
+          text: "Hello world",
+        },
+      },
+    });
+
+    expect(registry.getActiveTurn("thread-1")).toEqual({
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        status: {
+          type: "inProgress",
+        },
+      },
+      items: [
+        {
+          item: {
+            id: "item-1",
+            kind: "agent_message",
+            rawItem: {
+              id: "item-1",
+              type: "agent_message",
+              status: "completed",
+              text: "Hello world",
+            },
+          },
+          messageText: "Hello world",
+          reasoningText: "",
+          reasoningSummaryText: "",
+          commandOutput: "",
+          toolProgress: [],
+        },
+      ],
+    });
+  });
+
+  test("clears per-thread state", () => {
+    const registry = createActiveTurnRegistry();
+
+    registry.startTurn({
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        status: {
+          type: "inProgress",
+        },
+      },
+    });
+
+    expect(registry.clearThread("thread-1")).toEqual({
+      threadId: "thread-1",
+      turn: {
+        id: "turn-1",
+        status: {
+          type: "inProgress",
+        },
+      },
+      items: [],
+    });
+    expect(registry.getActiveTurn("thread-1")).toBeUndefined();
+  });
+});

--- a/AppServer/src/turns/active-turn-registry.ts
+++ b/AppServer/src/turns/active-turn-registry.ts
@@ -1,0 +1,221 @@
+import { err, ok, type Result } from "@/core/shared";
+import type { Turn, TurnItem } from "@/turns/schemas";
+
+export type ActiveTurnConflictError = Readonly<{
+  type: "activeTurnConflict";
+  threadId: string;
+  activeTurnId?: string;
+  message: string;
+}>;
+
+export type ActiveTurnItemState = Readonly<{
+  item?: TurnItem;
+  messageText: string;
+  reasoningText: string;
+  reasoningSummaryText: string;
+  commandOutput: string;
+  toolProgress: readonly string[];
+}>;
+
+export type ActiveTurnSnapshot = Readonly<{
+  threadId: string;
+  turn?: Turn;
+  items: readonly ActiveTurnItemState[];
+}>;
+
+export type ActiveTurnRegistry = Readonly<{
+  reserveThread: (
+    threadId: string,
+  ) => Result<Readonly<{ release: () => void }>, ActiveTurnConflictError>;
+  startTurn: (input: Readonly<{ threadId: string; turn: Turn }>) => void;
+  recordTurnCompleted: (input: Readonly<{ threadId: string; turn: Turn }>) => void;
+  recordItemStarted: (
+    input: Readonly<{ threadId: string; turnId: string; item: TurnItem }>,
+  ) => void;
+  recordItemCompleted: (
+    input: Readonly<{ threadId: string; turnId: string; item: TurnItem }>,
+  ) => void;
+  appendMessageText: (
+    input: Readonly<{ threadId: string; turnId: string; itemId: string; delta: string }>,
+  ) => void;
+  appendReasoningText: (
+    input: Readonly<{ threadId: string; turnId: string; itemId: string; delta: string }>,
+  ) => void;
+  appendReasoningSummaryText: (
+    input: Readonly<{ threadId: string; turnId: string; itemId: string; delta: string }>,
+  ) => void;
+  appendCommandOutput: (
+    input: Readonly<{ threadId: string; turnId: string; itemId: string; delta: string }>,
+  ) => void;
+  appendToolProgress: (
+    input: Readonly<{ threadId: string; turnId: string; itemId: string; message: string }>,
+  ) => void;
+  getActiveTurn: (threadId: string) => ActiveTurnSnapshot | undefined;
+  clearThread: (threadId: string) => ActiveTurnSnapshot | undefined;
+  clearAll: () => void;
+}>;
+
+type MutableActiveTurnItemState = {
+  item?: TurnItem;
+  messageText: string;
+  reasoningText: string;
+  reasoningSummaryText: string;
+  commandOutput: string;
+  toolProgress: string[];
+};
+
+type MutableActiveTurnState = {
+  turn?: Turn;
+  itemsById: Map<string, MutableActiveTurnItemState>;
+};
+
+export const createActiveTurnRegistry = (): ActiveTurnRegistry => {
+  const statesByThreadId = new Map<string, MutableActiveTurnState>();
+
+  const getOrCreateThreadState = (threadId: string): MutableActiveTurnState => {
+    const existing = statesByThreadId.get(threadId);
+
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const state: MutableActiveTurnState = {
+      itemsById: new Map(),
+    };
+    statesByThreadId.set(threadId, state);
+    return state;
+  };
+
+  const ensureObservedTurn = (threadId: string, turnId: string): MutableActiveTurnState => {
+    const state = getOrCreateThreadState(threadId);
+
+    if (state.turn?.id !== turnId) {
+      state.turn = Object.freeze({
+        id: turnId,
+        status: Object.freeze({ type: "inProgress" as const }),
+      });
+      state.itemsById.clear();
+    }
+
+    return state;
+  };
+
+  const getOrCreateItemState = (
+    threadId: string,
+    turnId: string,
+    itemId: string,
+  ): MutableActiveTurnItemState => {
+    const state = ensureObservedTurn(threadId, turnId);
+    const existing = state.itemsById.get(itemId);
+
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const itemState: MutableActiveTurnItemState = {
+      messageText: "",
+      reasoningText: "",
+      reasoningSummaryText: "",
+      commandOutput: "",
+      toolProgress: [],
+    };
+    state.itemsById.set(itemId, itemState);
+    return itemState;
+  };
+
+  const toSnapshot = (threadId: string, state: MutableActiveTurnState): ActiveTurnSnapshot =>
+    Object.freeze({
+      threadId,
+      ...(state.turn !== undefined ? { turn: state.turn } : {}),
+      items: [...state.itemsById.values()].map((item) =>
+        Object.freeze({
+          ...(item.item !== undefined ? { item: item.item } : {}),
+          messageText: item.messageText,
+          reasoningText: item.reasoningText,
+          reasoningSummaryText: item.reasoningSummaryText,
+          commandOutput: item.commandOutput,
+          toolProgress: Object.freeze([...item.toolProgress]),
+        }),
+      ),
+    });
+
+  return Object.freeze({
+    reserveThread: (threadId) => {
+      const existing = statesByThreadId.get(threadId);
+
+      if (existing !== undefined) {
+        return err({
+          type: "activeTurnConflict",
+          threadId,
+          ...(existing.turn !== undefined ? { activeTurnId: existing.turn.id } : {}),
+          message: "Thread already has an active turn.",
+        });
+      }
+
+      const state: MutableActiveTurnState = {
+        itemsById: new Map(),
+      };
+      statesByThreadId.set(threadId, state);
+
+      return ok(
+        Object.freeze({
+          release: () => {
+            const current = statesByThreadId.get(threadId);
+
+            if (current === state && current.turn === undefined) {
+              statesByThreadId.delete(threadId);
+            }
+          },
+        }),
+      );
+    },
+    startTurn: ({ threadId, turn }) => {
+      const state = getOrCreateThreadState(threadId);
+      state.turn = turn;
+    },
+    recordTurnCompleted: ({ threadId, turn }) => {
+      const state = ensureObservedTurn(threadId, turn.id);
+      state.turn = turn;
+    },
+    recordItemStarted: ({ threadId, turnId, item }) => {
+      const itemState = getOrCreateItemState(threadId, turnId, item.id);
+      itemState.item = item;
+    },
+    recordItemCompleted: ({ threadId, turnId, item }) => {
+      const itemState = getOrCreateItemState(threadId, turnId, item.id);
+      itemState.item = item;
+    },
+    appendMessageText: ({ threadId, turnId, itemId, delta }) => {
+      getOrCreateItemState(threadId, turnId, itemId).messageText += delta;
+    },
+    appendReasoningText: ({ threadId, turnId, itemId, delta }) => {
+      getOrCreateItemState(threadId, turnId, itemId).reasoningText += delta;
+    },
+    appendReasoningSummaryText: ({ threadId, turnId, itemId, delta }) => {
+      getOrCreateItemState(threadId, turnId, itemId).reasoningSummaryText += delta;
+    },
+    appendCommandOutput: ({ threadId, turnId, itemId, delta }) => {
+      getOrCreateItemState(threadId, turnId, itemId).commandOutput += delta;
+    },
+    appendToolProgress: ({ threadId, turnId, itemId, message }) => {
+      getOrCreateItemState(threadId, turnId, itemId).toolProgress.push(message);
+    },
+    getActiveTurn: (threadId) => {
+      const state = statesByThreadId.get(threadId);
+      return state === undefined ? undefined : toSnapshot(threadId, state);
+    },
+    clearThread: (threadId) => {
+      const state = statesByThreadId.get(threadId);
+
+      if (state === undefined) {
+        return undefined;
+      }
+
+      statesByThreadId.delete(threadId);
+      return toSnapshot(threadId, state);
+    },
+    clearAll: () => {
+      statesByThreadId.clear();
+    },
+  });
+};

--- a/AppServer/src/turns/active-turn-registry.ts
+++ b/AppServer/src/turns/active-turn-registry.ts
@@ -27,29 +27,29 @@ export type ActiveTurnRegistry = Readonly<{
   reserveThread: (
     threadId: string,
   ) => Result<Readonly<{ release: () => void }>, ActiveTurnConflictError>;
-  startTurn: (input: Readonly<{ threadId: string; turn: Turn }>) => void;
-  recordTurnCompleted: (input: Readonly<{ threadId: string; turn: Turn }>) => void;
+  startTurn: (input: Readonly<{ threadId: string; turn: Turn }>) => boolean;
+  recordTurnCompleted: (input: Readonly<{ threadId: string; turn: Turn }>) => boolean;
   recordItemStarted: (
     input: Readonly<{ threadId: string; turnId: string; item: TurnItem }>,
-  ) => void;
+  ) => boolean;
   recordItemCompleted: (
     input: Readonly<{ threadId: string; turnId: string; item: TurnItem }>,
-  ) => void;
+  ) => boolean;
   appendMessageText: (
     input: Readonly<{ threadId: string; turnId: string; itemId: string; delta: string }>,
-  ) => void;
+  ) => boolean;
   appendReasoningText: (
     input: Readonly<{ threadId: string; turnId: string; itemId: string; delta: string }>,
-  ) => void;
+  ) => boolean;
   appendReasoningSummaryText: (
     input: Readonly<{ threadId: string; turnId: string; itemId: string; delta: string }>,
-  ) => void;
+  ) => boolean;
   appendCommandOutput: (
     input: Readonly<{ threadId: string; turnId: string; itemId: string; delta: string }>,
-  ) => void;
+  ) => boolean;
   appendToolProgress: (
     input: Readonly<{ threadId: string; turnId: string; itemId: string; message: string }>,
-  ) => void;
+  ) => boolean;
   getActiveTurn: (threadId: string) => ActiveTurnSnapshot | undefined;
   clearThread: (threadId: string) => ActiveTurnSnapshot | undefined;
   clearAll: () => void;
@@ -86,15 +86,22 @@ export const createActiveTurnRegistry = (): ActiveTurnRegistry => {
     return state;
   };
 
-  const ensureObservedTurn = (threadId: string, turnId: string): MutableActiveTurnState => {
+  const ensureObservedTurn = (
+    threadId: string,
+    turnId: string,
+  ): MutableActiveTurnState | undefined => {
     const state = getOrCreateThreadState(threadId);
 
-    if (state.turn?.id !== turnId) {
+    if (state.turn === undefined) {
       state.turn = Object.freeze({
         id: turnId,
         status: Object.freeze({ type: "inProgress" as const }),
       });
-      state.itemsById.clear();
+      return state;
+    }
+
+    if (state.turn.id !== turnId) {
+      return undefined;
     }
 
     return state;
@@ -104,8 +111,13 @@ export const createActiveTurnRegistry = (): ActiveTurnRegistry => {
     threadId: string,
     turnId: string,
     itemId: string,
-  ): MutableActiveTurnItemState => {
+  ): MutableActiveTurnItemState | undefined => {
     const state = ensureObservedTurn(threadId, turnId);
+
+    if (state === undefined) {
+      return undefined;
+    }
+
     const existing = state.itemsById.get(itemId);
 
     if (existing !== undefined) {
@@ -171,34 +183,84 @@ export const createActiveTurnRegistry = (): ActiveTurnRegistry => {
     },
     startTurn: ({ threadId, turn }) => {
       const state = getOrCreateThreadState(threadId);
+      if (state.turn !== undefined && state.turn.id !== turn.id) {
+        return false;
+      }
+
       state.turn = turn;
+      return true;
     },
     recordTurnCompleted: ({ threadId, turn }) => {
       const state = ensureObservedTurn(threadId, turn.id);
+      if (state === undefined) {
+        return false;
+      }
+
       state.turn = turn;
+      return true;
     },
     recordItemStarted: ({ threadId, turnId, item }) => {
       const itemState = getOrCreateItemState(threadId, turnId, item.id);
+      if (itemState === undefined) {
+        return false;
+      }
+
       itemState.item = item;
+      return true;
     },
     recordItemCompleted: ({ threadId, turnId, item }) => {
       const itemState = getOrCreateItemState(threadId, turnId, item.id);
+      if (itemState === undefined) {
+        return false;
+      }
+
       itemState.item = item;
+      return true;
     },
     appendMessageText: ({ threadId, turnId, itemId, delta }) => {
-      getOrCreateItemState(threadId, turnId, itemId).messageText += delta;
+      const itemState = getOrCreateItemState(threadId, turnId, itemId);
+      if (itemState === undefined) {
+        return false;
+      }
+
+      itemState.messageText += delta;
+      return true;
     },
     appendReasoningText: ({ threadId, turnId, itemId, delta }) => {
-      getOrCreateItemState(threadId, turnId, itemId).reasoningText += delta;
+      const itemState = getOrCreateItemState(threadId, turnId, itemId);
+      if (itemState === undefined) {
+        return false;
+      }
+
+      itemState.reasoningText += delta;
+      return true;
     },
     appendReasoningSummaryText: ({ threadId, turnId, itemId, delta }) => {
-      getOrCreateItemState(threadId, turnId, itemId).reasoningSummaryText += delta;
+      const itemState = getOrCreateItemState(threadId, turnId, itemId);
+      if (itemState === undefined) {
+        return false;
+      }
+
+      itemState.reasoningSummaryText += delta;
+      return true;
     },
     appendCommandOutput: ({ threadId, turnId, itemId, delta }) => {
-      getOrCreateItemState(threadId, turnId, itemId).commandOutput += delta;
+      const itemState = getOrCreateItemState(threadId, turnId, itemId);
+      if (itemState === undefined) {
+        return false;
+      }
+
+      itemState.commandOutput += delta;
+      return true;
     },
     appendToolProgress: ({ threadId, turnId, itemId, message }) => {
-      getOrCreateItemState(threadId, turnId, itemId).toolProgress.push(message);
+      const itemState = getOrCreateItemState(threadId, turnId, itemId);
+      if (itemState === undefined) {
+        return false;
+      }
+
+      itemState.toolProgress.push(message);
+      return true;
     },
     getActiveTurn: (threadId) => {
       const state = statesByThreadId.get(threadId);

--- a/AppServer/src/turns/index.ts
+++ b/AppServer/src/turns/index.ts
@@ -1,4 +1,5 @@
-import { createLifecyclePlaceholder, type LifecycleComponent } from "@/core/shared";
-
-export const createTurnsModulePlaceholder = (): LifecycleComponent =>
-  createLifecyclePlaceholder("module.turns");
+export * from "@/turns/active-turn-registry";
+export * from "@/turns/schemas";
+export * from "@/turns/service";
+export * from "@/turns/service-types";
+export * from "@/turns/turn.handlers";

--- a/AppServer/src/turns/schemas.ts
+++ b/AppServer/src/turns/schemas.ts
@@ -1,0 +1,149 @@
+import { type Static, Type } from "@sinclair/typebox";
+
+export const TurnStatusSchema = Type.Union([
+  Type.Object(
+    {
+      type: Type.Literal("inProgress"),
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("awaitingInput"),
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("completed"),
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("failed"),
+      message: Type.Optional(Type.String({ minLength: 1 })),
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("cancelled"),
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("interrupted"),
+    },
+    { additionalProperties: false },
+  ),
+]);
+export type TurnStatus = Static<typeof TurnStatusSchema>;
+
+export const TurnSchema = Type.Object(
+  {
+    id: Type.String({ minLength: 1 }),
+    status: TurnStatusSchema,
+  },
+  { additionalProperties: false },
+);
+export type Turn = Static<typeof TurnSchema>;
+
+export const TurnItemSchema = Type.Object(
+  {
+    id: Type.String({ minLength: 1 }),
+    kind: Type.String({ minLength: 1 }),
+    rawItem: Type.Unknown(),
+  },
+  { additionalProperties: false },
+);
+export type TurnItem = Static<typeof TurnItemSchema>;
+
+export const TurnStartParamsSchema = Type.Object(
+  {
+    threadId: Type.String({ minLength: 1 }),
+    prompt: Type.String({ minLength: 1 }),
+  },
+  { additionalProperties: false },
+);
+export type TurnStartParams = Static<typeof TurnStartParamsSchema>;
+
+export const TurnStartResultSchema = Type.Object(
+  {
+    turn: TurnSchema,
+  },
+  { additionalProperties: false },
+);
+export type TurnStartResult = Static<typeof TurnStartResultSchema>;
+
+export const TurnStartedNotificationParamsSchema = Type.Object(
+  {
+    threadId: Type.String({ minLength: 1 }),
+    turn: TurnSchema,
+  },
+  { additionalProperties: false },
+);
+export type TurnStartedNotificationParams = Static<typeof TurnStartedNotificationParamsSchema>;
+
+export const TurnCompletedNotificationParamsSchema = TurnStartedNotificationParamsSchema;
+export type TurnCompletedNotificationParams = Static<typeof TurnCompletedNotificationParamsSchema>;
+
+export const ItemStartedNotificationParamsSchema = Type.Object(
+  {
+    threadId: Type.String({ minLength: 1 }),
+    turnId: Type.String({ minLength: 1 }),
+    item: TurnItemSchema,
+  },
+  { additionalProperties: false },
+);
+export type ItemStartedNotificationParams = Static<typeof ItemStartedNotificationParamsSchema>;
+
+export const ItemCompletedNotificationParamsSchema = ItemStartedNotificationParamsSchema;
+export type ItemCompletedNotificationParams = Static<typeof ItemCompletedNotificationParamsSchema>;
+
+const createDeltaNotificationParamsSchema = () =>
+  Type.Object(
+    {
+      threadId: Type.String({ minLength: 1 }),
+      turnId: Type.String({ minLength: 1 }),
+      itemId: Type.String({ minLength: 1 }),
+      delta: Type.String(),
+    },
+    { additionalProperties: false },
+  );
+
+export const ItemMessageTextDeltaNotificationParamsSchema = createDeltaNotificationParamsSchema();
+export type ItemMessageTextDeltaNotificationParams = Static<
+  typeof ItemMessageTextDeltaNotificationParamsSchema
+>;
+
+export const ItemReasoningTextDeltaNotificationParamsSchema = createDeltaNotificationParamsSchema();
+export type ItemReasoningTextDeltaNotificationParams = Static<
+  typeof ItemReasoningTextDeltaNotificationParamsSchema
+>;
+
+export const ItemReasoningSummaryTextDeltaNotificationParamsSchema =
+  createDeltaNotificationParamsSchema();
+export type ItemReasoningSummaryTextDeltaNotificationParams = Static<
+  typeof ItemReasoningSummaryTextDeltaNotificationParamsSchema
+>;
+
+export const ItemCommandExecutionOutputDeltaNotificationParamsSchema =
+  createDeltaNotificationParamsSchema();
+export type ItemCommandExecutionOutputDeltaNotificationParams = Static<
+  typeof ItemCommandExecutionOutputDeltaNotificationParamsSchema
+>;
+
+export const ItemToolProgressNotificationParamsSchema = Type.Object(
+  {
+    threadId: Type.String({ minLength: 1 }),
+    turnId: Type.String({ minLength: 1 }),
+    itemId: Type.String({ minLength: 1 }),
+    message: Type.String(),
+  },
+  { additionalProperties: false },
+);
+export type ItemToolProgressNotificationParams = Static<
+  typeof ItemToolProgressNotificationParamsSchema
+>;

--- a/AppServer/src/turns/schemas.ts
+++ b/AppServer/src/turns/schemas.ts
@@ -102,35 +102,34 @@ export type ItemStartedNotificationParams = Static<typeof ItemStartedNotificatio
 export const ItemCompletedNotificationParamsSchema = ItemStartedNotificationParamsSchema;
 export type ItemCompletedNotificationParams = Static<typeof ItemCompletedNotificationParamsSchema>;
 
-const createDeltaNotificationParamsSchema = () =>
-  Type.Object(
-    {
-      threadId: Type.String({ minLength: 1 }),
-      turnId: Type.String({ minLength: 1 }),
-      itemId: Type.String({ minLength: 1 }),
-      delta: Type.String(),
-    },
-    { additionalProperties: false },
-  );
+const ItemTextDeltaNotificationParamsSchema = Type.Object(
+  {
+    threadId: Type.String({ minLength: 1 }),
+    turnId: Type.String({ minLength: 1 }),
+    itemId: Type.String({ minLength: 1 }),
+    delta: Type.String(),
+  },
+  { additionalProperties: false },
+);
 
-export const ItemMessageTextDeltaNotificationParamsSchema = createDeltaNotificationParamsSchema();
+export const ItemMessageTextDeltaNotificationParamsSchema = ItemTextDeltaNotificationParamsSchema;
 export type ItemMessageTextDeltaNotificationParams = Static<
   typeof ItemMessageTextDeltaNotificationParamsSchema
 >;
 
-export const ItemReasoningTextDeltaNotificationParamsSchema = createDeltaNotificationParamsSchema();
+export const ItemReasoningTextDeltaNotificationParamsSchema = ItemTextDeltaNotificationParamsSchema;
 export type ItemReasoningTextDeltaNotificationParams = Static<
   typeof ItemReasoningTextDeltaNotificationParamsSchema
 >;
 
 export const ItemReasoningSummaryTextDeltaNotificationParamsSchema =
-  createDeltaNotificationParamsSchema();
+  ItemTextDeltaNotificationParamsSchema;
 export type ItemReasoningSummaryTextDeltaNotificationParams = Static<
   typeof ItemReasoningSummaryTextDeltaNotificationParamsSchema
 >;
 
 export const ItemCommandExecutionOutputDeltaNotificationParamsSchema =
-  createDeltaNotificationParamsSchema();
+  ItemTextDeltaNotificationParamsSchema;
 export type ItemCommandExecutionOutputDeltaNotificationParams = Static<
   typeof ItemCommandExecutionOutputDeltaNotificationParamsSchema
 >;

--- a/AppServer/src/turns/service-types.ts
+++ b/AppServer/src/turns/service-types.ts
@@ -1,0 +1,41 @@
+import type {
+  AgentRemoteError,
+  AgentRequestId,
+  AgentSessionLookupError,
+  AgentSessionUnavailableError,
+} from "@/agents/contracts";
+import type { AgentRegistry } from "@/agents/registry";
+import type { Logger } from "@/app/logger";
+import type { ActiveTurnConflictError, ActiveTurnRegistry } from "@/turns/active-turn-registry";
+import type { TurnStartParams, TurnStartResult } from "@/turns/schemas";
+import type { Workspace } from "@/workspaces/schemas";
+
+export type InvalidTurnProviderPayloadError = Readonly<{
+  type: "invalidProviderPayload";
+  agentId: string;
+  provider: string;
+  operation: "turn/start";
+  message: string;
+  detail?: Record<string, unknown>;
+}>;
+
+export type TurnsServiceError =
+  | AgentSessionLookupError
+  | AgentSessionUnavailableError
+  | AgentRemoteError
+  | ActiveTurnConflictError
+  | InvalidTurnProviderPayloadError;
+
+export type TurnsService = Readonly<{
+  startTurn: (
+    requestId: AgentRequestId,
+    workspace: Workspace,
+    params: TurnStartParams,
+  ) => Promise<{ ok: true; data: TurnStartResult } | { ok: false; error: TurnsServiceError }>;
+}>;
+
+export type CreateTurnsServiceOptions = Readonly<{
+  logger: Logger;
+  registry: AgentRegistry;
+  activeTurns: ActiveTurnRegistry;
+}>;

--- a/AppServer/src/turns/service.test.ts
+++ b/AppServer/src/turns/service.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createFakeAgentRegistry,
+  createFakeAgentSession,
+  createTestAgentTurn,
+} from "@/test-support/agents";
+import { createSilentLogger } from "@/test-support/logger";
+import { createActiveTurnRegistry } from "@/turns";
+import { createTurnsService } from "@/turns/service";
+
+const workspace = Object.freeze({
+  id: "workspace-1",
+  workspacePath: "/tmp/project",
+  createdAt: "2026-04-10T09:00:00.000Z",
+  lastOpenedAt: "2026-04-10T09:00:00.000Z",
+});
+
+describe("createTurnsService", () => {
+  test("enforces one active turn per thread", async () => {
+    const activeTurns = createActiveTurnRegistry();
+    const session = createFakeAgentSession({
+      startTurn: async () => ({
+        ok: true,
+        data: {
+          turn: createTestAgentTurn({
+            id: "turn-1",
+          }),
+        },
+      }),
+    });
+    const service = createTurnsService({
+      logger: createSilentLogger("error"),
+      registry: createFakeAgentRegistry(session),
+      activeTurns,
+    });
+
+    await expect(
+      service.startTurn("req-1", workspace, {
+        threadId: "thread-1",
+        prompt: "Start the first turn",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      data: {
+        turn: {
+          id: "turn-1",
+          status: {
+            type: "inProgress",
+          },
+        },
+      },
+    });
+    await expect(
+      service.startTurn("req-2", workspace, {
+        threadId: "thread-1",
+        prompt: "Try to start another turn",
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: {
+        type: "activeTurnConflict",
+        threadId: "thread-1",
+        activeTurnId: "turn-1",
+        message: "Thread already has an active turn.",
+      },
+    });
+  });
+
+  test("releases a pending reservation when turn/start fails", async () => {
+    let callCount = 0;
+    const service = createTurnsService({
+      logger: createSilentLogger("error"),
+      registry: createFakeAgentRegistry(
+        createFakeAgentSession({
+          startTurn: async () => {
+            callCount += 1;
+
+            if (callCount === 1) {
+              return {
+                ok: false,
+                error: {
+                  type: "remoteError",
+                  agentId: "codex",
+                  provider: "codex",
+                  requestId: "req-1",
+                  code: -32603,
+                  message: "provider failed",
+                },
+              };
+            }
+
+            return {
+              ok: true,
+              data: {
+                turn: createTestAgentTurn({
+                  id: "turn-2",
+                }),
+              },
+            };
+          },
+        }),
+      ),
+      activeTurns: createActiveTurnRegistry(),
+    });
+
+    await expect(
+      service.startTurn("req-1", workspace, {
+        threadId: "thread-1",
+        prompt: "This one fails",
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: {
+        type: "remoteError",
+        agentId: "codex",
+        provider: "codex",
+        requestId: "req-1",
+        code: -32603,
+        message: "provider failed",
+      },
+    });
+    await expect(
+      service.startTurn("req-2", workspace, {
+        threadId: "thread-1",
+        prompt: "This one succeeds",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      data: {
+        turn: {
+          id: "turn-2",
+          status: {
+            type: "inProgress",
+          },
+        },
+      },
+    });
+  });
+});

--- a/AppServer/src/turns/service.ts
+++ b/AppServer/src/turns/service.ts
@@ -59,10 +59,17 @@ export const createTurnsService = (options: CreateTurnsServiceOptions): TurnsSer
         id: startTurnResult.data.turn.id,
         status: mapTurnStatus(startTurnResult.data.turn.status),
       });
-      options.activeTurns.startTurn({
+      const wasRecorded = options.activeTurns.startTurn({
         threadId: params.threadId,
         turn,
       });
+      if (!wasRecorded) {
+        options.logger.warn("Ignored turn/start response with mismatched active turn", {
+          threadId: params.threadId,
+          turnId: turn.id,
+          activeTurnId: options.activeTurns.getActiveTurn(params.threadId)?.turn?.id ?? null,
+        });
+      }
 
       return ok({
         turn,

--- a/AppServer/src/turns/service.ts
+++ b/AppServer/src/turns/service.ts
@@ -1,0 +1,119 @@
+import type { AgentInvalidMessageError, AgentTurnStatus } from "@/agents/contracts";
+import {
+  createActiveTurnAlreadyExistsError,
+  createInvalidProviderPayloadError,
+  type ProtocolMethodError,
+} from "@/core/protocol/errors";
+import { assertNever, err, ok } from "@/core/shared";
+import type { ActiveTurnConflictError } from "@/turns/active-turn-registry";
+import type {
+  CreateTurnsServiceOptions,
+  InvalidTurnProviderPayloadError,
+  TurnsService,
+} from "@/turns/service-types";
+
+export type {
+  CreateTurnsServiceOptions,
+  InvalidTurnProviderPayloadError,
+  TurnsServiceError,
+} from "@/turns/service-types";
+
+export const createTurnsService = (options: CreateTurnsServiceOptions): TurnsService =>
+  Object.freeze({
+    startTurn: async (requestId, workspace, params) => {
+      const sessionResult = await options.registry.getSession();
+
+      if (!sessionResult.ok) {
+        return err(sessionResult.error);
+      }
+
+      const reservationResult = options.activeTurns.reserveThread(params.threadId);
+
+      if (!reservationResult.ok) {
+        return err(reservationResult.error);
+      }
+
+      const session = sessionResult.data;
+      const reservation = reservationResult.data;
+      const startTurnResult = await session.startTurn(requestId, {
+        threadId: params.threadId,
+        prompt: params.prompt,
+        cwd: workspace.workspacePath,
+      });
+
+      if (!startTurnResult.ok) {
+        reservation.release();
+
+        switch (startTurnResult.error.type) {
+          case "sessionUnavailable":
+          case "remoteError":
+            return err(startTurnResult.error);
+          case "invalidProviderMessage":
+            return err(createInvalidProviderPayloadServiceError(startTurnResult.error));
+          default:
+            return assertNever(startTurnResult.error, "Unhandled turn/start service error");
+        }
+      }
+
+      const turn = Object.freeze({
+        id: startTurnResult.data.turn.id,
+        status: mapTurnStatus(startTurnResult.data.turn.status),
+      });
+      options.activeTurns.startTurn({
+        threadId: params.threadId,
+        turn,
+      });
+
+      return ok({
+        turn,
+      });
+    },
+  });
+
+export const mapInvalidProviderPayloadToProtocolError = (
+  error: InvalidTurnProviderPayloadError,
+): ProtocolMethodError =>
+  createInvalidProviderPayloadError({
+    agentId: error.agentId,
+    provider: error.provider,
+    operation: error.operation,
+    providerMessage: error.message,
+  });
+
+export const createActiveTurnConflictProtocolError = (
+  error: ActiveTurnConflictError,
+): ProtocolMethodError => createActiveTurnAlreadyExistsError(error.threadId, error.activeTurnId);
+
+const createInvalidProviderPayloadServiceError = (
+  error: AgentInvalidMessageError,
+): InvalidTurnProviderPayloadError =>
+  Object.freeze({
+    type: "invalidProviderPayload",
+    agentId: error.agentId,
+    provider: error.provider,
+    operation: "turn/start",
+    message: error.message,
+    ...(error.detail ? { detail: error.detail } : {}),
+  });
+
+const mapTurnStatus = (status: AgentTurnStatus) => {
+  switch (status.type) {
+    case "inProgress":
+      return Object.freeze({ type: "inProgress" as const });
+    case "awaitingInput":
+      return Object.freeze({ type: "awaitingInput" as const });
+    case "completed":
+      return Object.freeze({ type: "completed" as const });
+    case "cancelled":
+      return Object.freeze({ type: "cancelled" as const });
+    case "interrupted":
+      return Object.freeze({ type: "interrupted" as const });
+    case "failed":
+      return Object.freeze({
+        type: "failed" as const,
+        ...(status.message ? { message: status.message } : {}),
+      });
+    default:
+      return assertNever(status, "Unhandled turn status");
+  }
+};

--- a/AppServer/src/turns/turn.handlers.ts
+++ b/AppServer/src/turns/turn.handlers.ts
@@ -1,0 +1,477 @@
+import type {
+  AgentNotification,
+  AgentSession,
+  AgentSessionLookupError,
+  AgentTurnNotification,
+} from "@/agents/contracts";
+import { createAgentSessionUnavailableError, createProviderError } from "@/agents/protocol-errors";
+import type { AgentRegistry } from "@/agents/registry";
+import { createAgentRequestId } from "@/agents/request-id";
+import type { Logger } from "@/app/logger";
+import type { ProtocolDispatcher, ProtocolEngine, ProtocolNotification } from "@/core/protocol";
+import {
+  createSessionNotInitializedResult,
+  createThreadNotLoadedForConnectionError,
+  createWorkspaceNotOpenedResult,
+  isProtocolMethodError,
+  type ProtocolMethodError,
+} from "@/core/protocol/errors";
+import {
+  assertNever,
+  err,
+  getErrorMessage,
+  type LifecycleComponent,
+  ok,
+  type Result,
+} from "@/core/shared";
+import { createActiveTurnRegistry } from "@/turns/active-turn-registry";
+import {
+  type Turn,
+  type TurnStartParams,
+  TurnStartParamsSchema,
+  type TurnStartResult,
+  TurnStartResultSchema,
+} from "@/turns/schemas";
+import {
+  createActiveTurnConflictProtocolError,
+  createTurnsService,
+  mapInvalidProviderPayloadToProtocolError,
+  type TurnsServiceError,
+} from "@/turns/service";
+import type { Workspace } from "@/workspaces/schemas";
+
+export type LoadedThreadAccess = Readonly<{
+  isThreadLoadedForConnection: (
+    input: Readonly<{ connectionId: string; threadId: string }>,
+  ) => boolean;
+  listLoadedThreadSubscribers: (threadId: string) => readonly string[];
+}>;
+
+export type TurnsModule = Readonly<{
+  lifecycle: LifecycleComponent;
+}>;
+
+export type CreateTurnsModuleOptions = Readonly<{
+  logger: Logger;
+  registerMethod: ProtocolDispatcher["registerMethod"];
+  sendNotification: ProtocolEngine["sendNotification"];
+  registry: AgentRegistry;
+  getOpenedWorkspace: (connectionId: string) => Workspace | undefined;
+  loadedThreads: LoadedThreadAccess;
+}>;
+
+export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModule => {
+  const activeTurns = createActiveTurnRegistry();
+  const service = createTurnsService({
+    logger: options.logger,
+    registry: options.registry,
+    activeTurns,
+  });
+
+  let subscribedSession: AgentSession | undefined;
+  let unsubscribeFromSession: (() => void) | undefined;
+  let notificationChain = Promise.resolve();
+
+  const resetSessionSubscription = (): void => {
+    unsubscribeFromSession?.();
+    unsubscribeFromSession = undefined;
+    subscribedSession = undefined;
+  };
+
+  const enqueueNotification = (notification: AgentNotification): void => {
+    notificationChain = notificationChain
+      .catch(() => {})
+      .then(() => forwardAgentNotification(notification));
+  };
+
+  const ensureSessionNotificationBinding = async (): Promise<
+    Result<void, AgentSessionLookupError>
+  > => {
+    const sessionResult = await options.registry.getSession();
+
+    if (!sessionResult.ok) {
+      return err(sessionResult.error);
+    }
+
+    if (subscribedSession === sessionResult.data) {
+      return ok(undefined);
+    }
+
+    resetSessionSubscription();
+    subscribedSession = sessionResult.data;
+    unsubscribeFromSession = sessionResult.data.subscribe((notification) => {
+      enqueueNotification(notification);
+    });
+
+    return ok(undefined);
+  };
+
+  const sendTurnNotification = async (
+    connectionId: string,
+    threadId: string,
+    notification: ProtocolNotification,
+  ): Promise<void> => {
+    try {
+      await options.sendNotification({
+        connectionId,
+        notification,
+      });
+    } catch (error) {
+      options.logger.warn("Failed to send turn notification", {
+        connectionId,
+        threadId,
+        method: notification.method,
+        error: getErrorMessage(error),
+      });
+    }
+  };
+
+  const fanOutThreadNotification = async (
+    threadId: string,
+    notification: ProtocolNotification,
+  ): Promise<void> => {
+    const connectionIds = options.loadedThreads.listLoadedThreadSubscribers(threadId);
+
+    if (connectionIds.length === 0) {
+      return;
+    }
+
+    for (const connectionId of connectionIds) {
+      await sendTurnNotification(connectionId, threadId, notification);
+    }
+  };
+
+  const forwardAgentNotification = async (notification: AgentNotification): Promise<void> => {
+    switch (notification.type) {
+      case "disconnect":
+        activeTurns.clearAll();
+        resetSessionSubscription();
+        return;
+      case "thread":
+        if (notification.event === "closed" && notification.threadId !== undefined) {
+          activeTurns.clearThread(notification.threadId);
+        }
+        return;
+      case "turn":
+        await handleTurnNotification(notification);
+        return;
+      case "item":
+        await handleItemNotification(notification);
+        return;
+      case "message":
+        if (
+          notification.threadId === undefined ||
+          notification.turnId === undefined ||
+          notification.itemId === undefined
+        ) {
+          return;
+        }
+
+        activeTurns.appendMessageText({
+          threadId: notification.threadId,
+          turnId: notification.turnId,
+          itemId: notification.itemId,
+          delta: notification.delta,
+        });
+        await fanOutThreadNotification(notification.threadId, {
+          method: "item/message/textDelta",
+          params: {
+            threadId: notification.threadId,
+            turnId: notification.turnId,
+            itemId: notification.itemId,
+            delta: notification.delta,
+          },
+        });
+        return;
+      case "reasoning":
+        if (
+          notification.threadId === undefined ||
+          notification.turnId === undefined ||
+          notification.itemId === undefined ||
+          notification.delta === undefined
+        ) {
+          return;
+        }
+
+        if (notification.event === "textDelta") {
+          activeTurns.appendReasoningText({
+            threadId: notification.threadId,
+            turnId: notification.turnId,
+            itemId: notification.itemId,
+            delta: notification.delta,
+          });
+          await fanOutThreadNotification(notification.threadId, {
+            method: "item/reasoning/textDelta",
+            params: {
+              threadId: notification.threadId,
+              turnId: notification.turnId,
+              itemId: notification.itemId,
+              delta: notification.delta,
+            },
+          });
+        } else if (notification.event === "summaryTextDelta") {
+          activeTurns.appendReasoningSummaryText({
+            threadId: notification.threadId,
+            turnId: notification.turnId,
+            itemId: notification.itemId,
+            delta: notification.delta,
+          });
+          await fanOutThreadNotification(notification.threadId, {
+            method: "item/reasoning/summaryTextDelta",
+            params: {
+              threadId: notification.threadId,
+              turnId: notification.turnId,
+              itemId: notification.itemId,
+              delta: notification.delta,
+            },
+          });
+        }
+        return;
+      case "command":
+        if (
+          notification.threadId === undefined ||
+          notification.turnId === undefined ||
+          notification.itemId === undefined
+        ) {
+          return;
+        }
+
+        activeTurns.appendCommandOutput({
+          threadId: notification.threadId,
+          turnId: notification.turnId,
+          itemId: notification.itemId,
+          delta: notification.delta,
+        });
+        await fanOutThreadNotification(notification.threadId, {
+          method: "item/commandExecution/outputDelta",
+          params: {
+            threadId: notification.threadId,
+            turnId: notification.turnId,
+            itemId: notification.itemId,
+            delta: notification.delta,
+          },
+        });
+        return;
+      case "tool":
+        if (
+          notification.threadId === undefined ||
+          notification.turnId === undefined ||
+          notification.itemId === undefined
+        ) {
+          return;
+        }
+
+        activeTurns.appendToolProgress({
+          threadId: notification.threadId,
+          turnId: notification.turnId,
+          itemId: notification.itemId,
+          message: notification.message,
+        });
+        await fanOutThreadNotification(notification.threadId, {
+          method: "item/tool/progress",
+          params: {
+            threadId: notification.threadId,
+            turnId: notification.turnId,
+            itemId: notification.itemId,
+            message: notification.message,
+          },
+        });
+        return;
+      case "approval":
+      case "plan":
+      case "diff":
+      case "error":
+        return;
+      default:
+        return assertNever(notification, "Unhandled agent notification");
+    }
+  };
+
+  const handleTurnNotification = async (notification: AgentTurnNotification): Promise<void> => {
+    if (notification.threadId === undefined) {
+      return;
+    }
+
+    const turn = mapTurnSummary(notification.turn);
+
+    if (notification.event === "started") {
+      activeTurns.startTurn({
+        threadId: notification.threadId,
+        turn,
+      });
+      await fanOutThreadNotification(notification.threadId, {
+        method: "turn/started",
+        params: {
+          threadId: notification.threadId,
+          turn,
+        },
+      });
+      return;
+    }
+
+    activeTurns.recordTurnCompleted({
+      threadId: notification.threadId,
+      turn,
+    });
+    await fanOutThreadNotification(notification.threadId, {
+      method: "turn/completed",
+      params: {
+        threadId: notification.threadId,
+        turn,
+      },
+    });
+    activeTurns.clearThread(notification.threadId);
+  };
+
+  const handleItemNotification = async (
+    notification: Extract<AgentNotification, { type: "item" }>,
+  ): Promise<void> => {
+    if (notification.threadId === undefined || notification.turnId === undefined) {
+      return;
+    }
+
+    const item = Object.freeze({
+      id: notification.item.id,
+      kind: notification.item.kind,
+      rawItem: notification.item.rawItem,
+    });
+
+    if (notification.event === "started") {
+      activeTurns.recordItemStarted({
+        threadId: notification.threadId,
+        turnId: notification.turnId,
+        item,
+      });
+      await fanOutThreadNotification(notification.threadId, {
+        method: "item/started",
+        params: {
+          threadId: notification.threadId,
+          turnId: notification.turnId,
+          item,
+        },
+      });
+      return;
+    }
+
+    activeTurns.recordItemCompleted({
+      threadId: notification.threadId,
+      turnId: notification.turnId,
+      item,
+    });
+    await fanOutThreadNotification(notification.threadId, {
+      method: "item/completed",
+      params: {
+        threadId: notification.threadId,
+        turnId: notification.turnId,
+        item,
+      },
+    });
+  };
+
+  options.registerMethod({
+    method: "turn/start",
+    paramsSchema: TurnStartParamsSchema,
+    resultSchema: TurnStartResultSchema,
+    handler: async ({ connectionId, params, requestId, session }) => {
+      if (!session.isInitialized()) {
+        return createSessionNotInitializedResult();
+      }
+
+      const workspace = options.getOpenedWorkspace(connectionId);
+
+      if (workspace === undefined) {
+        return createWorkspaceNotOpenedResult();
+      }
+
+      if (
+        !options.loadedThreads.isThreadLoadedForConnection({
+          connectionId,
+          threadId: params.threadId,
+        })
+      ) {
+        return err(createThreadNotLoadedForConnectionError(params.threadId));
+      }
+
+      const bindResult = await ensureSessionNotificationBinding();
+      if (!bindResult.ok) {
+        return err(mapTurnError(bindResult.error));
+      }
+
+      const agentRequestId = createAgentRequestId({
+        connectionId,
+        method: "turn/start",
+        requestId,
+      });
+      const result = await service.startTurn(
+        agentRequestId,
+        workspace,
+        normalizeTurnStartParams(params),
+      );
+      return mapTurnResult(result);
+    },
+  });
+
+  return Object.freeze({
+    lifecycle: Object.freeze({
+      name: "module.turns",
+      start: async () => {
+        options.logger.info("Turns module ready");
+      },
+      stop: async (reason: string) => {
+        activeTurns.clearAll();
+        resetSessionSubscription();
+        await notificationChain.catch(() => {});
+        options.logger.info("Turns module stopped", { reason });
+      },
+    }),
+  });
+};
+
+const normalizeTurnStartParams = (params: TurnStartParams): TurnStartParams =>
+  Object.freeze({
+    threadId: params.threadId,
+    prompt: params.prompt,
+  });
+
+const mapTurnSummary = (turn: AgentTurnNotification["turn"]): Turn =>
+  Object.freeze({
+    id: turn.id,
+    status:
+      turn.status.type === "failed"
+        ? Object.freeze({
+            type: "failed" as const,
+            ...(turn.status.message ? { message: turn.status.message } : {}),
+          })
+        : Object.freeze({ type: turn.status.type }),
+  });
+
+const mapTurnResult = (
+  result: Result<TurnStartResult, AgentSessionLookupError | TurnsServiceError>,
+): Result<TurnStartResult, ProtocolMethodError> => {
+  if (result.ok) {
+    return ok(result.data);
+  }
+
+  return err(mapTurnError(result.error));
+};
+
+const mapTurnError = (error: AgentSessionLookupError | TurnsServiceError): ProtocolMethodError => {
+  if (isProtocolMethodError(error)) {
+    return error;
+  }
+
+  switch (error.type) {
+    case "sessionUnavailable":
+      return createAgentSessionUnavailableError(error);
+    case "remoteError":
+      return createProviderError(error);
+    case "invalidProviderPayload":
+      return mapInvalidProviderPayloadToProtocolError(error);
+    case "activeTurnConflict":
+      return createActiveTurnConflictProtocolError(error);
+    case "agentNotFound":
+      throw new Error(error.message);
+    default:
+      return assertNever(error, "Unhandled turn protocol error");
+  }
+};

--- a/AppServer/src/turns/turn.handlers.ts
+++ b/AppServer/src/turns/turn.handlers.ts
@@ -141,6 +141,25 @@ export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModul
     }
   };
 
+  const warnIgnoredTurnNotification = (
+    details: Readonly<{
+      type: string;
+      event: string;
+      threadId: string;
+      turnId?: string;
+      itemId?: string;
+    }>,
+  ): void => {
+    options.logger.warn("Ignored turn notification with mismatched active turn", {
+      notificationType: details.type,
+      event: details.event,
+      threadId: details.threadId,
+      ...(details.turnId !== undefined ? { turnId: details.turnId } : {}),
+      ...(details.itemId !== undefined ? { itemId: details.itemId } : {}),
+      activeTurnId: activeTurns.getActiveTurn(details.threadId)?.turn?.id ?? null,
+    });
+  };
+
   const forwardAgentNotification = async (notification: AgentNotification): Promise<void> => {
     switch (notification.type) {
       case "disconnect":
@@ -158,7 +177,7 @@ export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModul
       case "item":
         await handleItemNotification(notification);
         return;
-      case "message":
+      case "message": {
         if (
           notification.threadId === undefined ||
           notification.turnId === undefined ||
@@ -167,12 +186,23 @@ export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModul
           return;
         }
 
-        activeTurns.appendMessageText({
+        const wasRecorded = activeTurns.appendMessageText({
           threadId: notification.threadId,
           turnId: notification.turnId,
           itemId: notification.itemId,
           delta: notification.delta,
         });
+        if (!wasRecorded) {
+          warnIgnoredTurnNotification({
+            type: notification.type,
+            event: notification.event,
+            threadId: notification.threadId,
+            turnId: notification.turnId,
+            itemId: notification.itemId,
+          });
+          return;
+        }
+
         await fanOutThreadNotification(notification.threadId, {
           method: "item/message/textDelta",
           params: {
@@ -183,7 +213,8 @@ export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModul
           },
         });
         return;
-      case "reasoning":
+      }
+      case "reasoning": {
         if (
           notification.threadId === undefined ||
           notification.turnId === undefined ||
@@ -193,13 +224,26 @@ export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModul
           return;
         }
 
+        // Only text deltas are surfaced live in this phase. Summary-part payloads
+        // are normalized at the adapter boundary but intentionally not relayed yet.
         if (notification.event === "textDelta") {
-          activeTurns.appendReasoningText({
+          const wasRecorded = activeTurns.appendReasoningText({
             threadId: notification.threadId,
             turnId: notification.turnId,
             itemId: notification.itemId,
             delta: notification.delta,
           });
+          if (!wasRecorded) {
+            warnIgnoredTurnNotification({
+              type: notification.type,
+              event: notification.event,
+              threadId: notification.threadId,
+              turnId: notification.turnId,
+              itemId: notification.itemId,
+            });
+            return;
+          }
+
           await fanOutThreadNotification(notification.threadId, {
             method: "item/reasoning/textDelta",
             params: {
@@ -210,12 +254,23 @@ export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModul
             },
           });
         } else if (notification.event === "summaryTextDelta") {
-          activeTurns.appendReasoningSummaryText({
+          const wasRecorded = activeTurns.appendReasoningSummaryText({
             threadId: notification.threadId,
             turnId: notification.turnId,
             itemId: notification.itemId,
             delta: notification.delta,
           });
+          if (!wasRecorded) {
+            warnIgnoredTurnNotification({
+              type: notification.type,
+              event: notification.event,
+              threadId: notification.threadId,
+              turnId: notification.turnId,
+              itemId: notification.itemId,
+            });
+            return;
+          }
+
           await fanOutThreadNotification(notification.threadId, {
             method: "item/reasoning/summaryTextDelta",
             params: {
@@ -227,7 +282,8 @@ export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModul
           });
         }
         return;
-      case "command":
+      }
+      case "command": {
         if (
           notification.threadId === undefined ||
           notification.turnId === undefined ||
@@ -236,12 +292,23 @@ export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModul
           return;
         }
 
-        activeTurns.appendCommandOutput({
+        const wasRecorded = activeTurns.appendCommandOutput({
           threadId: notification.threadId,
           turnId: notification.turnId,
           itemId: notification.itemId,
           delta: notification.delta,
         });
+        if (!wasRecorded) {
+          warnIgnoredTurnNotification({
+            type: notification.type,
+            event: notification.event,
+            threadId: notification.threadId,
+            turnId: notification.turnId,
+            itemId: notification.itemId,
+          });
+          return;
+        }
+
         await fanOutThreadNotification(notification.threadId, {
           method: "item/commandExecution/outputDelta",
           params: {
@@ -252,7 +319,8 @@ export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModul
           },
         });
         return;
-      case "tool":
+      }
+      case "tool": {
         if (
           notification.threadId === undefined ||
           notification.turnId === undefined ||
@@ -261,12 +329,23 @@ export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModul
           return;
         }
 
-        activeTurns.appendToolProgress({
+        const wasRecorded = activeTurns.appendToolProgress({
           threadId: notification.threadId,
           turnId: notification.turnId,
           itemId: notification.itemId,
           message: notification.message,
         });
+        if (!wasRecorded) {
+          warnIgnoredTurnNotification({
+            type: notification.type,
+            event: notification.event,
+            threadId: notification.threadId,
+            turnId: notification.turnId,
+            itemId: notification.itemId,
+          });
+          return;
+        }
+
         await fanOutThreadNotification(notification.threadId, {
           method: "item/tool/progress",
           params: {
@@ -277,6 +356,7 @@ export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModul
           },
         });
         return;
+      }
       case "approval":
       case "plan":
       case "diff":
@@ -294,33 +374,59 @@ export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModul
 
     const turn = mapTurnSummary(notification.turn);
 
-    if (notification.event === "started") {
-      activeTurns.startTurn({
-        threadId: notification.threadId,
-        turn,
-      });
-      await fanOutThreadNotification(notification.threadId, {
-        method: "turn/started",
-        params: {
+    switch (notification.event) {
+      case "started": {
+        const wasRecorded = activeTurns.startTurn({
           threadId: notification.threadId,
           turn,
-        },
-      });
-      return;
-    }
+        });
+        if (!wasRecorded) {
+          warnIgnoredTurnNotification({
+            type: notification.type,
+            event: notification.event,
+            threadId: notification.threadId,
+            turnId: notification.turnId,
+          });
+          return;
+        }
 
-    activeTurns.recordTurnCompleted({
-      threadId: notification.threadId,
-      turn,
-    });
-    await fanOutThreadNotification(notification.threadId, {
-      method: "turn/completed",
-      params: {
-        threadId: notification.threadId,
-        turn,
-      },
-    });
-    activeTurns.clearThread(notification.threadId);
+        await fanOutThreadNotification(notification.threadId, {
+          method: "turn/started",
+          params: {
+            threadId: notification.threadId,
+            turn,
+          },
+        });
+        return;
+      }
+      case "completed": {
+        const wasRecorded = activeTurns.recordTurnCompleted({
+          threadId: notification.threadId,
+          turn,
+        });
+        if (!wasRecorded) {
+          warnIgnoredTurnNotification({
+            type: notification.type,
+            event: notification.event,
+            threadId: notification.threadId,
+            turnId: notification.turnId,
+          });
+          return;
+        }
+
+        activeTurns.clearThread(notification.threadId);
+        await fanOutThreadNotification(notification.threadId, {
+          method: "turn/completed",
+          params: {
+            threadId: notification.threadId,
+            turn,
+          },
+        });
+        return;
+      }
+      default:
+        return assertNever(notification.event, "Unhandled turn notification event");
+    }
   };
 
   const handleItemNotification = async (
@@ -337,11 +443,22 @@ export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModul
     });
 
     if (notification.event === "started") {
-      activeTurns.recordItemStarted({
+      const wasRecorded = activeTurns.recordItemStarted({
         threadId: notification.threadId,
         turnId: notification.turnId,
         item,
       });
+      if (!wasRecorded) {
+        warnIgnoredTurnNotification({
+          type: notification.type,
+          event: notification.event,
+          threadId: notification.threadId,
+          turnId: notification.turnId,
+          itemId: notification.item.id,
+        });
+        return;
+      }
+
       await fanOutThreadNotification(notification.threadId, {
         method: "item/started",
         params: {
@@ -353,11 +470,22 @@ export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModul
       return;
     }
 
-    activeTurns.recordItemCompleted({
+    const wasRecorded = activeTurns.recordItemCompleted({
       threadId: notification.threadId,
       turnId: notification.turnId,
       item,
     });
+    if (!wasRecorded) {
+      warnIgnoredTurnNotification({
+        type: notification.type,
+        event: notification.event,
+        threadId: notification.threadId,
+        turnId: notification.turnId,
+        itemId: notification.item.id,
+      });
+      return;
+    }
+
     await fanOutThreadNotification(notification.threadId, {
       method: "item/completed",
       params: {


### PR DESCRIPTION
## Summary
- replace the placeholder `src/turns/` module with a real turn execution feature
- add `turn/start` end to end with execution-rule validation for loaded-thread and one-active-turn invariants
- fan out `turn/started`, `turn/completed`, item lifecycle events, and supported live item deltas only to loaded-thread subscribers
- normalize additional Codex adapter delta notifications for assistant messages, reasoning summaries, command output, and tool progress
- clean up active-turn state on turn completion, thread close, and agent disconnect
- add service, adapter, and protocol harness coverage for sequencing, reconciliation, and notification fanout

## Testing
- `bun run check`
- `bun run typecheck`
- `bun test src/turns/active-turn-registry.test.ts src/turns/service.test.ts src/agents/codex-adapter/notification-mapper.test.ts src/agents/codex-adapter/session.test.ts src/app/protocol-harness.test.ts`