### PR TITLE
Add typed App Server turn history readback and item event models

### DIFF
--- a/AppServer/src/agents/codex-adapter/model-mapper.test.ts
+++ b/AppServer/src/agents/codex-adapter/model-mapper.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mapCodexThread } from "@/agents/codex-adapter/model-mapper";
+import { mapCodexThread, mapCodexThreadDetail } from "@/agents/codex-adapter/model-mapper";
 
 describe("mapCodexThread", () => {
   test("rejects negative provider timestamps instead of clamping them", () => {
@@ -14,5 +14,58 @@ describe("mapCodexThread", () => {
         cwd: "/tmp/project",
       }),
     ).toThrow("Codex thread createdAt must be a non-negative unix timestamp.");
+  });
+
+  test("maps typed turn history on thread detail responses", () => {
+    expect(
+      mapCodexThreadDetail({
+        id: "thread-1",
+        preview: "Thread preview",
+        createdAt: 1,
+        updatedAt: 2,
+        name: null,
+        status: { type: "idle" },
+        cwd: "/tmp/project",
+        turns: [
+          {
+            id: "turn-1",
+            status: "completed",
+            items: [
+              {
+                id: "item-1",
+                type: "agentMessage",
+                text: "History item",
+                phase: null,
+              },
+            ],
+            error: null,
+          },
+        ],
+      }),
+    ).toEqual({
+      id: "thread-1",
+      preview: "Thread preview",
+      createdAt: "1970-01-01T00:00:01.000Z",
+      updatedAt: "1970-01-01T00:00:02.000Z",
+      workspacePath: "/tmp/project",
+      name: null,
+      archived: false,
+      status: { type: "idle" },
+      turns: [
+        {
+          id: "turn-1",
+          status: { type: "completed" },
+          items: [
+            {
+              id: "item-1",
+              type: "agentMessage",
+              text: "History item",
+              phase: null,
+            },
+          ],
+          error: null,
+        },
+      ],
+    });
   });
 });

--- a/AppServer/src/agents/codex-adapter/model-mapper.ts
+++ b/AppServer/src/agents/codex-adapter/model-mapper.ts
@@ -1,16 +1,25 @@
+import { Value } from "@sinclair/typebox/value";
 import type {
   CodexModel,
   CodexThread,
+  CodexThreadItem,
   CodexThreadStatus,
   CodexTurn,
+  CodexTurnDetail,
+  CodexTurnError,
 } from "@/agents/codex-adapter/protocol";
+import { CodexTurnDetailSchema } from "@/agents/codex-adapter/protocol";
 import type {
   AgentModelSummary,
   AgentThread,
+  AgentThreadDetail,
   AgentThreadExecutionStatus,
   AgentThreadSummary,
+  AgentTurnDetail,
+  AgentTurnItem,
   AgentTurnStatus,
   AgentTurnSummary,
+  AgentTurnTerminalError,
 } from "@/agents/contracts";
 
 export const mapCodexModelSummary = (model: CodexModel): AgentModelSummary =>
@@ -72,6 +81,17 @@ export const mapCodexThread = (
     status: mapCodexThreadStatus(thread.status),
   });
 
+export const mapCodexThreadDetail = (
+  thread: CodexThread,
+  options: { archived?: boolean } = {},
+): AgentThreadDetail =>
+  Object.freeze({
+    ...mapCodexThread(thread, options),
+    turns: (thread.turns ?? []).map((turn, index) =>
+      mapCodexTurnDetail(assertCodexTurnDetail(turn, index)),
+    ),
+  });
+
 export const mapCodexTurnStatus = (turn: CodexTurn): AgentTurnStatus => {
   switch (turn.status) {
     case "completed":
@@ -96,6 +116,161 @@ export const mapCodexTurnSummary = (turn: CodexTurn): AgentTurnSummary =>
     status: mapCodexTurnStatus(turn),
   });
 
+export const mapCodexTurnDetail = (turn: CodexTurnDetail): AgentTurnDetail =>
+  Object.freeze({
+    id: turn.id,
+    status: mapCodexTurnStatus(turn),
+    items: turn.items.map((item) => mapCodexThreadItem(item)),
+    error: mapCodexTurnError(turn.error),
+  });
+
+export const mapCodexThreadItem = (item: CodexThreadItem): AgentTurnItem => {
+  switch (item.type) {
+    case "userMessage":
+      return Object.freeze({
+        type: "userMessage",
+        id: item.id,
+        content: [...item.content],
+      });
+    case "agentMessage":
+      return Object.freeze({
+        type: "agentMessage",
+        id: item.id,
+        text: item.text,
+        phase: item.phase,
+      });
+    case "plan":
+      return Object.freeze({
+        type: "plan",
+        id: item.id,
+        text: item.text,
+      });
+    case "reasoning":
+      return Object.freeze({
+        type: "reasoning",
+        id: item.id,
+        summary: [...item.summary],
+        content: [...item.content],
+      });
+    case "commandExecution":
+      return Object.freeze({
+        type: "commandExecution",
+        id: item.id,
+        command: item.command,
+        cwd: item.cwd,
+        processId: item.processId,
+        status: item.status,
+        commandActions: [...item.commandActions],
+        aggregatedOutput: item.aggregatedOutput,
+        exitCode: item.exitCode === null ? null : Math.trunc(item.exitCode),
+        durationMs: item.durationMs,
+      });
+    case "fileChange":
+      return Object.freeze({
+        type: "fileChange",
+        id: item.id,
+        changes: [...item.changes],
+        status: item.status,
+      });
+    case "mcpToolCall":
+      return Object.freeze({
+        type: "mcpToolCall",
+        id: item.id,
+        server: item.server,
+        tool: item.tool,
+        status: item.status,
+        arguments: item.arguments,
+        result: item.result,
+        error: item.error,
+        durationMs: item.durationMs,
+      });
+    case "dynamicToolCall":
+      return Object.freeze({
+        type: "dynamicToolCall",
+        id: item.id,
+        tool: item.tool,
+        arguments: item.arguments,
+        status: item.status,
+        contentItems: item.contentItems === null ? null : [...item.contentItems],
+        success: item.success,
+        durationMs: item.durationMs,
+      });
+    case "collabAgentToolCall":
+      return Object.freeze({
+        type: "collabAgentToolCall",
+        id: item.id,
+        tool: item.tool,
+        status: item.status,
+        senderThreadId: item.senderThreadId,
+        receiverThreadIds: [...item.receiverThreadIds],
+        prompt: item.prompt,
+        agentsStates: { ...item.agentsStates },
+      });
+    case "webSearch":
+      return Object.freeze({
+        type: "webSearch",
+        id: item.id,
+        query: item.query,
+        action:
+          item.action === null
+            ? null
+            : item.action.type === "search"
+              ? Object.freeze({
+                  type: "search",
+                  query: item.action.query,
+                  queries: item.action.queries === null ? null : [...item.action.queries],
+                })
+              : item.action.type === "openPage"
+                ? Object.freeze({
+                    type: "openPage",
+                    url: item.action.url,
+                  })
+                : item.action.type === "findInPage"
+                  ? Object.freeze({
+                      type: "findInPage",
+                      url: item.action.url,
+                      pattern: item.action.pattern,
+                    })
+                  : Object.freeze({
+                      type: "other",
+                    }),
+      });
+    case "imageView":
+      return Object.freeze({
+        type: "imageView",
+        id: item.id,
+        path: item.path,
+      });
+    case "imageGeneration":
+      return Object.freeze({
+        type: "imageGeneration",
+        id: item.id,
+        status: item.status,
+        revisedPrompt: item.revisedPrompt,
+        result: item.result,
+      });
+    case "enteredReviewMode":
+      return Object.freeze({
+        type: "enteredReviewMode",
+        id: item.id,
+        review: item.review,
+      });
+    case "exitedReviewMode":
+      return Object.freeze({
+        type: "exitedReviewMode",
+        id: item.id,
+        review: item.review,
+      });
+    case "contextCompaction":
+      return Object.freeze({
+        type: "contextCompaction",
+        id: item.id,
+      });
+    default:
+      return assertNever(item);
+  }
+};
+
 const mapAgentThreadSummary = (thread: AgentThread): AgentThreadSummary =>
   Object.freeze({
     id: thread.id,
@@ -108,6 +283,25 @@ const mapAgentThreadSummary = (thread: AgentThread): AgentThreadSummary =>
 
 const assertNever = (value: never): never => {
   throw new Error(`Unhandled Codex mapping variant: ${JSON.stringify(value)}`);
+};
+
+const mapCodexTurnError = (
+  error: CodexTurnError | null | undefined,
+): AgentTurnTerminalError | null =>
+  error === undefined || error === null
+    ? null
+    : Object.freeze({
+        message: error.message,
+        providerError: error.codexErrorInfo,
+        additionalDetails: error.additionalDetails,
+      });
+
+const assertCodexTurnDetail = (candidate: unknown, index: number): CodexTurnDetail => {
+  if (!Value.Check(CodexTurnDetailSchema, candidate)) {
+    throw new Error(`Invalid Codex thread turn history at turns[${index}].`);
+  }
+
+  return candidate;
 };
 
 const mapUnixTimestampToIso = (value: number, fieldName: "createdAt" | "updatedAt"): string => {

--- a/AppServer/src/agents/codex-adapter/model-mapper.ts
+++ b/AppServer/src/agents/codex-adapter/model-mapper.ts
@@ -1,4 +1,3 @@
-import { Value } from "@sinclair/typebox/value";
 import type {
   CodexModel,
   CodexThread,
@@ -8,7 +7,6 @@ import type {
   CodexTurnDetail,
   CodexTurnError,
 } from "@/agents/codex-adapter/protocol";
-import { CodexTurnDetailSchema } from "@/agents/codex-adapter/protocol";
 import type {
   AgentModelSummary,
   AgentThread,
@@ -87,9 +85,8 @@ export const mapCodexThreadDetail = (
 ): AgentThreadDetail =>
   Object.freeze({
     ...mapCodexThread(thread, options),
-    turns: (thread.turns ?? []).map((turn, index) =>
-      mapCodexTurnDetail(assertCodexTurnDetail(turn, index)),
-    ),
+    // Codex omits `turns` on responses that do not carry history.
+    turns: (thread.turns ?? []).map((turn) => mapCodexTurnDetail(turn)),
   });
 
 export const mapCodexTurnStatus = (turn: CodexTurn): AgentTurnStatus => {
@@ -295,14 +292,6 @@ const mapCodexTurnError = (
         providerError: error.codexErrorInfo,
         additionalDetails: error.additionalDetails,
       });
-
-const assertCodexTurnDetail = (candidate: unknown, index: number): CodexTurnDetail => {
-  if (!Value.Check(CodexTurnDetailSchema, candidate)) {
-    throw new Error(`Invalid Codex thread turn history at turns[${index}].`);
-  }
-
-  return candidate;
-};
 
 const mapUnixTimestampToIso = (value: number, fieldName: "createdAt" | "updatedAt"): string => {
   if (!Number.isFinite(value) || value < 0) {

--- a/AppServer/src/agents/codex-adapter/notification-mapper.test.ts
+++ b/AppServer/src/agents/codex-adapter/notification-mapper.test.ts
@@ -375,6 +375,73 @@ describe("mapCodexTransportNotification", () => {
       },
     ]);
   });
+
+  test("maps typed item lifecycle notifications", () => {
+    expect(
+      mapCodexTransportNotification(
+        {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              id: "item-1",
+              type: "commandExecution",
+              command: "echo hello",
+              cwd: "/tmp/project",
+              processId: null,
+              status: "completed",
+              commandActions: [],
+              aggregatedOutput: "hello\n",
+              exitCode: 0,
+              durationMs: null,
+            },
+          },
+        },
+        context,
+      ),
+    ).toEqual([
+      {
+        agentId: "codex",
+        provider: "codex",
+        receivedAt: "2026-04-10T12:00:00.000Z",
+        rawMethod: "item/completed",
+        rawPayload: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "item-1",
+            type: "commandExecution",
+            command: "echo hello",
+            cwd: "/tmp/project",
+            processId: null,
+            status: "completed",
+            commandActions: [],
+            aggregatedOutput: "hello\n",
+            exitCode: 0,
+            durationMs: null,
+          },
+        },
+        type: "item",
+        event: "completed",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "item-1",
+        item: {
+          id: "item-1",
+          type: "commandExecution",
+          command: "echo hello",
+          cwd: "/tmp/project",
+          processId: null,
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: "hello\n",
+          exitCode: 0,
+          durationMs: null,
+        },
+      },
+    ]);
+  });
 });
 
 describe("mapCodexServerRequest", () => {

--- a/AppServer/src/agents/codex-adapter/notification-mapper.ts
+++ b/AppServer/src/agents/codex-adapter/notification-mapper.ts
@@ -1,5 +1,6 @@
 import { Value } from "@sinclair/typebox/value";
 import {
+  mapCodexThreadItem,
   mapCodexThreadStatus,
   mapCodexThreadSummary,
   mapCodexTurnSummary,
@@ -10,6 +11,7 @@ import {
   CodexMcpToolCallProgressNotificationSchema,
   CodexReasoningSummaryTextDeltaNotificationSchema,
   CodexReasoningTextDeltaNotificationSchema,
+  CodexThreadItemSchema,
 } from "@/agents/codex-adapter/protocol";
 import type {
   CodexTransportDisconnectInfo,
@@ -182,9 +184,7 @@ export const mapCodexTransportNotification = (
       return params &&
         typeof params.threadId === "string" &&
         typeof params.turnId === "string" &&
-        isPlainObject(params.item) &&
-        typeof params.item.id === "string" &&
-        typeof params.item.type === "string"
+        Value.Check(CodexThreadItemSchema, params.item)
         ? [
             {
               ...base,
@@ -193,11 +193,7 @@ export const mapCodexTransportNotification = (
               threadId: params.threadId,
               turnId: params.turnId,
               itemId: params.item.id,
-              item: {
-                id: params.item.id,
-                kind: params.item.type,
-                rawItem: params.item,
-              },
+              item: mapCodexThreadItem(params.item),
             },
           ]
         : [buildMalformedMessage(base, notification.method)];

--- a/AppServer/src/agents/codex-adapter/protocol.ts
+++ b/AppServer/src/agents/codex-adapter/protocol.ts
@@ -80,6 +80,226 @@ const CodexThreadStatusSchema = Type.Union([
   ),
 ]);
 
+const CodexCommandExecutionStatusSchema = Type.Union([
+  Type.Literal("inProgress"),
+  Type.Literal("completed"),
+  Type.Literal("failed"),
+  Type.Literal("declined"),
+]);
+
+const CodexPatchApplyStatusSchema = Type.Union([
+  Type.Literal("inProgress"),
+  Type.Literal("completed"),
+  Type.Literal("failed"),
+  Type.Literal("declined"),
+]);
+
+const CodexToolCallStatusSchema = Type.Union([
+  Type.Literal("inProgress"),
+  Type.Literal("completed"),
+  Type.Literal("failed"),
+]);
+
+const CodexCollabAgentToolSchema = Type.Union([
+  Type.Literal("spawnAgent"),
+  Type.Literal("sendInput"),
+  Type.Literal("resumeAgent"),
+  Type.Literal("wait"),
+  Type.Literal("closeAgent"),
+]);
+
+const CodexWebSearchActionSchema = Type.Union([
+  Type.Object(
+    {
+      type: Type.Literal("search"),
+      query: Type.Union([Type.String(), Type.Null()]),
+      queries: Type.Union([Type.Array(Type.String()), Type.Null()]),
+    },
+    { additionalProperties: true },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("openPage"),
+      url: Type.Union([Type.String(), Type.Null()]),
+    },
+    { additionalProperties: true },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("findInPage"),
+      url: Type.Union([Type.String(), Type.Null()]),
+      pattern: Type.Union([Type.String(), Type.Null()]),
+    },
+    { additionalProperties: true },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("other"),
+    },
+    { additionalProperties: true },
+  ),
+]);
+
+export const CodexThreadItemSchema = Type.Union([
+  Type.Object(
+    {
+      type: Type.Literal("userMessage"),
+      id: Type.String(),
+      content: Type.Array(Type.Unknown()),
+    },
+    { additionalProperties: true },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("agentMessage"),
+      id: Type.String(),
+      text: Type.String(),
+      phase: Type.Union([Type.String(), Type.Null()]),
+    },
+    { additionalProperties: true },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("plan"),
+      id: Type.String(),
+      text: Type.String(),
+    },
+    { additionalProperties: true },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("reasoning"),
+      id: Type.String(),
+      summary: Type.Array(Type.String()),
+      content: Type.Array(Type.String()),
+    },
+    { additionalProperties: true },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("commandExecution"),
+      id: Type.String(),
+      command: Type.String(),
+      cwd: Type.String(),
+      processId: Type.Union([Type.String(), Type.Null()]),
+      status: CodexCommandExecutionStatusSchema,
+      commandActions: Type.Array(Type.Unknown()),
+      aggregatedOutput: Type.Union([Type.String(), Type.Null()]),
+      exitCode: Type.Union([Type.Number(), Type.Null()]),
+      durationMs: Type.Union([Type.Number(), Type.Null()]),
+    },
+    { additionalProperties: true },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("fileChange"),
+      id: Type.String(),
+      changes: Type.Array(Type.Unknown()),
+      status: CodexPatchApplyStatusSchema,
+    },
+    { additionalProperties: true },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("mcpToolCall"),
+      id: Type.String(),
+      server: Type.String(),
+      tool: Type.String(),
+      status: CodexToolCallStatusSchema,
+      arguments: Type.Unknown(),
+      result: Type.Union([Type.Unknown(), Type.Null()]),
+      error: Type.Union([Type.Unknown(), Type.Null()]),
+      durationMs: Type.Union([Type.Number(), Type.Null()]),
+    },
+    { additionalProperties: true },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("dynamicToolCall"),
+      id: Type.String(),
+      tool: Type.String(),
+      arguments: Type.Unknown(),
+      status: CodexToolCallStatusSchema,
+      contentItems: Type.Union([Type.Array(Type.Unknown()), Type.Null()]),
+      success: Type.Union([Type.Boolean(), Type.Null()]),
+      durationMs: Type.Union([Type.Number(), Type.Null()]),
+    },
+    { additionalProperties: true },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("collabAgentToolCall"),
+      id: Type.String(),
+      tool: CodexCollabAgentToolSchema,
+      status: CodexToolCallStatusSchema,
+      senderThreadId: Type.String(),
+      receiverThreadIds: Type.Array(Type.String()),
+      prompt: Type.Union([Type.String(), Type.Null()]),
+      agentsStates: Type.Record(Type.String(), Type.Unknown()),
+    },
+    { additionalProperties: true },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("webSearch"),
+      id: Type.String(),
+      query: Type.String(),
+      action: Type.Union([CodexWebSearchActionSchema, Type.Null()]),
+    },
+    { additionalProperties: true },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("imageView"),
+      id: Type.String(),
+      path: Type.String(),
+    },
+    { additionalProperties: true },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("imageGeneration"),
+      id: Type.String(),
+      status: Type.String(),
+      revisedPrompt: Type.Union([Type.String(), Type.Null()]),
+      result: Type.String(),
+    },
+    { additionalProperties: true },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("enteredReviewMode"),
+      id: Type.String(),
+      review: Type.String(),
+    },
+    { additionalProperties: true },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("exitedReviewMode"),
+      id: Type.String(),
+      review: Type.String(),
+    },
+    { additionalProperties: true },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("contextCompaction"),
+      id: Type.String(),
+    },
+    { additionalProperties: true },
+  ),
+]);
+
+const CodexTurnErrorSchema = Type.Object(
+  {
+    message: Type.String(),
+    codexErrorInfo: Type.Union([Type.Unknown(), Type.Null()]),
+    additionalDetails: Type.Union([Type.String(), Type.Null()]),
+  },
+  { additionalProperties: true },
+);
+
 const CodexThreadSchema = Type.Object(
   {
     id: Type.String(),
@@ -89,6 +309,7 @@ const CodexThreadSchema = Type.Object(
     name: Type.Union([Type.String(), Type.Null()]),
     status: CodexThreadStatusSchema,
     cwd: Type.String(),
+    turns: Type.Optional(Type.Array(Type.Unknown())),
   },
   { additionalProperties: true },
 );
@@ -128,17 +349,22 @@ const CodexTurnSchema = Type.Object(
       Type.Literal("failed"),
       Type.Literal("inProgress"),
     ]),
