### PR TITLE
Remote folder picker and Cockpit file browsing API

### DIFF
--- a/AtelierCode/AtelierCode.xcodeproj/project.pbxproj
+++ b/AtelierCode/AtelierCode.xcodeproj/project.pbxproj
@@ -11,16 +11,33 @@
 		AC00000000000000000000B2 /* GhosttyKit in Frameworks */ = {isa = PBXBuildFile; productRef = AC00000000000000000000A2 /* GhosttyKit */; };
 		AC00000000000000000000B3 /* GhosttyTerminal in Frameworks */ = {isa = PBXBuildFile; productRef = AC00000000000000000000A3 /* GhosttyTerminal */; };
 		AC00000000000000000000B4 /* GhosttyTheme in Frameworks */ = {isa = PBXBuildFile; productRef = AC00000000000000000000A4 /* GhosttyTheme */; };
+		AC00000000000000000000B5 /* CockpitAPI in Frameworks */ = {isa = PBXBuildFile; productRef = AC00000000000000000000A5 /* CockpitAPI */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		AC00000000000000000000D7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DE7C71162FF757CA00D8D7E5 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DE7C711D2FF757CA00D8D7E5;
+			remoteInfo = AtelierCode;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		DE7C711E2FF757CA00D8D7E5 /* AtelierCode.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AtelierCode.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		AC00000000000000000000D3 /* AtelierCodeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AtelierCodeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		DE7C71202FF757CA00D8D7E5 /* AtelierCode */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = AtelierCode;
+			sourceTree = "<group>";
+		};
+		AC00000000000000000000D1 /* AtelierCodeTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = AtelierCodeTests;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -37,6 +54,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		AC00000000000000000000D5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AC00000000000000000000B5 /* CockpitAPI in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -44,6 +69,7 @@
 			isa = PBXGroup;
 			children = (
 				DE7C71202FF757CA00D8D7E5 /* AtelierCode */,
+				AC00000000000000000000D1 /* AtelierCodeTests */,
 				DE7C711F2FF757CA00D8D7E5 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -52,6 +78,7 @@
 			isa = PBXGroup;
 			children = (
 				DE7C711E2FF757CA00D8D7E5 /* AtelierCode.app */,
+				AC00000000000000000000D3 /* AtelierCodeTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -85,6 +112,29 @@
 			productReference = DE7C711E2FF757CA00D8D7E5 /* AtelierCode.app */;
 			productType = "com.apple.product-type.application";
 		};
+		AC00000000000000000000D2 /* AtelierCodeTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AC00000000000000000000D9 /* Build configuration list for PBXNativeTarget "AtelierCodeTests" */;
+			buildPhases = (
+				AC00000000000000000000D4 /* Sources */,
+				AC00000000000000000000D5 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AC00000000000000000000D8 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				AC00000000000000000000D1 /* AtelierCodeTests */,
+			);
+			name = AtelierCodeTests;
+			packageProductDependencies = (
+				AC00000000000000000000A5 /* CockpitAPI */,
+			);
+			productName = AtelierCodeTests;
+			productReference = AC00000000000000000000D3 /* AtelierCodeTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -97,6 +147,10 @@
 				TargetAttributes = {
 					DE7C711D2FF757CA00D8D7E5 = {
 						CreatedOnToolsVersion = 26.6;
+					};
+					AC00000000000000000000D2 = {
+						CreatedOnToolsVersion = 26.6;
+						TestTargetID = DE7C711D2FF757CA00D8D7E5;
 					};
 				};
 			};
@@ -119,6 +173,7 @@
 			projectRoot = "";
 			targets = (
 				DE7C711D2FF757CA00D8D7E5 /* AtelierCode */,
+				AC00000000000000000000D2 /* AtelierCodeTests */,
 			);
 		};
 /* End PBXProject section */
@@ -141,7 +196,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		AC00000000000000000000D4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		AC00000000000000000000D8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DE7C711D2FF757CA00D8D7E5 /* AtelierCode */;
+			targetProxy = AC00000000000000000000D7 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		DE7C71272FF757CB00D8D7E5 /* Debug */ = {
@@ -331,6 +401,47 @@
 			};
 			name = Release;
 		};
+		AC00000000000000000000DA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 337D6CNU4E;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ElevenIdeas.AtelierCodeTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AtelierCode.app/Contents/MacOS/AtelierCode";
+			};
+			name = Debug;
+		};
+		AC00000000000000000000DB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 337D6CNU4E;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ElevenIdeas.AtelierCodeTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AtelierCode.app/Contents/MacOS/AtelierCode";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -348,6 +459,15 @@
 			buildConfigurations = (
 				DE7C712A2FF757CB00D8D7E5 /* Debug */,
 				DE7C712B2FF757CB00D8D7E5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AC00000000000000000000D9 /* Build configuration list for PBXNativeTarget "AtelierCodeTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AC00000000000000000000DA /* Debug */,
+				AC00000000000000000000DB /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -374,6 +494,10 @@
 
 /* Begin XCSwiftPackageProductDependency section */
 		AC00000000000000000000A1 /* CockpitAPI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = CockpitAPI;
+		};
+		AC00000000000000000000A5 /* CockpitAPI */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = CockpitAPI;
 		};

--- a/AtelierCode/AtelierCode.xcodeproj/project.pbxproj
+++ b/AtelierCode/AtelierCode.xcodeproj/project.pbxproj
@@ -25,24 +25,32 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		DE7C711E2FF757CA00D8D7E5 /* AtelierCode.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AtelierCode.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC00000000000000000000D3 /* AtelierCodeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AtelierCodeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DE7C711E2FF757CA00D8D7E5 /* AtelierCode.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AtelierCode.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		DE7C71202FF757CA00D8D7E5 /* AtelierCode */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = AtelierCode;
-			sourceTree = "<group>";
-		};
 		AC00000000000000000000D1 /* AtelierCodeTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = AtelierCodeTests;
 			sourceTree = "<group>";
 		};
+		DE7C71202FF757CA00D8D7E5 /* AtelierCode */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = AtelierCode;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		AC00000000000000000000D5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AC00000000000000000000B5 /* CockpitAPI in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DE7C711B2FF757CA00D8D7E5 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -51,14 +59,6 @@
 				AC00000000000000000000B2 /* GhosttyKit in Frameworks */,
 				AC00000000000000000000B3 /* GhosttyTerminal in Frameworks */,
 				AC00000000000000000000B4 /* GhosttyTheme in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		AC00000000000000000000D5 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				AC00000000000000000000B5 /* CockpitAPI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -86,6 +86,29 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		AC00000000000000000000D2 /* AtelierCodeTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AC00000000000000000000D9 /* Build configuration list for PBXNativeTarget "AtelierCodeTests" */;
+			buildPhases = (
+				AC00000000000000000000D4 /* Sources */,
+				AC00000000000000000000D5 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AC00000000000000000000D8 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				AC00000000000000000000D1 /* AtelierCodeTests */,
+			);
+			name = AtelierCodeTests;
+			packageProductDependencies = (
+				AC00000000000000000000A5 /* CockpitAPI */,
+			);
+			productName = AtelierCodeTests;
+			productReference = AC00000000000000000000D3 /* AtelierCodeTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		DE7C711D2FF757CA00D8D7E5 /* AtelierCode */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = DE7C71292FF757CB00D8D7E5 /* Build configuration list for PBXNativeTarget "AtelierCode" */;
@@ -112,29 +135,6 @@
 			productReference = DE7C711E2FF757CA00D8D7E5 /* AtelierCode.app */;
 			productType = "com.apple.product-type.application";
 		};
-		AC00000000000000000000D2 /* AtelierCodeTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = AC00000000000000000000D9 /* Build configuration list for PBXNativeTarget "AtelierCodeTests" */;
-			buildPhases = (
-				AC00000000000000000000D4 /* Sources */,
-				AC00000000000000000000D5 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				AC00000000000000000000D8 /* PBXTargetDependency */,
-			);
-			fileSystemSynchronizedGroups = (
-				AC00000000000000000000D1 /* AtelierCodeTests */,
-			);
-			name = AtelierCodeTests;
-			packageProductDependencies = (
-				AC00000000000000000000A5 /* CockpitAPI */,
-			);
-			productName = AtelierCodeTests;
-			productReference = AC00000000000000000000D3 /* AtelierCodeTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -145,12 +145,12 @@
 				LastSwiftUpdateCheck = 2660;
 				LastUpgradeCheck = 2660;
 				TargetAttributes = {
-					DE7C711D2FF757CA00D8D7E5 = {
-						CreatedOnToolsVersion = 26.6;
-					};
 					AC00000000000000000000D2 = {
 						CreatedOnToolsVersion = 26.6;
 						TestTargetID = DE7C711D2FF757CA00D8D7E5;
+					};
+					DE7C711D2FF757CA00D8D7E5 = {
+						CreatedOnToolsVersion = 26.6;
 					};
 				};
 			};
@@ -189,14 +189,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		DE7C711A2FF757CA00D8D7E5 /* Sources */ = {
+		AC00000000000000000000D4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		AC00000000000000000000D4 /* Sources */ = {
+		DE7C711A2FF757CA00D8D7E5 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -214,6 +214,47 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		AC00000000000000000000DA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 337D6CNU4E;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ElevenIdeas.AtelierCodeTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AtelierCode.app/Contents/MacOS/AtelierCode";
+			};
+			name = Debug;
+		};
+		AC00000000000000000000DB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 337D6CNU4E;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ElevenIdeas.AtelierCodeTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AtelierCode.app/Contents/MacOS/AtelierCode";
+			};
+			name = Release;
+		};
 		DE7C71272FF757CB00D8D7E5 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -401,50 +442,18 @@
 			};
 			name = Release;
 		};
-		AC00000000000000000000DA /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_IDENTITY = "-";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 337D6CNU4E;
-				GENERATE_INFOPLIST_FILE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 26.5;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = ElevenIdeas.AtelierCodeTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_APPROACHABLE_CONCURRENCY = YES;
-				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AtelierCode.app/Contents/MacOS/AtelierCode";
-			};
-			name = Debug;
-		};
-		AC00000000000000000000DB /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 337D6CNU4E;
-				GENERATE_INFOPLIST_FILE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 26.5;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = ElevenIdeas.AtelierCodeTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_APPROACHABLE_CONCURRENCY = YES;
-				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AtelierCode.app/Contents/MacOS/AtelierCode";
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		AC00000000000000000000D9 /* Build configuration list for PBXNativeTarget "AtelierCodeTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AC00000000000000000000DA /* Debug */,
+				AC00000000000000000000DB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		DE7C71192FF757CA00D8D7E5 /* Build configuration list for PBXProject "AtelierCode" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -459,15 +468,6 @@
 			buildConfigurations = (
 				DE7C712A2FF757CB00D8D7E5 /* Debug */,
 				DE7C712B2FF757CB00D8D7E5 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		AC00000000000000000000D9 /* Build configuration list for PBXNativeTarget "AtelierCodeTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				AC00000000000000000000DA /* Debug */,
-				AC00000000000000000000DB /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -497,10 +497,6 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = CockpitAPI;
 		};
-		AC00000000000000000000A5 /* CockpitAPI */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = CockpitAPI;
-		};
 		AC00000000000000000000A2 /* GhosttyKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = AC00000000000000000000C2 /* XCRemoteSwiftPackageReference "libghostty-spm" */;
@@ -515,6 +511,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = AC00000000000000000000C2 /* XCRemoteSwiftPackageReference "libghostty-spm" */;
 			productName = GhosttyTheme;
