### PR TITLE
Add App Server turn controls and approval lifecycle handling

### DIFF
--- a/AppServer/src/agents/codex-adapter/notification-mapper.test.ts
+++ b/AppServer/src/agents/codex-adapter/notification-mapper.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  mapCodexResolvedApproval,
   mapCodexServerRequest,
   mapCodexTransportNotification,
 } from "@/agents/codex-adapter/notification-mapper";
@@ -507,5 +508,206 @@ describe("mapCodexServerRequest", () => {
         },
       },
     ]);
+  });
+
+  test("maps file change approval requests into provider-neutral approval notifications", () => {
+    const approvalFixture = {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "item-2",
+      reason: "Needs write access",
+      grantRoot: "/tmp/project",
+    };
+
+    expect(
+      mapCodexServerRequest(
+        {
+          id: "approval-2",
+          method: "item/fileChange/requestApproval",
+          params: approvalFixture,
+        },
+        context,
+      ),
+    ).toEqual([
+      {
+        agentId: "codex",
+        provider: "codex",
+        receivedAt: "2026-04-10T12:00:00.000Z",
+        rawMethod: "item/fileChange/requestApproval",
+        rawPayload: approvalFixture,
+        type: "approval",
+        event: "requested",
+        requestId: "approval-2",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "item-2",
+        approval: {
+          requestId: "approval-2",
+          kind: "fileChange",
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "item-2",
+          supportedResolutions: ["approved", "approvedForSession", "declined", "cancelled"],
+          reason: "Needs write access",
+          grantRoot: "/tmp/project",
+          rawRequest: {
+            id: "approval-2",
+            method: "item/fileChange/requestApproval",
+            params: approvalFixture,
+          },
+        },
+      },
+    ]);
+  });
+
+  test("maps MCP elicitation approval requests with form and url variants", () => {
+    const formFixture = {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "item-3",
+      serverName: "docs",
+      mode: "form",
+      message: "Need extra fields",
+      requestedSchema: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+          },
+        },
+      },
+      _meta: {
+        source: "mcp",
+      },
+    };
+    const urlFixture = {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "item-4",
+      serverName: "browser",
+      mode: "url",
+      message: "Open this link",
+      url: "https://example.com",
+      elicitationId: "elicit-1",
+    };
+
+    expect(
+      mapCodexServerRequest(
+        {
+          id: "approval-3",
+          method: "mcpServer/elicitation/request",
+          params: formFixture,
+        },
+        context,
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        requestId: "approval-3",
+        approval: {
+          requestId: "approval-3",
+          kind: "mcpElicitation",
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "item-3",
+          supportedResolutions: ["approved", "declined", "cancelled"],
+          serverName: "docs",
+          mode: "form",
+          message: "Need extra fields",
+          requestedSchema: formFixture.requestedSchema,
+          url: null,
+          elicitationId: null,
+          metadata: {
+            source: "mcp",
+          },
+          rawRequest: {
+            id: "approval-3",
+            method: "mcpServer/elicitation/request",
+            params: formFixture,
+          },
+        },
+      }),
+    ]);
+    expect(
+      mapCodexServerRequest(
+        {
+          id: "approval-4",
+          method: "mcpServer/elicitation/request",
+          params: urlFixture,
+        },
+        context,
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        requestId: "approval-4",
+        approval: {
+          requestId: "approval-4",
+          kind: "mcpElicitation",
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "item-4",
+          supportedResolutions: ["approved", "declined", "cancelled"],
+          serverName: "browser",
+          mode: "url",
+          message: "Open this link",
+          requestedSchema: null,
+          url: "https://example.com",
+          elicitationId: "elicit-1",
+          metadata: null,
+          rawRequest: {
+            id: "approval-4",
+            method: "mcpServer/elicitation/request",
+            params: urlFixture,
+          },
+        },
+      }),
+    ]);
+  });
+});
+
+describe("mapCodexResolvedApproval", () => {
+  test("maps resolved approvals with the recorded client resolution", () => {
+    expect(
+      mapCodexResolvedApproval(
+        "approval-1",
+        {
+          approval: {
+            requestId: "approval-1",
+            kind: "fileChange",
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "item-1",
+            supportedResolutions: ["approved", "declined", "cancelled"],
+            reason: "Write files",
+            grantRoot: "/tmp/project",
+            rawRequest: {},
+          },
+          resolution: "declined",
+        },
+        context,
+      ),
+    ).toEqual({
+      agentId: "codex",
+      provider: "codex",
+      receivedAt: "2026-04-10T12:00:00.000Z",
+      rawMethod: "serverRequest/resolved",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "item-1",
+      type: "approval",
+      event: "resolved",
+      requestId: "approval-1",
+      approval: {
+        requestId: "approval-1",
+        kind: "fileChange",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "item-1",
+        supportedResolutions: ["approved", "declined", "cancelled"],
+        reason: "Write files",
+        grantRoot: "/tmp/project",
+        rawRequest: {},
+      },
+      resolution: "declined",
+    });
   });
 });