-    error: Type.Optional(
-      Type.Union([
-        Type.Object(
-          {
-            message: Type.Optional(Type.String()),
-          },
-          { additionalProperties: true },
-        ),
-        Type.Null(),
-      ]),
-    ),
+    error: Type.Optional(Type.Union([CodexTurnErrorSchema, Type.Null()])),
+  },
+  { additionalProperties: true },
+);
+
+export const CodexTurnDetailSchema = Type.Object(
+  {
+    id: Type.String(),
+    status: Type.Union([
+      Type.Literal("completed"),
+      Type.Literal("interrupted"),
+      Type.Literal("failed"),
+      Type.Literal("inProgress"),
+    ]),
+    items: Type.Array(CodexThreadItemSchema),
+    error: Type.Union([CodexTurnErrorSchema, Type.Null()]),
   },
   { additionalProperties: true },
 );
@@ -262,9 +488,12 @@ export type CodexModel = Static<typeof CodexModelSchema>;
 export type CodexModelListResponse = Static<typeof CodexModelListResponseSchema>;
 export type CodexThreadStatus = Static<typeof CodexThreadStatusSchema>;
 export type CodexThread = Static<typeof CodexThreadSchema>;
+export type CodexThreadItem = Static<typeof CodexThreadItemSchema>;
 export type CodexThreadListResponse = Static<typeof CodexThreadListResponseSchema>;
 export type CodexConfiguredThreadResponse = Static<typeof CodexConfiguredThreadResponseSchema>;
 export type CodexTurn = Static<typeof CodexTurnSchema>;
+export type CodexTurnDetail = Static<typeof CodexTurnDetailSchema>;
+export type CodexTurnError = Static<typeof CodexTurnErrorSchema>;
 export type CodexInitializeResponse = Static<typeof CodexInitializeResponseSchema>;
 export type CodexTurnPlanUpdatedNotification = Static<
   typeof CodexTurnPlanUpdatedNotificationSchema

--- a/AppServer/src/agents/codex-adapter/protocol.ts
+++ b/AppServer/src/agents/codex-adapter/protocol.ts
@@ -300,6 +300,21 @@ const CodexTurnErrorSchema = Type.Object(
   { additionalProperties: true },
 );
 
+export const CodexTurnDetailSchema = Type.Object(
+  {
+    id: Type.String(),
+    status: Type.Union([
+      Type.Literal("completed"),
+      Type.Literal("interrupted"),
+      Type.Literal("failed"),
+      Type.Literal("inProgress"),
+    ]),
+    items: Type.Array(CodexThreadItemSchema),
+    error: Type.Union([CodexTurnErrorSchema, Type.Null()]),
+  },
+  { additionalProperties: true },
+);
+
 const CodexThreadSchema = Type.Object(
   {
     id: Type.String(),
@@ -309,7 +324,7 @@ const CodexThreadSchema = Type.Object(
     name: Type.Union([Type.String(), Type.Null()]),
     status: CodexThreadStatusSchema,
     cwd: Type.String(),
-    turns: Type.Optional(Type.Array(Type.Unknown())),
+    turns: Type.Optional(Type.Array(CodexTurnDetailSchema)),
   },
   { additionalProperties: true },
 );
@@ -350,21 +365,6 @@ const CodexTurnSchema = Type.Object(
       Type.Literal("inProgress"),
     ]),
     error: Type.Optional(Type.Union([CodexTurnErrorSchema, Type.Null()])),
-  },
-  { additionalProperties: true },
-);
-
-export const CodexTurnDetailSchema = Type.Object(
-  {
-    id: Type.String(),
-    status: Type.Union([
-      Type.Literal("completed"),
-      Type.Literal("interrupted"),
-      Type.Literal("failed"),
-      Type.Literal("inProgress"),
-    ]),
-    items: Type.Array(CodexThreadItemSchema),
-    error: Type.Union([CodexTurnErrorSchema, Type.Null()]),
   },
   { additionalProperties: true },
 );