+		};
+		AC00000000000000000000A5 /* CockpitAPI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = CockpitAPI;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/AtelierCode/AtelierCode.xcodeproj/xcshareddata/xcschemes/AtelierCode.xcscheme
+++ b/AtelierCode/AtelierCode.xcodeproj/xcshareddata/xcschemes/AtelierCode.xcscheme
@@ -29,6 +29,18 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AC00000000000000000000D2"
+               BuildableName = "AtelierCodeTests.xctest"
+               BlueprintName = "AtelierCodeTests"
+               ReferencedContainer = "container:AtelierCode.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/AtelierCode/AtelierCode/Features/RemoteFiles/RemoteFileBrowser.swift
+++ b/AtelierCode/AtelierCode/Features/RemoteFiles/RemoteFileBrowser.swift
@@ -1,0 +1,166 @@
+import Foundation
+import Observation
+import CockpitAPI
+
+/// Picker-workflow state for browsing the workstation's filesystem via
+/// `/api/fs`. Not a generic tree engine — exactly the folder picker's
+/// drill-down state. Knows nothing about views.
+@Observable
+final class RemoteFileBrowser {
+    private let client: any CockpitClient
+
+    private(set) var roots: [RemoteWorkspaceRoot] = []
+    private(set) var activeRoot: RemoteWorkspaceRoot?
+    /// `nil` ⇒ showing the roots list.
+    private(set) var listing: DirectoryListing?
+    private(set) var isLoading = false
+    private(set) var hasLoadedRoots = false
+    var lastError: String?
+    /// Highlighted Entry (List selection) — never the Chosen Folder.
+    var highlightedPath: String?
+    /// Path-field draft; synced to `currentPath` on every navigation.
+    var typedPath: String = ""
+    var showHidden = false {
+        didSet {
+            guard showHidden != oldValue, listing != nil else { return }
+            reloadTask = Task { await self.reloadCurrentDirectory() }
+        }
+    }
+    /// Awaitable handle for the hidden-toggle reload; tests await it for
+    /// determinism.
+    private(set) var reloadTask: Task<Void, Never>?
+
+    init(client: any CockpitClient) {
+        self.client = client
+    }
+
+    // MARK: - Derived
+
+    /// The Chosen Folder candidate — the directory currently on screen.
+    var currentPath: String? { listing?.path }
+
+    /// Whether Up navigates to a parent directory (false at the active
+    /// root's top and on the roots list). `goUp()` at the root still works:
+    /// it returns to the roots list.
+    var canGoUp: Bool {
+        guard let currentPath else { return false }
+        return currentPath != activeRoot?.path
+    }
+
+    /// Active root's label followed by the lexical path segments below it.
+    var breadcrumbs: [(label: String, path: String)] {
+        guard let currentPath, let activeRoot else { return [] }
+        var crumbs = [(label: activeRoot.label, path: activeRoot.path)]
+        guard currentPath != activeRoot.path else { return crumbs }
+        let relative = String(currentPath.dropFirst(activeRoot.path.count).drop(while: { $0 == "/" }))
+        var accumulated = activeRoot.path
+        for segment in relative.split(separator: "/") {
+            accumulated += "/\(segment)"
+            crumbs.append((label: String(segment), path: accumulated))
+        }
+        return crumbs
+    }
+
+    // MARK: - Commands
+
+    func loadRoots() async {
+        isLoading = true
+        defer {
+            isLoading = false
+            hasLoadedRoots = true
+        }
+        do {
+            roots = try await client.workspaceRoots()
+            lastError = nil
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+
+    func open(root: RemoteWorkspaceRoot) async {
+        guard let fetched = await list(root.path) else { return }
+        activeRoot = root
+        apply(fetched)
+    }
+
+    func descend(into entry: RemoteEntry) async {
+        guard entry.kind == .directory else { return }
+        guard let fetched = await list(entry.path) else { return }
+        apply(fetched)
+    }
+
+    func goUp() async {
+        guard let currentPath else { return }
+        if !canGoUp {
+            // At the active root's top: back out to the roots list.
+            listing = nil
+            activeRoot = nil
+            typedPath = ""
+            highlightedPath = nil
+            return
+        }
+        let parent = (currentPath as NSString).deletingLastPathComponent
+        guard let fetched = await list(parent) else { return }
+        apply(fetched)
+    }
+
+    /// Return / Go on the path field. The server is the sole validator:
+    /// the trimmed string goes straight to `fs/list` and a failure renders
+    /// the typed error while navigation state stays put.
+    func commitTypedPath() async {
+        if !hasLoadedRoots {
+            await loadRoots()
+        }
+        let trimmed = typedPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let fetched = await list(trimmed) else { return }
+        activeRoot = longestPrefixRoot(of: fetched.path)
+        apply(fetched)
+    }
+
+    /// Breadcrumb segment tap.
+    func jump(to path: String) async {
+        guard let fetched = await list(path) else { return }
+        apply(fetched)
+    }
+
+    // MARK: - Internals
+
+    private func reloadCurrentDirectory() async {
+        guard let currentPath else { return }
+        let highlighted = highlightedPath
+        guard let fetched = await list(currentPath) else { return }
+        apply(fetched)
+        // Keep the highlight only if the entry survived the re-list.
+        if let highlighted, fetched.entries.contains(where: { $0.path == highlighted }) {
+            highlightedPath = highlighted
+        }
+    }
+
+    private func list(_ path: String) async -> DirectoryListing? {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            let fetched = try await client.listDirectory(path: path, showHidden: showHidden)
+            lastError = nil
+            return fetched
+        } catch {
+            lastError = error.localizedDescription
+            return nil
+        }
+    }
+
+    private func apply(_ fetched: DirectoryListing) {
+        listing = fetched
+        typedPath = fetched.path
+        highlightedPath = nil
+    }
+
+    /// The root whose path is the longest lexical prefix of `path`. The
+    /// server already guaranteed containment, so a match exists whenever
+    /// the roots are current.
+    private func longestPrefixRoot(of path: String) -> RemoteWorkspaceRoot? {
+        roots
+            .filter { path == $0.path || path.hasPrefix($0.path == "/" ? "/" : $0.path + "/") }
+            .max { $0.path.count < $1.path.count }
+    }
+}

--- a/AtelierCode/AtelierCode/Features/RemoteFiles/RemoteFolderPickerSheet.swift
+++ b/AtelierCode/AtelierCode/Features/RemoteFiles/RemoteFolderPickerSheet.swift
@@ -1,0 +1,264 @@
+import SwiftUI
+import CockpitAPI
+
+/// Drill-down folder picker over Cockpit's `/api/fs`. Presented as a
+/// nested sheet from `CreateSessionSheet`; commits the *viewed* directory
+/// (never the highlighted row) via `onChoose`.
+struct RemoteFolderPickerSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var browser: RemoteFileBrowser
+    private let initialPath: String
+    private let onChoose: (String) -> Void
+
+    init(client: any CockpitClient, initialPath: String = "", onChoose: @escaping (String) -> Void) {
+        _browser = State(initialValue: RemoteFileBrowser(client: client))
+        self.initialPath = initialPath.trimmingCharacters(in: .whitespaces)
+        self.onChoose = onChoose
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            if browser.listing == nil {
+                rootsList
+            } else {
+                directoryList
+            }
+            Divider()
+            footer
+        }
+        .frame(width: 520, height: 480)
+        .task {
+            if initialPath.isEmpty {
+                await browser.loadRoots()
+            } else {
+                // Prefill from the working-dir field; on failure the roots
+                // list shows with the error visible above.
+                browser.typedPath = initialPath
+                await browser.commitTypedPath()
+            }
+        }
+    }
+
+    // MARK: - Header (path field, Up, breadcrumbs, error)
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                TextField("Path", text: $browser.typedPath, prompt: Text("/path/on/the/server"))
+                    .textFieldStyle(.roundedBorder)
+                    .autocorrectionDisabled()
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .onSubmit { Task { await browser.commitTypedPath() } }
+                Button("Go") { Task { await browser.commitTypedPath() } }
+            }
+            HStack(spacing: 8) {
+                Button {
+                    Task { await browser.goUp() }
+                } label: {
+                    Image(systemName: "arrow.up")
+                }
+                .disabled(browser.listing == nil)
+                .help("Up")
+                breadcrumbBar
+            }
+            if let message = browser.lastError {
+                Label(message, systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(.red)
+                    .font(.callout)
+                    .lineLimit(2)
+            }
+        }
+        .padding(12)
+    }
+
+    private var breadcrumbBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 3) {
+                let crumbs = browser.breadcrumbs
+                ForEach(Array(crumbs.enumerated()), id: \.element.path) { index, crumb in
+                    if index > 0 {
+                        Image(systemName: "chevron.right")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+                    Button(crumb.label) {
+                        Task { await browser.jump(to: crumb.path) }
+                    }
+                    .buttonStyle(.plain)
+                    .fontWeight(index == crumbs.count - 1 ? .semibold : .regular)
+                    .lineLimit(1)
+                }
+            }
+        }
+        .frame(height: 20)
+    }
+
+    // MARK: - Roots list
+
+    @ViewBuilder
+    private var rootsList: some View {
+        if browser.isLoading && !browser.hasLoadedRoots {
+            ProgressView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if browser.roots.isEmpty && browser.hasLoadedRoots {
+            ContentUnavailableView(
+                "No browsable roots",
+                systemImage: "folder.badge.questionmark",
+                description: Text("Workspace roots are configured on the Cockpit server in the [fs] config section.")
+            )
+        } else {
+            List(selection: $browser.highlightedPath) {
+                ForEach(browser.roots) { root in
+                    rootRow(root)
+                        .tag(root.path)
+                }
+            }
+            .listStyle(.inset)
+            .onKeyPress(.return) { openHighlightedRoot() }
+        }
+    }
+
+    private func rootRow(_ root: RemoteWorkspaceRoot) -> some View {
+        HStack {
+            Image(systemName: "folder")
+            Text(root.label)
+            Spacer()
+            Text(root.path)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture(count: 2) {
+            Task { await browser.open(root: root) }
+        }
+    }
+
+    private func openHighlightedRoot() -> KeyPress.Result {
+        guard let path = browser.highlightedPath,
+              let root = browser.roots.first(where: { $0.path == path }) else { return .ignored }
+        Task { await browser.open(root: root) }
+        return .handled
+    }
+
+    // MARK: - Directory list
+
+    private var directoryList: some View {
+        VStack(spacing: 0) {
+            if browser.listing?.truncated == true {
+                HStack(spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle")
+                    Text("Listing truncated at 10,000 entries")
+                }
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                Divider()
+            }
+            List(selection: $browser.highlightedPath) {
+                ForEach(browser.listing?.entries ?? []) { entry in
+                    entryRow(entry)
+                        .tag(entry.path)
+                }
+            }
+            .listStyle(.inset)
+            .onKeyPress(.return) { descendHighlighted() }
+            .overlay {
+                if browser.isLoading {
+                    ProgressView()
+                } else if browser.listing?.entries.isEmpty == true {
+                    Text("Empty folder")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private func entryRow(_ entry: RemoteEntry) -> some View {
+        let enterable = entry.kind == .directory
+        return HStack {
+            Image(systemName: icon(for: entry.kind))
+            Text(entry.name)
+            Spacer()
+        }
+        .foregroundStyle(enterable ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary))
+        .contentShape(Rectangle())
+        .onTapGesture(count: 2) {
+            guard enterable else { return }
+            Task { await browser.descend(into: entry) }
+        }
+    }
+
+    private func icon(for kind: RemoteEntryKind) -> String {
+        switch kind {
+        case .directory: "folder"
+        case .file: "doc"
+        case .unknown: "questionmark.square.dashed"
+        }
+    }
+
+    private func descendHighlighted() -> KeyPress.Result {
+        guard let path = browser.highlightedPath,
+              let entry = browser.listing?.entries.first(where: { $0.path == path }) else { return .ignored }
+        if entry.kind == .directory {
+            Task { await browser.descend(into: entry) }
+        }
+        // Files and unknown entries consume the key and stay inert.
+        return .handled
+    }
+
+    // MARK: - Footer
+
+    private var footer: some View {
+        HStack {
+            Toggle("Show hidden files", isOn: $browser.showHidden)
+                .toggleStyle(.checkbox)
+            Spacer()
+            Button("Cancel", role: .cancel) { dismiss() }
+                .keyboardShortcut(.cancelAction)
+            Button("Use This Folder") {
+                guard let path = browser.currentPath else { return }
+                onChoose(path)
+                dismiss()
+            }
+            .keyboardShortcut(.defaultAction)
+            .disabled(browser.currentPath == nil)
+        }
+        .padding(12)
+    }
+}
+
+#Preview("Roots") {
+    RemoteFolderPickerSheet(client: MockCockpitClient()) { _ in }
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Directory") {
+    RemoteFolderPickerSheet(client: MockCockpitClient(), initialPath: "/home/dev/Projects/atelier") { _ in }
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Prefill error") {
+    RemoteFolderPickerSheet(client: MockCockpitClient(), initialPath: "/home/dev/Projects/secrets") { _ in }
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Truncated") {
+    RemoteFolderPickerSheet(client: MockCockpitClient(), initialPath: "/home/dev/Projects/huge") { _ in }
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Empty folder") {
+    RemoteFolderPickerSheet(client: MockCockpitClient(), initialPath: "/home/dev/Projects/empty") { _ in }
+        .preferredColorScheme(.dark)
+}
+
+#Preview("No roots") {
+    RemoteFolderPickerSheet(client: MockCockpitClient(mockRoots: [])) { _ in }
+        .preferredColorScheme(.dark)
+}

--- a/AtelierCode/AtelierCode/Features/RemoteFiles/RemoteFolderPickerSheet.swift
+++ b/AtelierCode/AtelierCode/Features/RemoteFiles/RemoteFolderPickerSheet.swift
@@ -20,10 +20,13 @@ struct RemoteFolderPickerSheet: View {
         VStack(spacing: 0) {
             header
             Divider()
+            // Panes are child structs and their rows are inline in the
+            // ForEach: rows built by view-returning helpers crash Xcode
+            // preview dynamic replacement (ViewListTree identity assert).
             if browser.listing == nil {
-                rootsList
+                RootsListPane(browser: browser)
             } else {
-                directoryList
+                DirectoryListPane(browser: browser)
             }
             Divider()
             footer
@@ -96,122 +99,6 @@ struct RemoteFolderPickerSheet: View {
         .frame(height: 20)
     }
 
-    // MARK: - Roots list
-
-    @ViewBuilder
-    private var rootsList: some View {
-        if browser.isLoading && !browser.hasLoadedRoots {
-            ProgressView()
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else if browser.roots.isEmpty && browser.hasLoadedRoots {
-            ContentUnavailableView(
-                "No browsable roots",
-                systemImage: "folder.badge.questionmark",
-                description: Text("Workspace roots are configured on the Cockpit server in the [fs] config section.")
-            )
-        } else {
-            List(selection: $browser.highlightedPath) {
-                ForEach(browser.roots) { root in
-                    rootRow(root)
-                        .tag(root.path)
-                }
-            }
-            .listStyle(.inset)
-            .onKeyPress(.return) { openHighlightedRoot() }
-        }
-    }
-
-    private func rootRow(_ root: RemoteWorkspaceRoot) -> some View {
-        HStack {
-            Image(systemName: "folder")
-            Text(root.label)
-            Spacer()
-            Text(root.path)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .truncationMode(.middle)
-        }
-        .contentShape(Rectangle())
-        .onTapGesture(count: 2) {
-            Task { await browser.open(root: root) }
-        }
-    }
-
-    private func openHighlightedRoot() -> KeyPress.Result {
-        guard let path = browser.highlightedPath,
-              let root = browser.roots.first(where: { $0.path == path }) else { return .ignored }
-        Task { await browser.open(root: root) }
-        return .handled
-    }
-
-    // MARK: - Directory list
-
-    private var directoryList: some View {
-        VStack(spacing: 0) {
-            if browser.listing?.truncated == true {
-                HStack(spacing: 6) {
-                    Image(systemName: "exclamationmark.triangle")
-                    Text("Listing truncated at 10,000 entries")
-                }
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 6)
-                Divider()
-            }
-            List(selection: $browser.highlightedPath) {
-                ForEach(browser.listing?.entries ?? []) { entry in
-                    entryRow(entry)
-                        .tag(entry.path)
-                }
-            }
-            .listStyle(.inset)
-            .onKeyPress(.return) { descendHighlighted() }
-            .overlay {
-                if browser.isLoading {
-                    ProgressView()
-                } else if browser.listing?.entries.isEmpty == true {
-                    Text("Empty folder")
-                        .foregroundStyle(.secondary)
-                }
-            }
-        }
-    }
-
-    private func entryRow(_ entry: RemoteEntry) -> some View {
-        let enterable = entry.kind == .directory
-        return HStack {
-            Image(systemName: icon(for: entry.kind))
-            Text(entry.name)
-            Spacer()
-        }
-        .foregroundStyle(enterable ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary))
-        .contentShape(Rectangle())
-        .onTapGesture(count: 2) {
-            guard enterable else { return }
-            Task { await browser.descend(into: entry) }
-        }
-    }
-
-    private func icon(for kind: RemoteEntryKind) -> String {
-        switch kind {
-        case .directory: "folder"
-        case .file: "doc"
-        case .unknown: "questionmark.square.dashed"
-        }
-    }
-
-    private func descendHighlighted() -> KeyPress.Result {
-        guard let path = browser.highlightedPath,
-              let entry = browser.listing?.entries.first(where: { $0.path == path }) else { return .ignored }
-        if entry.kind == .directory {
-            Task { await browser.descend(into: entry) }
-        }
-        // Files and unknown entries consume the key and stay inert.
-        return .handled
-    }
-
     // MARK: - Footer
 
     private var footer: some View {
@@ -230,6 +117,121 @@ struct RemoteFolderPickerSheet: View {
             .disabled(browser.currentPath == nil)
         }
         .padding(12)
+    }
+}
+
+// MARK: - Roots list pane
+
+private struct RootsListPane: View {
+    @Bindable var browser: RemoteFileBrowser
+
+    var body: some View {
+        if browser.isLoading && !browser.hasLoadedRoots {
+            ProgressView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if browser.roots.isEmpty && browser.hasLoadedRoots {
+            ContentUnavailableView(
+                "No browsable roots",
+                systemImage: "folder.badge.questionmark",
+                description: Text("Workspace roots are configured on the Cockpit server in the [fs] config section.")
+            )
+        } else {
+            List(selection: $browser.highlightedPath) {
+                ForEach(browser.roots) { root in
+                    HStack {
+                        Image(systemName: "folder")
+                        Text(root.label)
+                        Spacer()
+                        Text(root.path)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    .contentShape(Rectangle())
+                    .onTapGesture(count: 2) {
+                        Task { await browser.open(root: root) }
+                    }
+                    .tag(root.path)
+                }
+            }
+            .listStyle(.inset)
+            .onKeyPress(.return) { openHighlightedRoot() }
+        }
+    }
+
+    private func openHighlightedRoot() -> KeyPress.Result {
+        guard let path = browser.highlightedPath,
+              let root = browser.roots.first(where: { $0.path == path }) else { return .ignored }
+        Task { await browser.open(root: root) }
+        return .handled
+    }
+}
+
+// MARK: - Directory list pane
+
+private struct DirectoryListPane: View {
+    @Bindable var browser: RemoteFileBrowser
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if browser.listing?.truncated == true {
+                HStack(spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle")
+                    Text("Listing truncated at 10,000 entries")
+                }
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                Divider()
+            }
+            List(selection: $browser.highlightedPath) {
+                ForEach(browser.listing?.entries ?? []) { entry in
+                    let enterable = entry.kind == .directory
+                    HStack {
+                        Image(systemName: Self.icon(for: entry.kind))
+                        Text(entry.name)
+                        Spacer()
+                    }
+                    .foregroundStyle(enterable ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary))
+                    .contentShape(Rectangle())
+                    .onTapGesture(count: 2) {
+                        guard enterable else { return }
+                        Task { await browser.descend(into: entry) }
+                    }
+                    .tag(entry.path)
+                }
+            }
+            .listStyle(.inset)
+            .onKeyPress(.return) { descendHighlighted() }
+            .overlay {
+                if browser.isLoading {
+                    ProgressView()
+                } else if browser.listing?.entries.isEmpty == true {
+                    Text("Empty folder")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private func descendHighlighted() -> KeyPress.Result {
+        guard let path = browser.highlightedPath,
+              let entry = browser.listing?.entries.first(where: { $0.path == path }) else { return .ignored }
+        if entry.kind == .directory {
+            Task { await browser.descend(into: entry) }
+        }
+        // Files and unknown entries consume the key and stay inert.
+        return .handled
+    }
+
+    private static func icon(for kind: RemoteEntryKind) -> String {
+        switch kind {
+        case .directory: "folder"
+        case .file: "doc"
+        case .unknown: "questionmark.square.dashed"
+        }
     }
 }
 

--- a/AtelierCode/AtelierCode/Features/Sessions/CreateSessionSheet.swift
+++ b/AtelierCode/AtelierCode/Features/Sessions/CreateSessionSheet.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import UniformTypeIdentifiers
 import CockpitAPI
 
 /// Form for `POST /sessions/start`, driven by live `/actions` and
@@ -52,7 +51,7 @@ struct CreateSessionSheet: View {
                         } label: {
                             Image(systemName: "folder")
                         }
-                        .help("Choose a local folder (path is used on the server)")
+                        .help("Browse folders on the Cockpit workstation")
                     }
                     TextField("Name (optional)", text: $name)
                 }
@@ -107,9 +106,9 @@ struct CreateSessionSheet: View {
         .frame(width: 460, height: 440)
         .task { await loadDiscovery() }
         .onChange(of: selectedActionName) { resetParams() }
-        .fileImporter(isPresented: $showFolderPicker, allowedContentTypes: [.folder]) { result in
-            if case .success(let url) = result {
-                workingDir = url.path
+        .sheet(isPresented: $showFolderPicker) {
+            RemoteFolderPickerSheet(client: appModel.client, initialPath: workingDir) { path in
+                workingDir = path
             }
         }
     }

--- a/AtelierCode/AtelierCode/PreviewSupport/MockCockpitClient.swift
+++ b/AtelierCode/AtelierCode/PreviewSupport/MockCockpitClient.swift
@@ -126,6 +126,106 @@ nonisolated struct MockCockpitClient: CockpitClient {
         return try JSONDecoder().decode(Envelope.self, from: json).environments
     }
 
+    // MARK: - File system
+
+    var mockRoots: [RemoteWorkspaceRoot] = [
+        RemoteWorkspaceRoot(label: "Projects", path: "/home/dev/Projects"),
+        RemoteWorkspaceRoot(label: "Home", path: "/home/dev"),
+    ]
+
+    /// Directory path → full (unfiltered) children. `listDirectory` filters
+    /// dot-entries itself and throws typed errors, mimicking the server so
+    /// `RemoteFileBrowser` tests cover error handling.
+    var mockTree: [String: [RemoteEntry]] = {
+        func dir(_ path: String, symlink: Bool = false) -> RemoteEntry {
+            RemoteEntry(
+                name: (path as NSString).lastPathComponent, path: path,
+                kind: .directory, isSymlink: symlink,
+                modifiedAt: Date(timeIntervalSinceNow: -3600)
+            )
+        }
+        func file(_ path: String, size: Int64 = 2048, symlink: Bool = false) -> RemoteEntry {
+            RemoteEntry(
+                name: (path as NSString).lastPathComponent, path: path,
+                kind: .file, isSymlink: symlink, size: size,
+                modifiedAt: Date(timeIntervalSinceNow: -7200)
+            )
+        }
+        return [
+            "/home/dev": [
+                dir("/home/dev/.config"),
+                dir("/home/dev/Documents"),
+                dir("/home/dev/Projects"),
+                file("/home/dev/.zshrc", size: 512),
+            ],
+            "/home/dev/Projects": [
+                dir("/home/dev/Projects/atelier"),
+                dir("/home/dev/Projects/empty"),
+                dir("/home/dev/Projects/huge"),
+                dir("/home/dev/Projects/secrets"),
+                file("/home/dev/Projects/notes.md", size: 128),
+            ],
+            "/home/dev/Projects/atelier": [
+                dir("/home/dev/Projects/atelier/.git"),
+                dir("/home/dev/Projects/atelier/docs"),
+                dir("/home/dev/Projects/atelier/shared", symlink: true),
+                dir("/home/dev/Projects/atelier/src"),
+                file("/home/dev/Projects/atelier/.gitignore", size: 64),
+                RemoteEntry(
+                    name: "dangling", path: "/home/dev/Projects/atelier/dangling",
+                    kind: .unknown, isSymlink: true
+                ),
+                file("/home/dev/Projects/atelier/LICENSE", symlink: true),
+                file("/home/dev/Projects/atelier/README.md"),
+            ],
+            "/home/dev/Projects/atelier/src": [
+                dir("/home/dev/Projects/atelier/src/components"),
+                file("/home/dev/Projects/atelier/src/main.swift"),
+            ],
+            "/home/dev/Projects/atelier/src/components": [
+                file("/home/dev/Projects/atelier/src/components/Button.swift"),
+            ],
+            "/home/dev/Projects/atelier/docs": [
+                file("/home/dev/Projects/atelier/docs/plan.md"),
+            ],
+            // Symlinked dir: same children reachable under the lexical path.
+            "/home/dev/Projects/atelier/shared": [
+                file("/home/dev/Projects/atelier/shared/asset.png", size: 9000),
+            ],
+            "/home/dev/Projects/empty": [],
+            "/home/dev/Projects/huge": (1...40).map {
+                file("/home/dev/Projects/huge/file-\(String(format: "%03d", $0)).txt")
+            },
+            "/home/dev/.config": [
+                file("/home/dev/.config/settings.toml", size: 300),
+            ],
+            "/home/dev/Documents": [
+                file("/home/dev/Documents/taxes.pdf", size: 120_000),
+            ],
+        ]
+    }()
+
+    func workspaceRoots() async throws -> [RemoteWorkspaceRoot] {
+        mockRoots
+    }
+
+    func listDirectory(path: String, showHidden: Bool) async throws -> DirectoryListing {
+        if path.hasSuffix("/secrets") {
+            throw CockpitError.api(
+                code: "permission_denied", message: "permission denied: \(path)", sessionID: nil
+            )
+        }
+        guard let children = mockTree[path] else {
+            throw CockpitError.api(code: "not_found", message: "not found: \(path)", sessionID: nil)
+        }
+        let visible = children.filter { showHidden || !$0.name.hasPrefix(".") }
+        return DirectoryListing(
+            path: path,
+            truncated: path.hasSuffix("/huge"),
+            entries: visible
+        )
+    }
+
     func attachURL(sessionID: String) -> URL {
         URL(string: "ws://127.0.0.1:7331/api/sessions/\(sessionID)/attach")!
     }

--- a/AtelierCode/AtelierCodeTests/PickerHostingSmokeTest.swift
+++ b/AtelierCode/AtelierCodeTests/PickerHostingSmokeTest.swift
@@ -1,0 +1,43 @@
+import AppKit
+import SwiftUI
+import Testing
+import CockpitAPI
+@testable import AtelierCode
+
+/// Hosts the picker in a real window and pumps the run loop so the List
+/// actually lays out — catches row-diff crashes previews can't attribute.
+@Suite("RemoteFolderPickerSheet hosting smoke")
+struct PickerHostingSmokeTest {
+    private func pump(seconds: TimeInterval) {
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: seconds))
+    }
+
+    @Test("sheet hosts, loads roots, drills down without crashing")
+    func hostAndNavigate() async throws {
+        let sheet = RemoteFolderPickerSheet(client: MockCockpitClient()) { _ in }
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 480),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        window.contentView = NSHostingView(rootView: sheet)
+        window.orderFront(nil)
+        pump(seconds: 0.5)   // roots load + List render
+        window.orderOut(nil)
+    }
+
+    @Test("prefilled sheet renders a directory listing without crashing")
+    func hostPrefilled() async throws {
+        let sheet = RemoteFolderPickerSheet(
+            client: MockCockpitClient(),
+            initialPath: "/home/dev/Projects/atelier"
+        ) { _ in }
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 480),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        window.contentView = NSHostingView(rootView: sheet)
+        window.orderFront(nil)
+        pump(seconds: 0.5)
+        window.orderOut(nil)
+    }
+}

--- a/AtelierCode/AtelierCodeTests/RemoteFileBrowserTests.swift
+++ b/AtelierCode/AtelierCodeTests/RemoteFileBrowserTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Testing
+import CockpitAPI
+@testable import AtelierCode
+
+/// Drives the picker-workflow model against `MockCockpitClient`'s canned
+/// tree (two roots; `secrets` throws permission_denied; `huge` is
+/// truncated; `shared` is a symlinked directory).
+@Suite("RemoteFileBrowser")
+struct RemoteFileBrowserTests {
+    let browser = RemoteFileBrowser(client: MockCockpitClient())
+
+    private var projectsRoot: RemoteWorkspaceRoot {
+        RemoteWorkspaceRoot(label: "Projects", path: "/home/dev/Projects")
+    }
+
+    private func entry(named name: String) throws -> RemoteEntry {
+        try #require(browser.listing?.entries.first { $0.name == name })
+    }
+
+    @Test("loadRoots populates roots")
+    func loadRoots() async {
+        #expect(!browser.hasLoadedRoots)
+        await browser.loadRoots()
+        #expect(browser.hasLoadedRoots)
+        #expect(browser.roots.map(\.label) == ["Projects", "Home"])
+        #expect(browser.listing == nil)
+    }
+
+    @Test("open(root:) lists it and sets activeRoot")
+    func openRoot() async {
+        await browser.loadRoots()
+        await browser.open(root: projectsRoot)
+        #expect(browser.activeRoot == projectsRoot)
+        #expect(browser.currentPath == "/home/dev/Projects")
+        #expect(browser.typedPath == "/home/dev/Projects")
+        #expect(browser.lastError == nil)
+    }
+
+    @Test("descend into directory updates state and clears highlight")
+    func descendDirectory() async throws {
+        await browser.open(root: projectsRoot)
+        browser.highlightedPath = "/home/dev/Projects/notes.md"
+        await browser.descend(into: try entry(named: "atelier"))
+        #expect(browser.currentPath == "/home/dev/Projects/atelier")
+        #expect(browser.typedPath == "/home/dev/Projects/atelier")
+        #expect(browser.highlightedPath == nil)
+    }
+
+    @Test("descend into file or unknown is a no-op")
+    func descendInert() async throws {
+        await browser.open(root: projectsRoot)
+        await browser.descend(into: try entry(named: "atelier"))
+
+        let before = browser.listing
+        await browser.descend(into: try entry(named: "README.md"))
+        #expect(browser.listing == before)
+        await browser.descend(into: try entry(named: "dangling"))
+        #expect(browser.listing == before)
+    }
+
+    @Test("goUp stops at activeRoot, then returns to roots list")
+    func goUpBoundary() async throws {
+        await browser.open(root: projectsRoot)
+        await browser.descend(into: try entry(named: "atelier"))
+        #expect(browser.canGoUp)
+
+        await browser.goUp()
+        #expect(browser.currentPath == "/home/dev/Projects")
+        #expect(!browser.canGoUp)
+
+        await browser.goUp()
+        #expect(browser.listing == nil)
+        #expect(browser.activeRoot == nil)
+        #expect(browser.typedPath.isEmpty)
+    }
+
+    @Test("breadcrumbs follow the lexical path through a symlinked dir")
+    func breadcrumbs() async throws {
+        await browser.open(root: projectsRoot)
+        #expect(browser.breadcrumbs.map(\.label) == ["Projects"])
+
+        await browser.descend(into: try entry(named: "atelier"))
+        await browser.descend(into: try entry(named: "shared"))
+        #expect(browser.breadcrumbs.map(\.label) == ["Projects", "atelier", "shared"])
+        #expect(browser.breadcrumbs.map(\.path) == [
+            "/home/dev/Projects",
+            "/home/dev/Projects/atelier",
+            "/home/dev/Projects/atelier/shared",
+        ])
+    }
+
+    @Test("breadcrumb jump re-lists that segment")
+    func breadcrumbJump() async throws {
+        await browser.open(root: projectsRoot)
+        await browser.descend(into: try entry(named: "atelier"))
+        await browser.descend(into: try entry(named: "src"))
+
+        await browser.jump(to: "/home/dev/Projects/atelier")
+        #expect(browser.currentPath == "/home/dev/Projects/atelier")
+        #expect(browser.activeRoot == projectsRoot)
+    }
+
+    @Test("commitTypedPath lists and recomputes activeRoot by longest prefix")
+    func commitValidPath() async {
+        // No loadRoots first — the prefill flow starts cold.
+        browser.typedPath = "/home/dev/Projects/atelier/src"
+        await browser.commitTypedPath()
+        #expect(browser.currentPath == "/home/dev/Projects/atelier/src")
+        // Projects wins over Home even though both contain the path.
+        #expect(browser.activeRoot == projectsRoot)
+        #expect(browser.hasLoadedRoots)
+    }
+
+    @Test("commitTypedPath failure keeps navigation state")
+    func commitInvalidPath() async {
+        await browser.open(root: projectsRoot)
+        browser.typedPath = "/home/dev/Projects/nope"
+        await browser.commitTypedPath()
+        #expect(browser.lastError == "not found: /home/dev/Projects/nope")
+        #expect(browser.currentPath == "/home/dev/Projects")
+        #expect(browser.activeRoot == projectsRoot)
+    }
+
+    @Test("showHidden toggle re-lists the current directory")
+    func hiddenToggle() async throws {
+        await browser.open(root: projectsRoot)
+        await browser.descend(into: try entry(named: "atelier"))
+        #expect(browser.listing?.entries.contains { $0.name == ".gitignore" } == false)
+
+        browser.showHidden = true
+        await browser.reloadTask?.value
+        #expect(browser.listing?.entries.contains { $0.name == ".gitignore" } == true)
+        #expect(browser.currentPath == "/home/dev/Projects/atelier")
+    }
+
+    @Test("truncated listing exposes the flag")
+    func truncated() async throws {
+        await browser.open(root: projectsRoot)
+        await browser.descend(into: try entry(named: "huge"))
+        #expect(browser.listing?.truncated == true)
+    }
+
+    @Test("permission_denied surfaces the server message, listing survives")
+    func permissionDenied() async throws {
+        await browser.open(root: projectsRoot)
+        await browser.descend(into: try entry(named: "secrets"))
+        #expect(browser.lastError == "permission denied: /home/dev/Projects/secrets")
+        #expect(browser.currentPath == "/home/dev/Projects")
+    }
+
+    @Test("chosen folder is the viewed directory, never the highlight")
+    func chosenFolder() async throws {
+        await browser.open(root: projectsRoot)
+        browser.highlightedPath = try entry(named: "atelier").path
+
+        // The sheet's Use This Folder wiring: onChoose(currentPath).
+        var chosen: String?
+        let onChoose: (String) -> Void = { chosen = $0 }
+        if let path = browser.currentPath { onChoose(path) }
+        #expect(chosen == "/home/dev/Projects")
+    }
+}

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,17 @@
+# AtelierCode
+
+AtelierCode is a native client for working with Cockpit sessions on a remote workstation.
+
+## Language
+
+**Remote Workspace Root**:
+A named folder on the Cockpit workstation that AtelierCode uses as a starting namespace for browsing and selecting session working directories. Directory symlinks reachable from a Remote Workspace Root remain inside the app's remote browsing domain, including their children, even when the symlink target resolves outside the root.
+_Avoid_: Configured root, favorite, full-host browse, sandbox
+
+**Highlighted Entry**:
+The file or folder row currently targeted by pointer or keyboard navigation in a remote file browser.
+_Avoid_: Selected row
+
+**Chosen Folder**:
+The current viewed remote directory that AtelierCode will use as a session working directory when the user confirms a folder picker.
+_Avoid_: Selected file, selected row

--- a/Packages/CockpitKit/Sources/CockpitAPI/CockpitClient.swift
+++ b/Packages/CockpitKit/Sources/CockpitAPI/CockpitClient.swift
@@ -15,6 +15,8 @@ public protocol CockpitClient: Sendable {
     func sendKey(sessionID: String, key: String) async throws
     func actions() async throws -> [CockpitAction]
     func environments() async throws -> [CockpitEnvironment]
+    func workspaceRoots() async throws -> [RemoteWorkspaceRoot]
+    func listDirectory(path: String, showHidden: Bool) async throws -> DirectoryListing
 
     /// WebSocket URL for `GET /api/sessions/{id}/attach`.
     func attachURL(sessionID: String) -> URL
@@ -25,5 +27,9 @@ public protocol CockpitClient: Sendable {
 public extension CockpitClient {
     func sessions() async throws -> [Session] {
         try await sessions(includeArchived: false, status: nil)
+    }
+
+    func listDirectory(path: String) async throws -> DirectoryListing {
+        try await listDirectory(path: path, showHidden: false)
     }
 }

--- a/Packages/CockpitKit/Sources/CockpitAPI/HTTPCockpitClient.swift
+++ b/Packages/CockpitKit/Sources/CockpitAPI/HTTPCockpitClient.swift
@@ -70,6 +70,19 @@ public struct HTTPCockpitClient: CockpitClient {
         return envelope.environments
     }
 
+    public func workspaceRoots() async throws -> [RemoteWorkspaceRoot] {
+        let envelope: RootsEnvelope = try await get("fs/roots")
+        return envelope.roots
+    }
+
+    public func listDirectory(path: String, showHidden: Bool) async throws -> DirectoryListing {
+        var query = [URLQueryItem(name: "path", value: path)]
+        if showHidden {
+            query.append(URLQueryItem(name: "showHidden", value: "true"))
+        }
+        return try await get("fs/list", query: query)
+    }
+
     public func attachURL(sessionID: String) -> URL {
         server.attachURL(sessionID: sessionID)
     }

--- a/Packages/CockpitKit/Sources/CockpitAPI/Models/FileSystemModels.swift
+++ b/Packages/CockpitKit/Sources/CockpitAPI/Models/FileSystemModels.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// One entry from `GET /api/fs/roots` (wrapped in `{"roots":[...]}`).
+/// `path` is the expanded, cleaned, absolute path on the workstation.
+public struct RemoteWorkspaceRoot: Codable, Sendable, Hashable, Identifiable {
+    public var id: String { path }
+    public let label: String
+    public let path: String
+
+    public init(label: String, path: String) {
+        self.label = label
+        self.path = path
+    }
+}
+
+/// Classification of a directory entry. Symlinks are classified by their
+/// target; broken symlinks, sockets, FIFOs, and devices are `.unknown`
+/// (visible, not enterable).
+public enum RemoteEntryKind: String, Codable, Sendable {
+    case directory
+    case file
+    case unknown
+
+    /// Unrecognized raw values decode as `.unknown` so a future server
+    /// adding kinds doesn't break old clients.
+    public init(from decoder: any Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = RemoteEntryKind(rawValue: raw) ?? .unknown
+    }
+}
+
+/// One child of a listed directory. `path` is lexical
+/// (symlink-preserving) and is the entry's identity — there are no IDs.
+public struct RemoteEntry: Codable, Sendable, Hashable, Identifiable {
+    public var id: String { path }
+    public let name: String
+    public let path: String
+    public let kind: RemoteEntryKind
+    public let isSymlink: Bool
+    /// Bytes; present only for `kind == .file`.
+    public let size: Int64?
+    /// Present for `.file` and `.directory`, absent for `.unknown`.
+    public let modifiedAt: Date?
+
+    public init(
+        name: String,
+        path: String,
+        kind: RemoteEntryKind,
+        isSymlink: Bool,
+        size: Int64? = nil,
+        modifiedAt: Date? = nil
+    ) {
+        self.name = name
+        self.path = path
+        self.kind = kind
+        self.isSymlink = isSymlink
+        self.size = size
+        self.modifiedAt = modifiedAt
+    }
+}
+
+/// Response of `GET /api/fs/list`. `path` is the cleaned lexical path that
+/// was listed — the client's canonical current-directory state. Entries
+/// arrive pre-sorted (directories first, dotfiles first within group,
+/// case-insensitive) and pre-filtered per `showHidden`.
+public struct DirectoryListing: Codable, Sendable, Hashable {
+    public let path: String
+    public let truncated: Bool
+    public let entries: [RemoteEntry]
+
+    public init(path: String, truncated: Bool, entries: [RemoteEntry]) {
+        self.path = path
+        self.truncated = truncated
+        self.entries = entries
+    }
+}
+
+struct RootsEnvelope: Decodable {
+    var roots: [RemoteWorkspaceRoot]
+}

--- a/Packages/CockpitKit/Tests/CockpitAPITests/FileSystemDecodingTests.swift
+++ b/Packages/CockpitKit/Tests/CockpitAPITests/FileSystemDecodingTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+@testable import CockpitAPI
+
+/// Fixtures captured from the live server on 2026-07-06.
+
+/// `GET /api/fs/roots`
+private let rootsFixture = Data(#"""
+{"roots":[{"label":"Home","path":"/home/jeremytondo"}]}
+"""#.utf8)
+
+/// `GET /api/fs/list?path=/home/jeremytondo/fixture-tree&showHidden=true` —
+/// a tree built to exercise every entry shape: plain dir, dir symlink,
+/// hidden file, broken symlink (`unknown`, no size/modifiedAt), file
+/// symlink, plain file.
+private let listFixture = Data(#"""
+{"path":"/home/jeremytondo/fixture-tree","truncated":false,"entries":[{"name":"link-dir","path":"/home/jeremytondo/fixture-tree/link-dir","kind":"directory","isSymlink":true,"modifiedAt":"2026-07-06T14:21:52.175602772Z"},{"name":"subdir","path":"/home/jeremytondo/fixture-tree/subdir","kind":"directory","isSymlink":false,"modifiedAt":"2026-07-06T14:21:52.175602772Z"},{"name":".hidden","path":"/home/jeremytondo/fixture-tree/.hidden","kind":"file","isSymlink":false,"size":2,"modifiedAt":"2026-07-06T14:21:52.175602772Z"},{"name":"dangling","path":"/home/jeremytondo/fixture-tree/dangling","kind":"unknown","isSymlink":true},{"name":"link-file","path":"/home/jeremytondo/fixture-tree/link-file","kind":"file","isSymlink":true,"size":6,"modifiedAt":"2026-07-06T14:21:52.175602772Z"},{"name":"readme.md","path":"/home/jeremytondo/fixture-tree/readme.md","kind":"file","isSymlink":false,"size":6,"modifiedAt":"2026-07-06T14:21:52.175602772Z"}]}
+"""#.utf8)
+
+/// `GET /api/fs/list?path=/home/jeremytondo/fixture-tree/subdir`
+private let emptyListFixture = Data(#"""
+{"path":"/home/jeremytondo/fixture-tree/subdir","truncated":false,"entries":[]}
+"""#.utf8)
+
+/// Hand-trimmed from a capped-directory capture — the 10,000 verbatim
+/// entries are elided; the flag is what matters.
+private let truncatedListFixture = Data(#"""
+{"path":"/home/jeremytondo/huge","truncated":true,"entries":[{"name":"0001","path":"/home/jeremytondo/huge/0001","kind":"file","isSymlink":false,"size":0,"modifiedAt":"2026-07-06T14:21:52.175602772Z"}]}
+"""#.utf8)
+
+@Suite("File system decoding")
+struct FileSystemDecodingTests {
+    @Test("roots envelope decodes")
+    func rootsDecode() throws {
+        let envelope = try JSONDecoder.cockpit().decode(RootsEnvelope.self, from: rootsFixture)
+        #expect(envelope.roots == [RemoteWorkspaceRoot(label: "Home", path: "/home/jeremytondo")])
+        #expect(envelope.roots[0].id == "/home/jeremytondo")
+    }
+
+    @Test("listing decodes with real server shapes")
+    func listDecodes() throws {
+        let listing = try JSONDecoder.cockpit().decode(DirectoryListing.self, from: listFixture)
+        #expect(listing.path == "/home/jeremytondo/fixture-tree")
+        #expect(!listing.truncated)
+        #expect(listing.entries.count == 6)
+
+        let linkDir = listing.entries[0]
+        #expect(linkDir.kind == .directory)
+        #expect(linkDir.isSymlink)
+        #expect(linkDir.size == nil)
+        #expect(linkDir.modifiedAt != nil)
+
+        let hidden = listing.entries[2]
+        #expect(hidden.name == ".hidden")
+        #expect(hidden.kind == .file)
+        #expect(hidden.size == 2)
+
+        let dangling = listing.entries[3]
+        #expect(dangling.kind == .unknown)
+        #expect(dangling.isSymlink)
+        #expect(dangling.size == nil)
+        #expect(dangling.modifiedAt == nil)
+
+        let file = listing.entries[5]
+        #expect(file.id == file.path)
+        #expect(file.kind == .file)
+        #expect(!file.isSymlink)
+        #expect(file.size == 6)
+    }
+
+    @Test("empty directory decodes to empty entries")
+    func emptyDecodes() throws {
+        let listing = try JSONDecoder.cockpit().decode(DirectoryListing.self, from: emptyListFixture)
+        #expect(listing.entries.isEmpty)
+        #expect(!listing.truncated)
+    }
+
+    @Test("truncated flag decodes")
+    func truncatedDecodes() throws {
+        let listing = try JSONDecoder.cockpit().decode(DirectoryListing.self, from: truncatedListFixture)
+        #expect(listing.truncated)
+    }
+
+    @Test("unrecognized kind decodes as unknown")
+    func forwardCompatibleKind() throws {
+        let body = Data(#"""
+        {"path":"/x","truncated":false,"entries":[{"name":"pipe","path":"/x/pipe","kind":"named-pipe","isSymlink":false}]}
+        """#.utf8)
+        let listing = try JSONDecoder.cockpit().decode(DirectoryListing.self, from: body)
+        #expect(listing.entries[0].kind == .unknown)
+    }
+}
+
+/// Error bodies captured from the live server on 2026-07-06
+/// (`internal_error` synthesized — not triggerable on demand).
+@Suite("File system error envelopes")
+struct FileSystemErrorTests {
+    private static let bodies: [(code: String, json: String)] = [
+        ("invalid_path", #"{"error":"invalid_path","message":"invalid path: path must be absolute"}"#),
+        ("outside_browsable_roots", #"{"error":"outside_browsable_roots","message":"outside browsable roots: /etc/passwd"}"#),
+        ("not_found", #"{"error":"not_found","message":"not found: /home/jeremytondo/nope-not-here"}"#),
+        ("not_directory", #"{"error":"not_directory","message":"not a directory: /home/jeremytondo/fixture-tree/readme.md"}"#),
+        ("permission_denied", #"{"error":"permission_denied","message":"permission denied: /home/jeremytondo/fixture-tree/locked"}"#),
+        ("internal_error", #"{"error":"internal_error","message":"internal error"}"#),
+    ]
+
+    @Test("each FS error body decodes and surfaces its code", arguments: bodies.map(\.code))
+    func decodes(code: String) throws {
+        let body = Data(Self.bodies.first { $0.code == code }!.json.utf8)
+        let envelope = try JSONDecoder.cockpit().decode(ErrorEnvelope.self, from: body)
+        #expect(envelope.error == code)
+        let error = CockpitError.api(code: envelope.error, message: envelope.message, sessionID: envelope.sessionId)
+        #expect(error.apiCode == code)
+        #expect(error.errorDescription == envelope.message)
+    }
+}

--- a/Packages/CockpitKit/Tests/CockpitAPITests/FileSystemRequestTests.swift
+++ b/Packages/CockpitKit/Tests/CockpitAPITests/FileSystemRequestTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+@testable import CockpitAPI
+
+/// Captures the request URL and serves a canned 200 body so
+/// `HTTPCockpitClient`'s real query construction can be asserted.
+private final class CapturingURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var lastURL: URL?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.lastURL = request.url
+        let body = Data(#"{"path":"/x","truncated":false,"entries":[]}"#.utf8)
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+@Suite("File system request URLs", .serialized)
+struct FileSystemRequestTests {
+    private func makeClient() -> HTTPCockpitClient {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [CapturingURLProtocol.self]
+        let server = CockpitServer(baseURL: URL(string: "http://example.com:7331")!)
+        return HTTPCockpitClient(server: server, session: URLSession(configuration: configuration))
+    }
+
+    @Test("fs/list sends path; showHidden omitted when false")
+    func defaultQuery() async throws {
+        _ = try await makeClient().listDirectory(path: "/home/j/Projects")
+        #expect(CapturingURLProtocol.lastURL?.absoluteString
+            == "http://example.com:7331/api/fs/list?path=/home/j/Projects")
+    }
+
+    @Test("fs/list appends showHidden only when true")
+    func showHiddenQuery() async throws {
+        _ = try await makeClient().listDirectory(path: "/home/j", showHidden: true)
+        #expect(CapturingURLProtocol.lastURL?.absoluteString
+            == "http://example.com:7331/api/fs/list?path=/home/j&showHidden=true")
+    }
+
+    @Test("fs/list percent-encodes the path")
+    func percentEncoding() async throws {
+        _ = try await makeClient().listDirectory(path: "/home/j/My Projects#1")
+        #expect(CapturingURLProtocol.lastURL?.absoluteString
+            == "http://example.com:7331/api/fs/list?path=/home/j/My%20Projects%231")
+    }
+}

--- a/docs/adr/0001-remote-workspace-roots.md
+++ b/docs/adr/0001-remote-workspace-roots.md
@@ -1,0 +1,3 @@
+# Remote file browsing starts from Remote Workspace Roots
+
+AtelierCode remote file browsing starts from static Cockpit-configured Remote Workspace Roots, with Cockpit synthesizing a `Home` root at the server user's `$HOME` when none are configured. This gives the app a clear set of remote browsing starting points without making the first file browser a full-host explorer or a root-management UI. Remote Workspace Roots are a browsing namespace, not a resolved-path sandbox: symlinked directories reached from a root remain browseable, and the boundary does not yet globally restrict `POST /api/sessions/start`.

--- a/docs/projects-brief.md
+++ b/docs/projects-brief.md
@@ -1,0 +1,144 @@
+# Projects Brief
+
+Status: Draft
+
+## Purpose
+
+Projects should give AtelierCode and Cockpit a durable way to group related
+Terminal Sessions around a specific workstation directory. A Terminal Session is
+a ZMX-backed terminal process, which may run an agent, editor, Git tool, shell,
+or other terminal app. A project becomes the user-facing container for work in a
+codebase, while Cockpit remains useful as a standalone API and CLI service that
+other front ends or agents can build on.
+
+## Idea Definition
+
+A project is a Cockpit-owned record with metadata such as name and working
+directory. Terminal Sessions can be started within a project, and
+project-scoped Terminal Sessions inherit the project's working directory unless
+the API intentionally allows an override.
+
+The first version should treat projects as environment-local workstation
+resources:
+
+- A project points to one absolute directory on the workstation where Cockpit is
+  installed.
+- A project can have one or more associated Terminal Sessions.
+- Terminal Sessions can still exist outside a project for backward
+  compatibility and direct Cockpit usage.
+- Cockpit exposes project behavior through API and CLI surfaces before the
+  SwiftUI app treats it as a primary navigation concept.
+
+## Recommended Direction
+
+Start with a server-first model. Cockpit should own project persistence, project
+IDs, validation, project/Terminal Session relationships, and CLI workflows. The
+SwiftUI app should consume those APIs rather than inventing local-only project
+state.
+
+Keep the v1 project model intentionally small:
+
+- `id`
+- `name`
+- `workingDir`
+- `createdAt`
+- `updatedAt`
+- optional `archivedAt`
+- optional lightweight display metadata, such as `lastSessionAt` or Terminal
+  Session counts, if it is cheap for Cockpit to provide
+
+Use projects as the preferred Terminal Session creation path, but avoid making
+every existing session endpoint project-mandatory immediately. That lets
+Cockpit remain compatible with scripts, agents, and other clients that only
+know how to create a Terminal Session with an action, environment, and working
+directory.
+
+The T3 Code reference is useful mostly for product shape: projects group units
+of work, project lists sort by recent activity, and only a limited number of
+recent Terminal Sessions may need to appear in the project view. AtelierCode
+should borrow that grouping behavior without treating projects as agent-only
+containers or coupling the model to a specific front end.
+
+## Key Features
+
+- Create, list, inspect, update, archive, and unarchive projects in Cockpit.
+- Start a Terminal Session from a project through Cockpit API and CLI.
+- List Terminal Sessions by project, with recent activity ordering.
+- Surface project metadata in Terminal Session responses so clients can render
+  mixed project and non-project Terminal Sessions during migration.
+- Add Swift models and client methods in `CockpitAPI` for project endpoints.
+- Add an AtelierCode project list or project-first sidebar that drills into the
+  project's Terminal Sessions.
+- Add project selection to Terminal Session creation, with the project's working
+  directory prefilled or inherited.
+- Preserve direct working-directory Terminal Session creation as an advanced or
+  legacy path.
+
+## Non-Goals / Deferred Ideas
+
+- Cross-workstation project identity.
+- Repository identity or clone correlation across machines.
+- Project-level agent memory, rules, environment variables, or secrets.
+- Treating projects as agent-only containers.
+- Agent-specific session semantics such as turns, prompts, checkpoints, model
+  metadata, or approval history.
+- Project templates.
+- Multi-root projects.
+- Fine-grained project permissions.
+- Automatic project discovery from every Git checkout on the workstation.
+- Moving remote workspace roots into projects immediately.
+
+## System Shape
+
+- **Cockpit Domain Model**: Owns project records, validates project working
+  directories, and defines the project/Terminal Session relationship.
+- **Cockpit API**: Exposes project CRUD, project-scoped Terminal Session
+  creation, and project-scoped Terminal Session listing.
+- **Cockpit CLI**: Provides standalone workflows such as listing projects,
+  creating a project, showing project Terminal Sessions, and starting a
+  Terminal Session in a project.
+- **Cockpit Terminal Session Model**: Adds an optional `projectId` on sessions
+  and keeps `workingDir` on each session as the historical execution snapshot.
+  Existing API names may remain `sessions` for compatibility even if product
+  language becomes more explicit.
+- **AtelierCode CockpitAPI Package**: Adds DTOs, request models, decoding tests,
+  and `HTTPCockpitClient` methods for projects.
+- **AtelierCode App State**: Adds a `ProjectsStore` alongside `SessionsStore`,
+  probably polling at the same cadence until Cockpit has push events.
+- **AtelierCode UI**: Makes projects a first-class browsing and creation
+  surface while still allowing non-project Terminal Sessions to appear somewhere
+  predictable.
+
+## Core Concepts
+
+- **Project**: A named Cockpit record that points to one workstation working
+  directory and groups related Terminal Sessions.
+- **Project Working Directory**: The default directory used when starting a
+  Terminal Session from a project.
+- **Terminal Session**: A ZMX-backed terminal process. It may run an agent,
+  editor, Git tool, shell, or another terminal app.
+- **Agent Session**: A future specialization of Terminal Session with
+  agent-specific behavior and metadata.
+- **Project Terminal Session**: A Terminal Session associated with a project
+  through `projectId`.
+- **Unscoped Terminal Session**: A backward-compatible Terminal Session with no
+  project.
+- **Archived Project**: A hidden-but-retained project record; associated
+  Terminal Sessions remain intact.
+
+## Open Questions
+
+- Should a project working directory be required to sit under a configured
+  Remote Workspace Root, or should Cockpit allow any valid absolute path like
+  direct Terminal Session creation does today?
+- When a project is archived, should active Terminal Sessions block archiving,
+  continue running, or be terminated by default?
+- Should Terminal Sessions started from a project be allowed to override
+  `workingDir`, or should project association imply exactly one working
+  directory?
+- Should project names be unique globally, unique per working directory, or not
+  unique at all?
+- Where should non-project Terminal Sessions live in the first AtelierCode UI
+  once projects become the primary container?
+- Should v1 include project renaming and working-directory edits, or only create
+  plus archive?

--- a/docs/remote-file-browsing-design-1-cockpit.md
+++ b/docs/remote-file-browsing-design-1-cockpit.md
@@ -1,0 +1,473 @@
+# Tech Design — Remote File Browsing, Part 1: Cockpit `/api/fs`
+
+> Implements the server half of `docs/remote-file-browsing-prd.md` and ADR
+> `docs/adr/0001-remote-workspace-roots.md`. This part lands first, in the
+> `cockpit` repo (https://github.com/jeremytondo/cockpit), so the AtelierCode
+> client (Part 2, `docs/remote-file-browsing-design-2-app.md`) implements a real
+> contract instead of inventing one. This document is self-contained: it can be
+> handed to a session working only in the cockpit repo.
+
+## 1. Scope
+
+Add a read-only remote filesystem browse API to Cockpit:
+
+- `GET /api/fs/roots` — usable Remote Workspace Roots.
+- `GET /api/fs/list` — immediate children of one directory.
+- A `[fs]` config section defining Remote Workspace Roots, with a synthesized
+  `Home` root when none are configured.
+
+No file reading, no mutation, no recursive walking, no fuzzy-find index. Those
+are future endpoints; nothing here should block them.
+
+## 2. Changes from the PRD (and why)
+
+The PRD allowed judgment calls. These are the deltas this design makes:
+
+1. **No `parent` field in the `fs/list` response.** The earlier exploration
+   draft sketched one. With symlink-preserving lexical paths, the parent is a
+   pure string operation the client must do anyway to enforce the
+   active-root Up boundary — and the server *cannot* know the client's active
+   root (a path can sit under multiple roots). Returning `parent` would imply
+   server knowledge that doesn't exist. The response is `path` + `entries` +
+   `truncated`, nothing else.
+2. **`label` is optional in root config**, defaulting to the last path
+   component. Less config to type; the PRD's "roots have `label` and `path`"
+   still holds on the wire — the server always sends a label.
+3. **Containment is defined as lexical-prefix containment** (§5.2). This is the
+   concrete algorithm that operationalizes the ADR's "browsing namespace, not a
+   resolved-path sandbox": the server never resolves symlinks for boundary
+   checks, only for classifying entries.
+4. **Non-regular, non-directory entries (sockets, FIFOs, devices) map to
+   `kind: "unknown"`**, same as broken symlinks: visible, not enterable. The PRD
+   only named broken symlinks; this rule covers everything that is neither a
+   listable directory nor an ordinary file.
+5. **Deterministic sort tie-break**: case-insensitive name compare, ties broken
+   by byte-wise compare. The PRD asked for "case-insensitive by name," which is
+   non-deterministic for names differing only by case.
+6. **Roots are re-validated on every `fs/roots` request** (stat + open), not
+   only at config load. This is what makes user story 6 (config drift
+   troubleshooting) true at runtime; config load only validates shape.
+7. **`size` is populated only for `kind: "file"`** (null for directories and
+   unknown); `modifiedAt` is populated for files and directories (null for
+   unknown). Directory byte sizes are filesystem noise.
+8. **Timeout/cancellation map to `internal_error` (500)**, not a new error
+   code. The PRD fixed the v1 error vocabulary at five codes; a server-side
+   deadline is an infrastructure failure, not a contract state.
+
+Everything else follows the PRD as written.
+
+## 3. API contract
+
+Both endpoints live under the existing `/api` mount, so bearer/Unix-socket auth
+(`internal/server/auth.go`) applies automatically. JSON field names are
+camelCase; error codes are lower_snake_case — both per existing convention.
+
+### 3.1 `GET /api/fs/roots`
+
+Returns the usable Remote Workspace Roots, in configuration order.
+
+```json
+{
+  "roots": [
+    { "label": "Projects", "path": "/home/jeremy/Projects" },
+    { "label": "Home",     "path": "/home/jeremy" }
+  ]
+}
+```
+
+- `path` is always the expanded, cleaned, absolute path (`~` already resolved).
+  Clients feed it directly to `fs/list`.
+- A configured root is **omitted** (and logged at `warn`, §7) when, at request
+  time, it does not exist, is not a directory, or cannot be opened for reading.
+- Zero configured roots → the server synthesizes one root:
+  `{ "label": "Home", "path": <os.UserHomeDir()> }`. Explicit configuration
+  replaces the synthesized root entirely — if all configured roots are invalid,
+  the response is `{ "roots": [] }` (the client shows an empty state).
+- Errors: only `internal_error` (500), e.g. home-dir resolution failure with no
+  configured roots.
+
+### 3.2 `GET /api/fs/list?path=<abs>&showHidden=<bool>`
+
+Lists the immediate children of one directory. Directory-only and lazy — never
+recursive.
+
+Query parameters:
+
+| Param        | Required | Meaning                                                        |
+|--------------|----------|----------------------------------------------------------------|
+| `path`       | yes      | Absolute path on the workstation. Cleaned server-side (§5.1).  |
+| `showHidden` | no       | Include dot-prefixed entries. Default `false`.                 |
+
+Success (200):
+
+```json
+{
+  "path": "/home/jeremy/Projects/atelier",
+  "truncated": false,
+  "entries": [
+    { "name": ".config", "path": "/home/jeremy/Projects/atelier/.config",
+      "kind": "directory", "isSymlink": false,
+      "modifiedAt": "2026-07-05T14:03:22.123456789Z" },
+    { "name": "src", "path": "/home/jeremy/Projects/atelier/src",
+      "kind": "directory", "isSymlink": true,
+      "modifiedAt": "2026-07-01T09:00:00Z" },
+    { "name": "README.md", "path": "/home/jeremy/Projects/atelier/README.md",
+      "kind": "file", "isSymlink": false,
+      "size": 2048, "modifiedAt": "2026-06-28T18:12:45.5Z" },
+    { "name": "dangling", "path": "/home/jeremy/Projects/atelier/dangling",
+      "kind": "unknown", "isSymlink": true }
+  ]
+}
+```
+
+Field semantics:
+
+- `path` — the cleaned **lexical** path that was listed. Never
+  symlink-resolved; if the client navigated `/Projects/shared/...` through a
+  symlink, that is what comes back. This string is the client's canonical
+  current-directory state.
+- `entries[].path` — `path` + `/` + `name` (lexical). Path strings are entry
+  identity; there are no entry IDs.
+- `kind` — `directory` | `file` | `unknown`.
+  - Symlinks are classified by their **target**: a symlink to a directory is
+    `directory` (enterable like any folder), to a regular file is `file`.
+  - Broken symlinks, sockets, FIFOs, and devices are `unknown` — visible, not
+    enterable.
+- `isSymlink` — from `lstat`, orthogonal to `kind`.
+- `size` — bytes; present only for `kind: "file"` (of the symlink target when
+  applicable). Absent otherwise.
+- `modifiedAt` — RFC3339Nano UTC (existing `formatTime` convention); present
+  for `file` and `directory`, absent for `unknown`.
+- `truncated` — `true` when the listing was cut at the cap (§5.5).
+- Empty directory → `"entries": []` (never `null`; pre-allocate the slice, same
+  as `sessions.go`).
+
+Ordering (stable, applied server-side; clients may re-sort):
+
+1. Directories before non-directories (`file` and `unknown` are one group).
+2. Within each group, dot-prefixed names before others.
+3. Then case-insensitive name compare; ties broken byte-wise.
+
+Errors — existing envelope `{"error": <code>, "message": <human text>}`:
+
+| Code                      | HTTP | When                                                                 |
+|---------------------------|------|----------------------------------------------------------------------|
+| `invalid_path`            | 400  | Missing/empty `path`, not absolute, or contains a NUL byte.          |
+| `outside_browsable_roots` | 403  | Cleaned path is not lexically inside any configured root (§5.2).     |
+| `not_found`               | 404  | Path does not exist (including a dangling symlink as the target).    |
+| `not_directory`           | 400  | Path exists but is not a directory (files, sockets, etc.).           |
+| `permission_denied`       | 403  | The requested directory itself cannot be read.                       |
+| `internal_error`          | 500  | Timeout, unexpected I/O failure.                                     |
+
+Invalid `showHidden` values follow the existing `boolQuery` helper's behavior
+for consistency with `GET /sessions`.
+
+## 4. Configuration
+
+New TOML section (parsed by the existing `pelletier/go-toml/v2` loader in
+`internal/config/config.go`):
+
+```toml
+[[fs.roots]]
+label = "Projects"      # optional — defaults to the last path component
+path  = "~/Projects"
+
+[[fs.roots]]
+path  = "/srv/work"     # label defaults to "work"
+```
+
+Struct additions to `config.Config` (`config.go:43`):
+
+```go
+FS FSConfig `toml:"fs"`
+
+type FSConfig struct {
+    Roots []FSRootConfig `toml:"roots"`
+}
+
+type FSRootConfig struct {
+    Label string `toml:"label"`
+    Path  string `toml:"path"`
+}
+```
+
+Load-time validation (in `Config.validate()`, following the `Environments`
+registry precedent):
+
+- `path` must be non-empty. Error otherwise.
+- `~` and `~/...` expand to `os.UserHomeDir()`. `~user` and environment
+  variables are **not** expanded (PRD: out of scope) — a path containing `$` is
+  passed through literally.
+- After expansion the path must be absolute; it is `filepath.Clean`ed.
+- Duplicate expanded paths are a config error. Duplicate labels are allowed
+  (paths are identity).
+- Empty `label` → last path component of the expanded path.
+- Existence/readability is **not** checked at load time — that is runtime
+  drift, handled per-request by `fs/roots` (§2 item 6).
+
+No env var or flag for roots in v1 (config file only). No TOML knob for the
+listing cap or timeout — they are constants (§5.5, §5.6).
+
+## 5. Semantics
+
+### 5.1 Path normalization
+
+For every `fs/list` request:
+
+1. Reject empty, non-absolute, or NUL-containing paths → `invalid_path`.
+2. `filepath.Clean` the path. This collapses `//`, `/./`, and resolves `..`
+   **lexically** — which is exactly the PRD's rule that raw `..` segments are
+   allowed only when the normalized result stays inside the namespace.
+3. All subsequent checks and all filesystem calls use the cleaned lexical path.
+
+The server never calls `filepath.EvalSymlinks` on the request path. The OS
+resolves symlinks naturally when `os.Stat`/`os.ReadDir` hit the lexical path —
+that is what keeps breadcrumbs on the path the user followed while still
+listing real contents.
+
+### 5.2 Containment: the lexical namespace
+
+A cleaned path `p` is **inside the browsable namespace** iff for some root `r`
+(expanded, cleaned):
+
+```go
+p == r || strings.HasPrefix(p, r + "/")   // special-case r == "/"
+```
+
+Consequences (all intended, per the ADR):
+
+- Descending through a directory symlink keeps the lexical path under the root,
+  so symlinked subtrees remain browseable even when they resolve outside the
+  root. The boundary is a namespace, not a sandbox.
+- Pasting the symlink's *resolved* target (e.g. `/mnt/big/shared`) when only
+  `/home/jeremy/Projects` is a root → `outside_browsable_roots`. Consistent:
+  the namespace is defined by lexical paths.
+- Symlink cycles cannot hang the server: listing is one directory per request
+  and never recursive; a user can drill into a cycle forever, one bounded
+  request at a time.
+- When no roots are configured, the synthesized Home root defines the
+  namespace.
+
+### 5.3 Entry classification
+
+For each `os.ReadDir` entry of the (followed) directory:
+
+| Condition (lstat, then stat for symlinks)         | `kind`      | `isSymlink` |
+|---------------------------------------------------|-------------|-------------|
+| directory                                         | `directory` | false       |
+| regular file                                      | `file`      | false       |
+| symlink → directory                               | `directory` | true        |
+| symlink → regular file                            | `file`      | true        |
+| symlink → missing target (broken)                 | `unknown`   | true        |
+| symlink → socket/FIFO/device                      | `unknown`   | true        |
+| socket / FIFO / device / other                    | `unknown`   | false       |
+
+`size`/`modifiedAt` come from the followed (`os.Stat`) info; if that stat
+fails, the entry stays visible as `unknown` with both fields absent.
+
+An unreadable directory under a readable parent is still classified
+`directory` here (lstat/stat succeed; only reading it fails) — it appears in
+listings, and attempting to list it returns `permission_denied`. If the
+**requested** directory is unreadable, the request itself is
+`permission_denied`.
+
+### 5.4 Hidden filtering
+
+An entry is hidden iff its name starts with `.`. With `showHidden=false`
+(default), hidden entries are dropped **before** sorting and the cap, so
+truncation counts only entries the client will see.
+
+### 5.5 Cap and truncation
+
+Pipeline: read all entries → filter hidden → sort → cap at **10,000** →
+`truncated: true` if cut. (`os.ReadDir` reads the whole directory regardless,
+so the cap protects response size and client memory, not server reads.)
+
+### 5.6 Cancellation and timeout
+
+- Handlers pass `r.Context()` down, so a client disconnect cancels metadata
+  work. Check `ctx.Err()` every ~1,000 entries during the per-entry stat pass.
+- The service wraps each `List` in `context.WithTimeout(ctx, 10*time.Second)`.
+  The blocking `os.ReadDir` runs in a goroutine raced against `ctx.Done()`
+  (a leaked goroutine on a dead-NFS hang is acceptable; note it in a comment).
+- Deadline exceeded → `internal_error` (500). A canceled client context just
+  aborts; the response is unread.
+
+The timeout is a field on the service (default 10s) so tests can inject a tiny
+value — it is not exposed in config.
+
+## 6. Implementation plan
+
+Follows the existing package layout: a domain package + thin API handlers.
+
+### 6.1 New package `internal/fs`
+
+Mirrors `internal/session`'s shape (domain service + sentinel errors):
+
+```go
+package fs
+
+type Root struct{ Label, Path string }          // Path: expanded, cleaned, absolute
+
+type Entry struct {
+    Name, Path, Kind string                     // Kind: "directory" | "file" | "unknown"
+    IsSymlink        bool
+    Size             *int64
+    ModifiedAt       *time.Time
+}
+
+type Listing struct {
+    Path      string
+    Entries   []Entry
+    Truncated bool
+}
+
+var (
+    ErrInvalidPath      = errors.New("invalid path")
+    ErrOutsideRoots     = errors.New("outside browsable roots")
+    ErrNotFound         = errors.New("not found")
+    ErrNotDirectory     = errors.New("not a directory")
+    ErrPermissionDenied = errors.New("permission denied")
+)
+
+func NewService(roots []Root, logger *slog.Logger) *Service
+func (s *Service) Roots(ctx context.Context) []Root                 // stat+open filtered, logs omissions
+func (s *Service) List(ctx context.Context, path string, showHidden bool) (Listing, error)
+```
+
+- Home-root synthesis happens in `NewService` (or a small constructor helper)
+  when `roots` is empty, so `Roots`/`List` always operate on a concrete
+  namespace.
+- OS error mapping: `errors.Is(err, iofs.ErrNotExist)` → `ErrNotFound`,
+  `iofs.ErrPermission` → `ErrPermissionDenied`, `syscall.ENOTDIR` (and
+  stat-says-not-dir) → `ErrNotDirectory`.
+- POSIX-only assumptions (path separators, dot-hidden convention) are fine —
+  Cockpit targets Linux/macOS workstations.
+
+### 6.2 API handlers `internal/api/fs.go`
+
+Follow the canonical handler pattern (`sessions.go`):
+
+- `apiRoutes` (`routes.go:12`) gains `fs *fs.Service`; `Routes(...)` gains the
+  parameter. Handlers guard with a `requireFS` helper (same shape as
+  `requireSessions`), tolerating nil for isolated tests.
+- Register in `Routes`:
+  `mux.HandleFunc("GET /fs/roots", routes.fsRoots)` and
+  `mux.HandleFunc("GET /fs/list", routes.fsList)`.
+- Response DTO structs local to `fs.go` (`rootsResponse`, `listResponse`,
+  `entryResponse`) with camelCase tags; `modifiedAt` via the existing
+  `formatOptionalTime`; `entries` pre-allocated with `make([]entryResponse, 0, n)`.
+- `writeFSError(w, err)` mapper switching on the `fs` sentinels per the table
+  in §3.2, defaulting to 500 `internal_error`.
+- `showHidden` parsed with the existing `boolQuery` helper.
+
+### 6.3 Plumbing
+
+Thread the config exactly like `Environments`/`AuthToken`:
+
+1. `config.Config.FS` (§4) with validation + `~` expansion in `validate()`.
+2. `cli/root.go:99` — map into `server.Config` (new field, e.g.
+   `FSRoots []fs.Root`).
+3. `internal/server/server.go` — construct `fs.NewService(cfg.FSRoots, logger)`
+   next to the session service; pass to `Router`.
+4. `internal/server/router.go` — pass through to `api.Routes(...)`.
+
+Auth requires zero new code: the `/api/` mount already wraps everything.
+
+### 6.4 Logging
+
+`log/slog`, key/value style, from the `fs` service (the api package does not
+log, per existing convention):
+
+- Root omitted: `logger.Warn("fs root unusable", "label", r.Label, "path", r.Path, "err", err)` — every `fs/roots` request that omits it (drift stays visible).
+- Optional debug on `List` failures. No logging on the success path.
+
+## 7. Test plan
+
+Standard `testing` + `net/http/httptest` + `t.TempDir()`, tests beside code
+(`internal/fs/service_test.go`, `internal/api/fs_test.go`,
+`internal/config/config_test.go` additions). Build real temp trees with
+`os.MkdirAll` / `os.WriteFile` / `os.Symlink` / `os.Chmod`.
+
+Permission-denied cases use `chmod 0000` and must
+`t.Skip` when `os.Geteuid() == 0` (root ignores modes).
+
+**Config (`internal/config`)**
+- `[fs.roots]` parses; `~` and `~/x` expand to home; label defaults to
+  basename; empty path errors; relative path errors; duplicate expanded paths
+  error; `$VAR` passes through literally; absent `[fs]` section → empty roots.
+
+**Service — roots (`internal/fs`)**
+- No roots configured → synthesized Home root at `os.UserHomeDir()`.
+- Configured roots returned in order with expanded paths.
+- Missing / non-directory / unreadable root omitted and logged; other roots
+  survive. All-invalid → empty slice (not Home fallback).
+
+**Service — list**
+- Happy path: mixed tree lists with correct `name`/`path`/`kind`/`isSymlink`;
+  `size` only on files; `modifiedAt` on files+dirs; empty dir → `[]`.
+- Sorting: dirs first; dotfiles first within group; case-insensitive order;
+  case-only tie broken deterministically.
+- Hidden: excluded by default; included with `showHidden`; cap counts
+  post-filter.
+- Truncation: directory with cap+N entries → 10,000 entries, `truncated: true`
+  (use a lowered cap via an internal field if 10k files per test is too slow —
+  prefer testing the real constant once).
+- Normalization: trailing slash, `//`, `/./`, and `a/b/../b` all list; `..`
+  climbing lexically outside every root → `ErrOutsideRoots`; relative/empty/NUL
+  → `ErrInvalidPath`.
+- Containment: path equal to root OK; sibling-with-common-prefix
+  (`/root2` vs root `/root`) → `ErrOutsideRoots`; path under a symlinked dir
+  inside the root (lexical) OK even when target is outside; pasting the
+  resolved outside target → `ErrOutsideRoots`.
+- Symlinks: dir symlink listed as `directory` and enterable (listing it returns
+  the target's children under the *lexical* path); file symlink → `file`;
+  broken symlink → `unknown`, `isSymlink: true`, no size/modifiedAt; FIFO →
+  `unknown` (use `syscall.Mkfifo`).
+- Errors: missing path → `ErrNotFound`; file path → `ErrNotDirectory`;
+  unreadable requested dir → `ErrPermissionDenied`; unreadable child remains
+  visible as `directory` in the parent listing.
+- Cancellation: pre-canceled context → error promptly. Timeout: service with
+  1ns timeout → `internal_error`-mapped failure.
+
+**Handlers (`internal/api`)**
+- `GET /fs/roots` → 200 `{"roots":[...]}` shape; empty → `{"roots":[]}`.
+- `GET /fs/list` happy path → 200, camelCase fields, RFC3339Nano `modifiedAt`.
+- Each error code → exact `{error,message}` body + status per §3.2 table.
+- `showHidden=true` honored; absent → hidden filtered.
+- nil fs service → 500 `internal_error` (the `requireFS` guard), matching
+  `Routes(diagnostics, nil, nil)`-style isolated tests.
+- Auth: one test confirming `/api/fs/roots` 401s without a token when a token
+  is configured (piggybacks existing auth tests).
+
+## 8. Manual verification
+
+Against a live server (Unix socket is auth-free; TCP needs the bearer token):
+
+```sh
+curl -s -H "Authorization: Bearer $TOKEN" "http://HOST:PORT/api/fs/roots" | jq
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://HOST:PORT/api/fs/list?path=/home/jeremy/Projects&showHidden=true" | jq
+# error spot-checks
+curl -s ... "…/api/fs/list?path=/etc/passwd"        # → not_directory
+curl -s ... "…/api/fs/list?path=relative/path"      # → invalid_path
+curl -s ... "…/api/fs/list?path=/nonexistent-root"  # → outside_browsable_roots
+```
+
+Capture the real `fs/roots` and `fs/list` response bodies (including one error
+body) — Part 2 uses verbatim captured fixtures for its decoding tests, per the
+existing CockpitKit convention.
+
+## 9. Milestones
+
+1. **Config**: `FSConfig` + validation + `~` expansion + tests.
+2. **Domain**: `internal/fs` service — roots synthesis/filtering, normalization,
+   containment, classification, sort/cap, timeout — with the full service test
+   suite.
+3. **API**: handlers, error mapper, route registration, plumbing through
+   `cli/root.go` → `server.Config` → `Router` → `api.Routes`, handler tests.
+4. **Verify**: run against the real workstation; walk a symlinked dir, an
+   unreadable dir, a huge dir; capture fixtures for Part 2.
+
+Acceptance: all §7 tests pass; the §8 manual checks return the documented
+shapes and codes; fixtures are captured and handed to Part 2.

--- a/docs/remote-file-browsing-design-2-app.md
+++ b/docs/remote-file-browsing-design-2-app.md
@@ -1,0 +1,340 @@
+# Tech Design — Remote File Browsing, Part 2: AtelierCode Remote Folder Picker
+
+> Implements the client half of `docs/remote-file-browsing-prd.md` against the
+> Cockpit contract defined in `docs/remote-file-browsing-design-1-cockpit.md`
+> (Part 1). **Prerequisite:** Part 1 is deployed to the workstation and its
+> captured response fixtures are available. Work happens in this repo; jj
+> protocol per `AGENTS.md`.
+
+## 1. Scope
+
+Replace `CreateSessionSheet`'s local `.fileImporter` with a remote folder
+picker driven by Cockpit's `/api/fs`:
+
+- `CockpitAPI` package: FS DTOs, two `CockpitClient` methods, HTTP
+  implementation, decoding tests against captured fixtures.
+- `MockCockpitClient`: a canned in-memory remote tree for previews and tests.
+- `RemoteFileBrowser`: a narrow `@Observable` picker-workflow model in
+  `Features/RemoteFiles/`.
+- `RemoteFolderPickerSheet`: the drill-down UI.
+- `CreateSessionSheet` integration + copy fix.
+- A new app unit-test target for the browser model.
+
+## 2. Contract recap (from Part 1)
+
+| Endpoint | Success shape |
+|---|---|
+| `GET /api/fs/roots` | `{"roots":[{"label":"Projects","path":"/home/j/Projects"}]}` |
+| `GET /api/fs/list?path=<abs>&showHidden=<bool>` | `{"path":"/abs/lexical","truncated":false,"entries":[{"name","path","kind","isSymlink","size?","modifiedAt?"}]}` |
+
+- `kind` ∈ `directory` \| `file` \| `unknown` (broken symlinks, sockets, etc. —
+  visible, not enterable). `isSymlink` is metadata only; symlinked dirs behave
+  as folders.
+- `path` values are lexical (symlink-preserving) — the client's canonical
+  navigation state. Entry identity is the path string; no IDs.
+- Entries arrive pre-sorted (dirs first, dotfiles first, case-insensitive);
+  hidden entries are already filtered server-side per `showHidden`.
+- Errors use the existing envelope and surface as
+  `CockpitError.api(code:message:sessionID:)` with `apiCode` one of:
+  `invalid_path` (400), `outside_browsable_roots` (403), `not_found` (404),
+  `not_directory` (400), `permission_denied` (403), `internal_error` (500).
+- `modifiedAt` is RFC3339Nano — decodes via the existing
+  `JSONDecoder.cockpit()` / `.cockpitRFC3339Nano` strategy unchanged.
+
+## 3. Changes from the PRD (and why)
+
+1. **The mock tree stays in the app's `PreviewSupport/MockCockpitClient.swift`**,
+   not the package. The PRD says the package owns "mock data," but the codebase
+   already keeps `MockCockpitClient` in the app; moving it is unrelated churn.
+   The package owns DTOs, decoding, methods, and the HTTP implementation.
+2. **Scripted UI tests are replaced by a manual verification checklist plus a
+   model-level test suite** (§9). The app has no test target of any kind today;
+   XCUITest for keyboard/double-click list behavior on macOS is brittle and a
+   poor first investment. Instead: a new *unit*-test target covers the
+   `RemoteFileBrowser` workflow (the PRD's third seam) with the mock client,
+   and the picker's visual behaviors are a manual checklist. This trades
+   automation of the thinnest layer for a durable seam we keep.
+3. **No `parent` field exists in the contract** (Part 1 §2.1) — the app
+   computes parents and breadcrumbs lexically from the current path, which it
+   needs to do anyway to enforce the active-root Up boundary.
+4. **The server is the sole path validator.** On manual path commit the app
+   sends the trimmed string to `fs/list` and renders the typed error; it does
+   no client-side syntax checking beyond trimming. One validator, no drift.
+5. **Unrecognized `kind` values decode as `.unknown`** (custom `Decodable`
+   init), so a future server adding kinds doesn't break old clients. Unknown
+   entries are already inert in the UI, making this safe forward compatibility.
+
+Everything else follows the PRD as written.
+
+## 4. `CockpitAPI` package changes
+
+New file `Sources/CockpitAPI/Models/FileSystemModels.swift`:
+
+```swift
+public struct RemoteWorkspaceRoot: Codable, Sendable, Hashable, Identifiable {
+    public var id: String { path }        // path-as-identity, like everywhere else
+    public let label: String
+    public let path: String
+}
+
+public enum RemoteEntryKind: String, Codable, Sendable {
+    case directory, file, unknown
+    // custom init(from:) — unrecognized raw values decode as .unknown
+}
+
+public struct RemoteEntry: Codable, Sendable, Hashable, Identifiable {
+    public var id: String { path }
+    public let name: String
+    public let path: String
+    public let kind: RemoteEntryKind
+    public let isSymlink: Bool
+    public let size: Int64?
+    public let modifiedAt: Date?
+}
+
+public struct DirectoryListing: Codable, Sendable, Hashable {
+    public let path: String
+    public let truncated: Bool
+    public let entries: [RemoteEntry]
+}
+
+struct RootsEnvelope: Decodable { let roots: [RemoteWorkspaceRoot] }  // internal, like SessionsEnvelope
+```
+
+`CockpitClient` protocol additions (both implementors must conform):
+
+```swift
+func workspaceRoots() async throws -> [RemoteWorkspaceRoot]
+func listDirectory(path: String, showHidden: Bool) async throws -> DirectoryListing
+```
+
+Plus a protocol-extension default `listDirectory(path:)` with
+`showHidden: false`, mirroring the `sessions()` default.
+
+`HTTPCockpitClient`:
+
+- `workspaceRoots()` → `get(RootsEnvelope.self, "fs/roots").roots`.
+- `listDirectory` → `get(DirectoryListing.self, "fs/list", query: items)` where
+  `items` always contains `path` and appends `showHidden=true` **only when
+  true** — the exact `includeArchived` precedent.
+
+No decoder changes: fields are camelCase (no key strategy needed) and
+`modifiedAt` rides the existing date strategy. Server errors flow through the
+existing non-2xx → `ErrorEnvelope` → `CockpitError.api` path untouched.
+
+## 5. Mock data — `MockCockpitClient`
+
+Extend the existing `nonisolated struct` with a canned tree. A programmatic
+dictionary beats inline JSON here because the mock must *navigate*, not just
+decode:
+
+```swift
+// roots: [RemoteWorkspaceRoot], tree: [String: [RemoteEntry]] keyed by directory path
+```
+
+Content requirements (so previews exercise every UI state):
+
+- Two roots (`Projects`, `Home`); 3-4 levels of nesting.
+- Files and folders mixed; several dotfiles/dot-dirs (hidden-toggle demo);
+  a directory symlink, a file symlink, and a broken symlink (`.unknown`);
+  one directory whose listing throws `CockpitError.api(code:
+  "permission_denied", ...)`; one listing with `truncated: true`; one empty
+  directory.
+- `listDirectory` filters dot-entries itself when `showHidden` is false and
+  throws `.api(code: "not_found", ...)` for unknown paths — the mock mimics
+  server behavior so `RemoteFileBrowser` tests cover error handling.
+
+## 6. `RemoteFileBrowser` — the `@Observable` picker model
+
+New file `AtelierCode/Features/RemoteFiles/RemoteFileBrowser.swift`. Follows
+the `SessionsStore` template: `@Observable final class` (main-actor by project
+default), knows nothing about views, takes `any CockpitClient` in `init`
+(injected from `AppModel.client` by the presenting view; no `AppModel`
+dependency, which keeps the model trivially testable).
+
+Not a generic tree engine — exactly the picker's workflow state:
+
+```swift
+@Observable final class RemoteFileBrowser {
+    // State (private(set) unless bound by the UI)
+    private(set) var roots: [RemoteWorkspaceRoot] = []
+    private(set) var activeRoot: RemoteWorkspaceRoot?
+    private(set) var listing: DirectoryListing?      // nil ⇒ showing the roots list
+    private(set) var isLoading = false
+    private(set) var hasLoadedRoots = false
+    var lastError: String?
+    var highlightedPath: String?                     // Highlighted Entry (List selection)
+    var typedPath: String = ""                       // path-field draft; synced on navigation
+    var showHidden = false                           // didSet → reload current directory
+
+    // Commands
+    func loadRoots() async
+    func open(root: RemoteWorkspaceRoot) async
+    func descend(into entry: RemoteEntry) async      // no-op unless kind == .directory
+    func goUp() async
+    func commitTypedPath() async                     // Return / Go
+    func jump(to path: String) async                 // breadcrumb segment tap
+
+    // Derived
+    var currentPath: String? { listing?.path }       // the Chosen Folder candidate
+    var canGoUp: Bool                                // false at activeRoot or roots list
+    var breadcrumbs: [(label: String, path: String)] // root label + lexical segments below it
+}
+```
+
+Semantics:
+
+- **Loading**: every command sets `isLoading`/clears-or-sets `lastError` with
+  the `SessionsStore` `defer` pattern; failures store
+  `error.localizedDescription` (which is the server's human message for
+  `.api`). A failed navigation keeps the previous listing on screen with the
+  error shown — no blanking.
+- **Active root**: set directly by `open(root:)`. After `commitTypedPath` /
+  prefill, it is the root whose path is the **longest lexical prefix** of the
+  listed path (ties impossible after Part 1's duplicate-path config rule). The
+  server already guaranteed containment, so a match always exists.
+- **Up boundary**: `canGoUp` is false when `currentPath == activeRoot.path`.
+  `goUp()` lists the lexical parent (string operation on `currentPath`).
+  Going "up" from a root returns to the roots list (`listing = nil`,
+  `activeRoot = nil`) — cheap, and gives the roots list a way back.
+- **Breadcrumbs**: `activeRoot.label` followed by the path segments of
+  `currentPath` relative to `activeRoot.path` — lexical, symlink-preserving by
+  construction. `jump(to:)` re-lists any crumb.
+- **Typed path**: `typedPath` mirrors `currentPath` after every successful
+  navigation. `commitTypedPath()` trims, then calls `listDirectory` — the
+  server validates (§3.4). Success replaces the listing and recomputes
+  `activeRoot`; failure sets `lastError` and leaves navigation state alone.
+- **Hidden toggle**: `showHidden` change re-lists `currentPath` (server-side
+  filter; entries are not cached client-side). Highlight is cleared if the
+  highlighted entry disappears.
+- **Descend** ignores `.file` and `.unknown` entries (PRD: inert in v1).
+- Navigation clears `highlightedPath`.
+
+## 7. `RemoteFolderPickerSheet` — the UI
+
+New file `Features/RemoteFiles/RemoteFolderPickerSheet.swift`. Presented as a
+nested sheet from `CreateSessionSheet`; fixed frame (~`520×480`); standard
+sheet chrome (bottom `Divider` + `HStack`: Cancel with `.cancelAction`,
+primary with `.defaultAction`); `.preferredColorScheme(.dark)` in previews.
+
+```
+┌──────────────────────────────────────────────┐
+│ [path field ............................][Go]│  ← typedPath; commit on Return/Go only
+│ [↑] Projects ▸ atelier ▸ src                 │  ← Up button + clickable breadcrumbs
+├──────────────────────────────────────────────┤
+│ ⚠ Listing truncated at 10,000 entries        │  ← only when listing.truncated
+│ folder  .config                              │
+│ folder  src                                  │  ← List(selection:), rows = entries
+│ doc     README.md            (dimmed)        │
+│ …                                            │
+├──────────────────────────────────────────────┤
+│ ☐ Show hidden files      Cancel  Use This Folder │
+└──────────────────────────────────────────────┘
+```
+
+- **Two visual modes on one sheet**: `browser.listing == nil` shows the roots
+  list (rows: `folder.badge.gearshape`-free, just `folder` + label + dimmed
+  path); otherwise the directory list. Empty roots →
+  `ContentUnavailableView("No browsable roots", …)` explaining that roots are
+  configured on the Cockpit server. Loading → `ProgressView`; errors → the
+  existing inline red `Label` convention (persistent field-adjacent text for
+  path-commit errors, not an alert).
+- **List + Highlighted Entry**: `List(selection: $browser.highlightedPath)`
+  with rows `.tag(entry.path)` — single-click and arrow keys (when the list
+  has focus) come free from AppKit-backed `List`. This is the app's first
+  keyboard-navigable list; no precedent exists, and `List` selection is the
+  lowest-machinery way to get PRD stories 9-10.
+- **Drill-in**: Return via `.onKeyPress(.return)` scoped to the list (macOS
+  14+): if the highlighted entry is a `.directory`, `descend`; `.file` /
+  `.unknown` → consume and do nothing. Double-click via
+  `TapGesture(count: 2)` on the row content (no first-party List double-click
+  API; this is the standard approach). Rows for roots behave the same
+  (Enter/double-click opens the root).
+- **Rows**: SF Symbols only — `folder` for `.directory`, `doc` for `.file`,
+  `questionmark.square.dashed` (or `doc` dimmed) for `.unknown`. No
+  symlink-specific treatment (PRD). `.file`/`.unknown` rows render with
+  `.foregroundStyle(.secondary)` — visible, clearly not choosable, still
+  highlightable.
+- **Paths**: path field and breadcrumb overflow use `.lineLimit(1)` +
+  `.truncationMode(.middle)` (deliberate PRD deviation from the app's existing
+  `.head` truncation for `workingDir` display — middle keeps both the root and
+  the leaf visible).
+- **Truncation warning**: when `listing.truncated`, a compact warning row
+  pinned above the list (`exclamationmark.triangle`, `.secondary`).
+- **Use This Folder**: enabled iff `browser.currentPath != nil`; commits the
+  **Chosen Folder** = current viewed directory (never the Highlighted Entry),
+  calls `onChoose(path)` and dismisses. Cancel dismisses with no write-back.
+
+Component boundary: keep the sheet one file with small private subviews
+(`rootsList`, `directoryList`, `breadcrumbBar`, `entryRow`) — same style as
+`CreateSessionSheet`. No new abstractions until a second presentation (tree /
+fuzzy finder) exists.
+
+## 8. `CreateSessionSheet` integration
+
+- Delete the `.fileImporter(...)` modifier, the
+  `"Choose a local folder (path is used on the server)"` `.help` string, and
+  the now-unused `import UniformTypeIdentifiers`.
+- The `folder` button now sets `showFolderPicker = true` to present
+  `RemoteFolderPickerSheet` via `.sheet(isPresented:)`, constructing
+  `RemoteFileBrowser(client: appModel.client)`. New `.help`:
+  `"Browse folders on the Cockpit workstation"`.
+- `onChoose:` writes the chosen path into the existing `workingDir` `@State`.
+  The `TextField` prompt stays `/path/on/the/server`.
+- **Prefill** (PRD "may"): on picker appear, if trimmed `workingDir` is
+  non-empty → `typedPath = workingDir; await commitTypedPath()`; on failure the
+  picker shows the roots list with the error visible in the path-field area.
+  Empty `workingDir` → `loadRoots()` directly.
+
+## 9. Testing
+
+**Seam 1 — package (`CockpitAPITests`, Swift Testing, existing target).**
+Fixtures are verbatim captures from the live Part 1 server (raw-string `Data`,
+capture-date comment — house convention):
+- Decode `fs/roots` fixture via `RootsEnvelope`; decode `fs/list` fixture
+  (entries incl. nullable `size`/`modifiedAt`, a symlink, an `unknown`,
+  `truncated` both ways, empty `entries`); unrecognized `kind` → `.unknown`.
+- `CockpitServerTests`-style URL tests: `fs/list` query contains `path`;
+  `showHidden` present only when true; path percent-encoding.
+- `ErrorEnvelopeTests`-style: each of the five FS error bodies decodes and
+  surfaces the right `apiCode`/`errorDescription`.
+
+**Seam 2 — new app unit-test target `AtelierCodeTests`** (Swift Testing; first
+app test target — add to the pbxproj). Tests drive `RemoteFileBrowser` with
+`MockCockpitClient`:
+- loadRoots populates roots; open(root:) lists it and sets activeRoot.
+- descend into directory updates listing/typedPath and clears highlight;
+  descend into file/unknown is a no-op.
+- goUp stops at activeRoot (`canGoUp == false`), then returns to roots list.
+- breadcrumbs reflect the lexical path incl. through the mock's symlinked dir.
+- commitTypedPath: valid path lists and recomputes activeRoot (longest-prefix);
+  error path sets `lastError` and preserves the current listing.
+- showHidden toggle re-lists; truncated listing exposes `truncated`.
+- permission_denied listing surfaces the server message in `lastError`.
+- CreateSession seam: choosing a folder writes `workingDir` (test the
+  `onChoose` wiring at the model/callback level).
+
+**Manual checklist (replaces scripted UI tests — §3.2)** against the live
+workstation: open picker → roots appear; arrow-key + Enter drill-in;
+double-click drill-in; Enter/double-click inert on files; breadcrumb jump; Up
+stops at root then shows roots list; hidden toggle reveals dotfiles; paste a
+valid path + Return opens it; paste each invalid-path class and see the typed
+error; truncation banner on a huge dir; symlinked dir browses with preserved
+breadcrumbs; **Use This Folder → session actually starts in that directory on
+the workstation** (end-to-end, per PRD).
+
+## 10. Milestones
+
+1. **Fixtures + DTOs**: capture live responses; `FileSystemModels.swift`,
+   protocol methods, `HTTPCockpitClient` impl; Seam-1 tests green
+   (`swift test --package-path Packages/CockpitKit`).
+2. **Mock tree**: `MockCockpitClient` conformance + canned tree (§5).
+3. **Model + test target**: `RemoteFileBrowser`; create `AtelierCodeTests`;
+   Seam-2 tests green.
+4. **UI**: `RemoteFolderPickerSheet` with previews for roots/list/error/empty/
+   truncated states.
+5. **Integration**: `CreateSessionSheet` swap, prefill, copy fix.
+6. **Verify**: full manual checklist against the live server.
+
+Acceptance: both automated seams green; manual checklist passes end-to-end;
+`.fileImporter` and the misleading help text are gone.

--- a/docs/remote-file-browsing-exploration.md
+++ b/docs/remote-file-browsing-exploration.md
@@ -1,0 +1,306 @@
+# Remote File Browsing — Exploration / Rough Draft
+
+> **Status: exploratory. Nothing here is decided.** This is a thinking document
+> capturing the problem, what we learned from the current code, and a *design
+> space* of options. Where a direction is currently appealing it's called out as
+> a "leaning" — a starting hypothesis to poke at, not a commitment. Expect this
+> to change as we explore further. No code has been written against any of it.
+
+## Overview
+
+We want AtelierCode to work with the file trees on the remote Cockpit
+workstation — browsing, picking, and selecting files/folders. This is broad, and
+we expect to grow into several UI shapes over time:
+
+- a **file-tree browser** (drill down / expand a directory tree),
+- a **fuzzy-finder picker** (type-to-match a file within a project),
+- and likely others we haven't named yet.
+
+Everything the app knows about the remote host comes through the **Cockpit
+API**, so any of this is really two intertwined problems: (1) the **SwiftUI**
+mechanisms to render and drive each interaction, and (2) the **Cockpit API**
+surface that feeds them. Neither exists yet.
+
+The proposed *first* concrete target — small enough to learn from, useful on its
+own — is **selecting a remote folder when starting a new session**. The rest of
+this doc explores that slice while trying to keep the door open for the bigger
+picture.
+
+A useful reference for the *shape* of a mature file-tree component (web, so not
+directly usable here, but worth borrowing ideas from):
+<https://trees.software/>.
+
+## Where things stand today
+
+Two findings frame the whole effort:
+
+1. **The current folder picker is local, and that's semantically wrong.**
+   `CreateSessionSheet` uses SwiftUI's `.fileImporter` to pick a folder on *this
+   Mac* and copies its path into `workingDir` — but `workingDir` is a path on
+   the *Cockpit workstation*. The field's own help text admits it: "Choose a
+   local folder (path is used on the server)." So this feature isn't net-new
+   surface so much as fixing an existing mismatch.
+
+2. **Cockpit has no filesystem API at all.** There are no list/browse/find
+   endpoints. `workingDir` is passed straight through to the session as an
+   opaque string — never listed, validated, or resolved. So *any* remote
+   browsing depends on new server work; it cannot be built against today's API.
+
+A helpful third observation: Cockpit's existing **"actions/environments
+discovery + dynamic param renderer"** pattern is a close analog to a directory
+browser (server describes a shape → client fetches and renders it generically),
+and the app's async-load conventions (`.task`, `@State` for loading/error,
+`ContentUnavailableView`, `ProgressView`) would carry over. So there's a
+well-worn groove to follow if/when we build.
+
+## Ideas worth borrowing from trees.software
+
+Not endorsing the library — just its concepts, which seem sound for a native
+reimplementation:
+
+- **Path-as-identity.** Canonical path strings are the primary key for a node,
+  not object references. Keeps UI state and data in sync trivially. For
+  symlinked directories, navigation preserves the path the user followed (for
+  example `/Projects/shared/...`) rather than rewriting breadcrumbs to the
+  symlink's resolved target.
+- **Focus vs. selection as distinct concepts.** "Where keyboard actions land"
+  is separate from "what the app treats as chosen." For a folder *picker* these
+  genuinely differ (you navigate through folders you don't ultimately pick).
+  For the first picker, the **Highlighted Entry** drives navigation: pressing
+  Enter on a highlighted folder drills into it; single-click highlights with the
+  mouse; double-click drills in. The **Chosen Folder** is the current viewed
+  directory committed by a separate UI action, such as "Use This Folder."
+- **Framework-agnostic core.** The tree logic is a plain model any UI can wrap.
+  Suggests keeping our browsing logic out of the views.
+- **Prepare once, off the UI boundary.** They lean toward shaping the tree on
+  the server rather than doing heavy work in the client.
+- **Search modes** (for an eventual fuzzy finder): hide-non-matches /
+  collapse-non-matches / expand-matches.
+
+## The design space
+
+### API: likely two loading modes, not one
+
+The two future use cases pull in different directions, and it may be cleanest to
+name both even if we only build one first:
+
+- **Browse — lazy, one directory at a time.** For "pick a folder anywhere," you
+  can't enumerate a whole host up front; load per-directory on demand. Natural
+  fit for a drill-down picker or an expandable tree.
+- **Find — bounded set prepared up front.** For a fuzzy finder scoped to a
+  project root, walk once on the server (potentially `.gitignore`-aware, capped)
+  and let the client match on every keystroke. This is the trees.software
+  "prepare once" idea. Keep this as a separate future endpoint (for example
+  `GET /api/fs/prepare?...` or `GET /api/fs/find-index?...`) rather than making
+  `fs/list` do recursive search.
+
+These aren't mutually exclusive — they'd likely be two endpoints serving two
+interaction styles. Only *browse* is needed for the folder-picker slice.
+
+Browse API shape. The browse API should return both files and folders from day
+one, even though the first picker UI only enables selecting folders:
+
+```
+GET /api/fs/roots
+  → { "roots": [ { "label":"Projects", "path":"/home/me/Projects" } ] }
+```
+
+```
+GET /api/fs/list?path=<abs>&showHidden=<bool>
+  → { "path":    "/…/atelier",          // canonicalized absolute
+      "parent":  "/…",                  // null when at a boundary
+      "truncated": false,
+      "entries": [ { "name":"src", "path":"/…/atelier/src", "kind":"directory", "isSymlink":false, "size":4096, "modifiedAt":"…" }, … ] }
+```
+
+Use path strings as entry identity and navigation state. Do not introduce
+separate entry IDs unless Cockpit later supports virtual roots or non-filesystem
+providers. Hidden entries are excluded by default (`showHidden=false`), but the
+endpoint supports including them because developer workflows often need
+directories such as `.git`, `.codex`, or `.config`.
+V1 entry metadata should stay focused: `name`, `path`, `kind`, and `isSymlink`
+are required; `size` and `modifiedAt` are optional/nullable. Defer permissions,
+owner/group, MIME type, git status, children counts, and resolved symlink
+targets. Broken symlinks should be returned as `kind: "unknown"` with
+`isSymlink: true`; they are visible but not enterable.
+Unreadable directories discovered while listing a readable parent should remain
+visible as directory entries; attempting to enter them returns
+`permission_denied`. If the requested parent itself is unreadable, `fs/list`
+returns `permission_denied` for that request.
+Cockpit should clean/normalize requested paths before validation. Raw `..`
+segments are allowed only when the normalized result remains in the browsable
+namespace.
+Cockpit should return a stable default order: directories first, then files,
+dot-prefixed entries before others within each group, then case-insensitive by
+name. Clients may still re-sort for their own UI.
+`GET /api/fs/list` is directory-only: it returns children for directory paths
+and returns a typed `not_directory` error for file paths. Files are still
+included as entries in directory listings, and future file viewing should use a
+separate endpoint such as `GET /api/fs/read?path=...`.
+`fs/list` should apply a generous server-side entry cap of 10,000 entries and
+return `truncated: true` when the result was cut off, so huge directories cannot
+make the picker sluggish or memory-heavy.
+V1 `fs/list` errors should use Cockpit's existing error envelope with one of:
+`not_found`, `not_directory`, `permission_denied`, `outside_browsable_roots`,
+or `invalid_path`.
+Cockpit should respect normal request-context cancellation and apply a
+server-side timeout for slow listings; no custom cancel endpoint is needed.
+
+Whatever we pick should fit Cockpit's existing conventions (stdlib `net/http`
+`ServeMux`, `writeJSON`, named-wrapper responses like `{"entries":[…]}`, the
+`{error,message}` envelope, free bearer auth under `/api`).
+
+### Access scope: Remote Workspace Roots
+
+Cockpit's auth today is all-or-nothing at the transport, and session-start
+already runs arbitrary commands in any `workingDir` — so *listing* doesn't
+really widen the trust boundary, but it does widen what's easily readable.
+AtelierCode should browse only inside **Remote Workspace Roots**: named folders
+on the Cockpit workstation that define starting namespaces for
+remote browsing and session working-directory selection.
+
+Alternatives considered:
+
+- **Full-host browse**, seeded at `$HOME`, relying on the existing token
+  boundary (+ a symlink/`..` escape guard).
+- **Remote Workspace Roots** — a new Cockpit config section names the parent
+  folders the API is allowed to expose as browsing starting points. This is not
+  a resolved-path sandbox: directory symlinks reachable from a root remain
+  browseable, including their children, even when the symlink target resolves
+  outside the root.
+- **Hybrid** — browse widely but seed the UI with configured favorites /
+  recents.
+
+**Decision:** use Remote Workspace Roots, expressed as settings in Cockpit. This
+turns the browsing boundary into a small config list and gives the client an
+obvious set of starting points. For the first version, roots are static server
+configuration: AtelierCode reads and displays them, but does not add, edit, or
+remove them at runtime. Root paths may use `~` for the server user's home
+directory, but v1 should not expand arbitrary environment variables. The exact
+config shape is still open. A rough illustration only:
+
+```
+# candidate config — shape TBD
+[[fs.roots]]
+label = "Projects"
+path  = "/…/Projects"
+```
+
+If no roots are configured, Cockpit should synthesize a default `Home` root at
+the server user's `$HOME` so the feature works out of the box. Explicit config
+replaces that default. If configured roots are invalid or unreadable, Cockpit
+should omit them from `fs/roots` and log the cause server-side; the picker shows
+an empty state if no usable roots are returned.
+
+A small `GET /api/fs/roots` companion endpoint (returning the allowed roots) is
+a natural partner to `GET /api/fs/list`. Directory listing should treat symlinks
+like normal filesystem entries: a directory symlink is browsed like a directory,
+and a file symlink is represented like a file. The API can still expose
+`isSymlink` metadata, but symlinks do not need traversal tokens or special
+capabilities. Broken symlinks appear as visible, non-enterable unknown entries.
+For the first version, Remote Workspace Roots constrain remote browsing and
+AtelierCode-driven working-directory selection only. They are not yet a global
+Cockpit execution policy: `POST /api/sessions/start` can keep accepting
+arbitrary `workingDir` strings until Cockpit intentionally introduces broader
+workspace enforcement.
+
+### Client architecture: layered, with a reusable core
+
+Borrowing trees.software's "framework-agnostic core," a candidate layering that
+lets one investment serve all three future UIs:
+
+1. **`CockpitAPI` (package):** directory-listing method(s) on the `CockpitClient`
+   protocol + `HTTPCockpitClient` + `MockCockpitClient`, plus `RemoteEntry` /
+   `DirectoryListing` DTOs (with `RemoteEntry.id == path`). Pure Foundation, no
+   UI — same boundary the rest of the package respects.
+2. **A narrow app-side `@Observable` browsing model** (e.g.
+   `RemoteFileBrowser` in `Features/RemoteFiles/`): picker workflow state such
+   as current listing, loading/error, selected path, typed path, `showHidden`,
+   and commands such as `loadRoots`, `openRoot`, `descend`, `goUp`, and
+   `setPath`. The Cockpit-owned remote filesystem contract belongs in
+   `CockpitKit` (DTOs and `CockpitClient` methods); `RemoteFileBrowser` belongs
+   in the app because it represents what the picker is currently doing with
+   that data. It is not an API DTO, not a SwiftUI view, and not a generic
+   tree/search engine.
+3. **UI presentations** on top: start with a folder picker; later a tree view
+   (SwiftUI `OutlineGroup`/`List(children:)` gives lazy-expandable trees
+   natively) and a fuzzy finder — all fed by the same model + API.
+
+The appeal is that the first small slice isn't throwaway: it establishes the API
+contract and the core model that the later shapes reuse. Whether that
+abstraction earns its keep before we've built more than one presentation is
+itself worth questioning.
+
+## A possible first slice: remote folder picker
+
+One concrete way to start (again — *a* starting point, not the plan):
+
+- Add the browse DTOs + client method, with a canned in-memory tree in
+  `MockCockpitClient` so the UI is buildable before any server work exists.
+- Build the `RemoteFileBrowser` model.
+- Build a drill-down `RemoteFolderPicker` sheet: roots list → directory list,
+  clickable breadcrumb segments plus an Up button, an editable path field, a
+  hidden-files toggle, visible-but-disabled file rows, and a "use this folder"
+  action. Long paths should middle-truncate instead of wrapping into multiple
+  rows. Standard load/loading/error conventions. Manual path entry remains in
+  the first slice: pasted paths are remote paths validated by Cockpit, and the
+  action is enabled only when the path lists as a directory within the browsable
+  namespace. Manual path validation happens only when the user commits the field
+  with Return or a Go button, not on every keystroke.
+  V1 starts at the roots list rather than remembering recents; if
+  `CreateSessionSheet` already has a `workingDir`, the picker may prefill and
+  validate that path.
+  If a directory listing is truncated, show the returned entries with a small
+  warning row or banner.
+  Up navigation stops at the active Remote Workspace Root for ordinary paths, so
+  the picker cannot climb above a root via parent navigation. Directory symlinks
+  still behave like normal folders when entered.
+  Interaction model: single-click or arrow keys set the Highlighted Entry, which
+  can be a file or folder. Enter or double-click drills into a highlighted
+  folder; Enter or double-click on a highlighted file does nothing in v1. The
+  explicit "Use This Folder" action writes the Chosen Folder (the current viewed
+  directory), not the Highlighted Entry, back to `workingDir`.
+  Use basic SF Symbols only (`folder` and `doc`); do not add symlink-specific
+  visual treatment in v1.
+- Replace `CreateSessionSheet`'s `.fileImporter` button with this sheet, writing
+  the chosen path into `workingDir` (and fix the misleading help text).
+
+Build the server contract first, then the app UI against that contract. The
+boundary decisions live mostly in Cockpit (roots, `$HOME` fallback, symlink
+behavior, path identity, hidden files, and error codes), so a mock-first UI would
+risk inventing a contract the server then fights. Once the server shape exists,
+add matching `CockpitKit` DTOs/tests, then `MockCockpitClient` data for previews,
+then `RemoteFileBrowser` and `RemoteFolderPicker`.
+
+**Current leaning on scope:** keep the first slice to *just* the folder picker
+(defer the tree browser and fuzzy finder), so we learn from a small, shippable
+piece before investing in the broader shapes. Not decided.
+
+## Open questions / still to explore
+
+- **Access scope & config:** final config shape.
+- **Path validation & safety:** Cockpit has no browsing guard today — how do we
+  represent and validate traversal through directory symlinks without treating
+  Remote Workspace Roots as a resolved-path sandbox?
+- **API shape details:** resolved for v1.
+- **Lazy vs. prepared trade-off:** resolved at the endpoint level — `fs/list`
+  stays lazy and one-directory-at-a-time; a future fuzzy finder gets a separate
+  prepared, bounded path-list endpoint. Exact DTO sharing is still open.
+- **Is the reusable-core abstraction worth it now,** or premature before a second
+  presentation exists?
+- **Folder-only vs. file-aware browsing:** resolved for the API — return both
+  files and folders from day one; the first picker UI only enables selecting
+  folders.
+- **UI form factor for the picker:** resolved for the first slice — use a
+  drill-down list; columns and expandable trees are later presentation options.
+- **Fuzzy finder mechanics (later):** server-side vs. client-side ranking,
+  `.gitignore` awareness, result caps, the search-mode behaviors.
+- **Cross-repo coordination:** the server changes live in the separate
+  `cockpit` repo; how we stage client + server work together.
+
+## References
+
+- Reference component (web): <https://trees.software/>
+- Cockpit server: <https://github.com/jeremytondo/cockpit>
+- Related: `docs/poc-plan.md` (documents the current Cockpit API surface and the
+  app's layering conventions).

--- a/docs/remote-file-browsing-prd.md
+++ b/docs/remote-file-browsing-prd.md
@@ -1,0 +1,138 @@
+# PRD: Remote Folder Selection
+
+## Problem Statement
+
+When a user starts a new AtelierCode session today, the create-session flow offers a local Mac folder picker and copies that path into `workingDir`. That is semantically wrong because `workingDir` is evaluated on the remote Cockpit workstation, not on the local Mac. Users either hand-type remote paths from memory or risk starting sessions in invalid or unintended directories.
+
+Cockpit also has no read-only filesystem API. AtelierCode cannot list Remote Workspace Roots, validate a pasted remote path, or browse the remote workstation before creating a session. This blocks a correct folder-selection experience and prevents future remote file-tree and fuzzy-finder workflows.
+
+## Solution
+
+Add remote folder selection for session creation. Cockpit will expose a small read-only `/api/fs` browse contract, rooted in static Remote Workspace Roots. AtelierCode will replace the local folder importer with a drill-down remote folder picker that lists roots, browses one directory at a time, supports hidden entries, validates manually entered remote paths on commit, and writes the Chosen Folder back to `workingDir`.
+
+The first version focuses only on choosing a remote working directory. It establishes the Cockpit filesystem contract and a narrow app-side browsing model that later remote file-tree and fuzzy-finder presentations can reuse.
+
+## User Stories
+
+1. As an AtelierCode user, I want to choose a folder on the remote Cockpit workstation, so that my new session starts in the correct remote working directory
+2. As an AtelierCode user, I want the create-session folder button to browse remote folders instead of local Mac folders, so that I do not accidentally choose an unusable local path
+3. As an AtelierCode user, I want to see configured Remote Workspace Roots when opening the picker, so that I know where remote browsing is expected to start
+4. As an AtelierCode user, I want Cockpit to provide a Home root when no roots are configured, so that remote folder selection works out of the box
+5. As an AtelierCode user, I want invalid or unreadable configured roots to be absent from the picker, so that I only interact with usable roots
+6. As a Cockpit operator, I want invalid root configuration to be logged server-side, so that I can troubleshoot workstation configuration drift
+7. As an AtelierCode user, I want to drill into remote folders with the keyboard, so that I can choose a working directory without using the mouse
+8. As an AtelierCode user, I want to drill into remote folders by double-clicking, so that the picker behaves like a familiar file browser
+9. As an AtelierCode user, I want single-click and arrow-key navigation to set the Highlighted Entry, so that I can inspect rows before drilling in
+10. As an AtelierCode user, I want Enter on a highlighted folder to drill in, so that keyboard navigation is efficient
+11. As an AtelierCode user, I want Enter or double-click on a highlighted file to do nothing in v1, so that files can be visible without implying file opening exists yet
+12. As an AtelierCode user, I want Use This Folder to choose the current viewed directory, so that confirming a folder is explicit and not confused with the Highlighted Entry
+13. As an AtelierCode user, I want files to be visible in directory listings, so that the browser reflects the actual contents of a remote directory
+14. As an AtelierCode user, I want only directories to be usable as the Chosen Folder, so that session creation receives a valid working directory
+15. As an AtelierCode user, I want hidden entries excluded by default, so that common directories remain easy to scan
+16. As an AtelierCode user, I want a hidden-files toggle, so that I can navigate to developer directories such as dot-config or dot-repo folders when needed
+17. As an AtelierCode user, I want an editable remote path field, so that I can paste or type a known workstation path
+18. As an AtelierCode user, I want manual path validation to happen only when I press Return or click Go, so that the app does not show noisy errors while I am still typing
+19. As an AtelierCode user, I want valid pasted remote directory paths to open in the picker, so that I can combine terminal-copy workflows with browsing
+20. As an AtelierCode user, I want invalid pasted paths to show a useful error, so that I understand whether the path was missing, not a directory, unreadable, outside the browsable roots, or malformed
+21. As an AtelierCode user, I want the picker to preserve the path I followed through symlinks, so that breadcrumbs match my navigation rather than jumping to resolved targets
+22. As an AtelierCode user, I want directory symlinks to behave like folders, so that common linked workspace layouts work naturally
+23. As an AtelierCode user, I want file symlinks to behave like files, so that the listing stays consistent with the effective filesystem entry
+24. As an AtelierCode user, I want broken symlinks to remain visible but not enterable, so that filesystem issues are not silently hidden
+25. As an AtelierCode user, I want unreadable directories under readable parents to remain visible, so that the listing reflects that the directory exists even if opening it fails
+26. As an AtelierCode user, I want parent navigation to stop at the active Remote Workspace Root, so that the picker does not become a full-host browser by climbing above a root
+27. As an AtelierCode user, I want clickable breadcrumb segments, so that I can jump back multiple levels quickly
+28. As an AtelierCode user, I want an Up button, so that parent navigation is always available
+29. As an AtelierCode user, I want long paths to middle-truncate, so that the picker stays readable without wrapping path text across multiple rows
+30. As an AtelierCode user, I want very large directories to show a truncation warning, so that I know the listing is incomplete
+31. As an AtelierCode user, I want the picker to use basic system folder and file icons, so that it is visually clear without adding icon complexity
+32. As an AtelierCode user, I want the final chosen remote path to populate the session working directory field, so that session creation uses the path I confirmed
+33. As an AtelierCode user, I want the old misleading local-folder help text removed, so that the UI no longer suggests that local folders are valid session working directories
+34. As a Cockpit API consumer, I want stable path-string identity for filesystem entries, so that client state can use paths directly without separate IDs
+35. As a Cockpit API consumer, I want deterministic default sorting, so that simple clients and tests get stable directory output
+36. As a Cockpit API consumer, I want clients to remain free to re-sort entries, so that future UIs can sort by their own criteria
+37. As a Cockpit API consumer, I want directory listing to return files and folders, so that future file-viewing features can build on the same browse contract
+38. As a Cockpit API consumer, I want file content reading to be separate from directory listing, so that `fs/list` remains simple and predictable
+39. As a Cockpit maintainer, I want slow listings to respect request cancellation and server-side timeouts, so that abandoned picker requests do not consume resources indefinitely
+40. As a future AtelierCode user, I want the first browse contract to leave room for a file tree and fuzzy finder, so that v1 folder selection is not throwaway work
+
+## Implementation Decisions
+
+- Remote folder selection is v1 of remote file browsing. File-tree browsing, fuzzy finding, and file viewing are future presentations or endpoints.
+- Cockpit is the source of truth for remote filesystem data. Server contract work happens before the Swift UI is built against it.
+- Remote browsing starts from static Remote Workspace Roots configured on the Cockpit server.
+- When no Remote Workspace Roots are configured, Cockpit synthesizes a `Home` root at the server user's home directory.
+- Explicitly configured roots replace the synthesized Home root.
+- Configured roots that are invalid or unreadable are omitted from the roots response and logged server-side.
+- Remote Workspace Root paths may use `~` for the server user's home directory. Arbitrary environment-variable expansion is out of scope for v1.
+- Remote Workspace Roots are a browsing namespace, not a resolved-path sandbox. Directory symlinks reached from a root remain browseable, including their children, even when they resolve outside the root.
+- Remote Workspace Roots constrain remote browsing and AtelierCode-driven working-directory selection only. They do not globally restrict session-start requests in v1.
+- The Cockpit browse API lives under `/api/fs`.
+- The roots endpoint returns a named wrapper containing usable roots with `label` and `path`.
+- The list endpoint lists immediate children for a directory path and accepts a `showHidden` flag.
+- The list endpoint is directory-only. If the requested path is a file, it returns `not_directory`.
+- File reading or previewing will use a future endpoint, not the directory-list endpoint.
+- Entry identity is the path string. Do not introduce entry IDs in v1.
+- The path shown during navigation preserves the path the user followed, including through symlinked directories, rather than rewriting breadcrumbs to resolved targets.
+- Directory entries include required `name`, `path`, `kind`, and `isSymlink` fields.
+- Directory entries may include nullable `size` and `modifiedAt` fields.
+- Deferred entry metadata includes permissions, owner/group, MIME type, Git status, children count, and resolved symlink target.
+- Entry `kind` supports `directory`, `file`, and `unknown`.
+- Broken symlinks are visible as `unknown` entries with `isSymlink` set and are not enterable.
+- Unreadable directories discovered under a readable parent remain visible as directory entries; entering them returns `permission_denied`.
+- If the requested directory itself is unreadable, the list endpoint returns `permission_denied`.
+- Cockpit cleans and normalizes requested paths before validation. Raw `..` segments are allowed only when the normalized result remains in the browsable namespace.
+- Cockpit returns a stable default order: directories first, then files; dot-prefixed entries before others within each group; then case-insensitive by name.
+- Clients may re-sort entries for their own UI.
+- The list endpoint applies a server-side cap of 10,000 entries and returns `truncated` when the result is cut off.
+- The v1 list errors are `not_found`, `not_directory`, `permission_denied`, `outside_browsable_roots`, and `invalid_path`, using Cockpit's existing error envelope.
+- Cockpit respects request-context cancellation and applies a server-side timeout for slow listings.
+- The Cockpit API package owns DTOs, decoding, request methods, mock data, and HTTP implementation for the remote filesystem contract.
+- The app owns a narrow observable remote-file browsing model for picker workflow state: current listing, loading/error, highlighted path, typed path, hidden toggle, root loading, opening roots, descending, going up, and setting a manual path.
+- The browsing model is not a generic tree engine, not an API DTO, and not a SwiftUI view.
+- The first UI is a drill-down sheet: roots list, directory list, breadcrumbs, Up button, path field, hidden-files toggle, rows for files and folders, and a Use This Folder action.
+- The picker starts at the roots list in v1 and does not remember recents.
+- If the create-session flow already has a working-directory value, the picker may prefill and validate it.
+- Manual path validation happens only on field commit via Return or Go.
+- Up navigation stops at the active Remote Workspace Root for ordinary paths.
+- The Highlighted Entry is the file or folder row targeted by pointer or keyboard navigation.
+- The Chosen Folder is the current viewed directory committed by Use This Folder.
+- Single-click or arrow keys set the Highlighted Entry.
+- Enter or double-click on a highlighted folder drills into that folder.
+- Enter or double-click on a highlighted file does nothing in v1.
+- Use This Folder writes the Chosen Folder, not the Highlighted Entry, back to the session working-directory field.
+- The UI uses basic SF Symbols for folders and files and does not add symlink-specific visual treatment in v1.
+- Long paths middle-truncate rather than wrap.
+- Truncated listings show a small warning row or banner.
+- The create-session flow replaces its local folder importer with the remote folder picker and fixes misleading local-folder copy.
+- A future fuzzy finder should use a separate prepared, bounded path-list endpoint. The directory-list endpoint remains lazy and one-directory-at-a-time.
+
+## Testing Decisions
+
+- Good tests should cover externally visible behavior at the highest seam available. Avoid tests that assert private view state, internal helper structure, or implementation-only method calls.
+- The first test seam is the Cockpit filesystem API contract. Server tests should exercise roots fallback, configured roots, invalid roots being omitted, path normalization, root boundary enforcement, symlink behavior, hidden filtering, sorting, truncation, unreadable directories, broken symlinks, typed errors, request cancellation, and timeout behavior.
+- The second test seam is the Cockpit API package. Package tests should decode roots and directory listings, encode query parameters correctly, surface Cockpit error envelopes, and verify the remote filesystem methods behave like the existing sessions/actions/environments methods.
+- The third test seam is the app's create-session workflow with an injected mock Cockpit client. Tests should verify that picking a Chosen Folder updates the session working-directory value and that the local folder importer behavior is gone.
+- UI tests should focus on user-visible picker behavior: opening roots, drilling into folders with Enter and double-click, leaving files inert on Enter/double-click, using breadcrumbs and Up, toggling hidden files, committing manual paths, showing truncation warnings, and confirming the current viewed directory.
+- Existing package tests for session/action/environment decoding are prior art for DTO decoding and error-envelope coverage.
+- Existing app preview and mock-client patterns are prior art for building the picker against canned remote filesystem data.
+- End-to-end manual verification should run against a live Cockpit server and confirm that a new session starts in the remote path chosen by the picker.
+
+## Out of Scope
+
+- File content reading, previewing, editing, upload, download, create, rename, move, delete, or any other filesystem mutation.
+- A full remote file-tree browser.
+- A fuzzy finder or prepared path-list endpoint implementation.
+- Runtime management of Remote Workspace Roots from AtelierCode.
+- Persisted recents or favorites.
+- Global enforcement of Remote Workspace Roots on session-start requests.
+- Resolved-path sandboxing for symlinks.
+- Rich file metadata, Git status, custom file-type icons, and symlink-specific UI treatment.
+- Server-side fuzzy ranking or `.gitignore`-aware indexing.
+- App-managed Cockpit server configuration editing.
+
+## Further Notes
+
+- This PRD follows the domain language in the glossary: Remote Workspace Root, Highlighted Entry, and Chosen Folder.
+- The Remote Workspace Root boundary is recorded as an ADR and should be treated as a durable design decision for v1.
+- The design borrows the path-first and prepared-input split from the Pierre Trees reference: directory browsing stays lazy, while future fuzzy finding can use a separate prepared path-list endpoint.
+- The work spans the Cockpit server and the AtelierCode client. The server contract should land first so the client and mocks implement a real contract rather than inventing one.


### PR DESCRIPTION
## Summary

Adds the first remote file browsing slice for AtelierCode:

- adds Cockpit file system DTOs and client methods for workspace roots and directory listing
- adds mock filesystem data, remote file browser picker state, and focused unit coverage
- adds `RemoteFolderPickerSheet` and wires it into `CreateSessionSheet`
- fixes preview hosting for inline list rows and adds picker smoke coverage
- adds the remote file browsing planning docs, glossary context, ADR stub, and PRD

## Validation

- Full test suite was run in the top stack commit before pushing, per commit history.
- GitHub compare shows `remote-folder-picker` is 5 commits ahead of `main` and 0 behind.

Draft until you do a final review of the scope, especially because this PR includes both implementation and planning docs.