--- a/AppServer/src/agents/codex-adapter/notification-mapper.test.ts
+++ b/AppServer/src/agents/codex-adapter/notification-mapper.test.ts
@@ -488,6 +488,17 @@ describe("mapCodexServerRequest", () => {
           threadId: "thread-1",
           turnId: "turn-1",
           itemId: "item-1",
+          supportedResolutions: ["approved", "approvedForSession", "declined", "cancelled"],
+          approvalId: null,
+          reason: null,
+          command: "git status",
+          cwd: "/tmp/project",
+          commandActions: [
+            {
+              type: "unknown",
+              command: "git status",
+            },
+          ],
           rawRequest: {
             id: "approval-1",
             method: "item/commandExecution/requestApproval",

--- a/AppServer/src/agents/codex-adapter/notification-mapper.ts
+++ b/AppServer/src/agents/codex-adapter/notification-mapper.ts
@@ -19,6 +19,7 @@ import type {
   CodexTransportServerRequest,
 } from "@/agents/codex-adapter/transport";
 import type {
+  AgentApprovalDecisionResolution,
   AgentApprovalNotification,
   AgentApprovalRequest,
   AgentApprovalResolution,
@@ -379,10 +380,12 @@ export const mapCodexServerRequest = (
   switch (request.method) {
     case "item/commandExecution/requestApproval":
     case "item/fileChange/requestApproval":
-    case "mcpServer/elicitation/request":
+    case "mcpServer/elicitation/request": {
       if (params === null) {
         return [buildMalformedMessage(base, request.method)];
       }
+
+      const approval = mapApprovalRequest(request, params);
 
       return [
         {
@@ -390,19 +393,13 @@ export const mapCodexServerRequest = (
           type: "approval",
           event: "requested",
           requestId: request.id,
-          threadId: typeof params.threadId === "string" ? params.threadId : undefined,
-          turnId: typeof params.turnId === "string" ? params.turnId : undefined,
-          itemId: typeof params.itemId === "string" ? params.itemId : undefined,
-          approval: {
-            requestId: request.id,
-            kind: mapApprovalKind(request.method),
-            threadId: typeof params.threadId === "string" ? params.threadId : undefined,
-            turnId: typeof params.turnId === "string" ? params.turnId : undefined,
-            itemId: typeof params.itemId === "string" ? params.itemId : undefined,
-            rawRequest: request,
-          },
+          threadId: approval.threadId,
+          turnId: approval.turnId ?? undefined,
+          itemId: approval.itemId ?? undefined,
+          approval,
         },
       ];
+    }
     default:
       return [
         {
@@ -431,8 +428,8 @@ export const mapCodexResolvedApproval = (
     receivedAt: context.receivedAt ?? new Date().toISOString(),
     rawMethod: "serverRequest/resolved",
     threadId: pendingApproval.approval.threadId,
-    turnId: pendingApproval.approval.turnId,
-    itemId: pendingApproval.approval.itemId,
+    turnId: pendingApproval.approval.turnId ?? undefined,
+    itemId: pendingApproval.approval.itemId ?? undefined,
     type: "approval",
     event: "resolved",
     requestId,
@@ -492,17 +489,116 @@ const buildPartialThreadSummary = (
     status,
   });
 
-const mapApprovalKind = (method: string): AgentApprovalRequest["kind"] => {
-  switch (method) {
+const mapApprovalRequest = (
+  request: CodexTransportServerRequest,
+  params: Record<string, unknown>,
+): AgentApprovalRequest => {
+  switch (request.method) {
     case "item/commandExecution/requestApproval":
-      return "commandExecution";
+      return Object.freeze({
+        requestId: request.id,
+        kind: "commandExecution" as const,
+        threadId: typeof params.threadId === "string" ? params.threadId : undefined,
+        turnId: typeof params.turnId === "string" ? params.turnId : null,
+        itemId: typeof params.itemId === "string" ? params.itemId : null,
+        supportedResolutions: Object.freeze(
+          getSupportedCommandApprovalResolutions(params.availableDecisions),
+        ),
+        approvalId: typeof params.approvalId === "string" ? params.approvalId : null,
+        reason: typeof params.reason === "string" ? params.reason : null,
+        command: typeof params.command === "string" ? params.command : null,
+        cwd: typeof params.cwd === "string" ? params.cwd : null,
+        commandActions: Array.isArray(params.commandActions)
+          ? Object.freeze([...params.commandActions])
+          : null,
+        rawRequest: request,
+      });
     case "item/fileChange/requestApproval":
-      return "fileChange";
+      return Object.freeze({
+        requestId: request.id,
+        kind: "fileChange" as const,
+        threadId: typeof params.threadId === "string" ? params.threadId : undefined,
+        turnId: typeof params.turnId === "string" ? params.turnId : null,
+        itemId: typeof params.itemId === "string" ? params.itemId : null,
+        supportedResolutions: Object.freeze([
+          "approved",
+          "approvedForSession",
+          "declined",
+          "cancelled",
+        ] as const),
+        reason: typeof params.reason === "string" ? params.reason : null,
+        grantRoot: typeof params.grantRoot === "string" ? params.grantRoot : null,
+        rawRequest: request,
+      });
     case "mcpServer/elicitation/request":
-      return "mcpElicitation";
+      return Object.freeze({
+        requestId: request.id,
+        kind: "mcpElicitation" as const,
+        threadId: typeof params.threadId === "string" ? params.threadId : undefined,
+        turnId: typeof params.turnId === "string" ? params.turnId : null,
+        itemId: typeof params.itemId === "string" ? params.itemId : null,
+        supportedResolutions: Object.freeze(["approved", "declined", "cancelled"] as const),
+        serverName: typeof params.serverName === "string" ? params.serverName : "unknown",
+        mode: params.mode === "url" ? "url" : "form",
+        message: typeof params.message === "string" ? params.message : "",
+        requestedSchema:
+          params.mode === "form" && "requestedSchema" in params
+            ? (params.requestedSchema ?? null)
+            : null,
+        url: params.mode === "url" && typeof params.url === "string" ? params.url : null,
+        elicitationId:
+          params.mode === "url" && typeof params.elicitationId === "string"
+            ? params.elicitationId
+            : null,
+        metadata: "_meta" in params ? (params._meta ?? null) : null,
+        rawRequest: request,
+      });
     default:
-      return "unknown";
+      return Object.freeze({
+        requestId: request.id,
+        kind: "unknown" as const,
+        threadId: typeof params.threadId === "string" ? params.threadId : undefined,
+        turnId: typeof params.turnId === "string" ? params.turnId : null,
+        itemId: typeof params.itemId === "string" ? params.itemId : null,
+        supportedResolutions: Object.freeze(["cancelled"] as const),
+        rawRequest: request,
+      });
   }
+};
+
+const getSupportedCommandApprovalResolutions = (
+  availableDecisions: unknown,
+): readonly AgentApprovalDecisionResolution[] => {
+  if (!Array.isArray(availableDecisions)) {
+    return Object.freeze(["approved", "approvedForSession", "declined", "cancelled"] as const);
+  }
+
+  const resolutions = new Set<AgentApprovalDecisionResolution>();
+
+  for (const decision of availableDecisions) {
+    switch (decision) {
+      case "accept":
+        resolutions.add("approved");
+        break;
+      case "acceptForSession":
+        resolutions.add("approvedForSession");
+        break;
+      case "decline":
+        resolutions.add("declined");
+        break;
+      case "cancel":
+        resolutions.add("cancelled");
+        break;
+      default:
+        break;
+    }
+  }
+
+  if (resolutions.size === 0) {
+    return Object.freeze(["approved", "approvedForSession", "declined", "cancelled"] as const);
+  }
+
+  return Object.freeze([...resolutions]);
 };
 
 const summarizeDiff = (diff: string): readonly AgentDiffFileSummary[] => {

--- a/AppServer/src/agents/codex-adapter/notification-mapper.ts
+++ b/AppServer/src/agents/codex-adapter/notification-mapper.ts
@@ -12,6 +12,9 @@ import {
   CodexReasoningSummaryTextDeltaNotificationSchema,
   CodexReasoningTextDeltaNotificationSchema,
   CodexThreadItemSchema,
+  CodexThreadSchema,
+  CodexThreadStatusSchema,
+  CodexTurnSchema,
 } from "@/agents/codex-adapter/protocol";
 import type {
   CodexTransportDisconnectInfo,
@@ -55,19 +58,21 @@ export const mapCodexTransportNotification = (
 
   switch (notification.method) {
     case "thread/started":
-      return params && isPlainObject(params.thread)
+      return params && Value.Check(CodexThreadSchema, params.thread)
         ? [
             {
               ...base,
               type: "thread",
               event: "started",
               threadId: typeof params.thread.id === "string" ? params.thread.id : undefined,
-              thread: mapCodexThreadSummary(params.thread as never),
+              thread: mapCodexThreadSummary(params.thread),
             },
           ]
         : [buildMalformedMessage(base, "thread/started")];
     case "thread/status/changed":
-      return params && typeof params.threadId === "string" && isPlainObject(params.status)
+      return params &&
+        typeof params.threadId === "string" &&
+        Value.Check(CodexThreadStatusSchema, params.status)
         ? [
             {
               ...base,
@@ -78,7 +83,7 @@ export const mapCodexTransportNotification = (
                 params.threadId,
                 receivedAt,
                 false,
-                mapCodexThreadStatus(params.status as never),
+                mapCodexThreadStatus(params.status),
               ),
             },
           ]
@@ -151,8 +156,7 @@ export const mapCodexTransportNotification = (
     case "turn/started":
       return params &&
         typeof params.threadId === "string" &&
-        isPlainObject(params.turn) &&
-        typeof params.turn.id === "string"
+        Value.Check(CodexTurnSchema, params.turn)
         ? [
             {
               ...base,
@@ -160,15 +164,14 @@ export const mapCodexTransportNotification = (
               event: "started",
               threadId: params.threadId,
               turnId: params.turn.id,
-              turn: mapCodexTurnSummary(params.turn as never),
+              turn: mapCodexTurnSummary(params.turn),
             },
           ]
         : [buildMalformedMessage(base, "turn/started")];
     case "turn/completed":
       return params &&
         typeof params.threadId === "string" &&
-        isPlainObject(params.turn) &&
-        typeof params.turn.id === "string"
+        Value.Check(CodexTurnSchema, params.turn)
         ? [
             {
               ...base,
@@ -176,7 +179,7 @@ export const mapCodexTransportNotification = (
               event: "completed",
               threadId: params.threadId,
               turnId: params.turn.id,
-              turn: mapCodexTurnSummary(params.turn as never),
+              turn: mapCodexTurnSummary(params.turn),
             },
           ]
         : [buildMalformedMessage(base, "turn/completed")];

--- a/AppServer/src/agents/codex-adapter/protocol.ts
+++ b/AppServer/src/agents/codex-adapter/protocol.ts
@@ -42,7 +42,7 @@ const CodexModelListResponseSchema = Type.Object(
   { additionalProperties: true },
 );
 
-const CodexThreadStatusSchema = Type.Union([
+export const CodexThreadStatusSchema = Type.Union([
   Type.Object(
     {
       type: Type.Literal("notLoaded"),
@@ -114,7 +114,7 @@ export const CodexTurnDetailSchema = Type.Object(
   { additionalProperties: true },
 );
 
-const CodexThreadSchema = Type.Object(
+export const CodexThreadSchema = Type.Object(
   {
     id: Type.String(),
     preview: Type.String(),
@@ -154,7 +154,7 @@ const CodexConfiguredThreadResponseSchema = Type.Object(
   { additionalProperties: true },
 );
 
-const CodexTurnSchema = Type.Object(
+export const CodexTurnSchema = Type.Object(
   {
     id: Type.String(),
     status: Type.Union([

--- a/AppServer/src/agents/codex-adapter/session.test.ts
+++ b/AppServer/src/agents/codex-adapter/session.test.ts
@@ -1013,6 +1013,95 @@ describe("createCodexAgentSession", () => {
     );
   });
 
+  test("rejects duplicate approval resolves while a provider response is already in flight", async () => {
+    let releaseRespond = () => {};
+    const respondBlocked = new Promise<void>((resolve) => {
+      releaseRespond = resolve;
+    });
+    const executablePath = createFakeExecutable();
+    const transport = new FakeTransport([{ userAgent: "Codex/Test" }], {
+      onRespond: async () => {
+        await respondBlocked;
+      },
+    });
+    const sessionResult = await createCodexAgentSession({
+      agentId: "codex",
+      config: {
+        id: "codex",
+        provider: "codex",
+      },
+      logger: createSilentLogger(),
+      transport,
+      environmentResolver: new BaseEnvironmentResolver({
+        inheritedEnvironment: {
+          ATELIERCODE_CODEX_PATH: executablePath,
+          PATH: path.dirname(executablePath),
+          HOME: "/Users/tester",
+          SHELL: "/bin/zsh",
+        },
+      }),
+    });
+
+    expect(sessionResult.ok).toBe(true);
+    if (!sessionResult.ok) {
+      throw new Error("Expected the Codex session to be created.");
+    }
+
+    await sessionResult.data.listModels("req-init", {});
+
+    transport.emit({
+      type: "serverRequest",
+      request: {
+        id: "approval-1",
+        method: "item/commandExecution/requestApproval",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "item-1",
+        },
+      },
+    });
+
+    const firstResolvePromise = sessionResult.data.resolveApproval({
+      requestId: "approval-1",
+      resolution: "approved",
+    });
+    await Promise.resolve();
+
+    await expect(
+      sessionResult.data.resolveApproval({
+        requestId: "approval-1",
+        resolution: "declined",
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: {
+        type: "invalidProviderMessage",
+        agentId: "codex",
+        provider: "codex",
+        message: "Approval request approval-1 is already being resolved.",
+        detail: {
+          requestId: "approval-1",
+        },
+      },
+    });
+
+    releaseRespond();
+    await expect(firstResolvePromise).resolves.toEqual({
+      ok: true,
+      data: {
+        requestId: "approval-1",
+        resolution: "approved",
+      },
+    });
+    expect(transport.responded).toEqual([
+      {
+        id: "approval-1",
+        result: "accept",
+      },
+    ]);
+  });
+
   test("does not mark the session ready when transport disconnects during initialized notification", async () => {
     const executablePath = createFakeExecutable();
     const transport = new FakeTransport([{ userAgent: "Codex/Test" }], {
@@ -1183,6 +1272,7 @@ describe("createCodexAgentSession", () => {
 
 type FakeTransportOptions = Readonly<{
   onNotify?: (notification: CodexTransportNotification, transport: FakeTransport) => void;
+  onRespond?: (response: CodexTransportResponse, transport: FakeTransport) => Promise<void> | void;
 }>;
 
 class FakeTransport implements CodexTransport {
@@ -1233,6 +1323,7 @@ class FakeTransport implements CodexTransport {
     }
 
     this.responded.push(response);
+    await this.options.onRespond?.(response, this);
   }
 
   subscribe(listener: (event: CodexTransportEvent) => void): () => void {

--- a/AppServer/src/agents/codex-adapter/session.ts
+++ b/AppServer/src/agents/codex-adapter/session.ts
@@ -173,7 +173,11 @@ const createConnectedSession = (options: ConnectedSessionOptions): AgentSession 
   const listeners = new Set<(notification: AgentNotification) => void>();
   const approvalsByRequestId = new Map<
     string,
-    { approval: AgentApprovalRequest; resolution?: AgentApprovalResolveParams["resolution"] }
+    {
+      approval: AgentApprovalRequest;
+      resolution?: AgentApprovalResolveParams["resolution"];
+      responding: boolean;
+    }
   >();
   let state: AgentSession["getState"] extends () => infer T ? T : never = "idle";
   let initializePromise: Promise<Result<void, AgentOperationError>> | null = null;
@@ -243,6 +247,7 @@ const createConnectedSession = (options: ConnectedSessionOptions): AgentSession 
           if (notification.type === "approval" && notification.event === "requested") {
             approvalsByRequestId.set(requestIdKey(notification.requestId), {
               approval: notification.approval,
+              responding: false,
             });
           }
           emit(notification);
@@ -619,7 +624,21 @@ const createConnectedSession = (options: ConnectedSessionOptions): AgentSession 
       });
     }
 
-    pendingApproval.resolution = params.resolution;
+    if (pendingApproval.responding) {
+      return err({
+        type: "invalidProviderMessage",
+        agentId: options.agentId,
+        provider: "codex",
+        message: `Approval request ${String(params.requestId)} is already being resolved.`,
+        detail: { requestId: params.requestId },
+      });
+    }
+
+    approvalsByRequestId.set(requestIdKey(params.requestId), {
+      ...pendingApproval,
+      resolution: params.resolution,
+      responding: true,
+    });
 
     try {
       const response: CodexTransportResponse = {
@@ -632,6 +651,7 @@ const createConnectedSession = (options: ConnectedSessionOptions): AgentSession 
         resolution: params.resolution,
       });
     } catch (error) {
+      approvalsByRequestId.set(requestIdKey(params.requestId), pendingApproval);
       return err(
         normalizeOperationError(
           options.agentId,
@@ -752,7 +772,7 @@ const buildApprovalDecision = (
     case "mcpElicitation":
       return mapMcpElicitationResolution(params.resolution);
     case "unknown":
-      return mapFileChangeApprovalResolution(params.resolution);
+      return mapUnknownApprovalResolution(params.resolution);
   }
 };
 
@@ -798,6 +818,19 @@ const mapMcpElicitationResolution = (
   content: null,
   _meta: null,
 });
+
+const mapUnknownApprovalResolution = (
+  resolution: AgentApprovalResolveParams["resolution"],
+): CodexFileChangeApprovalDecision => {
+  switch (resolution) {
+    case "cancelled":
+      return "cancel";
+    case "approved":
+    case "approvedForSession":
+    case "declined":
+      throw new Error(`Unknown approval requests cannot be resolved as ${resolution}.`);
+  }
+};
 
 const applyCodexEnvironmentOverrides = (
   environment: Readonly<Record<string, string | undefined>>,

--- a/AppServer/src/agents/codex-adapter/session.ts
+++ b/AppServer/src/agents/codex-adapter/session.ts
@@ -767,7 +767,6 @@ const mapCommandApprovalResolution = (
     case "declined":
       return "decline";
     case "cancelled":
-    case "stale":
       return "cancel";
   }
 };
@@ -783,7 +782,6 @@ const mapFileChangeApprovalResolution = (
     case "declined":
       return "decline";
     case "cancelled":
-    case "stale":
       return "cancel";
   }
 };

--- a/AppServer/src/agents/contracts.ts
+++ b/AppServer/src/agents/contracts.ts
@@ -233,21 +233,73 @@ export type AgentDiffFileSummary = Readonly<{
 
 export type AgentApprovalKind = "commandExecution" | "fileChange" | "mcpElicitation" | "unknown";
 
-export type AgentApprovalRequest = Readonly<{
-  requestId: AgentRequestId;
-  kind: AgentApprovalKind;
-  threadId?: string;
-  turnId?: string;
-  itemId?: string;
-  rawRequest: unknown;
-}>;
-
-export type AgentApprovalResolution =
+export type AgentApprovalDecisionResolution =
   | "approved"
   | "approvedForSession"
   | "declined"
-  | "cancelled"
-  | "stale";
+  | "cancelled";
+
+export type AgentApprovalCommandExecutionRequest = Readonly<{
+  requestId: AgentRequestId;
+  kind: "commandExecution";
+  threadId?: string;
+  turnId?: string | null;
+  itemId?: string | null;
+  supportedResolutions: readonly AgentApprovalDecisionResolution[];
+  approvalId: string | null;
+  reason: string | null;
+  command: string | null;
+  cwd: string | null;
+  commandActions: readonly unknown[] | null;
+  rawRequest: unknown;
+}>;
+
+export type AgentApprovalFileChangeRequest = Readonly<{
+  requestId: AgentRequestId;
+  kind: "fileChange";
+  threadId?: string;
+  turnId?: string | null;
+  itemId?: string | null;
+  supportedResolutions: readonly AgentApprovalDecisionResolution[];
+  reason: string | null;
+  grantRoot: string | null;
+  rawRequest: unknown;
+}>;
+
+export type AgentApprovalMcpElicitationRequest = Readonly<{
+  requestId: AgentRequestId;
+  kind: "mcpElicitation";
+  threadId?: string;
+  turnId?: string | null;
+  itemId?: string | null;
+  supportedResolutions: readonly AgentApprovalDecisionResolution[];
+  serverName: string;
+  mode: "form" | "url";
+  message: string;
+  requestedSchema: unknown | null;
+  url: string | null;
+  elicitationId: string | null;
+  metadata: unknown | null;
+  rawRequest: unknown;
+}>;
+
+export type AgentApprovalUnknownRequest = Readonly<{
+  requestId: AgentRequestId;
+  kind: "unknown";
+  threadId?: string;
+  turnId?: string | null;
+  itemId?: string | null;
+  supportedResolutions: readonly AgentApprovalDecisionResolution[];
+  rawRequest: unknown;
+}>;
+
+export type AgentApprovalRequest =
+  | AgentApprovalCommandExecutionRequest
+  | AgentApprovalFileChangeRequest
+  | AgentApprovalMcpElicitationRequest
+  | AgentApprovalUnknownRequest;
+
+export type AgentApprovalResolution = AgentApprovalDecisionResolution | "stale";
 
 export type AgentNotificationBase = Readonly<{
   agentId: string;
@@ -517,12 +569,12 @@ export type AgentTurnResult = Readonly<{
 
 export type AgentApprovalResolveParams = Readonly<{
   requestId: AgentRequestId;
-  resolution: AgentApprovalResolution;
+  resolution: AgentApprovalDecisionResolution;
 }>;
 
 export type AgentApprovalResolveResult = Readonly<{
   requestId: AgentRequestId;
-  resolution: AgentApprovalResolution;
+  resolution: AgentApprovalDecisionResolution;
 }>;
 
 export type AgentSession = Readonly<{

--- a/AppServer/src/agents/protocol-errors.ts
+++ b/AppServer/src/agents/protocol-errors.ts
@@ -1,5 +1,6 @@
 import type { AgentRemoteError, AgentSessionUnavailableError } from "@/agents/contracts";
 import {
+  ATELIER_AGENT_NOT_FOUND_ERROR,
   ATELIER_AGENT_SESSION_UNAVAILABLE_ERROR,
   ATELIER_PROVIDER_ERROR,
   createProtocolMethodError,
@@ -31,5 +32,15 @@ export const createProviderError = (error: AgentRemoteError): ProtocolMethodErro
       provider: error.provider,
       providerCode: String(error.code),
       providerMessage: error.message,
+    }),
+  );
+
+export const createAgentNotFoundProtocolError = (agentId: string): ProtocolMethodError =>
+  createProtocolMethodError(
+    ATELIER_AGENT_NOT_FOUND_ERROR,
+    "Requested agent is not configured",
+    Object.freeze({
+      code: "AGENT_NOT_FOUND",
+      agentId,
     }),
   );

--- a/AppServer/src/app/protocol-harness.test.ts
+++ b/AppServer/src/app/protocol-harness.test.ts
@@ -12,7 +12,7 @@ import {
   createAppTransportComponent,
 } from "@/app/protocol";
 import { type AppServer, createAppServer, type SignalRegistrar } from "@/app/server";
-import { createApprovalsModulePlaceholder } from "@/approvals";
+import { createApprovalsModule } from "@/approvals";
 import { type AppDatabase, createStoreBootstrap } from "@/core/store";
 import {
   createFakeAgentAdapter,
@@ -2073,6 +2073,557 @@ describe("App Server protocol harness", () => {
     }
   });
 
+  test("fans out approval request and resolution notifications only to loaded-thread subscribers", async () => {
+    const workspacePath = await createWorkspaceDirectory();
+    const canonicalWorkspacePath = await realpath(workspacePath);
+    const session = createFakeAgentSession({
+      resumeThread: async (_requestId, params) => ({
+        ok: true,
+        data: {
+          thread: createTestAgentThread({
+            id: params.threadId,
+            workspacePath: canonicalWorkspacePath,
+          }),
+          model: "gpt-5.4",
+          reasoningEffort: "medium",
+        },
+      }),
+      startTurn: async () => ({
+        ok: true,
+        data: {
+          turn: createTestAgentTurn({
+            id: "turn-1",
+          }),
+        },
+      }),
+    });
+    const harness = await createProtocolHarness({
+      agentAdapters: [
+        createFakeAgentAdapter({
+          session,
+        }),
+      ],
+    });
+    const clientA = await connectProtocolClient(harness.port);
+    const clientB = await connectProtocolClient(harness.port);
+    const bystander = await connectProtocolClient(harness.port);
+
+    try {
+      await initializeClient(clientA);
+      await initializeClient(clientB);
+      await initializeClient(bystander);
+      await openWorkspaceClient(clientA, workspacePath);
+      await openWorkspaceClient(clientB, workspacePath);
+      await openWorkspaceClient(bystander, workspacePath);
+
+      clientA.sendJson({
+        id: "req-thread-resume-a",
+        method: "thread/resume",
+        params: {
+          threadId: "thread-live",
+        },
+      });
+      clientB.sendJson({
+        id: "req-thread-resume-b",
+        method: "thread/resume",
+        params: {
+          threadId: "thread-live",
+        },
+      });
+
+      await clientA.nextMessage();
+      await clientB.nextMessage();
+
+      clientA.sendJson({
+        id: "req-turn-start",
+        method: "turn/start",
+        params: {
+          threadId: "thread-live",
+          prompt: "Run the command",
+        },
+      });
+      await clientA.nextMessage();
+
+      session.emitNotification(
+        createItemStartedNotification({
+          threadId: "thread-live",
+          turnId: "turn-1",
+          itemId: "item-command",
+          itemType: "commandExecution",
+        }),
+      );
+      session.emitNotification(
+        createApprovalRequestedNotification({
+          threadId: "thread-live",
+          turnId: "turn-1",
+          itemId: "item-command",
+          requestId: "approval-1",
+        }),
+      );
+
+      await expect(clientA.nextMessage()).resolves.toEqual({
+        method: "item/started",
+        params: {
+          threadId: "thread-live",
+          turnId: "turn-1",
+          item: buildHarnessItem("commandExecution", "item-command", "started"),
+        },
+      });
+      await expect(clientB.nextMessage()).resolves.toEqual({
+        method: "item/started",
+        params: {
+          threadId: "thread-live",
+          turnId: "turn-1",
+          item: buildHarnessItem("commandExecution", "item-command", "started"),
+        },
+      });
+      await expect(clientA.nextMessage()).resolves.toEqual({
+        method: "approval/requested",
+        params: {
+          threadId: "thread-live",
+          approval: {
+            requestId: "approval-1",
+            kind: "commandExecution",
+            threadId: "thread-live",
+            turnId: "turn-1",
+            itemId: "item-command",
+            supportedResolutions: ["approved", "approvedForSession", "declined", "cancelled"],
+            approvalId: null,
+            reason: "Run git status",
+            command: "git status",
+            cwd: "/tmp/project",
+            commandActions: [
+              {
+                type: "unknown",
+                command: "git status",
+              },
+            ],
+          },
+        },
+      });
+      await expect(clientB.nextMessage()).resolves.toEqual({
+        method: "approval/requested",
+        params: {
+          threadId: "thread-live",
+          approval: {
+            requestId: "approval-1",
+            kind: "commandExecution",
+            threadId: "thread-live",
+            turnId: "turn-1",
+            itemId: "item-command",
+            supportedResolutions: ["approved", "approvedForSession", "declined", "cancelled"],
+            approvalId: null,
+            reason: "Run git status",
+            command: "git status",
+            cwd: "/tmp/project",
+            commandActions: [
+              {
+                type: "unknown",
+                command: "git status",
+              },
+            ],
+          },
+        },
+      });
+      await expect(bystander.nextMessage(150)).rejects.toThrow("Timed out waiting for message");
+
+      clientA.sendJson({
+        id: "req-approval-resolve",
+        method: "approval/resolve",
+        params: {
+          requestId: "approval-1",
+          resolution: "approved",
+        },
+      });
+
+      const clientAMessages = [await clientA.nextMessage(), await clientA.nextMessage()];
+      expect(clientAMessages).toContainEqual({
+        id: "req-approval-resolve",
+        result: {
+          requestId: "approval-1",
+          resolution: "approved",
+        },
+      });
+      expect(clientAMessages).toContainEqual({
+        method: "approval/resolved",
+        params: {
+          threadId: "thread-live",
+          approval: {
+            requestId: "approval-1",
+            kind: "commandExecution",
+            threadId: "thread-live",
+            turnId: "turn-1",
+            itemId: "item-command",
+            supportedResolutions: ["approved", "approvedForSession", "declined", "cancelled"],
+            approvalId: null,
+            reason: "Run git status",
+            command: "git status",
+            cwd: "/tmp/project",
+            commandActions: [
+              {
+                type: "unknown",
+                command: "git status",
+              },
+            ],
+          },
+          resolution: "approved",
+        },
+      });
+      await expect(clientB.nextMessage()).resolves.toEqual({
+        method: "approval/resolved",
+        params: {
+          threadId: "thread-live",
+          approval: {
+            requestId: "approval-1",
+            kind: "commandExecution",
+            threadId: "thread-live",
+            turnId: "turn-1",
+            itemId: "item-command",
+            supportedResolutions: ["approved", "approvedForSession", "declined", "cancelled"],
+            approvalId: null,
+            reason: "Run git status",
+            command: "git status",
+            cwd: "/tmp/project",
+            commandActions: [
+              {
+                type: "unknown",
+                command: "git status",
+              },
+            ],
+          },
+          resolution: "approved",
+        },
+      });
+      await expect(bystander.nextMessage(150)).rejects.toThrow("Timed out waiting for message");
+      expect(session.resolveApprovalCalls).toEqual([
+        {
+          params: {
+            requestId: "approval-1",
+            resolution: "approved",
+          },
+        },
+      ]);
+    } finally {
+      await clientA.close();
+      await clientB.close();
+      await bystander.close();
+    }
+  });
+
+  test("supports turn controls and rejects stale or inactive turn sequencing", async () => {
+    const workspacePath = await createWorkspaceDirectory();
+    const canonicalWorkspacePath = await realpath(workspacePath);
+    const session = createFakeAgentSession({
+      resumeThread: async (_requestId, params) => ({
+        ok: true,
+        data: {
+          thread: createTestAgentThread({
+            id: params.threadId,
+            workspacePath: canonicalWorkspacePath,
+          }),
+          model: "gpt-5.4",
+          reasoningEffort: "medium",
+        },
+      }),
+      startTurn: async () => ({
+        ok: true,
+        data: {
+          turn: createTestAgentTurn({
+            id: "turn-1",
+          }),
+        },
+      }),
+      steerTurn: async () => ({
+        ok: true,
+        data: {
+          turn: createTestAgentTurn({
+            id: "turn-1",
+            status: {
+              type: "awaitingInput",
+            },
+          }),
+        },
+      }),
+    });
+    const harness = await createProtocolHarness({
+      agentAdapters: [
+        createFakeAgentAdapter({
+          session,
+        }),
+      ],
+    });
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      await initializeClient(client);
+      await openWorkspaceClient(client, workspacePath);
+
+      client.sendJson({
+        id: "req-thread-resume",
+        method: "thread/resume",
+        params: {
+          threadId: "thread-live",
+        },
+      });
+      await client.nextMessage();
+
+      client.sendJson({
+        id: "req-turn-start",
+        method: "turn/start",
+        params: {
+          threadId: "thread-live",
+          prompt: "Start the turn",
+        },
+      });
+      await client.nextMessage();
+
+      client.sendJson({
+        id: "req-turn-steer",
+        method: "turn/steer",
+        params: {
+          threadId: "thread-live",
+          turnId: "turn-1",
+          prompt: "Steer the turn",
+        },
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-turn-steer",
+        result: {
+          turn: {
+            id: "turn-1",
+            status: {
+              type: "awaitingInput",
+            },
+          },
+        },
+      });
+
+      client.sendJson({
+        id: "req-turn-steer-stale",
+        method: "turn/steer",
+        params: {
+          threadId: "thread-live",
+          turnId: "turn-2",
+          prompt: "Use a stale turn id",
+        },
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-turn-steer-stale",
+        error: {
+          code: -33013,
+          message: "Requested turn is not the active turn",
+          data: {
+            code: "TURN_ID_MISMATCH",
+            threadId: "thread-live",
+            requestedTurnId: "turn-2",
+            activeTurnId: "turn-1",
+          },
+        },
+      });
+      expect(session.steerTurnCalls).toHaveLength(1);
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("marks pending approvals stale when a turn completes and returns interrupted turn summaries", async () => {
+    const workspacePath = await createWorkspaceDirectory();
+    const canonicalWorkspacePath = await realpath(workspacePath);
+    const session = createFakeAgentSession({
+      resumeThread: async (_requestId, params) => ({
+        ok: true,
+        data: {
+          thread: createTestAgentThread({
+            id: params.threadId,
+            workspacePath: canonicalWorkspacePath,
+          }),
+          model: "gpt-5.4",
+          reasoningEffort: "medium",
+        },
+      }),
+      startTurn: async () => ({
+        ok: true,
+        data: {
+          turn: createTestAgentTurn({
+            id: "turn-1",
+          }),
+        },
+      }),
+      interruptTurn: async () => ({
+        ok: true,
+        data: {
+          turn: createTestAgentTurn({
+            id: "turn-1",
+            status: {
+              type: "interrupted",
+            },
+          }),
+        },
+      }),
+    });
+    const harness = await createProtocolHarness({
+      agentAdapters: [
+        createFakeAgentAdapter({
+          session,
+        }),
+      ],
+    });
+    const client = await connectProtocolClient(harness.port);
+
+    try {
+      await initializeClient(client);
+      await openWorkspaceClient(client, workspacePath);
+
+      client.sendJson({
+        id: "req-thread-resume",
+        method: "thread/resume",
+        params: {
+          threadId: "thread-live",
+        },
+      });
+      await client.nextMessage();
+
+      client.sendJson({
+        id: "req-turn-start",
+        method: "turn/start",
+        params: {
+          threadId: "thread-live",
+          prompt: "Start the turn",
+        },
+      });
+      await client.nextMessage();
+
+      session.emitNotification(
+        createApprovalRequestedNotification({
+          threadId: "thread-live",
+          turnId: "turn-1",
+          itemId: "item-command",
+          requestId: "approval-1",
+        }),
+      );
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        method: "approval/requested",
+        params: {
+          threadId: "thread-live",
+          approval: {
+            requestId: "approval-1",
+            kind: "commandExecution",
+            threadId: "thread-live",
+            turnId: "turn-1",
+            itemId: "item-command",
+            supportedResolutions: ["approved", "approvedForSession", "declined", "cancelled"],
+            approvalId: null,
+            reason: "Run git status",
+            command: "git status",
+            cwd: "/tmp/project",
+            commandActions: [
+              {
+                type: "unknown",
+                command: "git status",
+              },
+            ],
+          },
+        },
+      });
+
+      client.sendJson({
+        id: "req-turn-interrupt",
+        method: "turn/interrupt",
+        params: {
+          threadId: "thread-live",
+          turnId: "turn-1",
+        },
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-turn-interrupt",
+        result: {
+          turn: {
+            id: "turn-1",
+            status: {
+              type: "interrupted",
+            },
+          },
+        },
+      });
+
+      client.sendJson({
+        id: "req-turn-interrupt-again",
+        method: "turn/interrupt",
+        params: {
+          threadId: "thread-live",
+          turnId: "turn-1",
+        },
+      });
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        id: "req-turn-interrupt-again",
+        error: {
+          code: -33012,
+          message: "Thread does not have an active turn",
+          data: {
+            code: "TURN_NOT_ACTIVE",
+            threadId: "thread-live",
+          },
+        },
+      });
+
+      session.emitNotification(
+        createTurnCompletedNotification({
+          threadId: "thread-live",
+          turnId: "turn-1",
+          status: {
+            type: "interrupted",
+          },
+        }),
+      );
+
+      await expect(client.nextMessage()).resolves.toEqual({
+        method: "approval/resolved",
+        params: {
+          threadId: "thread-live",
+          approval: {
+            requestId: "approval-1",
+            kind: "commandExecution",
+            threadId: "thread-live",
+            turnId: "turn-1",
+            itemId: "item-command",
+            supportedResolutions: ["approved", "approvedForSession", "declined", "cancelled"],
+            approvalId: null,
+            reason: "Run git status",
+            command: "git status",
+            cwd: "/tmp/project",
+            commandActions: [
+              {
+                type: "unknown",
+                command: "git status",
+              },
+            ],
+          },
+          resolution: "stale",
+        },
+      });
+      await expect(client.nextMessage()).resolves.toEqual({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-live",
+          turn: {
+            id: "turn-1",
+            status: {
+              type: "interrupted",
+            },
+          },
+        },
+      });
+      expect(session.interruptTurnCalls).toHaveLength(1);
+    } finally {
+      await client.close();
+    }
+  });
+
   test("keeps thread/read archive projections consistent after archive and unarchive mutations", async () => {
     const workspacePath = await createWorkspaceDirectory();
     const canonicalWorkspacePath = await realpath(workspacePath);
@@ -2970,6 +3521,14 @@ const createProtocolHarness = async (
     ],
     registerMethod: appProtocolRuntime.registerMethod,
   });
+  let approvalsModule: ReturnType<typeof createApprovalsModule> | undefined;
+  const getApprovalsModule = (): ReturnType<typeof createApprovalsModule> => {
+    if (approvalsModule === undefined) {
+      throw new Error("Approvals module is not initialized.");
+    }
+
+    return approvalsModule;
+  };
   threadsModule = createThreadsModule({
     logger: logger.withContext({ component: "module.threads" }),
     registerMethod: appProtocolRuntime.registerMethod,
@@ -2979,8 +3538,24 @@ const createProtocolHarness = async (
       options.threadsStoreFactory?.(storeBootstrap.getDatabase) ??
       createSqliteThreadsStore(storeBootstrap.getDatabase),
     getOpenedWorkspace: workspacesModule.getOpenedWorkspace,
+    onThreadClosed: async (threadId) => {
+      await approvalsModule?.handleThreadClosed(threadId);
+    },
+    onSessionDisconnected: async () => {
+      await approvalsModule?.handleSessionDisconnected();
+    },
   });
   const finalizedThreadsModule = threadsModule;
+  approvalsModule = createApprovalsModule({
+    logger: logger.withContext({ component: "module.approvals" }),
+    registerMethod: appProtocolRuntime.registerMethod,
+    sendNotification: appProtocolRuntime.sendNotification,
+    registry: agentsModule.registry,
+    loadedThreads: {
+      isThreadLoadedForConnection: finalizedThreadsModule.isThreadLoadedForConnection,
+      listLoadedThreadSubscribers: finalizedThreadsModule.listLoadedThreadSubscribers,
+    },
+  });
   const turnsModule = createTurnsModule({
     logger: logger.withContext({ component: "module.turns" }),
     registerMethod: appProtocolRuntime.registerMethod,
@@ -2990,6 +3565,10 @@ const createProtocolHarness = async (
     loadedThreads: {
       isThreadLoadedForConnection: finalizedThreadsModule.isThreadLoadedForConnection,
       listLoadedThreadSubscribers: finalizedThreadsModule.listLoadedThreadSubscribers,
+    },
+    ensureApprovalNotificationBinding: () => getApprovalsModule().ensureNotificationBinding(),
+    onTurnCompleted: async ({ threadId, turnId }) => {
+      await getApprovalsModule().handleTurnCompleted({ threadId, turnId });
     },
   });
   const transportComponent = createAppTransportComponent({
@@ -3014,7 +3593,7 @@ const createProtocolHarness = async (
       workspacesModule.lifecycle,
       finalizedThreadsModule.lifecycle,
       turnsModule.lifecycle,
-      createApprovalsModulePlaceholder(),
+      approvalsModule.lifecycle,
       transportComponent,
     ],
   });
@@ -3466,6 +4045,46 @@ const createDiffUpdatedNotification = (input: { threadId: string; turnId: string
       deletions: 0,
     },
   ],
+});
+
+const createApprovalRequestedNotification = (input: {
+  threadId: string;
+  turnId: string;
+  itemId: string;
+  requestId: string;
+}) => ({
+  agentId: "codex",
+  provider: "codex" as const,
+  receivedAt: "2026-04-10T12:00:00.000Z",
+  rawMethod: "item/commandExecution/requestApproval",
+  threadId: input.threadId,
+  turnId: input.turnId,
+  itemId: input.itemId,
+  type: "approval" as const,
+  event: "requested" as const,
+  requestId: input.requestId,
+  approval: {
+    requestId: input.requestId,
+    kind: "commandExecution" as const,
+    threadId: input.threadId,
+    turnId: input.turnId,
+    itemId: input.itemId,
+    supportedResolutions: ["approved", "approvedForSession", "declined", "cancelled"] as const,
+    approvalId: null,
+    reason: "Run git status",
+    command: "git status",
+    cwd: "/tmp/project",
+    commandActions: [
+      {
+        type: "unknown",
+        command: "git status",
+      },
+    ],
+    rawRequest: {
+      id: input.requestId,
+      method: "item/commandExecution/requestApproval",
+    },
+  },
 });
 
 const createItemStartedNotification = (input: {

--- a/AppServer/src/app/server.ts
+++ b/AppServer/src/app/server.ts
@@ -7,7 +7,7 @@ import {
 } from "@/app/config";
 import { createLogger, type Logger, type LogWriter } from "@/app/logger";
 import { createAppProtocolRuntime, createAppTransportComponent } from "@/app/protocol";
-import { createApprovalsModulePlaceholder } from "@/approvals";
+import { createApprovalsModule } from "@/approvals";
 import { getErrorMessage, type LifecycleComponent } from "@/core/shared";
 import { createStoreBootstrap } from "@/core/store";
 import { createSqliteThreadsStore, createThreadsModule } from "@/threads";
@@ -342,6 +342,14 @@ const createDefaultComponents = (
     ],
     registerMethod: appProtocolRuntime.registerMethod,
   });
+  let approvalsModule: ReturnType<typeof createApprovalsModule> | undefined;
+  const getApprovalsModule = (): ReturnType<typeof createApprovalsModule> => {
+    if (approvalsModule === undefined) {
+      throw new Error("Approvals module is not initialized.");
+    }
+
+    return approvalsModule;
+  };
   threadsModule = createThreadsModule({
     logger: logger.withContext({ component: "module.threads" }),
     registerMethod: appProtocolRuntime.registerMethod,
@@ -349,8 +357,24 @@ const createDefaultComponents = (
     registry: agentsModule.registry,
     store: createSqliteThreadsStore(storeBootstrap.getDatabase),
     getOpenedWorkspace: workspacesModule.getOpenedWorkspace,
+    onThreadClosed: async (threadId) => {
+      await approvalsModule?.handleThreadClosed(threadId);
+    },
+    onSessionDisconnected: async () => {
+      await approvalsModule?.handleSessionDisconnected();
+    },
   });
   const finalizedThreadsModule = threadsModule;
+  approvalsModule = createApprovalsModule({
+    logger: logger.withContext({ component: "module.approvals" }),
+    registerMethod: appProtocolRuntime.registerMethod,
+    sendNotification: appProtocolRuntime.sendNotification,
+    registry: agentsModule.registry,
+    loadedThreads: {
+      isThreadLoadedForConnection: finalizedThreadsModule.isThreadLoadedForConnection,
+      listLoadedThreadSubscribers: finalizedThreadsModule.listLoadedThreadSubscribers,
+    },
+  });
   const turnsModule = createTurnsModule({
     logger: logger.withContext({ component: "module.turns" }),
     registerMethod: appProtocolRuntime.registerMethod,
@@ -360,6 +384,10 @@ const createDefaultComponents = (
     loadedThreads: {
       isThreadLoadedForConnection: finalizedThreadsModule.isThreadLoadedForConnection,
       listLoadedThreadSubscribers: finalizedThreadsModule.listLoadedThreadSubscribers,
+    },
+    ensureApprovalNotificationBinding: () => getApprovalsModule().ensureNotificationBinding(),
+    onTurnCompleted: async ({ threadId, turnId }) => {
+      await getApprovalsModule().handleTurnCompleted({ threadId, turnId });
     },
   });
   const transportComponent = createAppTransportComponent({
@@ -381,7 +409,7 @@ const createDefaultComponents = (
     workspacesModule.lifecycle,
     finalizedThreadsModule.lifecycle,
     turnsModule.lifecycle,
-    createApprovalsModulePlaceholder(),
+    approvalsModule.lifecycle,
     transportComponent,
   ]);
 };

--- a/AppServer/src/approvals/approval-registry.test.ts
+++ b/AppServer/src/approvals/approval-registry.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { createApprovalRegistry } from "@/approvals/approval-registry";
+import type { ApprovalCommandExecutionRequest } from "@/approvals/schemas";
+
+const createCommandApproval = (requestId: string): ApprovalCommandExecutionRequest => ({
+  requestId,
+  kind: "commandExecution" as const,
+  threadId: "thread-1",
+  turnId: "turn-1",
+  itemId: "item-1",
+  supportedResolutions: ["approved", "declined", "cancelled"],
+  approvalId: null,
+  reason: null,
+  command: "git status",
+  cwd: "/tmp/project",
+  commandActions: null,
+});
+
+describe("createApprovalRegistry", () => {
+  test("tracks pending approvals and resolves them by request id", () => {
+    const registry = createApprovalRegistry();
+    registry.recordRequested(createCommandApproval("approval-1"));
+
+    expect(registry.getPending("approval-1")).toEqual({
+      approval: createCommandApproval("approval-1"),
+      state: "pending",
+    });
+
+    expect(registry.markResolved("approval-1", "approved")).toEqual({
+      approval: createCommandApproval("approval-1"),
+      state: "resolved",
+      resolution: "approved",
+    });
+    expect(registry.getPending("approval-1")).toBeUndefined();
+  });
+
+  test("clears only approvals scoped to the completed turn", () => {
+    const registry = createApprovalRegistry();
+    registry.recordRequested(createCommandApproval("approval-1"));
+    registry.recordRequested(
+      Object.freeze({
+        ...createCommandApproval("approval-2"),
+        turnId: "turn-2",
+      }),
+    );
+
+    expect(registry.clearTurn({ threadId: "thread-1", turnId: "turn-1" })).toEqual([
+      {
+        approval: createCommandApproval("approval-1"),
+        state: "pending",
+      },
+    ]);
+    expect(registry.getPending("approval-1")).toBeUndefined();
+    expect(registry.getPending("approval-2")).toEqual({
+      approval: Object.freeze({
+        ...createCommandApproval("approval-2"),
+        turnId: "turn-2",
+      }),
+      state: "pending",
+    });
+  });
+});

--- a/AppServer/src/approvals/approval-registry.test.ts
+++ b/AppServer/src/approvals/approval-registry.test.ts
@@ -59,4 +59,88 @@ describe("createApprovalRegistry", () => {
       state: "pending",
     });
   });
+
+  test("clears a single request without disturbing others", () => {
+    const registry = createApprovalRegistry();
+    registry.recordRequested(createCommandApproval("approval-1"));
+    registry.recordRequested(createCommandApproval("approval-2"));
+
+    expect(registry.clearRequest("approval-1")).toEqual({
+      approval: createCommandApproval("approval-1"),
+      state: "pending",
+    });
+    expect(registry.getPending("approval-1")).toBeUndefined();
+    expect(registry.getPending("approval-2")).toEqual({
+      approval: createCommandApproval("approval-2"),
+      state: "pending",
+    });
+  });
+
+  test("clears approvals for an entire thread", () => {
+    const registry = createApprovalRegistry();
+    registry.recordRequested(createCommandApproval("approval-1"));
+    registry.recordRequested(
+      Object.freeze({
+        ...createCommandApproval("approval-2"),
+        threadId: "thread-2",
+      }),
+    );
+
+    expect(registry.clearThread("thread-1")).toEqual([
+      {
+        approval: createCommandApproval("approval-1"),
+        state: "pending",
+      },
+    ]);
+    expect(registry.getPending("approval-1")).toBeUndefined();
+    expect(registry.getPending("approval-2")).toEqual({
+      approval: Object.freeze({
+        ...createCommandApproval("approval-2"),
+        threadId: "thread-2",
+      }),
+      state: "pending",
+    });
+  });
+
+  test("clears all tracked approvals", () => {
+    const registry = createApprovalRegistry();
+    registry.recordRequested(createCommandApproval("approval-1"));
+    registry.recordRequested(createCommandApproval("approval-2"));
+
+    expect(registry.clearAll()).toEqual([
+      {
+        approval: createCommandApproval("approval-1"),
+        state: "pending",
+      },
+      {
+        approval: createCommandApproval("approval-2"),
+        state: "pending",
+      },
+    ]);
+    expect(registry.getPending("approval-1")).toBeUndefined();
+    expect(registry.getPending("approval-2")).toBeUndefined();
+  });
+
+  test("treats numeric and string request ids as distinct keys", () => {
+    const registry = createApprovalRegistry();
+    registry.recordRequested(
+      Object.freeze({
+        ...createCommandApproval("123"),
+        requestId: 123,
+      }),
+    );
+    registry.recordRequested(createCommandApproval("123"));
+
+    expect(registry.getPending(123)).toEqual({
+      approval: Object.freeze({
+        ...createCommandApproval("123"),
+        requestId: 123,
+      }),
+      state: "pending",
+    });
+    expect(registry.getPending("123")).toEqual({
+      approval: createCommandApproval("123"),
+      state: "pending",
+    });
+  });
 });

--- a/AppServer/src/approvals/approval-registry.ts
+++ b/AppServer/src/approvals/approval-registry.ts
@@ -1,0 +1,102 @@
+import type { ApprovalDecisionResolution, ApprovalRequest } from "@/approvals/schemas";
+import type { RequestId } from "@/core/protocol";
+
+export type ApprovalRegistryRecord =
+  | Readonly<{
+      approval: ApprovalRequest;
+      state: "pending";
+    }>
+  | Readonly<{
+      approval: ApprovalRequest;
+      state: "resolved";
+      resolution: ApprovalDecisionResolution;
+    }>;
+
+export type ApprovalRegistry = Readonly<{
+  recordRequested: (approval: ApprovalRequest) => ApprovalRegistryRecord;
+  getPending: (requestId: RequestId) => ApprovalRegistryRecord | undefined;
+  markResolved: (
+    requestId: RequestId,
+    resolution: ApprovalDecisionResolution,
+  ) => ApprovalRegistryRecord | undefined;
+  clearRequest: (requestId: RequestId) => ApprovalRegistryRecord | undefined;
+  clearTurn: (
+    input: Readonly<{ threadId: string; turnId: string }>,
+  ) => readonly ApprovalRegistryRecord[];
+  clearThread: (threadId: string) => readonly ApprovalRegistryRecord[];
+  clearAll: () => readonly ApprovalRegistryRecord[];
+}>;
+
+export const createApprovalRegistry = (): ApprovalRegistry => {
+  const recordsByRequestId = new Map<string, ApprovalRegistryRecord>();
+
+  return Object.freeze({
+    recordRequested: (approval) => {
+      const record = Object.freeze({
+        approval,
+        state: "pending" as const,
+      });
+      recordsByRequestId.set(requestIdKey(approval.requestId), record);
+      return record;
+    },
+    getPending: (requestId) => {
+      const record = recordsByRequestId.get(requestIdKey(requestId));
+      if (record?.state !== "pending") {
+        return undefined;
+      }
+
+      return record;
+    },
+    markResolved: (requestId, resolution) => {
+      const record = recordsByRequestId.get(requestIdKey(requestId));
+      if (record?.state !== "pending") {
+        return undefined;
+      }
+
+      const resolvedRecord = Object.freeze({
+        approval: record.approval,
+        state: "resolved" as const,
+        resolution,
+      });
+      recordsByRequestId.set(requestIdKey(requestId), resolvedRecord);
+      return resolvedRecord;
+    },
+    clearRequest: (requestId) => {
+      const key = requestIdKey(requestId);
+      const record = recordsByRequestId.get(key);
+      if (record === undefined) {
+        return undefined;
+      }
+
+      recordsByRequestId.delete(key);
+      return record;
+    },
+    clearTurn: ({ threadId, turnId }) =>
+      clearMatchingRecords(recordsByRequestId, (record) => {
+        return record.approval.threadId === threadId && record.approval.turnId === turnId;
+      }),
+    clearThread: (threadId) =>
+      clearMatchingRecords(recordsByRequestId, (record) => record.approval.threadId === threadId),
+    clearAll: () => clearMatchingRecords(recordsByRequestId, () => true),
+  });
+};
+
+const clearMatchingRecords = (
+  recordsByRequestId: Map<string, ApprovalRegistryRecord>,
+  predicate: (record: ApprovalRegistryRecord) => boolean,
+): readonly ApprovalRegistryRecord[] => {
+  const clearedRecords: ApprovalRegistryRecord[] = [];
+
+  for (const [key, record] of recordsByRequestId.entries()) {
+    if (!predicate(record)) {
+      continue;
+    }
+
+    recordsByRequestId.delete(key);
+    clearedRecords.push(record);
+  }
+
+  return Object.freeze(clearedRecords);
+};
+
+const requestIdKey = (requestId: RequestId): string => `${typeof requestId}:${String(requestId)}`;

--- a/AppServer/src/approvals/approval.handlers.test.ts
+++ b/AppServer/src/approvals/approval.handlers.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentRegistry } from "@/agents/registry";
+import { createAppProtocolRuntime } from "@/app/protocol";
+import { createApprovalsModule } from "@/approvals/approval.handlers";
+import { createFakeAgentRegistry, createFakeAgentSession } from "@/test-support/agents";
+import { createSilentLogger } from "@/test-support/logger";
+
+const logger = createSilentLogger("error");
+const connectionId = "connection-1";
+
+describe("createApprovalsModule", () => {
+  test("maps agent lookup failures to protocol errors", async () => {
+    const outbound: string[] = [];
+    const runtime = createAppProtocolRuntime({ logger });
+    createApprovalsModule({
+      logger,
+      registerMethod: runtime.registerMethod,
+      sendNotification: runtime.sendNotification,
+      registry: createAgentNotFoundRegistry(),
+      loadedThreads: {
+        isThreadLoadedForConnection: () => true,
+        listLoadedThreadSubscribers: () => [connectionId],
+      },
+    });
+
+    await initializeConnection(runtime, outbound);
+    outbound.length = 0;
+
+    await runtime.handleIncomingText({
+      connectionId,
+      text: JSON.stringify({
+        id: "req-approval-resolve",
+        method: "approval/resolve",
+        params: {
+          requestId: "approval-1",
+          resolution: "approved",
+        },
+      }),
+    });
+
+    expect(JSON.parse(outbound[0] ?? "null")).toEqual({
+      id: "req-approval-resolve",
+      error: {
+        code: -33016,
+        message: "Requested agent is not configured",
+        data: {
+          code: "AGENT_NOT_FOUND",
+          agentId: "missing-agent",
+        },
+      },
+    });
+  });
+
+  test("emits the resolved notification before returning success", async () => {
+    const outbound: string[] = [];
+    const runtime = createAppProtocolRuntime({ logger });
+    const session = createFakeAgentSession();
+    const approvalsModule = createApprovalsModule({
+      logger,
+      registerMethod: runtime.registerMethod,
+      sendNotification: runtime.sendNotification,
+      registry: createFakeAgentRegistry(session),
+      loadedThreads: {
+        isThreadLoadedForConnection: () => true,
+        listLoadedThreadSubscribers: () => [connectionId],
+      },
+    });
+
+    await initializeConnection(runtime, outbound);
+    await approvalsModule.ensureNotificationBinding();
+
+    session.emitNotification({
+      agentId: "codex",
+      provider: "codex",
+      receivedAt: "2026-04-12T10:00:00.000Z",
+      rawMethod: "item/commandExecution/requestApproval",
+      rawPayload: {
+        threadId: "thread-1",
+      },
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "item-1",
+      type: "approval",
+      event: "requested",
+      requestId: "approval-1",
+      approval: {
+        requestId: "approval-1",
+        kind: "commandExecution",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "item-1",
+        supportedResolutions: ["approved", "declined", "cancelled"],
+        approvalId: null,
+        reason: null,
+        command: "git status",
+        cwd: "/tmp/project",
+        commandActions: null,
+        rawRequest: {},
+      },
+    });
+    await flushAsyncWork();
+    outbound.length = 0;
+
+    await runtime.handleIncomingText({
+      connectionId,
+      text: JSON.stringify({
+        id: "req-approval-resolve",
+        method: "approval/resolve",
+        params: {
+          requestId: "approval-1",
+          resolution: "approved",
+        },
+      }),
+    });
+
+    expect(outbound.map((message) => JSON.parse(message))).toEqual([
+      {
+        method: "approval/resolved",
+        params: {
+          threadId: "thread-1",
+          approval: {
+            requestId: "approval-1",
+            kind: "commandExecution",
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "item-1",
+            supportedResolutions: ["approved", "declined", "cancelled"],
+            approvalId: null,
+            reason: null,
+            command: "git status",
+            cwd: "/tmp/project",
+            commandActions: null,
+          },
+          resolution: "approved",
+        },
+      },
+      {
+        id: "req-approval-resolve",
+        result: {
+          requestId: "approval-1",
+          resolution: "approved",
+        },
+      },
+    ]);
+  });
+});
+
+const initializeConnection = async (
+  runtime: ReturnType<typeof createAppProtocolRuntime>,
+  outbound: string[],
+): Promise<void> => {
+  runtime.openConnection({
+    connectionId,
+    sendText: async (text) => {
+      outbound.push(text);
+    },
+  });
+
+  await runtime.handleIncomingText({
+    connectionId,
+    text: JSON.stringify({
+      id: "req-initialize",
+      method: "initialize",
+      params: {
+        clientInfo: {
+          name: "AtelierCode Test",
+          version: "0.1.0",
+        },
+      },
+    }),
+  });
+};
+
+const flushAsyncWork = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const createAgentNotFoundRegistry = (): AgentRegistry => ({
+  getDefaultAgentId: () => "missing-agent",
+  listAgents: () => [],
+  getAgent: () => undefined,
+  getSession: async () => ({
+    ok: false,
+    error: {
+      type: "agentNotFound",
+      agentId: "missing-agent",
+      message: 'Agent "missing-agent" is not configured.',
+    },
+  }),
+  disconnectAll: async () => {},
+});

--- a/AppServer/src/approvals/approval.handlers.ts
+++ b/AppServer/src/approvals/approval.handlers.ts
@@ -1,0 +1,340 @@
+import type {
+  AgentApprovalRequest,
+  AgentNotification,
+  AgentSession,
+  AgentSessionLookupError,
+} from "@/agents/contracts";
+import { createAgentSessionUnavailableError, createProviderError } from "@/agents/protocol-errors";
+import type { AgentRegistry } from "@/agents/registry";
+import type { Logger } from "@/app/logger";
+import { type ApprovalRegistryRecord, createApprovalRegistry } from "@/approvals/approval-registry";
+import {
+  type ApprovalRequest,
+  ApprovalResolveParamsSchema,
+  type ApprovalResolveResult,
+  ApprovalResolveResultSchema,
+} from "@/approvals/schemas";
+import {
+  type ApprovalsServiceError,
+  createApprovalsService,
+  mapInvalidApprovalProviderPayloadToProtocolError,
+} from "@/approvals/service";
+import type { ProtocolDispatcher, ProtocolEngine, ProtocolNotification } from "@/core/protocol";
+import {
+  createApprovalNotPendingError,
+  createSessionNotInitializedResult,
+  createThreadNotLoadedForConnectionError,
+  createUnsupportedApprovalResolutionError,
+  isProtocolMethodError,
+  type ProtocolMethodError,
+} from "@/core/protocol/errors";
+import {
+  assertNever,
+  err,
+  getErrorMessage,
+  type LifecycleComponent,
+  ok,
+  type Result,
+} from "@/core/shared";
+
+export type LoadedThreadAccess = Readonly<{
+  isThreadLoadedForConnection: (
+    input: Readonly<{ connectionId: string; threadId: string }>,
+  ) => boolean;
+  listLoadedThreadSubscribers: (threadId: string) => readonly string[];
+}>;
+
+export type ApprovalsModule = Readonly<{
+  lifecycle: LifecycleComponent;
+  ensureNotificationBinding: () => Promise<Result<void, AgentSessionLookupError>>;
+  handleTurnCompleted: (input: Readonly<{ threadId: string; turnId: string }>) => Promise<void>;
+  handleThreadClosed: (threadId: string) => Promise<void>;
+  handleSessionDisconnected: () => Promise<void>;
+}>;
+
+export type CreateApprovalsModuleOptions = Readonly<{
+  logger: Logger;
+  registerMethod: ProtocolDispatcher["registerMethod"];
+  sendNotification: ProtocolEngine["sendNotification"];
+  registry: AgentRegistry;
+  loadedThreads: LoadedThreadAccess;
+}>;
+
+export const createApprovalsModule = (options: CreateApprovalsModuleOptions): ApprovalsModule => {
+  const approvals = createApprovalRegistry();
+  const service = createApprovalsService({
+    registry: options.registry,
+    approvals,
+  });
+
+  let subscribedSession: AgentSession | undefined;
+  let unsubscribeFromSession: (() => void) | undefined;
+  let notificationChain = Promise.resolve();
+
+  const resetSessionSubscription = (): void => {
+    unsubscribeFromSession?.();
+    unsubscribeFromSession = undefined;
+    subscribedSession = undefined;
+  };
+
+  const sendApprovalNotification = async (
+    connectionId: string,
+    threadId: string,
+    notification: ProtocolNotification,
+  ): Promise<void> => {
+    try {
+      await options.sendNotification({
+        connectionId,
+        notification,
+      });
+    } catch (error) {
+      options.logger.warn("Failed to send approval notification", {
+        connectionId,
+        threadId,
+        method: notification.method,
+        error: getErrorMessage(error),
+      });
+    }
+  };
+
+  const fanOutThreadNotification = async (
+    threadId: string,
+    notification: ProtocolNotification,
+  ): Promise<void> => {
+    const connectionIds = options.loadedThreads.listLoadedThreadSubscribers(threadId);
+    if (connectionIds.length === 0) {
+      return;
+    }
+
+    for (const connectionId of connectionIds) {
+      await sendApprovalNotification(connectionId, threadId, notification);
+    }
+  };
+
+  const emitResolvedNotification = async (
+    approval: ApprovalRequest,
+    resolution: "approved" | "approvedForSession" | "declined" | "cancelled" | "stale",
+  ): Promise<void> => {
+    await fanOutThreadNotification(approval.threadId, {
+      method: "approval/resolved",
+      params: {
+        threadId: approval.threadId,
+        approval,
+        resolution,
+      },
+    });
+  };
+
+  const emitStaleResolutions = async (
+    clearedRecords: readonly ApprovalRegistryRecord[],
+  ): Promise<void> => {
+    for (const record of clearedRecords) {
+      if (record.state !== "pending") {
+        continue;
+      }
+
+      await emitResolvedNotification(record.approval, "stale");
+    }
+  };
+
+  const forwardAgentNotification = async (notification: AgentNotification): Promise<void> => {
+    if (notification.type !== "approval") {
+      return;
+    }
+
+    switch (notification.event) {
+      case "requested": {
+        if (notification.approval.threadId === undefined) {
+          return;
+        }
+
+        const approval = mapAgentApprovalRequest(notification.approval);
+        approvals.recordRequested(approval);
+        await fanOutThreadNotification(approval.threadId, {
+          method: "approval/requested",
+          params: {
+            threadId: approval.threadId,
+            approval,
+          },
+        });
+        return;
+      }
+      case "resolved": {
+        const clearedRecord = approvals.clearRequest(notification.requestId);
+        if (clearedRecord === undefined || clearedRecord.state === "resolved") {
+          return;
+        }
+
+        await emitResolvedNotification(clearedRecord.approval, notification.resolution ?? "stale");
+        return;
+      }
+      default:
+        return;
+    }
+  };
+
+  const ensureNotificationBinding = async (): Promise<Result<void, AgentSessionLookupError>> => {
+    const sessionResult = await options.registry.getSession();
+    if (!sessionResult.ok) {
+      return err(sessionResult.error);
+    }
+
+    if (subscribedSession === sessionResult.data) {
+      return ok(undefined);
+    }
+
+    resetSessionSubscription();
+    subscribedSession = sessionResult.data;
+    unsubscribeFromSession = sessionResult.data.subscribe((notification) => {
+      notificationChain = notificationChain
+        .catch(() => {})
+        .then(() => forwardAgentNotification(notification));
+    });
+
+    return ok(undefined);
+  };
+
+  options.registerMethod({
+    method: "approval/resolve",
+    paramsSchema: ApprovalResolveParamsSchema,
+    resultSchema: ApprovalResolveResultSchema,
+    handler: async ({ connectionId, params, session }) => {
+      if (!session.isInitialized()) {
+        return createSessionNotInitializedResult();
+      }
+
+      const pendingApproval = approvals.getPending(params.requestId);
+      if (
+        pendingApproval !== undefined &&
+        !options.loadedThreads.isThreadLoadedForConnection({
+          connectionId,
+          threadId: pendingApproval.approval.threadId,
+        })
+      ) {
+        return err(createThreadNotLoadedForConnectionError(pendingApproval.approval.threadId));
+      }
+
+      const bindResult = await ensureNotificationBinding();
+      if (!bindResult.ok) {
+        return err(mapApprovalError(bindResult.error));
+      }
+
+      const result = await service.resolveApproval(params);
+      if (!result.ok) {
+        return err(mapApprovalError(result.error));
+      }
+
+      void emitResolvedNotification(result.data.approval, result.data.resolution);
+
+      const resolveResult: ApprovalResolveResult = {
+        requestId: result.data.requestId,
+        resolution: result.data.resolution,
+      };
+      return ok(resolveResult);
+    },
+  });
+
+  return Object.freeze({
+    lifecycle: Object.freeze({
+      name: "module.approvals",
+      start: async () => {
+        options.logger.info("Approvals module ready");
+      },
+      stop: async (reason: string) => {
+        approvals.clearAll();
+        resetSessionSubscription();
+        await notificationChain.catch(() => {});
+        options.logger.info("Approvals module stopped", { reason });
+      },
+    }),
+    ensureNotificationBinding,
+    handleTurnCompleted: async ({ threadId, turnId }) => {
+      await emitStaleResolutions(approvals.clearTurn({ threadId, turnId }));
+    },
+    handleThreadClosed: async (threadId) => {
+      await emitStaleResolutions(approvals.clearThread(threadId));
+    },
+    handleSessionDisconnected: async () => {
+      await emitStaleResolutions(approvals.clearAll());
+      resetSessionSubscription();
+    },
+  });
+};
+
+const mapAgentApprovalRequest = (approval: AgentApprovalRequest): ApprovalRequest => {
+  const base = {
+    requestId: approval.requestId,
+    threadId: approval.threadId ?? "",
+    turnId: approval.turnId ?? null,
+    itemId: approval.itemId ?? null,
+    supportedResolutions: [...approval.supportedResolutions],
+  };
+
+  switch (approval.kind) {
+    case "commandExecution":
+      return Object.freeze({
+        ...base,
+        kind: "commandExecution" as const,
+        approvalId: approval.approvalId,
+        reason: approval.reason,
+        command: approval.command,
+        cwd: approval.cwd,
+        commandActions: approval.commandActions === null ? null : [...approval.commandActions],
+      });
+    case "fileChange":
+      return Object.freeze({
+        ...base,
+        kind: "fileChange" as const,
+        reason: approval.reason,
+        grantRoot: approval.grantRoot,
+      });
+    case "mcpElicitation":
+      return Object.freeze({
+        ...base,
+        kind: "mcpElicitation" as const,
+        serverName: approval.serverName,
+        mode: approval.mode,
+        message: approval.message,
+        requestedSchema: approval.requestedSchema,
+        url: approval.url,
+        elicitationId: approval.elicitationId,
+        metadata: approval.metadata,
+      });
+    case "unknown":
+      return Object.freeze({
+        ...base,
+        kind: "unknown" as const,
+      });
+    default:
+      return assertNever(approval, "Unhandled approval request");
+  }
+};
+
+const mapApprovalError = (
+  error: AgentSessionLookupError | ApprovalsServiceError,
+): ProtocolMethodError => {
+  if (isProtocolMethodError(error)) {
+    return error;
+  }
+
+  switch (error.type) {
+    case "sessionUnavailable":
+      return createAgentSessionUnavailableError(error);
+    case "remoteError":
+      return createProviderError(error);
+    case "invalidProviderPayload":
+      return mapInvalidApprovalProviderPayloadToProtocolError(error);
+    case "approvalNotPending":
+      return createApprovalNotPendingError(error.requestId);
+    case "unsupportedApprovalResolution":
+      return createUnsupportedApprovalResolutionError(
+        error.requestId,
+        error.resolution,
+        error.supportedResolutions,
+      );
+    case "agentNotFound":
+      throw new Error(error.message);
+    default:
+      return assertNever(error, "Unhandled approval protocol error");
+  }
+};

--- a/AppServer/src/approvals/approval.handlers.ts
+++ b/AppServer/src/approvals/approval.handlers.ts
@@ -4,7 +4,11 @@ import type {
   AgentSession,
   AgentSessionLookupError,
 } from "@/agents/contracts";
-import { createAgentSessionUnavailableError, createProviderError } from "@/agents/protocol-errors";
+import {
+  createAgentNotFoundProtocolError,
+  createAgentSessionUnavailableError,
+  createProviderError,
+} from "@/agents/protocol-errors";
 import type { AgentRegistry } from "@/agents/registry";
 import type { Logger } from "@/app/logger";
 import { type ApprovalRegistryRecord, createApprovalRegistry } from "@/approvals/approval-registry";
@@ -148,7 +152,10 @@ export const createApprovalsModule = (options: CreateApprovalsModuleOptions): Ap
           return;
         }
 
-        const approval = mapAgentApprovalRequest(notification.approval);
+        const approval = mapAgentApprovalRequest({
+          ...notification.approval,
+          threadId: notification.approval.threadId,
+        });
         approvals.recordRequested(approval);
         await fanOutThreadNotification(approval.threadId, {
           method: "approval/requested",
@@ -224,7 +231,7 @@ export const createApprovalsModule = (options: CreateApprovalsModuleOptions): Ap
         return err(mapApprovalError(result.error));
       }
 
-      void emitResolvedNotification(result.data.approval, result.data.resolution);
+      await emitResolvedNotification(result.data.approval, result.data.resolution);
 
       const resolveResult: ApprovalResolveResult = {
         requestId: result.data.requestId,
@@ -261,10 +268,12 @@ export const createApprovalsModule = (options: CreateApprovalsModuleOptions): Ap
   });
 };
 
-const mapAgentApprovalRequest = (approval: AgentApprovalRequest): ApprovalRequest => {
+const mapAgentApprovalRequest = (
+  approval: AgentApprovalRequest & Readonly<{ threadId: string }>,
+): ApprovalRequest => {
   const base = {
     requestId: approval.requestId,
-    threadId: approval.threadId ?? "",
+    threadId: approval.threadId,
     turnId: approval.turnId ?? null,
     itemId: approval.itemId ?? null,
     supportedResolutions: [...approval.supportedResolutions],
@@ -333,7 +342,7 @@ const mapApprovalError = (
         error.supportedResolutions,
       );
     case "agentNotFound":
-      throw new Error(error.message);
+      return createAgentNotFoundProtocolError(error.agentId);
     default:
       return assertNever(error, "Unhandled approval protocol error");
   }

--- a/AppServer/src/approvals/index.ts
+++ b/AppServer/src/approvals/index.ts
@@ -1,4 +1,5 @@
-import { createLifecyclePlaceholder, type LifecycleComponent } from "@/core/shared";
-
-export const createApprovalsModulePlaceholder = (): LifecycleComponent =>
-  createLifecyclePlaceholder("module.approvals");
+export * from "@/approvals/approval.handlers";
+export * from "@/approvals/approval-registry";
+export * from "@/approvals/schemas";
+export * from "@/approvals/service";
+export * from "@/approvals/service-types";

--- a/AppServer/src/approvals/schemas.ts
+++ b/AppServer/src/approvals/schemas.ts
@@ -23,6 +23,15 @@ const ApprovalRequestBase = {
   supportedResolutions: Type.Array(ApprovalDecisionResolutionSchema),
 } as const;
 
+// Provider-defined command action entries are forwarded transparently until the
+// App Server adopts a stable provider-neutral action contract.
+const CommandActionSchema = Type.Unknown();
+
+// MCP elicitation payloads can carry arbitrary JSON Schema fragments and
+// provider metadata at this boundary, so they remain intentionally opaque.
+const ApprovalRequestedSchemaPayloadSchema = Type.Unknown();
+const ApprovalMetadataSchema = Type.Unknown();
+
 export const ApprovalCommandExecutionRequestSchema = Type.Object(
   {
     ...ApprovalRequestBase,
@@ -31,7 +40,7 @@ export const ApprovalCommandExecutionRequestSchema = Type.Object(
     reason: Type.Union([Type.String(), Type.Null()]),
     command: Type.Union([Type.String(), Type.Null()]),
     cwd: Type.Union([Type.String(), Type.Null()]),
-    commandActions: Type.Union([Type.Array(Type.Unknown()), Type.Null()]),
+    commandActions: Type.Union([Type.Array(CommandActionSchema), Type.Null()]),
   },
   { additionalProperties: false },
 );
@@ -55,10 +64,10 @@ export const ApprovalMcpElicitationRequestSchema = Type.Object(
     serverName: Type.String({ minLength: 1 }),
     mode: Type.Union([Type.Literal("form"), Type.Literal("url")]),
     message: Type.String(),
-    requestedSchema: Type.Union([Type.Unknown(), Type.Null()]),
+    requestedSchema: Type.Union([ApprovalRequestedSchemaPayloadSchema, Type.Null()]),
     url: Type.Union([Type.String(), Type.Null()]),
     elicitationId: Type.Union([Type.String(), Type.Null()]),
-    metadata: Type.Union([Type.Unknown(), Type.Null()]),
+    metadata: Type.Union([ApprovalMetadataSchema, Type.Null()]),
   },
   { additionalProperties: false },
 );

--- a/AppServer/src/approvals/schemas.ts
+++ b/AppServer/src/approvals/schemas.ts
@@ -1,0 +1,123 @@
+import { type Static, Type } from "@sinclair/typebox";
+import { RequestIdSchema } from "@/core/protocol";
+
+export const ApprovalDecisionResolutionSchema = Type.Union([
+  Type.Literal("approved"),
+  Type.Literal("approvedForSession"),
+  Type.Literal("declined"),
+  Type.Literal("cancelled"),
+]);
+export type ApprovalDecisionResolution = Static<typeof ApprovalDecisionResolutionSchema>;
+
+export const ApprovalResolutionSchema = Type.Union([
+  ApprovalDecisionResolutionSchema,
+  Type.Literal("stale"),
+]);
+export type ApprovalResolution = Static<typeof ApprovalResolutionSchema>;
+
+const ApprovalRequestBase = {
+  requestId: RequestIdSchema,
+  threadId: Type.String({ minLength: 1 }),
+  turnId: Type.Union([Type.String({ minLength: 1 }), Type.Null()]),
+  itemId: Type.Union([Type.String({ minLength: 1 }), Type.Null()]),
+  supportedResolutions: Type.Array(ApprovalDecisionResolutionSchema),
+} as const;
+
+export const ApprovalCommandExecutionRequestSchema = Type.Object(
+  {
+    ...ApprovalRequestBase,
+    kind: Type.Literal("commandExecution"),
+    approvalId: Type.Union([Type.String({ minLength: 1 }), Type.Null()]),
+    reason: Type.Union([Type.String(), Type.Null()]),
+    command: Type.Union([Type.String(), Type.Null()]),
+    cwd: Type.Union([Type.String(), Type.Null()]),
+    commandActions: Type.Union([Type.Array(Type.Unknown()), Type.Null()]),
+  },
+  { additionalProperties: false },
+);
+export type ApprovalCommandExecutionRequest = Static<typeof ApprovalCommandExecutionRequestSchema>;
+
+export const ApprovalFileChangeRequestSchema = Type.Object(
+  {
+    ...ApprovalRequestBase,
+    kind: Type.Literal("fileChange"),
+    reason: Type.Union([Type.String(), Type.Null()]),
+    grantRoot: Type.Union([Type.String(), Type.Null()]),
+  },
+  { additionalProperties: false },
+);
+export type ApprovalFileChangeRequest = Static<typeof ApprovalFileChangeRequestSchema>;
+
+export const ApprovalMcpElicitationRequestSchema = Type.Object(
+  {
+    ...ApprovalRequestBase,
+    kind: Type.Literal("mcpElicitation"),
+    serverName: Type.String({ minLength: 1 }),
+    mode: Type.Union([Type.Literal("form"), Type.Literal("url")]),
+    message: Type.String(),
+    requestedSchema: Type.Union([Type.Unknown(), Type.Null()]),
+    url: Type.Union([Type.String(), Type.Null()]),
+    elicitationId: Type.Union([Type.String(), Type.Null()]),
+    metadata: Type.Union([Type.Unknown(), Type.Null()]),
+  },
+  { additionalProperties: false },
+);
+export type ApprovalMcpElicitationRequest = Static<typeof ApprovalMcpElicitationRequestSchema>;
+
+export const ApprovalUnknownRequestSchema = Type.Object(
+  {
+    ...ApprovalRequestBase,
+    kind: Type.Literal("unknown"),
+  },
+  { additionalProperties: false },
+);
+export type ApprovalUnknownRequest = Static<typeof ApprovalUnknownRequestSchema>;
+
+export const ApprovalRequestSchema = Type.Union([
+  ApprovalCommandExecutionRequestSchema,
+  ApprovalFileChangeRequestSchema,
+  ApprovalMcpElicitationRequestSchema,
+  ApprovalUnknownRequestSchema,
+]);
+export type ApprovalRequest = Static<typeof ApprovalRequestSchema>;
+
+export const ApprovalResolveParamsSchema = Type.Object(
+  {
+    requestId: RequestIdSchema,
+    resolution: ApprovalDecisionResolutionSchema,
+  },
+  { additionalProperties: false },
+);
+export type ApprovalResolveParams = Static<typeof ApprovalResolveParamsSchema>;
+
+export const ApprovalResolveResultSchema = Type.Object(
+  {
+    requestId: RequestIdSchema,
+    resolution: ApprovalDecisionResolutionSchema,
+  },
+  { additionalProperties: false },
+);
+export type ApprovalResolveResult = Static<typeof ApprovalResolveResultSchema>;
+
+export const ApprovalRequestedNotificationParamsSchema = Type.Object(
+  {
+    threadId: Type.String({ minLength: 1 }),
+    approval: ApprovalRequestSchema,
+  },
+  { additionalProperties: false },
+);
+export type ApprovalRequestedNotificationParams = Static<
+  typeof ApprovalRequestedNotificationParamsSchema
+>;
+
+export const ApprovalResolvedNotificationParamsSchema = Type.Object(
+  {
+    threadId: Type.String({ minLength: 1 }),
+    approval: ApprovalRequestSchema,
+    resolution: ApprovalResolutionSchema,
+  },
+  { additionalProperties: false },
+);
+export type ApprovalResolvedNotificationParams = Static<
+  typeof ApprovalResolvedNotificationParamsSchema
+>;

--- a/AppServer/src/approvals/service-types.ts
+++ b/AppServer/src/approvals/service-types.ts
@@ -1,0 +1,62 @@
+import type {
+  AgentRemoteError,
+  AgentSessionLookupError,
+  AgentSessionUnavailableError,
+} from "@/agents/contracts";
+import type { AgentRegistry } from "@/agents/registry";
+import type { ApprovalRegistry } from "@/approvals/approval-registry";
+import type {
+  ApprovalDecisionResolution,
+  ApprovalRequest,
+  ApprovalResolveParams,
+  ApprovalResolveResult,
+} from "@/approvals/schemas";
+
+export type InvalidApprovalProviderPayloadError = Readonly<{
+  type: "invalidProviderPayload";
+  agentId: string;
+  provider: string;
+  operation: "approval/resolve";
+  message: string;
+  detail?: Record<string, unknown>;
+}>;
+
+export type ApprovalNotPendingError = Readonly<{
+  type: "approvalNotPending";
+  requestId: string | number;
+  message: string;
+}>;
+
+export type UnsupportedApprovalResolutionError = Readonly<{
+  type: "unsupportedApprovalResolution";
+  requestId: string | number;
+  resolution: ApprovalDecisionResolution;
+  supportedResolutions: readonly ApprovalDecisionResolution[];
+  message: string;
+}>;
+
+export type ApprovalsServiceError =
+  | AgentSessionLookupError
+  | AgentSessionUnavailableError
+  | AgentRemoteError
+  | InvalidApprovalProviderPayloadError
+  | ApprovalNotPendingError
+  | UnsupportedApprovalResolutionError;
+
+export type ApprovalResolveServiceResult = ApprovalResolveResult &
+  Readonly<{
+    approval: ApprovalRequest;
+  }>;
+
+export type ApprovalsService = Readonly<{
+  resolveApproval: (
+    params: ApprovalResolveParams,
+  ) => Promise<
+    { ok: true; data: ApprovalResolveServiceResult } | { ok: false; error: ApprovalsServiceError }
+  >;
+}>;
+
+export type CreateApprovalsServiceOptions = Readonly<{
+  registry: AgentRegistry;
+  approvals: ApprovalRegistry;
+}>;

--- a/AppServer/src/approvals/service.ts
+++ b/AppServer/src/approvals/service.ts
@@ -1,0 +1,97 @@
+import type { AgentInvalidMessageError } from "@/agents/contracts";
+import type {
+  ApprovalNotPendingError,
+  ApprovalsService,
+  CreateApprovalsServiceOptions,
+  InvalidApprovalProviderPayloadError,
+  UnsupportedApprovalResolutionError,
+} from "@/approvals/service-types";
+import {
+  createInvalidProviderPayloadError,
+  type ProtocolMethodError,
+} from "@/core/protocol/errors";
+import { assertNever, err, ok } from "@/core/shared";
+
+export type {
+  ApprovalNotPendingError,
+  ApprovalResolveServiceResult,
+  ApprovalsServiceError,
+  CreateApprovalsServiceOptions,
+  InvalidApprovalProviderPayloadError,
+  UnsupportedApprovalResolutionError,
+} from "@/approvals/service-types";
+
+export const createApprovalsService = (options: CreateApprovalsServiceOptions): ApprovalsService =>
+  Object.freeze({
+    resolveApproval: async (params) => {
+      const pendingApproval = options.approvals.getPending(params.requestId);
+      if (pendingApproval === undefined) {
+        return err<ApprovalNotPendingError>({
+          type: "approvalNotPending",
+          requestId: params.requestId,
+          message: "Approval request is not pending.",
+        });
+      }
+
+      if (!pendingApproval.approval.supportedResolutions.includes(params.resolution)) {
+        return err<UnsupportedApprovalResolutionError>({
+          type: "unsupportedApprovalResolution",
+          requestId: params.requestId,
+          resolution: params.resolution,
+          supportedResolutions: pendingApproval.approval.supportedResolutions,
+          message: "Approval resolution is not supported for this request.",
+        });
+      }
+
+      const sessionResult = await options.registry.getSession();
+      if (!sessionResult.ok) {
+        return err(sessionResult.error);
+      }
+
+      const resolveResult = await sessionResult.data.resolveApproval({
+        requestId: params.requestId,
+        resolution: params.resolution,
+      });
+      if (!resolveResult.ok) {
+        switch (resolveResult.error.type) {
+          case "sessionUnavailable":
+          case "remoteError":
+            return err(resolveResult.error);
+          case "invalidProviderMessage":
+            return err(createInvalidProviderPayloadServiceError(resolveResult.error));
+          default:
+            return assertNever(resolveResult.error, "Unhandled approval/resolve service error");
+        }
+      }
+
+      options.approvals.markResolved(params.requestId, params.resolution);
+
+      return ok({
+        approval: pendingApproval.approval,
+        requestId: resolveResult.data.requestId,
+        resolution: resolveResult.data.resolution,
+      });
+    },
+  });
+
+export const mapInvalidApprovalProviderPayloadToProtocolError = (
+  error: InvalidApprovalProviderPayloadError,
+): ProtocolMethodError =>
+  createInvalidProviderPayloadError({
+    agentId: error.agentId,
+    provider: error.provider,
+    operation: error.operation,
+    providerMessage: error.message,
+  });
+
+const createInvalidProviderPayloadServiceError = (
+  error: AgentInvalidMessageError,
+): InvalidApprovalProviderPayloadError =>
+  Object.freeze({
+    type: "invalidProviderPayload",
+    agentId: error.agentId,
+    provider: error.provider,
+    operation: "approval/resolve",
+    message: error.message,
+    ...(error.detail ? { detail: error.detail } : {}),
+  });

--- a/AppServer/src/core/protocol/errors.ts
+++ b/AppServer/src/core/protocol/errors.ts
@@ -21,6 +21,10 @@ export const ATELIER_THREAD_WORKSPACE_MISMATCH_ERROR = -33008;
 export const ATELIER_INVALID_PROVIDER_PAYLOAD_ERROR = -33009;
 export const ATELIER_THREAD_NOT_LOADED_ERROR = -33010;
 export const ATELIER_ACTIVE_TURN_ALREADY_EXISTS_ERROR = -33011;
+export const ATELIER_ACTIVE_TURN_NOT_FOUND_ERROR = -33012;
+export const ATELIER_ACTIVE_TURN_MISMATCH_ERROR = -33013;
+export const ATELIER_APPROVAL_NOT_PENDING_ERROR = -33014;
+export const ATELIER_UNSUPPORTED_APPROVAL_RESOLUTION_ERROR = -33015;
 
 const PROTOCOL_METHOD_ERROR_BRAND = Symbol("ProtocolMethodError");
 
@@ -208,6 +212,58 @@ export const createActiveTurnAlreadyExistsResult = (
   activeTurnId?: string,
 ): Result<never, ProtocolMethodError> =>
   err(createActiveTurnAlreadyExistsError(threadId, activeTurnId));
+
+export const createActiveTurnNotFoundError = (threadId: string): ProtocolMethodError =>
+  createProtocolMethodError(
+    ATELIER_ACTIVE_TURN_NOT_FOUND_ERROR,
+    "Thread does not have an active turn",
+    Object.freeze({
+      code: "TURN_NOT_ACTIVE",
+      threadId,
+    }),
+  );
+
+export const createActiveTurnMismatchError = (
+  threadId: string,
+  requestedTurnId: string,
+  activeTurnId?: string,
+): ProtocolMethodError =>
+  createProtocolMethodError(
+    ATELIER_ACTIVE_TURN_MISMATCH_ERROR,
+    "Requested turn is not the active turn",
+    Object.freeze({
+      code: "TURN_ID_MISMATCH",
+      threadId,
+      requestedTurnId,
+      ...(activeTurnId ? { activeTurnId } : {}),
+    }),
+  );
+
+export const createApprovalNotPendingError = (requestId: string | number): ProtocolMethodError =>
+  createProtocolMethodError(
+    ATELIER_APPROVAL_NOT_PENDING_ERROR,
+    "Approval request is not pending",
+    Object.freeze({
+      code: "APPROVAL_NOT_PENDING",
+      requestId,
+    }),
+  );
+
+export const createUnsupportedApprovalResolutionError = (
+  requestId: string | number,
+  resolution: string,
+  supportedResolutions: readonly string[],
+): ProtocolMethodError =>
+  createProtocolMethodError(
+    ATELIER_UNSUPPORTED_APPROVAL_RESOLUTION_ERROR,
+    "Approval resolution is not supported for this request",
+    Object.freeze({
+      code: "UNSUPPORTED_APPROVAL_RESOLUTION",
+      requestId,
+      resolution,
+      supportedResolutions: [...supportedResolutions],
+    }),
+  );
 
 const brandProtocolMethodError = <T extends { code: number; message: string }>(
   error: T,

--- a/AppServer/src/core/protocol/errors.ts
+++ b/AppServer/src/core/protocol/errors.ts
@@ -25,6 +25,7 @@ export const ATELIER_ACTIVE_TURN_NOT_FOUND_ERROR = -33012;
 export const ATELIER_ACTIVE_TURN_MISMATCH_ERROR = -33013;
 export const ATELIER_APPROVAL_NOT_PENDING_ERROR = -33014;
 export const ATELIER_UNSUPPORTED_APPROVAL_RESOLUTION_ERROR = -33015;
+export const ATELIER_AGENT_NOT_FOUND_ERROR = -33016;
 
 const PROTOCOL_METHOD_ERROR_BRAND = Symbol("ProtocolMethodError");
 
@@ -262,6 +263,16 @@ export const createUnsupportedApprovalResolutionError = (
       requestId,
       resolution,
       supportedResolutions: [...supportedResolutions],
+    }),
+  );
+
+export const createAgentNotFoundError = (agentId: string): ProtocolMethodError =>
+  createProtocolMethodError(
+    ATELIER_AGENT_NOT_FOUND_ERROR,
+    "Requested agent is not configured",
+    Object.freeze({
+      code: "AGENT_NOT_FOUND",
+      agentId,
     }),
   );
 

--- a/AppServer/src/test-support/agents.ts
+++ b/AppServer/src/test-support/agents.ts
@@ -1,5 +1,7 @@
 import type { AgentAdapter } from "@/agents/adapter";
 import type {
+  AgentApprovalResolveParams,
+  AgentApprovalResolveResult,
   AgentListModelsParams,
   AgentListModelsResult,
   AgentListThreadsParams,
@@ -90,6 +92,24 @@ export type FakeAgentSession = AgentSession &
         cwd?: string;
       }>;
     }>[];
+    steerTurnCalls: readonly Readonly<{
+      requestId: AgentRequestId;
+      params: Readonly<{
+        threadId: string;
+        turnId: string;
+        prompt: string;
+      }>;
+    }>[];
+    interruptTurnCalls: readonly Readonly<{
+      requestId: AgentRequestId;
+      params: Readonly<{
+        threadId: string;
+        turnId: string;
+      }>;
+    }>[];
+    resolveApprovalCalls: readonly Readonly<{
+      params: AgentApprovalResolveParams;
+    }>[];
   }>;
 
 export type CreateFakeAgentSessionOptions = Readonly<{
@@ -155,6 +175,24 @@ export type CreateFakeAgentSessionOptions = Readonly<{
       cwd?: string;
     }>,
   ) => Promise<AgentOperationResult<AgentTurnResult>>;
+  steerTurn?: (
+    requestId: AgentRequestId,
+    params: Readonly<{
+      threadId: string;
+      turnId: string;
+      prompt: string;
+    }>,
+  ) => Promise<AgentOperationResult<AgentTurnResult>>;
+  interruptTurn?: (
+    requestId: AgentRequestId,
+    params: Readonly<{
+      threadId: string;
+      turnId: string;
+    }>,
+  ) => Promise<AgentOperationResult<AgentTurnResult>>;
+  resolveApproval?: (
+    params: AgentApprovalResolveParams,
+  ) => Promise<AgentOperationResult<AgentApprovalResolveResult>>;
 }>;
 
 export const createFakeAgentSession = (
@@ -240,6 +278,30 @@ export const createFakeAgentSession = (
         reasoningEffort?: AgentReasoningEffort;
         cwd?: string;
       }>;
+    }>
+  > = [];
+  const steerTurnCalls: Array<
+    Readonly<{
+      requestId: AgentRequestId;
+      params: Readonly<{
+        threadId: string;
+        turnId: string;
+        prompt: string;
+      }>;
+    }>
+  > = [];
+  const interruptTurnCalls: Array<
+    Readonly<{
+      requestId: AgentRequestId;
+      params: Readonly<{
+        threadId: string;
+        turnId: string;
+      }>;
+    }>
+  > = [];
+  const resolveApprovalCalls: Array<
+    Readonly<{
+      params: AgentApprovalResolveParams;
     }>
   > = [];
 
@@ -438,14 +500,61 @@ export const createFakeAgentSession = (
         }
       );
     },
-    steerTurn: async () => {
-      throw new Error("steerTurn should not be called in this test.");
+    steerTurn: async (requestId, params) => {
+      steerTurnCalls.push(
+        Object.freeze({
+          requestId,
+          params,
+        }),
+      );
+
+      return (
+        (await options.steerTurn?.(requestId, params)) ?? {
+          ok: true,
+          data: {
+            turn: createTestAgentTurn({
+              id: params.turnId,
+            }),
+          },
+        }
+      );
     },
-    interruptTurn: async () => {
-      throw new Error("interruptTurn should not be called in this test.");
+    interruptTurn: async (requestId, params) => {
+      interruptTurnCalls.push(
+        Object.freeze({
+          requestId,
+          params,
+        }),
+      );
+
+      return (
+        (await options.interruptTurn?.(requestId, params)) ?? {
+          ok: true,
+          data: {
+            turn: createTestAgentTurn({
+              id: params.turnId,
+              status: { type: "interrupted" },
+            }),
+          },
+        }
+      );
     },
-    resolveApproval: async () => {
-      throw new Error("resolveApproval should not be called in this test.");
+    resolveApproval: async (params) => {
+      resolveApprovalCalls.push(
+        Object.freeze({
+          params,
+        }),
+      );
+
+      return (
+        (await options.resolveApproval?.(params)) ?? {
+          ok: true,
+          data: {
+            requestId: params.requestId,
+            resolution: params.resolution,
+          },
+        }
+      );
     },
     disconnect: async () => {
       state = "disconnected";
@@ -465,6 +574,9 @@ export const createFakeAgentSession = (
     unarchiveThreadCalls,
     setThreadNameCalls,
     startTurnCalls,
+    steerTurnCalls,
+    interruptTurnCalls,
+    resolveApprovalCalls,
   };
 };
 

--- a/AppServer/src/threads/thread.handlers.ts
+++ b/AppServer/src/threads/thread.handlers.ts
@@ -75,6 +75,8 @@ export type CreateThreadsModuleOptions = Readonly<{
   store: ThreadsStore;
   getOpenedWorkspace: (connectionId: string) => Workspace | undefined;
   now?: () => string;
+  onThreadClosed?: (threadId: string) => Promise<void> | void;
+  onSessionDisconnected?: () => Promise<void> | void;
 }>;
 
 export const createThreadsModule = (options: CreateThreadsModuleOptions): ThreadsModule => {
@@ -140,6 +142,7 @@ export const createThreadsModule = (options: CreateThreadsModuleOptions): Thread
 
   const forwardAgentNotification = async (notification: AgentNotification): Promise<void> => {
     if (notification.type === "disconnect") {
+      await options.onSessionDisconnected?.();
       loadedThreads.clearAll();
       resetSessionSubscription();
       return;
@@ -160,6 +163,7 @@ export const createThreadsModule = (options: CreateThreadsModuleOptions): Thread
         });
         return;
       case "closed":
+        await options.onThreadClosed?.(notification.threadId);
         await fanOutThreadNotification(
           notification.threadId,
           {

--- a/AppServer/src/turns/active-turn-registry.ts
+++ b/AppServer/src/turns/active-turn-registry.ts
@@ -28,6 +28,7 @@ export type ActiveTurnRegistry = Readonly<{
     threadId: string,
   ) => Result<Readonly<{ release: () => void }>, ActiveTurnConflictError>;
   startTurn: (input: Readonly<{ threadId: string; turn: Turn }>) => boolean;
+  updateTurn: (input: Readonly<{ threadId: string; turn: Turn }>) => boolean;
   recordTurnCompleted: (input: Readonly<{ threadId: string; turn: Turn }>) => boolean;
   recordItemStarted: (
     input: Readonly<{ threadId: string; turnId: string; item: TurnItem }>,
@@ -101,6 +102,19 @@ export const createActiveTurnRegistry = (): ActiveTurnRegistry => {
     }
 
     if (state.turn.id !== turnId) {
+      return undefined;
+    }
+
+    return state;
+  };
+
+  const getTrackedTurnState = (
+    threadId: string,
+    turnId: string,
+  ): MutableActiveTurnState | undefined => {
+    const state = statesByThreadId.get(threadId);
+
+    if (state?.turn === undefined || state.turn.id !== turnId) {
       return undefined;
     }
 
@@ -184,6 +198,15 @@ export const createActiveTurnRegistry = (): ActiveTurnRegistry => {
     startTurn: ({ threadId, turn }) => {
       const state = getOrCreateThreadState(threadId);
       if (state.turn !== undefined && state.turn.id !== turn.id) {
+        return false;
+      }
+
+      state.turn = turn;
+      return true;
+    },
+    updateTurn: ({ threadId, turn }) => {
+      const state = getTrackedTurnState(threadId, turn.id);
+      if (state === undefined) {
         return false;
       }
 

--- a/AppServer/src/turns/schemas.ts
+++ b/AppServer/src/turns/schemas.ts
@@ -122,6 +122,31 @@ export const TurnStartResultSchema = Type.Object(
 );
 export type TurnStartResult = Static<typeof TurnStartResultSchema>;
 
+export const TurnSteerParamsSchema = Type.Object(
+  {
+    threadId: Type.String({ minLength: 1 }),
+    turnId: Type.String({ minLength: 1 }),
+    prompt: Type.String({ minLength: 1 }),
+  },
+  { additionalProperties: false },
+);
+export type TurnSteerParams = Static<typeof TurnSteerParamsSchema>;
+
+export const TurnSteerResultSchema = TurnStartResultSchema;
+export type TurnSteerResult = Static<typeof TurnSteerResultSchema>;
+
+export const TurnInterruptParamsSchema = Type.Object(
+  {
+    threadId: Type.String({ minLength: 1 }),
+    turnId: Type.String({ minLength: 1 }),
+  },
+  { additionalProperties: false },
+);
+export type TurnInterruptParams = Static<typeof TurnInterruptParamsSchema>;
+
+export const TurnInterruptResultSchema = TurnStartResultSchema;
+export type TurnInterruptResult = Static<typeof TurnInterruptResultSchema>;
+
 export const TurnStartedNotificationParamsSchema = Type.Object(
   {
     threadId: Type.String({ minLength: 1 }),

--- a/AppServer/src/turns/service-types.ts
+++ b/AppServer/src/turns/service-types.ts
@@ -7,16 +7,37 @@ import type {
 import type { AgentRegistry } from "@/agents/registry";
 import type { Logger } from "@/app/logger";
 import type { ActiveTurnConflictError, ActiveTurnRegistry } from "@/turns/active-turn-registry";
-import type { TurnStartParams, TurnStartResult } from "@/turns/schemas";
+import type {
+  TurnInterruptParams,
+  TurnInterruptResult,
+  TurnStartParams,
+  TurnStartResult,
+  TurnSteerParams,
+  TurnSteerResult,
+} from "@/turns/schemas";
 import type { Workspace } from "@/workspaces/schemas";
 
 export type InvalidTurnProviderPayloadError = Readonly<{
   type: "invalidProviderPayload";
   agentId: string;
   provider: string;
-  operation: "turn/start";
+  operation: "turn/start" | "turn/steer" | "turn/interrupt";
   message: string;
   detail?: Record<string, unknown>;
+}>;
+
+export type ActiveTurnNotFoundError = Readonly<{
+  type: "activeTurnNotFound";
+  threadId: string;
+  message: string;
+}>;
+
+export type ActiveTurnMismatchError = Readonly<{
+  type: "activeTurnMismatch";
+  threadId: string;
+  requestedTurnId: string;
+  activeTurnId?: string;
+  message: string;
 }>;
 
 export type TurnsServiceError =
@@ -24,6 +45,8 @@ export type TurnsServiceError =
   | AgentSessionUnavailableError
   | AgentRemoteError
   | ActiveTurnConflictError
+  | ActiveTurnNotFoundError
+  | ActiveTurnMismatchError
   | InvalidTurnProviderPayloadError;
 
 export type TurnsService = Readonly<{
@@ -32,6 +55,14 @@ export type TurnsService = Readonly<{
     workspace: Workspace,
     params: TurnStartParams,
   ) => Promise<{ ok: true; data: TurnStartResult } | { ok: false; error: TurnsServiceError }>;
+  steerTurn: (
+    requestId: AgentRequestId,
+    params: TurnSteerParams,
+  ) => Promise<{ ok: true; data: TurnSteerResult } | { ok: false; error: TurnsServiceError }>;
+  interruptTurn: (
+    requestId: AgentRequestId,
+    params: TurnInterruptParams,
+  ) => Promise<{ ok: true; data: TurnInterruptResult } | { ok: false; error: TurnsServiceError }>;
 }>;
 
 export type CreateTurnsServiceOptions = Readonly<{

--- a/AppServer/src/turns/service.test.ts
+++ b/AppServer/src/turns/service.test.ts
@@ -136,4 +136,121 @@ describe("createTurnsService", () => {
       },
     });
   });
+
+  test("steers the active turn when the requested turn matches", async () => {
+    const activeTurns = createActiveTurnRegistry();
+    const session = createFakeAgentSession({
+      startTurn: async () => ({
+        ok: true,
+        data: {
+          turn: createTestAgentTurn({
+            id: "turn-1",
+          }),
+        },
+      }),
+      steerTurn: async () => ({
+        ok: true,
+        data: {
+          turn: createTestAgentTurn({
+            id: "turn-1",
+            status: {
+              type: "awaitingInput",
+            },
+          }),
+        },
+      }),
+    });
+    const service = createTurnsService({
+      logger: createSilentLogger("error"),
+      registry: createFakeAgentRegistry(session),
+      activeTurns,
+    });
+
+    await service.startTurn("req-start", workspace, {
+      threadId: "thread-1",
+      prompt: "Start a turn",
+    });
+
+    await expect(
+      service.steerTurn("req-steer", {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        prompt: "Tighten the plan",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      data: {
+        turn: {
+          id: "turn-1",
+          status: {
+            type: "awaitingInput",
+          },
+        },
+      },
+    });
+    expect(session.steerTurnCalls).toEqual([
+      {
+        requestId: "req-steer",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          prompt: "Tighten the plan",
+        },
+      },
+    ]);
+  });
+
+  test("rejects turn controls when the requested turn is not active", async () => {
+    const activeTurns = createActiveTurnRegistry();
+    const session = createFakeAgentSession({
+      startTurn: async () => ({
+        ok: true,
+        data: {
+          turn: createTestAgentTurn({
+            id: "turn-1",
+          }),
+        },
+      }),
+    });
+    const service = createTurnsService({
+      logger: createSilentLogger("error"),
+      registry: createFakeAgentRegistry(session),
+      activeTurns,
+    });
+
+    await service.startTurn("req-start", workspace, {
+      threadId: "thread-1",
+      prompt: "Start a turn",
+    });
+
+    await expect(
+      service.steerTurn("req-steer", {
+        threadId: "thread-1",
+        turnId: "turn-2",
+        prompt: "Use the wrong turn id",
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: {
+        type: "activeTurnMismatch",
+        threadId: "thread-1",
+        requestedTurnId: "turn-2",
+        activeTurnId: "turn-1",
+        message: "Requested turn is not the active turn.",
+      },
+    });
+    await expect(
+      service.interruptTurn("req-interrupt", {
+        threadId: "thread-2",
+        turnId: "turn-2",
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: {
+        type: "activeTurnNotFound",
+        threadId: "thread-2",
+        message: "Thread does not have an active turn.",
+      },
+    });
+  });
 });

--- a/AppServer/src/turns/service.test.ts
+++ b/AppServer/src/turns/service.test.ts
@@ -188,6 +188,12 @@ describe("createTurnsService", () => {
         },
       },
     });
+    expect(activeTurns.getActiveTurn("thread-1")?.turn).toEqual({
+      id: "turn-1",
+      status: {
+        type: "awaitingInput",
+      },
+    });
     expect(session.steerTurnCalls).toEqual([
       {
         requestId: "req-steer",
@@ -252,5 +258,72 @@ describe("createTurnsService", () => {
         message: "Thread does not have an active turn.",
       },
     });
+  });
+
+  test("interrupts the active turn and records the completed state", async () => {
+    const activeTurns = createActiveTurnRegistry();
+    const session = createFakeAgentSession({
+      startTurn: async () => ({
+        ok: true,
+        data: {
+          turn: createTestAgentTurn({
+            id: "turn-1",
+          }),
+        },
+      }),
+      interruptTurn: async () => ({
+        ok: true,
+        data: {
+          turn: createTestAgentTurn({
+            id: "turn-1",
+            status: {
+              type: "interrupted",
+            },
+          }),
+        },
+      }),
+    });
+    const service = createTurnsService({
+      logger: createSilentLogger("error"),
+      registry: createFakeAgentRegistry(session),
+      activeTurns,
+    });
+
+    await service.startTurn("req-start", workspace, {
+      threadId: "thread-1",
+      prompt: "Start a turn",
+    });
+
+    await expect(
+      service.interruptTurn("req-interrupt", {
+        threadId: "thread-1",
+        turnId: "turn-1",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      data: {
+        turn: {
+          id: "turn-1",
+          status: {
+            type: "interrupted",
+          },
+        },
+      },
+    });
+    expect(activeTurns.getActiveTurn("thread-1")?.turn).toEqual({
+      id: "turn-1",
+      status: {
+        type: "interrupted",
+      },
+    });
+    expect(session.interruptTurnCalls).toEqual([
+      {
+        requestId: "req-interrupt",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+        },
+      },
+    ]);
   });
 });

--- a/AppServer/src/turns/service.ts
+++ b/AppServer/src/turns/service.ts
@@ -117,12 +117,12 @@ export const createTurnsService = (options: CreateTurnsServiceOptions): TurnsSer
         id: steerTurnResult.data.turn.id,
         status: mapTurnStatus(steerTurnResult.data.turn.status),
       });
-      const wasRecorded = options.activeTurns.startTurn({
+      const wasRecorded = options.activeTurns.updateTurn({
         threadId: params.threadId,
         turn,
       });
       if (!wasRecorded) {
-        options.logger.warn("Ignored turn/steer response with mismatched active turn", {
+        options.logger.warn("Ignored turn/steer response for an untracked active turn", {
           threadId: params.threadId,
           turnId: turn.id,
           activeTurnId: options.activeTurns.getActiveTurn(params.threadId)?.turn?.id ?? null,

--- a/AppServer/src/turns/service.ts
+++ b/AppServer/src/turns/service.ts
@@ -1,12 +1,16 @@
 import type { AgentInvalidMessageError, AgentTurnStatus } from "@/agents/contracts";
 import {
   createActiveTurnAlreadyExistsError,
+  createActiveTurnMismatchError,
+  createActiveTurnNotFoundError,
   createInvalidProviderPayloadError,
   type ProtocolMethodError,
 } from "@/core/protocol/errors";
 import { assertNever, err, ok } from "@/core/shared";
 import type { ActiveTurnConflictError } from "@/turns/active-turn-registry";
 import type {
+  ActiveTurnMismatchError,
+  ActiveTurnNotFoundError,
   CreateTurnsServiceOptions,
   InvalidTurnProviderPayloadError,
   TurnsService,
@@ -49,7 +53,9 @@ export const createTurnsService = (options: CreateTurnsServiceOptions): TurnsSer
           case "remoteError":
             return err(startTurnResult.error);
           case "invalidProviderMessage":
-            return err(createInvalidProviderPayloadServiceError(startTurnResult.error));
+            return err(
+              createInvalidProviderPayloadServiceError(startTurnResult.error, "turn/start"),
+            );
           default:
             return assertNever(startTurnResult.error, "Unhandled turn/start service error");
         }
@@ -65,6 +71,109 @@ export const createTurnsService = (options: CreateTurnsServiceOptions): TurnsSer
       });
       if (!wasRecorded) {
         options.logger.warn("Ignored turn/start response with mismatched active turn", {
+          threadId: params.threadId,
+          turnId: turn.id,
+          activeTurnId: options.activeTurns.getActiveTurn(params.threadId)?.turn?.id ?? null,
+        });
+      }
+
+      return ok({
+        turn,
+      });
+    },
+    steerTurn: async (requestId, params) => {
+      const activeTurnResult = getValidatedActiveTurn(options, params.threadId, params.turnId);
+      if (!activeTurnResult.ok) {
+        return err(activeTurnResult.error);
+      }
+
+      const sessionResult = await options.registry.getSession();
+      if (!sessionResult.ok) {
+        return err(sessionResult.error);
+      }
+
+      const session = sessionResult.data;
+      const steerTurnResult = await session.steerTurn(requestId, {
+        threadId: params.threadId,
+        turnId: params.turnId,
+        prompt: params.prompt,
+      });
+
+      if (!steerTurnResult.ok) {
+        switch (steerTurnResult.error.type) {
+          case "sessionUnavailable":
+          case "remoteError":
+            return err(steerTurnResult.error);
+          case "invalidProviderMessage":
+            return err(
+              createInvalidProviderPayloadServiceError(steerTurnResult.error, "turn/steer"),
+            );
+          default:
+            return assertNever(steerTurnResult.error, "Unhandled turn/steer service error");
+        }
+      }
+
+      const turn = Object.freeze({
+        id: steerTurnResult.data.turn.id,
+        status: mapTurnStatus(steerTurnResult.data.turn.status),
+      });
+      const wasRecorded = options.activeTurns.startTurn({
+        threadId: params.threadId,
+        turn,
+      });
+      if (!wasRecorded) {
+        options.logger.warn("Ignored turn/steer response with mismatched active turn", {
+          threadId: params.threadId,
+          turnId: turn.id,
+          activeTurnId: options.activeTurns.getActiveTurn(params.threadId)?.turn?.id ?? null,
+        });
+      }
+
+      return ok({
+        turn,
+      });
+    },
+    interruptTurn: async (requestId, params) => {
+      const activeTurnResult = getValidatedActiveTurn(options, params.threadId, params.turnId);
+      if (!activeTurnResult.ok) {
+        return err(activeTurnResult.error);
+      }
+
+      const sessionResult = await options.registry.getSession();
+      if (!sessionResult.ok) {
+        return err(sessionResult.error);
+      }
+
+      const session = sessionResult.data;
+      const interruptTurnResult = await session.interruptTurn(requestId, {
+        threadId: params.threadId,
+        turnId: params.turnId,
+      });
+
+      if (!interruptTurnResult.ok) {
+        switch (interruptTurnResult.error.type) {
+          case "sessionUnavailable":
+          case "remoteError":
+            return err(interruptTurnResult.error);
+          case "invalidProviderMessage":
+            return err(
+              createInvalidProviderPayloadServiceError(interruptTurnResult.error, "turn/interrupt"),
+            );
+          default:
+            return assertNever(interruptTurnResult.error, "Unhandled turn/interrupt service error");
+        }
+      }
+
+      const turn = Object.freeze({
+        id: interruptTurnResult.data.turn.id,
+        status: mapTurnStatus(interruptTurnResult.data.turn.status),
+      });
+      const wasRecorded = options.activeTurns.recordTurnCompleted({
+        threadId: params.threadId,
+        turn,
+      });
+      if (!wasRecorded) {
+        options.logger.warn("Ignored turn/interrupt response with mismatched active turn", {
           threadId: params.threadId,
           turnId: turn.id,
           activeTurnId: options.activeTurns.getActiveTurn(params.threadId)?.turn?.id ?? null,
@@ -91,17 +200,58 @@ export const createActiveTurnConflictProtocolError = (
   error: ActiveTurnConflictError,
 ): ProtocolMethodError => createActiveTurnAlreadyExistsError(error.threadId, error.activeTurnId);
 
+export const createActiveTurnNotFoundProtocolError = (
+  error: ActiveTurnNotFoundError,
+): ProtocolMethodError => createActiveTurnNotFoundError(error.threadId);
+
+export const createActiveTurnMismatchProtocolError = (
+  error: ActiveTurnMismatchError,
+): ProtocolMethodError =>
+  createActiveTurnMismatchError(error.threadId, error.requestedTurnId, error.activeTurnId);
+
 const createInvalidProviderPayloadServiceError = (
   error: AgentInvalidMessageError,
+  operation: InvalidTurnProviderPayloadError["operation"],
 ): InvalidTurnProviderPayloadError =>
   Object.freeze({
     type: "invalidProviderPayload",
     agentId: error.agentId,
     provider: error.provider,
-    operation: "turn/start",
+    operation,
     message: error.message,
     ...(error.detail ? { detail: error.detail } : {}),
   });
+
+const getValidatedActiveTurn = (
+  options: CreateTurnsServiceOptions,
+  threadId: string,
+  requestedTurnId: string,
+) => {
+  const activeTurn = options.activeTurns.getActiveTurn(threadId)?.turn;
+
+  if (
+    activeTurn === undefined ||
+    (activeTurn.status.type !== "inProgress" && activeTurn.status.type !== "awaitingInput")
+  ) {
+    return err<ActiveTurnNotFoundError>({
+      type: "activeTurnNotFound",
+      threadId,
+      message: "Thread does not have an active turn.",
+    });
+  }
+
+  if (activeTurn.id !== requestedTurnId) {
+    return err<ActiveTurnMismatchError>({
+      type: "activeTurnMismatch",
+      threadId,
+      requestedTurnId,
+      activeTurnId: activeTurn.id,
+      message: "Requested turn is not the active turn.",
+    });
+  }
+
+  return ok(activeTurn);
+};
 
 const mapTurnStatus = (status: AgentTurnStatus) => {
   switch (status.type) {

--- a/AppServer/src/turns/turn.handlers.test.ts
+++ b/AppServer/src/turns/turn.handlers.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, test } from "bun:test";
+import { createAppProtocolRuntime } from "@/app/protocol";
+import {
+  createFakeAgentRegistry,
+  createFakeAgentSession,
+  createTestAgentTurn,
+} from "@/test-support/agents";
+import { createSilentLogger } from "@/test-support/logger";
+import { createTurnsModule } from "@/turns/turn.handlers";
+
+const logger = createSilentLogger("error");
+const connectionId = "connection-1";
+const workspace = Object.freeze({
+  id: "workspace-1",
+  workspacePath: "/tmp/project",
+  createdAt: "2026-04-10T09:00:00.000Z",
+  lastOpenedAt: "2026-04-10T09:00:00.000Z",
+});
+
+describe("createTurnsModule", () => {
+  test("binds approval notifications before interrupting a turn", async () => {
+    const outbound: string[] = [];
+    const runtime = createAppProtocolRuntime({ logger });
+    const session = createFakeAgentSession();
+    let approvalBindingCalls = 0;
+
+    createTurnsModule({
+      logger,
+      registerMethod: runtime.registerMethod,
+      sendNotification: runtime.sendNotification,
+      registry: createFakeAgentRegistry(session),
+      getOpenedWorkspace: () => workspace,
+      loadedThreads: {
+        isThreadLoadedForConnection: () => true,
+        listLoadedThreadSubscribers: () => [connectionId],
+      },
+      ensureApprovalNotificationBinding: async () => {
+        approvalBindingCalls += 1;
+        return { ok: true, data: undefined };
+      },
+    });
+
+    await initializeConnection(runtime, outbound);
+
+    await runtime.handleIncomingText({
+      connectionId,
+      text: JSON.stringify({
+        id: "req-turn-start",
+        method: "turn/start",
+        params: {
+          threadId: "thread-1",
+          prompt: "Start a turn",
+        },
+      }),
+    });
+    approvalBindingCalls = 0;
+    outbound.length = 0;
+
+    await runtime.handleIncomingText({
+      connectionId,
+      text: JSON.stringify({
+        id: "req-turn-interrupt",
+        method: "turn/interrupt",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+        },
+      }),
+    });
+
+    expect(approvalBindingCalls).toBe(1);
+    expect(session.interruptTurnCalls).toEqual([
+      {
+        requestId: "atelier-appserver:turn/interrupt:connection-1:req-turn-interrupt",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+        },
+      },
+    ]);
+    expect(JSON.parse(outbound[0] ?? "null")).toEqual({
+      id: "req-turn-interrupt",
+      result: {
+        turn: {
+          id: "turn-1",
+          status: {
+            type: "interrupted",
+          },
+        },
+      },
+    });
+  });
+
+  test("clears the completed turn before running the completion callback", async () => {
+    const outbound: string[] = [];
+    const runtime = createAppProtocolRuntime({ logger });
+    let startTurnCallCount = 0;
+    const session = createFakeAgentSession({
+      startTurn: async () => {
+        startTurnCallCount += 1;
+        return {
+          ok: true,
+          data: {
+            turn: createTestAgentTurn({
+              id: startTurnCallCount === 1 ? "turn-1" : "turn-2",
+            }),
+          },
+        };
+      },
+    });
+
+    createTurnsModule({
+      logger,
+      registerMethod: runtime.registerMethod,
+      sendNotification: runtime.sendNotification,
+      registry: createFakeAgentRegistry(session),
+      getOpenedWorkspace: () => workspace,
+      loadedThreads: {
+        isThreadLoadedForConnection: () => true,
+        listLoadedThreadSubscribers: () => [connectionId],
+      },
+      onTurnCompleted: async ({ threadId }) => {
+        await runtime.handleIncomingText({
+          connectionId,
+          text: JSON.stringify({
+            id: "req-turn-restart",
+            method: "turn/start",
+            params: {
+              threadId,
+              prompt: "Start the next turn",
+            },
+          }),
+        });
+      },
+    });
+
+    await initializeConnection(runtime, outbound);
+
+    await runtime.handleIncomingText({
+      connectionId,
+      text: JSON.stringify({
+        id: "req-turn-start",
+        method: "turn/start",
+        params: {
+          threadId: "thread-1",
+          prompt: "Start the first turn",
+        },
+      }),
+    });
+    outbound.length = 0;
+
+    session.emitNotification({
+      agentId: "codex",
+      provider: "codex",
+      receivedAt: "2026-04-12T10:00:00.000Z",
+      rawMethod: "turn/completed",
+      rawPayload: {},
+      threadId: "thread-1",
+      type: "turn",
+      event: "completed",
+      turn: {
+        id: "turn-1",
+        status: {
+          type: "completed",
+        },
+      },
+    });
+    await waitForCondition(() => startTurnCallCount === 2 && outbound.length === 2);
+
+    expect(startTurnCallCount).toBe(2);
+    expect(outbound.map((message) => JSON.parse(message))).toEqual([
+      {
+        id: "req-turn-restart",
+        result: {
+          turn: {
+            id: "turn-2",
+            status: {
+              type: "inProgress",
+            },
+          },
+        },
+      },
+      {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turn: {
+            id: "turn-1",
+            status: {
+              type: "completed",
+            },
+          },
+        },
+      },
+    ]);
+  });
+});
+
+const initializeConnection = async (
+  runtime: ReturnType<typeof createAppProtocolRuntime>,
+  outbound: string[],
+): Promise<void> => {
+  runtime.openConnection({
+    connectionId,
+    sendText: async (text) => {
+      outbound.push(text);
+    },
+  });
+
+  await runtime.handleIncomingText({
+    connectionId,
+    text: JSON.stringify({
+      id: "req-initialize",
+      method: "initialize",
+      params: {
+        clientInfo: {
+          name: "AtelierCode Test",
+          version: "0.1.0",
+        },
+      },
+    }),
+  });
+};
+
+const flushAsyncWork = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const waitForCondition = async (
+  predicate: () => boolean,
+  attempts = 20,
+): Promise<void> => {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (predicate()) {
+      return;
+    }
+
+    await flushAsyncWork();
+  }
+
+  throw new Error("Timed out waiting for asynchronous turn handling.");
+};

--- a/AppServer/src/turns/turn.handlers.ts
+++ b/AppServer/src/turns/turn.handlers.ts
@@ -27,13 +27,21 @@ import {
 import { createActiveTurnRegistry } from "@/turns/active-turn-registry";
 import {
   type Turn,
+  TurnInterruptParamsSchema,
+  type TurnInterruptResult,
+  TurnInterruptResultSchema,
   type TurnStartParams,
   TurnStartParamsSchema,
   type TurnStartResult,
   TurnStartResultSchema,
+  TurnSteerParamsSchema,
+  type TurnSteerResult,
+  TurnSteerResultSchema,
 } from "@/turns/schemas";
 import {
   createActiveTurnConflictProtocolError,
+  createActiveTurnMismatchProtocolError,
+  createActiveTurnNotFoundProtocolError,
   createTurnsService,
   mapInvalidProviderPayloadToProtocolError,
   type TurnsServiceError,
@@ -58,6 +66,8 @@ export type CreateTurnsModuleOptions = Readonly<{
   registry: AgentRegistry;
   getOpenedWorkspace: (connectionId: string) => Workspace | undefined;
   loadedThreads: LoadedThreadAccess;
+  ensureApprovalNotificationBinding?: () => Promise<Result<void, AgentSessionLookupError>>;
+  onTurnCompleted?: (input: Readonly<{ threadId: string; turnId: string }>) => Promise<void> | void;
 }>;
 
 export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModule => {
@@ -453,6 +463,10 @@ export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModul
           return;
         }
 
+        await options.onTurnCompleted?.({
+          threadId: notification.threadId,
+          turnId: turn.id,
+        });
         activeTurns.clearThread(notification.threadId);
         await fanOutThreadNotification(notification.threadId, {
           method: "turn/completed",
@@ -560,6 +574,11 @@ export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModul
         return err(mapTurnError(bindResult.error));
       }
 
+      const approvalBindResult = await options.ensureApprovalNotificationBinding?.();
+      if (approvalBindResult !== undefined && !approvalBindResult.ok) {
+        return err(mapTurnError(approvalBindResult.error));
+      }
+
       const agentRequestId = createAgentRequestId({
         connectionId,
         method: "turn/start",
@@ -570,6 +589,77 @@ export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModul
         workspace,
         normalizeTurnStartParams(params),
       );
+      return mapTurnResult(result);
+    },
+  });
+
+  options.registerMethod({
+    method: "turn/steer",
+    paramsSchema: TurnSteerParamsSchema,
+    resultSchema: TurnSteerResultSchema,
+    handler: async ({ connectionId, params, requestId, session }) => {
+      if (!session.isInitialized()) {
+        return createSessionNotInitializedResult();
+      }
+
+      if (
+        !options.loadedThreads.isThreadLoadedForConnection({
+          connectionId,
+          threadId: params.threadId,
+        })
+      ) {
+        return err(createThreadNotLoadedForConnectionError(params.threadId));
+      }
+
+      const bindResult = await ensureSessionNotificationBinding();
+      if (!bindResult.ok) {
+        return err(mapTurnError(bindResult.error));
+      }
+
+      const approvalBindResult = await options.ensureApprovalNotificationBinding?.();
+      if (approvalBindResult !== undefined && !approvalBindResult.ok) {
+        return err(mapTurnError(approvalBindResult.error));
+      }
+
+      const agentRequestId = createAgentRequestId({
+        connectionId,
+        method: "turn/steer",
+        requestId,
+      });
+      const result = await service.steerTurn(agentRequestId, params);
+      return mapTurnResult(result);
+    },
+  });
+
+  options.registerMethod({
+    method: "turn/interrupt",
+    paramsSchema: TurnInterruptParamsSchema,
+    resultSchema: TurnInterruptResultSchema,
+    handler: async ({ connectionId, params, requestId, session }) => {
+      if (!session.isInitialized()) {
+        return createSessionNotInitializedResult();
+      }
+
+      if (
+        !options.loadedThreads.isThreadLoadedForConnection({
+          connectionId,
+          threadId: params.threadId,
+        })
+      ) {
+        return err(createThreadNotLoadedForConnectionError(params.threadId));
+      }
+
+      const bindResult = await ensureSessionNotificationBinding();
+      if (!bindResult.ok) {
+        return err(mapTurnError(bindResult.error));
+      }
+
+      const agentRequestId = createAgentRequestId({
+        connectionId,
+        method: "turn/interrupt",
+        requestId,
+      });
+      const result = await service.interruptTurn(agentRequestId, params);
       return mapTurnResult(result);
     },
   });
@@ -608,9 +698,9 @@ const mapTurnSummary = (turn: AgentTurnNotification["turn"]): Turn =>
         : Object.freeze({ type: turn.status.type }),
   });
 
-const mapTurnResult = (
-  result: Result<TurnStartResult, AgentSessionLookupError | TurnsServiceError>,
-): Result<TurnStartResult, ProtocolMethodError> => {
+const mapTurnResult = <TResult extends TurnStartResult | TurnSteerResult | TurnInterruptResult>(
+  result: Result<TResult, AgentSessionLookupError | TurnsServiceError>,
+): Result<TResult, ProtocolMethodError> => {
   if (result.ok) {
     return ok(result.data);
   }
@@ -632,6 +722,10 @@ const mapTurnError = (error: AgentSessionLookupError | TurnsServiceError): Proto
       return mapInvalidProviderPayloadToProtocolError(error);
     case "activeTurnConflict":
       return createActiveTurnConflictProtocolError(error);
+    case "activeTurnNotFound":
+      return createActiveTurnNotFoundProtocolError(error);
+    case "activeTurnMismatch":
+      return createActiveTurnMismatchProtocolError(error);
     case "agentNotFound":
       throw new Error(error.message);
     default:

--- a/AppServer/src/turns/turn.handlers.ts
+++ b/AppServer/src/turns/turn.handlers.ts
@@ -4,7 +4,11 @@ import type {
   AgentSessionLookupError,
   AgentTurnNotification,
 } from "@/agents/contracts";
-import { createAgentSessionUnavailableError, createProviderError } from "@/agents/protocol-errors";
+import {
+  createAgentNotFoundProtocolError,
+  createAgentSessionUnavailableError,
+  createProviderError,
+} from "@/agents/protocol-errors";
 import type { AgentRegistry } from "@/agents/registry";
 import { createAgentRequestId } from "@/agents/request-id";
 import type { Logger } from "@/app/logger";
@@ -463,11 +467,11 @@ export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModul
           return;
         }
 
+        activeTurns.clearThread(notification.threadId);
         await options.onTurnCompleted?.({
           threadId: notification.threadId,
           turnId: turn.id,
         });
-        activeTurns.clearThread(notification.threadId);
         await fanOutThreadNotification(notification.threadId, {
           method: "turn/completed",
           params: {
@@ -654,6 +658,11 @@ export const createTurnsModule = (options: CreateTurnsModuleOptions): TurnsModul
         return err(mapTurnError(bindResult.error));
       }
 
+      const approvalBindResult = await options.ensureApprovalNotificationBinding?.();
+      if (approvalBindResult !== undefined && !approvalBindResult.ok) {
+        return err(mapTurnError(approvalBindResult.error));
+      }
+
       const agentRequestId = createAgentRequestId({
         connectionId,
         method: "turn/interrupt",
@@ -727,7 +736,7 @@ const mapTurnError = (error: AgentSessionLookupError | TurnsServiceError): Proto
     case "activeTurnMismatch":
       return createActiveTurnMismatchProtocolError(error);
     case "agentNotFound":
-      throw new Error(error.message);
+      return createAgentNotFoundProtocolError(error.agentId);
     default:
       return assertNever(error, "Unhandled turn protocol error");
   }


### PR DESCRIPTION
## Summary
- add `turn/steer`, `turn/interrupt`, and `approval/resolve` end to end in the App Server
- replace the approvals placeholder with a real in-memory approvals feature that tracks pending requests and stale cleanup
- emit provider-neutral approval request and resolution notifications for loaded thread subscribers
- wire turn completion, thread closure, and session disconnect cleanup into approval state handling
- expand Codex adapter approval mapping and protocol coverage for turn controls and approvals

## Testing
- `bun run check`
- `bun run typecheck`
- `bun test src/turns/service.test.ts src/approvals/approval-registry.test.ts src/agents/codex-adapter/notification-mapper.test.ts src/agents/codex-adapter/session.test.ts src/app/protocol-harness.test.ts`