--- a/AppServer/src/agents/codex-adapter/session.test.ts
+++ b/AppServer/src/agents/codex-adapter/session.test.ts
@@ -437,6 +437,113 @@ describe("createCodexAgentSession", () => {
           status: {
             type: "idle",
           },
+          turns: [],
+        },
+      },
+    });
+  });
+
+  test("maps thread/read with includeTurns true into typed turn and item history", async () => {
+    const executablePath = createFakeExecutable();
+    const transport = new FakeTransport([
+      { userAgent: "Codex/Test" },
+      {
+        thread: {
+          id: "thread-1",
+          preview: "Read this thread",
+          ephemeral: false,
+          modelProvider: "openai",
+          createdAt: 1_744_280_000,
+          updatedAt: 1_744_283_600,
+          status: {
+            type: "idle",
+          },
+          path: null,
+          cwd: "/tmp/project",
+          cliVersion: "0.114.0",
+          source: "app-server",
+          agentNickname: null,
+          agentRole: null,
+          gitInfo: null,
+          name: "Readable thread",
+          turns: [
+            {
+              id: "turn-1",
+              status: "completed",
+              items: [
+                {
+                  id: "item-1",
+                  type: "agentMessage",
+                  text: "History item",
+                  phase: null,
+                },
+              ],
+              error: null,
+            },
+          ],
+        },
+      },
+    ]);
+    const sessionResult = await createCodexAgentSession({
+      agentId: "codex",
+      config: {
+        id: "codex",
+        provider: "codex",
+      },
+      logger: createSilentLogger(),
+      transport,
+      environmentResolver: new BaseEnvironmentResolver({
+        inheritedEnvironment: {
+          ATELIERCODE_CODEX_PATH: executablePath,
+          PATH: path.dirname(executablePath),
+          HOME: "/Users/tester",
+          SHELL: "/bin/zsh",
+        },
+      }),
+    });
+
+    expect(sessionResult.ok).toBe(true);
+    if (!sessionResult.ok) {
+      throw new Error("Expected the Codex session to be created.");
+    }
+
+    const readResult = await sessionResult.data.readThread("req-thread-read", {
+      threadId: "thread-1",
+      includeTurns: true,
+      archived: false,
+    });
+
+    expect(readResult).toEqual({
+      ok: true,
+      data: {
+        thread: {
+          id: "thread-1",
+          preview: "Read this thread",
+          createdAt: "2025-04-10T10:13:20.000Z",
+          updatedAt: "2025-04-10T11:13:20.000Z",
+          workspacePath: "/tmp/project",
+          name: "Readable thread",
+          archived: false,
+          status: {
+            type: "idle",
+          },
+          turns: [
+            {
+              id: "turn-1",
+              status: {
+                type: "completed",
+              },
+              items: [
+                {
+                  id: "item-1",
+                  type: "agentMessage",
+                  text: "History item",
+                  phase: null,
+                },
+              ],
+              error: null,
+            },
+          ],
         },
       },
     });

--- a/AppServer/src/agents/codex-adapter/session.test.ts
+++ b/AppServer/src/agents/codex-adapter/session.test.ts
@@ -549,6 +549,95 @@ describe("createCodexAgentSession", () => {
     });
   });
 
