### PR TITLE
Fix terminal reconnect and flow control

### DIFF
--- a/macos/ATC/AppModel.swift
+++ b/macos/ATC/AppModel.swift
@@ -206,8 +206,4 @@ final class AppModel {
             selection = nil
         }
     }
-
-    deinit {
-        terminalRecoveryMonitor.stop()
-    }
 }

--- a/macos/ATC/AppModel.swift
+++ b/macos/ATC/AppModel.swift
@@ -33,10 +33,14 @@ final class AppModel {
     private(set) var terminals: [SessionRef: TerminalSessionController] = [:]
 
     private let clientFactory: (ConnectionRecord) -> any ATCClient
+    private let terminalControllerFactory: (String, any ATCClient) -> TerminalSessionController
+    private let terminalRecoveryMonitor: TerminalRecoveryMonitor
 
     init(
         connections: ConnectionsStore? = nil,
-        clientFactory: ((ConnectionRecord) -> any ATCClient)? = nil
+        clientFactory: ((ConnectionRecord) -> any ATCClient)? = nil,
+        terminalControllerFactory: ((String, any ATCClient) -> TerminalSessionController)? = nil,
+        terminalRecoveryMonitor: TerminalRecoveryMonitor? = nil
     ) {
         self.connections = connections ?? ConnectionsStore()
         self.clientFactory = clientFactory ?? { record in
@@ -45,11 +49,19 @@ final class AppModel {
             let url = URL(string: record.urlString)!
             return HTTPATCClient(server: ATCServer(baseURL: url, token: record.token))
         }
+        self.terminalControllerFactory = terminalControllerFactory ?? { sessionID, client in
+            TerminalSessionController(sessionID: sessionID, client: client)
+        }
+        self.terminalRecoveryMonitor = terminalRecoveryMonitor ?? TerminalRecoveryMonitor()
         for record in self.connections.connections {
             if let runtime = makeRuntime(record) {
                 runtimes.append(runtime)
             }
         }
+        self.terminalRecoveryMonitor.onRecovery = { [weak self] in
+            self?.recoverTerminalsAfterInterruption()
+        }
+        self.terminalRecoveryMonitor.start()
     }
 
     // MARK: - Runtime access
@@ -148,12 +160,21 @@ final class AppModel {
         guard session.attachable,
               terminals[ref] == nil,
               let runtime = runtime(id: connectionID) else { return }
-        terminals[ref] = TerminalSessionController(sessionID: session.id, client: runtime.client)
+        terminals[ref] = terminalControllerFactory(session.id, runtime.client)
     }
 
     func disconnectTerminal(ref: SessionRef) {
         terminals[ref]?.disconnect()
         terminals.removeValue(forKey: ref)
+    }
+
+    /// Wake and path recovery are app-wide signals. A controller decides
+    /// whether it is still expected to be live; ended sessions and explicit
+    /// disconnects therefore remain stopped.
+    func recoverTerminalsAfterInterruption() {
+        for controller in terminals.values {
+            controller.recoverAfterInterruption()
+        }
     }
 
     // MARK: - Private
@@ -184,5 +205,9 @@ final class AppModel {
         if selection?.connectionID == runtime.id {
             selection = nil
         }
+    }
+
+    deinit {
+        terminalRecoveryMonitor.stop()
     }
 }

--- a/macos/ATC/Features/Terminal/TerminalPane.swift
+++ b/macos/ATC/Features/Terminal/TerminalPane.swift
@@ -46,6 +46,11 @@ struct TerminalStatusBanner: View {
             }
         case .connected:
             EmptyView()
+        case .reconnecting:
+            banner {
+                ProgressView().controlSize(.small)
+                Text("Reconnecting…")
+            }
         case .ended(.sessionEnded):
             banner {
                 Image(systemName: "checkmark.circle")

--- a/macos/ATC/Features/Terminal/TerminalRecoveryMonitor.swift
+++ b/macos/ATC/Features/Terminal/TerminalRecoveryMonitor.swift
@@ -12,7 +12,10 @@ final class TerminalRecoveryMonitor {
     private let wakeNotification: Notification.Name
     private let pathMonitor: NWPathMonitor?
     private let pathQueue = DispatchQueue(label: "ElevenIdeas.atc.terminal-path")
-    private var wakeObserver: (any NSObjectProtocol)?
+    // Read from the nonisolated `deinit` to release the observer. Only
+    // mutated on the main actor while the monitor is alive, and deinit runs
+    // strictly after the last reference is gone, so this cannot race.
+    private nonisolated(unsafe) var wakeObserver: (any NSObjectProtocol)?
     private var previousPathWasSatisfied: Bool?
     private var started = false
 

--- a/macos/ATC/Features/Terminal/TerminalRecoveryMonitor.swift
+++ b/macos/ATC/Features/Terminal/TerminalRecoveryMonitor.swift
@@ -1,0 +1,86 @@
+import AppKit
+import Foundation
+import Network
+
+/// One app-wide source of recovery signals for retained terminal attaches.
+/// An initial healthy path is normal startup, not recovery; only a transition
+/// from an unavailable path to `.satisfied` emits.
+final class TerminalRecoveryMonitor {
+    var onRecovery: (() -> Void)?
+
+    private let notificationCenter: NotificationCenter?
+    private let wakeNotification: Notification.Name
+    private let pathMonitor: NWPathMonitor?
+    private let pathQueue = DispatchQueue(label: "ElevenIdeas.atc.terminal-path")
+    private var wakeObserver: (any NSObjectProtocol)?
+    private var previousPathWasSatisfied: Bool?
+    private var started = false
+
+    init(
+        notificationCenter: NotificationCenter? = NSWorkspace.shared.notificationCenter,
+        wakeNotification: Notification.Name = NSWorkspace.didWakeNotification,
+        pathMonitor: NWPathMonitor? = NWPathMonitor()
+    ) {
+        self.notificationCenter = notificationCenter
+        self.wakeNotification = wakeNotification
+        self.pathMonitor = pathMonitor
+    }
+
+    static func disabled() -> TerminalRecoveryMonitor {
+        TerminalRecoveryMonitor(notificationCenter: nil, pathMonitor: nil)
+    }
+
+    func start() {
+        guard !started else { return }
+        started = true
+
+        if let notificationCenter {
+            wakeObserver = notificationCenter.addObserver(
+                forName: wakeNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.onRecovery?()
+                }
+            }
+        }
+
+        if let pathMonitor {
+            pathMonitor.pathUpdateHandler = { [weak self] path in
+                let isSatisfied = path.status == .satisfied
+                Task { @MainActor [weak self] in
+                    self?.recordNetworkPath(isSatisfied: isSatisfied)
+                }
+            }
+            pathMonitor.start(queue: pathQueue)
+        }
+    }
+
+    func stop() {
+        guard started else { return }
+        started = false
+        pathMonitor?.pathUpdateHandler = nil
+        pathMonitor?.cancel()
+        if let wakeObserver, let notificationCenter {
+            notificationCenter.removeObserver(wakeObserver)
+        }
+        wakeObserver = nil
+    }
+
+    /// Internal so transition behavior can be tested without depending on
+    /// the machine's live network configuration.
+    func recordNetworkPath(isSatisfied: Bool) {
+        defer { previousPathWasSatisfied = isSatisfied }
+        guard previousPathWasSatisfied == false, isSatisfied else { return }
+        onRecovery?()
+    }
+
+    deinit {
+        pathMonitor?.pathUpdateHandler = nil
+        pathMonitor?.cancel()
+        if let wakeObserver, let notificationCenter {
+            notificationCenter.removeObserver(wakeObserver)
+        }
+    }
+}

--- a/macos/ATC/Features/Terminal/TerminalSessionController.swift
+++ b/macos/ATC/Features/Terminal/TerminalSessionController.swift
@@ -11,6 +11,33 @@ private let logger = Logger(subsystem: "ElevenIdeas.atc", category: "terminal")
 /// sidebar switches; views only render it.
 @Observable
 final class TerminalSessionController: Identifiable {
+    struct RetryPolicy: Sendable {
+        let baseDelayMilliseconds: Int64
+        let maximumDelayMilliseconds: Int64
+        let jitterFraction: Double
+
+        static let `default` = RetryPolicy(
+            baseDelayMilliseconds: 500,
+            maximumDelayMilliseconds: 8_000,
+            jitterFraction: 0.2
+        )
+
+        /// Exponential delay with symmetric jitter. The final value is
+        /// capped too, so a positive jitter never exceeds the advertised
+        /// maximum.
+        func delay(forAttempt attempt: Int, jitterUnit: Double) -> Duration {
+            var nominal = baseDelayMilliseconds
+            for _ in 0..<max(0, attempt) {
+                nominal = min(maximumDelayMilliseconds, nominal * 2)
+            }
+
+            let unit = min(1, max(0, jitterUnit))
+            let factor = (1 - jitterFraction) + (2 * jitterFraction * unit)
+            let jittered = Int64((Double(nominal) * factor).rounded())
+            return .milliseconds(min(maximumDelayMilliseconds, max(0, jittered)))
+        }
+    }
+
     enum Phase: Equatable {
         case connecting
         case connected
@@ -42,10 +69,20 @@ final class TerminalSessionController: Identifiable {
 
     private let attachURL: URL
     private let attachHeaders: [String: String]
-    private let terminalSession: InMemoryTerminalSession
+    private var terminalSession: InMemoryTerminalSession
     private let connectionRef: ConnectionRef
-    private var connection: AttachConnection?
+    private let connectionFactory: TerminalAttachFactory
+    private let retryPolicy: RetryPolicy
+    private let retrySleep: (Duration) async throws -> Void
+    private let jitterUnit: () -> Double
+    private var connection: TerminalAttachHandle?
     private var eventTask: Task<Void, Never>?
+    private var retryTask: Task<Void, Never>?
+    private var connectionGeneration = 0
+    private var retryGeneration = 0
+    private var retryAttempt = 0
+    private var automaticRecoveryEnabled = true
+    private var replayResetGeneration: Int?
 
     /// Output received before the Ghostty surface exists (zmx replays the
     /// screen immediately on attach) is buffered, then drained in order.
@@ -53,53 +90,88 @@ final class TerminalSessionController: Identifiable {
     private var drainTask: Task<Void, Never>?
     private var surfaceIsReady = false
 
-    init(sessionID: String, client: any ATCClient) {
+    init(
+        sessionID: String,
+        client: any ATCClient,
+        connectionFactory: @escaping TerminalAttachFactory = TerminalAttachHandle.live,
+        retryPolicy: RetryPolicy = .default,
+        retrySleep: @escaping (Duration) async throws -> Void = { duration in
+            try await Task.sleep(for: duration)
+        },
+        jitterUnit: @escaping () -> Double = { Double.random(in: 0...1) }
+    ) {
         self.sessionID = sessionID
         attachURL = client.attachURL(sessionID: sessionID)
         attachHeaders = client.attachHeaders()
+        self.connectionFactory = connectionFactory
+        self.retryPolicy = retryPolicy
+        self.retrySleep = retrySleep
+        self.jitterUnit = jitterUnit
 
         let ref = ConnectionRef()
         connectionRef = ref
         // Both callbacks fire on Ghostty threads. Going through the
         // lock-guarded ref and the connection's synchronous enqueue keeps
         // byte order intact — no Task-hop reordering.
-        terminalSession = InMemoryTerminalSession(
-            write: { data in
-                ref.enqueue(data)
-            },
-            resize: { viewport in
-                ref.enqueueResize(cols: viewport.columns, rows: viewport.rows)
-            }
-        )
+        terminalSession = Self.makeTerminalSession(connectionRef: ref)
 
         viewState = TerminalViewState(controller: Self.sharedGhostty)
         viewState.configuration = TerminalSurfaceOptions(backend: .inMemory(terminalSession))
 
-        connect()
+        connect(isReconnect: false)
     }
 
     // MARK: - Connection lifecycle
 
     func reconnect() {
         guard connection == nil || phase != .connected else { return }
-        eventTask?.cancel()
-        connect()
+        automaticRecoveryEnabled = true
+        retryAttempt = 0
+        beginReconnect()
+    }
+
+    /// A wake or recovered network path can leave URLSession believing a
+    /// dead WebSocket is still open. Replace any controller that should
+    /// still be attached, including one whose stale socket has not failed
+    /// locally yet. Terminal/session end states deliberately opt out.
+    func recoverAfterInterruption() {
+        guard automaticRecoveryEnabled else { return }
+        retryAttempt = 0
+        beginReconnect()
     }
 
     /// Detach: WS close = zmx detach; the session keeps running server-side.
     func disconnect() {
+        automaticRecoveryEnabled = false
+        cancelRetry()
         let connection = connection
         self.connection = nil
         connectionRef.set(nil)
         eventTask?.cancel()
+        eventTask = nil
         drainTask?.cancel()
+        drainTask = nil
         phase = .ended(.closedByClient)
         Task { await connection?.close() }
     }
 
-    private func connect() {
+    private func beginReconnect() {
+        cancelRetry()
+        connectionGeneration += 1
+        let connection = connection
+        self.connection = nil
+        connectionRef.set(nil)
+        eventTask?.cancel()
+        eventTask = nil
+        Task { await connection?.close() }
+        connect(isReconnect: true)
+    }
+
+    private func connect(isReconnect: Bool) {
         phase = .connecting
-        let connection = AttachConnection(url: attachURL, headers: attachHeaders)
+        connectionGeneration += 1
+        let generation = connectionGeneration
+        let connection = connectionFactory(attachURL, attachHeaders)
         self.connection = connection
         connectionRef.set(connection)
 
@@ -107,14 +179,17 @@ final class TerminalSessionController: Identifiable {
             let events = await connection.start()
             for await event in events {
                 guard let self, !Task.isCancelled else { return }
-                self.handle(event)
+                self.handle(event, generation: generation, isReconnect: isReconnect)
             }
         }
     }
 
-    private func handle(_ event: AttachEvent) {
+    private func handle(_ event: AttachEvent, generation: Int, isReconnect: Bool) {
+        guard generation == connectionGeneration else { return }
         switch event {
         case .connected:
+            prepareSurfaceForReplayIfNeeded(generation: generation, isReconnect: isReconnect)
+            retryAttempt = 0
             phase = .connected
             logger.debug("attached \(self.sessionID)")
             // zmx needs dimensions before it repaints; resend the last
@@ -123,13 +198,84 @@ final class TerminalSessionController: Identifiable {
                 connection?.enqueueResize(cols: viewport.cols, rows: viewport.rows)
             }
         case .output(let data):
+            // `connected` is expected first, but keep the replay safe if
+            // URLSession ever delivers buffered bytes before its delegate
+            // callback reaches this task.
+            prepareSurfaceForReplayIfNeeded(generation: generation, isReconnect: isReconnect)
             deliver(data)
         case .ended(let reason):
             logger.debug("attach ended \(self.sessionID): \(String(describing: reason))")
             connection = nil
             connectionRef.set(nil)
+            eventTask = nil
             phase = .ended(reason)
+            switch reason {
+            case .serverError, .transportFailure:
+                scheduleAutomaticReconnect()
+            case .sessionEnded, .closedByClient:
+                automaticRecoveryEnabled = false
+                retryAttempt = 0
+                cancelRetry()
+            }
         }
+    }
+
+    private func scheduleAutomaticReconnect() {
+        guard automaticRecoveryEnabled, retryTask == nil else { return }
+        let delay = retryPolicy.delay(forAttempt: retryAttempt, jitterUnit: jitterUnit())
+        retryAttempt += 1
+        retryGeneration += 1
+        let generation = retryGeneration
+        let sleep = retrySleep
+
+        retryTask = Task { [weak self] in
+            do {
+                try await sleep(delay)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled, let self,
+                  generation == self.retryGeneration,
+                  self.automaticRecoveryEnabled,
+                  self.connection == nil
+            else { return }
+            self.retryTask = nil
+            self.connect(isReconnect: true)
+        }
+    }
+
+    private func cancelRetry() {
+        retryGeneration += 1
+        retryTask?.cancel()
+        retryTask = nil
+    }
+
+    /// zmx sends a complete VT snapshot on every reattach. Feeding it into
+    /// the retained Ghostty surface duplicates the already-rendered screen
+    /// and scrollback, so reconnects swap to a fresh in-memory backend first.
+    /// GhosttyTerminal treats a different backend identity as a surface
+    /// configuration change and rebuilds the surface. The initial attach is
+    /// intentionally left alone.
+    private func prepareSurfaceForReplayIfNeeded(generation: Int, isReconnect: Bool) {
+        guard isReconnect, replayResetGeneration != generation else { return }
+        replayResetGeneration = generation
+        drainTask?.cancel()
+        drainTask = nil
+        pendingOutput.removeAll(keepingCapacity: true)
+        surfaceIsReady = false
+        terminalSession = Self.makeTerminalSession(connectionRef: connectionRef)
+        viewState.configuration = TerminalSurfaceOptions(backend: .inMemory(terminalSession))
+    }
+
+    private static func makeTerminalSession(connectionRef: ConnectionRef) -> InMemoryTerminalSession {
+        InMemoryTerminalSession(
+            write: { data in
+                connectionRef.enqueue(data)
+            },
+            resize: { viewport in
+                connectionRef.enqueueResize(cols: viewport.columns, rows: viewport.rows)
+            }
+        )
     }
 
     // MARK: - Output delivery
@@ -145,19 +291,25 @@ final class TerminalSessionController: Identifiable {
 
     private func startDrainIfNeeded() {
         guard drainTask == nil else { return }
+        let terminalSession = terminalSession
         drainTask = Task {
             // Wait (bounded) for the surface to come up; readViewportText()
             // is nil until Ghostty attaches the surface.
             var attempts = 0
             while !surfaceIsReady, attempts < 100 {
+                guard !Task.isCancelled else { return }
                 if terminalSession.readViewportText() != nil { break }
                 attempts += 1
-                try? await Task.sleep(for: .milliseconds(50))
+                do {
+                    try await Task.sleep(for: .milliseconds(50))
+                } catch {
+                    return
+                }
             }
             // Proceed either way — receive() safely drops without a surface,
             // and marking ready stops unbounded buffering.
-            surfaceIsReady = true
             guard !Task.isCancelled else { return }
+            surfaceIsReady = true
             // Drain by index: repeated removeFirst() is quadratic on a large
             // replay, and the buffer must stay non-empty while draining so
             // concurrent deliver() calls keep appending behind the cursor.
@@ -172,18 +324,56 @@ final class TerminalSessionController: Identifiable {
     }
 }
 
+/// Sendable type erasure keeps the controller testable without widening
+/// `AttachConnection` itself or making its actor API synchronous.
+nonisolated struct TerminalAttachHandle: Sendable {
+    private let startHandler: @Sendable () async -> AsyncStream<AttachEvent>
+    private let enqueueHandler: @Sendable (Data) -> Void
+    private let resizeHandler: @Sendable (UInt16, UInt16) -> Void
+    private let closeHandler: @Sendable () async -> Void
+
+    init(
+        start: @escaping @Sendable () async -> AsyncStream<AttachEvent>,
+        enqueue: @escaping @Sendable (Data) -> Void,
+        enqueueResize: @escaping @Sendable (UInt16, UInt16) -> Void,
+        close: @escaping @Sendable () async -> Void
+    ) {
+        startHandler = start
+        enqueueHandler = enqueue
+        resizeHandler = enqueueResize
+        closeHandler = close
+    }
+
+    func start() async -> AsyncStream<AttachEvent> { await startHandler() }
+    func enqueue(_ data: Data) { enqueueHandler(data) }
+    func enqueueResize(cols: UInt16, rows: UInt16) { resizeHandler(cols, rows) }
+    func close() async { await closeHandler() }
+
+    static func live(url: URL, headers: [String: String]) -> TerminalAttachHandle {
+        let connection = AttachConnection(url: url, headers: headers)
+        return TerminalAttachHandle(
+            start: { await connection.start() },
+            enqueue: { connection.enqueue($0) },
+            enqueueResize: { connection.enqueueResize(cols: $0, rows: $1) },
+            close: { await connection.close() }
+        )
+    }
+}
+
+typealias TerminalAttachFactory = (URL, [String: String]) -> TerminalAttachHandle
+
 /// Lock-guarded handle to the current connection so Ghostty's background
 /// callbacks can enqueue synchronously across reconnects.
-private final class ConnectionRef: @unchecked Sendable {
+private nonisolated final class ConnectionRef: @unchecked Sendable {
     private let lock = NSLock()
-    private var connection: AttachConnection?
+    private var connection: TerminalAttachHandle?
     private var viewport: (cols: UInt16, rows: UInt16)?
 
     var lastViewport: (cols: UInt16, rows: UInt16)? {
         lock.withLock { viewport }
     }
 
-    func set(_ connection: AttachConnection?) {
+    func set(_ connection: TerminalAttachHandle?) {
         lock.withLock { self.connection = connection }
     }
 

--- a/macos/ATC/Features/Terminal/TerminalSessionController.swift
+++ b/macos/ATC/Features/Terminal/TerminalSessionController.swift
@@ -15,11 +15,19 @@ final class TerminalSessionController: Identifiable {
         let baseDelayMilliseconds: Int64
         let maximumDelayMilliseconds: Int64
         let jitterFraction: Double
+        /// Consecutive automatic retries before giving up. A permanent
+        /// failure (revoked token, deleted server) surfaces as an endless
+        /// stream of transport failures; without a budget the controller
+        /// would churn connection attempts forever. Manual reconnect and
+        /// wake/path recovery reset the budget, so an environment that
+        /// heals later still recovers without user action.
+        let maximumAttempts: Int
 
         static let `default` = RetryPolicy(
             baseDelayMilliseconds: 500,
             maximumDelayMilliseconds: 8_000,
-            jitterFraction: 0.2
+            jitterFraction: 0.2,
+            maximumAttempts: 10
         )
 
         /// Exponential delay with symmetric jitter. The final value is
@@ -41,6 +49,12 @@ final class TerminalSessionController: Identifiable {
     enum Phase: Equatable {
         case connecting
         case connected
+        /// A dropped attach is being replaced automatically — either a
+        /// backoff timer is pending or a replacement attempt is in flight.
+        /// Distinct from `.connecting` so the status banner reads
+        /// "Reconnecting" instead of flickering through `.ended` and
+        /// "Connecting" on every retry cycle.
+        case reconnecting
         case ended(AttachEndReason)
 
         /// Whether the WebSocket bridge is (or is becoming) live. Ended
@@ -48,7 +62,7 @@ final class TerminalSessionController: Identifiable {
         /// connection indicators must check this, not registry membership.
         var isActivelyAttached: Bool {
             switch self {
-            case .connecting, .connected: return true
+            case .connecting, .connected, .reconnecting: return true
             case .ended: return false
             }
         }
@@ -157,7 +171,6 @@ final class TerminalSessionController: Identifiable {
 
     private func beginReconnect() {
         cancelRetry()
-        connectionGeneration += 1
         let connection = connection
         self.connection = nil
         connectionRef.set(nil)
@@ -168,7 +181,7 @@ final class TerminalSessionController: Identifiable {
     }
 
     private func connect(isReconnect: Bool) {
-        phase = .connecting
+        phase = isReconnect ? .reconnecting : .connecting
         connectionGeneration += 1
         let generation = connectionGeneration
         let connection = connectionFactory(attachURL, attachHeaders)
@@ -208,20 +221,27 @@ final class TerminalSessionController: Identifiable {
             connection = nil
             connectionRef.set(nil)
             eventTask = nil
-            phase = .ended(reason)
             switch reason {
             case .serverError, .transportFailure:
-                scheduleAutomaticReconnect()
+                // Stay in `.reconnecting` across backoff cycles so the banner
+                // doesn't flicker. `.ended` is the give-up state: its banner
+                // offers a manual Reconnect, and wake/path recovery still
+                // revives the controller with a fresh retry budget.
+                phase = scheduleAutomaticReconnect() ? .reconnecting : .ended(reason)
             case .sessionEnded, .closedByClient:
                 automaticRecoveryEnabled = false
                 retryAttempt = 0
                 cancelRetry()
+                phase = .ended(reason)
             }
         }
     }
 
-    private func scheduleAutomaticReconnect() {
-        guard automaticRecoveryEnabled, retryTask == nil else { return }
+    /// Returns whether a retry was scheduled; false once the policy's
+    /// attempt budget is spent (or recovery is disabled entirely).
+    private func scheduleAutomaticReconnect() -> Bool {
+        guard automaticRecoveryEnabled, retryTask == nil,
+              retryAttempt < retryPolicy.maximumAttempts else { return false }
         let delay = retryPolicy.delay(forAttempt: retryAttempt, jitterUnit: jitterUnit())
         retryAttempt += 1
         retryGeneration += 1
@@ -242,6 +262,7 @@ final class TerminalSessionController: Identifiable {
             self.retryTask = nil
             self.connect(isReconnect: true)
         }
+        return true
     }
 
     private func cancelRetry() {

--- a/macos/ATC/PreviewSupport/MockATCClient.swift
+++ b/macos/ATC/PreviewSupport/MockATCClient.swift
@@ -9,7 +9,11 @@ extension AppModel {
         let defaults = UserDefaults(suiteName: "preview.appmodel.\(UUID().uuidString)")!
         let store = ConnectionsStore(defaults: defaults, credentials: InMemoryCredentialStore())
         _ = try? store.add(name: "Workstation", urlString: "http://workstation.example:7331", token: "")
-        return AppModel(connections: store, clientFactory: { _ in client })
+        return AppModel(
+            connections: store,
+            clientFactory: { _ in client },
+            terminalRecoveryMonitor: .disabled()
+        )
     }
 
     /// Preview/test fixture with several Connections, each backed by its own
@@ -30,7 +34,11 @@ extension AppModel {
                 clientsByID[record.id] = connection.client
             }
         }
-        return AppModel(connections: store, clientFactory: { clientsByID[$0.id] ?? MockATCClient() })
+        return AppModel(
+            connections: store,
+            clientFactory: { clientsByID[$0.id] ?? MockATCClient() },
+            terminalRecoveryMonitor: .disabled()
+        )
     }
 }
 

--- a/macos/ATC/TerminalBridge/AttachConnection.swift
+++ b/macos/ATC/TerminalBridge/AttachConnection.swift
@@ -24,9 +24,9 @@ enum AttachEvent: Sendable {
 /// keystrokes; client→server TEXT = `{"type":"resize","cols":N,"rows":N}`.
 /// One instance per connection attempt — reconnect makes a new one.
 actor AttachConnection {
-    /// Server frame read limit is 1 MiB; stay well under it.
-    private static let chunkSize = 256 * 1024
-    private static let pingInterval: Duration = .seconds(30)
+    /// Frequent pings are a liveness backstop for sleeping Macs, network
+    /// changes, and idle SSH-tunnel forwards.
+    private static let pingInterval: Duration = .seconds(10)
 
     private let request: URLRequest
     private let socketDelegate: SocketDelegate
@@ -60,8 +60,12 @@ actor AttachConnection {
     // the lock-guarded queue keeps keystroke ordering intact)
 
     nonisolated func enqueue(_ data: Data) {
-        outbound.enqueue(data)
-        outboundSignalContinuation.yield(())
+        outbound.enqueue(data) {
+            // Large writes may block for backpressure and enter the queue in
+            // several chunks. Wake the pump after every chunk so it can make
+            // room for the remainder of the same synchronous callback.
+            outboundSignalContinuation.yield(())
+        }
     }
 
     nonisolated func enqueueResize(cols: UInt16, rows: UInt16) {
@@ -103,6 +107,9 @@ actor AttachConnection {
     private func tearDown() {
         pingTask?.cancel()
         pumpTask?.cancel()
+        // Cancelled pumps cannot make more queue space. Finish the queue to
+        // wake any Ghostty callback currently waiting on backpressure.
+        outbound.finish()
         outboundSignalContinuation.finish()
         urlSession.finishTasksAndInvalidate()
     }
@@ -161,14 +168,15 @@ actor AttachConnection {
                     do {
                         switch item {
                         case .data(let data):
-                            for chunk in Self.chunked(data) {
-                                try await task.send(.data(chunk))
-                            }
+                            try await task.send(.data(data))
                         case .resize(let cols, let rows):
                             try await task.send(.string(#"{"type":"resize","cols":\#(cols),"rows":\#(rows)}"#))
                         }
                     } catch {
-                        // The receive loop surfaces the failure; just stop pumping.
+                        // The receive loop surfaces the transport failure.
+                        // Stop accepting input immediately so a producer
+                        // cannot remain blocked behind this dead pump.
+                        outbound.finish()
                         return
                     }
                 }
@@ -191,61 +199,136 @@ actor AttachConnection {
         }
     }
 
-    private static func chunked(_ data: Data) -> [Data] {
-        guard data.count > chunkSize else { return [data] }
-        var chunks: [Data] = []
-        var offset = data.startIndex
-        while offset < data.endIndex {
-            let end = data.index(offset, offsetBy: chunkSize, limitedBy: data.endIndex) ?? data.endIndex
-            chunks.append(data.subdata(in: offset..<end))
-            offset = end
-        }
-        return chunks
-    }
 }
 
 /// Lock-guarded outbound buffer. Keystroke chunks keep their order under a
-/// byte bound — a stalled socket plus a huge paste drops the excess instead
-/// of growing memory — and only the most recent resize is kept, sent ahead
-/// of data so the server sizes the PTY before applying input.
-private final class OutboundQueue: @unchecked Sendable {
-    /// Matches the server's per-frame read limit; more than this buffered
-    /// means the socket is effectively dead anyway.
-    private static let maxBufferedBytes = 1 << 20
+/// byte bound. A full queue applies synchronous backpressure to Ghostty's
+/// background write callback instead of discarding paste data. Only the most
+/// recent resize is kept, sent ahead of data so the server sizes the PTY
+/// before applying input.
+nonisolated final class OutboundQueue: @unchecked Sendable {
+    /// The server's 1 MiB limit applies to individual WebSocket frames, not
+    /// the aggregate backlog. Eight MiB accommodates paste-heavy workflows
+    /// while still bounding a stalled connection's retained input.
+    private static let defaultMaxBufferedBytes = 8 << 20
+    /// Stay comfortably below the server's per-frame read limit.
+    private static let defaultMaxChunkBytes = 256 << 10
 
-    private let lock = NSLock()
+    /// Serializes whole producer calls. Without this, two Ghostty callbacks
+    /// could interleave when the first one waits for queue space.
+    private let producerLock = NSLock()
+    private let condition = NSCondition()
+    private let maxBufferedBytes: Int
+    private let maxChunkBytes: Int
     private var chunks: [Data] = []
+    private var firstChunkIndex = 0
     private var bufferedBytes = 0
     private var pendingResize: (cols: UInt16, rows: UInt16)?
+    private var isFinished = false
 
     enum Item {
         case data(Data)
         case resize(cols: UInt16, rows: UInt16)
     }
 
-    func enqueue(_ data: Data) {
-        lock.withLock {
-            guard bufferedBytes + data.count <= Self.maxBufferedBytes else { return }
-            chunks.append(data)
-            bufferedBytes += data.count
-        }
+    init(
+        maxBufferedBytes: Int = OutboundQueue.defaultMaxBufferedBytes,
+        maxChunkBytes: Int = OutboundQueue.defaultMaxChunkBytes
+    ) {
+        precondition(maxBufferedBytes > 0)
+        precondition(maxChunkBytes > 0)
+        self.maxBufferedBytes = maxBufferedBytes
+        self.maxChunkBytes = min(maxChunkBytes, maxBufferedBytes)
+    }
+
+    /// Returns false only when shutdown interrupts or precedes the write.
+    /// `didEnqueue` must wake the consumer after each accepted chunk: a write
+    /// larger than the byte bound cannot finish until the consumer drains it.
+    @discardableResult
+    func enqueue(_ data: Data, didEnqueue: @Sendable () -> Void = {}) -> Bool {
+        producerLock.lock()
+        defer { producerLock.unlock() }
+
+        var offset = data.startIndex
+        repeat {
+            condition.lock()
+            while !isFinished && bufferedBytes == maxBufferedBytes {
+                condition.wait()
+            }
+            guard !isFinished else {
+                condition.unlock()
+                return false
+            }
+            guard offset < data.endIndex else {
+                condition.unlock()
+                return true
+            }
+
+            let availableBytes = maxBufferedBytes - bufferedBytes
+            let chunkCount = min(maxChunkBytes, availableBytes, data.distance(from: offset, to: data.endIndex))
+            let end = data.index(offset, offsetBy: chunkCount)
+            let chunk = data.subdata(in: offset..<end)
+            chunks.append(chunk)
+            bufferedBytes += chunk.count
+            offset = end
+            condition.unlock()
+
+            didEnqueue()
+        } while offset < data.endIndex
+
+        return true
     }
 
     func setResize(cols: UInt16, rows: UInt16) {
-        lock.withLock { pendingResize = (cols, rows) }
+        condition.lock()
+        if !isFinished {
+            pendingResize = (cols, rows)
+        }
+        condition.unlock()
     }
 
     func dequeue() -> Item? {
-        lock.withLock {
-            if let resize = pendingResize {
-                pendingResize = nil
-                return .resize(cols: resize.cols, rows: resize.rows)
-            }
-            guard !chunks.isEmpty else { return nil }
-            let data = chunks.removeFirst()
-            bufferedBytes -= data.count
-            return .data(data)
+        condition.lock()
+        defer { condition.unlock() }
+
+        if let resize = pendingResize {
+            pendingResize = nil
+            return .resize(cols: resize.cols, rows: resize.rows)
         }
+        guard firstChunkIndex < chunks.count else { return nil }
+
+        let data = chunks[firstChunkIndex]
+        // Release the queue's reference immediately without paying the
+        // removeFirst() copy on every keystroke.
+        chunks[firstChunkIndex] = Data()
+        firstChunkIndex += 1
+        bufferedBytes -= data.count
+        if firstChunkIndex == chunks.count {
+            chunks.removeAll(keepingCapacity: true)
+            firstChunkIndex = 0
+        } else if firstChunkIndex >= 64, firstChunkIndex * 2 >= chunks.count {
+            chunks.removeFirst(firstChunkIndex)
+            firstChunkIndex = 0
+        }
+        condition.signal()
+        return .data(data)
+    }
+
+    /// Discards input only as part of explicit connection teardown and wakes
+    /// every producer that may be blocked waiting for the cancelled pump.
+    func finish() {
+        condition.lock()
+        guard !isFinished else {
+            condition.unlock()
+            return
+        }
+        isFinished = true
+        chunks.removeAll()
+        firstChunkIndex = 0
+        bufferedBytes = 0
+        pendingResize = nil
+        condition.broadcast()
+        condition.unlock()
     }
 }
 

--- a/macos/ATC/TerminalBridge/AttachConnection.swift
+++ b/macos/ATC/TerminalBridge/AttachConnection.swift
@@ -192,8 +192,11 @@ actor AttachConnection {
                 try? await Task.sleep(for: Self.pingInterval)
                 guard !Task.isCancelled else { return }
                 task.sendPing { _ in
-                    // A failed ping tears the connection; the receive loop
-                    // reports it.
+                    // Best effort: pings keep tunnels and NATs from reaping
+                    // an idle connection and give the OS traffic with which
+                    // to notice a dead peer. A failure here is not a
+                    // reliable disconnect signal — the receive loop and the
+                    // recovery monitor own failure detection.
                 }
             }
         }
@@ -248,6 +251,13 @@ nonisolated final class OutboundQueue: @unchecked Sendable {
     func enqueue(_ data: Data, didEnqueue: @Sendable () -> Void = {}) -> Bool {
         producerLock.lock()
         defer { producerLock.unlock() }
+
+        // Nothing to buffer — don't park an empty write behind a full queue.
+        if data.isEmpty {
+            condition.lock()
+            defer { condition.unlock() }
+            return !isFinished
+        }
 
         var offset = data.startIndex
         repeat {

--- a/macos/ATCTests/OutboundQueueTests.swift
+++ b/macos/ATCTests/OutboundQueueTests.swift
@@ -70,6 +70,32 @@ struct OutboundQueueTests {
         #expect(received == firstData + secondData)
     }
 
+    @Test("an empty write returns immediately even when the queue is full")
+    func emptyWriteNeverBlocks() async {
+        let queue = OutboundQueue(maxBufferedBytes: 4, maxChunkBytes: 4)
+        let probe = ProducerProbe()
+        #expect(queue.enqueue(Data("full".utf8)))
+
+        // Run detached so a regression shows up as a failed expectation
+        // instead of hanging the suite on the blocked producer.
+        let empty = Task.detached {
+            let accepted = queue.enqueue(Data())
+            probe.recordFinished(accepted: accepted)
+            return accepted
+        }
+        let finished = await waitUntil { probe.accepted != nil }
+        if !finished {
+            queue.finish()
+        }
+        let accepted = await empty.value
+        #expect(finished, "empty write blocked behind a full queue")
+        #expect(accepted)
+
+        // After shutdown even an empty write reports the queue as unusable.
+        queue.finish()
+        #expect(!queue.enqueue(Data()))
+    }
+
     @Test("finish wakes a backpressured producer and rejects later writes")
     func finishWakesBlockedProducer() async {
         let queue = OutboundQueue(maxBufferedBytes: 4, maxChunkBytes: 4)

--- a/macos/ATCTests/OutboundQueueTests.swift
+++ b/macos/ATCTests/OutboundQueueTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Testing
+@testable import ATC
+
+@Suite("Terminal outbound queue")
+struct OutboundQueueTests {
+    @Test("a paste larger than one MiB is queued intact")
+    func largePasteIsLossless() {
+        let queue = OutboundQueue()
+        let paste = patternedData(count: (1 << 20) + 1_337)
+
+        #expect(queue.enqueue(paste))
+
+        var received = Data()
+        while let item = queue.dequeue() {
+            switch item {
+            case .data(let data):
+                // Each WebSocket message stays below the server's frame cap.
+                #expect(data.count <= 256 << 10)
+                received.append(data)
+            case .resize:
+                Issue.record("unexpected resize")
+            }
+        }
+
+        #expect(received == paste)
+    }
+
+    @Test("backpressure preserves whole-write ordering across producers")
+    func backpressurePreservesProducerOrdering() async {
+        let queue = OutboundQueue(maxBufferedBytes: 4, maxChunkBytes: 2)
+        let firstProbe = ProducerProbe()
+        let firstData = Data("AAAAAA".utf8)
+        let secondData = Data("BBBB".utf8)
+
+        let first = Task.detached {
+            queue.enqueue(firstData) { firstProbe.recordEnqueuedChunk() }
+        }
+
+        // Two chunks fill the four-byte queue, leaving the first producer
+        // blocked with two bytes still to write.
+        let firstFilledQueue = await waitUntil { firstProbe.enqueuedChunks == 2 }
+        guard firstFilledQueue else {
+            queue.finish()
+            _ = await first.value
+            Issue.record("first producer never filled the queue")
+            return
+        }
+
+        let second = Task.detached { queue.enqueue(secondData) }
+        var received = Data()
+        let receivedEverything = await waitUntil {
+            while let item = queue.dequeue() {
+                if case .data(let data) = item {
+                    received.append(data)
+                }
+            }
+            return received.count == firstData.count + secondData.count
+        }
+
+        if !receivedEverything {
+            queue.finish()
+        }
+        let firstAccepted = await first.value
+        let secondAccepted = await second.value
+
+        #expect(receivedEverything)
+        #expect(firstAccepted)
+        #expect(secondAccepted)
+        #expect(received == firstData + secondData)
+    }
+
+    @Test("finish wakes a backpressured producer and rejects later writes")
+    func finishWakesBlockedProducer() async {
+        let queue = OutboundQueue(maxBufferedBytes: 4, maxChunkBytes: 4)
+        let probe = ProducerProbe()
+        #expect(queue.enqueue(Data("full".utf8)))
+
+        let blocked = Task.detached {
+            probe.recordStarted()
+            let accepted = queue.enqueue(Data("x".utf8))
+            probe.recordFinished(accepted: accepted)
+            return accepted
+        }
+
+        let producerStarted = await waitUntil { probe.started }
+        // Give the synchronous enqueue enough time to reach its condition
+        // wait. It must remain pending while the active queue is full.
+        try? await Task.sleep(for: .milliseconds(20))
+        #expect(producerStarted)
+        #expect(probe.accepted == nil)
+
+        queue.finish()
+        let accepted = await blocked.value
+        #expect(!accepted)
+        #expect(probe.accepted == false)
+        #expect(queue.dequeue() == nil)
+        #expect(!queue.enqueue(Data("later".utf8)))
+    }
+}
+
+private func patternedData(count: Int) -> Data {
+    Data((0..<count).map { UInt8(truncatingIfNeeded: $0) })
+}
+
+private func waitUntil(
+    attempts: Int = 2_000,
+    _ condition: () -> Bool
+) async -> Bool {
+    for _ in 0..<attempts {
+        if condition() { return true }
+        try? await Task.sleep(for: .milliseconds(1))
+    }
+    return condition()
+}
+
+nonisolated private final class ProducerProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedStarted = false
+    private var storedEnqueuedChunks = 0
+    private var storedAccepted: Bool?
+
+    var started: Bool { lock.withLock { storedStarted } }
+    var enqueuedChunks: Int { lock.withLock { storedEnqueuedChunks } }
+    var accepted: Bool? { lock.withLock { storedAccepted } }
+
+    func recordStarted() {
+        lock.withLock { storedStarted = true }
+    }
+
+    func recordEnqueuedChunk() {
+        lock.withLock { storedEnqueuedChunks += 1 }
+    }
+
+    func recordFinished(accepted: Bool) {
+        lock.withLock { storedAccepted = accepted }
+    }
+}

--- a/macos/ATCTests/TerminalReconnectTests.swift
+++ b/macos/ATCTests/TerminalReconnectTests.swift
@@ -108,6 +108,85 @@ struct TerminalReconnectTests {
         #expect(delays.delays == [.milliseconds(500), .seconds(1), .milliseconds(500)])
     }
 
+    @Test("automatic retries stop at the policy budget; recovery signals restore it")
+    func retryBudgetExhaustion() async {
+        let harness = AttachHarness()
+        let delays = RetryDelayRecorder()
+        let policy = TerminalSessionController.RetryPolicy(
+            baseDelayMilliseconds: 500,
+            maximumDelayMilliseconds: 8_000,
+            jitterFraction: 0.2,
+            maximumAttempts: 2
+        )
+        let controller = TerminalSessionController(
+            sessionID: "session",
+            client: MockATCClient(),
+            connectionFactory: harness.makeHandle,
+            retryPolicy: policy,
+            retrySleep: delays.sleep,
+            jitterUnit: { 0.5 }
+        )
+        defer { controller.disconnect() }
+
+        harness.send(.ended(.transportFailure("offline")), attempt: 0, finish: true)
+        await waitFor { harness.attempts.count == 2 }
+        harness.send(.ended(.transportFailure("offline")), attempt: 1, finish: true)
+        await waitFor { harness.attempts.count == 3 }
+        #expect(delays.delays.count == 2)
+
+        // The budget is spent: the third failure must give up rather than
+        // churn forever against a permanent failure.
+        harness.send(.ended(.transportFailure("offline")), attempt: 2, finish: true)
+        await waitFor { controller.phase == .ended(.transportFailure("offline")) }
+        await Task.yield()
+        #expect(harness.attempts.count == 3)
+        #expect(delays.delays.count == 2)
+        #expect(!controller.isActivelyAttached)
+
+        // Wake/path recovery revives a given-up controller with a fresh
+        // budget — a healed environment must not require a manual click.
+        controller.recoverAfterInterruption()
+        #expect(harness.attempts.count == 4)
+        #expect(controller.phase == .reconnecting)
+        harness.send(.ended(.transportFailure("offline")), attempt: 3, finish: true)
+        await waitFor { harness.attempts.count == 5 }
+        #expect(delays.delays.count == 3)
+    }
+
+    @Test("a pending backoff reports reconnecting and manual reconnect skips the wait")
+    func pendingRetryReportsReconnecting() async {
+        let harness = AttachHarness()
+        // A one-hour backoff (with the default real-clock sleep) pins the
+        // controller in the waiting-for-retry window for the whole test.
+        let policy = TerminalSessionController.RetryPolicy(
+            baseDelayMilliseconds: 3_600_000,
+            maximumDelayMilliseconds: 3_600_000,
+            jitterFraction: 0,
+            maximumAttempts: 10
+        )
+        let controller = TerminalSessionController(
+            sessionID: "session",
+            client: MockATCClient(),
+            connectionFactory: harness.makeHandle,
+            retryPolicy: policy,
+            jitterUnit: { 0.5 }
+        )
+        defer { controller.disconnect() }
+
+        harness.send(.ended(.transportFailure("offline")), attempt: 0, finish: true)
+        await waitFor { controller.phase == .reconnecting }
+        // No `.ended` flicker while the timer waits, and indicators still
+        // treat the terminal as attached.
+        #expect(controller.phase == .reconnecting)
+        #expect(controller.isActivelyAttached)
+        #expect(harness.attempts.count == 1)
+
+        controller.reconnect()
+        await waitFor { harness.attempts.count == 2 }
+        #expect(harness.attempts.count == 2)
+        #expect(controller.phase == .reconnecting)
+    }
+
     @Test("terminal end and client close never auto-retry or recover")
     func terminalEndStatesStayStopped() async {
         for reason in [AttachEndReason.sessionEnded, .closedByClient] {
@@ -158,7 +237,7 @@ struct TerminalReconnectTests {
         // started. It must not overwrite the new attempt's phase or policy.
         harness.send(.ended(.sessionEnded), attempt: 0, finish: true)
         await Task.yield()
-        #expect(controller.phase == .connecting)
+        #expect(controller.phase == .reconnecting)
 
         // A reconnect that fails before opening also preserves the surface.
         harness.send(.ended(.transportFailure("still offline")), attempt: 1, finish: true)

--- a/macos/ATCTests/TerminalReconnectTests.swift
+++ b/macos/ATCTests/TerminalReconnectTests.swift
@@ -1,0 +1,239 @@
+import Foundation
+import Testing
+import ATCAPI
+import GhosttyTerminal
+@testable import ATC
+
+private final class AttachHarness {
+    struct Attempt {
+        let continuation: AsyncStream<AttachEvent>.Continuation
+    }
+
+    private(set) var attempts: [Attempt] = []
+
+    func makeHandle(url _: URL, headers _: [String: String]) -> TerminalAttachHandle {
+        let (stream, continuation) = AsyncStream.makeStream(of: AttachEvent.self)
+        attempts.append(Attempt(continuation: continuation))
+        return TerminalAttachHandle(
+            start: { stream },
+            enqueue: { _ in },
+            enqueueResize: { _, _ in },
+            // Intentionally leave the stream open. This lets tests prove a
+            // late event from a replaced attach is generation-gated.
+            close: {}
+        )
+    }
+
+    func send(_ event: AttachEvent, attempt: Int, finish: Bool = false) {
+        attempts[attempt].continuation.yield(event)
+        if finish {
+            attempts[attempt].continuation.finish()
+        }
+    }
+}
+
+private final class RetryDelayRecorder {
+    private(set) var delays: [Duration] = []
+
+    func sleep(for duration: Duration) async throws {
+        delays.append(duration)
+    }
+}
+
+@MainActor
+private func waitFor(_ condition: () -> Bool) async {
+    for _ in 0..<200 {
+        if condition() { return }
+        await Task.yield()
+    }
+}
+
+@MainActor
+private func backendIdentity(of controller: TerminalSessionController) -> ObjectIdentifier {
+    guard case .inMemory(let session) = controller.viewState.configuration.backend else {
+        fatalError("terminal controller must use the in-memory backend")
+    }
+    return ObjectIdentifier(session)
+}
+
+@MainActor
+@Suite("Terminal reconnect")
+struct TerminalReconnectTests {
+    @Test("retry policy doubles, jitters symmetrically, and never exceeds its cap")
+    func retryPolicy() {
+        let policy = TerminalSessionController.RetryPolicy.default
+
+        #expect(policy.delay(forAttempt: 0, jitterUnit: 0) == .milliseconds(400))
+        #expect(policy.delay(forAttempt: 0, jitterUnit: 0.5) == .milliseconds(500))
+        #expect(policy.delay(forAttempt: 0, jitterUnit: 1) == .milliseconds(600))
+        #expect((0...5).map { policy.delay(forAttempt: $0, jitterUnit: 0.5) } == [
+            .milliseconds(500),
+            .seconds(1),
+            .seconds(2),
+            .seconds(4),
+            .seconds(8),
+            .seconds(8),
+        ])
+        #expect(policy.delay(forAttempt: 20, jitterUnit: 1) == .seconds(8))
+    }
+
+    @Test("transport and server failures retry with deterministic exponential delays")
+    func retryableFailures() async {
+        let harness = AttachHarness()
+        let delays = RetryDelayRecorder()
+        let controller = TerminalSessionController(
+            sessionID: "session",
+            client: MockATCClient(),
+            connectionFactory: harness.makeHandle,
+            retrySleep: delays.sleep,
+            jitterUnit: { 0.5 }
+        )
+        defer { controller.disconnect() }
+
+        #expect(harness.attempts.count == 1)
+        harness.send(.ended(.transportFailure("offline")), attempt: 0, finish: true)
+        await waitFor { harness.attempts.count == 2 }
+        #expect(delays.delays == [.milliseconds(500)])
+        #expect(harness.attempts.count == 2)
+
+        harness.send(.ended(.serverError), attempt: 1, finish: true)
+        await waitFor { harness.attempts.count == 3 }
+        #expect(delays.delays == [.milliseconds(500), .seconds(1)])
+
+        // A successful attach resets the failure sequence.
+        harness.send(.connected, attempt: 2)
+        await waitFor { controller.phase == .connected }
+        harness.send(.ended(.transportFailure("again")), attempt: 2, finish: true)
+        await waitFor { harness.attempts.count == 4 }
+        #expect(delays.delays == [.milliseconds(500), .seconds(1), .milliseconds(500)])
+    }
+
+    @Test("terminal end and client close never auto-retry or recover")
+    func terminalEndStatesStayStopped() async {
+        for reason in [AttachEndReason.sessionEnded, .closedByClient] {
+            let harness = AttachHarness()
+            let delays = RetryDelayRecorder()
+            let controller = TerminalSessionController(
+                sessionID: "session",
+                client: MockATCClient(),
+                connectionFactory: harness.makeHandle,
+                retrySleep: delays.sleep,
+                jitterUnit: { 0.5 }
+            )
+
+            harness.send(.ended(reason), attempt: 0, finish: true)
+            await waitFor { controller.phase == .ended(reason) }
+            controller.recoverAfterInterruption()
+            await Task.yield()
+            #expect(harness.attempts.count == 1)
+            #expect(delays.delays.isEmpty)
+            #expect(controller.phase == .ended(reason))
+            controller.disconnect()
+        }
+    }
+
+    @Test("recovery replaces a live attach and its Ghostty backend, then ignores stale events")
+    func recoveryReplacesSurfaceAndGatesOldEvents() async {
+        let harness = AttachHarness()
+        let controller = TerminalSessionController(
+            sessionID: "session",
+            client: MockATCClient(),
+            connectionFactory: harness.makeHandle,
+            retrySleep: { _ in },
+            jitterUnit: { 0.5 }
+        )
+        defer { controller.disconnect() }
+
+        let initialBackend = backendIdentity(of: controller)
+        harness.send(.connected, attempt: 0)
+        await waitFor { controller.phase == .connected }
+
+        controller.recoverAfterInterruption()
+        #expect(harness.attempts.count == 2)
+        // Preserve the visible screen while a reconnect is merely trying to
+        // establish transport; no replay exists to justify clearing it yet.
+        #expect(backendIdentity(of: controller) == initialBackend)
+
+        // The old connection may report its close after the replacement has
+        // started. It must not overwrite the new attempt's phase or policy.
+        harness.send(.ended(.sessionEnded), attempt: 0, finish: true)
+        await Task.yield()
+        #expect(controller.phase == .connecting)
+
+        // A reconnect that fails before opening also preserves the surface.
+        harness.send(.ended(.transportFailure("still offline")), attempt: 1, finish: true)
+        await waitFor { harness.attempts.count == 3 }
+        #expect(backendIdentity(of: controller) == initialBackend)
+
+        // The backend is replaced only once transport opens, immediately
+        // before the controller sends the resize that triggers zmx replay.
+        harness.send(.connected, attempt: 2)
+        await waitFor { controller.phase == .connected }
+        #expect(backendIdentity(of: controller) != initialBackend)
+        #expect(controller.phase == .connected)
+    }
+
+    @Test("initial network satisfaction is ignored; recovery and wake reconnect app terminals")
+    func monitorAndAppModelIntegration() async throws {
+        let center = NotificationCenter()
+        let wake = Notification.Name("TerminalReconnectTests.wake")
+        let monitor = TerminalRecoveryMonitor(
+            notificationCenter: center,
+            wakeNotification: wake,
+            pathMonitor: nil
+        )
+        let harness = AttachHarness()
+        let suite = "TerminalReconnectTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let store = ConnectionsStore(defaults: defaults, credentials: InMemoryCredentialStore())
+        let record = try store.add(name: "Test", urlString: "http://test:7331", token: "")
+        let model = AppModel(
+            connections: store,
+            clientFactory: { _ in MockATCClient() },
+            terminalControllerFactory: { sessionID, client in
+                TerminalSessionController(
+                    sessionID: sessionID,
+                    client: client,
+                    connectionFactory: harness.makeHandle,
+                    retrySleep: { _ in },
+                    jitterUnit: { 0.5 }
+                )
+            },
+            terminalRecoveryMonitor: monitor
+        )
+        let runtime = try #require(model.runtime(id: record.id))
+        runtime.stopPolling()
+        await runtime.refresh()
+        let session = try #require(runtime.sessions.sessions.first { $0.attachable })
+        model.attachIfNeeded(to: session, connectionID: record.id)
+        let ref = SessionRef(connectionID: record.id, sessionID: session.id)
+        let controller = try #require(model.terminals[ref])
+        harness.send(.connected, attempt: 0)
+        await waitFor { controller.phase == .connected }
+
+        // NWPathMonitor always reports its current path after start. A
+        // healthy initial value must not duplicate the initial attach.
+        monitor.recordNetworkPath(isSatisfied: true)
+        #expect(harness.attempts.count == 1)
+        monitor.recordNetworkPath(isSatisfied: false)
+        monitor.recordNetworkPath(isSatisfied: true)
+        #expect(harness.attempts.count == 2)
+
+        harness.send(.connected, attempt: 1)
+        await waitFor { controller.phase == .connected }
+        center.post(name: wake, object: nil)
+        await waitFor { harness.attempts.count == 3 }
+        #expect(harness.attempts.count == 3)
+
+        // Once the server reports the session ended, neither recovery source
+        // is allowed to revive it.
+        harness.send(.ended(.sessionEnded), attempt: 2, finish: true)
+        await waitFor { controller.phase == .ended(.sessionEnded) }
+        monitor.recordNetworkPath(isSatisfied: false)
+        monitor.recordNetworkPath(isSatisfied: true)
+        center.post(name: wake, object: nil)
+        await Task.yield()
+        #expect(harness.attempts.count == 3)
+    }
+}

--- a/server/internal/api/attach.go
+++ b/server/internal/api/attach.go
@@ -41,6 +41,18 @@ var attachInitialResizeTimeout = 2 * time.Second
 // keepalive cycles before the bridge is torn down.
 const attachWriteTimeout = 2 * time.Minute
 
+// attachPingInterval/attachPingTimeout drive the server-side liveness probe.
+// The write timeout above only arms while PTY output is flowing, so a client
+// that vanished without closing TCP would otherwise hold its bridge (and zmx
+// attach child) forever once the terminal goes quiet. Ping waits for the
+// matching pong, which catches that case even on an idle terminal. The pong
+// bound matches attachWriteTimeout so recoverable stalls get the same grace
+// as slow writes. Variables so tests can shrink them.
+var (
+	attachPingInterval = 30 * time.Second
+	attachPingTimeout  = attachWriteTimeout
+)
+
 // attachInitialInputLimit caps the aggregate bytes buffered while waiting for
 // the initial resize. Each frame is already capped by the read limit, but a
 // client pasting heavily before its resize arrives could otherwise grow the
@@ -138,6 +150,29 @@ func (routes apiRoutes) attachSession(w http.ResponseWriter, r *http.Request) {
 			}
 			if readErr != nil {
 				closeSessionEnded(conn)
+				return
+			}
+		}
+	}()
+
+	// Liveness probe: a dead client stops answering pings, and Ping blocks
+	// until the matching pong arrives (surfaced by the read loop below).
+	// Cancelling tears down both pumps, which closes the PTY and detaches
+	// the zmx child instead of holding them for a vanished peer.
+	go func() {
+		defer cancel()
+		ticker := time.NewTicker(attachPingInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+			pingCtx, cancelPing := context.WithTimeout(ctx, attachPingTimeout)
+			err := conn.Ping(pingCtx)
+			cancelPing()
+			if err != nil {
 				return
 			}
 		}

--- a/server/internal/api/attach.go
+++ b/server/internal/api/attach.go
@@ -35,6 +35,12 @@ type resizeMessage struct {
 
 var attachInitialResizeTimeout = 2 * time.Second
 
+// attachWriteTimeout is a last-resort bound for a genuinely dead client. A
+// temporarily slow client should instead apply TCP backpressure to the PTY, so
+// this must leave enough time for recoverable network stalls and several client
+// keepalive cycles before the bridge is torn down.
+const attachWriteTimeout = 2 * time.Minute
+
 // attachInitialInputLimit caps the aggregate bytes buffered while waiting for
 // the initial resize. Each frame is already capped by the read limit, but a
 // client pasting heavily before its resize arrives could otherwise grow the
@@ -121,9 +127,9 @@ func (routes apiRoutes) attachSession(w http.ResponseWriter, r *http.Request) {
 		for {
 			n, readErr := pty.Read(buf)
 			if n > 0 {
-				// Bound each write so a stalled client cannot block this pump
-				// indefinitely while holding the zmx attach child open.
-				writeCtx, cancelWrite := context.WithTimeout(ctx, 10*time.Second)
+				// Preserve PTY/TCP backpressure for a temporarily slow client,
+				// while still bounding a write to a genuinely dead connection.
+				writeCtx, cancelWrite := context.WithTimeout(ctx, attachWriteTimeout)
 				err := conn.Write(writeCtx, websocket.MessageBinary, buf[:n])
 				cancelWrite()
 				if err != nil {

--- a/server/internal/api/attach_test.go
+++ b/server/internal/api/attach_test.go
@@ -296,6 +296,68 @@ func TestAttachClosesPTYWhenClientDisconnects(t *testing.T) {
 	}
 }
 
+func TestAttachPingReapsDeadClient(t *testing.T) {
+	oldInterval, oldTimeout := attachPingInterval, attachPingTimeout
+	attachPingInterval, attachPingTimeout = 10*time.Millisecond, 50*time.Millisecond
+	t.Cleanup(func() { attachPingInterval, attachPingTimeout = oldInterval, oldTimeout })
+
+	pty := newPipePTY()
+	mux := &fakeMux{attachPTY: pty}
+	conn, srv := dialAttach(t, mux, "ses_attach")
+	defer srv.Close()
+	defer conn.CloseNow()
+
+	// A client that never reads never answers pings — the same signature as
+	// a peer that vanished without closing TCP. The bridge must reap it even
+	// though the PTY is silent and no write ever arms the write timeout.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if pty.isClosed() {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("bridge was not reaped after unanswered pings")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestAttachPingKeepsHealthyClientAttached(t *testing.T) {
+	oldInterval, oldTimeout := attachPingInterval, attachPingTimeout
+	attachPingInterval, attachPingTimeout = 10*time.Millisecond, 500*time.Millisecond
+	t.Cleanup(func() { attachPingInterval, attachPingTimeout = oldInterval, oldTimeout })
+
+	pty := newPipePTY()
+	mux := &fakeMux{attachPTY: pty}
+	conn, srv := dialAttach(t, mux, "ses_attach")
+	defer srv.Close()
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	// Reading is what lets the client library answer pings; hold a read open
+	// across many ping cycles, then confirm the bridge still delivers.
+	readCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, data, err := conn.Read(readCtx)
+		if err == nil && string(data) != "still here" {
+			err = errors.New("unexpected payload " + string(data))
+		}
+		done <- err
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	if _, err := pty.toClientIn.Write([]byte("still here")); err != nil {
+		t.Fatalf("pty write: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if pty.isClosed() {
+		t.Fatal("ping loop tore down a healthy client")
+	}
+}
+
 func TestAttachClosesWithSessionEndedWhenPTYEnds(t *testing.T) {
 	pty := newPipePTY()
 	mux := &fakeMux{attachPTY: pty}


### PR DESCRIPTION
## What changed

- Automatically reconnect transient terminal attach failures with capped exponential backoff (nominal 500 ms to 8 s, ±20% jitter) and a 10-attempt budget per failure streak, while leaving ended sessions and explicit disconnects stopped. A dedicated Reconnecting phase keeps the status banner steady across backoff cycles; once the budget is spent the banner offers a manual Reconnect, and wake/network recovery restores the budget automatically.
- Re-attach on macOS wake and recovered network paths, shorten the WebSocket ping interval to 10 seconds, and ignore late events from superseded connections.
- Rebuild the Ghostty in-memory backend only after a replacement transport opens, immediately before the resize that triggers zmx snapshot replay. Failed reconnect attempts keep the existing screen and scrollback visible.
- Replace the client’s silent 1 MiB paste truncation with an 8 MiB bounded queue that applies synchronous backpressure, preserves whole-write ordering, and emits 256 KiB WebSocket frames. Empty writes return immediately instead of parking behind a full queue.
- Extend the server’s PTY-to-WebSocket dead-write bound from 10 seconds to 2 minutes so temporary stalls use normal TCP/PTY backpressure instead of forcing a reconnect.
- Add a server-side ping/pong liveness probe (30-second interval, 2-minute pong bound) so a client that vanished without closing TCP cannot hold its attach bridge and zmx child indefinitely on an idle terminal.

## Why

The terminal session survived on the server, but the client did not recover after sleep or network loss. Reconnects then replayed zmx’s complete terminal snapshot into an already-populated Ghostty surface, duplicating screen and scrollback content. Separately, outbound client input silently dropped when its queue crossed 1 MiB, and the server converted recoverable write stalls into disconnects after 10 seconds.

The reconnect reset timing follows zmx v0.6.0’s attach flow: terminal state is serialized on re-attach before resize and includes scrollback plus the visible screen.

The retry budget bounds churn on permanent failures (revoked token, deleted server) without sacrificing unattended recovery: wake and network-path transitions reset the budget, so any environment that heals later reconnects on its own.

## Validation

- `TMPDIR=/tmp mise run check`
  - server formatting, vet, and Go tests (including dead-client reaping and healthy-client survival under fast pings)
  - web type check and 8 tests
  - ATCKit: 46 tests
  - macOS: 125 tests
- Focused terminal suites: 11 tests covering retry policy, retry-budget exhaustion and restoration, reconnecting-phase stability, terminal stop states, stale-event gating, wake/path recovery, delayed surface replacement, large-paste integrity, ordered backpressure, empty-write fast path, and teardown wakeup.
- Independent full-diff subagent review completed; all actionable findings addressed in the follow-up polish commit.

## Issues

- Fixes [DEV-25](https://linear.app/elevenideas/issue/DEV-25/terminal-sessions-dont-auto-reconnect-after-sleepnetwork-drop)
- Fixes [DEV-26](https://linear.app/elevenideas/issue/DEV-26/reconnect-visually-corrupts-terminal-screen-duplicated-snapshot)
- Fixes [DEV-27](https://linear.app/elevenideas/issue/DEV-27/reconsider-the-10s-attach-write-timeout-it-drops-recoverable-stalls)
- Fixes [DEV-29](https://linear.app/elevenideas/issue/DEV-29/large-pastes-silently-truncate-at-1-mib-instead-of-applying)