+  test("rejects invalid turn history at the thread/read parse boundary", async () => {
+    const executablePath = createFakeExecutable();
+    const transport = new FakeTransport([
+      { userAgent: "Codex/Test" },
+      {
+        thread: {
+          id: "thread-1",
+          preview: "Read this thread",
+          ephemeral: false,
+          modelProvider: "openai",
+          createdAt: 1_744_280_000,
+          updatedAt: 1_744_283_600,
+          status: {
+            type: "idle",
+          },
+          path: null,
+          cwd: "/tmp/project",
+          cliVersion: "0.114.0",
+          source: "app-server",
+          agentNickname: null,
+          agentRole: null,
+          gitInfo: null,
+          name: "Readable thread",
+          turns: [
+            {
+              id: "turn-1",
+              status: "completed",
+              items: [
+                {
+                  id: "item-1",
+                  type: "agentMessage",
+                  phase: null,
+                },
+              ],
+              error: null,
+            },
+          ],
+        },
+      },
+    ]);
+    const sessionResult = await createCodexAgentSession({
+      agentId: "codex",
+      config: {
+        id: "codex",
+        provider: "codex",
+      },
+      logger: createSilentLogger(),
+      transport,
+      environmentResolver: new BaseEnvironmentResolver({
+        inheritedEnvironment: {
+          ATELIERCODE_CODEX_PATH: executablePath,
+          PATH: path.dirname(executablePath),
+          HOME: "/Users/tester",
+          SHELL: "/bin/zsh",
+        },
+      }),
+    });
+
+    expect(sessionResult.ok).toBe(true);
+    if (!sessionResult.ok) {
+      throw new Error("Expected the Codex session to be created.");
+    }
+
+    const readResult = await sessionResult.data.readThread("req-thread-read", {
+      threadId: "thread-1",
+      includeTurns: true,
+      archived: false,
+    });
+
+    expect(readResult.ok).toBe(false);
+    if (readResult.ok) {
+      throw new Error("Expected malformed turn history to be rejected.");
+    }
+
+    expect(readResult.error).toMatchObject({
+      type: "invalidProviderMessage",
+      agentId: "codex",
+      provider: "codex",
+      message: "Codex operation req-thread-read failed unexpectedly.",
+      detail: {
+        error: expect.stringContaining("Invalid Codex thread response."),
+      },
+    });
+    expect(readResult.error.type).toBe("invalidProviderMessage");
+    if (readResult.error.type !== "invalidProviderMessage") {
+      throw new Error("Expected an invalid provider payload error.");
+    }
+  });
+
   test("maps thread mutations through the Codex transport contract", async () => {
     const executablePath = createFakeExecutable();
     const transport = new FakeTransport([

--- a/AppServer/src/agents/codex-adapter/session.ts
+++ b/AppServer/src/agents/codex-adapter/session.ts
@@ -1,6 +1,7 @@
 import {
   mapCodexModelSummary,
   mapCodexThread,
+  mapCodexThreadDetail,
   mapCodexTurnSummary,
 } from "@/agents/codex-adapter/model-mapper";
 import {
@@ -71,6 +72,7 @@ import type {
   AgentThreadForkParams,
   AgentThreadMutationResult,
   AgentThreadReadParams,
+  AgentThreadReadResult,
   AgentThreadResult,
   AgentThreadResumeParams,
   AgentThreadSetNameParams,
@@ -435,7 +437,7 @@ const createConnectedSession = (options: ConnectedSessionOptions): AgentSession 
   const readThread = async (
     requestId: AgentRequestId,
     params: AgentThreadReadParams,
-  ): Promise<AgentOperationResult<AgentThreadResult>> =>
+  ): Promise<AgentOperationResult<AgentThreadReadResult>> =>
     runOperation(requestId, async () => {
       const rawParams: CodexThreadReadParams = {
         threadId: params.threadId,
@@ -450,7 +452,7 @@ const createConnectedSession = (options: ConnectedSessionOptions): AgentSession 
       );
 
       return {
-        thread: mapCodexThread(response.thread, {
+        thread: mapCodexThreadDetail(response.thread, {
           archived: params.archived,
         }),
       };

--- a/AppServer/src/agents/contracts.ts
+++ b/AppServer/src/agents/contracts.ts
@@ -78,6 +78,122 @@ export type AgentTurnStatus =
   | Readonly<{ type: "cancelled" }>
   | Readonly<{ type: "interrupted" }>;
 
+export type AgentTurnTerminalError = Readonly<{
+  message: string;
+  providerError: unknown | null;
+  additionalDetails: string | null;
+}>;
+
+export type AgentTurnItem =
+  | Readonly<{
+      type: "userMessage";
+      id: string;
+      content: unknown[];
+    }>
+  | Readonly<{
+      type: "agentMessage";
+      id: string;
+      text: string;
+      phase: string | null;
+    }>
+  | Readonly<{
+      type: "plan";
+      id: string;
+      text: string;
+    }>
+  | Readonly<{
+      type: "reasoning";
+      id: string;
+      summary: string[];
+      content: string[];
+    }>
+  | Readonly<{
+      type: "commandExecution";
+      id: string;
+      command: string;
+      cwd: string;
+      processId: string | null;
+      status: "inProgress" | "completed" | "failed" | "declined";
+      commandActions: unknown[];
+      aggregatedOutput: string | null;
+      exitCode: number | null;
+      durationMs: number | null;
+    }>
+  | Readonly<{
+      type: "fileChange";
+      id: string;
+      changes: unknown[];
+      status: "inProgress" | "completed" | "failed" | "declined";
+    }>
+  | Readonly<{
+      type: "mcpToolCall";
+      id: string;
+      server: string;
+      tool: string;
+      status: "inProgress" | "completed" | "failed";
+      arguments: unknown;
+      result: unknown | null;
+      error: unknown | null;
+      durationMs: number | null;
+    }>
+  | Readonly<{
+      type: "dynamicToolCall";
+      id: string;
+      tool: string;
+      arguments: unknown;
+      status: "inProgress" | "completed" | "failed";
+      contentItems: unknown[] | null;
+      success: boolean | null;
+      durationMs: number | null;
+    }>
+  | Readonly<{
+      type: "collabAgentToolCall";
+      id: string;
+      tool: "spawnAgent" | "sendInput" | "resumeAgent" | "wait" | "closeAgent";
+      status: "inProgress" | "completed" | "failed";
+      senderThreadId: string;
+      receiverThreadIds: string[];
+      prompt: string | null;
+      agentsStates: Record<string, unknown>;
+    }>
+  | Readonly<{
+      type: "webSearch";
+      id: string;
+      query: string;
+      action:
+        | Readonly<{ type: "search"; query: string | null; queries: string[] | null }>
+        | Readonly<{ type: "openPage"; url: string | null }>
+        | Readonly<{ type: "findInPage"; url: string | null; pattern: string | null }>
+        | Readonly<{ type: "other" }>
+        | null;
+    }>
+  | Readonly<{
+      type: "imageView";
+      id: string;
+      path: string;
+    }>
+  | Readonly<{
+      type: "imageGeneration";
+      id: string;
+      status: string;
+      revisedPrompt: string | null;
+      result: string;
+    }>
+  | Readonly<{
+      type: "enteredReviewMode";
+      id: string;
+      review: string;
+    }>
+  | Readonly<{
+      type: "exitedReviewMode";
+      id: string;
+      review: string;
+    }>
+  | Readonly<{
+      type: "contextCompaction";
+      id: string;
+    }>;
+
 export type AgentThreadSummary = Readonly<{
   id: string;
   preview: string;
@@ -91,6 +207,18 @@ export type AgentTurnSummary = Readonly<{
   id: string;
   status: AgentTurnStatus;
 }>;
+
+export type AgentTurnDetail = Readonly<{
+  id: string;
+  status: AgentTurnStatus;
+  items: readonly AgentTurnItem[];
+  error: AgentTurnTerminalError | null;
+}>;
+
+export type AgentThreadDetail = AgentThread &
+  Readonly<{
+    turns: readonly AgentTurnDetail[];
+  }>;
 
 export type AgentPlanStep = Readonly<{
   step: string;
@@ -151,11 +279,7 @@ export type AgentItemNotification = AgentNotificationBase &
   Readonly<{
     type: "item";
     event: "started" | "completed";
-    item: Readonly<{
-      id: string;
-      kind: string;
-      rawItem: unknown;
-    }>;
+    item: AgentTurnItem;
   }>;
 
 export type AgentMessageNotification = AgentNotificationBase &
@@ -359,6 +483,10 @@ export type AgentThreadResult = Readonly<{
   reasoningEffort?: AgentReasoningEffort | null;
 }>;
 
+export type AgentThreadReadResult = Readonly<{
+  thread: AgentThreadDetail;
+}>;
+
 export type AgentThreadMutationResult = Record<string, never>;
 
 export type AgentTurnStartParams = Readonly<{
@@ -418,7 +546,7 @@ export type AgentSession = Readonly<{
   readThread: (
     requestId: AgentRequestId,
     params: AgentThreadReadParams,
-  ) => Promise<AgentOperationResult<AgentThreadResult>>;
+  ) => Promise<AgentOperationResult<AgentThreadReadResult>>;
   forkThread: (
     requestId: AgentRequestId,
     params: AgentThreadForkParams,

--- a/AppServer/src/agents/registry.test.ts
+++ b/AppServer/src/agents/registry.test.ts
@@ -197,6 +197,7 @@ const createFakeSession = (
           name: null,
           archived: false,
           status: { type: "idle" },
+          turns: [],
         },
       },
     }),

--- a/AppServer/src/app/protocol-harness.test.ts
+++ b/AppServer/src/app/protocol-harness.test.ts
@@ -17,9 +17,12 @@ import { type AppDatabase, createStoreBootstrap } from "@/core/store";
 import {
   createFakeAgentAdapter,
   createFakeAgentSession,
+  createTestAgentItem,
   createTestAgentModel,
   createTestAgentThread,
+  createTestAgentThreadDetail,
   createTestAgentTurn,
+  createTestAgentTurnDetail,
 } from "@/test-support/agents";
 import { getAvailablePort } from "@/test-support/network";
 import { createSqliteThreadsStore, createThreadsModule, type ThreadsStore } from "@/threads";
@@ -898,7 +901,7 @@ describe("App Server protocol harness", () => {
       readThread: async () => ({
         ok: true,
         data: {
-          thread: createTestAgentThread({
+          thread: createTestAgentThreadDetail({
             id: "thread-read-only",
             workspacePath: canonicalWorkspacePath,
           }),
@@ -948,7 +951,7 @@ describe("App Server protocol harness", () => {
       readThread: async (_requestId, params) => ({
         ok: true,
         data: {
-          thread: createTestAgentThread({
+          thread: createTestAgentThreadDetail({
             id: params.threadId,
             workspacePath: canonicalWorkspacePath,
           }),
@@ -1471,11 +1474,19 @@ describe("App Server protocol harness", () => {
           threadId: "thread-live",
           turnId: "turn-1",
         }),
+        createPlanUpdatedNotification({
+          threadId: "thread-live",
+          turnId: "turn-1",
+        }),
+        createDiffUpdatedNotification({
+          threadId: "thread-live",
+          turnId: "turn-1",
+        }),
         createItemStartedNotification({
           threadId: "thread-live",
           turnId: "turn-1",
           itemId: "item-message",
-          kind: "agent_message",
+          itemType: "agentMessage",
         }),
         createMessageDeltaNotification({
           threadId: "thread-live",
@@ -1487,19 +1498,13 @@ describe("App Server protocol harness", () => {
           threadId: "thread-live",
           turnId: "turn-1",
           itemId: "item-message",
-          kind: "agent_message",
-          rawItem: {
-            id: "item-message",
-            type: "agent_message",
-            status: "completed",
-            text: "Working on it...",
-          },
+          item: buildHarnessItem("agentMessage", "item-message", "completed"),
         }),
         createItemStartedNotification({
           threadId: "thread-live",
           turnId: "turn-1",
           itemId: "item-reasoning",
-          kind: "reasoning",
+          itemType: "reasoning",
         }),
         createReasoningTextDeltaNotification({
           threadId: "thread-live",
@@ -1517,18 +1522,13 @@ describe("App Server protocol harness", () => {
           threadId: "thread-live",
           turnId: "turn-1",
           itemId: "item-reasoning",
-          kind: "reasoning",
-          rawItem: {
-            id: "item-reasoning",
-            type: "reasoning",
-            status: "completed",
-          },
+          item: buildHarnessItem("reasoning", "item-reasoning", "completed"),
         }),
         createItemStartedNotification({
           threadId: "thread-live",
           turnId: "turn-1",
           itemId: "item-command",
-          kind: "command_execution",
+          itemType: "commandExecution",
         }),
         createCommandOutputDeltaNotification({
           threadId: "thread-live",
@@ -1540,18 +1540,13 @@ describe("App Server protocol harness", () => {
           threadId: "thread-live",
           turnId: "turn-1",
           itemId: "item-command",
-          kind: "command_execution",
-          rawItem: {
-            id: "item-command",
-            type: "command_execution",
-            status: "completed",
-          },
+          item: buildHarnessItem("commandExecution", "item-command", "completed"),
         }),
         createItemStartedNotification({
           threadId: "thread-live",
           turnId: "turn-1",
           itemId: "item-tool",
-          kind: "mcp_tool_call",
+          itemType: "mcpToolCall",
         }),
         createToolProgressNotification({
           threadId: "thread-live",
@@ -1563,12 +1558,7 @@ describe("App Server protocol harness", () => {
           threadId: "thread-live",
           turnId: "turn-1",
           itemId: "item-tool",
-          kind: "mcp_tool_call",
-          rawItem: {
-            id: "item-tool",
-            type: "mcp_tool_call",
-            status: "completed",
-          },
+          item: buildHarnessItem("mcpToolCall", "item-tool", "completed"),
         }),
         createTurnCompletedNotification({
           threadId: "thread-live",
@@ -1601,19 +1591,44 @@ describe("App Server protocol harness", () => {
           },
         },
         {
+          method: "turn/plan/updated",
+          params: {
+            threadId: "thread-live",
+            turnId: "turn-1",
+            explanation: "Ship it",
+            steps: [
+              {
+                step: "Inspect state",
+                status: "completed",
+              },
+              {
+                step: "Write patch",
+                status: "in_progress",
+              },
+            ],
+          },
+        },
+        {
+          method: "turn/diff/updated",
+          params: {
+            threadId: "thread-live",
+            turnId: "turn-1",
+            diff: ["diff --git a/src/example.ts b/src/example.ts", "+added"].join("\n"),
+            summary: [
+              {
+                path: "src/example.ts",
+                additions: 1,
+                deletions: 0,
+              },
+            ],
+          },
+        },
+        {
           method: "item/started",
           params: {
             threadId: "thread-live",
             turnId: "turn-1",
-            item: {
-              id: "item-message",
-              kind: "agent_message",
-              rawItem: {
-                id: "item-message",
-                type: "agent_message",
-                status: "in_progress",
-              },
-            },
+            item: buildHarnessItem("agentMessage", "item-message", "started"),
           },
         },
         {
@@ -1630,16 +1645,7 @@ describe("App Server protocol harness", () => {
           params: {
             threadId: "thread-live",
             turnId: "turn-1",
-            item: {
-              id: "item-message",
-              kind: "agent_message",
-              rawItem: {
-                id: "item-message",
-                type: "agent_message",
-                status: "completed",
-                text: "Working on it...",
-              },
-            },
+            item: buildHarnessItem("agentMessage", "item-message", "completed"),
           },
         },
         {
@@ -1647,15 +1653,7 @@ describe("App Server protocol harness", () => {
           params: {
             threadId: "thread-live",
             turnId: "turn-1",
-            item: {
-              id: "item-reasoning",
-              kind: "reasoning",
-              rawItem: {
-                id: "item-reasoning",
-                type: "reasoning",
-                status: "in_progress",
-              },
-            },
+            item: buildHarnessItem("reasoning", "item-reasoning", "started"),
           },
         },
         {
@@ -1681,15 +1679,7 @@ describe("App Server protocol harness", () => {
           params: {
             threadId: "thread-live",
             turnId: "turn-1",
-            item: {
-              id: "item-reasoning",
-              kind: "reasoning",
-              rawItem: {
-                id: "item-reasoning",
-                type: "reasoning",
-                status: "completed",
-              },
-            },
+            item: buildHarnessItem("reasoning", "item-reasoning", "completed"),
           },
         },
         {
@@ -1697,15 +1687,7 @@ describe("App Server protocol harness", () => {
           params: {
             threadId: "thread-live",
             turnId: "turn-1",
-            item: {
-              id: "item-command",
-              kind: "command_execution",
-              rawItem: {
-                id: "item-command",
-                type: "command_execution",
-                status: "in_progress",
-              },
-            },
+            item: buildHarnessItem("commandExecution", "item-command", "started"),
           },
         },
         {
@@ -1722,15 +1704,7 @@ describe("App Server protocol harness", () => {
           params: {
             threadId: "thread-live",
             turnId: "turn-1",
-            item: {
-              id: "item-command",
-              kind: "command_execution",
-              rawItem: {
-                id: "item-command",
-                type: "command_execution",
-                status: "completed",
-              },
-            },
+            item: buildHarnessItem("commandExecution", "item-command", "completed"),
           },
         },
         {
@@ -1738,15 +1712,7 @@ describe("App Server protocol harness", () => {
           params: {
             threadId: "thread-live",
             turnId: "turn-1",
-            item: {
-              id: "item-tool",
-              kind: "mcp_tool_call",
-              rawItem: {
-                id: "item-tool",
-                type: "mcp_tool_call",
-                status: "in_progress",
-              },
-            },
+            item: buildHarnessItem("mcpToolCall", "item-tool", "started"),
           },
         },
         {
@@ -1763,15 +1729,7 @@ describe("App Server protocol harness", () => {
           params: {
             threadId: "thread-live",
             turnId: "turn-1",
-            item: {
-              id: "item-tool",
-              kind: "mcp_tool_call",
-              rawItem: {
-                id: "item-tool",
-                type: "mcp_tool_call",
-                status: "completed",
-              },
-            },
+            item: buildHarnessItem("mcpToolCall", "item-tool", "completed"),
           },
         },
         {
@@ -1956,7 +1914,7 @@ describe("App Server protocol harness", () => {
             threadId: "thread-live",
             turnId: "turn-1",
             itemId: "item-message",
-            kind: "agent_message",
+            itemType: "agentMessage",
           }),
         );
         session.emitNotification(
@@ -2033,15 +1991,7 @@ describe("App Server protocol harness", () => {
         params: {
           threadId: "thread-live",
           turnId: "turn-1",
-          item: {
-            id: "item-message",
-            kind: "agent_message",
-            rawItem: {
-              id: "item-message",
-              type: "agent_message",
-              status: "in_progress",
-            },
-          },
+          item: buildHarnessItem("agentMessage", "item-message", "started"),
         },
       });
       expect(messages).toContainEqual({
@@ -2131,7 +2081,7 @@ describe("App Server protocol harness", () => {
       readThread: async (_requestId, params) => ({
         ok: true,
         data: {
-          thread: createTestAgentThread({
+          thread: createTestAgentThreadDetail({
             id: params.threadId,
             workspacePath: canonicalWorkspacePath,
             archived,
@@ -2211,6 +2161,7 @@ describe("App Server protocol harness", () => {
             status: {
               type: "idle",
             },
+            turns: [],
           },
         },
       });
@@ -2266,6 +2217,7 @@ describe("App Server protocol harness", () => {
             status: {
               type: "idle",
             },
+            turns: [],
           },
         },
       });
@@ -2558,7 +2510,7 @@ describe("App Server protocol harness", () => {
           readThreadResult: {
             ok: true,
             data: {
-              thread: createTestAgentThread({
+              thread: createTestAgentThreadDetail({
                 id: "thread-1",
                 preview: "Read me",
                 workspacePath: canonicalWorkspacePath,
@@ -2601,6 +2553,7 @@ describe("App Server protocol harness", () => {
               type: "systemError",
               message: "Provider disconnected",
             },
+            turns: [],
           },
         },
       });
@@ -2729,9 +2682,31 @@ describe("App Server protocol harness", () => {
     }
   });
 
-  test("returns an explicit error for thread/read includeTurns=true", async () => {
+  test("returns turn history for thread/read includeTurns=true", async () => {
     const workspacePath = await createWorkspaceDirectory();
-    const harness = await createProtocolHarness();
+    const canonicalWorkspacePath = await realpath(workspacePath);
+    const harness = await createProtocolHarness({
+      agentAdapters: [
+        createFakeProtocolAgentAdapter({
+          readThreadResult: {
+            ok: true,
+            data: {
+              thread: createTestAgentThreadDetail({
+                id: "thread-1",
+                preview: "Read me",
+                workspacePath: canonicalWorkspacePath,
+                turns: [
+                  createTestAgentTurnDetail({
+                    id: "turn-1",
+                    items: [createTestAgentItem({ id: "item-1", text: "History item" })],
+                  }),
+                ],
+              }),
+            },
+          },
+        }),
+      ],
+    });
     const client = await connectProtocolClient(harness.port);
 
     try {
@@ -2749,11 +2724,36 @@ describe("App Server protocol harness", () => {
 
       await expect(client.nextMessage()).resolves.toEqual({
         id: "req-thread-read",
-        error: {
-          code: -33007,
-          message: "Thread read with includeTurns=true is not supported yet",
-          data: {
-            code: "THREAD_READ_INCLUDE_TURNS_UNSUPPORTED",
+        result: {
+          thread: {
+            id: "thread-1",
+            preview: "Read me",
+            createdAt: "2026-04-10T10:00:00.000Z",
+            updatedAt: "2026-04-10T11:00:00.000Z",
+            name: null,
+            archived: false,
+            model: null,
+            reasoningEffort: null,
+            status: {
+              type: "idle",
+            },
+            turns: [
+              {
+                id: "turn-1",
+                status: {
+                  type: "completed",
+                },
+                items: [
+                  {
+                    id: "item-1",
+                    type: "agentMessage",
+                    text: "History item",
+                    phase: null,
+                  },
+                ],
+                error: null,
+              },
+            ],
           },
         },
       });
@@ -2871,7 +2871,7 @@ describe("App Server protocol harness", () => {
           readThreadResult: {
             ok: true,
             data: {
-              thread: createTestAgentThread({
+              thread: createTestAgentThreadDetail({
                 id: "thread-1",
                 workspacePath: "/tmp/other-project",
               }),
@@ -3277,7 +3277,7 @@ const createFakeProtocolAgentAdapter = (options: {
     | Readonly<{
         ok: true;
         data: {
-          thread: ReturnType<typeof createTestAgentThread>;
+          thread: ReturnType<typeof createTestAgentThreadDetail>;
         };
       }>
     | Readonly<{
@@ -3322,7 +3322,7 @@ const createFakeProtocolAgentAdapter = (options: {
         options.readThreadResult ?? {
           ok: true,
           data: {
-            thread: createTestAgentThread(),
+            thread: createTestAgentThreadDetail(),
           },
         },
     }),
@@ -3427,11 +3427,52 @@ const createTurnCompletedNotification = (input: {
   },
 });
 
+const createPlanUpdatedNotification = (input: { threadId: string; turnId: string }) => ({
+  agentId: "codex",
+  provider: "codex" as const,
+  receivedAt: "2026-04-10T12:00:00.000Z",
+  rawMethod: "turn/plan/updated",
+  threadId: input.threadId,
+  turnId: input.turnId,
+  type: "plan" as const,
+  event: "updated" as const,
+  explanation: "Ship it",
+  steps: [
+    {
+      step: "Inspect state",
+      status: "completed" as const,
+    },
+    {
+      step: "Write patch",
+      status: "in_progress" as const,
+    },
+  ],
+});
+
+const createDiffUpdatedNotification = (input: { threadId: string; turnId: string }) => ({
+  agentId: "codex",
+  provider: "codex" as const,
+  receivedAt: "2026-04-10T12:00:00.000Z",
+  rawMethod: "turn/diff/updated",
+  threadId: input.threadId,
+  turnId: input.turnId,
+  type: "diff" as const,
+  event: "updated" as const,
+  diff: ["diff --git a/src/example.ts b/src/example.ts", "+added"].join("\n"),
+  summary: [
+    {
+      path: "src/example.ts",
+      additions: 1,
+      deletions: 0,
+    },
+  ],
+});
+
 const createItemStartedNotification = (input: {
   threadId: string;
   turnId: string;
   itemId: string;
-  kind: string;
+  itemType: "agentMessage" | "reasoning" | "commandExecution" | "mcpToolCall";
 }) => ({
   agentId: "codex",
   provider: "codex" as const,
@@ -3442,23 +3483,14 @@ const createItemStartedNotification = (input: {
   itemId: input.itemId,
   type: "item" as const,
   event: "started" as const,
-  item: {
-    id: input.itemId,
-    kind: input.kind,
-    rawItem: {
-      id: input.itemId,
-      type: input.kind,
-      status: "in_progress",
-    },
-  },
+  item: buildHarnessItem(input.itemType, input.itemId, "started"),
 });
 
 const createItemCompletedNotification = (input: {
   threadId: string;
   turnId: string;
   itemId: string;
-  kind: string;
-  rawItem: Record<string, unknown>;
+  item: ReturnType<typeof buildHarnessItem>;
 }) => ({
   agentId: "codex",
   provider: "codex" as const,
@@ -3469,11 +3501,7 @@ const createItemCompletedNotification = (input: {
   itemId: input.itemId,
   type: "item" as const,
   event: "completed" as const,
-  item: {
-    id: input.itemId,
-    kind: input.kind,
-    rawItem: input.rawItem,
-  },
+  item: input.item,
 });
 
 const createMessageDeltaNotification = (input: {
@@ -3565,6 +3593,58 @@ const createToolProgressNotification = (input: {
   event: "progress" as const,
   message: input.message,
 });
+
+const buildHarnessItem = (
+  itemType: "agentMessage" | "reasoning" | "commandExecution" | "mcpToolCall",
+  itemId: string,
+  phase: "started" | "completed",
+) => {
+  switch (itemType) {
+    case "agentMessage":
+      return {
+        id: itemId,
+        type: "agentMessage" as const,
+        text: phase === "completed" ? "Working on it..." : "",
+        phase: null,
+      };
+    case "reasoning":
+      return {
+        id: itemId,
+        type: "reasoning" as const,
+        summary: phase === "completed" ? ["Short summary"] : [],
+        content: phase === "completed" ? ["Thinking..."] : [],
+      };
+    case "commandExecution": {
+      const status: "completed" | "inProgress" = phase === "completed" ? "completed" : "inProgress";
+      return {
+        id: itemId,
+        type: "commandExecution" as const,
+        command: "echo hello",
+        cwd: "/tmp/project",
+        processId: null,
+        status,
+        commandActions: [],
+        aggregatedOutput: phase === "completed" ? "stdout line\n" : null,
+        exitCode: phase === "completed" ? 0 : null,
+        durationMs: null,
+      };
+    }
+    case "mcpToolCall": {
+      const status: "completed" | "inProgress" = phase === "completed" ? "completed" : "inProgress";
+      return {
+        id: itemId,
+        type: "mcpToolCall" as const,
+        server: "filesystem",
+        tool: "read_file",
+        status,
+        arguments: {},
+        result: null,
+        error: null,
+        durationMs: null,
+      };
+    }
+  }
+};
 
 const toMessageText = (data: unknown): string => {
   if (typeof data === "string") {

--- a/AppServer/src/app/protocol-harness.test.ts
+++ b/AppServer/src/app/protocol-harness.test.ts
@@ -3597,25 +3597,26 @@ const createToolProgressNotification = (input: {
 const buildHarnessItem = (
   itemType: "agentMessage" | "reasoning" | "commandExecution" | "mcpToolCall",
   itemId: string,
-  phase: "started" | "completed",
+  lifecycle: "started" | "completed",
 ) => {
   switch (itemType) {
     case "agentMessage":
       return {
         id: itemId,
         type: "agentMessage" as const,
-        text: phase === "completed" ? "Working on it..." : "",
+        text: lifecycle === "completed" ? "Working on it..." : "",
         phase: null,
       };
     case "reasoning":
       return {
         id: itemId,
         type: "reasoning" as const,
-        summary: phase === "completed" ? ["Short summary"] : [],
-        content: phase === "completed" ? ["Thinking..."] : [],
+        summary: lifecycle === "completed" ? ["Short summary"] : [],
+        content: lifecycle === "completed" ? ["Thinking..."] : [],
       };
     case "commandExecution": {
-      const status: "completed" | "inProgress" = phase === "completed" ? "completed" : "inProgress";
+      const status: "completed" | "inProgress" =
+        lifecycle === "completed" ? "completed" : "inProgress";
       return {
         id: itemId,
         type: "commandExecution" as const,
@@ -3624,13 +3625,14 @@ const buildHarnessItem = (
         processId: null,
         status,
         commandActions: [],
-        aggregatedOutput: phase === "completed" ? "stdout line\n" : null,
-        exitCode: phase === "completed" ? 0 : null,
+        aggregatedOutput: lifecycle === "completed" ? "stdout line\n" : null,
+        exitCode: lifecycle === "completed" ? 0 : null,
         durationMs: null,
       };
     }
     case "mcpToolCall": {
-      const status: "completed" | "inProgress" = phase === "completed" ? "completed" : "inProgress";
+      const status: "completed" | "inProgress" =
+        lifecycle === "completed" ? "completed" : "inProgress";
       return {
         id: itemId,
         type: "mcpToolCall" as const,

--- a/AppServer/src/core/protocol/errors.ts
+++ b/AppServer/src/core/protocol/errors.ts
@@ -17,7 +17,6 @@ export const ATELIER_WORKSPACE_PATH_NOT_DIRECTORY_ERROR = -33003;
 export const ATELIER_AGENT_SESSION_UNAVAILABLE_ERROR = -33004;
 export const ATELIER_PROVIDER_ERROR = -33005;
 export const ATELIER_WORKSPACE_NOT_OPENED_ERROR = -33006;
-export const ATELIER_THREAD_READ_INCLUDE_TURNS_UNSUPPORTED_ERROR = -33007;
 export const ATELIER_THREAD_WORKSPACE_MISMATCH_ERROR = -33008;
 export const ATELIER_INVALID_PROVIDER_PAYLOAD_ERROR = -33009;
 export const ATELIER_THREAD_NOT_LOADED_ERROR = -33010;
@@ -132,20 +131,6 @@ export const createWorkspaceNotOpenedError = (): ProtocolMethodError =>
 
 export const createWorkspaceNotOpenedResult = (): Result<never, ProtocolMethodError> =>
   err(createWorkspaceNotOpenedError());
-
-export const createThreadReadIncludeTurnsUnsupportedError = (): ProtocolMethodError =>
-  createProtocolMethodError(
-    ATELIER_THREAD_READ_INCLUDE_TURNS_UNSUPPORTED_ERROR,
-    "Thread read with includeTurns=true is not supported yet",
-    Object.freeze({
-      code: "THREAD_READ_INCLUDE_TURNS_UNSUPPORTED",
-    }),
-  );
-
-export const createThreadReadIncludeTurnsUnsupportedResult = (): Result<
-  never,
-  ProtocolMethodError
-> => err(createThreadReadIncludeTurnsUnsupportedError());
 
 export const createThreadWorkspaceMismatchError = (
   threadId: string,

--- a/AppServer/src/test-support/agents.ts
+++ b/AppServer/src/test-support/agents.ts
@@ -13,12 +13,16 @@ import type {
   AgentSessionState,
   AgentThread,
   AgentThreadArchiveParams,
+  AgentThreadDetail,
   AgentThreadForkParams,
   AgentThreadMutationResult,
   AgentThreadReadParams,
+  AgentThreadReadResult,
   AgentThreadResult,
   AgentThreadSetNameParams,
   AgentThreadUnarchiveParams,
+  AgentTurnDetail,
+  AgentTurnItem,
   AgentTurnResult,
 } from "@/agents/contracts";
 import type { AgentRegistry } from "@/agents/registry";
@@ -124,7 +128,7 @@ export type CreateFakeAgentSessionOptions = Readonly<{
   readThread?: (
     requestId: AgentRequestId,
     params: AgentThreadReadParams,
-  ) => Promise<AgentOperationResult<AgentThreadResult>>;
+  ) => Promise<AgentOperationResult<AgentThreadReadResult>>;
   forkThread?: (
     requestId: AgentRequestId,
     params: AgentThreadForkParams,
@@ -341,7 +345,7 @@ export const createFakeAgentSession = (
         (await options.readThread?.(requestId, params)) ?? {
           ok: true,
           data: {
-            thread: createTestAgentThread(),
+            thread: createTestAgentThreadDetail(),
           },
         }
       );
@@ -581,6 +585,26 @@ export const createTestAgentThread = (
     status: overrides.status ?? ({ type: "idle" } as const),
   });
 
+export const createTestAgentThreadDetail = (
+  overrides: Partial<
+    Readonly<{
+      id: string;
+      preview: string;
+      createdAt: string;
+      updatedAt: string;
+      workspacePath: string;
+      name: string | null;
+      archived: boolean;
+      status: AgentThread["status"];
+      turns: readonly AgentTurnDetail[];
+    }>
+  > = {},
+): AgentThreadDetail =>
+  Object.freeze({
+    ...createTestAgentThread(overrides),
+    turns: overrides.turns ?? [],
+  });
+
 export const createTestAgentTurn = (
   overrides: Partial<
     Readonly<{
@@ -592,4 +616,36 @@ export const createTestAgentTurn = (
   Object.freeze({
     id: overrides.id ?? "turn-1",
     status: overrides.status ?? ({ type: "inProgress" } as const),
+  });
+
+export const createTestAgentTurnDetail = (
+  overrides: Partial<
+    Readonly<{
+      id: string;
+      status: AgentTurnResult["turn"]["status"];
+      items: readonly AgentTurnItem[];
+      error: AgentTurnDetail["error"];
+    }>
+  > = {},
+): AgentTurnDetail =>
+  Object.freeze({
+    id: overrides.id ?? "turn-1",
+    status: overrides.status ?? ({ type: "completed" } as const),
+    items: overrides.items ?? [],
+    error: overrides.error ?? null,
+  });
+
+export const createTestAgentItem = (
+  overrides: Partial<
+    Readonly<{
+      id: string;
+      text: string;
+    }>
+  > = {},
+): AgentTurnItem =>
+  Object.freeze({
+    type: "agentMessage",
+    id: overrides.id ?? "item-1",
+    text: overrides.text ?? "",
+    phase: null,
   });

--- a/AppServer/src/threads/methods/read-thread.ts
+++ b/AppServer/src/threads/methods/read-thread.ts
@@ -1,10 +1,7 @@
-import {
-  createThreadReadIncludeTurnsUnsupportedResult,
-  createThreadWorkspaceMismatchResult,
-} from "@/core/protocol/errors";
+import { createThreadWorkspaceMismatchResult } from "@/core/protocol/errors";
 import { assertNever, err, ok } from "@/core/shared";
 import type { ThreadMethodDependencies } from "@/threads/methods/method-dependencies";
-import { getThreadDefaults, mapPublicThread } from "@/threads/response-mapper";
+import { getThreadDefaults, mapPublicThreadDetail } from "@/threads/response-mapper";
 import type { ThreadsService } from "@/threads/service-types";
 import {
   createInvalidProviderPayloadServiceError,
@@ -14,10 +11,6 @@ import {
 export const createReadThreadMethod =
   (context: ThreadMethodDependencies): ThreadsService["readThread"] =>
   async (requestId, workspace, params) => {
-    if (params.includeTurns === true) {
-      return createThreadReadIncludeTurnsUnsupportedResult();
-    }
-
     const sessionResult = await context.registry.getSession();
 
     if (!sessionResult.ok) {
@@ -36,7 +29,7 @@ export const createReadThreadMethod =
     });
     const readResult = await sessionResult.data.readThread(requestId, {
       threadId: params.threadId,
-      includeTurns: false,
+      includeTurns: params.includeTurns ?? false,
     });
 
     if (!readResult.ok) {
@@ -79,6 +72,6 @@ export const createReadThreadMethod =
     });
 
     return ok({
-      thread: mapPublicThread(readResult.data.thread, getThreadDefaults(existingLink)),
+      thread: mapPublicThreadDetail(readResult.data.thread, getThreadDefaults(existingLink)),
     });
   };

--- a/AppServer/src/threads/response-mapper.ts
+++ b/AppServer/src/threads/response-mapper.ts
@@ -1,8 +1,16 @@
-import type { AgentReasoningEffort, AgentThread } from "@/agents/contracts";
+import type {
+  AgentReasoningEffort,
+  AgentThread,
+  AgentThreadDetail,
+  AgentTurnDetail,
+  AgentTurnItem,
+  AgentTurnStatus,
+} from "@/agents/contracts";
 import type { Logger } from "@/app/logger";
 import { assertNever } from "@/core/shared";
-import type { Thread, ThreadExecutionStatus } from "@/threads/schemas";
+import type { Thread, ThreadDetail, ThreadExecutionStatus } from "@/threads/schemas";
 import type { WorkspaceThreadLink } from "@/threads/store";
+import type { TurnDetail, TurnItem, TurnStatus, TurnTerminalError } from "@/turns/schemas";
 import type { Workspace } from "@/workspaces/schemas";
 
 export type ThreadDefaults = Readonly<{
@@ -76,6 +84,23 @@ export const mapPublicThread = (thread: AgentThread, defaults: ThreadDefaults): 
     status: mapPublicThreadStatus(thread.status),
   });
 
+export const mapPublicThreadDetail = (
+  thread: AgentThreadDetail,
+  defaults: ThreadDefaults,
+): ThreadDetail =>
+  Object.freeze({
+    id: thread.id,
+    preview: thread.preview,
+    createdAt: thread.createdAt,
+    updatedAt: thread.updatedAt,
+    name: thread.name,
+    archived: thread.archived,
+    model: defaults.model,
+    reasoningEffort: defaults.reasoningEffort,
+    status: mapPublicThreadStatus(thread.status),
+    turns: thread.turns.map((turn) => mapPublicTurnDetail(turn)),
+  });
+
 const mapPublicThreadStatus = (status: AgentThread["status"]): ThreadExecutionStatus => {
   switch (status.type) {
     case "notLoaded":
@@ -94,5 +119,191 @@ const mapPublicThreadStatus = (status: AgentThread["status"]): ThreadExecutionSt
       });
     default:
       return assertNever(status, "Unhandled public thread status");
+  }
+};
+
+const mapPublicTurnDetail = (turn: AgentTurnDetail): TurnDetail =>
+  Object.freeze({
+    id: turn.id,
+    status: mapPublicTurnStatus(turn.status),
+    items: turn.items.map((item) => mapPublicTurnItem(item)),
+    error: mapPublicTurnTerminalError(turn.error),
+  });
+
+const mapPublicTurnTerminalError = (error: AgentTurnDetail["error"]): TurnTerminalError | null =>
+  error === null
+    ? null
+    : Object.freeze({
+        message: error.message,
+        providerError: error.providerError,
+        additionalDetails: error.additionalDetails,
+      });
+
+const mapPublicTurnStatus = (status: AgentTurnStatus): TurnStatus => {
+  switch (status.type) {
+    case "inProgress":
+      return Object.freeze({ type: "inProgress" });
+    case "awaitingInput":
+      return Object.freeze({ type: "awaitingInput" });
+    case "completed":
+      return Object.freeze({ type: "completed" });
+    case "cancelled":
+      return Object.freeze({ type: "cancelled" });
+    case "interrupted":
+      return Object.freeze({ type: "interrupted" });
+    case "failed":
+      return Object.freeze({
+        type: "failed",
+        ...(status.message ? { message: status.message } : {}),
+      });
+    default:
+      return assertNever(status, "Unhandled public turn status");
+  }
+};
+
+const mapPublicTurnItem = (item: AgentTurnItem): TurnItem => {
+  switch (item.type) {
+    case "userMessage":
+      return Object.freeze({
+        type: "userMessage",
+        id: item.id,
+        content: [...item.content],
+      });
+    case "agentMessage":
+      return Object.freeze({
+        type: "agentMessage",
+        id: item.id,
+        text: item.text,
+        phase: item.phase,
+      });
+    case "plan":
+      return Object.freeze({
+        type: "plan",
+        id: item.id,
+        text: item.text,
+      });
+    case "reasoning":
+      return Object.freeze({
+        type: "reasoning",
+        id: item.id,
+        summary: [...item.summary],
+        content: [...item.content],
+      });
+    case "commandExecution":
+      return Object.freeze({
+        type: "commandExecution",
+        id: item.id,
+        command: item.command,
+        cwd: item.cwd,
+        processId: item.processId,
+        status: item.status,
+        commandActions: [...item.commandActions],
+        aggregatedOutput: item.aggregatedOutput,
+        exitCode: item.exitCode,
+        durationMs: item.durationMs,
+      });
+    case "fileChange":
+      return Object.freeze({
+        type: "fileChange",
+        id: item.id,
+        changes: [...item.changes],
+        status: item.status,
+      });
+    case "mcpToolCall":
+      return Object.freeze({
+        type: "mcpToolCall",
+        id: item.id,
+        server: item.server,
+        tool: item.tool,
+        status: item.status,
+        arguments: item.arguments,
+        result: item.result,
+        error: item.error,
+        durationMs: item.durationMs,
+      });
+    case "dynamicToolCall":
+      return Object.freeze({
+        type: "dynamicToolCall",
+        id: item.id,
+        tool: item.tool,
+        arguments: item.arguments,
+        status: item.status,
+        contentItems: item.contentItems === null ? null : [...item.contentItems],
+        success: item.success,
+        durationMs: item.durationMs,
+      });
+    case "collabAgentToolCall":
+      return Object.freeze({
+        type: "collabAgentToolCall",
+        id: item.id,
+        tool: item.tool,
+        status: item.status,
+        senderThreadId: item.senderThreadId,
+        receiverThreadIds: [...item.receiverThreadIds],
+        prompt: item.prompt,
+        agentsStates: { ...item.agentsStates },
+      });
+    case "webSearch":
+      return Object.freeze({
+        type: "webSearch",
+        id: item.id,
+        query: item.query,
+        action:
+          item.action === null
+            ? null
+            : item.action.type === "search"
+              ? Object.freeze({
+                  type: "search",
+                  query: item.action.query,
+                  queries: item.action.queries === null ? null : [...item.action.queries],
+                })
+              : item.action.type === "openPage"
+                ? Object.freeze({
+                    type: "openPage",
+                    url: item.action.url,
+                  })
+                : item.action.type === "findInPage"
+                  ? Object.freeze({
+                      type: "findInPage",
+                      url: item.action.url,
+                      pattern: item.action.pattern,
+                    })
+                  : Object.freeze({
+                      type: "other",
+                    }),
+      });
+    case "imageView":
+      return Object.freeze({
+        type: "imageView",
+        id: item.id,
+        path: item.path,
+      });
+    case "imageGeneration":
+      return Object.freeze({
+        type: "imageGeneration",
+        id: item.id,
+        status: item.status,
+        revisedPrompt: item.revisedPrompt,
+        result: item.result,
+      });
+    case "enteredReviewMode":
+      return Object.freeze({
+        type: "enteredReviewMode",
+        id: item.id,
+        review: item.review,
+      });
+    case "exitedReviewMode":
+      return Object.freeze({
+        type: "exitedReviewMode",
+        id: item.id,
+        review: item.review,
+      });
+    case "contextCompaction":
+      return Object.freeze({
+        type: "contextCompaction",
+        id: item.id,
+      });
+    default:
+      return assertNever(item, "Unhandled public turn item");
   }
 };

--- a/AppServer/src/threads/schemas.ts
+++ b/AppServer/src/threads/schemas.ts
@@ -1,5 +1,6 @@
 import { type Static, Type } from "@sinclair/typebox";
 import { ModelReasoningEffortSchema } from "@/agents/schemas";
+import { TurnDetailSchema } from "@/turns/schemas";
 
 export const ThreadExecutionStatusSchema = Type.Union([
   Type.Object(
@@ -47,6 +48,23 @@ export const ThreadSchema = Type.Object(
 );
 export type Thread = Static<typeof ThreadSchema>;
 
+export const ThreadDetailSchema = Type.Object(
+  {
+    id: Type.String({ minLength: 1 }),
+    preview: Type.String(),
+    createdAt: Type.String({ minLength: 1 }),
+    updatedAt: Type.String({ minLength: 1 }),
+    name: Type.Union([Type.String({ minLength: 1 }), Type.Null()]),
+    archived: Type.Boolean(),
+    model: Type.Union([Type.String({ minLength: 1 }), Type.Null()]),
+    reasoningEffort: Type.Union([ModelReasoningEffortSchema, Type.Null()]),
+    status: ThreadExecutionStatusSchema,
+    turns: Type.Array(TurnDetailSchema),
+  },
+  { additionalProperties: false },
+);
+export type ThreadDetail = Static<typeof ThreadDetailSchema>;
+
 export const ThreadListParamsSchema = Type.Object(
   {
     cursor: Type.Optional(Type.String({ minLength: 1 })),
@@ -86,14 +104,19 @@ export type ThreadStartParams = Static<typeof ThreadStartParamsSchema>;
 
 export const ThreadReadResultSchema = Type.Object(
   {
-    thread: ThreadSchema,
+    thread: ThreadDetailSchema,
   },
   { additionalProperties: false },
 );
 export type ThreadReadResult = Static<typeof ThreadReadResultSchema>;
 
-export const ThreadStartResultSchema = ThreadReadResultSchema;
-export type ThreadStartResult = ThreadReadResult;
+export const ThreadStartResultSchema = Type.Object(
+  {
+    thread: ThreadSchema,
+  },
+  { additionalProperties: false },
+);
+export type ThreadStartResult = Static<typeof ThreadStartResultSchema>;
 
 export const ThreadResumeParamsSchema = Type.Object(
   {
@@ -105,8 +128,8 @@ export const ThreadResumeParamsSchema = Type.Object(
 );
 export type ThreadResumeParams = Static<typeof ThreadResumeParamsSchema>;
 
-export const ThreadResumeResultSchema = ThreadReadResultSchema;
-export type ThreadResumeResult = ThreadReadResult;
+export const ThreadResumeResultSchema = ThreadStartResultSchema;
+export type ThreadResumeResult = ThreadStartResult;
 
 export const ThreadForkParamsSchema = Type.Object(
   {
@@ -117,8 +140,8 @@ export const ThreadForkParamsSchema = Type.Object(
 );
 export type ThreadForkParams = Static<typeof ThreadForkParamsSchema>;
 
-export const ThreadForkResultSchema = ThreadReadResultSchema;
-export type ThreadForkResult = ThreadReadResult;
+export const ThreadForkResultSchema = ThreadStartResultSchema;
+export type ThreadForkResult = ThreadStartResult;
 
 export const ThreadArchiveParamsSchema = Type.Object(
   {
@@ -139,8 +162,8 @@ export const ThreadUnarchiveParamsSchema = Type.Object(
 );
 export type ThreadUnarchiveParams = Static<typeof ThreadUnarchiveParamsSchema>;
 
-export const ThreadUnarchiveResultSchema = ThreadReadResultSchema;
-export type ThreadUnarchiveResult = ThreadReadResult;
+export const ThreadUnarchiveResultSchema = ThreadStartResultSchema;
+export type ThreadUnarchiveResult = ThreadStartResult;
 
 export const ThreadSetNameParamsSchema = Type.Object(
   {

--- a/AppServer/src/threads/service.test.ts
+++ b/AppServer/src/threads/service.test.ts
@@ -6,7 +6,10 @@ import {
   type CreateFakeAgentSessionOptions,
   createFakeAgentRegistry,
   createFakeAgentSession,
+  createTestAgentItem,
   createTestAgentThread,
+  createTestAgentThreadDetail,
+  createTestAgentTurnDetail,
 } from "@/test-support/agents";
 import { createCapturingLogger, createSilentLogger } from "@/test-support/logger";
 import { createThreadsService } from "@/threads/service";
@@ -542,8 +545,23 @@ describe("createThreadsService", () => {
     }
   });
 
-  test("returns an explicit domain error when thread/read requests turns", async () => {
-    const session = createFakeAgentSession();
+  test("reads provider-authoritative turn history when thread/read requests turns", async () => {
+    const session = createFakeAgentSession({
+      readThread: async () => ({
+        ok: true,
+        data: {
+          thread: createTestAgentThreadDetail({
+            id: "thread-1",
+            turns: [
+              createTestAgentTurnDetail({
+                id: "turn-1",
+                items: [createTestAgentItem({ id: "item-1", text: "Hello from history" })],
+              }),
+            ],
+          }),
+        },
+      }),
+    });
     const service = createThreadsService({
       logger: createSilentLogger("error"),
       registry: createFakeAgentRegistry(session),
@@ -555,17 +573,46 @@ describe("createThreadsService", () => {
       includeTurns: true,
     });
 
-    expect(result).toMatchObject({
-      ok: false,
-      error: {
-        code: -33007,
-        message: "Thread read with includeTurns=true is not supported yet",
-        data: {
-          code: "THREAD_READ_INCLUDE_TURNS_UNSUPPORTED",
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        thread: {
+          id: "thread-1",
+          preview: "Thread preview",
+          createdAt: "2026-04-10T10:00:00.000Z",
+          updatedAt: "2026-04-10T11:00:00.000Z",
+          name: null,
+          archived: false,
+          model: null,
+          reasoningEffort: null,
+          status: { type: "idle" },
+          turns: [
+            {
+              id: "turn-1",
+              status: { type: "completed" },
+              items: [
+                {
+                  id: "item-1",
+                  type: "agentMessage",
+                  text: "Hello from history",
+                  phase: null,
+                },
+              ],
+              error: null,
+            },
+          ],
         },
       },
     });
-    expect(session.readThreadCalls).toEqual([]);
+    expect(session.readThreadCalls).toEqual([
+      {
+        requestId: "req-1",
+        params: {
+          threadId: "thread-1",
+          includeTurns: true,
+        },
+      },
+    ]);
   });
 
   test("thread/read returns provider-authoritative archived and does not pass cached archived back upstream", async () => {
@@ -586,7 +633,7 @@ describe("createThreadsService", () => {
       readThread: async () => ({
         ok: true,
         data: {
-          thread: createTestAgentThread({
+          thread: createTestAgentThreadDetail({
             id: "thread-1",
             workspacePath: "/tmp/project",
             archived: false,
@@ -619,6 +666,7 @@ describe("createThreadsService", () => {
           model: "gpt-5.4",
           reasoningEffort: null,
           status: { type: "idle" },
+          turns: [],
         },
       },
     });
@@ -638,7 +686,7 @@ describe("createThreadsService", () => {
       readThread: async (_requestId, params) => ({
         ok: true,
         data: {
-          thread: createTestAgentThread({
+          thread: createTestAgentThreadDetail({
             id: params.threadId,
             workspacePath: "/tmp/project",
             archived: true,
@@ -725,7 +773,7 @@ describe("createThreadsService", () => {
       readThread: async (_requestId, params) => ({
         ok: true,
         data: {
-          thread: createTestAgentThread({
+          thread: createTestAgentThreadDetail({
             id: params.threadId,
             workspacePath: "/tmp/other-project",
           }),
@@ -853,7 +901,7 @@ describe("createThreadsService", () => {
       readThread: async (_requestId, params) => ({
         ok: true,
         data: {
-          thread: createTestAgentThread({
+          thread: createTestAgentThreadDetail({
             id: params.threadId,
             workspacePath: "/tmp/project",
             name: "Old name",
@@ -985,7 +1033,7 @@ describe("createThreadsService", () => {
       readThread: async (_requestId, params) => ({
         ok: true,
         data: {
-          thread: createTestAgentThread({
+          thread: createTestAgentThreadDetail({
             id: params.threadId,
             workspacePath: "/tmp/project",
           }),

--- a/AppServer/src/turns/active-turn-registry.test.ts
+++ b/AppServer/src/turns/active-turn-registry.test.ts
@@ -19,12 +19,9 @@ describe("active turn registry", () => {
       turnId: "turn-1",
       item: {
         id: "item-1",
-        kind: "agent_message",
-        rawItem: {
-          id: "item-1",
-          type: "agent_message",
-          status: "in_progress",
-        },
+        type: "agentMessage",
+        text: "",
+        phase: null,
       },
     });
     registry.appendMessageText({
@@ -44,13 +41,9 @@ describe("active turn registry", () => {
       turnId: "turn-1",
       item: {
         id: "item-1",
-        kind: "agent_message",
-        rawItem: {
-          id: "item-1",
-          type: "agent_message",
-          status: "completed",
-          text: "Hello world",
-        },
+        type: "agentMessage",
+        text: "Hello world",
+        phase: null,
       },
     });
 
@@ -66,13 +59,9 @@ describe("active turn registry", () => {
         {
           item: {
             id: "item-1",
-            kind: "agent_message",
-            rawItem: {
-              id: "item-1",
-              type: "agent_message",
-              status: "completed",
-              text: "Hello world",
-            },
+            type: "agentMessage",
+            text: "Hello world",
+            phase: null,
           },
           messageText: "Hello world",
           reasoningText: "",
@@ -146,12 +135,9 @@ describe("active turn registry", () => {
       turnId: "turn-1",
       item: {
         id: "item-1",
-        kind: "agent_message",
-        rawItem: {
-          id: "item-1",
-          type: "agent_message",
-          status: "in_progress",
-        },
+        type: "agentMessage",
+        text: "",
+        phase: null,
       },
     });
 
@@ -169,12 +155,9 @@ describe("active turn registry", () => {
         turnId: "turn-2",
         item: {
           id: "item-2",
-          kind: "agent_message",
-          rawItem: {
-            id: "item-2",
-            type: "agent_message",
-            status: "completed",
-          },
+          type: "agentMessage",
+          text: "",
+          phase: null,
         },
       }),
     ).toBe(false);
@@ -191,12 +174,9 @@ describe("active turn registry", () => {
         {
           item: {
             id: "item-1",
-            kind: "agent_message",
-            rawItem: {
-              id: "item-1",
-              type: "agent_message",
-              status: "in_progress",
-            },
+            type: "agentMessage",
+            text: "",
+            phase: null,
           },
           messageText: "",
           reasoningText: "",

--- a/AppServer/src/turns/active-turn-registry.ts
+++ b/AppServer/src/turns/active-turn-registry.ts
@@ -215,6 +215,7 @@ export const createActiveTurnRegistry = (): ActiveTurnRegistry => {
       }
 
       itemState.item = item;
+      reconcileCompletedItemState(itemState, item);
       return true;
     },
     appendMessageText: ({ threadId, turnId, itemId, delta }) => {
@@ -224,6 +225,12 @@ export const createActiveTurnRegistry = (): ActiveTurnRegistry => {
       }
 
       itemState.messageText += delta;
+      if (itemState.item?.type === "agentMessage") {
+        itemState.item = Object.freeze({
+          ...itemState.item,
+          text: itemState.messageText,
+        });
+      }
       return true;
     },
     appendReasoningText: ({ threadId, turnId, itemId, delta }) => {
@@ -233,6 +240,12 @@ export const createActiveTurnRegistry = (): ActiveTurnRegistry => {
       }
 
       itemState.reasoningText += delta;
+      if (itemState.item?.type === "reasoning") {
+        itemState.item = Object.freeze({
+          ...itemState.item,
+          content: [itemState.reasoningText],
+        });
+      }
       return true;
     },
     appendReasoningSummaryText: ({ threadId, turnId, itemId, delta }) => {
@@ -242,6 +255,12 @@ export const createActiveTurnRegistry = (): ActiveTurnRegistry => {
       }
 
       itemState.reasoningSummaryText += delta;
+      if (itemState.item?.type === "reasoning") {
+        itemState.item = Object.freeze({
+          ...itemState.item,
+          summary: [itemState.reasoningSummaryText],
+        });
+      }
       return true;
     },
     appendCommandOutput: ({ threadId, turnId, itemId, delta }) => {
@@ -251,6 +270,12 @@ export const createActiveTurnRegistry = (): ActiveTurnRegistry => {
       }
 
       itemState.commandOutput += delta;
+      if (itemState.item?.type === "commandExecution") {
+        itemState.item = Object.freeze({
+          ...itemState.item,
+          aggregatedOutput: itemState.commandOutput,
+        });
+      }
       return true;
     },
     appendToolProgress: ({ threadId, turnId, itemId, message }) => {
@@ -280,4 +305,24 @@ export const createActiveTurnRegistry = (): ActiveTurnRegistry => {
       statesByThreadId.clear();
     },
   });
+};
+
+const reconcileCompletedItemState = (
+  itemState: MutableActiveTurnItemState,
+  item: TurnItem,
+): void => {
+  switch (item.type) {
+    case "agentMessage":
+      itemState.messageText = item.text;
+      return;
+    case "reasoning":
+      itemState.reasoningText = item.content.join("");
+      itemState.reasoningSummaryText = item.summary.join("");
+      return;
+    case "commandExecution":
+      itemState.commandOutput = item.aggregatedOutput ?? "";
+      return;
+    default:
+      return;
+  }
 };

--- a/AppServer/src/turns/schemas.ts
+++ b/AppServer/src/turns/schemas.ts
@@ -50,15 +50,295 @@ export const TurnSchema = Type.Object(
 );
 export type Turn = Static<typeof TurnSchema>;
 
-export const TurnItemSchema = Type.Object(
+const CommandExecutionItemStatusSchema = Type.Union([
+  Type.Literal("inProgress"),
+  Type.Literal("completed"),
+  Type.Literal("failed"),
+  Type.Literal("declined"),
+]);
+
+const PatchApplyItemStatusSchema = Type.Union([
+  Type.Literal("inProgress"),
+  Type.Literal("completed"),
+  Type.Literal("failed"),
+  Type.Literal("declined"),
+]);
+
+const ToolCallItemStatusSchema = Type.Union([
+  Type.Literal("inProgress"),
+  Type.Literal("completed"),
+  Type.Literal("failed"),
+]);
+
+const CollabAgentToolSchema = Type.Union([
+  Type.Literal("spawnAgent"),
+  Type.Literal("sendInput"),
+  Type.Literal("resumeAgent"),
+  Type.Literal("wait"),
+  Type.Literal("closeAgent"),
+]);
+
+const CollabAgentToolCallStatusSchema = ToolCallItemStatusSchema;
+
+const DynamicToolCallStatusSchema = ToolCallItemStatusSchema;
+
+const WebSearchActionSchema = Type.Union([
+  Type.Object(
+    {
+      type: Type.Literal("search"),
+      query: Type.Union([Type.String(), Type.Null()]),
+      queries: Type.Union([Type.Array(Type.String()), Type.Null()]),
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("openPage"),
+      url: Type.Union([Type.String(), Type.Null()]),
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("findInPage"),
+      url: Type.Union([Type.String(), Type.Null()]),
+      pattern: Type.Union([Type.String(), Type.Null()]),
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      type: Type.Literal("other"),
+    },
+    { additionalProperties: false },
+  ),
+]);
+
+const UserMessageItemSchema = Type.Object(
   {
+    type: Type.Literal("userMessage"),
     id: Type.String({ minLength: 1 }),
-    kind: Type.String({ minLength: 1 }),
-    rawItem: Type.Unknown(),
+    content: Type.Array(Type.Unknown()),
   },
   { additionalProperties: false },
 );
+
+const AgentMessageItemSchema = Type.Object(
+  {
+    type: Type.Literal("agentMessage"),
+    id: Type.String({ minLength: 1 }),
+    text: Type.String(),
+    phase: Type.Union([Type.String(), Type.Null()]),
+  },
+  { additionalProperties: false },
+);
+
+const PlanItemSchema = Type.Object(
+  {
+    type: Type.Literal("plan"),
+    id: Type.String({ minLength: 1 }),
+    text: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+const ReasoningItemSchema = Type.Object(
+  {
+    type: Type.Literal("reasoning"),
+    id: Type.String({ minLength: 1 }),
+    summary: Type.Array(Type.String()),
+    content: Type.Array(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+const CommandExecutionItemSchema = Type.Object(
+  {
+    type: Type.Literal("commandExecution"),
+    id: Type.String({ minLength: 1 }),
+    command: Type.String(),
+    cwd: Type.String(),
+    processId: Type.Union([Type.String(), Type.Null()]),
+    status: CommandExecutionItemStatusSchema,
+    commandActions: Type.Array(Type.Unknown()),
+    aggregatedOutput: Type.Union([Type.String(), Type.Null()]),
+    exitCode: Type.Union([Type.Integer(), Type.Null()]),
+    durationMs: Type.Union([Type.Number(), Type.Null()]),
+  },
+  { additionalProperties: false },
+);
+
+const FileChangeItemSchema = Type.Object(
+  {
+    type: Type.Literal("fileChange"),
+    id: Type.String({ minLength: 1 }),
+    changes: Type.Array(Type.Unknown()),
+    status: PatchApplyItemStatusSchema,
+  },
+  { additionalProperties: false },
+);
+
+const McpToolCallItemSchema = Type.Object(
+  {
+    type: Type.Literal("mcpToolCall"),
+    id: Type.String({ minLength: 1 }),
+    server: Type.String(),
+    tool: Type.String(),
+    status: ToolCallItemStatusSchema,
+    arguments: Type.Unknown(),
+    result: Type.Union([Type.Unknown(), Type.Null()]),
+    error: Type.Union([Type.Unknown(), Type.Null()]),
+    durationMs: Type.Union([Type.Number(), Type.Null()]),
+  },
+  { additionalProperties: false },
+);
+
+const DynamicToolCallItemSchema = Type.Object(
+  {
+    type: Type.Literal("dynamicToolCall"),
+    id: Type.String({ minLength: 1 }),
+    tool: Type.String(),
+    arguments: Type.Unknown(),
+    status: DynamicToolCallStatusSchema,
+    contentItems: Type.Union([Type.Array(Type.Unknown()), Type.Null()]),
+    success: Type.Union([Type.Boolean(), Type.Null()]),
+    durationMs: Type.Union([Type.Number(), Type.Null()]),
+  },
+  { additionalProperties: false },
+);
+
+const CollabAgentToolCallItemSchema = Type.Object(
+  {
+    type: Type.Literal("collabAgentToolCall"),
+    id: Type.String({ minLength: 1 }),
+    tool: CollabAgentToolSchema,
+    status: CollabAgentToolCallStatusSchema,
+    senderThreadId: Type.String({ minLength: 1 }),
+    receiverThreadIds: Type.Array(Type.String({ minLength: 1 })),
+    prompt: Type.Union([Type.String(), Type.Null()]),
+    agentsStates: Type.Record(Type.String(), Type.Unknown()),
+  },
+  { additionalProperties: false },
+);
+
+const WebSearchItemSchema = Type.Object(
+  {
+    type: Type.Literal("webSearch"),
+    id: Type.String({ minLength: 1 }),
+    query: Type.String(),
+    action: Type.Union([WebSearchActionSchema, Type.Null()]),
+  },
+  { additionalProperties: false },
+);
+
+const ImageViewItemSchema = Type.Object(
+  {
+    type: Type.Literal("imageView"),
+    id: Type.String({ minLength: 1 }),
+    path: Type.String({ minLength: 1 }),
+  },
+  { additionalProperties: false },
+);
+
+const ImageGenerationItemSchema = Type.Object(
+  {
+    type: Type.Literal("imageGeneration"),
+    id: Type.String({ minLength: 1 }),
+    status: Type.String({ minLength: 1 }),
+    revisedPrompt: Type.Union([Type.String(), Type.Null()]),
+    result: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+const EnteredReviewModeItemSchema = Type.Object(
+  {
+    type: Type.Literal("enteredReviewMode"),
+    id: Type.String({ minLength: 1 }),
+    review: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+const ExitedReviewModeItemSchema = Type.Object(
+  {
+    type: Type.Literal("exitedReviewMode"),
+    id: Type.String({ minLength: 1 }),
+    review: Type.String(),
+  },
+  { additionalProperties: false },
+);
+
+const ContextCompactionItemSchema = Type.Object(
+  {
+    type: Type.Literal("contextCompaction"),
+    id: Type.String({ minLength: 1 }),
+  },
+  { additionalProperties: false },
+);
+
+export const TurnItemSchema = Type.Union([
+  UserMessageItemSchema,
+  AgentMessageItemSchema,
+  PlanItemSchema,
+  ReasoningItemSchema,
+  CommandExecutionItemSchema,
+  FileChangeItemSchema,
+  McpToolCallItemSchema,
+  DynamicToolCallItemSchema,
+  CollabAgentToolCallItemSchema,
+  WebSearchItemSchema,
+  ImageViewItemSchema,
+  ImageGenerationItemSchema,
+  EnteredReviewModeItemSchema,
+  ExitedReviewModeItemSchema,
+  ContextCompactionItemSchema,
+]);
 export type TurnItem = Static<typeof TurnItemSchema>;
+
+export const TurnTerminalErrorSchema = Type.Object(
+  {
+    message: Type.String({ minLength: 1 }),
+    providerError: Type.Union([Type.Unknown(), Type.Null()]),
+    additionalDetails: Type.Union([Type.String(), Type.Null()]),
+  },
+  { additionalProperties: false },
+);
+export type TurnTerminalError = Static<typeof TurnTerminalErrorSchema>;
+
+export const TurnDetailSchema = Type.Object(
+  {
+    id: Type.String({ minLength: 1 }),
+    status: TurnStatusSchema,
+    items: Type.Array(TurnItemSchema),
+    error: Type.Union([TurnTerminalErrorSchema, Type.Null()]),
+  },
+  { additionalProperties: false },
+);
+export type TurnDetail = Static<typeof TurnDetailSchema>;
+
+export const TurnPlanStepSchema = Type.Object(
+  {
+    step: Type.String({ minLength: 1 }),
+    status: Type.Union([
+      Type.Literal("pending"),
+      Type.Literal("in_progress"),
+      Type.Literal("completed"),
+    ]),
+  },
+  { additionalProperties: false },
+);
+export type TurnPlanStep = Static<typeof TurnPlanStepSchema>;
+
+export const TurnDiffFileSummarySchema = Type.Object(
+  {
+    path: Type.String({ minLength: 1 }),
+    additions: Type.Integer(),
+    deletions: Type.Integer(),
+  },
+  { additionalProperties: false },
+);
+export type TurnDiffFileSummary = Static<typeof TurnDiffFileSummarySchema>;
 
 export const TurnStartParamsSchema = Type.Object(
   {
@@ -88,6 +368,32 @@ export type TurnStartedNotificationParams = Static<typeof TurnStartedNotificatio
 
 export const TurnCompletedNotificationParamsSchema = TurnStartedNotificationParamsSchema;
 export type TurnCompletedNotificationParams = Static<typeof TurnCompletedNotificationParamsSchema>;
+
+export const TurnPlanUpdatedNotificationParamsSchema = Type.Object(
+  {
+    threadId: Type.String({ minLength: 1 }),
+    turnId: Type.String({ minLength: 1 }),
+    explanation: Type.Optional(Type.String()),
+    steps: Type.Array(TurnPlanStepSchema),
+  },
+  { additionalProperties: false },
+);
+export type TurnPlanUpdatedNotificationParams = Static<
+  typeof TurnPlanUpdatedNotificationParamsSchema
+>;
+
+export const TurnDiffUpdatedNotificationParamsSchema = Type.Object(
+  {
+    threadId: Type.String({ minLength: 1 }),
+    turnId: Type.String({ minLength: 1 }),
+    diff: Type.String(),
+    summary: Type.Array(TurnDiffFileSummarySchema),
+  },
+  { additionalProperties: false },
+);
+export type TurnDiffUpdatedNotificationParams = Static<
+  typeof TurnDiffUpdatedNotificationParamsSchema
+>;
 
 export const ItemStartedNotificationParamsSchema = Type.Object(
   {

--- a/AppServer/src/turns/turn.handlers.ts
+++ b/AppServer/src/turns/turn.handlers.ts
@@ -357,9 +357,41 @@ export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModul
         });
         return;
       }
+      case "plan": {
+        if (notification.threadId === undefined || notification.turnId === undefined) {
+          return;
+        }
+
+        await fanOutThreadNotification(notification.threadId, {
+          method: "turn/plan/updated",
+          params: {
+            threadId: notification.threadId,
+            turnId: notification.turnId,
+            ...(notification.explanation !== undefined
+              ? { explanation: notification.explanation }
+              : {}),
+            steps: [...notification.steps],
+          },
+        });
+        return;
+      }
+      case "diff": {
+        if (notification.threadId === undefined || notification.turnId === undefined) {
+          return;
+        }
+
+        await fanOutThreadNotification(notification.threadId, {
+          method: "turn/diff/updated",
+          params: {
+            threadId: notification.threadId,
+            turnId: notification.turnId,
+            diff: notification.diff,
+            summary: [...notification.summary],
+          },
+        });
+        return;
+      }
       case "approval":
-      case "plan":
-      case "diff":
       case "error":
         return;
       default:
@@ -436,11 +468,7 @@ export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModul
       return;
     }
 
-    const item = Object.freeze({
-      id: notification.item.id,
-      kind: notification.item.kind,
-      rawItem: notification.item.rawItem,
-    });
+    const item = notification.item;
 
     if (notification.event === "started") {
       const wasRecorded = activeTurns.recordItemStarted({

--- a/AppServer/src/turns/turn.handlers.ts
+++ b/AppServer/src/turns/turn.handlers.ts
@@ -362,6 +362,10 @@ export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModul
           return;
         }
 
+        // Plan updates are intentionally live-only in this phase. We forward the
+        // latest provider event to loaded-thread subscribers, but do not fold
+        // plan state into active-turn snapshots until recovery/reattachment work
+        // gives the turns module a durable replay surface for them.
         await fanOutThreadNotification(notification.threadId, {
           method: "turn/plan/updated",
           params: {
@@ -380,6 +384,9 @@ export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModul
           return;
         }
 
+        // Diff updates follow the same live-only tradeoff as plan updates in
+        // this phase: they are streamed to active subscribers, but not stored
+        // in active-turn snapshots yet.
         await fanOutThreadNotification(notification.threadId, {
           method: "turn/diff/updated",
           params: {


### PR DESCRIPTION
## Summary
- add typed App Server item, turn-detail, and thread-detail contracts for readback and notifications
- enable `thread/read` with `includeTurns: true` to return provider-authoritative turn and item history without loading the thread
- forward `turn/plan/updated` and `turn/diff/updated` notifications and reconcile active turn state so completed items override delta-built state
- expand the Codex adapter protocol and mappers to parse typed turn history and item lifecycle payloads
- remove the obsolete `includeTurns=true` unsupported path

## Testing
- `bun x biome check src`
- `bun x tsc --noEmit`
- `bun test src/threads/service.test.ts src/turns/active-turn-registry.test.ts src/app/protocol-harness.test.ts src/agents/codex-adapter/session.test.ts src/agents/codex-adapter/notification-mapper.test.ts src/agents/codex-adapter/model-mapper.test.ts`