### PR TITLE
Rework macOS navigation UI

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,33 @@
+# atc Product Context
+
+Canonical product language for the atc app and its user-facing domain.
+
+## Language
+
+**Active Workspace**:
+The Workspace currently scoping workspace-specific navigation and commands in a window. It remains active while global content is shown and may be disconnected or archived; it ceases to be active only when cleared or removed.
+_Avoid_: Open Workspace, Available Workspace
+
+**Navigator**:
+A window-level sidebar mode that determines which navigation collection the sidebar presents. Its selection remains stable when the Active Workspace changes and does not select main content by itself.
+_Avoid_: Sidebar tab, Workspace navigator state
+
+**Projects Navigator**:
+The app-wide Navigator containing the Dashboard and multiple unarchived Projects with their unarchived nested Workspaces. The plural name reflects that its scope crosses Project boundaries; archived records are managed from the Dashboard instead of this Navigator.
+_Avoid_: Global Navigator, Home Navigator, Project Navigator
+
+**Workspace Navigator**:
+The Navigator containing the Sessions and Terminals of the single Active Workspace.
+_Avoid_: Workspaces Navigator, Sessions Navigator
+
+**File Navigator**:
+The Navigator containing the file tree of the single Active Workspace.
+_Avoid_: Files Navigator, File browser Navigator
+
+**Workspace Switcher**:
+The toolbar control that identifies the Active Workspace as `Project › Workspace` and opens the app-wide Workspace selection menu. Its status indicator reflects the Active Workspace's Connection.
+_Avoid_: Workspace picker, Project picker, Breadcrumb
+
+**Dashboard**:
+The app-wide main-content destination for viewing and managing work across Connections, Projects, and Workspaces. Showing the Dashboard does not clear the Active Workspace or change the selected Navigator.
+_Avoid_: Overview, Dashboard mode, Dashboard route

--- a/docs/ui-polish-plan.md
+++ b/docs/ui-polish-plan.md
@@ -1,0 +1,171 @@
+# macOS UI Polish Plan — Design System, Spacing, Liquid Glass
+
+Status: proposed
+Date: 2026-07-13
+
+## Context
+
+The macOS app (`macos/ATC`) looks unpolished: spacing is ad-hoc everywhere, similar
+components are hand-rolled multiple times with drifting styles, and despite targeting
+**macOS 26** the app uses zero Liquid Glass APIs. Audit findings:
+
+- **No design tokens exist.** 14 distinct `spacing:` values (1–34), 16 padding forms
+  (horizontal: 5, 6, 7, 8, 12, 14, 18, 36), 4 corner radii (4, 5, 6, 12), split-brain
+  dimming (0.5 vs 0.55 for the same "archived" intent), 9 bespoke sheet/window sizes.
+- **Duplication:** reachability dots hand-rolled in 5 places at 4 sizes; 4+ pill/badge
+  implementations mixing Capsule vs RoundedRectangle; the "Action Failed" `.alert`
+  block copy-pasted 5×; identical +/− settings list bars duplicated in two files.
+- **Dashboard uses its own visual language** — oversized custom scale (spacing 34,
+  padding 32/36) unlike the rest of the app.
+- **Hand-rolled controls fight the framework:** the sidebar navigator selector is plain
+  Buttons with manual accent fills and a hardcoded 13pt font
+  (`NavigatorSidebar.swift:29-57`).
+
+**Decisions (fixed):** stay dark-only (`.preferredColorScheme(.dark)` stays); keep
+dashboard cards but polish them; standard (non-expressive) Liquid Glass adoption.
+Xcode 26 is the visual reference; prefer default SwiftUI components; minimal clutter.
+
+## Phase 0 — Design token layer
+
+New file `macos/ATC/Shared/DesignTokens.swift` — three tiny caseless enums, no
+theming framework:
+
+```swift
+enum Spacing {  // 4pt grid
+    static let xs: CGFloat = 4    // intra-label gaps (dot–text)
+    static let sm: CGFloat = 8    // control clusters, row internals
+    static let md: CGFloat = 12   // standard container/bar padding
+    static let lg: CGFloat = 16   // card interior padding
+    static let xxl: CGFloat = 32  // dashboard page margins / section gaps
+}
+enum Radius {
+    static let control: CGFloat = 6
+    static let card: CGFloat = 12
+}
+enum Dimming {
+    static let archived: Double = 0.5   // also replaces the stray 0.55
+}
+```
+
+Mapping rules (mechanical, by intent not by old number):
+
+- 3, 4, 6, 7 gaps → `xs` (dot–text) or `sm` (element gaps); keep literal `2` for tight
+  two-line text stacks
+- 8, 9, 10 → `sm`; 12, 14 → `md`; 18 → `lg`; 32/34/36 → `xxl`
+- radius 4/5/6 → `Radius.control` (the 5pt badge becomes a Capsule via TagBadge);
+  12 → `Radius.card`
+- `.font(.system(size: 13, weight: .medium))` at `NavigatorSidebar.swift:38` → dies
+  with Phase 2a
+- **Keep** the Catppuccin Mocha RGB in `TerminalPane.swift:13` (pairs with the Ghostty
+  surface, not app chrome) — add a comment saying so
+
+Files touched: DashboardView, NavigatorSidebar, SessionContentView,
+ConnectionsSettingsView, ActionsSettingsView, the three create/start sheets,
+RemoteFolderPickerSheet, TerminalPane, WorkspaceShellView, SessionRowView,
+ConnectionChip, StatusBadge.
+
+## Phase 1 — Shared components (all in `macos/ATC/Shared/`)
+
+1. **`StatusDot.swift`** — the one reachability/liveness dot. Two sizes (inline 6pt /
+   standard 8pt), optional `hollow` (dashboard "no active sessions" ring). Compose into
+   existing `StatusBadge` and `ConnectionChip`; adopt at
+   `ConnectionsSettingsView.swift:61`, `DashboardView.swift:170-173` (**drop the glow
+   shadow** — only glow in the app, off-idiom), `DashboardView.swift:394-401`,
+   `NavigatorSidebar.swift:218`, `WorkspaceSwitcher.swift:54`. Also move
+   `Features/Sessions/StatusBadge.swift` → `Shared/`.
+2. **`TagBadge.swift`** — the one text pill: `.caption2`, secondary, `.quaternary`
+   Capsule, padding (6, 2). Replaces the LOCAL/REMOTE badge
+   (`DashboardView.swift:178-183`, gets `monospaced: true`), both Archived pills
+   (`DashboardView.swift:274-279`, `407-413`), the action-label pill
+   (`SessionContentView.swift:152-157`), and `ActionOriginBadge`
+   (`ActionsSettingsView.swift:263-282`, delete the struct).
+3. **`ErrorAlert.swift`** — `func actionErrorAlert(_ error: Binding<String?>, title:
+   String = "Action Failed")` view extension. Replaces the 5 copy-pasted alert blocks:
+   `DashboardView.swift:154`, `NavigatorSidebar.swift:202`, `WorkspaceShellView.swift:76`
+   & `:314`, `SessionContentView.swift:235` (custom titles preserved via param). Leave
+   the per-view `run{}` helpers alone — they genuinely differ.
+4. **`SheetScaffold.swift`** — standard form-sheet chrome: `Label` title header
+   (headline) + Divider, grouped `Form` content, Divider, trailing button row
+   (`Spacer / Cancel / Primary`) with `.cancelAction`/`.defaultAction` shortcuts and an
+   `isBusy` spinner state. **Button order: Cancel adjacent-left of primary, both
+   trailing** — the HIG/Xcode-correct arrangement (the folder picker already does this;
+   the three form sheets change to match).
+5. **`ListEditorBar.swift`** — the +/− bar under settings master lists; replaces
+   `ConnectionsSettingsView.swift:80-100` and `ActionsSettingsView.swift:160-181`
+   verbatim.
+
+## Phase 2 — Per-surface fixes
+
+- **2a. Navigator selector → native control** (`NavigatorSidebar.swift:29-57`): replace
+  the hand-rolled buttons with `Picker` + `.pickerStyle(.palette)`, `.labelsHidden()`,
+  icon items tagged by `NavigatorID`, `.selectionDisabled(!option.isEnabled)` + `.help`
+  per item. Placement stays at the top of the sidebar (matches Xcode's navigator bar).
+  Keep `NavigatorSelectorOption` unchanged — `NavigationPresentationTests` asserts on
+  it. *Fallback if `.selectionDisabled` doesn't gate palette items on macOS 26:* row of
+  `.buttonStyle(.accessoryBar)` buttons with per-item `.disabled`.
+- **2b. Dashboard** (`DashboardView.swift`): token pass (34→xxl etc.), `StatusDot`
+  (no glow), `TagBadge`, hollow ring → `StatusDot(hollow:)`, dashed empty box radius →
+  `Radius.card`, `maxWidth: 1280` stays, alert → `actionErrorAlert`.
+- **2c. SessionHeaderBar** (`SessionContentView.swift:103-263`): pill → `TagBadge`;
+  padding → md/sm; apply `.buttonStyle(.borderless)` + `.labelStyle(.iconOnly)` at the
+  HStack level so the action buttons read as a toolbar row, keep `.help` strings;
+  alert → `actionErrorAlert(title: "Session Action Failed")`.
+- **2d. Settings**: one window size 720×500 for both tabs (constant in
+  `SettingsView.swift`); master column width unified to 240; both bottom bars →
+  `ListEditorBar`; inline spinners standardize on `.controlSize(.small)` (pane-level
+  loader stays regular). Update `SettingsHostingSmokeTest` frames to match.
+- **2e. Sheets**: CreateProjectSheet → scaffold "New Project" 460×300;
+  CreateWorkspaceSheet → "New Workspace" 460×280; StartWorkspaceSessionSheet → title
+  moves from the Form-section hack into the scaffold header, 460×280.
+  RemoteFolderPickerSheet is a browser, not a form — keep custom body, just token pass
+  + same footer padding (its trailing button pair is already correct).
+- **2f. Terminal status banner** (`TerminalPane.swift:77-84`):
+  `.background(.regularMaterial, in: Capsule())` → `.glassEffect()` with token padding.
+
+## Phase 3 — Liquid Glass boundaries
+
+- `glassEffect()` **only** on the terminal status banner (the app's one true floating
+  overlay). No tint, no `interactive()`, no `GlassEffectContainer`, no
+  `.buttonStyle(.glass)`.
+- Everything else gets glass for free from system components (sidebar, toolbar,
+  inspector, sheets, menus) — the codebase sets no
+  `toolbarBackground`/`scrollContentBackground` overrides, so nothing to remove. The 2a
+  native Picker is the main "use the system control, get glass" win.
+- No glass on dashboard cards or session header (HIG: glass is the control layer, not
+  content).
+
+## Sequencing — jj checkpoints (each buildable, tests green; `jj describe -m` + `jj new`)
+
+1. `design: add DesignTokens, apply spacing/radius/dimming scale` (Phase 0 —
+   mechanical, zero behavior change)
+2. `design: add StatusDot + TagBadge, adopt across dots and pills`
+3. `design: shared actionErrorAlert modifier`
+4. `design: native palette Picker for navigator selector` (isolated — contained revert
+   if fallback needed)
+5. `design: SheetScaffold + unify create/start sheets, folder picker polish`
+6. `design: settings — unified frame, master width, ListEditorBar`
+7. `design: dashboard + session header polish`
+8. `design: liquid glass terminal status banner`
+
+## Verification
+
+Per checkpoint:
+
+- Build: `xcodebuild -project macos/atc.xcodeproj -scheme atc -destination
+  'platform=macOS' build`
+- Tests: same command with `test` — the four hosting smoke suites
+  (Settings/ProjectUI/Picker/Shell) are the regression net for checkpoints 4–7
+- Visual: run the app; walk Dashboard → open workspace → new session sheet → both
+  settings tabs → folder picker; toggle sidebar navigators; kill the server to check
+  the glass reconnect banner. Verify each sheet with its conditional error section
+  visible (heights can clip). Previews exist for all touched surfaces.
+
+## Risks
+
+- `NavigationPresentationTests.swift` asserts `NavigatorSelectorOption.all`
+  ordering/gating/help strings and `WorkspaceSwitcherPresentation` labels — keep
+  symbols and semantics intact.
+- `.selectionDisabled` on palette Picker items unverified on macOS 26 — fallback
+  documented in 2a.
+- Sheet heights with grouped Forms need per-sheet eyeballing with error states visible.
+- Do not touch the Ghostty terminal background RGB.

--- a/docs/ui-rework-brief.md
+++ b/docs/ui-rework-brief.md
@@ -39,7 +39,7 @@ The left sidebar includes an Xcode-style navigator selector at the top. Selectin
 The initial Navigators are:
 
 - **Projects Navigator:** Displays the Dashboard followed by a flat app-wide list of unarchived Projects with their unarchived Workspaces nested beneath them. The plural name reflects its multi-Project scope. Connections are not Navigator rows; each Project row shows its Connection name and status as secondary context so same-named Projects remain distinguishable. Archived Projects and Workspaces are managed from the Dashboard and MUST NOT appear in this Navigator.
-- **Workspace Navigator:** Displays agent sessions and terminals belonging to the active workspace. Its existing Show Archived control remains the macOS access point for archived Sessions and Terminals until a separate archive-management surface exists.
+- **Workspace Navigator:** Displays agent sessions and terminals belonging to the active workspace without a search field. Its Show Archived control remains the macOS access point for archived Sessions and Terminals until a separate archive-management surface exists.
 - **File Navigator:** Reserves the future active-workspace file tree. In this implementation its selector is visible, disabled when no workspace is active, and selectable when a workspace is active. Its sidebar shows a restrained `File navigation is not available yet` empty state and does not replace the main content. This stub MUST NOT add file APIs, tree state, or fake file data.
 
 Selecting an item within a navigator opens or focuses that item in the main content area.

--- a/docs/ui-rework-brief.md
+++ b/docs/ui-rework-brief.md
@@ -8,7 +8,7 @@ This should give users a clear global view of the app while allowing them to foc
 
 ## Problem
 
-The current UI treats the global overview and workspace experience as separate modes with different layout behavior. Moving between them can recreate or destabilize parts of the view hierarchy, contributing to layout bugs and inconsistent sidebar and toolbar behavior.
+The current UI treats Dashboard and the workspace experience as separate modes with different layout behavior. Moving between them can recreate or destabilize parts of the view hierarchy, contributing to layout bugs and inconsistent sidebar and toolbar behavior.
 
 The app also needs a navigation model that can grow to support projects, machine-specific workspaces, agent sessions, terminals, files, and future workspace tools without placing everything in one crowded sidebar.
 
@@ -28,6 +28,7 @@ The app also needs a navigation model that can grow to support projects, machine
 - Define every future navigator.
 - Introduce multi-window workspace support as part of the initial implementation.
 - Turn the trailing sidebar into primary navigation.
+- Add Navigator commands, workspace-switching commands, or keyboard shortcuts; these belong in a later keyboard-focused pass.
 
 ## Proposed Experience
 
@@ -35,44 +36,58 @@ The app also needs a navigation model that can grow to support projects, machine
 
 The left sidebar includes an Xcode-style navigator selector at the top. Selecting an icon changes only the sidebar contents; it does not immediately replace the main content.
 
-The initial navigators are:
+The initial Navigators are:
 
-- **Global navigator:** Displays app-wide content such as projects, their related workspaces, connections, and an overview destination.
-- **Workspace navigator:** Displays agent sessions and terminals belonging to the active workspace.
-- **File navigator:** Displays the active workspace's file tree. (Note that this does not exist just yet so will be a future state addition. For now we should just stub it in with nothing in the navigator.)
+- **Projects Navigator:** Displays the Dashboard followed by a flat app-wide list of unarchived Projects with their unarchived Workspaces nested beneath them. The plural name reflects its multi-Project scope. Connections are not Navigator rows; each Project row shows its Connection name and status as secondary context so same-named Projects remain distinguishable. Archived Projects and Workspaces are managed from the Dashboard and MUST NOT appear in this Navigator.
+- **Workspace Navigator:** Displays agent sessions and terminals belonging to the active workspace. Its existing Show Archived control remains the macOS access point for archived Sessions and Terminals until a separate archive-management surface exists.
+- **File Navigator:** Reserves the future active-workspace file tree. In this implementation its selector is visible, disabled when no workspace is active, and selectable when a workspace is active. Its sidebar shows a restrained `File navigation is not available yet` empty state and does not replace the main content. This stub MUST NOT add file APIs, tree state, or fake file data.
 
 Selecting an item within a navigator opens or focuses that item in the main content area.
 
+Within the Projects Navigator, Dashboard and Workspace rows are destinations. Project rows are structural: their disclosure control expands or collapses their Workspaces, row selection does not replace the main content, contextual actions remain available from the row menu, and Project management remains on Dashboard. This implementation MUST NOT add a Project-detail destination.
+
+Dashboard is always the first row. Projects sort alphabetically using a case-insensitive comparison, with Connection name and then stable identity as tie-breakers. Each Project's Workspaces remain newest-created-first, matching Dashboard. Project disclosure state lasts for the current app run and resets on launch; this version does not add manual reordering.
+
 ### Active Workspace Context
 
-The window prominently displays the active `Project > Workspace`, preferably in the toolbar above the main content area. This control remains visible when the sidebar is hidden or displaying a different navigator.
+The toolbar prominently displays a clickable Workspace Switcher labeled `Project › Workspace`, preceded by a small Connection-status dot. The persistent label omits the Connection name to remain compact; the menu, tooltip, and accessibility description include it. With no active workspace, the control reads `Select Workspace…`. An archived workspace is identified inside the menu rather than with another permanent toolbar badge. The Workspace Switcher remains visible when the sidebar is hidden or displaying a different Navigator.
 
-The workspace context is clickable and opens a quick switcher grouped by project. Switching workspaces updates the entire window context together, including workspace-scoped navigators and main content. The target workspace should restore its most recent useful UI state when possible.
+The workspace context is clickable and opens a quick switcher grouped by project, with Connection identity included where needed to disambiguate Projects. Switching workspaces preserves the selected navigator, updates any workspace-scoped navigator contents, and restores the target workspace's most recent useful main content when possible.
 
-The Global navigator and the toolbar workspace switcher must use the same underlying workspace-selection behavior.
+The Projects Navigator and the toolbar workspace switcher must use the same underlying workspace-selection behavior.
 
 ### No Active Workspace
 
-The Global navigator is always available. Workspace-scoped navigators are unavailable when no workspace is active and should explain their requirement through tooltips and disabled menu commands.
+The Projects Navigator is always available. Workspace-scoped Navigators are unavailable when no workspace is active and should explain their requirement through tooltips and disabled menu commands.
 
-Selecting a workspace in the Global navigator establishes it as active and enables the Workspace and File navigators. If an active workspace is temporarily offline, its navigators remain available and display an appropriate disconnected state. If the workspace is closed or removed, the sidebar returns to the Global navigator.
+Selecting a workspace in the Projects Navigator establishes it as active and enables the Workspace and File Navigators. If an active workspace is temporarily offline, its Navigators remain available and display an appropriate disconnected state. If the workspace is closed or removed, the sidebar returns to the Projects Navigator.
 
 ### Trailing Inspector
 
 The right side of the window remains a contextual inspector rather than workspace navigation. Its availability and contents are derived from the item selected in the main content area. SwiftUI's native inspector behavior should be preferred over a custom trailing panel.
+
+The stable root content host owns one native SwiftUI inspector and one window-level presentation Boolean. Dashboard, no-selection, unsupported-content, and workspace-switch transitions close it. Selecting another inspectable item while it is open updates its contents; changing Navigators alone leaves it unchanged. Inspector visibility is not remembered per workspace or persisted by the app. The inspector toggle is available only when the selected main content supports inspection.
 
 ## State and Behavior
 
 The design should distinguish between:
 
 - The selected navigator, which controls the left sidebar.
-- The active project and workspace, which scope workspace-specific tools.
+- The active workspace and its derived Project context, which scope workspace-specific tools.
 - The selected content, which controls the main content area.
 - Inspector presentation and selection-specific details.
 
 Changing navigators must not unnecessarily replace the main content. Changing the active workspace is an explicit context switch and must not leave content from the previous workspace presented as though it belongs to the new one.
 
-Workspace-specific UI state should be preserved where practical, including the selected navigator, selected session, terminal or file, sidebar expansion state, and inspector visibility.
+Navigator selection is window-level state and remains stable when the active workspace changes. Workspace-specific UI state should be preserved where practical, including the selected session, terminal or file and workspace-scoped sidebar expansion state.
+
+Workspace activation restores the last selected session or terminal only when it still exists, still belongs to that workspace, and is not archived. Running, ended, and failed content are all restorable, and a disconnected Connection does not invalidate the selection. Deleted, moved, or archived content clears the stale memory and falls back to the workspace's no-selection state; the app must not choose a replacement automatically.
+
+Showing the Dashboard does not clear the active workspace. Workspace-scoped commands are evaluated against the active workspace rather than the selected Navigator or main content; connectivity and archival state may still disable individual commands.
+
+Archiving the active workspace removes it from the Projects Navigator but does not clear it or replace its main content. It remains active with creation commands disabled until the user activates another workspace or it is removed.
+
+The app launches with the Projects Navigator selected, the Dashboard shown in the main content area, and no active workspace. Each workspace's last selected session or terminal persists across launches and is restored only after the user explicitly activates that workspace. Other window state, including Navigator selection and inspector visibility, resets for a new launch.
 
 ## Implementation Direction
 
@@ -80,22 +95,12 @@ Workspace-specific UI state should be preserved where practical, including the s
 - Swap navigator content within the sidebar instead of replacing the root navigation hierarchy.
 - Model navigator selection, active workspace, main-content selection, and inspector presentation as separate state.
 - Prefer native SwiftUI sidebar, list, toolbar, menu, and inspector APIs.
-- Make navigator and workspace-selection actions available to the app's keyboard shortcut system.
 
 ## Success Criteria
 
-- Moving between Global, Workspace, and File navigators does not disturb the main content or window layout.
+- Moving between Projects, Workspace, and File Navigators does not disturb the main content or window layout.
 - Users can always identify the active project and workspace.
-- Users can switch workspaces quickly from the toolbar or Global navigator.
+- Users can switch workspaces quickly from the toolbar or Projects Navigator.
 - Workspace-scoped navigation cannot silently operate against the wrong workspace.
 - Returning to a workspace restores a useful working context.
 - The Dashboard-to-workspace layout bugs and incorrect trailing-sidebar controls described in DEV-41 are eliminated by the new structure.
-
-## Questions for the Spec
-
-- What should the Global navigator be called in the UI, and which destinations belong in its first version?
-- What exact content should be restored when switching back to a workspace?
-- Should selecting a workspace initially show a workspace overview or immediately restore its last-open content?
-- How should the toolbar represent workspace location and connection status without becoming visually busy?
-- Which navigator and workspace state should persist across app launches versus only for the current window session?
-1Password menu is available. Press down arrow to select.

--- a/docs/ui-rework-spec.md
+++ b/docs/ui-rework-spec.md
@@ -34,7 +34,7 @@ This implementation MUST:
 This implementation MUST NOT:
 
 - Change server, CLI, web, SQLite, or `ATCAPI` contracts.
-- Redesign Dashboard cards, Session or Terminal content, terminal rendering, creation sheets, lifecycle actions, or file browsing.
+- Redesign Session or Terminal content, terminal rendering, creation sheets, lifecycle actions, or file browsing.
 - Add Project-detail or Connection-detail destinations.
 - Add multi-window support.
 - Add Navigator or Workspace-switching command IDs, menu commands, or keyboard shortcuts.
@@ -242,7 +242,8 @@ Archived Projects and Workspaces MUST NOT appear in the Projects Navigator. Dash
 
 ### 6.3 Workspace Navigator
 
-- The Workspace Navigator MUST reuse the existing Workspace-scoped Sessions and Terminals sections, search, creation actions, classification, ordering, row display, context menus, and Show Archived behavior.
+- The Workspace Navigator MUST reuse the existing Workspace-scoped Sessions and Terminals sections, creation actions, classification, ordering, row display, context menus, and Show Archived behavior.
+- The Workspace Navigator MUST NOT include session search. The row count is intentionally small enough to scan directly, and the sidebar should avoid controls without a demonstrated need.
 - Its contents MUST derive from the Active Workspace, never from a Workspace identity captured by a replaced view hierarchy.
 - When the Active Workspace changes, the Navigator MUST update its rows without changing `selectedNavigator`.
 - A disconnected Active Workspace retains cached rows and a visible disconnected state; network-dependent actions are disabled.
@@ -262,6 +263,11 @@ Archived Projects and Workspaces MUST NOT appear in the Projects Navigator. Dash
 - Dashboard MUST remain the existing app-wide Project and Workspace management surface.
 - It MUST render as `.dashboard` inside `MainContentHost`, not as an opaque root cover.
 - Its existing Connection sections, creation flows, archived filter, lifecycle actions, and empty states remain in scope and SHOULD be moved with minimal behavioral change.
+- Connection sections MUST use a restrained, full-width hierarchy: Connection identity and reachability, followed by Project groups containing Workspace rows.
+- Project groups with Workspaces SHOULD use a rounded system content surface with aligned header and row separators. Empty Projects SHOULD use a lighter dashed treatment with one explicit New Workspace action.
+- Workspace rows SHOULD show only name, activity state, and recency in the default presentation. Lifecycle and management actions remain in context menus.
+- Dashboard chrome MUST stay minimal. New Project remains a primary toolbar action; archived visibility and refresh belong in one secondary options menu.
+- Dashboard content MUST use system colors, typography, controls, and spacing so it adapts to appearance and accessibility settings. Custom glass effects are not permitted.
 - Dashboard's Show Archived control remains the only native macOS place to reveal archived Projects and Workspaces.
 - Selecting or showing Dashboard MUST NOT clear the Active Workspace, change Navigator, disconnect terminals, or disable Workspace commands solely because Dashboard is visible.
 - Dashboard MAY activate an archived Workspace for review; creation remains disabled while that Workspace is active.
@@ -275,7 +281,7 @@ All entry points MUST call one shared Workspace activation operation. This inclu
 For a target `WorkspaceRef`, activation MUST:
 
 1. Validate that the connection-qualified Workspace still exists in the current store.
-2. Treat activation of the already Active Workspace as idempotent and preserve current content and inspector state.
+2. Treat activation of the already Active Workspace as idempotent while Workspace content is visible. From Dashboard, the same action restores that Workspace's remembered content so its row and the Workspace Switcher provide a way back.
 3. Set `activeWorkspace` to the target.
 4. Preserve `selectedNavigator`.
 5. Close the inspector when the target differs from the previous Active Workspace.
@@ -403,7 +409,7 @@ Every app launch MUST begin with:
 - Dashboard selected in main content.
 - No Active Workspace.
 - Inspector closed.
-- Navigator searches, filters, and disclosure state reset.
+- Navigator filters and disclosure state reset.
 
 Only the connection-qualified last Session/Terminal selection per Workspace persists across launches. SwiftUI MAY restore native inspector column width, but the app MUST NOT persist inspector presentation.
 
@@ -449,6 +455,7 @@ The implementation is complete when all of the following are true:
 - Projects Navigator shows Dashboard plus correctly ordered unarchived Projects and Workspaces, without Connection rows or archived records.
 - Project rows expand/collapse without creating a Project-detail destination.
 - Projects Navigator and Workspace Switcher use the same activation operation.
+- Workspace Navigator contains no session search field.
 - Workspace activation preserves Navigator, closes inspector, and restores only valid remembered content.
 - Switching Workspace never presents content from the previous Workspace under the new context.
 - Disconnection preserves Active Workspace; confirmed removal clears it and returns to Projects Navigator plus Dashboard.

--- a/docs/ui-rework-spec.md
+++ b/docs/ui-rework-spec.md
@@ -1,0 +1,555 @@
+# macOS Navigation Rework Implementation Specification
+
+Status: Draft v1
+
+Purpose: Replace the macOS app's Dashboard-cover and Workspace-shell routing with one stable, native SwiftUI navigation structure that separates sidebar navigation, active Workspace context, main content, and inspector presentation.
+
+Scope: `macos/ATC` and `macos/ATCTests`. This work consumes the existing server and `ATCAPI` contracts without changing them.
+
+Related:
+
+- [ui-rework-brief.md](ui-rework-brief.md) — normative product direction and resolved grilling decisions.
+- [CONTEXT.md](../CONTEXT.md) — canonical product language.
+- [workspaces-phase2-spec.md](workspaces-phase2-spec.md) — existing Dashboard and Workspace behavior retained except where this specification supersedes its navigation, selection, toolbar, inspector, and command-availability rules.
+- [keyboard-shortcuts-spec.md](keyboard-shortcuts-spec.md) — existing keyboard work; this specification adds no commands or bindings.
+- [DEV-41](https://linear.app/elevenideas/issue/DEV-41/ui-review) — layout and inspector regressions motivating this work.
+
+## Normative Language
+
+The key words `MUST`, `MUST NOT`, `REQUIRED`, `SHOULD`, `SHOULD NOT`, `RECOMMENDED`, `MAY`, and `OPTIONAL` are to be interpreted as described in RFC 2119.
+
+## 1. Problem and Boundary
+
+The current root alternates between an opaque Dashboard cover and a nested Workspace `NavigationSplitView`. The covered Workspace shell remains mounted to preserve terminal surfaces, but its toolbar and inspector state can leak into Dashboard, and repeated transitions can destabilize the Dashboard layout.
+
+This implementation MUST:
+
+- Use one stable window-root `NavigationSplitView`.
+- Keep Navigator selection independent from main-content selection.
+- Keep one explicit Active Workspace independent from both.
+- Preserve existing terminal controllers, Ghostty surfaces, and WebSocket attachments across Navigator and Workspace transitions.
+- Make Dashboard a main-content destination, not a route or mode.
+- Eliminate the Dashboard layout and trailing-inspector regressions identified by DEV-41.
+
+This implementation MUST NOT:
+
+- Change server, CLI, web, SQLite, or `ATCAPI` contracts.
+- Redesign Dashboard cards, Session or Terminal content, terminal rendering, creation sheets, lifecycle actions, or file browsing.
+- Add Project-detail or Connection-detail destinations.
+- Add multi-window support.
+- Add Navigator or Workspace-switching command IDs, menu commands, or keyboard shortcuts.
+- Add a file-tree API, file-tree state, or fake file data.
+
+## 2. Goals and Non-Goals
+
+### 2.1 Goals
+
+- Navigator switching MUST leave the main content and window layout unchanged.
+- Users MUST be able to identify and switch the Active Workspace while any Navigator is selected or the sidebar is hidden.
+- Workspace activation MUST restore the target Workspace's last useful main content without showing stale content from the previous Workspace.
+- Dashboard MUST remain available without clearing the Active Workspace.
+- Workspace-scoped capabilities MUST be evaluated against the Active Workspace, not the currently visible Navigator or main content.
+- Native SwiftUI `NavigationSplitView`, toolbar, list, menu, and inspector behavior SHOULD own platform presentation wherever possible.
+
+### 2.2 Non-Goals
+
+- Persisting the Active Workspace across launches.
+- Persisting Navigator choice, inspector visibility, searches, filters, or disclosure state across launches.
+- Showing archived Projects or Workspaces in the Projects Navigator.
+- Defining future Search, Source Control, Task, History, or other Navigators.
+- Making the trailing inspector a navigation surface.
+
+## 3. Implementation Profile
+
+This section is normative. Implementation work MUST follow this profile unless this specification is amended.
+
+### 3.1 Technical Context
+
+- Language: Swift 5 language mode as configured by `macos/atc.xcodeproj`.
+- UI: SwiftUI with Observation.
+- Target: macOS 26.0, single `WindowGroup`.
+- API dependency: existing `ATCAPI` package.
+- Storage: existing stores plus `UserDefaults` for connection-qualified main-content memory only.
+- Tests: Swift Testing for state and grouping; existing `NSHostingView`/`NSWindow` hosting-test patterns for UI structure.
+- Required verification command: `mise run macos:test`.
+- Full repository verification before completion: `mise run check`.
+
+### 3.2 Dependency Policy
+
+- No new production dependency is permitted for this work.
+- Shared navigation transitions, identity checks, and sorting MUST be implemented once and reused by the Projects Navigator, Workspace Switcher, Dashboard actions, and menu actions.
+- Views MUST NOT duplicate Workspace activation or stale-selection cleanup logic.
+
+### 3.3 Performance and Reliability
+
+- Navigator changes and Dashboard presentation MUST NOT create or destroy terminal controllers or Ghostty surfaces.
+- Workspace activation MUST NOT disconnect terminal controllers solely because their Workspace is no longer active; the existing attachment budget remains responsible for later eviction.
+- The rework MUST NOT introduce additional server polling or per-row network requests.
+- Projects Navigator grouping and ordering SHOULD remain pure and deterministic for inexpensive recomputation and unit testing.
+- State transitions that change Active Workspace and main content MUST be atomic from the rendered UI's perspective.
+
+## 4. Canonical UI Model
+
+The canonical terms in `CONTEXT.md` apply throughout this specification.
+
+### 4.1 Navigator Identity
+
+The implementation MUST define exactly these initial Navigator identities:
+
+```swift
+enum NavigatorID: String, CaseIterable, Sendable {
+    case projects
+    case workspace
+    case file
+}
+```
+
+User-facing labels MUST be:
+
+- `.projects` → `Projects Navigator`
+- `.workspace` → `Workspace Navigator`
+- `.file` → `File Navigator`
+
+The Projects Navigator is plural because it crosses Project boundaries. Workspace and File Navigators are singular because each is scoped to one Active Workspace.
+
+### 4.2 Main-Content Identity
+
+Main content MUST have an explicit, connection-qualified selection model equivalent to:
+
+```swift
+enum MainContentSelection: Equatable, Sendable {
+    case dashboard
+    case workspace(WorkspaceRef)
+    case session(SessionRef)
+}
+```
+
+- `.dashboard` renders Dashboard.
+- `.workspace(ref)` renders the existing Workspace empty/no-selection content for `ref`.
+- `.session(ref)` renders the selected Session or Terminal using the existing shared Session content and terminal surfaces.
+- File content is absent from this version and MUST NOT be represented by a fake selection.
+
+The Active Project MUST be derived from the Active Workspace's current model record. It MUST NOT be stored as a second independently mutable identity.
+
+### 4.3 Window State
+
+Per-window state MUST have one owner, `WindowState` or an equivalently focused type. It MUST own:
+
+- `selectedNavigator`, defaulting to `.projects`.
+- `activeWorkspace`, defaulting to `nil`.
+- `selectedContent`, defaulting to `.dashboard`.
+- `columnVisibility`, defaulting to `.all`.
+- One inspector-presentation Boolean, defaulting to `false`.
+- Projects Navigator disclosure and focus state for the current app run.
+- Existing sheet-presentation state used by window commands.
+
+`Route` and `hasOpenedWorkspaceShell` MUST be removed. Dashboard and Workspace MUST NOT remain mutually exclusive routes.
+
+`AppModel` MUST continue to own Connections, per-Connection runtimes, stores, and terminal controllers. It MUST NOT remain the independent source of truth for Active Workspace or selected main content.
+
+### 4.4 Terminal Retention Context
+
+The existing attachment budget MUST continue protecting the selected Session and Sessions belonging to the Active Workspace. Because navigation state moves to the window, eviction MUST receive a derived retention context rather than reading duplicate navigation state from `AppModel`.
+
+An interface equivalent to the following is RECOMMENDED:
+
+```swift
+struct TerminalRetentionContext {
+    let activeWorkspace: WorkspaceRef?
+    let selectedSession: SessionRef?
+}
+```
+
+`attachIfNeeded` or its eviction helper MUST receive this context when an attachment can trigger eviction. The implementation MUST NOT maintain a second mutable copy of Active Workspace or selected content in `AppModel` merely for eviction.
+
+## 5. Stable Window Structure
+
+The window MUST use one stable hierarchy equivalent to:
+
+```text
+RootView
+└── NavigationSplitView
+    ├── NavigatorSidebar
+    │   ├── NavigatorSelector
+    │   └── NavigatorContent
+    └── MainContentHost
+        ├── persistent TerminalPane stack
+        └── opaque content/state covers
+```
+
+### 5.1 Root `NavigationSplitView`
+
+- `RootView` MUST own the only window-root `NavigationSplitView`.
+- Selecting a Navigator MUST swap only `NavigatorContent`.
+- Dashboard MUST NOT cover or replace the root split view.
+- The leading column MUST use native sidebar behavior and the existing practical width range unless validation shows a necessary adjustment.
+- Sidebar visibility MUST be meaningful in every main-content state; the existing Toggle Sidebar action MUST no longer depend on a Dashboard/Workspace route.
+
+### 5.2 Persistent Main Content
+
+- `MainContentHost` MUST keep the shared `TerminalPane` stack mounted while the window exists.
+- Dashboard, Workspace no-selection, disconnected, ended, and other non-live-terminal states MUST be opaque layers over that stable host where necessary.
+- Changing Navigator MUST NOT change `selectedContent`.
+- Selecting Dashboard MUST change only `selectedContent` to `.dashboard`; it MUST NOT clear `activeWorkspace`.
+- Existing Session headers, terminal status behavior, reconnect behavior, and detail views MUST be reused rather than reimplemented.
+
+## 6. Navigator Sidebar
+
+### 6.1 Navigator Selector
+
+- The selector MUST appear at the top of the leading sidebar and use an Xcode-style row of icon controls.
+- Every icon MUST have its canonical label as help and accessibility text.
+- Projects Navigator MUST always be enabled.
+- Workspace and File Navigators MUST be visible but disabled when there is no Active Workspace.
+- Disabled Navigator help MUST explain `Requires an Active Workspace`.
+- Changing Navigator MUST preserve main content and inspector presentation.
+
+### 6.2 Projects Navigator
+
+The Projects Navigator MUST contain:
+
+1. Dashboard as the first row and a main-content destination.
+2. A flat, app-wide list of unarchived Projects.
+3. Each Project's unarchived Workspaces nested under that Project.
+
+Connections MUST NOT appear as hierarchy rows. Each Project row MUST show its Connection name and reachability status as secondary context so same-named Projects remain distinguishable.
+
+Project rows are structural:
+
+- Their disclosure control expands or collapses Workspaces.
+- Focusing or clicking the Project row MUST NOT replace main content.
+- Existing Project actions remain available through the row context menu.
+- Project management remains on Dashboard.
+- No Project-detail destination may be added.
+
+Workspace rows are destinations:
+
+- Selecting an enabled Workspace row MUST invoke the shared Workspace activation transition in Section 8.
+- A Workspace on a disconnected Connection SHOULD remain visible from cached data but MUST be disabled for new activation, matching existing Dashboard reachability behavior.
+- The already Active Workspace MAY remain active if its Connection later disconnects.
+
+Ordering MUST be deterministic:
+
+- Dashboard first.
+- Projects by localized case-insensitive name.
+- Same-named Projects by localized case-insensitive Connection name.
+- Remaining ties by stable connection-qualified Project identity.
+- Workspaces newest-created-first, matching Dashboard.
+
+Project disclosure state lasts for the current app run and resets on launch. Manual reordering is out of scope.
+
+Archived Projects and Workspaces MUST NOT appear in the Projects Navigator. Dashboard remains the native macOS management surface for viewing and unarchiving them.
+
+### 6.3 Workspace Navigator
+
+- The Workspace Navigator MUST reuse the existing Workspace-scoped Sessions and Terminals sections, search, creation actions, classification, ordering, row display, context menus, and Show Archived behavior.
+- Its contents MUST derive from the Active Workspace, never from a Workspace identity captured by a replaced view hierarchy.
+- When the Active Workspace changes, the Navigator MUST update its rows without changing `selectedNavigator`.
+- A disconnected Active Workspace retains cached rows and a visible disconnected state; network-dependent actions are disabled.
+- An archived Active Workspace remains browseable, with creation actions disabled.
+- Show Archived remains available for archived Sessions and Terminals because no other native macOS management surface currently exposes them.
+
+### 6.4 File Navigator Stub
+
+- The File Navigator icon MUST be visible.
+- It MUST be disabled without an Active Workspace and selectable with one.
+- Its sidebar MUST show a restrained `File navigation is not available yet` empty state.
+- Selecting it MUST NOT replace main content.
+- It MUST NOT call filesystem APIs, maintain tree state, or display fixture/fake files.
+
+## 7. Dashboard
+
+- Dashboard MUST remain the existing app-wide Project and Workspace management surface.
+- It MUST render as `.dashboard` inside `MainContentHost`, not as an opaque root cover.
+- Its existing Connection sections, creation flows, archived filter, lifecycle actions, and empty states remain in scope and SHOULD be moved with minimal behavioral change.
+- Dashboard's Show Archived control remains the only native macOS place to reveal archived Projects and Workspaces.
+- Selecting or showing Dashboard MUST NOT clear the Active Workspace, change Navigator, disconnect terminals, or disable Workspace commands solely because Dashboard is visible.
+- Dashboard MAY activate an archived Workspace for review; creation remains disabled while that Workspace is active.
+
+## 8. Workspace Activation and State Transitions
+
+All entry points MUST call one shared Workspace activation operation. This includes Workspace rows in Projects Navigator, Dashboard open actions, Workspace creation completion, and Workspace Switcher selections.
+
+### 8.1 Activate Workspace
+
+For a target `WorkspaceRef`, activation MUST:
+
+1. Validate that the connection-qualified Workspace still exists in the current store.
+2. Treat activation of the already Active Workspace as idempotent and preserve current content and inspector state.
+3. Set `activeWorkspace` to the target.
+4. Preserve `selectedNavigator`.
+5. Close the inspector when the target differs from the previous Active Workspace.
+6. Restore the target's remembered content under Section 10.
+7. Fall back to `.workspace(target)` when no remembered content is valid.
+8. Attach the restored Session only through the existing attach/reconnect path and only when its current state permits attachment.
+
+The transition MUST NOT briefly render content from the previous Workspace under the new Workspace Switcher label.
+
+### 8.2 Select Session or Terminal
+
+Selecting a Session or Terminal row MUST:
+
+- Verify that it belongs to the Active Workspace and uses the same Connection identity.
+- Set `selectedContent` to `.session(ref)`.
+- Remember the selection under the Active Workspace's composite identity.
+- Attach through the existing terminal path when attachable.
+- Update an already-presented inspector to the new selection.
+
+An invalid cross-Workspace selection MUST be rejected and MUST NOT be rendered.
+
+### 8.3 Show Dashboard
+
+Showing Dashboard MUST:
+
+- Set `selectedContent` to `.dashboard`.
+- Preserve `activeWorkspace`.
+- Preserve `selectedNavigator`.
+- Close the inspector.
+- Preserve remembered Workspace content for later activation/restoration.
+
+### 8.4 Disconnected Active Workspace
+
+When the Active Workspace's Connection becomes disconnected:
+
+- The Workspace remains active.
+- Navigator selection and main content remain unchanged.
+- Cached navigation and metadata remain visible.
+- Creation and other network-dependent mutations become unavailable.
+- Existing terminal reconnect/status behavior remains responsible for its own presentation.
+- A transient refresh failure MUST NOT clear the Active Workspace.
+
+### 8.5 Archived Active Workspace
+
+When the Active Workspace is archived:
+
+- It remains active and its main content remains selected.
+- It disappears from the Projects Navigator.
+- Workspace and File Navigators remain enabled.
+- New Session and New Terminal become unavailable.
+- The Workspace Switcher menu identifies the current Workspace as archived.
+- The user may leave it by activating another Workspace; archival alone MUST NOT force navigation.
+
+### 8.6 Removed Active Workspace or Connection
+
+Once current store data positively establishes that the Active Workspace or its Connection was removed, the window MUST atomically:
+
+- Clear `activeWorkspace`.
+- Clear stale remembered content for that Workspace when appropriate.
+- Set `selectedNavigator` to `.projects`.
+- Set `selectedContent` to `.dashboard`.
+- Close the inspector.
+- Disconnect affected terminal controllers through the existing teardown path when the Connection was removed.
+
+Before the relevant store has completed its first load, absence MUST be treated as unresolved rather than removed.
+
+## 9. Workspace Switcher
+
+The toolbar MUST contain one Workspace Switcher that remains visible when the sidebar is hidden or any Navigator is selected.
+
+### 9.1 Label
+
+With an Active Workspace, the label MUST contain:
+
+- A small status dot using the Active Workspace's Connection reachability.
+- `Project › Workspace` as the persistent text.
+- A menu affordance.
+
+The persistent label MUST NOT include the Connection name. The menu, tooltip, and accessibility description MUST include Connection identity and connected/disconnected state.
+
+With no Active Workspace, the label MUST read `Select Workspace…`.
+
+### 9.2 Menu Contents
+
+- Workspaces MUST be grouped by unarchived Project.
+- Connection identity MUST accompany Project context where names could be ambiguous.
+- Archived Projects and Workspaces MUST NOT be offered as switch targets.
+- Disconnected cached targets SHOULD remain visible but disabled.
+- Projects and Workspaces SHOULD use the same deterministic ordering as the Projects Navigator.
+- If the current Active Workspace is archived, the menu header or current-context section MUST identify that fact even though the archived Workspace is omitted from switch targets.
+
+Selecting a target MUST call the shared activation operation from Section 8.1.
+
+## 10. Restoration and Persistence
+
+### 10.1 Restorable Content
+
+The remembered Session or Terminal is valid only when it:
+
+- Still exists in the target Connection's Session store.
+- Still belongs to the target Workspace.
+- Is not archived.
+
+Running, starting, ended, terminated, and failed lifecycle states are restorable. Connection disconnection does not invalidate remembered content.
+
+Deleted, moved, or archived content MUST clear its stale memory and fall back to `.workspace(target)`. The implementation MUST NOT automatically select a replacement Session or Terminal.
+
+### 10.2 Composite Persistence Identity
+
+Persistence MUST key Workspace memory by both local Connection UUID and server Workspace ID. A bare Workspace ID is prohibited because independent Connections may issue the same server ID.
+
+The existing bare-ID `workspaceSelections` storage MUST be replaced by a versioned, connection-qualified representation. Because the old keys are ambiguous across Connections, the implementation SHOULD ignore or remove the old map rather than guess a migration.
+
+Persisted records need only contain:
+
+- Connection UUID.
+- Workspace ID.
+- Session ID.
+
+### 10.3 Launch State
+
+Every app launch MUST begin with:
+
+- Projects Navigator selected.
+- Dashboard selected in main content.
+- No Active Workspace.
+- Inspector closed.
+- Navigator searches, filters, and disclosure state reset.
+
+Only the connection-qualified last Session/Terminal selection per Workspace persists across launches. SwiftUI MAY restore native inspector column width, but the app MUST NOT persist inspector presentation.
+
+## 11. Inspector
+
+- One native SwiftUI `.inspector(isPresented:content:)` modifier MUST be attached to the stable root content host.
+- One window-level Boolean MUST control presentation.
+- The inspector target MUST be derived from current main content; Session and Terminal selections use the existing `SessionDetailView` contract.
+- Dashboard, Workspace no-selection, unsupported content, removed content, and a different Workspace activation MUST close the inspector.
+- Selecting another inspectable Session while the inspector is open MUST update its contents without closing it.
+- Navigator changes alone MUST leave inspector state unchanged.
+- Inspector presentation MUST NOT be remembered per Workspace or persisted by app code.
+- The inspector toggle MUST be absent or disabled whenever current main content has no inspector target.
+- Existing native flexible column width behavior SHOULD remain.
+
+## 12. Commands and Availability
+
+This rework changes the context evaluation of existing actions but adds no new keyboard work.
+
+- New Session and New Terminal MUST require an Active Workspace that is unarchived and on a connected Connection. Dashboard visibility and Navigator choice MUST NOT affect availability.
+- New Workspace SHOULD preselect the Active Workspace's Project when that Project remains a valid creation target; otherwise it uses the existing context-free Project picker.
+- Toggle Sidebar MUST be available for the stable root split view regardless of main content.
+- Refresh remains app-wide.
+- Existing menu titles and compiled shortcuts remain unchanged.
+- No `navigator.*` or `workspace.switch` command identifiers or `⌘1`–`⌘3` bindings may be added in this scope.
+
+## 13. Failure Handling and Recovery
+
+- Workspace activation failures MUST leave the previous Active Workspace, main content, and Navigator unchanged.
+- Store refresh failures MUST preserve cached rows and mark Connection status through existing reachability behavior.
+- A stale remembered selection MUST fail closed to the target Workspace no-selection state.
+- A Workspace-switch transition MUST never retain an inspector target or main-content reference from the previous Workspace.
+- Removing a Connection MUST clear all window references into that Connection and use existing terminal teardown.
+- User-facing errors from retained Project, Workspace, and Session actions remain governed by existing behavior and MUST NOT be swallowed by the new navigation layer.
+
+## 14. Acceptance Criteria
+
+The implementation is complete when all of the following are true:
+
+- The window contains one stable root `NavigationSplitView` in Dashboard and Workspace states.
+- Projects, Workspace, and File Navigator switching changes only sidebar contents.
+- Dashboard can be shown while an Active Workspace remains visible in the Workspace Switcher and eligible Workspace commands remain available.
+- Projects Navigator shows Dashboard plus correctly ordered unarchived Projects and Workspaces, without Connection rows or archived records.
+- Project rows expand/collapse without creating a Project-detail destination.
+- Projects Navigator and Workspace Switcher use the same activation operation.
+- Workspace activation preserves Navigator, closes inspector, and restores only valid remembered content.
+- Switching Workspace never presents content from the previous Workspace under the new context.
+- Disconnection preserves Active Workspace; confirmed removal clears it and returns to Projects Navigator plus Dashboard.
+- File Navigator exhibits only the specified placeholder behavior.
+- The inspector toggle cannot appear for Dashboard or other unsupported content.
+- Terminal surfaces and attachments survive Dashboard and Navigator transitions without unnecessary replay or reconnection.
+- All persisted Workspace selections are connection-qualified.
+- No new keyboard commands, bindings, production dependencies, or API changes are introduced.
+
+The implementation is not acceptable if:
+
+- Dashboard remains a root cover or route.
+- More than one root navigation hierarchy is conditionally mounted.
+- Navigator selection implicitly changes main content.
+- Active Workspace identity is duplicated as independently mutable state across `WindowState` and `AppModel`.
+- Archived Projects or Workspaces appear in Projects Navigator or Workspace Switcher targets.
+- A blank File Navigator appears without explanatory state.
+
+## 15. Verification Plan
+
+### 15.1 State and Unit Tests
+
+Tests MUST cover:
+
+- Launch defaults.
+- Navigator selection preserving main content.
+- Dashboard preserving Active Workspace and Navigator.
+- Workspace activation preserving Navigator and restoring valid content.
+- Same-Workspace activation idempotence.
+- Cross-Workspace and cross-Connection selection rejection.
+- Connection-qualified persistence and old bare-key handling.
+- Running, ended, failed, archived, deleted, and moved-selection restoration cases.
+- Disconnected, archived, removed, and unresolved Active Workspace transitions.
+- Inspector close/update rules.
+- Command availability independent of Dashboard/Navigator and dependent on Active Workspace capability.
+- Attachment-budget retention using the window-derived context.
+
+### 15.2 Pure Grouping Tests
+
+Projects Navigator grouping tests MUST cover:
+
+- Dashboard-first ordering.
+- Case-insensitive Project ordering.
+- Connection-name and stable-identity tie-breakers.
+- Newest-first Workspace ordering.
+- Same-named Projects on different Connections.
+- Archived Project and Workspace exclusion.
+- Connection context and reachability projection.
+
+### 15.3 UI Hosting Tests
+
+Hosting tests MUST verify:
+
+- One stable split view hosts Dashboard and Workspace content.
+- All three Navigator selector states.
+- Workspace and File disabled states without an Active Workspace.
+- File placeholder with an Active Workspace.
+- Workspace Switcher active, disconnected, archived, ambiguous-Project, and no-active states.
+- Dashboard does not expose an inspector toggle.
+- Session content exposes the inspector and updates it when selection changes.
+- Switching Navigator does not replace hosted main content.
+
+### 15.4 Regression and Manual Checks
+
+Manual checks MUST include:
+
+- Repeated Dashboard, Navigator, and Workspace transitions without Dashboard layout corruption.
+- Sidebar hide/show from Dashboard and Session content.
+- Live terminal typing and scrollback preservation across Navigator and Dashboard transitions.
+- Workspace switching from both Projects Navigator and Workspace Switcher.
+- Connection loss and recovery while a Workspace is active.
+- Archiving and removing the Active Workspace.
+- VoiceOver/help labels for Navigator icons and Workspace Switcher.
+
+Required commands:
+
+```sh
+mise run macos:test
+mise run check
+```
+
+## 16. Definition of Done
+
+Required for completion:
+
+- Root navigation, Navigator contents, Workspace Switcher, activation transitions, restoration, and inspector behavior satisfy this specification.
+- Obsolete Dashboard/Workspace route and cover state is removed.
+- Shared activation and selection logic has one owner.
+- Existing Project, Workspace, Session, Terminal, Dashboard, and lifecycle behavior remains covered.
+- New state, grouping, persistence, hosting, and regression tests pass.
+- `mise run macos:test` and `mise run check` pass.
+- Relevant code comments and documentation use the canonical language from `CONTEXT.md`.
+
+Out of scope for completion:
+
+- File browsing.
+- Additional Navigators.
+- Multi-window behavior.
+- Navigator or Workspace-switch keyboard commands and shortcuts.
+- Dedicated archive-management UI beyond existing Dashboard and Workspace Navigator controls.
+
+## 17. Open Questions
+
+None. Product decisions needed for this implementation are resolved in the source brief and this specification.

--- a/macos/ATC/AppCommands.swift
+++ b/macos/ATC/AppCommands.swift
@@ -10,7 +10,8 @@ struct AppCommands: Commands {
 
     var body: some Commands {
         CommandGroup(replacing: .newItem) {
-            // session.new / terminal.new: need an active open Workspace.
+            // Availability is based on the Active Workspace, independent of
+            // the visible Navigator or main-content destination.
             Button("New Session") {
                 windowState.startSessionKind = .agentSession
             }
@@ -41,12 +42,11 @@ struct AppCommands: Commands {
         }
 
         CommandGroup(after: .sidebar) {
-            // view.toggle-sidebar: only meaningful in the Workspace shell.
+            // The stable root split view makes this meaningful everywhere.
             Button("Toggle Sidebar") {
                 windowState.toggleSidebar()
             }
             .keyboardShortcut("b", modifiers: .command)
-            .disabled(windowState.route != .workspace)
 
             // data.refresh: always available.
             Button("Refresh") {

--- a/macos/ATC/AppModel.swift
+++ b/macos/ATC/AppModel.swift
@@ -53,6 +53,12 @@ final class AppModel {
     /// LRU order over `terminals` keys, least-recently-used first.
     private var attachOrder: [SessionRef] = []
 
+    /// Refs whose terminals were torn down through `disconnectTerminal`.
+    /// Window reconciliation consults this so a Disconnect sticks instead
+    /// of being silently undone on the next store change; any explicit
+    /// attach clears the mark.
+    private var detachedRefs: Set<SessionRef> = []
+
     private let clientFactory: (ConnectionRecord) -> any ATCClient
     private let terminalControllerFactory: (String, any ATCClient) -> TerminalSessionController
     private let terminalRecoveryMonitor: TerminalRecoveryMonitor
@@ -232,6 +238,7 @@ final class AppModel {
         retentionContext: TerminalRetentionContext = .empty
     ) {
         let ref = SessionRef(connectionID: connectionID, sessionID: session.id)
+        detachedRefs.remove(ref)
         if terminals[ref] != nil {
             markRecentlyUsed(ref)
             return
@@ -252,6 +259,12 @@ final class AppModel {
         terminals[ref]?.disconnect()
         terminals.removeValue(forKey: ref)
         attachOrder.removeAll { $0 == ref }
+        detachedRefs.insert(ref)
+    }
+
+    /// Whether this ref was disconnected and never explicitly re-attached.
+    func isDetached(_ ref: SessionRef) -> Bool {
+        detachedRefs.contains(ref)
     }
 
     /// Wake and path recovery are app-wide signals. A controller decides
@@ -321,5 +334,8 @@ final class AppModel {
         for ref in terminals.keys where ref.connectionID == runtime.id {
             disconnectTerminal(ref: ref)
         }
+        // A teardown disconnect is infrastructure, not user intent: a
+        // rebuilt Connection may auto-reattach its selected session.
+        detachedRefs = detachedRefs.filter { $0.connectionID != runtime.id }
     }
 }

--- a/macos/ATC/AppModel.swift
+++ b/macos/ATC/AppModel.swift
@@ -18,7 +18,6 @@ struct WindowNavigationSnapshot: Equatable {
             let workspaceID: String?
             let isArchived: Bool
             let attachable: Bool
-            let status: String
         }
 
         let id: UUID
@@ -150,8 +149,7 @@ final class AppModel {
                         id: $0.id,
                         workspaceID: $0.workspace?.id,
                         isArchived: $0.isArchived,
-                        attachable: $0.attachable,
-                        status: String(describing: $0.status)
+                        attachable: $0.attachable
                     )
                 }
             )
@@ -311,7 +309,7 @@ final class AppModel {
         guard let activeWorkspace = retentionContext.activeWorkspace,
               activeWorkspace.connectionID == ref.connectionID
         else { return false }
-        return session(for: ref)?.workspace?.id == activeWorkspace.workspaceID
+        return session(for: ref)?.belongs(to: activeWorkspace) == true
     }
 
     // MARK: - Private

--- a/macos/ATC/AppModel.swift
+++ b/macos/ATC/AppModel.swift
@@ -5,6 +5,32 @@ import ATCAPI
 
 private let logger = Logger(subsystem: "ElevenIdeas.atc", category: "appmodel")
 
+struct WindowNavigationSnapshot: Equatable {
+    struct Connection: Equatable {
+        struct WorkspaceRecord: Equatable {
+            let id: String
+            let projectID: String
+            let isArchived: Bool
+        }
+
+        struct SessionRecord: Equatable {
+            let id: String
+            let workspaceID: String?
+            let isArchived: Bool
+            let attachable: Bool
+            let status: String
+        }
+
+        let id: UUID
+        let workspacesLoaded: Bool
+        let sessionsLoaded: Bool
+        let workspaces: [WorkspaceRecord]
+        let sessions: [SessionRecord]
+    }
+
+    let connections: [Connection]
+}
+
 /// Root domain model: owns the Connection list and one `ConnectionRuntime`
 /// per Connection. Aggregation across Connections happens above the
 /// per-runtime stores, in pure code (`DashboardGroups`).
@@ -13,24 +39,6 @@ final class AppModel {
     let connections: ConnectionsStore
     private(set) var runtimes: [ConnectionRuntime] = []
 
-    /// Sidebar selection. Lives here (not in a view) so deleting a
-    /// Connection can clear a selection that pointed into it. Selecting an
-    /// attached session marks it most-recently-used for the attachment
-    /// budget (cold sessions enter the order when they attach).
-    var selection: SessionRef? {
-        didSet {
-            if let selection, terminals[selection] != nil {
-                markRecentlyUsed(selection)
-            }
-        }
-    }
-
-    /// The Workspace mounted in the window's shell (stays set while the
-    /// Dashboard covers it). Lives here so the attachment budget can pin
-    /// its sessions and so store-driven cleanup (a remote delete) has one
-    /// owner; the window's route (Dashboard vs shell) stays view state.
-    var openWorkspace: WorkspaceRef?
-
     /// Live terminal attaches by composite ref. Connections and surfaces
     /// stay alive here while the user switches around the sidebar, bounded
     /// by `attachmentBudget`.
@@ -38,9 +46,8 @@ final class AppModel {
 
     /// Maximum simultaneously attached terminals (WebSocket + Ghostty
     /// surface each). Not user-facing configuration. Pinned refs — the
-    /// current selection and the open Workspace's sessions — are never
-    /// evicted, even if that means exceeding the budget until the
-    /// Workspace closes (correctness over the cap).
+    /// the selected Session and Active Workspace supplied by the window are
+    /// never evicted, even if that means temporarily exceeding the budget.
     let attachmentBudget: Int
 
     /// LRU order over `terminals` keys, least-recently-used first.
@@ -96,14 +103,28 @@ final class AppModel {
         runtime(id: ref.connectionID)?.sessions.session(id: ref.sessionID)
     }
 
-    /// Whether the open Workspace still exists: false once its Connection
-    /// is gone, or its workspaces store has loaded and no longer contains
-    /// it (deleted via web/CLI). Drives the window back to the Dashboard.
-    var openWorkspaceExists: Bool {
-        guard let ref = openWorkspace,
-              let runtime = runtime(id: ref.connectionID) else { return false }
-        return !runtime.workspaces.hasLoadedOnce
-            || runtime.workspaces.workspace(id: ref.workspaceID) != nil
+    /// A compact, value-semantic projection used by the window to reconcile
+    /// store-driven removals and delayed selection restoration.
+    func windowNavigationSnapshot() -> WindowNavigationSnapshot {
+        WindowNavigationSnapshot(connections: runtimes.map { runtime in
+            WindowNavigationSnapshot.Connection(
+                id: runtime.id,
+                workspacesLoaded: runtime.workspaces.hasLoadedOnce,
+                sessionsLoaded: runtime.sessions.hasLoadedOnce,
+                workspaces: runtime.workspaces.workspaces.map {
+                    .init(id: $0.id, projectID: $0.projectId, isArchived: $0.isArchived)
+                },
+                sessions: runtime.sessions.sessions.map {
+                    .init(
+                        id: $0.id,
+                        workspaceID: $0.workspace?.id,
+                        isArchived: $0.isArchived,
+                        attachable: $0.attachable,
+                        status: String(describing: $0.status)
+                    )
+                }
+            )
+        })
     }
 
     /// Refreshes every Connection concurrently so one unreachable server
@@ -169,9 +190,8 @@ final class AppModel {
         }
     }
 
-    /// Deletes a Connection locally: stops polling, disconnects its
-    /// terminals, clears a selection pointing into it. No server calls —
-    /// Projects and Sessions remain on the atc server.
+    /// Deletes a Connection locally and disconnects its terminals. Window
+    /// navigation references are reconciled by `WindowState`.
     func removeConnection(id: UUID) {
         connections.remove(id: id)
         guard let index = runtimes.firstIndex(where: { $0.id == id }) else { return }
@@ -181,7 +201,11 @@ final class AppModel {
 
     // MARK: - Terminal registry
 
-    func attachIfNeeded(to session: Session, connectionID: UUID) {
+    func attachIfNeeded(
+        to session: Session,
+        connectionID: UUID,
+        retentionContext: TerminalRetentionContext = .empty
+    ) {
         let ref = SessionRef(connectionID: connectionID, sessionID: session.id)
         if terminals[ref] != nil {
             markRecentlyUsed(ref)
@@ -191,7 +215,12 @@ final class AppModel {
               let runtime = runtime(id: connectionID) else { return }
         terminals[ref] = terminalControllerFactory(session.id, runtime.client)
         markRecentlyUsed(ref)
-        evictOverBudget()
+        evictOverBudget(retentionContext: retentionContext)
+    }
+
+    func touchTerminal(_ ref: SessionRef) {
+        guard terminals[ref] != nil else { return }
+        markRecentlyUsed(ref)
     }
 
     func disconnectTerminal(ref: SessionRef) {
@@ -223,24 +252,28 @@ final class AppModel {
     /// standard disconnect path. Pinned refs and the just-attached ref
     /// (the LRU tail) are skipped; if they alone exceed the budget, it is
     /// simply exceeded.
-    private func evictOverBudget() {
+    private func evictOverBudget(retentionContext: TerminalRetentionContext) {
         guard terminals.count > attachmentBudget else { return }
         // Ordering invariant: every terminals key was appended in
         // markRecentlyUsed, so attachOrder covers all candidates.
         let newest = attachOrder.last
         for ref in attachOrder where terminals.count > attachmentBudget {
-            if ref == newest || isPinned(ref) { continue }
+            if ref == newest || isPinned(ref, retentionContext: retentionContext) { continue }
             disconnectTerminal(ref: ref)
         }
     }
 
-    /// The current selection and the open Workspace's sessions are never
-    /// evicted. A session no longer in its store (deleted remotely) can't
-    /// be resolved to a workspace and is therefore evictable.
-    private func isPinned(_ ref: SessionRef) -> Bool {
-        if ref == selection { return true }
-        guard let openWorkspace, openWorkspace.connectionID == ref.connectionID else { return false }
-        return session(for: ref)?.workspace?.id == openWorkspace.workspaceID
+    /// Navigation state is window-owned, so eviction receives a derived
+    /// retention context instead of reading a duplicate mutable selection.
+    private func isPinned(
+        _ ref: SessionRef,
+        retentionContext: TerminalRetentionContext
+    ) -> Bool {
+        if ref == retentionContext.selectedSession { return true }
+        guard let activeWorkspace = retentionContext.activeWorkspace,
+              activeWorkspace.connectionID == ref.connectionID
+        else { return false }
+        return session(for: ref)?.workspace?.id == activeWorkspace.workspaceID
     }
 
     // MARK: - Private
@@ -262,12 +295,6 @@ final class AppModel {
         runtime.stopPolling()
         for ref in terminals.keys where ref.connectionID == runtime.id {
             disconnectTerminal(ref: ref)
-        }
-        if selection?.connectionID == runtime.id {
-            selection = nil
-        }
-        if openWorkspace?.connectionID == runtime.id {
-            openWorkspace = nil
         }
     }
 }

--- a/macos/ATC/AppModel.swift
+++ b/macos/ATC/AppModel.swift
@@ -22,8 +22,8 @@ struct WindowNavigationSnapshot: Equatable {
         }
 
         let id: UUID
-        let workspacesLoaded: Bool
-        let sessionsLoaded: Bool
+        let workspacesCurrent: Bool
+        let sessionsCurrent: Bool
         let workspaces: [WorkspaceRecord]
         let sessions: [SessionRecord]
     }
@@ -99,6 +99,29 @@ final class AppModel {
         runtime(id: id)?.reachability ?? .unknown
     }
 
+    /// Network-backed mutations are only offered after the Connection's
+    /// latest combined refresh succeeded. Unknown and unreachable runtimes
+    /// are read-only until polling establishes a current model again.
+    func canMutate(connectionID: UUID) -> Bool {
+        runtime(id: connectionID)?.reachability == .connected
+    }
+
+    func canCreateWorkspace(in ref: ProjectRef) -> Bool {
+        guard canMutate(connectionID: ref.connectionID),
+              let project = runtime(id: ref.connectionID)?.projects.project(id: ref.projectID)
+        else { return false }
+        return !project.isArchived
+    }
+
+    func canStartSession(in ref: WorkspaceRef) -> Bool {
+        guard canMutate(connectionID: ref.connectionID),
+              let workspace = runtime(id: ref.connectionID)?.workspaces.workspace(
+                id: ref.workspaceID
+              )
+        else { return false }
+        return !workspace.isArchived
+    }
+
     func session(for ref: SessionRef) -> Session? {
         runtime(id: ref.connectionID)?.sessions.session(id: ref.sessionID)
     }
@@ -109,8 +132,10 @@ final class AppModel {
         WindowNavigationSnapshot(connections: runtimes.map { runtime in
             WindowNavigationSnapshot.Connection(
                 id: runtime.id,
-                workspacesLoaded: runtime.workspaces.hasLoadedOnce,
-                sessionsLoaded: runtime.sessions.hasLoadedOnce,
+                workspacesCurrent: runtime.workspaces.hasLoadedOnce
+                    && runtime.workspaces.lastError == nil,
+                sessionsCurrent: runtime.sessions.hasLoadedOnce
+                    && runtime.sessions.lastError == nil,
                 workspaces: runtime.workspaces.workspaces.map {
                     .init(id: $0.id, projectID: $0.projectId, isArchived: $0.isArchived)
                 },

--- a/macos/ATC/ConnectionRuntime.swift
+++ b/macos/ATC/ConnectionRuntime.swift
@@ -5,19 +5,19 @@ import ATCAPI
 /// Composite identity for a session: local Connection ID plus the server's
 /// record ID. Selection, the terminal registry, and every cross-Connection
 /// reference use these — never a bare server ID.
-struct SessionRef: Hashable {
+struct SessionRef: Hashable, Sendable {
     let connectionID: UUID
     let sessionID: String
 }
 
 /// Composite identity for a project (see `SessionRef`).
-struct ProjectRef: Hashable {
+struct ProjectRef: Hashable, Sendable {
     let connectionID: UUID
     let projectID: String
 }
 
 /// Composite identity for a workspace (see `SessionRef`).
-struct WorkspaceRef: Hashable {
+struct WorkspaceRef: Hashable, Sendable {
     let connectionID: UUID
     let workspaceID: String
 }

--- a/macos/ATC/Features/Dashboard/DashboardGroups.swift
+++ b/macos/ATC/Features/Dashboard/DashboardGroups.swift
@@ -62,6 +62,11 @@ struct DashboardGroups {
     /// True when no section has any visible card.
     var isEmpty: Bool { sections.allSatisfy(\.cards.isEmpty) }
 
+    /// Visible Workspace refs in display order, for keyboard navigation.
+    var workspaceRefs: [WorkspaceRef] {
+        sections.flatMap { $0.cards.flatMap { $0.rows.map(\.ref) } }
+    }
+
     init(inputs: [ConnectionInput], showArchived: Bool) {
         for input in inputs {
             totalProjectCount += input.projects.count
@@ -73,7 +78,7 @@ struct DashboardGroups {
                 let all = workspacesByProject[project.id] ?? []
                 let rows = all
                     .filter { showArchived || !$0.isArchived }
-                    .sorted { $0.createdAt > $1.createdAt }
+                    .sortedNewestFirst()
                     .map { workspace in
                         let members = sessionsByWorkspace[workspace.id] ?? []
                         let active = members.filter {

--- a/macos/ATC/Features/Dashboard/DashboardView.swift
+++ b/macos/ATC/Features/Dashboard/DashboardView.swift
@@ -167,20 +167,15 @@ struct DashboardView: View {
         let reachability = appModel.reachability(of: section.connectionID)
         return VStack(alignment: .leading, spacing: Spacing.md) {
             HStack(spacing: Spacing.sm) {
-                Circle()
-                    .fill(reachability.color)
-                    .frame(width: 9, height: 9)
-                    .shadow(color: reachability.color.opacity(0.45), radius: 5)
+                StatusDot(color: reachability.color)
 
                 Text(section.connectionName)
                     .font(.title3.weight(.semibold))
 
-                Text(section.contextLabel == "Local" ? "LOCAL" : "REMOTE")
-                    .font(.caption2.monospaced().weight(.semibold))
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 7)
-                    .padding(.vertical, 2)
-                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 5))
+                TagBadge(
+                    text: section.contextLabel == "Local" ? "LOCAL" : "REMOTE",
+                    monospaced: true
+                )
 
                 if section.contextLabel != "Local" {
                     Text("·  \(section.contextLabel)")
@@ -271,12 +266,7 @@ struct DashboardView: View {
                 .truncationMode(.head)
 
             if card.project.isArchived {
-                Text("Archived")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(.quaternary, in: Capsule())
+                TagBadge(text: "Archived")
             }
 
             Spacer(minLength: Spacing.md)
@@ -391,26 +381,14 @@ struct DashboardView: View {
             onOpenWorkspace(row.ref)
         } label: {
             HStack(spacing: Spacing.md) {
-                Circle()
-                    .fill(row.hasActiveSessions ? Color.green : Color.clear)
-                    .frame(width: 8, height: 8)
-                    .overlay {
-                        if !row.hasActiveSessions {
-                            Circle().stroke(.tertiary, lineWidth: 2)
-                        }
-                    }
+                StatusDot(color: .green, hollow: !row.hasActiveSessions)
 
                 Text(workspace.name)
                     .font(.body.monospaced())
                     .lineLimit(1)
 
                 if workspace.isArchived {
-                    Text("Archived")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(.quaternary, in: Capsule())
+                    TagBadge(text: "Archived")
                 }
 
                 Spacer()

--- a/macos/ATC/Features/Dashboard/DashboardView.swift
+++ b/macos/ATC/Features/Dashboard/DashboardView.swift
@@ -11,8 +11,12 @@ struct DashboardView: View {
     /// Presents the create-Workspace sheet fixed to a Project.
     var onCreateWorkspace: (ProjectRef) -> Void
     var onCreateProject: () -> Void
+    /// Clears window selection memory for a deleted Workspace.
+    var onWorkspaceDeleted: (WorkspaceRef) -> Void
 
     @State private var showArchived = false
+    /// Keyboard focus over workspace rows: arrows move, Return opens.
+    @State private var focusedWorkspace: WorkspaceRef?
     @State private var renamingWorkspace: DashboardGroups.WorkspaceRow?
     @State private var renamingProject: DashboardGroups.ProjectCard?
     @State private var renameDraft = ""
@@ -33,16 +37,23 @@ struct DashboardView: View {
             },
             showArchived: showArchived
         )
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: Spacing.xxl) {
-                ForEach(groups.sections) { section in
-                    connectionSection(section)
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: Spacing.xxl) {
+                    ForEach(groups.sections) { section in
+                        connectionSection(section)
+                    }
                 }
+                .frame(maxWidth: 1_280, alignment: .leading)
+                .padding(.horizontal, Spacing.xxl)
+                .padding(.vertical, Spacing.xxl)
+                .frame(maxWidth: .infinity, alignment: .top)
             }
-            .frame(maxWidth: 1_280, alignment: .leading)
-            .padding(.horizontal, Spacing.xxl)
-            .padding(.vertical, Spacing.xxl)
-            .frame(maxWidth: .infinity, alignment: .top)
+            .focusable()
+            .focusEffectDisabled()
+            .onKeyPress(.downArrow) { moveFocus(1, through: groups.workspaceRefs, proxy: proxy) }
+            .onKeyPress(.upArrow) { moveFocus(-1, through: groups.workspaceRefs, proxy: proxy) }
+            .onKeyPress(.return) { openFocusedWorkspace() }
         }
         .toolbar {
             ToolbarItemGroup(placement: .primaryAction) {
@@ -83,7 +94,9 @@ struct DashboardView: View {
             Button("Rename") {
                 if let row = renamingWorkspace, let store = workspacesStore(for: row.ref.connectionID) {
                     let trimmed = renameDraft.trimmingCharacters(in: .whitespaces)
-                    run { try await store.rename(id: row.workspace.id, name: trimmed) }
+                    appModel.run(on: row.ref.connectionID, reporting: $actionError) {
+                        try await store.rename(id: row.workspace.id, name: trimmed)
+                    }
                 }
             }
             .disabled(
@@ -101,7 +114,9 @@ struct DashboardView: View {
                 if let card = renamingProject,
                    let store = appModel.runtime(id: card.ref.connectionID)?.projects {
                     let trimmed = renameDraft.trimmingCharacters(in: .whitespaces)
-                    run { try await store.rename(id: card.project.id, name: trimmed) }
+                    appModel.run(on: card.ref.connectionID, reporting: $actionError) {
+                        try await store.rename(id: card.project.id, name: trimmed)
+                    }
                 }
             }
             .disabled(
@@ -142,7 +157,9 @@ struct DashboardView: View {
             Button("Delete Project", role: .destructive) {
                 if let card = deletingProject,
                    let store = appModel.runtime(id: card.ref.connectionID)?.projects {
-                    run { try await store.delete(id: card.project.id) }
+                    appModel.run(on: card.ref.connectionID, reporting: $actionError) {
+                        try await store.delete(id: card.project.id)
+                    }
                 }
             }
             .disabled(!(deletingProject.map { canMutate($0.ref.connectionID) } ?? false))
@@ -194,7 +211,13 @@ struct DashboardView: View {
 
             VStack(spacing: Spacing.md) {
                 ForEach(section.cards) { card in
-                    projectCard(card, reachable: canMutate(section.connectionID))
+                    projectCard(
+                        card,
+                        reachable: canMutate(section.connectionID),
+                        // Opening is local navigation over cached data; only
+                        // a confirmed-unreachable Connection blocks it.
+                        canOpen: reachability != .unreachable
+                    )
                 }
 
                 if section.cards.isEmpty {
@@ -217,7 +240,11 @@ struct DashboardView: View {
     // MARK: - Project card
 
     @ViewBuilder
-    private func projectCard(_ card: DashboardGroups.ProjectCard, reachable: Bool) -> some View {
+    private func projectCard(
+        _ card: DashboardGroups.ProjectCard,
+        reachable: Bool,
+        canOpen: Bool
+    ) -> some View {
         if card.rows.isEmpty && !card.project.isArchived {
             emptyProjectCard(card, reachable: reachable)
         } else {
@@ -227,7 +254,8 @@ struct DashboardView: View {
                 if !card.rows.isEmpty {
                     Divider()
                     ForEach(Array(card.rows.enumerated()), id: \.element.id) { index, row in
-                        workspaceRow(row, reachable: reachable)
+                        workspaceRow(row, reachable: reachable, canOpen: canOpen)
+                            .id(row.ref)
                         if index < card.rows.count - 1 {
                             Divider()
                         }
@@ -342,14 +370,18 @@ struct DashboardView: View {
             // is archived. A stale view still gets the 409 via the alert.
             Button("Archive Project", systemImage: "archivebox") {
                 if let store = appModel.runtime(id: card.ref.connectionID)?.projects {
-                    run { try await store.archive(id: project.id) }
+                    appModel.run(on: card.ref.connectionID, reporting: $actionError) {
+                        try await store.archive(id: project.id)
+                    }
                 }
             }
             .disabled(!reachable || card.hasUnarchivedWorkspaces)
         } else {
             Button("Unarchive Project", systemImage: "archivebox") {
                 if let store = appModel.runtime(id: card.ref.connectionID)?.projects {
-                    run { try await store.unarchive(id: project.id) }
+                    appModel.run(on: card.ref.connectionID, reporting: $actionError) {
+                        try await store.unarchive(id: project.id)
+                    }
                 }
             }
             .disabled(!reachable)
@@ -367,7 +399,8 @@ struct DashboardView: View {
     @ViewBuilder
     private func workspaceRow(
         _ row: DashboardGroups.WorkspaceRow,
-        reachable: Bool
+        reachable: Bool,
+        canOpen: Bool
     ) -> some View {
         let workspace = row.workspace
         Button {
@@ -395,13 +428,18 @@ struct DashboardView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .disabled(!reachable)
+        .background(
+            focusedWorkspace == row.ref
+                ? Color(nsColor: .quaternarySystemFill)
+                : .clear
+        )
+        .disabled(!canOpen)
         .opacity(workspace.isArchived ? Dimming.archived : 1)
         .contextMenu {
             Button("Open", systemImage: "arrow.up.forward.square") {
                 onOpenWorkspace(row.ref)
             }
-            .disabled(!reachable)
+            .disabled(!canOpen)
             Button("Rename…", systemImage: "pencil") {
                 renameDraft = workspace.name
                 renamingWorkspace = row
@@ -411,7 +449,9 @@ struct DashboardView: View {
             if workspace.isArchived {
                 Button("Unarchive", systemImage: "archivebox") {
                     if let store = workspacesStore(for: row.ref.connectionID) {
-                        run { try await store.unarchive(id: workspace.id) }
+                        appModel.run(on: row.ref.connectionID, reporting: $actionError) {
+                            try await store.unarchive(id: workspace.id)
+                        }
                     }
                 }
                 .disabled(!reachable)
@@ -419,7 +459,9 @@ struct DashboardView: View {
                 // Mirrors the server rule: no archiving with active sessions.
                 Button("Archive", systemImage: "archivebox") {
                     if let store = workspacesStore(for: row.ref.connectionID) {
-                        run { try await store.archive(id: workspace.id) }
+                        appModel.run(on: row.ref.connectionID, reporting: $actionError) {
+                            try await store.archive(id: workspace.id)
+                        }
                     }
                 }
                 .disabled(!reachable || row.hasActiveSessions)
@@ -490,31 +532,48 @@ struct DashboardView: View {
         appModel.canMutate(connectionID: connectionID)
     }
 
+    // MARK: - Keyboard navigation
+
+    private func moveFocus(
+        _ delta: Int,
+        through refs: [WorkspaceRef],
+        proxy: ScrollViewProxy
+    ) -> KeyPress.Result {
+        guard !refs.isEmpty else { return .ignored }
+        let current = focusedWorkspace.flatMap { refs.firstIndex(of: $0) }
+        let next = current.map { max(0, min(refs.count - 1, $0 + delta)) }
+            ?? (delta > 0 ? 0 : refs.count - 1)
+        focusedWorkspace = refs[next]
+        proxy.scrollTo(refs[next])
+        return .handled
+    }
+
+    private func openFocusedWorkspace() -> KeyPress.Result {
+        guard let focusedWorkspace else { return .ignored }
+        onOpenWorkspace(focusedWorkspace)
+        return .handled
+    }
+
     private func workspacesStore(for connectionID: UUID) -> WorkspacesStore? {
         appModel.runtime(id: connectionID)?.workspaces
     }
 
     private func deleteWorkspace(_ row: DashboardGroups.WorkspaceRow) {
-        run {
-            guard let store = workspacesStore(for: row.ref.connectionID) else { return }
+        guard let store = workspacesStore(for: row.ref.connectionID) else { return }
+        appModel.run(on: row.ref.connectionID, reporting: $actionError) {
             try await store.delete(id: row.workspace.id)
-            WorkspaceSelectionMemory().forget(row.ref)
-        }
-    }
-
-    private func run(_ operation: @escaping () async throws -> Void) {
-        Task {
-            do {
-                try await operation()
-            } catch {
-                actionError = error.localizedDescription
-            }
+            onWorkspaceDeleted(row.ref)
         }
     }
 }
 
 #Preview {
-    DashboardView(onOpenWorkspace: { _ in }, onCreateWorkspace: { _ in }, onCreateProject: {})
+    DashboardView(
+        onOpenWorkspace: { _ in },
+        onCreateWorkspace: { _ in },
+        onCreateProject: {},
+        onWorkspaceDeleted: { _ in }
+    )
         .environment(AppModel.preview())
         .preferredColorScheme(.dark)
 }

--- a/macos/ATC/Features/Dashboard/DashboardView.swift
+++ b/macos/ATC/Features/Dashboard/DashboardView.swift
@@ -1,10 +1,8 @@
 import SwiftUI
 import ATCAPI
 
-/// The launch surface: every Connection's Projects and Workspaces, for
-/// finding, creating, and opening Workspaces. Rendered as an opaque cover
-/// over the (possibly mounted) Workspace shell; opening a Workspace routes
-/// the window to the shell without tearing this down.
+/// App-wide Project and Workspace management rendered as a main-content
+/// destination inside the stable window split view.
 struct DashboardView: View {
     @Environment(AppModel.self) private var appModel
     /// Opens a Workspace in the shell.
@@ -393,7 +391,7 @@ struct DashboardView: View {
         run {
             guard let store = workspacesStore(for: row.ref.connectionID) else { return }
             try await store.delete(id: row.workspace.id)
-            WorkspaceSelectionMemory().forget(workspaceID: row.workspace.id)
+            WorkspaceSelectionMemory().forget(row.ref)
         }
     }
 

--- a/macos/ATC/Features/Dashboard/DashboardView.swift
+++ b/macos/ATC/Features/Dashboard/DashboardView.swift
@@ -151,14 +151,7 @@ struct DashboardView: View {
                 Text(DeleteConfirmation.projectMessage(name: card.project.name))
             }
         }
-        .alert("Action Failed", isPresented: Binding(
-            get: { actionError != nil },
-            set: { if !$0 { actionError = nil } }
-        )) {
-            Button("OK", role: .cancel) {}
-        } message: {
-            Text(actionError ?? "")
-        }
+        .actionErrorAlert($actionError)
     }
 
     // MARK: - Connection section

--- a/macos/ATC/Features/Dashboard/DashboardView.swift
+++ b/macos/ATC/Features/Dashboard/DashboardView.swift
@@ -34,14 +34,14 @@ struct DashboardView: View {
             showArchived: showArchived
         )
         ScrollView {
-            LazyVStack(alignment: .leading, spacing: 34) {
+            LazyVStack(alignment: .leading, spacing: Spacing.xxl) {
                 ForEach(groups.sections) { section in
                     connectionSection(section)
                 }
             }
             .frame(maxWidth: 1_280, alignment: .leading)
-            .padding(.horizontal, 36)
-            .padding(.vertical, 32)
+            .padding(.horizontal, Spacing.xxl)
+            .padding(.vertical, Spacing.xxl)
             .frame(maxWidth: .infinity, alignment: .top)
         }
         .toolbar {
@@ -165,8 +165,8 @@ struct DashboardView: View {
 
     private func connectionSection(_ section: DashboardGroups.Section) -> some View {
         let reachability = appModel.reachability(of: section.connectionID)
-        return VStack(alignment: .leading, spacing: 14) {
-            HStack(spacing: 9) {
+        return VStack(alignment: .leading, spacing: Spacing.md) {
+            HStack(spacing: Spacing.sm) {
                 Circle()
                     .fill(reachability.color)
                     .frame(width: 9, height: 9)
@@ -204,7 +204,7 @@ struct DashboardView: View {
                 }
             }
 
-            VStack(spacing: 14) {
+            VStack(spacing: Spacing.md) {
                 ForEach(section.cards) { card in
                     projectCard(card, reachable: canMutate(section.connectionID))
                 }
@@ -215,7 +215,7 @@ struct DashboardView: View {
                         .foregroundStyle(.tertiary)
                         .frame(maxWidth: .infinity, minHeight: 72, alignment: .center)
                         .overlay {
-                            RoundedRectangle(cornerRadius: 12)
+                            RoundedRectangle(cornerRadius: Radius.card)
                                 .stroke(
                                     Color(nsColor: .separatorColor),
                                     style: StrokeStyle(lineWidth: 1, dash: [5, 4])
@@ -251,7 +251,7 @@ struct DashboardView: View {
                 cardShape.stroke(Color(nsColor: .separatorColor), lineWidth: 1)
             }
             .clipShape(cardShape)
-            .opacity(card.project.isArchived ? 0.55 : 1)
+            .opacity(card.project.isArchived ? Dimming.archived : 1)
         }
     }
 
@@ -259,7 +259,7 @@ struct DashboardView: View {
         _ card: DashboardGroups.ProjectCard,
         reachable: Bool
     ) -> some View {
-        HStack(spacing: 10) {
+        HStack(spacing: Spacing.sm) {
             Text(card.project.name)
                 .font(.headline)
                 .lineLimit(1)
@@ -279,7 +279,7 @@ struct DashboardView: View {
                     .background(.quaternary, in: Capsule())
             }
 
-            Spacer(minLength: 12)
+            Spacer(minLength: Spacing.md)
 
             if !card.project.isArchived {
                 Button {
@@ -295,7 +295,7 @@ struct DashboardView: View {
                 .help("New workspace in \(card.project.name)")
             }
         }
-        .padding(.horizontal, 18)
+        .padding(.horizontal, Spacing.lg)
         .frame(minHeight: 54)
         .contentShape(Rectangle())
         .contextMenu { projectMenu(card, reachable: reachable) }
@@ -305,7 +305,7 @@ struct DashboardView: View {
         _ card: DashboardGroups.ProjectCard,
         reachable: Bool
     ) -> some View {
-        HStack(spacing: 10) {
+        HStack(spacing: Spacing.sm) {
             Text(card.project.name)
                 .font(.headline)
                 .lineLimit(1)
@@ -321,7 +321,7 @@ struct DashboardView: View {
                 .foregroundStyle(.tertiary)
                 .italic()
 
-            Spacer(minLength: 12)
+            Spacer(minLength: Spacing.md)
 
             Button("New Workspace", systemImage: "plus") {
                 onCreateWorkspace(card.ref)
@@ -329,7 +329,7 @@ struct DashboardView: View {
             .buttonStyle(.bordered)
             .disabled(!reachable)
         }
-        .padding(.horizontal, 18)
+        .padding(.horizontal, Spacing.lg)
         .frame(minHeight: 72)
         .contentShape(Rectangle())
         .contextMenu { projectMenu(card, reachable: reachable) }
@@ -390,7 +390,7 @@ struct DashboardView: View {
         Button {
             onOpenWorkspace(row.ref)
         } label: {
-            HStack(spacing: 12) {
+            HStack(spacing: Spacing.md) {
                 Circle()
                     .fill(row.hasActiveSessions ? Color.green : Color.clear)
                     .frame(width: 8, height: 8)
@@ -419,13 +419,13 @@ struct DashboardView: View {
                     .font(.callout)
                     .foregroundStyle(.tertiary)
             }
-            .padding(.horizontal, 18)
+            .padding(.horizontal, Spacing.lg)
             .frame(minHeight: 48)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .disabled(!reachable)
-        .opacity(workspace.isArchived ? 0.5 : 1)
+        .opacity(workspace.isArchived ? Dimming.archived : 1)
         .contextMenu {
             Button("Open", systemImage: "arrow.up.forward.square") {
                 onOpenWorkspace(row.ref)
@@ -499,7 +499,7 @@ struct DashboardView: View {
     // MARK: - Helpers
 
     private var cardShape: RoundedRectangle {
-        RoundedRectangle(cornerRadius: 12, style: .continuous)
+        RoundedRectangle(cornerRadius: Radius.card, style: .continuous)
     }
 
     private var canCreateProject: Bool {

--- a/macos/ATC/Features/Dashboard/DashboardView.swift
+++ b/macos/ATC/Features/Dashboard/DashboardView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import ATCAPI
 
@@ -12,8 +13,6 @@ struct DashboardView: View {
     var onCreateProject: () -> Void
 
     @State private var showArchived = false
-    /// Keyboard focus for arrow-key navigation; Return opens it.
-    @State private var focusedWorkspace: WorkspaceRef?
     @State private var renamingWorkspace: DashboardGroups.WorkspaceRow?
     @State private var renamingProject: DashboardGroups.ProjectCard?
     @State private var renameDraft = ""
@@ -22,7 +21,7 @@ struct DashboardView: View {
     @State private var actionError: String?
 
     var body: some View {
-        // One pass over the runtimes per render; the List indexes into it.
+        // One pass over the runtimes per render; sections reuse the result.
         let groups = DashboardGroups(
             inputs: appModel.runtimes.map {
                 DashboardGroups.ConnectionInput(
@@ -34,51 +33,40 @@ struct DashboardView: View {
             },
             showArchived: showArchived
         )
-        List(selection: $focusedWorkspace) {
-            ForEach(groups.sections) { section in
-                Section {
-                    ForEach(section.cards) { card in
-                        projectCard(card, reachable: canMutate(section.connectionID))
-                    }
-                    if section.cards.isEmpty {
-                        Text("No projects")
-                            .font(.caption)
-                            .foregroundStyle(.tertiary)
-                    }
-                } header: {
-                    connectionHeader(section)
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 34) {
+                ForEach(groups.sections) { section in
+                    connectionSection(section)
                 }
             }
+            .frame(maxWidth: 1_280, alignment: .leading)
+            .padding(.horizontal, 36)
+            .padding(.vertical, 32)
+            .frame(maxWidth: .infinity, alignment: .top)
         }
-        .onKeyPress(.return) {
-            guard let ref = focusedWorkspace, canMutate(ref.connectionID) else {
-                return .ignored
-            }
-            onOpenWorkspace(ref)
-            return .handled
-        }
-        .safeAreaInset(edge: .top, spacing: 0) {
-            HStack {
-                Text("Workspaces")
-                    .font(.headline)
-                Spacer()
-                Toggle("Show Archived", isOn: $showArchived)
-                    .toggleStyle(.checkbox)
-                Button("New Project…") { onCreateProject() }
-                    .disabled(!appModel.runtimes.contains {
-                        appModel.canMutate(connectionID: $0.id)
-                    })
-                Button {
-                    Task { await appModel.refreshAll() }
+        .toolbar {
+            ToolbarItemGroup(placement: .primaryAction) {
+                Menu {
+                    Toggle("Show Archived", isOn: $showArchived)
+                    Divider()
+                    Button("Refresh", systemImage: "arrow.clockwise") {
+                        Task { await appModel.refreshAll() }
+                    }
                 } label: {
-                    Label("Refresh", systemImage: "arrow.clockwise")
+                    Label("Dashboard Options", systemImage: "ellipsis.circle")
                 }
                 .labelStyle(.iconOnly)
-                .help("Refresh projects, workspaces, and sessions")
+                .help("Dashboard options")
+
+                Button {
+                    onCreateProject()
+                } label: {
+                    Label("New Project", systemImage: "plus")
+                }
+                .labelStyle(.iconOnly)
+                .disabled(!canCreateProject)
+                .help("New project")
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 10)
-            .background(.bar)
         }
         .overlay {
             if appModel.runtimes.isEmpty {
@@ -175,29 +163,66 @@ struct DashboardView: View {
 
     // MARK: - Connection section
 
-    @ViewBuilder
-    private func connectionHeader(_ section: DashboardGroups.Section) -> some View {
+    private func connectionSection(_ section: DashboardGroups.Section) -> some View {
         let reachability = appModel.reachability(of: section.connectionID)
-        HStack(spacing: 6) {
-            Circle()
-                .fill(reachability.color)
-                .frame(width: 7, height: 7)
-            Text(section.connectionName)
-            Text(section.contextLabel)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            if reachability == .unreachable {
-                Image(systemName: "cable.connector.slash")
+        return VStack(alignment: .leading, spacing: 14) {
+            HStack(spacing: 9) {
+                Circle()
+                    .fill(reachability.color)
+                    .frame(width: 9, height: 9)
+                    .shadow(color: reachability.color.opacity(0.45), radius: 5)
+
+                Text(section.connectionName)
+                    .font(.title3.weight(.semibold))
+
+                Text(section.contextLabel == "Local" ? "LOCAL" : "REMOTE")
+                    .font(.caption2.monospaced().weight(.semibold))
                     .foregroundStyle(.secondary)
-                Button("Retry") {
-                    if let runtime = appModel.runtime(id: section.connectionID) {
-                        Task { await runtime.refresh() }
-                    }
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 2)
+                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 5))
+
+                if section.contextLabel != "Local" {
+                    Text("·  \(section.contextLabel)")
+                        .foregroundStyle(.tertiary)
                 }
-                .buttonStyle(.link)
-                .font(.caption)
+
+                Text("·  \(projectCountLabel(section.cards.count))")
+                    .foregroundStyle(.tertiary)
+
+                Spacer()
+
+                if reachability == .unreachable {
+                    Button("Retry", systemImage: "arrow.clockwise") {
+                        if let runtime = appModel.runtime(id: section.connectionID) {
+                            Task { await runtime.refresh() }
+                        }
+                    }
+                    .labelStyle(.iconOnly)
+                    .buttonStyle(.borderless)
+                    .help("Retry \(section.connectionName)")
+                }
             }
-            Spacer()
+
+            VStack(spacing: 14) {
+                ForEach(section.cards) { card in
+                    projectCard(card, reachable: canMutate(section.connectionID))
+                }
+
+                if section.cards.isEmpty {
+                    Text("No projects")
+                        .font(.callout)
+                        .foregroundStyle(.tertiary)
+                        .frame(maxWidth: .infinity, minHeight: 72, alignment: .center)
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(
+                                    Color(nsColor: .separatorColor),
+                                    style: StrokeStyle(lineWidth: 1, dash: [5, 4])
+                                )
+                        }
+                }
+            }
         }
     }
 
@@ -205,52 +230,114 @@ struct DashboardView: View {
 
     @ViewBuilder
     private func projectCard(_ card: DashboardGroups.ProjectCard, reachable: Bool) -> some View {
-        let project = card.project
-        Group {
-            HStack(spacing: 6) {
-                Label {
-                    Text(project.name)
-                        .lineLimit(1)
-                } icon: {
-                    Image(systemName: project.isArchived ? "archivebox" : "folder")
-                }
-                Text(project.workingDir)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.head)
-                Spacer(minLength: 4)
-                if !project.isArchived {
-                    Button {
-                        onCreateWorkspace(card.ref)
-                    } label: {
-                        Image(systemName: "plus")
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.secondary)
-                    .disabled(!reachable)
-                    .help("New workspace in \(project.name)")
-                }
-            }
-            .opacity(project.isArchived ? 0.5 : 1)
-            .contextMenu { projectMenu(card, reachable: reachable) }
+        if card.rows.isEmpty && !card.project.isArchived {
+            emptyProjectCard(card, reachable: reachable)
+        } else {
+            VStack(spacing: 0) {
+                projectHeader(card, reachable: reachable)
 
-            ForEach(card.rows) { row in
-                workspaceRow(row, project: project, reachable: reachable)
+                if !card.rows.isEmpty {
+                    Divider()
+                    ForEach(Array(card.rows.enumerated()), id: \.element.id) { index, row in
+                        workspaceRow(row, reachable: reachable)
+                        if index < card.rows.count - 1 {
+                            Divider()
+                        }
+                    }
+                }
             }
-            if card.rows.isEmpty && !project.isArchived {
-                // Quiet inline row, not a full empty-state panel.
+            .background(Color(nsColor: .controlBackgroundColor), in: cardShape)
+            .overlay {
+                cardShape.stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+            }
+            .clipShape(cardShape)
+            .opacity(card.project.isArchived ? 0.55 : 1)
+        }
+    }
+
+    private func projectHeader(
+        _ card: DashboardGroups.ProjectCard,
+        reachable: Bool
+    ) -> some View {
+        HStack(spacing: 10) {
+            Text(card.project.name)
+                .font(.headline)
+                .lineLimit(1)
+
+            Text(card.project.workingDir)
+                .font(.callout.monospaced())
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+                .truncationMode(.head)
+
+            if card.project.isArchived {
+                Text("Archived")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(.quaternary, in: Capsule())
+            }
+
+            Spacer(minLength: 12)
+
+            if !card.project.isArchived {
                 Button {
                     onCreateWorkspace(card.ref)
                 } label: {
                     Label("New Workspace", systemImage: "plus")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .labelStyle(.iconOnly)
+                        .frame(width: 22, height: 22)
                 }
-                .buttonStyle(.plain)
-                .padding(.leading, 24)
+                .buttonStyle(.borderless)
+                .foregroundStyle(.secondary)
                 .disabled(!reachable)
+                .help("New workspace in \(card.project.name)")
             }
+        }
+        .padding(.horizontal, 18)
+        .frame(minHeight: 54)
+        .contentShape(Rectangle())
+        .contextMenu { projectMenu(card, reachable: reachable) }
+    }
+
+    private func emptyProjectCard(
+        _ card: DashboardGroups.ProjectCard,
+        reachable: Bool
+    ) -> some View {
+        HStack(spacing: 10) {
+            Text(card.project.name)
+                .font(.headline)
+                .lineLimit(1)
+
+            Text(card.project.workingDir)
+                .font(.callout.monospaced())
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+                .truncationMode(.head)
+
+            Text("No workspaces yet")
+                .font(.callout)
+                .foregroundStyle(.tertiary)
+                .italic()
+
+            Spacer(minLength: 12)
+
+            Button("New Workspace", systemImage: "plus") {
+                onCreateWorkspace(card.ref)
+            }
+            .buttonStyle(.bordered)
+            .disabled(!reachable)
+        }
+        .padding(.horizontal, 18)
+        .frame(minHeight: 72)
+        .contentShape(Rectangle())
+        .contextMenu { projectMenu(card, reachable: reachable) }
+        .overlay {
+            cardShape.stroke(
+                Color(nsColor: .separatorColor),
+                style: StrokeStyle(lineWidth: 1, dash: [5, 4])
+            )
         }
     }
 
@@ -297,34 +384,48 @@ struct DashboardView: View {
     @ViewBuilder
     private func workspaceRow(
         _ row: DashboardGroups.WorkspaceRow,
-        project: Project,
         reachable: Bool
     ) -> some View {
         let workspace = row.workspace
-        HStack(spacing: 6) {
-            Image(systemName: "square.on.square")
-                .foregroundStyle(.secondary)
-                .font(.caption)
-            Text(workspace.name)
-                .lineLimit(1)
-            if workspace.isArchived {
-                Text("Archived")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 5)
-                    .padding(.vertical, 1)
-                    .background(.quaternary.opacity(0.5), in: Capsule())
+        Button {
+            onOpenWorkspace(row.ref)
+        } label: {
+            HStack(spacing: 12) {
+                Circle()
+                    .fill(row.hasActiveSessions ? Color.green : Color.clear)
+                    .frame(width: 8, height: 8)
+                    .overlay {
+                        if !row.hasActiveSessions {
+                            Circle().stroke(.tertiary, lineWidth: 2)
+                        }
+                    }
+
+                Text(workspace.name)
+                    .font(.body.monospaced())
+                    .lineLimit(1)
+
+                if workspace.isArchived {
+                    Text("Archived")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.quaternary, in: Capsule())
+                }
+
+                Spacer()
+
+                Text(workspaceStatus(row))
+                    .font(.callout)
+                    .foregroundStyle(.tertiary)
             }
-            Spacer()
+            .padding(.horizontal, 18)
+            .frame(minHeight: 48)
+            .contentShape(Rectangle())
         }
-        .padding(.leading, 20)
+        .buttonStyle(.plain)
+        .disabled(!reachable)
         .opacity(workspace.isArchived ? 0.5 : 1)
-        .tag(row.ref)
-        .contentShape(Rectangle())
-        .onTapGesture {
-            focusedWorkspace = row.ref
-            if reachable { onOpenWorkspace(row.ref) }
-        }
         .contextMenu {
             Button("Open", systemImage: "arrow.up.forward.square") {
                 onOpenWorkspace(row.ref)
@@ -396,6 +497,23 @@ struct DashboardView: View {
     }
 
     // MARK: - Helpers
+
+    private var cardShape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+    }
+
+    private var canCreateProject: Bool {
+        appModel.runtimes.contains { appModel.canMutate(connectionID: $0.id) }
+    }
+
+    private func projectCountLabel(_ count: Int) -> String {
+        "\(count) \(count == 1 ? "project" : "projects")"
+    }
+
+    private func workspaceStatus(_ row: DashboardGroups.WorkspaceRow) -> String {
+        if row.hasActiveSessions { return "active now" }
+        return row.workspace.updatedAt.formatted(.relative(presentation: .numeric))
+    }
 
     private func canMutate(_ connectionID: UUID) -> Bool {
         appModel.canMutate(connectionID: connectionID)

--- a/macos/ATC/Features/Dashboard/DashboardView.swift
+++ b/macos/ATC/Features/Dashboard/DashboardView.swift
@@ -38,7 +38,7 @@ struct DashboardView: View {
             ForEach(groups.sections) { section in
                 Section {
                     ForEach(section.cards) { card in
-                        projectCard(card, reachable: isReachable(section.connectionID))
+                        projectCard(card, reachable: canMutate(section.connectionID))
                     }
                     if section.cards.isEmpty {
                         Text("No projects")
@@ -51,7 +51,7 @@ struct DashboardView: View {
             }
         }
         .onKeyPress(.return) {
-            guard let ref = focusedWorkspace, isReachable(ref.connectionID) else {
+            guard let ref = focusedWorkspace, canMutate(ref.connectionID) else {
                 return .ignored
             }
             onOpenWorkspace(ref)
@@ -65,7 +65,9 @@ struct DashboardView: View {
                 Toggle("Show Archived", isOn: $showArchived)
                     .toggleStyle(.checkbox)
                 Button("New Project…") { onCreateProject() }
-                    .disabled(appModel.runtimes.isEmpty)
+                    .disabled(!appModel.runtimes.contains {
+                        appModel.canMutate(connectionID: $0.id)
+                    })
                 Button {
                     Task { await appModel.refreshAll() }
                 } label: {
@@ -96,7 +98,10 @@ struct DashboardView: View {
                     run { try await store.rename(id: row.workspace.id, name: trimmed) }
                 }
             }
-            .disabled(renameDraft.trimmingCharacters(in: .whitespaces).isEmpty)
+            .disabled(
+                renameDraft.trimmingCharacters(in: .whitespaces).isEmpty
+                    || !(renamingWorkspace.map { canMutate($0.ref.connectionID) } ?? false)
+            )
             Button("Cancel", role: .cancel) {}
         }
         .alert("Rename Project", isPresented: Binding(
@@ -111,7 +116,10 @@ struct DashboardView: View {
                     run { try await store.rename(id: card.project.id, name: trimmed) }
                 }
             }
-            .disabled(renameDraft.trimmingCharacters(in: .whitespaces).isEmpty)
+            .disabled(
+                renameDraft.trimmingCharacters(in: .whitespaces).isEmpty
+                    || !(renamingProject.map { canMutate($0.ref.connectionID) } ?? false)
+            )
             Button("Cancel", role: .cancel) {}
         }
         .confirmationDialog(
@@ -126,6 +134,7 @@ struct DashboardView: View {
                     deleteWorkspace(row)
                 }
             }
+            .disabled(!(deletingWorkspace.map { canMutate($0.ref.connectionID) } ?? false))
         } message: {
             if let row = deletingWorkspace {
                 Text(DeleteConfirmation.workspaceMessage(
@@ -148,6 +157,7 @@ struct DashboardView: View {
                     run { try await store.delete(id: card.project.id) }
                 }
             }
+            .disabled(!(deletingProject.map { canMutate($0.ref.connectionID) } ?? false))
         } message: {
             if let card = deletingProject {
                 Text(DeleteConfirmation.projectMessage(name: card.project.name))
@@ -256,6 +266,7 @@ struct DashboardView: View {
                 renameDraft = project.name
                 renamingProject = card
             }
+            .disabled(!reachable)
             Divider()
             // Mirrors the server rule: archive only once every Workspace
             // is archived. A stale view still gets the 409 via the alert.
@@ -264,19 +275,20 @@ struct DashboardView: View {
                     run { try await store.archive(id: project.id) }
                 }
             }
-            .disabled(card.hasUnarchivedWorkspaces)
+            .disabled(!reachable || card.hasUnarchivedWorkspaces)
         } else {
             Button("Unarchive Project", systemImage: "archivebox") {
                 if let store = appModel.runtime(id: card.ref.connectionID)?.projects {
                     run { try await store.unarchive(id: project.id) }
                 }
             }
+            .disabled(!reachable)
         }
         Divider()
         Button("Delete Project…", systemImage: "trash", role: .destructive) {
             deletingProject = card
         }
-        .disabled(card.totalWorkspaceCount > 0)
+        .disabled(!reachable || card.totalWorkspaceCount > 0)
         .help(card.totalWorkspaceCount > 0 ? "Delete all Workspaces first" : "")
     }
 
@@ -322,6 +334,7 @@ struct DashboardView: View {
                 renameDraft = workspace.name
                 renamingWorkspace = row
             }
+            .disabled(!reachable)
             Divider()
             if workspace.isArchived {
                 Button("Unarchive", systemImage: "archivebox") {
@@ -329,6 +342,7 @@ struct DashboardView: View {
                         run { try await store.unarchive(id: workspace.id) }
                     }
                 }
+                .disabled(!reachable)
             } else {
                 // Mirrors the server rule: no archiving with active sessions.
                 Button("Archive", systemImage: "archivebox") {
@@ -336,12 +350,13 @@ struct DashboardView: View {
                         run { try await store.archive(id: workspace.id) }
                     }
                 }
-                .disabled(row.hasActiveSessions)
+                .disabled(!reachable || row.hasActiveSessions)
             }
             Divider()
             Button("Delete…", systemImage: "trash", role: .destructive) {
                 deletingWorkspace = row
             }
+            .disabled(!reachable)
         }
     }
 
@@ -367,6 +382,9 @@ struct DashboardView: View {
             Text("Create a project to start working in a codebase.")
         } actions: {
             Button("New Project") { onCreateProject() }
+                .disabled(!appModel.runtimes.contains {
+                    appModel.canMutate(connectionID: $0.id)
+                })
         }
         .background()
     }
@@ -379,8 +397,8 @@ struct DashboardView: View {
 
     // MARK: - Helpers
 
-    private func isReachable(_ connectionID: UUID) -> Bool {
-        appModel.reachability(of: connectionID) != .unreachable
+    private func canMutate(_ connectionID: UUID) -> Bool {
+        appModel.canMutate(connectionID: connectionID)
     }
 
     private func workspacesStore(for connectionID: UUID) -> WorkspacesStore? {

--- a/macos/ATC/Features/Projects/CreateProjectSheet.swift
+++ b/macos/ATC/Features/Projects/CreateProjectSheet.swift
@@ -52,72 +52,58 @@ struct CreateProjectSheet: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            Form {
+        SheetScaffold(
+            title: "New Project",
+            systemImage: "folder.badge.plus",
+            primaryLabel: "Create Project",
+            isBusy: isSubmitting,
+            canSubmit: canSubmit,
+            onCancel: { dismiss() },
+            onSubmit: { Task { await submit() } }
+        ) {
+            Section {
+                Picker("Connection", selection: Binding(
+                    get: { draft.connectionID },
+                    set: { draft.selectConnection($0) }
+                )) {
+                    // The selection is nil until onAppear preselects (and
+                    // always when no Connections exist); keep a matching
+                    // tag so AppKit doesn't log an invalid selection.
+                    if selectedRuntime == nil {
+                        Text(appModel.runtimes.isEmpty ? "No Connections" : "Select Connection")
+                            .tag(draft.connectionID)
+                    }
+                    ForEach(appModel.runtimes) { runtime in
+                        Text(runtime.record.name).tag(runtime.id as UUID?)
+                    }
+                }
+                TextField("Name", text: $draft.name, prompt: Text("My Project"))
+                HStack {
+                    TextField("Directory", text: $draft.workingDir, prompt: Text("/path/on/the/server"))
+                        .autocorrectionDisabled()
+                    Button {
+                        showFolderPicker = true
+                    } label: {
+                        Image(systemName: "folder")
+                    }
+                    .disabled(selectedRuntime == nil)
+                    .help("Browse folders on the server")
+                }
+            } footer: {
+                Text("Sessions started in this project run in its directory on the workstation.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let message = submitError {
                 Section {
-                    Picker("Connection", selection: Binding(
-                        get: { draft.connectionID },
-                        set: { draft.selectConnection($0) }
-                    )) {
-                        // The selection is nil until onAppear preselects (and
-                        // always when no Connections exist); keep a matching
-                        // tag so AppKit doesn't log an invalid selection.
-                        if selectedRuntime == nil {
-                            Text(appModel.runtimes.isEmpty ? "No Connections" : "Select Connection")
-                                .tag(draft.connectionID)
-                        }
-                        ForEach(appModel.runtimes) { runtime in
-                            Text(runtime.record.name).tag(runtime.id as UUID?)
-                        }
-                    }
-                    TextField("Name", text: $draft.name, prompt: Text("My Project"))
-                    HStack {
-                        TextField("Directory", text: $draft.workingDir, prompt: Text("/path/on/the/server"))
-                            .autocorrectionDisabled()
-                        Button {
-                            showFolderPicker = true
-                        } label: {
-                            Image(systemName: "folder")
-                        }
-                        .disabled(selectedRuntime == nil)
-                        .help("Browse folders on the server")
-                    }
-                } footer: {
-                    Text("Sessions started in this project run in its directory on the workstation.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                if let message = submitError {
-                    Section {
-                        Label(message, systemImage: "exclamationmark.triangle")
-                            .foregroundStyle(.red)
-                            .font(.callout)
-                    }
+                    Label(message, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.red)
+                        .font(.callout)
                 }
             }
-            .formStyle(.grouped)
-
-            Divider()
-            HStack {
-                Button("Cancel", role: .cancel) { dismiss() }
-                    .keyboardShortcut(.cancelAction)
-                Spacer()
-                Button {
-                    Task { await submit() }
-                } label: {
-                    if isSubmitting {
-                        ProgressView().controlSize(.small)
-                    } else {
-                        Text("Create Project")
-                    }
-                }
-                .keyboardShortcut(.defaultAction)
-                .disabled(!canSubmit)
-            }
-            .padding(Spacing.md)
         }
-        .frame(width: 460, height: 290)
+        .frame(width: 460, height: 300)
         .onAppear { draft.preselectFirst(in: appModel.runtimes) }
         .sheet(isPresented: $showFolderPicker) {
             if let runtime = selectedRuntime {

--- a/macos/ATC/Features/Projects/CreateProjectSheet.swift
+++ b/macos/ATC/Features/Projects/CreateProjectSheet.swift
@@ -115,7 +115,7 @@ struct CreateProjectSheet: View {
                 .keyboardShortcut(.defaultAction)
                 .disabled(!canSubmit)
             }
-            .padding(12)
+            .padding(Spacing.md)
         }
         .frame(width: 460, height: 290)
         .onAppear { draft.preselectFirst(in: appModel.runtimes) }

--- a/macos/ATC/Features/Projects/ProjectsNavigatorGroups.swift
+++ b/macos/ATC/Features/Projects/ProjectsNavigatorGroups.swift
@@ -1,0 +1,92 @@
+import Foundation
+import ATCAPI
+
+/// Pure, deterministic projection shared by the Projects Navigator and the
+/// Workspace Switcher.
+struct ProjectsNavigatorGroups {
+    struct Input {
+        let connection: ConnectionRecord
+        let reachability: Reachability
+        let projects: [Project]
+        let workspaces: [Workspace]
+        let sessions: [Session]
+    }
+
+    struct WorkspaceRow: Identifiable {
+        let ref: WorkspaceRef
+        let workspace: Workspace
+        let hasActiveSessions: Bool
+        let sessionCount: Int
+        let activeSessionCount: Int
+        var id: WorkspaceRef { ref }
+    }
+
+    struct ProjectGroup: Identifiable {
+        let ref: ProjectRef
+        let project: Project
+        let connectionName: String
+        let reachability: Reachability
+        let workspaces: [WorkspaceRow]
+        let totalWorkspaceCount: Int
+        let hasUnarchivedWorkspaces: Bool
+        var id: ProjectRef { ref }
+    }
+
+    let projects: [ProjectGroup]
+
+    init(inputs: [Input]) {
+        projects = inputs.flatMap { input -> [ProjectGroup] in
+            let allWorkspaces = Dictionary(grouping: input.workspaces, by: \.projectId)
+            let sessions = Dictionary(grouping: input.sessions, by: { $0.workspace?.id })
+            return input.projects.compactMap { project -> ProjectGroup? in
+                guard !project.isArchived else { return nil }
+                let all = allWorkspaces[project.id] ?? []
+                let rows = all
+                    .filter { !$0.isArchived }
+                    .sorted {
+                        if $0.createdAt != $1.createdAt { return $0.createdAt > $1.createdAt }
+                        return $0.id < $1.id
+                    }
+                    .map { workspace in
+                        let members = sessions[workspace.id] ?? []
+                        return WorkspaceRow(
+                            ref: WorkspaceRef(
+                                connectionID: input.connection.id,
+                                workspaceID: workspace.id
+                            ),
+                            workspace: workspace,
+                            hasActiveSessions: members.contains(where: \.isActive),
+                            sessionCount: members.count,
+                            activeSessionCount: members.filter(\.isActive).count
+                        )
+                    }
+                return ProjectGroup(
+                    ref: ProjectRef(
+                        connectionID: input.connection.id,
+                        projectID: project.id
+                    ),
+                    project: project,
+                    connectionName: input.connection.name,
+                    reachability: input.reachability,
+                    workspaces: rows,
+                    totalWorkspaceCount: all.count,
+                    hasUnarchivedWorkspaces: all.contains { !$0.isArchived }
+                )
+            }
+        }
+        .sorted(by: Self.projectComesFirst)
+    }
+
+    nonisolated private static func projectComesFirst(
+        _ lhs: ProjectGroup,
+        _ rhs: ProjectGroup
+    ) -> Bool {
+        let name = lhs.project.name.localizedCaseInsensitiveCompare(rhs.project.name)
+        if name != .orderedSame { return name == .orderedAscending }
+        let connection = lhs.connectionName.localizedCaseInsensitiveCompare(rhs.connectionName)
+        if connection != .orderedSame { return connection == .orderedAscending }
+        let connectionID = lhs.ref.connectionID.uuidString.compare(rhs.ref.connectionID.uuidString)
+        if connectionID != .orderedSame { return connectionID == .orderedAscending }
+        return lhs.ref.projectID < rhs.ref.projectID
+    }
+}

--- a/macos/ATC/Features/Projects/ProjectsNavigatorGroups.swift
+++ b/macos/ATC/Features/Projects/ProjectsNavigatorGroups.swift
@@ -34,6 +34,20 @@ struct ProjectsNavigatorGroups {
 
     let projects: [ProjectGroup]
 
+    /// The one projection from live runtimes shared by the Projects
+    /// Navigator and the Workspace Switcher.
+    init(runtimes: [ConnectionRuntime]) {
+        self.init(inputs: runtimes.map {
+            Input(
+                connection: $0.record,
+                reachability: $0.reachability,
+                projects: $0.projects.projects,
+                workspaces: $0.workspaces.workspaces,
+                sessions: $0.sessions.sessions
+            )
+        })
+    }
+
     init(inputs: [Input]) {
         projects = inputs.flatMap { input -> [ProjectGroup] in
             let allWorkspaces = Dictionary(grouping: input.workspaces, by: \.projectId)
@@ -43,10 +57,7 @@ struct ProjectsNavigatorGroups {
                 let all = allWorkspaces[project.id] ?? []
                 let rows = all
                     .filter { !$0.isArchived }
-                    .sorted {
-                        if $0.createdAt != $1.createdAt { return $0.createdAt > $1.createdAt }
-                        return $0.id < $1.id
-                    }
+                    .sortedNewestFirst()
                     .map { workspace in
                         let members = sessions[workspace.id] ?? []
                         return WorkspaceRow(

--- a/macos/ATC/Features/RemoteFiles/RemoteFolderPickerSheet.swift
+++ b/macos/ATC/Features/RemoteFiles/RemoteFolderPickerSheet.swift
@@ -41,7 +41,7 @@ struct RemoteFolderPickerSheet: View {
     // MARK: - Header (path field, Up, breadcrumbs, error)
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
             HStack {
                 TextField("Path", text: $browser.typedPath, prompt: Text("/path/on/the/server"))
                     .textFieldStyle(.roundedBorder)
@@ -51,7 +51,7 @@ struct RemoteFolderPickerSheet: View {
                     .onSubmit { Task { await browser.commitTypedPath() } }
                 Button("Go") { Task { await browser.commitTypedPath() } }
             }
-            HStack(spacing: 8) {
+            HStack(spacing: Spacing.sm) {
                 Button {
                     Task { await browser.goUp() }
                 } label: {
@@ -68,12 +68,12 @@ struct RemoteFolderPickerSheet: View {
                     .lineLimit(2)
             }
         }
-        .padding(12)
+        .padding(Spacing.md)
     }
 
     private var breadcrumbBar: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 3) {
+            HStack(spacing: Spacing.xs) {
                 let crumbs = browser.breadcrumbs
                 ForEach(Array(crumbs.enumerated()), id: \.element.path) { index, crumb in
                     if index > 0 {
@@ -110,7 +110,7 @@ struct RemoteFolderPickerSheet: View {
             .keyboardShortcut(.defaultAction)
             .disabled(browser.currentPath == nil)
         }
-        .padding(12)
+        .padding(Spacing.md)
     }
 }
 
@@ -140,15 +140,15 @@ private struct DirectoryListPane: View {
     var body: some View {
         VStack(spacing: 0) {
             if browser.listing?.truncated == true {
-                HStack(spacing: 6) {
+                HStack(spacing: Spacing.sm) {
                     Image(systemName: "exclamationmark.triangle")
                     Text("Listing truncated at 10,000 entries")
                 }
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 6)
+                .padding(.horizontal, Spacing.md)
+                .padding(.vertical, Spacing.xs)
                 Divider()
             }
             List(selection: $browser.highlightedPath) {

--- a/macos/ATC/Features/Sessions/SessionContentView.swift
+++ b/macos/ATC/Features/Sessions/SessionContentView.swift
@@ -227,14 +227,7 @@ struct SessionHeaderBar: View {
         } message: {
             Text(DeleteConfirmation.sessionMessage(displayName: displayName))
         }
-        .alert("Session Action Failed", isPresented: Binding(
-            get: { actionError != nil },
-            set: { if !$0 { actionError = nil } }
-        )) {
-            Button("OK", role: .cancel) {}
-        } message: {
-            Text(actionError ?? "")
-        }
+        .actionErrorAlert($actionError, title: "Session Action Failed")
     }
 
     /// Failure (stop error, 502) leaves the session and surfaces the alert.

--- a/macos/ATC/Features/Sessions/SessionContentView.swift
+++ b/macos/ATC/Features/Sessions/SessionContentView.swift
@@ -142,7 +142,7 @@ struct SessionHeaderBar: View {
     }
 
     var body: some View {
-        HStack(spacing: 12) {
+        HStack(spacing: Spacing.md) {
             StatusBadge(session: session, showLabel: true)
             Text(displayName)
                 .font(.headline)
@@ -197,8 +197,8 @@ struct SessionHeaderBar: View {
             }
             .help("Show session metadata")
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
+        .padding(.horizontal, Spacing.md)
+        .padding(.vertical, Spacing.sm)
         .confirmationDialog(
             "Stop “\(displayName)”?",
             isPresented: $confirmStop

--- a/macos/ATC/Features/Sessions/SessionContentView.swift
+++ b/macos/ATC/Features/Sessions/SessionContentView.swift
@@ -116,6 +116,10 @@ struct SessionHeaderBar: View {
         appModel.terminals[sessionRef]?.isActivelyAttached == true
     }
 
+    private var canMutate: Bool {
+        appModel.canMutate(connectionID: sessionRef.connectionID)
+    }
+
     private var canStop: Bool {
         session.status == .running || session.status == .starting
     }
@@ -167,23 +171,26 @@ struct SessionHeaderBar: View {
                 Button("Stop", systemImage: "stop.circle") {
                     confirmStop = true
                 }
+                .disabled(!canMutate)
                 .help("Terminate this session")
             }
             if session.isArchived {
                 Button("Unarchive", systemImage: "archivebox") {
                     Task { await run { try await sessionsStore?.unarchive(id: session.id) } }
                 }
+                .disabled(!canMutate)
                 .help("Unarchive this session")
             } else {
                 Button("Archive", systemImage: "archivebox") {
                     confirmArchive = true
                 }
-                .disabled(!canArchive)
+                .disabled(!canArchive || !canMutate)
                 .help(canArchive ? "Archive this session" : "Stop the session before archiving")
             }
             Button("Delete", systemImage: "trash") {
                 confirmDelete = true
             }
+            .disabled(!canMutate)
             .help("Delete this session")
             Button("Info", systemImage: "sidebar.trailing") {
                 showInspector.toggle()
@@ -199,6 +206,7 @@ struct SessionHeaderBar: View {
             Button("Stop Session", role: .destructive) {
                 Task { await run { try await sessionsStore?.terminate(id: session.id) } }
             }
+            .disabled(!canMutate)
         } message: {
             Text("The process will be terminated. The session record is kept until archived.")
         }
@@ -209,6 +217,7 @@ struct SessionHeaderBar: View {
             Button("Archive Session") {
                 Task { await run { try await sessionsStore?.archive(id: session.id) } }
             }
+            .disabled(!canMutate)
         } message: {
             Text("Archived sessions are hidden behind the archived filter.")
         }
@@ -219,6 +228,7 @@ struct SessionHeaderBar: View {
             Button("Delete Session", role: .destructive) {
                 Task { await deleteSession() }
             }
+            .disabled(!canMutate)
         } message: {
             Text(DeleteConfirmation.sessionMessage(displayName: displayName))
         }

--- a/macos/ATC/Features/Sessions/SessionContentView.swift
+++ b/macos/ATC/Features/Sessions/SessionContentView.swift
@@ -149,12 +149,7 @@ struct SessionHeaderBar: View {
                 .lineLimit(1)
             // What launched the session: "Claude", "Terminal", a custom
             // Action label.
-            Text(SessionKind.actionLabel(session: session, actions: actions))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2)
-                .background(.quaternary.opacity(0.5), in: Capsule())
+            TagBadge(text: SessionKind.actionLabel(session: session, actions: actions))
             Text(session.workingDir)
                 .font(.caption)
                 .foregroundStyle(.secondary)

--- a/macos/ATC/Features/Sessions/SessionContentView.swift
+++ b/macos/ATC/Features/Sessions/SessionContentView.swift
@@ -171,7 +171,9 @@ struct SessionHeaderBar: View {
             }
             if session.isArchived {
                 Button("Unarchive", systemImage: "archivebox") {
-                    Task { await run { try await sessionsStore?.unarchive(id: session.id) } }
+                    appModel.run(on: sessionRef.connectionID, reporting: $actionError) {
+                        try await sessionsStore?.unarchive(id: session.id)
+                    }
                 }
                 .disabled(!canMutate)
                 .help("Unarchive this session")
@@ -203,7 +205,9 @@ struct SessionHeaderBar: View {
             isPresented: $confirmStop
         ) {
             Button("Stop Session", role: .destructive) {
-                Task { await run { try await sessionsStore?.terminate(id: session.id) } }
+                appModel.run(on: sessionRef.connectionID, reporting: $actionError) {
+                    try await sessionsStore?.terminate(id: session.id)
+                }
             }
             .disabled(!canMutate)
         } message: {
@@ -214,7 +218,9 @@ struct SessionHeaderBar: View {
             isPresented: $confirmArchive
         ) {
             Button("Archive Session") {
-                Task { await run { try await sessionsStore?.archive(id: session.id) } }
+                appModel.run(on: sessionRef.connectionID, reporting: $actionError) {
+                    try await sessionsStore?.archive(id: session.id)
+                }
             }
             .disabled(!canMutate)
         } message: {
@@ -225,7 +231,7 @@ struct SessionHeaderBar: View {
             isPresented: $confirmDelete
         ) {
             Button("Delete Session", role: .destructive) {
-                Task { await deleteSession() }
+                deleteSession()
             }
             .disabled(!canMutate)
         } message: {
@@ -235,21 +241,13 @@ struct SessionHeaderBar: View {
     }
 
     /// Failure (stop error, 502) leaves the session and surfaces the alert.
-    private func deleteSession() async {
-        await run {
+    private func deleteSession() {
+        appModel.run(on: sessionRef.connectionID, reporting: $actionError) {
             try await sessionsStore?.delete(id: session.id)
             appModel.disconnectTerminal(ref: sessionRef)
             if windowState.selectedSession == sessionRef {
                 windowState.showWorkspaceEmpty()
             }
-        }
-    }
-
-    private func run(_ operation: () async throws -> Void) async {
-        do {
-            try await operation()
-        } catch {
-            actionError = error.localizedDescription
         }
     }
 }

--- a/macos/ATC/Features/Sessions/SessionContentView.swift
+++ b/macos/ATC/Features/Sessions/SessionContentView.swift
@@ -192,6 +192,10 @@ struct SessionHeaderBar: View {
             }
             .help("Show session metadata")
         }
+        // The trailing actions read as one toolbar row: icon-only,
+        // borderless, discoverable through their .help strings.
+        .buttonStyle(.borderless)
+        .labelStyle(.iconOnly)
         .padding(.horizontal, Spacing.md)
         .padding(.vertical, Spacing.sm)
         .confirmationDialog(

--- a/macos/ATC/Features/Sessions/SessionContentView.swift
+++ b/macos/ATC/Features/Sessions/SessionContentView.swift
@@ -21,24 +21,24 @@ struct SessionContentView: View {
     let selectedSession: Session?
     var emptyState: EmptyStateActions?
 
-    @State private var showInspector = false
+    @Environment(WindowState.self) private var windowState
 
     var body: some View {
         VStack(spacing: 0) {
             if let ref = selectedRef, let session = selectedSession {
-                SessionHeaderBar(sessionRef: ref, session: session, showInspector: $showInspector)
+                SessionHeaderBar(
+                    sessionRef: ref,
+                    session: session,
+                    showInspector: Binding(
+                        get: { windowState.isInspectorPresented },
+                        set: { windowState.isInspectorPresented = $0 }
+                    )
+                )
                 Divider()
             }
             ZStack {
                 TerminalPane(visibleRef: selectedRef)
                 cover
-            }
-        }
-        .inspector(isPresented: $showInspector) {
-            if let ref = selectedRef, let session = selectedSession,
-               let client = appModel.runtime(id: ref.connectionID)?.client {
-                SessionDetailView(session: session, client: client)
-                    .inspectorColumnWidth(min: 260, ideal: 320)
             }
         }
     }
@@ -61,7 +61,11 @@ struct SessionContentView: View {
                     Text("The session is running on the server.")
                 } actions: {
                     Button("Connect") {
-                        appModel.attachIfNeeded(to: session, connectionID: ref.connectionID)
+                        appModel.attachIfNeeded(
+                            to: session,
+                            connectionID: ref.connectionID,
+                            retentionContext: windowState.retentionContext
+                        )
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -98,6 +102,7 @@ struct SessionContentView: View {
 /// Compact header: name, action label, status, session actions.
 struct SessionHeaderBar: View {
     @Environment(AppModel.self) private var appModel
+    @Environment(WindowState.self) private var windowState
     let sessionRef: SessionRef
     let session: Session
     @Binding var showInspector: Bool
@@ -180,12 +185,10 @@ struct SessionHeaderBar: View {
                 confirmDelete = true
             }
             .help("Delete this session")
-            if isConnected {
-                Button("Info", systemImage: "sidebar.trailing") {
-                    showInspector.toggle()
-                }
-                .help("Show session metadata")
+            Button("Info", systemImage: "sidebar.trailing") {
+                showInspector.toggle()
             }
+            .help("Show session metadata")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -234,8 +237,8 @@ struct SessionHeaderBar: View {
         await run {
             try await sessionsStore?.delete(id: session.id)
             appModel.disconnectTerminal(ref: sessionRef)
-            if appModel.selection == sessionRef {
-                appModel.selection = nil
+            if windowState.selectedSession == sessionRef {
+                windowState.showWorkspaceEmpty()
             }
         }
     }

--- a/macos/ATC/Features/Sessions/SessionRowView.swift
+++ b/macos/ATC/Features/Sessions/SessionRowView.swift
@@ -9,7 +9,7 @@ struct SessionRowView: View {
     /// recency instead of repeating the path.
     var showsWorkingDir = true
     /// Overrides for callers that resolve names against the action
-    /// registry (the Workspace shell); nil falls back to the session's own
+    /// registry (the Workspace Navigator); nil falls back to the session's own
     /// labels.
     var title: String?
     var caption: String?

--- a/macos/ATC/Features/Sessions/SessionsStore.swift
+++ b/macos/ATC/Features/Sessions/SessionsStore.swift
@@ -19,7 +19,7 @@ final class SessionsStore {
     }
 
     /// Always includes archived sessions; surfaces filter locally (the
-    /// Workspace shell's Archived toggle).
+    /// Workspace Navigator's Archived toggle).
     private(set) var sessions: [Session] = []
     private(set) var isLoading = false
     private(set) var hasLoadedOnce = false

--- a/macos/ATC/Features/Sessions/StartWorkspaceSessionSheet.swift
+++ b/macos/ATC/Features/Sessions/StartWorkspaceSessionSheet.swift
@@ -66,55 +66,34 @@ struct StartWorkspaceSessionSheet: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            Form {
-                Section {
-                    picker
-                    TextField("Name (optional)", text: $name)
-                } header: {
-                    Label {
-                        Text(kind == .agentSession ? "New Session" : "New Terminal")
-                    } icon: {
-                        Image(systemName: kind == .agentSession ? "sparkles" : "terminal")
-                    }
-                    .font(.headline)
-                }
+        SheetScaffold(
+            title: kind == .agentSession ? "New Session" : "New Terminal",
+            systemImage: kind == .agentSession ? "sparkles" : "terminal",
+            primaryLabel: "Start",
+            isBusy: isSubmitting,
+            canSubmit: canSubmit,
+            onCancel: { dismiss() },
+            onSubmit: { Task { await submit() } }
+        ) {
+            Section {
+                picker
+                TextField("Name (optional)", text: $name)
+            }
 
-                if let message = submitError ?? availabilityError ?? loadError {
-                    Section {
-                        Label(message, systemImage: "exclamationmark.triangle")
-                            .foregroundStyle(.red)
-                            .font(.callout)
-                        if loadError != nil {
-                            Button("Retry") {
-                                Task { await actionsStore?.refresh() }
-                            }
+            if let message = submitError ?? availabilityError ?? loadError {
+                Section {
+                    Label(message, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.red)
+                        .font(.callout)
+                    if loadError != nil {
+                        Button("Retry") {
+                            Task { await actionsStore?.refresh() }
                         }
                     }
                 }
             }
-            .formStyle(.grouped)
-
-            Divider()
-            HStack {
-                Button("Cancel", role: .cancel) { dismiss() }
-                    .keyboardShortcut(.cancelAction)
-                Spacer()
-                Button {
-                    Task { await submit() }
-                } label: {
-                    if isSubmitting {
-                        ProgressView().controlSize(.small)
-                    } else {
-                        Text("Start")
-                    }
-                }
-                .keyboardShortcut(.defaultAction)
-                .disabled(!canSubmit)
-            }
-            .padding(Spacing.md)
         }
-        .frame(width: 380, height: 250)
+        .frame(width: 460, height: 280)
         .onAppear { preselect() }
         .onChange(of: choices.map(\.name)) { preselect() }
     }

--- a/macos/ATC/Features/Sessions/StartWorkspaceSessionSheet.swift
+++ b/macos/ATC/Features/Sessions/StartWorkspaceSessionSheet.swift
@@ -112,7 +112,7 @@ struct StartWorkspaceSessionSheet: View {
                 .keyboardShortcut(.defaultAction)
                 .disabled(!canSubmit)
             }
-            .padding(12)
+            .padding(Spacing.md)
         }
         .frame(width: 380, height: 250)
         .onAppear { preselect() }

--- a/macos/ATC/Features/Sessions/StartWorkspaceSessionSheet.swift
+++ b/macos/ATC/Features/Sessions/StartWorkspaceSessionSheet.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import ATCAPI
 
-/// The New Session / New Terminal sheet, always scoped to the active open
+/// The New Session / New Terminal sheet, always scoped to the Active
 /// Workspace. New Session picks among enabled Agent Actions; New Terminal
 /// offers the Interactive Shell (default) plus enabled general Actions. No
 /// prompt field, no params UI, no Environment picker — the server default
@@ -14,7 +14,7 @@ struct StartWorkspaceSessionSheet: View {
     @Environment(\.dismiss) private var dismiss
     let kind: StartSessionKind
     let workspaceRef: WorkspaceRef
-    /// Called with the new session's ref so the shell can select it.
+    /// Called with the new Session's ref so the window can select it.
     var onStarted: (SessionRef) -> Void = { _ in }
 
     @State private var selectedActionName = ""

--- a/macos/ATC/Features/Sessions/StartWorkspaceSessionSheet.swift
+++ b/macos/ATC/Features/Sessions/StartWorkspaceSessionSheet.swift
@@ -55,6 +55,16 @@ struct StartWorkspaceSessionSheet: View {
         return store.lastError
     }
 
+    private var availabilityError: String? {
+        guard runtime != nil else {
+            return "This workspace's connection is no longer configured."
+        }
+        guard appModel.canStartSession(in: workspaceRef) else {
+            return "This workspace is archived or its connection is unavailable."
+        }
+        return nil
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             Form {
@@ -70,7 +80,7 @@ struct StartWorkspaceSessionSheet: View {
                     .font(.headline)
                 }
 
-                if let message = submitError ?? loadError {
+                if let message = submitError ?? availabilityError ?? loadError {
                     Section {
                         Label(message, systemImage: "exclamationmark.triangle")
                             .foregroundStyle(.red)
@@ -142,7 +152,7 @@ struct StartWorkspaceSessionSheet: View {
     }
 
     private var canSubmit: Bool {
-        guard !isSubmitting, runtime != nil else { return false }
+        guard !isSubmitting, appModel.canStartSession(in: workspaceRef) else { return false }
         switch kind {
         case .agentSession: return selectedAction != nil
         case .terminal: return isInteractiveShell || selectedAction != nil
@@ -150,7 +160,10 @@ struct StartWorkspaceSessionSheet: View {
     }
 
     private func submit() async {
-        guard let runtime else { return }
+        guard appModel.canStartSession(in: workspaceRef), let runtime else {
+            submitError = "This workspace is archived or its connection is unavailable."
+            return
+        }
         isSubmitting = true
         defer { isSubmitting = false }
         do {

--- a/macos/ATC/Features/Sessions/StatusBadge.swift
+++ b/macos/ATC/Features/Sessions/StatusBadge.swift
@@ -7,7 +7,7 @@ struct StatusBadge: View {
     var showLabel = false
 
     var body: some View {
-        HStack(spacing: 4) {
+        HStack(spacing: Spacing.xs) {
             Circle()
                 .fill(color)
                 .frame(width: 8, height: 8)

--- a/macos/ATC/Features/Terminal/TerminalPane.swift
+++ b/macos/ATC/Features/Terminal/TerminalPane.swift
@@ -80,7 +80,9 @@ struct TerminalStatusBanner: View {
         HStack(spacing: Spacing.sm, content: content)
             .padding(.horizontal, Spacing.md)
             .padding(.vertical, Spacing.sm)
-            .background(.regularMaterial, in: Capsule())
+            // The app's one floating overlay — the only Liquid Glass call
+            // outside what system components provide for free.
+            .glassEffect()
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             .padding(.top, Spacing.lg)
     }

--- a/macos/ATC/Features/Terminal/TerminalPane.swift
+++ b/macos/ATC/Features/Terminal/TerminalPane.swift
@@ -10,7 +10,9 @@ struct TerminalPane: View {
 
     var body: some View {
         ZStack {
-            Color(red: 0.117, green: 0.117, blue: 0.180) // Mocha base, behind surface padding
+            // Catppuccin Mocha base: pairs with the Ghostty surface theme,
+            // not app chrome — keep this literal out of the design tokens.
+            Color(red: 0.117, green: 0.117, blue: 0.180)
             ForEach(refs, id: \.self) { ref in
                 if let controller = appModel.terminals[ref] {
                     TerminalHostView(controller: controller, focus: $focusedTerminal)
@@ -75,11 +77,11 @@ struct TerminalStatusBanner: View {
     }
 
     private func banner(@ViewBuilder content: () -> some View) -> some View {
-        HStack(spacing: 8, content: content)
-            .padding(.horizontal, 14)
-            .padding(.vertical, 8)
+        HStack(spacing: Spacing.sm, content: content)
+            .padding(.horizontal, Spacing.md)
+            .padding(.vertical, Spacing.sm)
             .background(.regularMaterial, in: Capsule())
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-            .padding(.top, 16)
+            .padding(.top, Spacing.lg)
     }
 }

--- a/macos/ATC/Features/Workspaces/CreateWorkspaceSheet.swift
+++ b/macos/ATC/Features/Workspaces/CreateWorkspaceSheet.swift
@@ -9,7 +9,7 @@ struct CreateWorkspaceSheet: View {
     @Environment(AppModel.self) private var appModel
     @Environment(\.dismiss) private var dismiss
     let context: CreateWorkspaceContext
-    /// Called with the new Workspace's ref so the window routes to the shell.
+    /// Called with the new Workspace's ref so the window activates it.
     var onCreated: (WorkspaceRef) -> Void = { _ in }
 
     @State private var selectedProject: ProjectRef?

--- a/macos/ATC/Features/Workspaces/CreateWorkspaceSheet.swift
+++ b/macos/ATC/Features/Workspaces/CreateWorkspaceSheet.swift
@@ -69,7 +69,7 @@ struct CreateWorkspaceSheet: View {
                         .foregroundStyle(.secondary)
                 }
 
-                if let message = submitError {
+                if let message = submitError ?? availabilityError {
                     Section {
                         Label(message, systemImage: "exclamationmark.triangle")
                             .foregroundStyle(.red)
@@ -118,13 +118,25 @@ struct CreateWorkspaceSheet: View {
 
     private var canSubmit: Bool {
         !isSubmitting
-            && selectedProject != nil
+            && (selectedProject.map { appModel.canCreateWorkspace(in: $0) } ?? false)
             && !name.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    private var availabilityError: String? {
+        guard let selectedProject else { return nil }
+        guard appModel.canCreateWorkspace(in: selectedProject) else {
+            return "This project is archived or its connection is unavailable."
+        }
+        return nil
     }
 
     private func submit() async {
         guard let ref = selectedProject,
-              let runtime = appModel.runtime(id: ref.connectionID) else { return }
+              appModel.canCreateWorkspace(in: ref),
+              let runtime = appModel.runtime(id: ref.connectionID) else {
+            submitError = "This project is archived or its connection is unavailable."
+            return
+        }
         isSubmitting = true
         defer { isSubmitting = false }
         do {

--- a/macos/ATC/Features/Workspaces/CreateWorkspaceSheet.swift
+++ b/macos/ATC/Features/Workspaces/CreateWorkspaceSheet.swift
@@ -96,7 +96,7 @@ struct CreateWorkspaceSheet: View {
                 .keyboardShortcut(.defaultAction)
                 .disabled(!canSubmit)
             }
-            .padding(12)
+            .padding(Spacing.md)
         }
         .frame(width: 420, height: 240)
         .onAppear {

--- a/macos/ATC/Features/Workspaces/CreateWorkspaceSheet.swift
+++ b/macos/ATC/Features/Workspaces/CreateWorkspaceSheet.swift
@@ -42,63 +42,49 @@ struct CreateWorkspaceSheet: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            Form {
+        SheetScaffold(
+            title: "New Workspace",
+            systemImage: "square.on.square",
+            primaryLabel: "Create Workspace",
+            isBusy: isSubmitting,
+            canSubmit: canSubmit,
+            onCancel: { dismiss() },
+            onSubmit: { Task { await submit() } }
+        ) {
+            Section {
+                if isProjectFixed {
+                    LabeledContent("Project") {
+                        Text(fixedProjectName)
+                    }
+                } else {
+                    Picker("Project", selection: $selectedProject) {
+                        if selectedProject == nil {
+                            Text("Select Project").tag(nil as ProjectRef?)
+                        }
+                        ForEach(projectChoices, id: \.ref) { choice in
+                            Text(showsConnectionNames
+                                ? "\(choice.project.name) — \(choice.connectionName)"
+                                : choice.project.name)
+                                .tag(choice.ref as ProjectRef?)
+                        }
+                    }
+                }
+                TextField("Name", text: $name, prompt: Text("What are you working on?"))
+            } footer: {
+                Text("The workspace uses its project's directory on the workstation.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let message = submitError ?? availabilityError {
                 Section {
-                    if isProjectFixed {
-                        LabeledContent("Project") {
-                            Text(fixedProjectName)
-                        }
-                    } else {
-                        Picker("Project", selection: $selectedProject) {
-                            if selectedProject == nil {
-                                Text("Select Project").tag(nil as ProjectRef?)
-                            }
-                            ForEach(projectChoices, id: \.ref) { choice in
-                                Text(showsConnectionNames
-                                    ? "\(choice.project.name) — \(choice.connectionName)"
-                                    : choice.project.name)
-                                    .tag(choice.ref as ProjectRef?)
-                            }
-                        }
-                    }
-                    TextField("Name", text: $name, prompt: Text("What are you working on?"))
-                } footer: {
-                    Text("The workspace uses its project's directory on the workstation.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                if let message = submitError ?? availabilityError {
-                    Section {
-                        Label(message, systemImage: "exclamationmark.triangle")
-                            .foregroundStyle(.red)
-                            .font(.callout)
-                    }
+                    Label(message, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(.red)
+                        .font(.callout)
                 }
             }
-            .formStyle(.grouped)
-
-            Divider()
-            HStack {
-                Button("Cancel", role: .cancel) { dismiss() }
-                    .keyboardShortcut(.cancelAction)
-                Spacer()
-                Button {
-                    Task { await submit() }
-                } label: {
-                    if isSubmitting {
-                        ProgressView().controlSize(.small)
-                    } else {
-                        Text("Create Workspace")
-                    }
-                }
-                .keyboardShortcut(.defaultAction)
-                .disabled(!canSubmit)
-            }
-            .padding(Spacing.md)
         }
-        .frame(width: 420, height: 240)
+        .frame(width: 460, height: 280)
         .onAppear {
             switch context.mode {
             case .fixed(let ref), .preselected(let ref):

--- a/macos/ATC/Features/Workspaces/WorkspaceSelectionMemory.swift
+++ b/macos/ATC/Features/Workspaces/WorkspaceSelectionMemory.swift
@@ -1,27 +1,48 @@
 import Foundation
 import ATCAPI
 
-/// Persists each Workspace's last-selected session (`workspaceID →
-/// sessionID`) in UserDefaults, so reopening a Workspace restores where the
-/// user left off. Restoration is best-effort: a remembered session that no
-/// longer exists (or moved) falls back to no selection.
+/// Persists each Workspace's last-selected session using the local
+/// Connection UUID plus the server Workspace ID. Server IDs are only unique
+/// within a Connection, so a bare Workspace ID is never a safe key.
 struct WorkspaceSelectionMemory {
+    private struct Record: Codable, Equatable {
+        let connectionID: UUID
+        let workspaceID: String
+        var sessionID: String
+    }
+
     private let defaults: UserDefaults
-    private static let key = "workspaceSelections"
+    private static let key = "workspaceSelections.v2"
+    private static let obsoleteKey = "workspaceSelections"
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
+        // The v1 map used bare server Workspace IDs and is ambiguous across
+        // Connections. Discard it instead of guessing a migration.
+        defaults.removeObject(forKey: Self.obsoleteKey)
     }
 
-    func sessionID(for workspaceID: String) -> String? {
-        stored()[workspaceID]
+    func sessionID(for ref: WorkspaceRef) -> String? {
+        stored().first {
+            $0.connectionID == ref.connectionID && $0.workspaceID == ref.workspaceID
+        }?.sessionID
     }
 
-    func remember(sessionID: String, for workspaceID: String) {
-        var map = stored()
-        guard map[workspaceID] != sessionID else { return }
-        map[workspaceID] = sessionID
-        defaults.set(map, forKey: Self.key)
+    func remember(sessionID: String, for ref: WorkspaceRef) {
+        var records = stored()
+        if let index = records.firstIndex(where: {
+            $0.connectionID == ref.connectionID && $0.workspaceID == ref.workspaceID
+        }) {
+            guard records[index].sessionID != sessionID else { return }
+            records[index].sessionID = sessionID
+        } else {
+            records.append(Record(
+                connectionID: ref.connectionID,
+                workspaceID: ref.workspaceID,
+                sessionID: sessionID
+            ))
+        }
+        save(records)
     }
 
     /// The selection to restore when opening a Workspace: the remembered
@@ -29,20 +50,41 @@ struct WorkspaceSelectionMemory {
     /// Workspace (any lifecycle state); nil otherwise, which shows the
     /// Workspace empty state.
     func restoredSelection(for ref: WorkspaceRef, in sessions: [Session]) -> SessionRef? {
-        guard let saved = sessionID(for: ref.workspaceID),
+        guard let saved = sessionID(for: ref),
               let session = sessions.first(where: { $0.id == saved }),
-              session.workspace?.id == ref.workspaceID
+              session.workspace?.id == ref.workspaceID,
+              !session.isArchived
         else { return nil }
         return SessionRef(connectionID: ref.connectionID, sessionID: session.id)
     }
 
-    func forget(workspaceID: String) {
-        var map = stored()
-        guard map.removeValue(forKey: workspaceID) != nil else { return }
-        defaults.set(map, forKey: Self.key)
+    func forget(_ ref: WorkspaceRef) {
+        var records = stored()
+        let previousCount = records.count
+        records.removeAll {
+            $0.connectionID == ref.connectionID && $0.workspaceID == ref.workspaceID
+        }
+        guard records.count != previousCount else { return }
+        save(records)
     }
 
-    private func stored() -> [String: String] {
-        defaults.dictionary(forKey: Self.key) as? [String: String] ?? [:]
+    func forget(connectionID: UUID) {
+        var records = stored()
+        let previousCount = records.count
+        records.removeAll { $0.connectionID == connectionID }
+        guard records.count != previousCount else { return }
+        save(records)
+    }
+
+    private func stored() -> [Record] {
+        guard let data = defaults.data(forKey: Self.key),
+              let records = try? JSONDecoder().decode([Record].self, from: data)
+        else { return [] }
+        return records
+    }
+
+    private func save(_ records: [Record]) {
+        guard let data = try? JSONEncoder().encode(records) else { return }
+        defaults.set(data, forKey: Self.key)
     }
 }

--- a/macos/ATC/Features/Workspaces/WorkspaceSelectionMemory.swift
+++ b/macos/ATC/Features/Workspaces/WorkspaceSelectionMemory.swift
@@ -13,13 +13,9 @@ struct WorkspaceSelectionMemory {
 
     private let defaults: UserDefaults
     private static let key = "workspaceSelections.v2"
-    private static let obsoleteKey = "workspaceSelections"
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
-        // The v1 map used bare server Workspace IDs and is ambiguous across
-        // Connections. Discard it instead of guessing a migration.
-        defaults.removeObject(forKey: Self.obsoleteKey)
     }
 
     func sessionID(for ref: WorkspaceRef) -> String? {

--- a/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
+++ b/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
@@ -73,14 +73,7 @@ struct WorkspaceNavigatorView: View {
                 Text(DeleteConfirmation.sessionMessage(displayName: row.title))
             }
         }
-        .alert("Workspace Action Failed", isPresented: Binding(
-            get: { actionError != nil },
-            set: { if !$0 { actionError = nil } }
-        )) {
-            Button("OK", role: .cancel) {}
-        } message: {
-            Text(actionError ?? "")
-        }
+        .actionErrorAlert($actionError, title: "Workspace Action Failed")
     }
 
     @ViewBuilder
@@ -311,14 +304,7 @@ struct WorkspaceActionsMenu: View {
                 ))
             }
         }
-        .alert("Workspace Action Failed", isPresented: Binding(
-            get: { actionError != nil },
-            set: { if !$0 { actionError = nil } }
-        )) {
-            Button("OK", role: .cancel) {}
-        } message: {
-            Text(actionError ?? "")
-        }
+        .actionErrorAlert($actionError, title: "Workspace Action Failed")
     }
 
     private var ref: WorkspaceRef? { windowState.activeWorkspace }

--- a/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
+++ b/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
@@ -9,15 +9,31 @@ struct WorkspaceNavigatorView: View {
 
     @State private var actionError: String?
     @State private var deletingSession: Row?
+    @State private var showArchived = false
 
     private struct Row: Identifiable {
         let ref: SessionRef
         let session: Session
         let title: String
+        let caption: String
         var id: SessionRef { ref }
     }
 
     var body: some View {
+        if workspaceRef == nil {
+            ContentUnavailableView(
+                "No Active Workspace",
+                systemImage: "rectangle.stack",
+                description: Text("Open a workspace to see its sessions and terminals.")
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            navigatorContent
+        }
+    }
+
+    @ViewBuilder
+    private var navigatorContent: some View {
         @Bindable var windowState = windowState
         let rows = sidebarRows()
         let agents = rows.filter { kind(of: $0.session) == .agent }
@@ -54,6 +70,17 @@ struct WorkspaceNavigatorView: View {
             }
         }
         .navigatorList()
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            HStack {
+                Toggle("Show Archived", isOn: $showArchived)
+                    .toggleStyle(.checkbox)
+                    .font(.caption)
+                Spacer()
+            }
+            .padding(.horizontal, Spacing.md)
+            .padding(.vertical, Spacing.sm)
+            .background(.bar)
+        }
         .confirmationDialog(
             "Delete Session “\(deletingSession?.title ?? "")”?",
             isPresented: Binding(
@@ -83,11 +110,16 @@ struct WorkspaceNavigatorView: View {
                 isSelected: windowState.selectedSession == row.ref,
                 action: { _ = windowState.selectSession(row.ref, in: appModel) }
             ) { _ in
-                Text(row.title)
-                    .lineLimit(1)
+                SessionRowView(
+                    session: row.session,
+                    isConnected: appModel.activelyAttachedRefs.contains(row.ref),
+                    title: row.title,
+                    caption: row.caption
+                )
             } actions: {
                 EmptyView()
             }
+            .opacity(row.session.isArchived ? Dimming.archived : 1)
             .contextMenu { sessionMenu(row) }
         }
         if rows.isEmpty {
@@ -101,7 +133,16 @@ struct WorkspaceNavigatorView: View {
     @ViewBuilder
     private func sessionMenu(_ row: Row) -> some View {
         let session = row.session
-        if session.status == .terminated || session.status == .failed {
+        if session.isArchived {
+            Button("Unarchive", systemImage: "archivebox") {
+                if let store = runtime?.sessions {
+                    run(on: row.ref.connectionID) {
+                        try await store.unarchive(id: session.id)
+                    }
+                }
+            }
+            .disabled(!isConnected)
+        } else if session.status == .terminated || session.status == .failed {
             Button("Archive", systemImage: "archivebox") {
                 if let store = runtime?.sessions {
                     run(on: row.ref.connectionID) {
@@ -140,21 +181,25 @@ struct WorkspaceNavigatorView: View {
         SessionKind.classify(session: session, actions: runtime?.actions.actions ?? [])
     }
 
+    /// Filtered, ordered sidebar rows: the Active Workspace's sessions,
+    /// newest-first, archived behind the footer toggle.
     private func sidebarRows() -> [Row] {
         guard let ref = workspaceRef else { return [] }
         let actions = runtime?.actions.actions ?? []
         return workspaceSessions()
-            .filter { !$0.isArchived }
+            .filter { showArchived || !$0.isArchived }
             .sorted {
                 if $0.createdAt != $1.createdAt { return $0.createdAt > $1.createdAt }
                 return $0.id < $1.id
             }
             .map { session in
-                let title = SessionKind.displayName(session: session, actions: actions)
+                let label = SessionKind.actionLabel(session: session, actions: actions)
+                let updated = session.updatedAt.formatted(.relative(presentation: .named))
                 return Row(
                     ref: SessionRef(connectionID: ref.connectionID, sessionID: session.id),
                     session: session,
-                    title: title
+                    title: SessionKind.displayName(session: session, actions: actions),
+                    caption: "\(label) · \(updated)"
                 )
             }
     }

--- a/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
+++ b/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
@@ -7,7 +7,6 @@ struct WorkspaceNavigatorView: View {
     @Environment(AppModel.self) private var appModel
     @Environment(WindowState.self) private var windowState
 
-    @State private var showArchivedSessions = false
     @State private var actionError: String?
     @State private var deletingSession: Row?
 
@@ -15,60 +14,43 @@ struct WorkspaceNavigatorView: View {
         let ref: SessionRef
         let session: Session
         let title: String
-        let caption: String
         var id: SessionRef { ref }
     }
 
     var body: some View {
+        @Bindable var windowState = windowState
         let rows = sidebarRows()
         let agents = rows.filter { kind(of: $0.session) == .agent }
         let terminals = rows.filter { kind(of: $0.session) == .terminal }
 
-        List(selection: selectionBinding) {
-            Section {
-                NavigatorRow(
-                    isEnabled: canStartSession,
-                    action: { windowState.startSessionKind = .agentSession }
-                ) {
-                    NavigatorIconLabel(title: "New Session", systemImage: "plus.bubble")
-                } actions: {
-                    EmptyView()
-                }
-                NavigatorRow(
-                    isEnabled: canStartSession,
-                    action: { windowState.startSessionKind = .terminal }
-                ) {
-                    NavigatorIconLabel(title: "New Terminal", systemImage: "terminal")
-                } actions: {
-                    EmptyView()
-                }
-            }
-
+        List {
             if runtime?.reachability == .unreachable {
-                Section {
-                    Label("Disconnected", systemImage: "cable.connector.slash")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .navigatorListRow()
-                }
-            }
-            section(
-                title: "Sessions",
-                rows: agents,
-                emptyText: "No sessions"
-            )
-            section(
-                title: "Terminals",
-                rows: terminals,
-                emptyText: "No terminals"
-            )
-
-            Section {
-                Toggle("Show Archived", isOn: $showArchivedSessions)
-                    .toggleStyle(.checkbox)
+                Label("Disconnected", systemImage: "cable.connector.slash")
                     .font(.caption)
-                    .frame(minHeight: NavigatorMetrics.rowHeight)
+                    .foregroundStyle(.secondary)
                     .navigatorListRow()
+            }
+
+            NavigatorDisclosureHeader(
+                title: "Sessions",
+                isExpanded: $windowState.isSessionsSectionExpanded,
+                addHelp: "New session",
+                isAddEnabled: canStartSession,
+                onAdd: { windowState.startSessionKind = .agentSession }
+            )
+            if windowState.isSessionsSectionExpanded {
+                sessionRows(agents, emptyText: "No sessions")
+            }
+
+            NavigatorDisclosureHeader(
+                title: "Terminals",
+                isExpanded: $windowState.isTerminalsSectionExpanded,
+                addHelp: "New terminal",
+                isAddEnabled: canStartSession,
+                onAdd: { windowState.startSessionKind = .terminal }
+            )
+            if windowState.isTerminalsSectionExpanded {
+                sessionRows(terminals, emptyText: "No terminals")
             }
         }
         .navigatorList()
@@ -92,80 +74,34 @@ struct WorkspaceNavigatorView: View {
     }
 
     @ViewBuilder
-    private func section(
-        title: String,
-        rows: [Row],
+    private func sessionRows(
+        _ rows: [Row],
         emptyText: String
     ) -> some View {
-        Section {
-            ForEach(rows) { row in
-                NavigatorRow(
-                    isSelected: windowState.selectedSession == row.ref,
-                    action: { _ = windowState.selectSession(row.ref, in: appModel) }
-                ) {
-                    SessionRowView(
-                        session: row.session,
-                        isConnected: appModel.activelyAttachedRefs.contains(row.ref),
-                        title: row.title,
-                        caption: row.caption
-                    )
-                } actions: {
-                    if canToggleArchive(row) {
-                        NavigatorActionButton(
-                            systemImage: row.session.isArchived ? "archivebox.fill" : "archivebox",
-                            help: row.session.isArchived ? "Unarchive session" : "Archive session"
-                        ) {
-                            toggleArchive(row)
-                        }
-                    }
-                    NavigatorActionMenu(systemImage: "ellipsis", help: "Session actions") {
-                        sessionMenu(row)
-                    }
-                }
-                .tag(row.ref)
-                .contextMenu { sessionMenu(row) }
+        ForEach(rows) { row in
+            NavigatorRow(
+                isSelected: windowState.selectedSession == row.ref,
+                action: { _ = windowState.selectSession(row.ref, in: appModel) }
+            ) { _ in
+                Text(row.title)
+                    .lineLimit(1)
+            } actions: {
+                EmptyView()
             }
-            if rows.isEmpty {
-                Text(emptyText)
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
-                    .navigatorListRow()
-            }
-        } header: {
-            NavigatorSectionHeader(title: title)
+            .contextMenu { sessionMenu(row) }
         }
-    }
-
-    private func canToggleArchive(_ row: Row) -> Bool {
-        row.session.isArchived
-            || row.session.status == .terminated
-            || row.session.status == .failed
-    }
-
-    private func toggleArchive(_ row: Row) {
-        guard let store = runtime?.sessions else { return }
-        run(on: row.ref.connectionID) {
-            if row.session.isArchived {
-                try await store.unarchive(id: row.session.id)
-            } else {
-                try await store.archive(id: row.session.id)
-            }
+        if rows.isEmpty {
+            Text(emptyText)
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .navigatorListRow()
         }
     }
 
     @ViewBuilder
     private func sessionMenu(_ row: Row) -> some View {
         let session = row.session
-        if session.isArchived {
-            Button("Unarchive", systemImage: "archivebox") {
-                if let store = runtime?.sessions {
-                    run(on: row.ref.connectionID) {
-                        try await store.unarchive(id: session.id)
-                    }
-                }
-            }
-            .disabled(!isConnected)
-        } else if session.status == .terminated || session.status == .failed {
+        if session.status == .terminated || session.status == .failed {
             Button("Archive", systemImage: "archivebox") {
                 if let store = runtime?.sessions {
                     run(on: row.ref.connectionID) {
@@ -179,17 +115,6 @@ struct WorkspaceNavigatorView: View {
             deletingSession = row
         }
         .disabled(!isConnected)
-    }
-
-    private var selectionBinding: Binding<SessionRef?> {
-        Binding(
-            get: { windowState.selectedSession },
-            set: { ref in
-                if let ref, ref != windowState.selectedSession {
-                    _ = windowState.selectSession(ref, in: appModel)
-                }
-            }
-        )
     }
 
     private var workspaceRef: WorkspaceRef? { windowState.activeWorkspace }
@@ -219,19 +144,17 @@ struct WorkspaceNavigatorView: View {
         guard let ref = workspaceRef else { return [] }
         let actions = runtime?.actions.actions ?? []
         return workspaceSessions()
-            .filter { showArchivedSessions || !$0.isArchived }
+            .filter { !$0.isArchived }
             .sorted {
                 if $0.createdAt != $1.createdAt { return $0.createdAt > $1.createdAt }
                 return $0.id < $1.id
             }
             .map { session in
                 let title = SessionKind.displayName(session: session, actions: actions)
-                let label = SessionKind.actionLabel(session: session, actions: actions)
                 return Row(
                     ref: SessionRef(connectionID: ref.connectionID, sessionID: session.id),
                     session: session,
-                    title: title,
-                    caption: "\(label) · \(session.updatedAt.formatted(.relative(presentation: .named)))"
+                    title: title
                 )
             }
     }

--- a/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
+++ b/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
@@ -136,7 +136,7 @@ struct WorkspaceNavigatorView: View {
         if session.isArchived {
             Button("Unarchive", systemImage: "archivebox") {
                 if let store = runtime?.sessions {
-                    run(on: row.ref.connectionID) {
+                    appModel.run(on: row.ref.connectionID, reporting: $actionError) {
                         try await store.unarchive(id: session.id)
                     }
                 }
@@ -145,7 +145,7 @@ struct WorkspaceNavigatorView: View {
         } else if session.status == .terminated || session.status == .failed {
             Button("Archive", systemImage: "archivebox") {
                 if let store = runtime?.sessions {
-                    run(on: row.ref.connectionID) {
+                    appModel.run(on: row.ref.connectionID, reporting: $actionError) {
                         try await store.archive(id: session.id)
                     }
                 }
@@ -174,7 +174,7 @@ struct WorkspaceNavigatorView: View {
 
     private func workspaceSessions() -> [Session] {
         guard let ref = workspaceRef, let runtime else { return [] }
-        return runtime.sessions.sessions.filter { $0.workspace?.id == ref.workspaceID }
+        return runtime.sessions.sessions.filter { $0.belongs(to: ref) }
     }
 
     private func kind(of session: Session) -> SessionKind {
@@ -188,10 +188,7 @@ struct WorkspaceNavigatorView: View {
         let actions = runtime?.actions.actions ?? []
         return workspaceSessions()
             .filter { showArchived || !$0.isArchived }
-            .sorted {
-                if $0.createdAt != $1.createdAt { return $0.createdAt > $1.createdAt }
-                return $0.id < $1.id
-            }
+            .sortedNewestFirst()
             .map { session in
                 let label = SessionKind.actionLabel(session: session, actions: actions)
                 let updated = session.updatedAt.formatted(.relative(presentation: .named))
@@ -206,26 +203,12 @@ struct WorkspaceNavigatorView: View {
 
     private func deleteSession(_ row: Row) {
         guard let store = runtime?.sessions else { return }
-        run(on: row.ref.connectionID) {
+        appModel.run(on: row.ref.connectionID, reporting: $actionError) {
             try await store.delete(id: row.session.id)
             appModel.disconnectTerminal(ref: row.ref)
             if windowState.selectedSession == row.ref {
                 windowState.showWorkspaceEmpty()
             }
-        }
-    }
-
-    private func run(
-        on connectionID: UUID,
-        _ operation: @escaping () async throws -> Void
-    ) {
-        Task {
-            guard appModel.canMutate(connectionID: connectionID) else {
-                actionError = "The connection is unavailable."
-                return
-            }
-            do { try await operation() }
-            catch { actionError = error.localizedDescription }
         }
     }
 }
@@ -256,7 +239,7 @@ struct WorkspaceActionsMenu: View {
                     Button("Unarchive Workspace", systemImage: "archivebox") {
                         if let runtime {
                             let store = runtime.workspaces
-                            run(on: runtime.id) {
+                            appModel.run(on: runtime.id, reporting: $actionError) {
                                 try await store.unarchive(id: workspace.id)
                             }
                         }
@@ -266,7 +249,7 @@ struct WorkspaceActionsMenu: View {
                     Button("Archive Workspace", systemImage: "archivebox") {
                         if let runtime {
                             let store = runtime.workspaces
-                            run(on: runtime.id) {
+                            appModel.run(on: runtime.id, reporting: $actionError) {
                                 try await store.archive(id: workspace.id)
                             }
                         }
@@ -289,7 +272,7 @@ struct WorkspaceActionsMenu: View {
                 if let workspace, let runtime {
                     let store = runtime.workspaces
                     let name = renameDraft.trimmingCharacters(in: .whitespaces)
-                    run(on: runtime.id) {
+                    appModel.run(on: runtime.id, reporting: $actionError) {
                         try await store.rename(id: workspace.id, name: name)
                     }
                 }
@@ -325,29 +308,15 @@ struct WorkspaceActionsMenu: View {
     }
     private var workspaceSessions: [Session] {
         guard let ref, let runtime else { return [] }
-        return runtime.sessions.sessions.filter { $0.workspace?.id == ref.workspaceID }
+        return runtime.sessions.sessions.filter { $0.belongs(to: ref) }
     }
     private var isConnected: Bool { runtime?.reachability == .connected }
 
     private func deleteWorkspace() {
         guard let ref, let store = runtime?.workspaces else { return }
-        run(on: ref.connectionID) {
+        appModel.run(on: ref.connectionID, reporting: $actionError) {
             try await store.delete(id: ref.workspaceID)
             windowState.forgetSelection(for: ref)
-        }
-    }
-
-    private func run(
-        on connectionID: UUID,
-        _ operation: @escaping () async throws -> Void
-    ) {
-        Task {
-            guard appModel.canMutate(connectionID: connectionID) else {
-                actionError = "The connection is unavailable."
-                return
-            }
-            do { try await operation() }
-            catch { actionError = error.localizedDescription }
         }
     }
 }

--- a/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
+++ b/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
@@ -1,28 +1,17 @@
 import SwiftUI
 import ATCAPI
 
-/// The Workspace surface: a sidebar of the open Workspace's Sessions and
-/// Terminals with the shared session content area. Mounted once a Workspace
-/// is opened and kept mounted while the Dashboard covers it, so terminal
-/// surfaces and their WebSockets survive Dashboard round-trips.
-struct WorkspaceShellView: View {
+/// Workspace-scoped Sessions and Terminals for the stable window sidebar.
+/// Its data always derives from `WindowState.activeWorkspace`.
+struct WorkspaceNavigatorView: View {
     @Environment(AppModel.self) private var appModel
     @Environment(WindowState.self) private var windowState
 
-    private let selectionMemory = WorkspaceSelectionMemory()
-
     @State private var searchText = ""
     @State private var showArchivedSessions = false
-    @State private var renamingWorkspace = false
-    @State private var renameDraft = ""
-    @State private var confirmDeleteWorkspace = false
     @State private var actionError: String?
     @State private var deletingSession: Row?
-    /// Set when the sessions store hadn't loaded at open time; the restore
-    /// re-runs once data arrives.
-    @State private var pendingSelectionRestore = false
 
-    /// One sidebar row: a session joined against the action registry.
     private struct Row: Identifiable {
         let ref: SessionRef
         let session: Session
@@ -32,123 +21,16 @@ struct WorkspaceShellView: View {
     }
 
     var body: some View {
-        @Bindable var appModel = appModel
-        @Bindable var windowState = windowState
         let rows = sidebarRows()
-        NavigationSplitView(columnVisibility: $windowState.columnVisibility) {
-            sidebar(rows: rows)
-                .navigationSplitViewColumnWidth(min: 220, ideal: 280)
-        } detail: {
-            SessionContentView(
-                selectedRef: appModel.selection,
-                selectedSession: selectedSession,
-                emptyState: workspaceIsEmpty
-                    ? SessionContentView.EmptyStateActions(
-                        newSession: { windowState.startSessionKind = .agentSession },
-                        newTerminal: { windowState.startSessionKind = .terminal },
-                        creationEnabled: canStartSession
-                    )
-                    : nil
-            )
-        }
-        .navigationTitle(workspace?.name ?? "atc")
-        .navigationSubtitle(project?.name ?? "")
-        .toolbar {
-            // The Dashboard is a content cover, not a window; hide the
-            // shell's toolbar while it is covered.
-            if windowState.route == .workspace {
-                ToolbarItem(placement: .navigation) {
-                    Button {
-                        windowState.showDashboard()
-                    } label: {
-                        Label("Dashboard", systemImage: "chevron.left")
-                    }
-                    .help("Back to the Dashboard")
-                    .keyboardShortcut(.upArrow, modifiers: .command)
-                }
-                ToolbarItem(placement: .navigation) {
-                    if let runtime {
-                        ConnectionChip(
-                            name: runtime.record.name,
-                            reachability: runtime.reachability
-                        )
-                    }
-                }
-                ToolbarItemGroup {
-                    workspaceMenu
-                }
-            }
-        }
-        .onChange(of: appModel.selection) {
-            persistSelection()
-            attachSelectedIfNeeded()
-        }
-        .onChange(of: selectedSession) { attachSelectedIfNeeded() }
-        .onChange(of: appModel.openWorkspace, initial: true) { restoreSelection() }
-        .onChange(of: sessionsLoadedOnce) {
-            if pendingSelectionRestore { restoreSelection() }
-        }
-        .alert("Rename Workspace", isPresented: $renamingWorkspace) {
-            TextField("Name", text: $renameDraft)
-            Button("Rename") {
-                if let workspace, let store = runtime?.workspaces {
-                    let trimmed = renameDraft.trimmingCharacters(in: .whitespaces)
-                    run { try await store.rename(id: workspace.id, name: trimmed) }
-                }
-            }
-            .disabled(renameDraft.trimmingCharacters(in: .whitespaces).isEmpty)
-            Button("Cancel", role: .cancel) {}
-        }
-        .confirmationDialog(
-            "Delete Workspace “\(workspace?.name ?? "")”?",
-            isPresented: $confirmDeleteWorkspace
-        ) {
-            Button("Delete Workspace", role: .destructive) { deleteOpenWorkspace() }
-        } message: {
-            if let workspace {
-                let members = workspaceSessions()
-                Text(DeleteConfirmation.workspaceMessage(
-                    name: workspace.name,
-                    sessionCount: members.count,
-                    activeCount: members.filter(\.isActive).count
-                ))
-            }
-        }
-        .confirmationDialog(
-            "Delete Session “\(deletingSession?.title ?? "")”?",
-            isPresented: Binding(
-                get: { deletingSession != nil },
-                set: { if !$0 { deletingSession = nil } }
-            )
-        ) {
-            Button("Delete Session", role: .destructive) {
-                if let row = deletingSession {
-                    deleteSession(row)
-                }
-            }
-        } message: {
-            if let row = deletingSession {
-                Text(DeleteConfirmation.sessionMessage(displayName: row.title))
-            }
-        }
-        .alert("Workspace Action Failed", isPresented: Binding(
-            get: { actionError != nil },
-            set: { if !$0 { actionError = nil } }
-        )) {
-            Button("OK", role: .cancel) {}
-        } message: {
-            Text(actionError ?? "")
-        }
-    }
-
-    // MARK: - Sidebar
-
-    @ViewBuilder
-    private func sidebar(rows: [Row]) -> some View {
-        @Bindable var appModel = appModel
         let agents = rows.filter { kind(of: $0.session) == .agent }
         let terminals = rows.filter { kind(of: $0.session) == .terminal }
-        List(selection: $appModel.selection) {
+
+        List(selection: selectionBinding) {
+            if runtime?.reachability == .unreachable {
+                Label("Disconnected", systemImage: "cable.connector.slash")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
             section(
                 title: "Sessions",
                 rows: agents,
@@ -164,6 +46,7 @@ struct WorkspaceShellView: View {
                 onNew: { windowState.startSessionKind = .terminal }
             )
         }
+        .listStyle(.sidebar)
         .searchable(text: $searchText, placement: .sidebar, prompt: "Search sessions")
         .safeAreaInset(edge: .bottom, spacing: 0) {
             HStack {
@@ -175,6 +58,29 @@ struct WorkspaceShellView: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
             .background(.bar)
+        }
+        .confirmationDialog(
+            "Delete Session “\(deletingSession?.title ?? "")”?",
+            isPresented: Binding(
+                get: { deletingSession != nil },
+                set: { if !$0 { deletingSession = nil } }
+            )
+        ) {
+            Button("Delete Session", role: .destructive) {
+                if let row = deletingSession { deleteSession(row) }
+            }
+        } message: {
+            if let row = deletingSession {
+                Text(DeleteConfirmation.sessionMessage(displayName: row.title))
+            }
+        }
+        .alert("Workspace Action Failed", isPresented: Binding(
+            get: { actionError != nil },
+            set: { if !$0 { actionError = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(actionError ?? "")
         }
     }
 
@@ -206,13 +112,11 @@ struct WorkspaceShellView: View {
             HStack {
                 Text(title)
                 Spacer()
-                Button(action: onNew) {
-                    Image(systemName: "plus")
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(.secondary)
-                .disabled(!canStartSession)
-                .help(newHelp)
+                Button(action: onNew) { Image(systemName: "plus") }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    .disabled(!canStartSession)
+                    .help(newHelp)
             }
         }
     }
@@ -226,29 +130,117 @@ struct WorkspaceShellView: View {
                     run { try await store.unarchive(id: session.id) }
                 }
             }
+            .disabled(!isConnected)
         } else if session.status == .terminated || session.status == .failed {
             Button("Archive", systemImage: "archivebox") {
                 if let store = runtime?.sessions {
                     run { try await store.archive(id: session.id) }
                 }
             }
+            .disabled(!isConnected)
         }
         Button("Delete…", systemImage: "trash", role: .destructive) {
             deletingSession = row
         }
+        .disabled(!isConnected)
     }
 
-    // MARK: - Workspace menu
+    private var selectionBinding: Binding<SessionRef?> {
+        Binding(
+            get: { windowState.selectedSession },
+            set: { ref in
+                if let ref { _ = windowState.selectSession(ref, in: appModel) }
+            }
+        )
+    }
 
-    private var workspaceMenu: some View {
+    private var workspaceRef: WorkspaceRef? { windowState.activeWorkspace }
+
+    private var runtime: ConnectionRuntime? {
+        workspaceRef.flatMap { appModel.runtime(id: $0.connectionID) }
+    }
+
+    private var canStartSession: Bool {
+        windowState.canStartSession(in: appModel)
+    }
+
+    private var isConnected: Bool {
+        runtime?.reachability == .connected
+    }
+
+    private func workspaceSessions() -> [Session] {
+        guard let ref = workspaceRef, let runtime else { return [] }
+        return runtime.sessions.sessions.filter { $0.workspace?.id == ref.workspaceID }
+    }
+
+    private func kind(of session: Session) -> SessionKind {
+        SessionKind.classify(session: session, actions: runtime?.actions.actions ?? [])
+    }
+
+    private func sidebarRows() -> [Row] {
+        guard let ref = workspaceRef else { return [] }
+        let actions = runtime?.actions.actions ?? []
+        return workspaceSessions()
+            .filter { showArchivedSessions || !$0.isArchived }
+            .sorted {
+                if $0.createdAt != $1.createdAt { return $0.createdAt > $1.createdAt }
+                return $0.id < $1.id
+            }
+            .compactMap { session in
+                let title = SessionKind.displayName(session: session, actions: actions)
+                if !searchText.isEmpty,
+                   !title.localizedCaseInsensitiveContains(searchText) {
+                    return nil
+                }
+                let label = SessionKind.actionLabel(session: session, actions: actions)
+                return Row(
+                    ref: SessionRef(connectionID: ref.connectionID, sessionID: session.id),
+                    session: session,
+                    title: title,
+                    caption: "\(label) · \(session.updatedAt.formatted(.relative(presentation: .named)))"
+                )
+            }
+    }
+
+    private func deleteSession(_ row: Row) {
+        guard let store = runtime?.sessions else { return }
+        run {
+            try await store.delete(id: row.session.id)
+            appModel.disconnectTerminal(ref: row.ref)
+            if windowState.selectedSession == row.ref {
+                windowState.showWorkspaceEmpty()
+            }
+        }
+    }
+
+    private func run(_ operation: @escaping () async throws -> Void) {
+        Task {
+            do { try await operation() }
+            catch { actionError = error.localizedDescription }
+        }
+    }
+}
+
+/// Existing Workspace lifecycle actions, presented from the stable toolbar.
+struct WorkspaceActionsMenu: View {
+    @Environment(AppModel.self) private var appModel
+    @Environment(WindowState.self) private var windowState
+
+    @State private var renaming = false
+    @State private var renameDraft = ""
+    @State private var confirmDelete = false
+    @State private var actionError: String?
+
+    var body: some View {
         Menu {
             Button("New Workspace…", systemImage: "plus.square.on.square") {
                 windowState.presentCreateWorkspace(in: appModel)
             }
             Button("Rename…", systemImage: "pencil") {
                 renameDraft = workspace?.name ?? ""
-                renamingWorkspace = true
+                renaming = true
             }
+            .disabled(!isConnected)
             Divider()
             if let workspace {
                 if workspace.isArchived {
@@ -257,171 +249,90 @@ struct WorkspaceShellView: View {
                             run { try await store.unarchive(id: workspace.id) }
                         }
                     }
+                    .disabled(!isConnected)
                 } else {
-                    // Mirrors the server rule: no archiving with active
-                    // sessions; the 409 remains the source of truth.
                     Button("Archive Workspace", systemImage: "archivebox") {
                         if let store = runtime?.workspaces {
                             run { try await store.archive(id: workspace.id) }
                         }
                     }
-                    .disabled(workspaceSessions().contains(where: \.isActive))
+                    .disabled(!isConnected || workspaceSessions.contains(where: \.isActive))
                 }
             }
             Divider()
             Button("Delete Workspace…", systemImage: "trash", role: .destructive) {
-                confirmDeleteWorkspace = true
+                confirmDelete = true
             }
+            .disabled(!isConnected)
         } label: {
             Label("Workspace", systemImage: "ellipsis.circle")
         }
         .help("Workspace actions")
+        .alert("Rename Workspace", isPresented: $renaming) {
+            TextField("Name", text: $renameDraft)
+            Button("Rename") {
+                if let workspace, let store = runtime?.workspaces {
+                    let name = renameDraft.trimmingCharacters(in: .whitespaces)
+                    run { try await store.rename(id: workspace.id, name: name) }
+                }
+            }
+            .disabled(renameDraft.trimmingCharacters(in: .whitespaces).isEmpty)
+            Button("Cancel", role: .cancel) {}
+        }
+        .confirmationDialog(
+            "Delete Workspace “\(workspace?.name ?? "")”?",
+            isPresented: $confirmDelete
+        ) {
+            Button("Delete Workspace", role: .destructive) { deleteWorkspace() }
+        } message: {
+            if let workspace {
+                Text(DeleteConfirmation.workspaceMessage(
+                    name: workspace.name,
+                    sessionCount: workspaceSessions.count,
+                    activeCount: workspaceSessions.filter(\.isActive).count
+                ))
+            }
+        }
+        .alert("Workspace Action Failed", isPresented: Binding(
+            get: { actionError != nil },
+            set: { if !$0 { actionError = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(actionError ?? "")
+        }
     }
 
-    // MARK: - Data
-
-    private var workspaceRef: WorkspaceRef? { appModel.openWorkspace }
-
+    private var ref: WorkspaceRef? { windowState.activeWorkspace }
     private var runtime: ConnectionRuntime? {
-        workspaceRef.flatMap { appModel.runtime(id: $0.connectionID) }
+        ref.flatMap { appModel.runtime(id: $0.connectionID) }
     }
-
     private var workspace: Workspace? {
-        guard let ref = workspaceRef else { return nil }
+        guard let ref else { return nil }
         return runtime?.workspaces.workspace(id: ref.workspaceID)
     }
-
-    private var project: Project? {
-        guard let workspace else { return nil }
-        return runtime?.projects.project(id: workspace.projectId)
-    }
-
-    private var selectedSession: Session? {
-        appModel.selection.flatMap { appModel.session(for: $0) }
-    }
-
-    private var sessionsLoadedOnce: Bool {
-        runtime?.sessions.hasLoadedOnce ?? false
-    }
-
-    private var canStartSession: Bool {
-        windowState.canStartSession(in: appModel)
-    }
-
-    /// Every session of the open Workspace, unfiltered.
-    private func workspaceSessions() -> [Session] {
-        guard let ref = workspaceRef, let runtime else { return [] }
+    private var workspaceSessions: [Session] {
+        guard let ref, let runtime else { return [] }
         return runtime.sessions.sessions.filter { $0.workspace?.id == ref.workspaceID }
     }
+    private var isConnected: Bool { runtime?.reachability == .connected }
 
-    /// No sessions at all (unfiltered) — drives the Workspace empty state.
-    private var workspaceIsEmpty: Bool {
-        workspaceRef != nil && workspaceSessions().isEmpty
-    }
-
-    private func kind(of session: Session) -> SessionKind {
-        SessionKind.classify(session: session, actions: runtime?.actions.actions ?? [])
-    }
-
-    /// Filtered, ordered sidebar rows: the open Workspace's sessions,
-    /// newest-first, archived behind the footer toggle, searched by title.
-    private func sidebarRows() -> [Row] {
-        guard let ref = workspaceRef else { return [] }
-        let actions = runtime?.actions.actions ?? []
-        return workspaceSessions()
-            .filter { showArchivedSessions || !$0.isArchived }
-            .sorted { $0.createdAt > $1.createdAt }
-            .compactMap { session in
-                let title = SessionKind.displayName(session: session, actions: actions)
-                if !searchText.isEmpty,
-                   !title.localizedCaseInsensitiveContains(searchText) {
-                    return nil
-                }
-                let label = SessionKind.actionLabel(session: session, actions: actions)
-                let caption = "\(label) · \(session.updatedAt.formatted(.relative(presentation: .named)))"
-                return Row(
-                    ref: SessionRef(connectionID: ref.connectionID, sessionID: session.id),
-                    session: session,
-                    title: title,
-                    caption: caption
-                )
-            }
-    }
-
-    // MARK: - Selection restore
-
-    /// Restores the Workspace's remembered session if it still exists in
-    /// the store (any lifecycle state); otherwise clears the selection so
-    /// the shell shows the Workspace empty state.
-    private func restoreSelection() {
-        guard let ref = workspaceRef else { return }
-        guard sessionsLoadedOnce else {
-            pendingSelectionRestore = true
-            return
-        }
-        pendingSelectionRestore = false
-        appModel.selection = selectionMemory.restoredSelection(
-            for: ref,
-            in: runtime?.sessions.sessions ?? []
-        )
-    }
-
-    /// Persists `workspaceID → sessionID` on every selection change.
-    private func persistSelection() {
-        guard let ref = workspaceRef,
-              let selection = appModel.selection,
-              selection.connectionID == ref.connectionID,
-              let session = appModel.session(for: selection),
-              session.workspace?.id == ref.workspaceID
-        else { return }
-        selectionMemory.remember(sessionID: selection.sessionID, for: ref.workspaceID)
-    }
-
-    /// Selecting an attachable session auto-attaches — no explicit Connect
-    /// step. Also fires when a selected starting session becomes attachable.
-    private func attachSelectedIfNeeded() {
-        if let ref = appModel.selection, let session = selectedSession, session.attachable {
-            appModel.attachIfNeeded(to: session, connectionID: ref.connectionID)
-        }
-    }
-
-    // MARK: - Actions
-
-    /// Failure (stop error, 502) leaves the row and surfaces the alert.
-    private func deleteSession(_ row: Row) {
-        guard let store = runtime?.sessions else { return }
-        run {
-            try await store.delete(id: row.session.id)
-            appModel.disconnectTerminal(ref: row.ref)
-            if appModel.selection == row.ref {
-                appModel.selection = nil
-            }
-        }
-    }
-
-    private func deleteOpenWorkspace() {
-        guard let ref = workspaceRef, let store = runtime?.workspaces else { return }
+    private func deleteWorkspace() {
+        guard let ref, let store = runtime?.workspaces else { return }
         run {
             try await store.delete(id: ref.workspaceID)
-            selectionMemory.forget(workspaceID: ref.workspaceID)
-            // Deleting the open Workspace routes back to the Dashboard.
-            windowState.handleOpenWorkspaceGone(in: appModel)
+            windowState.forgetSelection(for: ref)
         }
     }
 
     private func run(_ operation: @escaping () async throws -> Void) {
         Task {
-            do {
-                try await operation()
-            } catch {
-                actionError = error.localizedDescription
-            }
+            do { try await operation() }
+            catch { actionError = error.localizedDescription }
         }
     }
 }
 
 extension Session {
-    /// Active means the server may still be running a process: `starting`
-    /// or `running`.
     var isActive: Bool { status == .starting || status == .running }
 }

--- a/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
+++ b/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
@@ -53,8 +53,8 @@ struct WorkspaceNavigatorView: View {
                     .font(.caption)
                 Spacer()
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
+            .padding(.horizontal, Spacing.md)
+            .padding(.vertical, Spacing.xs)
             .background(.bar)
         }
         .confirmationDialog(

--- a/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
+++ b/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
@@ -69,6 +69,7 @@ struct WorkspaceNavigatorView: View {
             Button("Delete Session", role: .destructive) {
                 if let row = deletingSession { deleteSession(row) }
             }
+            .disabled(!isConnected)
         } message: {
             if let row = deletingSession {
                 Text(DeleteConfirmation.sessionMessage(displayName: row.title))
@@ -127,14 +128,18 @@ struct WorkspaceNavigatorView: View {
         if session.isArchived {
             Button("Unarchive", systemImage: "archivebox") {
                 if let store = runtime?.sessions {
-                    run { try await store.unarchive(id: session.id) }
+                    run(on: row.ref.connectionID) {
+                        try await store.unarchive(id: session.id)
+                    }
                 }
             }
             .disabled(!isConnected)
         } else if session.status == .terminated || session.status == .failed {
             Button("Archive", systemImage: "archivebox") {
                 if let store = runtime?.sessions {
-                    run { try await store.archive(id: session.id) }
+                    run(on: row.ref.connectionID) {
+                        try await store.archive(id: session.id)
+                    }
                 }
             }
             .disabled(!isConnected)
@@ -204,7 +209,7 @@ struct WorkspaceNavigatorView: View {
 
     private func deleteSession(_ row: Row) {
         guard let store = runtime?.sessions else { return }
-        run {
+        run(on: row.ref.connectionID) {
             try await store.delete(id: row.session.id)
             appModel.disconnectTerminal(ref: row.ref)
             if windowState.selectedSession == row.ref {
@@ -213,8 +218,15 @@ struct WorkspaceNavigatorView: View {
         }
     }
 
-    private func run(_ operation: @escaping () async throws -> Void) {
+    private func run(
+        on connectionID: UUID,
+        _ operation: @escaping () async throws -> Void
+    ) {
         Task {
+            guard appModel.canMutate(connectionID: connectionID) else {
+                actionError = "The connection is unavailable."
+                return
+            }
             do { try await operation() }
             catch { actionError = error.localizedDescription }
         }
@@ -245,15 +257,21 @@ struct WorkspaceActionsMenu: View {
             if let workspace {
                 if workspace.isArchived {
                     Button("Unarchive Workspace", systemImage: "archivebox") {
-                        if let store = runtime?.workspaces {
-                            run { try await store.unarchive(id: workspace.id) }
+                        if let runtime {
+                            let store = runtime.workspaces
+                            run(on: runtime.id) {
+                                try await store.unarchive(id: workspace.id)
+                            }
                         }
                     }
                     .disabled(!isConnected)
                 } else {
                     Button("Archive Workspace", systemImage: "archivebox") {
-                        if let store = runtime?.workspaces {
-                            run { try await store.archive(id: workspace.id) }
+                        if let runtime {
+                            let store = runtime.workspaces
+                            run(on: runtime.id) {
+                                try await store.archive(id: workspace.id)
+                            }
                         }
                     }
                     .disabled(!isConnected || workspaceSessions.contains(where: \.isActive))
@@ -271,12 +289,15 @@ struct WorkspaceActionsMenu: View {
         .alert("Rename Workspace", isPresented: $renaming) {
             TextField("Name", text: $renameDraft)
             Button("Rename") {
-                if let workspace, let store = runtime?.workspaces {
+                if let workspace, let runtime {
+                    let store = runtime.workspaces
                     let name = renameDraft.trimmingCharacters(in: .whitespaces)
-                    run { try await store.rename(id: workspace.id, name: name) }
+                    run(on: runtime.id) {
+                        try await store.rename(id: workspace.id, name: name)
+                    }
                 }
             }
-            .disabled(renameDraft.trimmingCharacters(in: .whitespaces).isEmpty)
+            .disabled(renameDraft.trimmingCharacters(in: .whitespaces).isEmpty || !isConnected)
             Button("Cancel", role: .cancel) {}
         }
         .confirmationDialog(
@@ -284,6 +305,7 @@ struct WorkspaceActionsMenu: View {
             isPresented: $confirmDelete
         ) {
             Button("Delete Workspace", role: .destructive) { deleteWorkspace() }
+                .disabled(!isConnected)
         } message: {
             if let workspace {
                 Text(DeleteConfirmation.workspaceMessage(
@@ -319,14 +341,21 @@ struct WorkspaceActionsMenu: View {
 
     private func deleteWorkspace() {
         guard let ref, let store = runtime?.workspaces else { return }
-        run {
+        run(on: ref.connectionID) {
             try await store.delete(id: ref.workspaceID)
             windowState.forgetSelection(for: ref)
         }
     }
 
-    private func run(_ operation: @escaping () async throws -> Void) {
+    private func run(
+        on connectionID: UUID,
+        _ operation: @escaping () async throws -> Void
+    ) {
         Task {
+            guard appModel.canMutate(connectionID: connectionID) else {
+                actionError = "The connection is unavailable."
+                return
+            }
             do { try await operation() }
             catch { actionError = error.localizedDescription }
         }

--- a/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
+++ b/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
@@ -25,38 +25,53 @@ struct WorkspaceNavigatorView: View {
         let terminals = rows.filter { kind(of: $0.session) == .terminal }
 
         List(selection: selectionBinding) {
+            Section {
+                NavigatorRow(
+                    isEnabled: canStartSession,
+                    action: { windowState.startSessionKind = .agentSession }
+                ) {
+                    NavigatorIconLabel(title: "New Session", systemImage: "plus.bubble")
+                } actions: {
+                    EmptyView()
+                }
+                NavigatorRow(
+                    isEnabled: canStartSession,
+                    action: { windowState.startSessionKind = .terminal }
+                ) {
+                    NavigatorIconLabel(title: "New Terminal", systemImage: "terminal")
+                } actions: {
+                    EmptyView()
+                }
+            }
+
             if runtime?.reachability == .unreachable {
-                Label("Disconnected", systemImage: "cable.connector.slash")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                Section {
+                    Label("Disconnected", systemImage: "cable.connector.slash")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .navigatorListRow()
+                }
             }
             section(
                 title: "Sessions",
                 rows: agents,
-                emptyText: "No sessions",
-                newHelp: "New session",
-                onNew: { windowState.startSessionKind = .agentSession }
+                emptyText: "No sessions"
             )
             section(
                 title: "Terminals",
                 rows: terminals,
-                emptyText: "No terminals",
-                newHelp: "New terminal",
-                onNew: { windowState.startSessionKind = .terminal }
+                emptyText: "No terminals"
             )
-        }
-        .listStyle(.sidebar)
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            HStack {
+
+            Section {
                 Toggle("Show Archived", isOn: $showArchivedSessions)
                     .toggleStyle(.checkbox)
                     .font(.caption)
-                Spacer()
+                    .frame(minHeight: NavigatorMetrics.rowHeight)
+                    .navigatorListRow()
             }
-            .padding(.horizontal, Spacing.md)
-            .padding(.vertical, Spacing.xs)
-            .background(.bar)
         }
+        .navigatorList()
         .confirmationDialog(
             "Delete Session “\(deletingSession?.title ?? "")”?",
             isPresented: Binding(
@@ -80,18 +95,33 @@ struct WorkspaceNavigatorView: View {
     private func section(
         title: String,
         rows: [Row],
-        emptyText: String,
-        newHelp: String,
-        onNew: @escaping () -> Void
+        emptyText: String
     ) -> some View {
         Section {
             ForEach(rows) { row in
-                SessionRowView(
-                    session: row.session,
-                    isConnected: appModel.activelyAttachedRefs.contains(row.ref),
-                    title: row.title,
-                    caption: row.caption
-                )
+                NavigatorRow(
+                    isSelected: windowState.selectedSession == row.ref,
+                    action: { _ = windowState.selectSession(row.ref, in: appModel) }
+                ) {
+                    SessionRowView(
+                        session: row.session,
+                        isConnected: appModel.activelyAttachedRefs.contains(row.ref),
+                        title: row.title,
+                        caption: row.caption
+                    )
+                } actions: {
+                    if canToggleArchive(row) {
+                        NavigatorActionButton(
+                            systemImage: row.session.isArchived ? "archivebox.fill" : "archivebox",
+                            help: row.session.isArchived ? "Unarchive session" : "Archive session"
+                        ) {
+                            toggleArchive(row)
+                        }
+                    }
+                    NavigatorActionMenu(systemImage: "ellipsis", help: "Session actions") {
+                        sessionMenu(row)
+                    }
+                }
                 .tag(row.ref)
                 .contextMenu { sessionMenu(row) }
             }
@@ -99,16 +129,26 @@ struct WorkspaceNavigatorView: View {
                 Text(emptyText)
                     .font(.caption)
                     .foregroundStyle(.tertiary)
+                    .navigatorListRow()
             }
         } header: {
-            HStack {
-                Text(title)
-                Spacer()
-                Button(action: onNew) { Image(systemName: "plus") }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.secondary)
-                    .disabled(!canStartSession)
-                    .help(newHelp)
+            NavigatorSectionHeader(title: title)
+        }
+    }
+
+    private func canToggleArchive(_ row: Row) -> Bool {
+        row.session.isArchived
+            || row.session.status == .terminated
+            || row.session.status == .failed
+    }
+
+    private func toggleArchive(_ row: Row) {
+        guard let store = runtime?.sessions else { return }
+        run(on: row.ref.connectionID) {
+            if row.session.isArchived {
+                try await store.unarchive(id: row.session.id)
+            } else {
+                try await store.archive(id: row.session.id)
             }
         }
     }

--- a/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
+++ b/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
@@ -7,7 +7,6 @@ struct WorkspaceNavigatorView: View {
     @Environment(AppModel.self) private var appModel
     @Environment(WindowState.self) private var windowState
 
-    @State private var searchText = ""
     @State private var showArchivedSessions = false
     @State private var actionError: String?
     @State private var deletingSession: Row?
@@ -47,7 +46,6 @@ struct WorkspaceNavigatorView: View {
             )
         }
         .listStyle(.sidebar)
-        .searchable(text: $searchText, placement: .sidebar, prompt: "Search sessions")
         .safeAreaInset(edge: .bottom, spacing: 0) {
             HStack {
                 Toggle("Show Archived", isOn: $showArchivedSessions)
@@ -154,7 +152,9 @@ struct WorkspaceNavigatorView: View {
         Binding(
             get: { windowState.selectedSession },
             set: { ref in
-                if let ref { _ = windowState.selectSession(ref, in: appModel) }
+                if let ref, ref != windowState.selectedSession {
+                    _ = windowState.selectSession(ref, in: appModel)
+                }
             }
         )
     }
@@ -191,12 +191,8 @@ struct WorkspaceNavigatorView: View {
                 if $0.createdAt != $1.createdAt { return $0.createdAt > $1.createdAt }
                 return $0.id < $1.id
             }
-            .compactMap { session in
+            .map { session in
                 let title = SessionKind.displayName(session: session, actions: actions)
-                if !searchText.isEmpty,
-                   !title.localizedCaseInsensitiveContains(searchText) {
-                    return nil
-                }
                 let label = SessionKind.actionLabel(session: session, actions: actions)
                 return Row(
                     ref: SessionRef(connectionID: ref.connectionID, sessionID: session.id),

--- a/macos/ATC/Features/Workspaces/WorkspaceSwitcher.swift
+++ b/macos/ATC/Features/Workspaces/WorkspaceSwitcher.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+import ATCAPI
+
+struct WorkspaceSwitcher: View {
+    @Environment(AppModel.self) private var appModel
+    @Environment(WindowState.self) private var windowState
+
+    var body: some View {
+        let groups = ProjectsNavigatorGroups(inputs: appModel.runtimes.map {
+            .init(
+                connection: $0.record,
+                reachability: $0.reachability,
+                projects: $0.projects.projects,
+                workspaces: $0.workspaces.workspaces,
+                sessions: $0.sessions.sessions
+            )
+        })
+        Menu {
+            if let context = activeContext, context.workspace.isArchived {
+                Section("Current Workspace") {
+                    Text("\(context.project.name) › \(context.workspace.name) — Archived")
+                }
+            }
+            ForEach(groups.projects) { project in
+                Section("\(project.project.name) — \(project.connectionName)") {
+                    ForEach(project.workspaces) { row in
+                        Button {
+                            _ = windowState.activateWorkspace(row.ref, in: appModel)
+                        } label: {
+                            if row.ref == windowState.activeWorkspace {
+                                Label(row.workspace.name, systemImage: "checkmark")
+                            } else {
+                                Text(row.workspace.name)
+                            }
+                        }
+                        .disabled(project.reachability != .connected)
+                    }
+                }
+            }
+            if groups.projects.allSatisfy({ $0.workspaces.isEmpty }) {
+                Text("No Workspaces")
+            }
+        } label: {
+            HStack(spacing: 6) {
+                if let context = activeContext {
+                    Circle()
+                        .fill(context.runtime.reachability.color)
+                        .frame(width: 7, height: 7)
+                    Text("\(context.project.name) › \(context.workspace.name)")
+                        .lineLimit(1)
+                } else {
+                    Text("Select Workspace…")
+                }
+                Image(systemName: "chevron.down")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .help(helpText)
+        .accessibilityLabel(helpText)
+    }
+
+    private var activeContext: (
+        runtime: ConnectionRuntime,
+        project: Project,
+        workspace: Workspace
+    )? {
+        guard let ref = windowState.activeWorkspace,
+              let runtime = appModel.runtime(id: ref.connectionID),
+              let workspace = runtime.workspaces.workspace(id: ref.workspaceID),
+              let project = runtime.projects.project(id: workspace.projectId)
+        else { return nil }
+        return (runtime, project, workspace)
+    }
+
+    private var helpText: String {
+        guard let context = activeContext else { return "Select an Active Workspace" }
+        let status = context.runtime.reachability == .connected ? "Connected" : "Disconnected"
+        let archived = context.workspace.isArchived ? ", Archived" : ""
+        return "\(context.project.name) › \(context.workspace.name), \(context.runtime.record.name), \(status)\(archived)"
+    }
+}

--- a/macos/ATC/Features/Workspaces/WorkspaceSwitcher.swift
+++ b/macos/ATC/Features/Workspaces/WorkspaceSwitcher.swift
@@ -6,15 +6,7 @@ struct WorkspaceSwitcher: View {
     @Environment(WindowState.self) private var windowState
 
     var body: some View {
-        let groups = ProjectsNavigatorGroups(inputs: appModel.runtimes.map {
-            .init(
-                connection: $0.record,
-                reachability: $0.reachability,
-                projects: $0.projects.projects,
-                workspaces: $0.workspaces.workspaces,
-                sessions: $0.sessions.sessions
-            )
-        })
+        let groups = ProjectsNavigatorGroups(runtimes: appModel.runtimes)
         let presentation = activeContext.map {
             WorkspaceSwitcherPresentation(
                 project: $0.project,

--- a/macos/ATC/Features/Workspaces/WorkspaceSwitcher.swift
+++ b/macos/ATC/Features/Workspaces/WorkspaceSwitcher.swift
@@ -59,9 +59,6 @@ struct WorkspaceSwitcher: View {
                 } else {
                     Text(presentation.label)
                 }
-                Image(systemName: "chevron.down")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
             }
         }
         .help(presentation.help)

--- a/macos/ATC/Features/Workspaces/WorkspaceSwitcher.swift
+++ b/macos/ATC/Features/Workspaces/WorkspaceSwitcher.swift
@@ -15,6 +15,14 @@ struct WorkspaceSwitcher: View {
                 sessions: $0.sessions.sessions
             )
         })
+        let presentation = activeContext.map {
+            WorkspaceSwitcherPresentation(
+                project: $0.project,
+                workspace: $0.workspace,
+                connectionName: $0.runtime.record.name,
+                reachability: $0.runtime.reachability
+            )
+        } ?? .noActiveWorkspace
         Menu {
             if let context = activeContext, context.workspace.isArchived {
                 Section("Current Workspace") {
@@ -46,18 +54,18 @@ struct WorkspaceSwitcher: View {
                     Circle()
                         .fill(context.runtime.reachability.color)
                         .frame(width: 7, height: 7)
-                    Text("\(context.project.name) › \(context.workspace.name)")
+                    Text(presentation.label)
                         .lineLimit(1)
                 } else {
-                    Text("Select Workspace…")
+                    Text(presentation.label)
                 }
                 Image(systemName: "chevron.down")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             }
         }
-        .help(helpText)
-        .accessibilityLabel(helpText)
+        .help(presentation.help)
+        .accessibilityLabel(presentation.help)
     }
 
     private var activeContext: (
@@ -72,11 +80,35 @@ struct WorkspaceSwitcher: View {
         else { return nil }
         return (runtime, project, workspace)
     }
+}
 
-    private var helpText: String {
-        guard let context = activeContext else { return "Select an Active Workspace" }
-        let status = context.runtime.reachability == .connected ? "Connected" : "Disconnected"
-        let archived = context.workspace.isArchived ? ", Archived" : ""
-        return "\(context.project.name) › \(context.workspace.name), \(context.runtime.record.name), \(status)\(archived)"
+struct WorkspaceSwitcherPresentation: Equatable {
+    let label: String
+    let help: String
+    let isArchived: Bool
+
+    static let noActiveWorkspace = WorkspaceSwitcherPresentation(
+        label: "Select Workspace…",
+        help: "Select an Active Workspace",
+        isArchived: false
+    )
+
+    private init(label: String, help: String, isArchived: Bool) {
+        self.label = label
+        self.help = help
+        self.isArchived = isArchived
+    }
+
+    init(
+        project: Project,
+        workspace: Workspace,
+        connectionName: String,
+        reachability: Reachability
+    ) {
+        label = "\(project.name) › \(workspace.name)"
+        let status = reachability == .connected ? "Connected" : "Disconnected"
+        let archived = workspace.isArchived ? ", Archived" : ""
+        help = "\(label), \(connectionName), \(status)\(archived)"
+        isArchived = workspace.isArchived
     }
 }

--- a/macos/ATC/Features/Workspaces/WorkspaceSwitcher.swift
+++ b/macos/ATC/Features/Workspaces/WorkspaceSwitcher.swift
@@ -49,11 +49,9 @@ struct WorkspaceSwitcher: View {
                 Text("No Workspaces")
             }
         } label: {
-            HStack(spacing: 6) {
+            HStack(spacing: Spacing.sm) {
                 if let context = activeContext {
-                    Circle()
-                        .fill(context.runtime.reachability.color)
-                        .frame(width: 7, height: 7)
+                    StatusDot(color: context.runtime.reachability.color)
                     Text(presentation.label)
                         .lineLimit(1)
                 } else {

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -132,10 +132,15 @@ struct ProjectsNavigatorView: View {
                 if let group = renamingProject,
                    let store = appModel.runtime(id: group.ref.connectionID)?.projects {
                     let name = renameDraft.trimmingCharacters(in: .whitespaces)
-                    run { try await store.rename(id: group.project.id, name: name) }
+                    run(on: group.ref.connectionID) {
+                        try await store.rename(id: group.project.id, name: name)
+                    }
                 }
             }
-            .disabled(renameDraft.trimmingCharacters(in: .whitespaces).isEmpty)
+            .disabled(
+                renameDraft.trimmingCharacters(in: .whitespaces).isEmpty
+                    || !(renamingProject.map { canMutate($0.ref.connectionID) } ?? false)
+            )
             Button("Cancel", role: .cancel) {}
         }
         .alert("Rename Workspace", isPresented: Binding(
@@ -147,10 +152,15 @@ struct ProjectsNavigatorView: View {
                 if let row = renamingWorkspace,
                    let store = appModel.runtime(id: row.ref.connectionID)?.workspaces {
                     let name = renameDraft.trimmingCharacters(in: .whitespaces)
-                    run { try await store.rename(id: row.workspace.id, name: name) }
+                    run(on: row.ref.connectionID) {
+                        try await store.rename(id: row.workspace.id, name: name)
+                    }
                 }
             }
-            .disabled(renameDraft.trimmingCharacters(in: .whitespaces).isEmpty)
+            .disabled(
+                renameDraft.trimmingCharacters(in: .whitespaces).isEmpty
+                    || !(renamingWorkspace.map { canMutate($0.ref.connectionID) } ?? false)
+            )
             Button("Cancel", role: .cancel) {}
         }
         .confirmationDialog(
@@ -163,9 +173,12 @@ struct ProjectsNavigatorView: View {
             Button("Delete Project", role: .destructive) {
                 if let group = deletingProject,
                    let store = appModel.runtime(id: group.ref.connectionID)?.projects {
-                    run { try await store.delete(id: group.project.id) }
+                    run(on: group.ref.connectionID) {
+                        try await store.delete(id: group.project.id)
+                    }
                 }
             }
+            .disabled(!(deletingProject.map { canMutate($0.ref.connectionID) } ?? false))
         }
         .confirmationDialog(
             "Delete Workspace “\(deletingWorkspace?.workspace.name ?? "")”?",
@@ -177,12 +190,13 @@ struct ProjectsNavigatorView: View {
             Button("Delete Workspace", role: .destructive) {
                 if let row = deletingWorkspace,
                    let store = appModel.runtime(id: row.ref.connectionID)?.workspaces {
-                    run {
+                    run(on: row.ref.connectionID) {
                         try await store.delete(id: row.workspace.id)
                         windowState.forgetSelection(for: row.ref)
                     }
                 }
             }
+            .disabled(!(deletingWorkspace.map { canMutate($0.ref.connectionID) } ?? false))
         } message: {
             if let row = deletingWorkspace {
                 Text(DeleteConfirmation.workspaceMessage(
@@ -233,7 +247,9 @@ struct ProjectsNavigatorView: View {
             Divider()
             Button("Archive Project", systemImage: "archivebox") {
                 if let store = appModel.runtime(id: group.ref.connectionID)?.projects {
-                    run { try await store.archive(id: group.project.id) }
+                    run(on: group.ref.connectionID) {
+                        try await store.archive(id: group.project.id)
+                    }
                 }
             }
             .disabled(group.reachability != .connected || group.hasUnarchivedWorkspaces)
@@ -282,7 +298,9 @@ struct ProjectsNavigatorView: View {
             Divider()
             Button("Archive", systemImage: "archivebox") {
                 if let store = appModel.runtime(id: row.ref.connectionID)?.workspaces {
-                    run { try await store.archive(id: row.workspace.id) }
+                    run(on: row.ref.connectionID) {
+                        try await store.archive(id: row.workspace.id)
+                    }
                 }
             }
             .disabled(!enabled || row.hasActiveSessions)
@@ -304,8 +322,19 @@ struct ProjectsNavigatorView: View {
         )
     }
 
-    private func run(_ operation: @escaping () async throws -> Void) {
+    private func canMutate(_ connectionID: UUID) -> Bool {
+        appModel.canMutate(connectionID: connectionID)
+    }
+
+    private func run(
+        on connectionID: UUID,
+        _ operation: @escaping () async throws -> Void
+    ) {
         Task {
+            guard canMutate(connectionID) else {
+                actionError = "The connection is unavailable."
+                return
+            }
             do { try await operation() }
             catch { actionError = error.localizedDescription }
         }

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -83,6 +83,7 @@ struct ProjectsNavigatorView: View {
     @State private var actionError: String?
 
     var body: some View {
+        @Bindable var windowState = windowState
         let groups = ProjectsNavigatorGroups(inputs: appModel.runtimes.map {
             .init(
                 connection: $0.record,
@@ -92,20 +93,25 @@ struct ProjectsNavigatorView: View {
                 sessions: $0.sessions.sessions
             )
         })
-        List(selection: selectionBinding) {
-            Section {
-                NavigatorRow(
-                    isSelected: windowState.selectedContent == .dashboard,
-                    action: { windowState.showDashboard() }
-                ) {
-                    NavigatorIconLabel(title: "Dashboard", systemImage: "rectangle.3.group")
-                } actions: {
-                    EmptyView()
-                }
-                .tag(ProjectsNavigatorSelection.dashboard)
+        List {
+            NavigatorRow(
+                isSelected: windowState.selectedContent == .dashboard,
+                action: { windowState.showDashboard() }
+            ) { _ in
+                NavigatorIconLabel(title: "Dashboard", systemImage: "rectangle.3.group")
+            } actions: {
+                EmptyView()
             }
 
-            Section {
+            NavigatorDisclosureHeader(
+                title: "Projects",
+                isExpanded: $windowState.isProjectsSectionExpanded,
+                addHelp: "New project",
+                isAddEnabled: true,
+                onAdd: { windowState.isCreateProjectPresented = true }
+            )
+
+            if windowState.isProjectsSectionExpanded {
                 ForEach(groups.projects) { group in
                     projectRow(group)
                     ForEach(group.workspaces) { row in
@@ -121,8 +127,6 @@ struct ProjectsNavigatorView: View {
                             .navigatorListRow()
                     }
                 }
-            } header: {
-                NavigatorSectionHeader(title: "Projects")
             }
         }
         .navigatorList()
@@ -221,32 +225,34 @@ struct ProjectsNavigatorView: View {
                     windowState.expandedProjects.insert(group.ref)
                 }
             }
-        ) {
+        ) { isHovering in
             HStack(spacing: Spacing.sm) {
                 Image(systemName: windowState.expandedProjects.contains(group.ref) ? "folder.fill" : "folder")
-                    .frame(width: NavigatorMetrics.iconWidth)
+                    .frame(width: NavigatorMetrics.iconWidth, alignment: .leading)
                     .foregroundStyle(.secondary)
                 Text(group.project.name)
                     .lineLimit(1)
                 Spacer(minLength: Spacing.sm)
-                HStack(spacing: Spacing.xs) {
-                    Text(group.connectionName)
-                        .lineLimit(1)
-                    StatusDot(color: group.reachability.color, size: .inline)
+                if !isHovering {
+                    HStack(spacing: Spacing.xs) {
+                        Text(group.connectionName)
+                            .lineLimit(1)
+                        StatusDot(color: group.reachability.color, size: .inline)
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
                 }
-                .font(.caption)
-                .foregroundStyle(.secondary)
             }
         } actions: {
+            NavigatorActionMenu(systemImage: "ellipsis", help: "Project actions") {
+                projectMenu(group)
+            }
             NavigatorActionButton(
                 systemImage: "plus",
                 help: "New workspace",
                 isEnabled: group.reachability == .connected
             ) {
                 windowState.createWorkspaceContext = .init(mode: .fixed(group.ref))
-            }
-            NavigatorActionMenu(systemImage: "ellipsis", help: "Project actions") {
-                projectMenu(group)
             }
         }
         .contextMenu { projectMenu(group) }
@@ -293,18 +299,10 @@ struct ProjectsNavigatorView: View {
             action: {
                 _ = windowState.activateWorkspace(row.ref, in: appModel)
             }
-        ) {
+        ) { _ in
             Text(row.workspace.name)
                 .lineLimit(1)
         } actions: {
-            NavigatorActionMenu(systemImage: "plus", help: "Start in this workspace") {
-                Button("New Session", systemImage: "plus.bubble") {
-                    presentStart(.agentSession, in: row.ref)
-                }
-                Button("New Terminal", systemImage: "terminal") {
-                    presentStart(.terminal, in: row.ref)
-                }
-            }
             NavigatorActionButton(
                 systemImage: "archivebox",
                 help: row.hasActiveSessions ? "Stop active sessions before archiving" : "Archive workspace",
@@ -313,7 +311,6 @@ struct ProjectsNavigatorView: View {
                 archiveWorkspace(row)
             }
         }
-        .tag(ProjectsNavigatorSelection.workspace(row.ref))
         .opacity(enabled ? 1 : Dimming.archived)
         .contextMenu { workspaceMenu(row, enabled: enabled) }
     }
@@ -352,13 +349,6 @@ struct ProjectsNavigatorView: View {
         .disabled(!enabled)
     }
 
-    private func presentStart(_ kind: StartSessionKind, in ref: WorkspaceRef) {
-        guard windowState.activateWorkspace(ref, in: appModel),
-              appModel.canStartSession(in: ref)
-        else { return }
-        windowState.startSessionKind = kind
-    }
-
     private func archiveWorkspace(_ row: ProjectsNavigatorGroups.WorkspaceRow) {
         guard let store = appModel.runtime(id: row.ref.connectionID)?.workspaces else { return }
         run(on: row.ref.connectionID) {
@@ -366,28 +356,11 @@ struct ProjectsNavigatorView: View {
         }
     }
 
-    private var selectionBinding: Binding<ProjectsNavigatorSelection?> {
-        Binding(
-            get: {
-                if windowState.selectedContent == .dashboard { return .dashboard }
-                return windowState.activeWorkspace.map(ProjectsNavigatorSelection.workspace)
-            },
-            set: { selection in
-                switch selection {
-                case .dashboard:
-                    if windowState.selectedContent != .dashboard {
-                        windowState.showDashboard()
-                    }
-                case .workspace(let ref):
-                    if windowState.activeWorkspace != ref
-                        || windowState.selectedContent == .dashboard {
-                        _ = windowState.activateWorkspace(ref, in: appModel)
-                    }
-                case nil:
-                    break
-                }
-            }
-        )
+    private func presentStart(_ kind: StartSessionKind, in ref: WorkspaceRef) {
+        guard windowState.activateWorkspace(ref, in: appModel),
+              appModel.canStartSession(in: ref)
+        else { return }
+        windowState.startSessionKind = kind
     }
 
     private func canMutate(_ connectionID: UUID) -> Bool {
@@ -407,11 +380,6 @@ struct ProjectsNavigatorView: View {
             catch { actionError = error.localizedDescription }
         }
     }
-}
-
-private enum ProjectsNavigatorSelection: Hashable {
-    case dashboard
-    case workspace(WorkspaceRef)
 }
 
 struct FileNavigatorView: View {

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -37,7 +37,9 @@ struct NavigatorSelector: View {
                     .accessibilityLabel(option.id.label)
                     .help(option.help)
                     .tag(option.id)
-                    .disabled(!option.isEnabled)
+                    // .disabled is inert on segmented picker options;
+                    // only .selectionDisabled actually blocks selection.
+                    .selectionDisabled(!option.isEnabled)
             }
         }
         .pickerStyle(.segmented)

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -50,7 +50,7 @@ struct NavigatorSelector: View {
             style: .continuous
         ))
         .padding(.horizontal, Spacing.md)
-        .padding(.vertical, Spacing.sm)
+        .padding(.bottom, NavigatorMetrics.selectorToContentSpacing)
     }
 }
 

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -28,28 +28,46 @@ struct NavigatorSelector: View {
 
     var body: some View {
         HStack(spacing: 4) {
-            ForEach(NavigatorID.allCases, id: \.self) { navigator in
-                let enabled = navigator == .projects || windowState.activeWorkspace != nil
+            ForEach(NavigatorSelectorOption.all(
+                hasActiveWorkspace: windowState.activeWorkspace != nil
+            )) { option in
                 Button {
-                    selection = navigator
+                    selection = option.id
                 } label: {
-                    Image(systemName: navigator.systemImage)
+                    Image(systemName: option.id.systemImage)
                         .frame(width: 28, height: 24)
                         .background(
-                            selection == navigator ? Color.accentColor.opacity(0.18) : .clear,
+                            selection == option.id ? Color.accentColor.opacity(0.18) : .clear,
                             in: RoundedRectangle(cornerRadius: 5)
                         )
                 }
                 .buttonStyle(.plain)
-                .disabled(!enabled)
-                .help(enabled ? navigator.label : "Requires an Active Workspace")
-                .accessibilityLabel(navigator.label)
+                .disabled(!option.isEnabled)
+                .help(option.help)
+                .accessibilityLabel(option.id.label)
             }
             Spacer()
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 7)
         .background(.bar)
+    }
+}
+
+struct NavigatorSelectorOption: Identifiable, Equatable {
+    let id: NavigatorID
+    let isEnabled: Bool
+    let help: String
+
+    static func all(hasActiveWorkspace: Bool) -> [NavigatorSelectorOption] {
+        NavigatorID.allCases.map { navigator in
+            let enabled = navigator == .projects || hasActiveWorkspace
+            return NavigatorSelectorOption(
+                id: navigator,
+                isEnabled: enabled,
+                help: enabled ? navigator.label : "Requires an Active Workspace"
+            )
+        }
     }
 }
 
@@ -295,9 +313,11 @@ struct ProjectsNavigatorView: View {
 }
 
 struct FileNavigatorView: View {
+    static let unavailableMessage = "File navigation is not available yet"
+
     var body: some View {
         ContentUnavailableView(
-            "File navigation is not available yet",
+            Self.unavailableMessage,
             systemImage: "doc"
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -1,0 +1,305 @@
+import SwiftUI
+import ATCAPI
+
+struct NavigatorSidebar: View {
+    @Environment(WindowState.self) private var windowState
+
+    var body: some View {
+        @Bindable var windowState = windowState
+        VStack(spacing: 0) {
+            NavigatorSelector(selection: $windowState.selectedNavigator)
+            Divider()
+            switch windowState.selectedNavigator {
+            case .projects:
+                ProjectsNavigatorView()
+            case .workspace:
+                WorkspaceNavigatorView()
+            case .file:
+                FileNavigatorView()
+            }
+        }
+        .navigationSplitViewColumnWidth(min: 220, ideal: 280)
+    }
+}
+
+struct NavigatorSelector: View {
+    @Environment(WindowState.self) private var windowState
+    @Binding var selection: NavigatorID
+
+    var body: some View {
+        HStack(spacing: 4) {
+            ForEach(NavigatorID.allCases, id: \.self) { navigator in
+                let enabled = navigator == .projects || windowState.activeWorkspace != nil
+                Button {
+                    selection = navigator
+                } label: {
+                    Image(systemName: navigator.systemImage)
+                        .frame(width: 28, height: 24)
+                        .background(
+                            selection == navigator ? Color.accentColor.opacity(0.18) : .clear,
+                            in: RoundedRectangle(cornerRadius: 5)
+                        )
+                }
+                .buttonStyle(.plain)
+                .disabled(!enabled)
+                .help(enabled ? navigator.label : "Requires an Active Workspace")
+                .accessibilityLabel(navigator.label)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(.bar)
+    }
+}
+
+struct ProjectsNavigatorView: View {
+    @Environment(AppModel.self) private var appModel
+    @Environment(WindowState.self) private var windowState
+
+    @State private var renamingProject: ProjectsNavigatorGroups.ProjectGroup?
+    @State private var renamingWorkspace: ProjectsNavigatorGroups.WorkspaceRow?
+    @State private var renameDraft = ""
+    @State private var deletingProject: ProjectsNavigatorGroups.ProjectGroup?
+    @State private var deletingWorkspace: ProjectsNavigatorGroups.WorkspaceRow?
+    @State private var actionError: String?
+
+    var body: some View {
+        let groups = ProjectsNavigatorGroups(inputs: appModel.runtimes.map {
+            .init(
+                connection: $0.record,
+                reachability: $0.reachability,
+                projects: $0.projects.projects,
+                workspaces: $0.workspaces.workspaces,
+                sessions: $0.sessions.sessions
+            )
+        })
+        List {
+            Button {
+                windowState.showDashboard()
+            } label: {
+                Label("Dashboard", systemImage: "square.grid.2x2")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .listRowBackground(
+                windowState.selectedContent == .dashboard
+                    ? Color.accentColor.opacity(0.16) : Color.clear
+            )
+
+            ForEach(groups.projects) { group in
+                DisclosureGroup(isExpanded: expansionBinding(for: group.ref)) {
+                    ForEach(group.workspaces) { row in
+                        workspaceRow(row, in: group)
+                    }
+                    if group.workspaces.isEmpty {
+                        Text("No workspaces")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                            .padding(.leading, 8)
+                    }
+                } label: {
+                    projectRow(group)
+                }
+            }
+        }
+        .listStyle(.sidebar)
+        .alert("Rename Project", isPresented: Binding(
+            get: { renamingProject != nil },
+            set: { if !$0 { renamingProject = nil } }
+        )) {
+            TextField("Name", text: $renameDraft)
+            Button("Rename") {
+                if let group = renamingProject,
+                   let store = appModel.runtime(id: group.ref.connectionID)?.projects {
+                    let name = renameDraft.trimmingCharacters(in: .whitespaces)
+                    run { try await store.rename(id: group.project.id, name: name) }
+                }
+            }
+            .disabled(renameDraft.trimmingCharacters(in: .whitespaces).isEmpty)
+            Button("Cancel", role: .cancel) {}
+        }
+        .alert("Rename Workspace", isPresented: Binding(
+            get: { renamingWorkspace != nil },
+            set: { if !$0 { renamingWorkspace = nil } }
+        )) {
+            TextField("Name", text: $renameDraft)
+            Button("Rename") {
+                if let row = renamingWorkspace,
+                   let store = appModel.runtime(id: row.ref.connectionID)?.workspaces {
+                    let name = renameDraft.trimmingCharacters(in: .whitespaces)
+                    run { try await store.rename(id: row.workspace.id, name: name) }
+                }
+            }
+            .disabled(renameDraft.trimmingCharacters(in: .whitespaces).isEmpty)
+            Button("Cancel", role: .cancel) {}
+        }
+        .confirmationDialog(
+            "Delete Project “\(deletingProject?.project.name ?? "")”?",
+            isPresented: Binding(
+                get: { deletingProject != nil },
+                set: { if !$0 { deletingProject = nil } }
+            )
+        ) {
+            Button("Delete Project", role: .destructive) {
+                if let group = deletingProject,
+                   let store = appModel.runtime(id: group.ref.connectionID)?.projects {
+                    run { try await store.delete(id: group.project.id) }
+                }
+            }
+        }
+        .confirmationDialog(
+            "Delete Workspace “\(deletingWorkspace?.workspace.name ?? "")”?",
+            isPresented: Binding(
+                get: { deletingWorkspace != nil },
+                set: { if !$0 { deletingWorkspace = nil } }
+            )
+        ) {
+            Button("Delete Workspace", role: .destructive) {
+                if let row = deletingWorkspace,
+                   let store = appModel.runtime(id: row.ref.connectionID)?.workspaces {
+                    run {
+                        try await store.delete(id: row.workspace.id)
+                        windowState.forgetSelection(for: row.ref)
+                    }
+                }
+            }
+        } message: {
+            if let row = deletingWorkspace {
+                Text(DeleteConfirmation.workspaceMessage(
+                    name: row.workspace.name,
+                    sessionCount: row.sessionCount,
+                    activeCount: row.activeSessionCount
+                ))
+            }
+        }
+        .alert("Action Failed", isPresented: Binding(
+            get: { actionError != nil },
+            set: { if !$0 { actionError = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(actionError ?? "")
+        }
+    }
+
+    private func projectRow(_ group: ProjectsNavigatorGroups.ProjectGroup) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "folder")
+            VStack(alignment: .leading, spacing: 1) {
+                Text(group.project.name).lineLimit(1)
+                HStack(spacing: 4) {
+                    Circle()
+                        .fill(group.reachability.color)
+                        .frame(width: 6, height: 6)
+                    Text(group.connectionName)
+                }
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .contentShape(Rectangle())
+        .onTapGesture { windowState.focusedProject = group.ref }
+        .contextMenu {
+            Button("New Workspace…", systemImage: "plus") {
+                windowState.createWorkspaceContext = .init(mode: .fixed(group.ref))
+            }
+            .disabled(group.reachability != .connected)
+            Button("Rename…", systemImage: "pencil") {
+                renameDraft = group.project.name
+                renamingProject = group
+            }
+            .disabled(group.reachability != .connected)
+            Divider()
+            Button("Archive Project", systemImage: "archivebox") {
+                if let store = appModel.runtime(id: group.ref.connectionID)?.projects {
+                    run { try await store.archive(id: group.project.id) }
+                }
+            }
+            .disabled(group.reachability != .connected || group.hasUnarchivedWorkspaces)
+            Divider()
+            Button("Delete Project…", systemImage: "trash", role: .destructive) {
+                deletingProject = group
+            }
+            .disabled(group.reachability != .connected || group.totalWorkspaceCount > 0)
+        }
+    }
+
+    private func workspaceRow(
+        _ row: ProjectsNavigatorGroups.WorkspaceRow,
+        in group: ProjectsNavigatorGroups.ProjectGroup
+    ) -> some View {
+        let enabled = group.reachability == .connected
+        return Button {
+            windowState.focusedWorkspace = row.ref
+            _ = windowState.activateWorkspace(row.ref, in: appModel)
+        } label: {
+            HStack {
+                Image(systemName: "square.on.square")
+                    .foregroundStyle(.secondary)
+                Text(row.workspace.name).lineLimit(1)
+                Spacer()
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!enabled)
+        .opacity(enabled ? 1 : 0.55)
+        .listRowBackground(
+            windowState.activeWorkspace == row.ref
+                ? Color.accentColor.opacity(0.16) : Color.clear
+        )
+        .contextMenu {
+            Button("Open", systemImage: "arrow.up.forward.square") {
+                _ = windowState.activateWorkspace(row.ref, in: appModel)
+            }
+            .disabled(!enabled)
+            Button("Rename…", systemImage: "pencil") {
+                renameDraft = row.workspace.name
+                renamingWorkspace = row
+            }
+            .disabled(!enabled)
+            Divider()
+            Button("Archive", systemImage: "archivebox") {
+                if let store = appModel.runtime(id: row.ref.connectionID)?.workspaces {
+                    run { try await store.archive(id: row.workspace.id) }
+                }
+            }
+            .disabled(!enabled || row.hasActiveSessions)
+            Divider()
+            Button("Delete…", systemImage: "trash", role: .destructive) {
+                deletingWorkspace = row
+            }
+            .disabled(!enabled)
+        }
+    }
+
+    private func expansionBinding(for ref: ProjectRef) -> Binding<Bool> {
+        Binding(
+            get: { windowState.expandedProjects.contains(ref) },
+            set: { expanded in
+                if expanded { windowState.expandedProjects.insert(ref) }
+                else { windowState.expandedProjects.remove(ref) }
+            }
+        )
+    }
+
+    private func run(_ operation: @escaping () async throws -> Void) {
+        Task {
+            do { try await operation() }
+            catch { actionError = error.localizedDescription }
+        }
+    }
+}
+
+struct FileNavigatorView: View {
+    var body: some View {
+        ContentUnavailableView(
+            "File navigation is not available yet",
+            systemImage: "doc"
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -27,7 +27,7 @@ struct NavigatorSelector: View {
     @Binding var selection: NavigatorID
 
     var body: some View {
-        HStack(spacing: 4) {
+        HStack(spacing: 6) {
             ForEach(NavigatorSelectorOption.all(
                 hasActiveWorkspace: windowState.activeWorkspace != nil
             )) { option in
@@ -35,10 +35,14 @@ struct NavigatorSelector: View {
                     selection = option.id
                 } label: {
                     Image(systemName: option.id.systemImage)
-                        .frame(width: 28, height: 24)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(
+                            selection == option.id ? Color.white : Color.secondary
+                        )
+                        .frame(width: 30, height: 26)
                         .background(
-                            selection == option.id ? Color.accentColor.opacity(0.18) : .clear,
-                            in: RoundedRectangle(cornerRadius: 5)
+                            selection == option.id ? Color.accentColor : .clear,
+                            in: RoundedRectangle(cornerRadius: 6, style: .continuous)
                         )
                 }
                 .buttonStyle(.plain)
@@ -48,9 +52,8 @@ struct NavigatorSelector: View {
             }
             Spacer()
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 7)
-        .background(.bar)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
     }
 }
 
@@ -92,19 +95,9 @@ struct ProjectsNavigatorView: View {
                 sessions: $0.sessions.sessions
             )
         })
-        List {
-            Button {
-                windowState.showDashboard()
-            } label: {
-                Label("Dashboard", systemImage: "square.grid.2x2")
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .listRowBackground(
-                windowState.selectedContent == .dashboard
-                    ? Color.accentColor.opacity(0.16) : Color.clear
-            )
+        List(selection: selectionBinding) {
+            Label("Dashboard", systemImage: "rectangle.3.group")
+                .tag(ProjectsNavigatorSelection.dashboard)
 
             ForEach(groups.projects) { group in
                 DisclosureGroup(isExpanded: expansionBinding(for: group.ref)) {
@@ -266,25 +259,17 @@ struct ProjectsNavigatorView: View {
         in group: ProjectsNavigatorGroups.ProjectGroup
     ) -> some View {
         let enabled = group.reachability == .connected
-        return Button {
-            windowState.focusedWorkspace = row.ref
-            _ = windowState.activateWorkspace(row.ref, in: appModel)
-        } label: {
-            HStack {
-                Image(systemName: "square.on.square")
-                    .foregroundStyle(.secondary)
-                Text(row.workspace.name).lineLimit(1)
-                Spacer()
-            }
-            .contentShape(Rectangle())
+        return HStack(spacing: 7) {
+            Image(systemName: "square.on.square")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(row.workspace.name).lineLimit(1)
+            Spacer()
         }
-        .buttonStyle(.plain)
+        .contentShape(Rectangle())
+        .tag(ProjectsNavigatorSelection.workspace(row.ref))
         .disabled(!enabled)
         .opacity(enabled ? 1 : 0.55)
-        .listRowBackground(
-            windowState.activeWorkspace == row.ref
-                ? Color.accentColor.opacity(0.16) : Color.clear
-        )
         .contextMenu {
             Button("Open", systemImage: "arrow.up.forward.square") {
                 _ = windowState.activateWorkspace(row.ref, in: appModel)
@@ -322,6 +307,31 @@ struct ProjectsNavigatorView: View {
         )
     }
 
+    private var selectionBinding: Binding<ProjectsNavigatorSelection?> {
+        Binding(
+            get: {
+                if windowState.selectedContent == .dashboard { return .dashboard }
+                return windowState.activeWorkspace.map(ProjectsNavigatorSelection.workspace)
+            },
+            set: { selection in
+                switch selection {
+                case .dashboard:
+                    if windowState.selectedContent != .dashboard {
+                        windowState.showDashboard()
+                    }
+                case .workspace(let ref):
+                    if windowState.activeWorkspace != ref
+                        || windowState.selectedContent == .dashboard {
+                        windowState.focusedWorkspace = ref
+                        _ = windowState.activateWorkspace(ref, in: appModel)
+                    }
+                case nil:
+                    break
+                }
+            }
+        )
+    }
+
     private func canMutate(_ connectionID: UUID) -> Bool {
         appModel.canMutate(connectionID: connectionID)
     }
@@ -339,6 +349,11 @@ struct ProjectsNavigatorView: View {
             catch { actionError = error.localizedDescription }
         }
     }
+}
+
+private enum ProjectsNavigatorSelection: Hashable {
+    case dashboard
+    case workspace(WorkspaceRef)
 }
 
 struct FileNavigatorView: View {

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -108,7 +108,7 @@ struct ProjectsNavigatorView: View {
                         Text("No workspaces")
                             .font(.caption)
                             .foregroundStyle(.tertiary)
-                            .padding(.leading, 8)
+                            .padding(.leading, Spacing.sm)
                     }
                 } label: {
                     projectRow(group)
@@ -210,11 +210,11 @@ struct ProjectsNavigatorView: View {
     }
 
     private func projectRow(_ group: ProjectsNavigatorGroups.ProjectGroup) -> some View {
-        HStack(spacing: 6) {
+        HStack(spacing: Spacing.sm) {
             Image(systemName: "folder")
             VStack(alignment: .leading, spacing: 1) {
                 Text(group.project.name).lineLimit(1)
-                HStack(spacing: 4) {
+                HStack(spacing: Spacing.xs) {
                     Circle()
                         .fill(group.reachability.color)
                         .frame(width: 6, height: 6)
@@ -259,7 +259,7 @@ struct ProjectsNavigatorView: View {
         in group: ProjectsNavigatorGroups.ProjectGroup
     ) -> some View {
         let enabled = group.reachability == .connected
-        return HStack(spacing: 7) {
+        return HStack(spacing: Spacing.sm) {
             Image(systemName: "square.on.square")
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -269,7 +269,7 @@ struct ProjectsNavigatorView: View {
         .contentShape(Rectangle())
         .tag(ProjectsNavigatorSelection.workspace(row.ref))
         .disabled(!enabled)
-        .opacity(enabled ? 1 : 0.55)
+        .opacity(enabled ? 1 : Dimming.archived)
         .contextMenu {
             Button("Open", systemImage: "arrow.up.forward.square") {
                 _ = windowState.activateWorkspace(row.ref, in: appModel)

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -27,33 +27,21 @@ struct NavigatorSelector: View {
     @Binding var selection: NavigatorID
 
     var body: some View {
-        HStack(spacing: 6) {
+        Picker("Navigator", selection: $selection) {
             ForEach(NavigatorSelectorOption.all(
                 hasActiveWorkspace: windowState.activeWorkspace != nil
             )) { option in
-                Button {
-                    selection = option.id
-                } label: {
-                    Image(systemName: option.id.systemImage)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundStyle(
-                            selection == option.id ? Color.white : Color.secondary
-                        )
-                        .frame(width: 30, height: 26)
-                        .background(
-                            selection == option.id ? Color.accentColor : .clear,
-                            in: RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        )
-                }
-                .buttonStyle(.plain)
-                .disabled(!option.isEnabled)
-                .help(option.help)
-                .accessibilityLabel(option.id.label)
+                Image(systemName: option.id.systemImage)
+                    .accessibilityLabel(option.id.label)
+                    .help(option.help)
+                    .tag(option.id)
+                    .selectionDisabled(!option.isEnabled)
             }
-            Spacer()
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
+        .pickerStyle(.palette)
+        .labelsHidden()
+        .padding(.horizontal, Spacing.md)
+        .padding(.vertical, Spacing.xs)
     }
 }
 

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -8,7 +8,6 @@ struct NavigatorSidebar: View {
         @Bindable var windowState = windowState
         VStack(spacing: 0) {
             NavigatorSelector(selection: $windowState.selectedNavigator)
-            Divider()
             switch windowState.selectedNavigator {
             case .projects:
                 ProjectsNavigatorView()
@@ -22,26 +21,64 @@ struct NavigatorSidebar: View {
     }
 }
 
+/// Xcode-style navigator bar: borderless icon buttons spread across the
+/// sidebar width, with an accent-filled rounded rect behind the selection.
 struct NavigatorSelector: View {
     @Environment(WindowState.self) private var windowState
     @Binding var selection: NavigatorID
 
     var body: some View {
-        Picker("Navigator", selection: $selection) {
+        HStack(spacing: 0) {
             ForEach(NavigatorSelectorOption.all(
                 hasActiveWorkspace: windowState.activeWorkspace != nil
             )) { option in
-                Image(systemName: option.id.systemImage)
-                    .accessibilityLabel(option.id.label)
-                    .help(option.help)
-                    .tag(option.id)
-                    .selectionDisabled(!option.isEnabled)
+                NavigatorSelectorButton(option: option, selection: $selection)
             }
         }
-        .pickerStyle(.palette)
-        .labelsHidden()
-        .padding(.horizontal, Spacing.md)
+        .padding(.horizontal, Spacing.sm)
         .padding(.vertical, Spacing.xs)
+    }
+}
+
+private struct NavigatorSelectorButton: View {
+    let option: NavigatorSelectorOption
+    @Binding var selection: NavigatorID
+    @State private var isHovering = false
+
+    private var isSelected: Bool { selection == option.id }
+
+    var body: some View {
+        Button {
+            selection = option.id
+        } label: {
+            Image(systemName: option.id.systemImage)
+                .foregroundStyle(symbolStyle)
+                .frame(width: 28, height: 22)
+                .background(
+                    RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                        .fill(backgroundStyle)
+                )
+                .frame(maxWidth: .infinity)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!option.isEnabled)
+        .onHover { isHovering = $0 }
+        .accessibilityLabel(option.id.label)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .help(option.help)
+    }
+
+    private var symbolStyle: AnyShapeStyle {
+        if isSelected { return AnyShapeStyle(.white) }
+        if !option.isEnabled { return AnyShapeStyle(.quaternary) }
+        return AnyShapeStyle(.secondary)
+    }
+
+    private var backgroundStyle: AnyShapeStyle {
+        if isSelected { return AnyShapeStyle(Color.accentColor) }
+        if isHovering && option.isEnabled { return AnyShapeStyle(.quaternary) }
+        return AnyShapeStyle(.clear)
     }
 }
 

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -199,14 +199,7 @@ struct ProjectsNavigatorView: View {
                 ))
             }
         }
-        .alert("Action Failed", isPresented: Binding(
-            get: { actionError != nil },
-            set: { if !$0 { actionError = nil } }
-        )) {
-            Button("OK", role: .cancel) {}
-        } message: {
-            Text(actionError ?? "")
-        }
+        .actionErrorAlert($actionError)
     }
 
     private func projectRow(_ group: ProjectsNavigatorGroups.ProjectGroup) -> some View {

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -86,15 +86,7 @@ struct ProjectsNavigatorView: View {
 
     var body: some View {
         @Bindable var windowState = windowState
-        let groups = ProjectsNavigatorGroups(inputs: appModel.runtimes.map {
-            .init(
-                connection: $0.record,
-                reachability: $0.reachability,
-                projects: $0.projects.projects,
-                workspaces: $0.workspaces.workspaces,
-                sessions: $0.sessions.sessions
-            )
-        })
+        let groups = ProjectsNavigatorGroups(runtimes: appModel.runtimes)
         List {
             NavigatorRow(
                 isSelected: windowState.selectedContent == .dashboard,
@@ -116,17 +108,17 @@ struct ProjectsNavigatorView: View {
             if windowState.isProjectsSectionExpanded {
                 ForEach(groups.projects) { group in
                     projectRow(group)
-                    ForEach(group.workspaces) { row in
-                        if windowState.expandedProjects.contains(group.ref) {
+                    if windowState.expandedProjects.contains(group.ref) {
+                        ForEach(group.workspaces) { row in
                             workspaceRow(row, in: group)
                         }
-                    }
-                    if windowState.expandedProjects.contains(group.ref), group.workspaces.isEmpty {
-                        Text("No workspaces")
-                            .font(.caption)
-                            .foregroundStyle(.tertiary)
-                            .padding(.leading, NavigatorMetrics.nestedIndent)
-                            .navigatorListRow()
+                        if group.workspaces.isEmpty {
+                            Text("No workspaces")
+                                .font(.caption)
+                                .foregroundStyle(.tertiary)
+                                .padding(.leading, NavigatorMetrics.nestedIndent)
+                                .navigatorListRow()
+                        }
                     }
                 }
             }
@@ -141,7 +133,7 @@ struct ProjectsNavigatorView: View {
                 if let group = renamingProject,
                    let store = appModel.runtime(id: group.ref.connectionID)?.projects {
                     let name = renameDraft.trimmingCharacters(in: .whitespaces)
-                    run(on: group.ref.connectionID) {
+                    appModel.run(on: group.ref.connectionID, reporting: $actionError) {
                         try await store.rename(id: group.project.id, name: name)
                     }
                 }
@@ -161,7 +153,7 @@ struct ProjectsNavigatorView: View {
                 if let row = renamingWorkspace,
                    let store = appModel.runtime(id: row.ref.connectionID)?.workspaces {
                     let name = renameDraft.trimmingCharacters(in: .whitespaces)
-                    run(on: row.ref.connectionID) {
+                    appModel.run(on: row.ref.connectionID, reporting: $actionError) {
                         try await store.rename(id: row.workspace.id, name: name)
                     }
                 }
@@ -182,7 +174,7 @@ struct ProjectsNavigatorView: View {
             Button("Delete Project", role: .destructive) {
                 if let group = deletingProject,
                    let store = appModel.runtime(id: group.ref.connectionID)?.projects {
-                    run(on: group.ref.connectionID) {
+                    appModel.run(on: group.ref.connectionID, reporting: $actionError) {
                         try await store.delete(id: group.project.id)
                     }
                 }
@@ -199,7 +191,7 @@ struct ProjectsNavigatorView: View {
             Button("Delete Workspace", role: .destructive) {
                 if let row = deletingWorkspace,
                    let store = appModel.runtime(id: row.ref.connectionID)?.workspaces {
-                    run(on: row.ref.connectionID) {
+                    appModel.run(on: row.ref.connectionID, reporting: $actionError) {
                         try await store.delete(id: row.workspace.id)
                         windowState.forgetSelection(for: row.ref)
                     }
@@ -274,7 +266,7 @@ struct ProjectsNavigatorView: View {
         Divider()
         Button("Archive Project", systemImage: "archivebox") {
             if let store = appModel.runtime(id: group.ref.connectionID)?.projects {
-                run(on: group.ref.connectionID) {
+                appModel.run(on: group.ref.connectionID, reporting: $actionError) {
                     try await store.archive(id: group.project.id)
                 }
             }
@@ -353,7 +345,7 @@ struct ProjectsNavigatorView: View {
 
     private func archiveWorkspace(_ row: ProjectsNavigatorGroups.WorkspaceRow) {
         guard let store = appModel.runtime(id: row.ref.connectionID)?.workspaces else { return }
-        run(on: row.ref.connectionID) {
+        appModel.run(on: row.ref.connectionID, reporting: $actionError) {
             try await store.archive(id: row.workspace.id)
         }
     }
@@ -367,20 +359,6 @@ struct ProjectsNavigatorView: View {
 
     private func canMutate(_ connectionID: UUID) -> Bool {
         appModel.canMutate(connectionID: connectionID)
-    }
-
-    private func run(
-        on connectionID: UUID,
-        _ operation: @escaping () async throws -> Void
-    ) {
-        Task {
-            guard canMutate(connectionID) else {
-                actionError = "The connection is unavailable."
-                return
-            }
-            do { try await operation() }
-            catch { actionError = error.localizedDescription }
-        }
     }
 }
 

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -21,64 +21,36 @@ struct NavigatorSidebar: View {
     }
 }
 
-/// Xcode-style navigator bar: borderless icon buttons spread across the
-/// sidebar width, with an accent-filled rounded rect behind the selection.
+/// Native segmented navigation in an inset system surface, matching the
+/// hierarchy and interaction model of Xcode's Navigator selector.
 struct NavigatorSelector: View {
     @Environment(WindowState.self) private var windowState
     @Binding var selection: NavigatorID
 
     var body: some View {
-        HStack(spacing: 0) {
-            ForEach(NavigatorSelectorOption.all(
-                hasActiveWorkspace: windowState.activeWorkspace != nil
-            )) { option in
-                NavigatorSelectorButton(option: option, selection: $selection)
+        let options = NavigatorSelectorOption.all(
+            hasActiveWorkspace: windowState.activeWorkspace != nil
+        )
+        Picker("Navigator", selection: $selection) {
+            ForEach(options) { option in
+                Image(systemName: option.id.systemImage)
+                    .accessibilityLabel(option.id.label)
+                    .help(option.help)
+                    .tag(option.id)
+                    .disabled(!option.isEnabled)
             }
         }
-        .padding(.horizontal, Spacing.sm)
-        .padding(.vertical, Spacing.xs)
-    }
-}
-
-private struct NavigatorSelectorButton: View {
-    let option: NavigatorSelectorOption
-    @Binding var selection: NavigatorID
-    @State private var isHovering = false
-
-    private var isSelected: Bool { selection == option.id }
-
-    var body: some View {
-        Button {
-            selection = option.id
-        } label: {
-            Image(systemName: option.id.systemImage)
-                .foregroundStyle(symbolStyle)
-                .frame(width: 28, height: 22)
-                .background(
-                    RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
-                        .fill(backgroundStyle)
-                )
-                .frame(maxWidth: .infinity)
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .disabled(!option.isEnabled)
-        .onHover { isHovering = $0 }
-        .accessibilityLabel(option.id.label)
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
-        .help(option.help)
-    }
-
-    private var symbolStyle: AnyShapeStyle {
-        if isSelected { return AnyShapeStyle(.white) }
-        if !option.isEnabled { return AnyShapeStyle(.quaternary) }
-        return AnyShapeStyle(.secondary)
-    }
-
-    private var backgroundStyle: AnyShapeStyle {
-        if isSelected { return AnyShapeStyle(Color.accentColor) }
-        if isHovering && option.isEnabled { return AnyShapeStyle(.quaternary) }
-        return AnyShapeStyle(.clear)
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .controlSize(.regular)
+        .tint(.accentColor)
+        .padding(2)
+        .background(.quaternary, in: RoundedRectangle(
+            cornerRadius: Radius.control,
+            style: .continuous
+        ))
+        .padding(.horizontal, Spacing.md)
+        .padding(.vertical, Spacing.sm)
     }
 }
 
@@ -121,26 +93,39 @@ struct ProjectsNavigatorView: View {
             )
         })
         List(selection: selectionBinding) {
-            Label("Dashboard", systemImage: "rectangle.3.group")
+            Section {
+                NavigatorRow(
+                    isSelected: windowState.selectedContent == .dashboard,
+                    action: { windowState.showDashboard() }
+                ) {
+                    NavigatorIconLabel(title: "Dashboard", systemImage: "rectangle.3.group")
+                } actions: {
+                    EmptyView()
+                }
                 .tag(ProjectsNavigatorSelection.dashboard)
+            }
 
-            ForEach(groups.projects) { group in
-                DisclosureGroup(isExpanded: expansionBinding(for: group.ref)) {
+            Section {
+                ForEach(groups.projects) { group in
+                    projectRow(group)
                     ForEach(group.workspaces) { row in
-                        workspaceRow(row, in: group)
+                        if windowState.expandedProjects.contains(group.ref) {
+                            workspaceRow(row, in: group)
+                        }
                     }
-                    if group.workspaces.isEmpty {
+                    if windowState.expandedProjects.contains(group.ref), group.workspaces.isEmpty {
                         Text("No workspaces")
                             .font(.caption)
                             .foregroundStyle(.tertiary)
-                            .padding(.leading, Spacing.sm)
+                            .padding(.leading, NavigatorMetrics.nestedIndent)
+                            .navigatorListRow()
                     }
-                } label: {
-                    projectRow(group)
                 }
+            } header: {
+                NavigatorSectionHeader(title: "Projects")
             }
         }
-        .listStyle(.sidebar)
+        .navigatorList()
         .alert("Rename Project", isPresented: Binding(
             get: { renamingProject != nil },
             set: { if !$0 { renamingProject = nil } }
@@ -228,46 +213,70 @@ struct ProjectsNavigatorView: View {
     }
 
     private func projectRow(_ group: ProjectsNavigatorGroups.ProjectGroup) -> some View {
-        HStack(spacing: Spacing.sm) {
-            Image(systemName: "folder")
-            VStack(alignment: .leading, spacing: 1) {
-                Text(group.project.name).lineLimit(1)
-                HStack(spacing: Spacing.xs) {
-                    StatusDot(color: group.reachability.color, size: .inline)
-                    Text(group.connectionName)
+        NavigatorRow(
+            action: {
+                if windowState.expandedProjects.contains(group.ref) {
+                    windowState.expandedProjects.remove(group.ref)
+                } else {
+                    windowState.expandedProjects.insert(group.ref)
                 }
-                .font(.caption2)
+            }
+        ) {
+            HStack(spacing: Spacing.sm) {
+                Image(systemName: windowState.expandedProjects.contains(group.ref) ? "folder.fill" : "folder")
+                    .frame(width: NavigatorMetrics.iconWidth)
+                    .foregroundStyle(.secondary)
+                Text(group.project.name)
+                    .lineLimit(1)
+                Spacer(minLength: Spacing.sm)
+                HStack(spacing: Spacing.xs) {
+                    Text(group.connectionName)
+                        .lineLimit(1)
+                    StatusDot(color: group.reachability.color, size: .inline)
+                }
+                .font(.caption)
                 .foregroundStyle(.secondary)
             }
-            Spacer()
-        }
-        .contentShape(Rectangle())
-        .onTapGesture { windowState.focusedProject = group.ref }
-        .contextMenu {
-            Button("New Workspace…", systemImage: "plus") {
+        } actions: {
+            NavigatorActionButton(
+                systemImage: "plus",
+                help: "New workspace",
+                isEnabled: group.reachability == .connected
+            ) {
                 windowState.createWorkspaceContext = .init(mode: .fixed(group.ref))
             }
-            .disabled(group.reachability != .connected)
-            Button("Rename…", systemImage: "pencil") {
-                renameDraft = group.project.name
-                renamingProject = group
+            NavigatorActionMenu(systemImage: "ellipsis", help: "Project actions") {
+                projectMenu(group)
             }
-            .disabled(group.reachability != .connected)
-            Divider()
-            Button("Archive Project", systemImage: "archivebox") {
-                if let store = appModel.runtime(id: group.ref.connectionID)?.projects {
-                    run(on: group.ref.connectionID) {
-                        try await store.archive(id: group.project.id)
-                    }
+        }
+        .contextMenu { projectMenu(group) }
+    }
+
+    @ViewBuilder
+    private func projectMenu(_ group: ProjectsNavigatorGroups.ProjectGroup) -> some View {
+        Button("New Workspace…", systemImage: "plus") {
+            windowState.createWorkspaceContext = .init(mode: .fixed(group.ref))
+        }
+        .disabled(group.reachability != .connected)
+        Button("Rename…", systemImage: "pencil") {
+            renameDraft = group.project.name
+            renamingProject = group
+        }
+        .disabled(group.reachability != .connected)
+        Divider()
+        Button("Archive Project", systemImage: "archivebox") {
+            if let store = appModel.runtime(id: group.ref.connectionID)?.projects {
+                run(on: group.ref.connectionID) {
+                    try await store.archive(id: group.project.id)
                 }
             }
-            .disabled(group.reachability != .connected || group.hasUnarchivedWorkspaces)
-            Divider()
-            Button("Delete Project…", systemImage: "trash", role: .destructive) {
-                deletingProject = group
-            }
-            .disabled(group.reachability != .connected || group.totalWorkspaceCount > 0)
         }
+        .disabled(group.reachability != .connected || group.hasUnarchivedWorkspaces)
+        Divider()
+        Button("Delete Project…", systemImage: "trash", role: .destructive) {
+            deletingProject = group
+        }
+        .disabled(group.reachability != .connected || group.totalWorkspaceCount > 0)
     }
 
     private func workspaceRow(
@@ -275,52 +284,86 @@ struct ProjectsNavigatorView: View {
         in group: ProjectsNavigatorGroups.ProjectGroup
     ) -> some View {
         let enabled = group.reachability == .connected
-        return HStack(spacing: Spacing.sm) {
-            Image(systemName: "square.on.square")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            Text(row.workspace.name).lineLimit(1)
-            Spacer()
-        }
-        .contentShape(Rectangle())
-        .tag(ProjectsNavigatorSelection.workspace(row.ref))
-        .disabled(!enabled)
-        .opacity(enabled ? 1 : Dimming.archived)
-        .contextMenu {
-            Button("Open", systemImage: "arrow.up.forward.square") {
+        let selected = windowState.selectedContent != .dashboard
+            && windowState.activeWorkspace == row.ref
+        return NavigatorRow(
+            isSelected: selected,
+            isEnabled: enabled,
+            leadingIndent: NavigatorMetrics.nestedIndent,
+            action: {
                 _ = windowState.activateWorkspace(row.ref, in: appModel)
             }
-            .disabled(!enabled)
-            Button("Rename…", systemImage: "pencil") {
-                renameDraft = row.workspace.name
-                renamingWorkspace = row
-            }
-            .disabled(!enabled)
-            Divider()
-            Button("Archive", systemImage: "archivebox") {
-                if let store = appModel.runtime(id: row.ref.connectionID)?.workspaces {
-                    run(on: row.ref.connectionID) {
-                        try await store.archive(id: row.workspace.id)
-                    }
+        ) {
+            Text(row.workspace.name)
+                .lineLimit(1)
+        } actions: {
+            NavigatorActionMenu(systemImage: "plus", help: "Start in this workspace") {
+                Button("New Session", systemImage: "plus.bubble") {
+                    presentStart(.agentSession, in: row.ref)
+                }
+                Button("New Terminal", systemImage: "terminal") {
+                    presentStart(.terminal, in: row.ref)
                 }
             }
-            .disabled(!enabled || row.hasActiveSessions)
-            Divider()
-            Button("Delete…", systemImage: "trash", role: .destructive) {
-                deletingWorkspace = row
+            NavigatorActionButton(
+                systemImage: "archivebox",
+                help: row.hasActiveSessions ? "Stop active sessions before archiving" : "Archive workspace",
+                isEnabled: !row.hasActiveSessions
+            ) {
+                archiveWorkspace(row)
             }
-            .disabled(!enabled)
         }
+        .tag(ProjectsNavigatorSelection.workspace(row.ref))
+        .opacity(enabled ? 1 : Dimming.archived)
+        .contextMenu { workspaceMenu(row, enabled: enabled) }
     }
 
-    private func expansionBinding(for ref: ProjectRef) -> Binding<Bool> {
-        Binding(
-            get: { windowState.expandedProjects.contains(ref) },
-            set: { expanded in
-                if expanded { windowState.expandedProjects.insert(ref) }
-                else { windowState.expandedProjects.remove(ref) }
-            }
-        )
+    @ViewBuilder
+    private func workspaceMenu(
+        _ row: ProjectsNavigatorGroups.WorkspaceRow,
+        enabled: Bool
+    ) -> some View {
+        Button("Open", systemImage: "arrow.up.forward.square") {
+            _ = windowState.activateWorkspace(row.ref, in: appModel)
+        }
+        .disabled(!enabled)
+        Button("New Session", systemImage: "plus.bubble") {
+            presentStart(.agentSession, in: row.ref)
+        }
+        .disabled(!enabled)
+        Button("New Terminal", systemImage: "terminal") {
+            presentStart(.terminal, in: row.ref)
+        }
+        .disabled(!enabled)
+        Divider()
+        Button("Rename…", systemImage: "pencil") {
+            renameDraft = row.workspace.name
+            renamingWorkspace = row
+        }
+        .disabled(!enabled)
+        Button("Archive", systemImage: "archivebox") {
+            archiveWorkspace(row)
+        }
+        .disabled(!enabled || row.hasActiveSessions)
+        Divider()
+        Button("Delete…", systemImage: "trash", role: .destructive) {
+            deletingWorkspace = row
+        }
+        .disabled(!enabled)
+    }
+
+    private func presentStart(_ kind: StartSessionKind, in ref: WorkspaceRef) {
+        guard windowState.activateWorkspace(ref, in: appModel),
+              appModel.canStartSession(in: ref)
+        else { return }
+        windowState.startSessionKind = kind
+    }
+
+    private func archiveWorkspace(_ row: ProjectsNavigatorGroups.WorkspaceRow) {
+        guard let store = appModel.runtime(id: row.ref.connectionID)?.workspaces else { return }
+        run(on: row.ref.connectionID) {
+            try await store.archive(id: row.workspace.id)
+        }
     }
 
     private var selectionBinding: Binding<ProjectsNavigatorSelection?> {
@@ -338,7 +381,6 @@ struct ProjectsNavigatorView: View {
                 case .workspace(let ref):
                     if windowState.activeWorkspace != ref
                         || windowState.selectedContent == .dashboard {
-                        windowState.focusedWorkspace = ref
                         _ = windowState.activateWorkspace(ref, in: appModel)
                     }
                 case nil:

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -215,9 +215,7 @@ struct ProjectsNavigatorView: View {
             VStack(alignment: .leading, spacing: 1) {
                 Text(group.project.name).lineLimit(1)
                 HStack(spacing: Spacing.xs) {
-                    Circle()
-                        .fill(group.reachability.color)
-                        .frame(width: 6, height: 6)
+                    StatusDot(color: group.reachability.color, size: .inline)
                     Text(group.connectionName)
                 }
                 .font(.caption2)

--- a/macos/ATC/RootView.swift
+++ b/macos/ATC/RootView.swift
@@ -17,8 +17,8 @@ struct RootView: View {
                     inspectorContent
                 }
         }
-        .navigationTitle(activeWorkspace?.name ?? "atc")
-        .navigationSubtitle(activeProject?.name ?? "")
+        .navigationTitle("atc")
+        .navigationSubtitle(activeRuntime?.record.name ?? "")
         .toolbar {
             if windowState.selectedContent != .dashboard {
                 ToolbarItem(placement: .navigation) {
@@ -27,6 +27,7 @@ struct RootView: View {
                     } label: {
                         Label("Dashboard", systemImage: "chevron.left")
                     }
+                    .labelStyle(.iconOnly)
                     .help("Show Dashboard")
                     .keyboardShortcut(.upArrow, modifiers: .command)
                 }
@@ -34,9 +35,11 @@ struct RootView: View {
             ToolbarItem(placement: .principal) {
                 WorkspaceSwitcher()
             }
-            if windowState.activeWorkspace != nil {
+            if windowState.activeWorkspace != nil,
+               windowState.selectedContent != .dashboard {
                 ToolbarItemGroup {
                     WorkspaceActionsMenu()
+                        .labelStyle(.iconOnly)
                 }
             }
         }
@@ -101,16 +104,6 @@ struct RootView: View {
 
     private var activeRuntime: ConnectionRuntime? {
         windowState.activeWorkspace.flatMap { appModel.runtime(id: $0.connectionID) }
-    }
-
-    private var activeWorkspace: Workspace? {
-        guard let ref = windowState.activeWorkspace else { return nil }
-        return activeRuntime?.workspaces.workspace(id: ref.workspaceID)
-    }
-
-    private var activeProject: Project? {
-        guard let activeWorkspace else { return nil }
-        return activeRuntime?.projects.project(id: activeWorkspace.projectId)
     }
 
     private var workspaceEmptyActions: SessionContentView.EmptyStateActions? {

--- a/macos/ATC/RootView.swift
+++ b/macos/ATC/RootView.swift
@@ -82,7 +82,8 @@ struct RootView: View {
 
     @ViewBuilder
     private var inspectorContent: some View {
-        if let ref = visibleSessionRef,
+        if windowState.hasInspectorTarget(in: appModel),
+           let ref = visibleSessionRef,
            let session = visibleSession,
            let client = appModel.runtime(id: ref.connectionID)?.client {
             SessionDetailView(session: session, client: client)

--- a/macos/ATC/RootView.swift
+++ b/macos/ATC/RootView.swift
@@ -1,30 +1,43 @@
 import SwiftUI
 import ATCAPI
 
-/// Thin per-window router: the Workspace shell (mounted once a Workspace
-/// has been opened, then kept mounted for the window's life) underneath an
-/// opaque Dashboard cover. This generalizes the `TerminalPane` cover
-/// pattern — returning from the Dashboard never tears down or replays a
-/// terminal surface.
+/// One stable window-root split view. Navigators replace only the leading
+/// column while the terminal stack remains mounted in the detail column.
 struct RootView: View {
     @Environment(AppModel.self) private var appModel
     @Environment(WindowState.self) private var windowState
 
     var body: some View {
         @Bindable var windowState = windowState
-        ZStack {
-            if windowState.hasOpenedWorkspaceShell {
-                WorkspaceShellView()
+        NavigationSplitView(columnVisibility: $windowState.columnVisibility) {
+            NavigatorSidebar()
+        } detail: {
+            mainContent
+                .inspector(isPresented: $windowState.isInspectorPresented) {
+                    inspectorContent
+                }
+        }
+        .navigationTitle(activeWorkspace?.name ?? "atc")
+        .navigationSubtitle(activeProject?.name ?? "")
+        .toolbar {
+            if windowState.selectedContent != .dashboard {
+                ToolbarItem(placement: .navigation) {
+                    Button {
+                        windowState.showDashboard()
+                    } label: {
+                        Label("Dashboard", systemImage: "chevron.left")
+                    }
+                    .help("Show Dashboard")
+                    .keyboardShortcut(.upArrow, modifiers: .command)
+                }
             }
-            if windowState.route == .dashboard {
-                DashboardView(
-                    onOpenWorkspace: { windowState.openWorkspace($0, in: appModel) },
-                    onCreateWorkspace: { ref in
-                        windowState.createWorkspaceContext = CreateWorkspaceContext(mode: .fixed(ref))
-                    },
-                    onCreateProject: { windowState.isCreateProjectPresented = true }
-                )
-                .background()
+            ToolbarItem(placement: .principal) {
+                WorkspaceSwitcher()
+            }
+            if windowState.activeWorkspace != nil {
+                ToolbarItemGroup {
+                    WorkspaceActionsMenu()
+                }
             }
         }
         .sheet(isPresented: $windowState.isCreateProjectPresented) {
@@ -32,28 +45,87 @@ struct RootView: View {
         }
         .sheet(item: $windowState.createWorkspaceContext) { context in
             CreateWorkspaceSheet(context: context) { ref in
-                // Creation opens the new Workspace, not just a selection.
-                windowState.openWorkspace(ref, in: appModel)
+                _ = windowState.activateWorkspace(ref, in: appModel)
             }
         }
         .sheet(item: $windowState.startSessionKind) { kind in
-            if let ref = appModel.openWorkspace {
+            if let ref = windowState.activeWorkspace {
                 StartWorkspaceSessionSheet(kind: kind, workspaceRef: ref) { newRef in
-                    appModel.selection = newRef
+                    _ = windowState.selectSession(newRef, in: appModel)
                 }
             }
         }
-        .onChange(of: appModel.openWorkspaceExists) { _, exists in
-            // Deleted via web/CLI, or its Connection removed: back to the
-            // Dashboard. Keyed on the route, not the ref — removing a
-            // Connection already nils openWorkspace in teardown, and the
-            // shell route must still fall back. Session terminations that
-            // accompany a remote delete flow through the existing
-            // attach-end machinery.
-            if !exists, windowState.route == .workspace {
-                windowState.handleOpenWorkspaceGone(in: appModel)
+        .onChange(of: appModel.windowNavigationSnapshot(), initial: true) {
+            windowState.reconcile(in: appModel)
+        }
+    }
+
+    private var mainContent: some View {
+        ZStack {
+            SessionContentView(
+                selectedRef: visibleSessionRef,
+                selectedSession: visibleSession,
+                emptyState: workspaceEmptyActions
+            )
+            if windowState.selectedContent == .dashboard {
+                DashboardView(
+                    onOpenWorkspace: { _ = windowState.activateWorkspace($0, in: appModel) },
+                    onCreateWorkspace: { ref in
+                        windowState.createWorkspaceContext = .init(mode: .fixed(ref))
+                    },
+                    onCreateProject: { windowState.isCreateProjectPresented = true }
+                )
+                .background()
             }
         }
+    }
+
+    @ViewBuilder
+    private var inspectorContent: some View {
+        if let ref = visibleSessionRef,
+           let session = visibleSession,
+           let client = appModel.runtime(id: ref.connectionID)?.client {
+            SessionDetailView(session: session, client: client)
+                .inspectorColumnWidth(min: 260, ideal: 320)
+        }
+    }
+
+    private var visibleSessionRef: SessionRef? {
+        windowState.selectedSession
+    }
+
+    private var visibleSession: Session? {
+        visibleSessionRef.flatMap { appModel.session(for: $0) }
+    }
+
+    private var activeRuntime: ConnectionRuntime? {
+        windowState.activeWorkspace.flatMap { appModel.runtime(id: $0.connectionID) }
+    }
+
+    private var activeWorkspace: Workspace? {
+        guard let ref = windowState.activeWorkspace else { return nil }
+        return activeRuntime?.workspaces.workspace(id: ref.workspaceID)
+    }
+
+    private var activeProject: Project? {
+        guard let activeWorkspace else { return nil }
+        return activeRuntime?.projects.project(id: activeWorkspace.projectId)
+    }
+
+    private var workspaceEmptyActions: SessionContentView.EmptyStateActions? {
+        guard case .workspace(let ref) = windowState.selectedContent,
+              ref == windowState.activeWorkspace,
+              let runtime = appModel.runtime(id: ref.connectionID)
+        else { return nil }
+        let isEmpty = !runtime.sessions.sessions.contains {
+            $0.workspace?.id == ref.workspaceID
+        }
+        guard isEmpty else { return nil }
+        return .init(
+            newSession: { windowState.startSessionKind = .agentSession },
+            newTerminal: { windowState.startSessionKind = .terminal },
+            creationEnabled: windowState.canStartSession(in: appModel)
+        )
     }
 }
 

--- a/macos/ATC/RootView.swift
+++ b/macos/ATC/RootView.swift
@@ -76,7 +76,8 @@ struct RootView: View {
                     onCreateWorkspace: { ref in
                         windowState.createWorkspaceContext = .init(mode: .fixed(ref))
                     },
-                    onCreateProject: { windowState.isCreateProjectPresented = true }
+                    onCreateProject: { windowState.isCreateProjectPresented = true },
+                    onWorkspaceDeleted: { windowState.forgetSelection(for: $0) }
                 )
                 .background()
             }
@@ -111,9 +112,7 @@ struct RootView: View {
               ref == windowState.activeWorkspace,
               let runtime = appModel.runtime(id: ref.connectionID)
         else { return nil }
-        let isEmpty = !runtime.sessions.sessions.contains {
-            $0.workspace?.id == ref.workspaceID
-        }
+        let isEmpty = !runtime.sessions.sessions.contains { $0.belongs(to: ref) }
         guard isEmpty else { return nil }
         return .init(
             newSession: { windowState.startSessionKind = .agentSession },

--- a/macos/ATC/Settings/ActionsSettingsView.swift
+++ b/macos/ATC/Settings/ActionsSettingsView.swift
@@ -49,7 +49,7 @@ struct ActionsSettingsView: View {
                 Divider()
                 HStack(spacing: 0) {
                     master
-                        .frame(width: 260)
+                        .frame(width: 240)
                     Divider()
                     detail
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -157,27 +157,13 @@ struct ActionsSettingsView: View {
                 }
             }
             Divider()
-            HStack(spacing: 2) {
-                Button {
-                    target = .new
-                } label: {
-                    Image(systemName: "plus")
-                        .frame(width: 24, height: 20)
-                }
-                .help("Add an action")
-                Button {
-                    confirmRemove = true
-                } label: {
-                    Image(systemName: "minus")
-                        .frame(width: 24, height: 20)
-                }
-                .help(minusHelp)
-                .disabled(selectedAction == nil || selectedAction?.isBuiltin == true)
-                Spacer()
-            }
-            .buttonStyle(.borderless)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 6)
+            ListEditorBar(
+                addHelp: "Add an action",
+                removeHelp: minusHelp,
+                canRemove: selectedAction != nil && selectedAction?.isBuiltin != true,
+                onAdd: { target = .new },
+                onRemove: { confirmRemove = true }
+            )
         }
     }
 

--- a/macos/ATC/Settings/ActionsSettingsView.swift
+++ b/macos/ATC/Settings/ActionsSettingsView.swift
@@ -82,7 +82,7 @@ struct ActionsSettingsView: View {
     // MARK: Header
 
     private var header: some View {
-        HStack(spacing: 12) {
+        HStack(spacing: Spacing.md) {
             Picker("Connection", selection: $connectionID) {
                 // The selection is nil until onAppear picks the first runtime
                 // (and dangles if that Connection is deleted); keep a matching
@@ -108,8 +108,8 @@ struct ActionsSettingsView: View {
                     .truncationMode(.tail)
             }
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
+        .padding(.horizontal, Spacing.md)
+        .padding(.vertical, Spacing.sm)
     }
 
     // MARK: Master list
@@ -119,12 +119,12 @@ struct ActionsSettingsView: View {
             List(selection: $target) {
                 if let store = runtime?.actions {
                     ForEach(store.actions) { action in
-                        HStack(spacing: 8) {
+                        HStack(spacing: Spacing.sm) {
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(action.displayLabel)
                                     .font(.headline)
                                     .lineLimit(1)
-                                HStack(spacing: 6) {
+                                HStack(spacing: Spacing.sm) {
                                     Text(action.name)
                                         .font(.caption)
                                         .foregroundStyle(.secondary)
@@ -132,7 +132,7 @@ struct ActionsSettingsView: View {
                                     ActionOriginBadge(origin: action.origin)
                                 }
                             }
-                            .opacity(action.enabled ? 1 : 0.5)
+                            .opacity(action.enabled ? 1 : Dimming.archived)
                             Spacer()
                             Toggle("Enabled", isOn: enabledBinding(for: action))
                                 .toggleStyle(.switch)
@@ -371,7 +371,7 @@ private struct ActionEditorView: View {
                         .font(.body.monospaced())
                         .frame(minHeight: 44, maxHeight: 88)
                         .scrollContentBackground(.hidden)
-                        .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 4))
+                        .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: Radius.control))
                 }
                 .help("One argument per line")
             } header: {
@@ -423,7 +423,7 @@ private struct ActionEditorView: View {
     }
 
     private var bottomBar: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: Spacing.sm) {
             if let submitError {
                 Label(submitError, systemImage: "exclamationmark.triangle.fill")
                     .font(.caption)
@@ -437,7 +437,7 @@ private struct ActionEditorView: View {
                 .keyboardShortcut(.defaultAction)
                 .disabled(!canSubmit)
         }
-        .padding(12)
+        .padding(Spacing.md)
     }
 
     // MARK: Actions
@@ -496,8 +496,8 @@ private struct ActionParamEditor: View {
 
     var body: some View {
         GroupBox {
-            VStack(alignment: .leading, spacing: 8) {
-                HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: Spacing.sm) {
+                HStack(spacing: Spacing.sm) {
                     TextField("Name", text: $param.name, prompt: Text("model"))
                         .fontDesign(.monospaced)
                         .autocorrectionDisabled()
@@ -538,7 +538,7 @@ private struct ActionParamEditor: View {
                     .autocorrectionDisabled()
                 TextField("Label", text: $param.label, prompt: Text("Model"))
             }
-            .padding(4)
+            .padding(Spacing.xs)
         }
     }
 }

--- a/macos/ATC/Settings/ActionsSettingsView.swift
+++ b/macos/ATC/Settings/ActionsSettingsView.swift
@@ -129,7 +129,7 @@ struct ActionsSettingsView: View {
                                         .font(.caption)
                                         .foregroundStyle(.secondary)
                                         .lineLimit(1)
-                                    ActionOriginBadge(origin: action.origin)
+                                    TagBadge(text: Self.originLabel(action.origin))
                                 }
                             }
                             .opacity(action.enabled ? 1 : Dimming.archived)
@@ -207,6 +207,15 @@ struct ActionsSettingsView: View {
         let generation: Int
     }
 
+    /// Where an action's definition comes from, for its list badge.
+    private static func originLabel(_ origin: String) -> String {
+        switch origin {
+        case "builtin": "Built-in"
+        case "modified": "Modified"
+        default: "Custom"
+        }
+    }
+
     // MARK: Mutations
 
     private var removePrompt: String {
@@ -255,28 +264,6 @@ struct ActionsSettingsView: View {
             } catch {
                 store.lastError = error.localizedDescription
             }
-        }
-    }
-}
-
-/// Small capsule showing where an action's definition comes from.
-private struct ActionOriginBadge: View {
-    let origin: String
-
-    var body: some View {
-        Text(label)
-            .font(.caption2.weight(.medium))
-            .padding(.horizontal, 5)
-            .padding(.vertical, 1)
-            .background(.quaternary, in: Capsule())
-            .foregroundStyle(.secondary)
-    }
-
-    private var label: String {
-        switch origin {
-        case "builtin": "Built-in"
-        case "modified": "Modified"
-        default: "Custom"
         }
     }
 }

--- a/macos/ATC/Settings/ConnectionsSettingsView.swift
+++ b/macos/ATC/Settings/ConnectionsSettingsView.swift
@@ -57,7 +57,7 @@ struct ConnectionsSettingsView: View {
         VStack(spacing: 0) {
             List(selection: $target) {
                 ForEach(store.connections) { record in
-                    HStack(spacing: 8) {
+                    HStack(spacing: Spacing.sm) {
                         Circle()
                             .fill(appModel.reachability(of: record.id).color)
                             .frame(width: 8, height: 8)
@@ -195,7 +195,7 @@ private struct ConnectionEditorView: View {
                     }
                 }
                 Section {
-                    HStack(spacing: 8) {
+                    HStack(spacing: Spacing.sm) {
                         Button("Test Connection") { testConnection() }
                             .disabled(!canTest)
                         if testState == .testing {
@@ -230,7 +230,7 @@ private struct ConnectionEditorView: View {
                     .keyboardShortcut(.defaultAction)
                     .disabled(!hasChanges)
             }
-            .padding(12)
+            .padding(Spacing.md)
         }
         .task(id: target) { seed() }
         .onChange(of: name) { invalidateTest() }

--- a/macos/ATC/Settings/ConnectionsSettingsView.swift
+++ b/macos/ATC/Settings/ConnectionsSettingsView.swift
@@ -75,27 +75,13 @@ struct ConnectionsSettingsView: View {
                 }
             }
             Divider()
-            HStack(spacing: 2) {
-                Button {
-                    target = .new
-                } label: {
-                    Image(systemName: "plus")
-                        .frame(width: 24, height: 20)
-                }
-                .help("Add a connection")
-                Button {
-                    confirmDelete = true
-                } label: {
-                    Image(systemName: "minus")
-                        .frame(width: 24, height: 20)
-                }
-                .help("Remove the selected connection")
-                .disabled(selectedExistingID == nil)
-                Spacer()
-            }
-            .buttonStyle(.borderless)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 6)
+            ListEditorBar(
+                addHelp: "Add a connection",
+                removeHelp: "Remove the selected connection",
+                canRemove: selectedExistingID != nil,
+                onAdd: { target = .new },
+                onRemove: { confirmDelete = true }
+            )
         }
     }
 

--- a/macos/ATC/Settings/ConnectionsSettingsView.swift
+++ b/macos/ATC/Settings/ConnectionsSettingsView.swift
@@ -58,9 +58,7 @@ struct ConnectionsSettingsView: View {
             List(selection: $target) {
                 ForEach(store.connections) { record in
                     HStack(spacing: Spacing.sm) {
-                        Circle()
-                            .fill(appModel.reachability(of: record.id).color)
-                            .frame(width: 8, height: 8)
+                        StatusDot(color: appModel.reachability(of: record.id).color)
                         VStack(alignment: .leading, spacing: 2) {
                             Text(record.name)
                                 .font(.headline)

--- a/macos/ATC/Settings/SettingsView.swift
+++ b/macos/ATC/Settings/SettingsView.swift
@@ -2,15 +2,18 @@ import SwiftUI
 
 /// App Settings window. macOS owns the menu item and standard keyboard shortcut.
 struct SettingsView: View {
+    /// One window size for every tab so switching tabs never resizes.
+    static let windowSize = CGSize(width: 720, height: 500)
+
     var body: some View {
         TabView {
             Tab("Connections", systemImage: "network") {
                 ConnectionsSettingsView()
-                    .frame(width: 700, height: 450)
+                    .frame(width: Self.windowSize.width, height: Self.windowSize.height)
             }
             Tab("Actions", systemImage: "bolt") {
                 ActionsSettingsView()
-                    .frame(width: 760, height: 540)
+                    .frame(width: Self.windowSize.width, height: Self.windowSize.height)
             }
         }
     }

--- a/macos/ATC/Shared/ConnectionChip.swift
+++ b/macos/ATC/Shared/ConnectionChip.swift
@@ -8,7 +8,7 @@ struct ConnectionChip: View {
     let reachability: Reachability
 
     var body: some View {
-        HStack(spacing: 4) {
+        HStack(spacing: Spacing.xs) {
             Circle()
                 .fill(reachability.color)
                 .frame(width: 6, height: 6)

--- a/macos/ATC/Shared/ConnectionChip.swift
+++ b/macos/ATC/Shared/ConnectionChip.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// Neutral chip naming the Connection a row belongs to, with the
-/// reachability dot. Shared by the Dashboard and the Workspace shell; the
+/// reachability dot. Shared by Dashboard and Workspace-scoped UI; the
 /// chip never uses color to identify the Connection.
 struct ConnectionChip: View {
     let name: String

--- a/macos/ATC/Shared/ConnectionChip.swift
+++ b/macos/ATC/Shared/ConnectionChip.swift
@@ -9,9 +9,7 @@ struct ConnectionChip: View {
 
     var body: some View {
         HStack(spacing: Spacing.xs) {
-            Circle()
-                .fill(reachability.color)
-                .frame(width: 6, height: 6)
+            StatusDot(color: reachability.color, size: .inline)
             Text(name)
                 .font(.caption2)
                 .foregroundStyle(.secondary)

--- a/macos/ATC/Shared/ConnectionMutations.swift
+++ b/macos/ATC/Shared/ConnectionMutations.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// The one shared wrapper for Connection-backed mutations: refuses when the
+/// Connection's model isn't current and routes failures into the caller's
+/// alert state. Views must not hand-roll this guard.
+extension AppModel {
+    func run(
+        on connectionID: UUID,
+        reporting actionError: Binding<String?>,
+        _ operation: @escaping () async throws -> Void
+    ) {
+        Task {
+            guard canMutate(connectionID: connectionID) else {
+                actionError.wrappedValue = "The connection is unavailable."
+                return
+            }
+            do {
+                try await operation()
+            } catch {
+                actionError.wrappedValue = error.localizedDescription
+            }
+        }
+    }
+}

--- a/macos/ATC/Shared/DesignTokens.swift
+++ b/macos/ATC/Shared/DesignTokens.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+/// The app-wide spacing scale (4pt grid). Use these instead of literal
+/// spacing/padding values; keep literal `2` only for tight two-line text
+/// stacks and pill interiors.
+enum Spacing {
+    /// Intra-label gaps (dot–text).
+    static let xs: CGFloat = 4
+    /// Control clusters, row internals.
+    static let sm: CGFloat = 8
+    /// Standard container/bar padding.
+    static let md: CGFloat = 12
+    /// Card interior padding.
+    static let lg: CGFloat = 16
+    /// Dashboard page margins / section gaps.
+    static let xxl: CGFloat = 32
+}
+
+/// Corner radii: small controls and cards. Text pills use `Capsule`.
+enum Radius {
+    static let control: CGFloat = 6
+    static let card: CGFloat = 12
+}
+
+/// Opacity applied to archived/unavailable content.
+enum Dimming {
+    static let archived: Double = 0.5
+}

--- a/macos/ATC/Shared/DomainRules.swift
+++ b/macos/ATC/Shared/DomainRules.swift
@@ -1,0 +1,30 @@
+import Foundation
+import ATCAPI
+
+/// The one display order for Workspace and Session lists: newest-created
+/// first, with a stable id tiebreak so equal timestamps keep a
+/// deterministic order across renders.
+protocol CreatedOrdered {
+    var createdAt: Date { get }
+    var id: String { get }
+}
+
+extension Session: CreatedOrdered {}
+extension Workspace: CreatedOrdered {}
+
+extension Sequence where Element: CreatedOrdered {
+    func sortedNewestFirst() -> [Element] {
+        sorted {
+            if $0.createdAt != $1.createdAt { return $0.createdAt > $1.createdAt }
+            return $0.id < $1.id
+        }
+    }
+}
+
+extension Session {
+    /// Whether this Session belongs to the Workspace. Server IDs are only
+    /// unique within a Connection, so callers compare same-Connection refs.
+    func belongs(to ref: WorkspaceRef) -> Bool {
+        workspace?.id == ref.workspaceID
+    }
+}

--- a/macos/ATC/Shared/ErrorAlert.swift
+++ b/macos/ATC/Shared/ErrorAlert.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+extension View {
+    /// The standard failure alert: presents while `error` holds a message
+    /// and clears it on dismiss.
+    func actionErrorAlert(
+        _ error: Binding<String?>,
+        title: String = "Action Failed"
+    ) -> some View {
+        alert(title, isPresented: Binding(
+            get: { error.wrappedValue != nil },
+            set: { if !$0 { error.wrappedValue = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(error.wrappedValue ?? "")
+        }
+    }
+}

--- a/macos/ATC/Shared/ListEditorBar.swift
+++ b/macos/ATC/Shared/ListEditorBar.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+/// The +/− bar under a settings master list.
+struct ListEditorBar: View {
+    var addHelp: String
+    var removeHelp: String
+    var canRemove: Bool
+    var onAdd: () -> Void
+    var onRemove: () -> Void
+
+    var body: some View {
+        HStack(spacing: 2) {
+            Button(action: onAdd) {
+                Image(systemName: "plus")
+                    .frame(width: 24, height: 20)
+            }
+            .help(addHelp)
+            Button(action: onRemove) {
+                Image(systemName: "minus")
+                    .frame(width: 24, height: 20)
+            }
+            .help(removeHelp)
+            .disabled(!canRemove)
+            Spacer()
+        }
+        .buttonStyle(.borderless)
+        .padding(.horizontal, Spacing.sm)
+        .padding(.vertical, Spacing.xs)
+    }
+}

--- a/macos/ATC/Shared/NavigatorComponents.swift
+++ b/macos/ATC/Shared/NavigatorComponents.swift
@@ -6,7 +6,9 @@ enum NavigatorMetrics {
     static let rowHeight: CGFloat = 28
     static let iconWidth: CGFloat = 18
     static let actionSize: CGFloat = 22
+    static let contentHorizontalPadding = Spacing.sm
     static let rowVerticalInset: CGFloat = 1
+    static let selectorToContentSpacing = Spacing.lg
     static let nestedIndent: CGFloat = iconWidth + Spacing.sm
 }
 
@@ -196,11 +198,12 @@ extension View {
     }
 
     func navigatorSurface(isActive: Bool) -> some View {
-        background {
-            if isActive {
-                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
-                    .fill(.quaternary)
+        padding(.horizontal, NavigatorMetrics.contentHorizontalPadding)
+            .background {
+                if isActive {
+                    RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                        .fill(.quaternary)
+                }
             }
-        }
     }
 }

--- a/macos/ATC/Shared/NavigatorComponents.swift
+++ b/macos/ATC/Shared/NavigatorComponents.swift
@@ -6,6 +6,7 @@ enum NavigatorMetrics {
     static let rowHeight: CGFloat = 28
     static let iconWidth: CGFloat = 18
     static let actionSize: CGFloat = 22
+    static let rowVerticalInset: CGFloat = 1
     static let nestedIndent: CGFloat = iconWidth + Spacing.sm
 }
 
@@ -16,7 +17,7 @@ struct NavigatorRow<Content: View, Actions: View>: View {
     let isEnabled: Bool
     let leadingIndent: CGFloat
     let action: () -> Void
-    let content: Content
+    let content: (Bool) -> Content
     let actions: Actions
 
     @State private var isHovering = false
@@ -26,21 +27,21 @@ struct NavigatorRow<Content: View, Actions: View>: View {
         isEnabled: Bool = true,
         leadingIndent: CGFloat = 0,
         action: @escaping () -> Void,
-        @ViewBuilder content: () -> Content,
+        @ViewBuilder content: @escaping (Bool) -> Content,
         @ViewBuilder actions: () -> Actions
     ) {
         self.isSelected = isSelected
         self.isEnabled = isEnabled
         self.leadingIndent = leadingIndent
         self.action = action
-        self.content = content()
+        self.content = content
         self.actions = actions()
     }
 
     var body: some View {
         HStack(spacing: Spacing.xs) {
             Button(action: action) {
-                content
+                content(isHovering)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .contentShape(Rectangle())
             }
@@ -57,14 +58,10 @@ struct NavigatorRow<Content: View, Actions: View>: View {
         .padding(.leading, leadingIndent)
         .frame(minHeight: NavigatorMetrics.rowHeight)
         .foregroundStyle(isEnabled ? AnyShapeStyle(.primary) : AnyShapeStyle(.tertiary))
-        .background {
-            if isHovering && !isSelected && isEnabled {
-                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
-                    .fill(.quaternary)
-            }
-        }
+        .navigatorSurface(isActive: isSelected || (isHovering && isEnabled))
         .contentShape(Rectangle())
         .onHover { isHovering = $0 }
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
         .navigatorListRow()
     }
 }
@@ -76,7 +73,7 @@ struct NavigatorIconLabel: View {
     var body: some View {
         HStack(spacing: Spacing.sm) {
             Image(systemName: systemImage)
-                .frame(width: NavigatorMetrics.iconWidth)
+                .frame(width: NavigatorMetrics.iconWidth, alignment: .leading)
                 .foregroundStyle(.secondary)
             Text(title)
                 .lineLimit(1)
@@ -134,15 +131,48 @@ struct NavigatorActionMenu<Content: View>: View {
     }
 }
 
-struct NavigatorSectionHeader: View {
+struct NavigatorDisclosureHeader: View {
     let title: String
+    @Binding var isExpanded: Bool
+    let addHelp: String
+    let isAddEnabled: Bool
+    let onAdd: () -> Void
+
+    @State private var isHovering = false
 
     var body: some View {
-        Text(title)
-            .font(.headline)
-            .foregroundStyle(.secondary)
-            .textCase(nil)
-            .padding(.top, Spacing.sm)
+        HStack(spacing: Spacing.xs) {
+            Button {
+                isExpanded.toggle()
+            } label: {
+                HStack(spacing: Spacing.xs) {
+                    Text(title)
+                        .font(.headline)
+                    if isHovering {
+                        Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                            .font(.caption)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if isHovering {
+                NavigatorActionButton(
+                    systemImage: "plus",
+                    help: addHelp,
+                    isEnabled: isAddEnabled,
+                    action: onAdd
+                )
+            }
+        }
+        .frame(minHeight: NavigatorMetrics.rowHeight)
+        .foregroundStyle(.secondary)
+        .navigatorSurface(isActive: isHovering)
+        .contentShape(Rectangle())
+        .onHover { isHovering = $0 }
+        .navigatorListRow(top: Spacing.sm)
     }
 }
 
@@ -152,12 +182,25 @@ extension View {
             .environment(\.defaultMinListRowHeight, NavigatorMetrics.rowHeight)
     }
 
-    func navigatorListRow() -> some View {
+    func navigatorListRow(
+        top: CGFloat = NavigatorMetrics.rowVerticalInset,
+        bottom: CGFloat = NavigatorMetrics.rowVerticalInset
+    ) -> some View {
         listRowInsets(EdgeInsets(
-            top: 1,
+            top: top,
             leading: Spacing.sm,
-            bottom: 1,
+            bottom: bottom,
             trailing: Spacing.sm
         ))
+        .listRowBackground(Color.clear)
+    }
+
+    func navigatorSurface(isActive: Bool) -> some View {
+        background {
+            if isActive {
+                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                    .fill(.quaternary)
+            }
+        }
     }
 }

--- a/macos/ATC/Shared/NavigatorComponents.swift
+++ b/macos/ATC/Shared/NavigatorComponents.swift
@@ -1,0 +1,163 @@
+import SwiftUI
+
+/// Shared geometry for every Navigator. Sidebar-specific values live here so
+/// individual views only compose rows and never invent their own insets.
+enum NavigatorMetrics {
+    static let rowHeight: CGFloat = 28
+    static let iconWidth: CGFloat = 18
+    static let actionSize: CGFloat = 22
+    static let nestedIndent: CGFloat = iconWidth + Spacing.sm
+}
+
+/// The standard interactive row used by all Navigators. Actions stay out of
+/// sight until hover while the primary hit target remains full width.
+struct NavigatorRow<Content: View, Actions: View>: View {
+    let isSelected: Bool
+    let isEnabled: Bool
+    let leadingIndent: CGFloat
+    let action: () -> Void
+    let content: Content
+    let actions: Actions
+
+    @State private var isHovering = false
+
+    init(
+        isSelected: Bool = false,
+        isEnabled: Bool = true,
+        leadingIndent: CGFloat = 0,
+        action: @escaping () -> Void,
+        @ViewBuilder content: () -> Content,
+        @ViewBuilder actions: () -> Actions
+    ) {
+        self.isSelected = isSelected
+        self.isEnabled = isEnabled
+        self.leadingIndent = leadingIndent
+        self.action = action
+        self.content = content()
+        self.actions = actions()
+    }
+
+    var body: some View {
+        HStack(spacing: Spacing.xs) {
+            Button(action: action) {
+                content
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(!isEnabled)
+
+            if isHovering && isEnabled {
+                HStack(spacing: Spacing.xs) {
+                    actions
+                }
+                .transition(.opacity)
+            }
+        }
+        .padding(.leading, leadingIndent)
+        .frame(minHeight: NavigatorMetrics.rowHeight)
+        .foregroundStyle(isEnabled ? AnyShapeStyle(.primary) : AnyShapeStyle(.tertiary))
+        .background {
+            if isHovering && !isSelected && isEnabled {
+                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                    .fill(.quaternary)
+            }
+        }
+        .contentShape(Rectangle())
+        .onHover { isHovering = $0 }
+        .navigatorListRow()
+    }
+}
+
+struct NavigatorIconLabel: View {
+    let title: String
+    let systemImage: String
+
+    var body: some View {
+        HStack(spacing: Spacing.sm) {
+            Image(systemName: systemImage)
+                .frame(width: NavigatorMetrics.iconWidth)
+                .foregroundStyle(.secondary)
+            Text(title)
+                .lineLimit(1)
+        }
+    }
+}
+
+struct NavigatorActionButton: View {
+    let systemImage: String
+    let help: String
+    var isEnabled = true
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .frame(width: NavigatorMetrics.actionSize, height: NavigatorMetrics.actionSize)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.secondary)
+        .disabled(!isEnabled)
+        .help(help)
+    }
+}
+
+struct NavigatorActionMenu<Content: View>: View {
+    let systemImage: String
+    let help: String
+    let content: Content
+
+    init(
+        systemImage: String,
+        help: String,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.systemImage = systemImage
+        self.help = help
+        self.content = content()
+    }
+
+    var body: some View {
+        Menu {
+            content
+        } label: {
+            Image(systemName: systemImage)
+                .frame(width: NavigatorMetrics.actionSize, height: NavigatorMetrics.actionSize)
+                .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .foregroundStyle(.secondary)
+        .help(help)
+    }
+}
+
+struct NavigatorSectionHeader: View {
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .font(.headline)
+            .foregroundStyle(.secondary)
+            .textCase(nil)
+            .padding(.top, Spacing.sm)
+    }
+}
+
+extension View {
+    func navigatorList() -> some View {
+        listStyle(.sidebar)
+            .environment(\.defaultMinListRowHeight, NavigatorMetrics.rowHeight)
+    }
+
+    func navigatorListRow() -> some View {
+        listRowInsets(EdgeInsets(
+            top: 1,
+            leading: Spacing.sm,
+            bottom: 1,
+            trailing: Spacing.sm
+        ))
+    }
+}

--- a/macos/ATC/Shared/SheetScaffold.swift
+++ b/macos/ATC/Shared/SheetScaffold.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+/// Standard chrome for form sheets: a Label title header, grouped Form
+/// content, and a trailing button row in the HIG arrangement — Cancel
+/// adjacent-left of the primary action, both trailing.
+struct SheetScaffold<Content: View>: View {
+    let title: String
+    let systemImage: String
+    /// The primary button's label; replaced by a spinner while `isBusy`.
+    let primaryLabel: String
+    var isBusy = false
+    var canSubmit = true
+    var onCancel: () -> Void
+    var onSubmit: () -> Void
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Label(title, systemImage: systemImage)
+                .font(.headline)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(Spacing.md)
+            Divider()
+            Form(content: content)
+                .formStyle(.grouped)
+            Divider()
+            HStack {
+                Spacer()
+                Button("Cancel", role: .cancel, action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                Button(action: onSubmit) {
+                    if isBusy {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Text(primaryLabel)
+                    }
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(!canSubmit)
+            }
+            .padding(Spacing.md)
+        }
+    }
+}

--- a/macos/ATC/Shared/StatusBadge.swift
+++ b/macos/ATC/Shared/StatusBadge.swift
@@ -8,9 +8,7 @@ struct StatusBadge: View {
 
     var body: some View {
         HStack(spacing: Spacing.xs) {
-            Circle()
-                .fill(color)
-                .frame(width: 8, height: 8)
+            StatusDot(color: color)
             if showLabel {
                 Text(label)
                     .font(.caption)

--- a/macos/ATC/Shared/StatusDot.swift
+++ b/macos/ATC/Shared/StatusDot.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// The one reachability/liveness dot used across the app.
+struct StatusDot: View {
+    enum Size {
+        /// 6pt — inside captions and chips.
+        case inline
+        /// 8pt — list rows and section headers.
+        case standard
+
+        var diameter: CGFloat {
+            switch self {
+            case .inline: 6
+            case .standard: 8
+            }
+        }
+    }
+
+    let color: Color
+    var size: Size = .standard
+    /// Hollow ring for "present but inactive" (e.g. no active sessions).
+    var hollow = false
+
+    var body: some View {
+        Circle()
+            .fill(hollow ? Color.clear : color)
+            .overlay {
+                if hollow {
+                    Circle().stroke(.tertiary, lineWidth: 2)
+                }
+            }
+            .frame(width: size.diameter, height: size.diameter)
+    }
+}

--- a/macos/ATC/Shared/TagBadge.swift
+++ b/macos/ATC/Shared/TagBadge.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+/// The one text pill: a secondary caption in a quaternary capsule.
+/// Used for archived markers, action labels, and origin/context tags.
+struct TagBadge: View {
+    let text: String
+    /// Monospaced-semibold variant for code-like tags (LOCAL/REMOTE).
+    var monospaced = false
+
+    var body: some View {
+        Text(text)
+            .font(monospaced ? .caption2.monospaced().weight(.semibold) : .caption2)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(.quaternary, in: Capsule())
+    }
+}

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -207,7 +207,10 @@ final class WindowState {
             if session.isArchived {
                 selectionMemory.forget(activeWorkspace)
             }
-            if session.attachable, appModel.terminals[selected] == nil {
+            // Never undo an explicit Disconnect: reconcile runs on every
+            // store change, not just selection changes.
+            if session.attachable, appModel.terminals[selected] == nil,
+               !appModel.isDetached(selected) {
                 appModel.attachIfNeeded(
                     to: session,
                     connectionID: selected.connectionID,
@@ -269,6 +272,9 @@ final class WindowState {
         selectedNavigator = .projects
         selectedContent = .dashboard
         isInspectorPresented = false
+        // The start-session sheet renders from the Active Workspace; left
+        // presented it would show an empty sheet with no way to cancel.
+        startSessionKind = nil
     }
 }
 

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -2,109 +2,273 @@ import SwiftUI
 import Observation
 import ATCAPI
 
-/// The window's top-level surface: the Dashboard cover or the Workspace
-/// shell beneath it.
-enum Route {
-    case dashboard
+enum NavigatorID: String, CaseIterable, Sendable {
+    case projects
     case workspace
+    case file
+
+    var label: String {
+        switch self {
+        case .projects: "Projects Navigator"
+        case .workspace: "Workspace Navigator"
+        case .file: "File Navigator"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .projects: "square.grid.2x2"
+        case .workspace: "rectangle.stack"
+        case .file: "doc"
+        }
+    }
 }
 
-/// Per-window navigation and command state. Kept out of `AppModel` so a
-/// future multi-window pass has one obvious seam; the app launches on the
-/// Dashboard (the route is never persisted). Menu commands mutate this
-/// object, `RootView` renders from it.
+enum MainContentSelection: Equatable, Sendable {
+    case dashboard
+    case workspace(WorkspaceRef)
+    case session(SessionRef)
+}
+
+struct TerminalRetentionContext: Equatable, Sendable {
+    let activeWorkspace: WorkspaceRef?
+    let selectedSession: SessionRef?
+
+    static let empty = TerminalRetentionContext(activeWorkspace: nil, selectedSession: nil)
+}
+
+/// Per-window navigation, inspector, disclosure, and command state. The
+/// AppModel continues to own shared data and terminal controllers; it does
+/// not duplicate these identities.
 @Observable
 final class WindowState {
-    var route: Route = .dashboard
-
-    /// Once a Workspace has been opened, the shell (and its terminal
-    /// surfaces) stays mounted for the window's life; the Dashboard is an
-    /// opaque cover over it, never a teardown.
-    private(set) var hasOpenedWorkspaceShell = false
-
+    var selectedNavigator: NavigatorID = .projects
+    private(set) var activeWorkspace: WorkspaceRef?
+    private(set) var selectedContent: MainContentSelection = .dashboard
     var columnVisibility: NavigationSplitViewVisibility = .all
+    var isInspectorPresented = false
 
-    // MARK: - Sheet routing (owned here so menu commands can present)
+    var expandedProjects: Set<ProjectRef> = []
+    var focusedProject: ProjectRef?
+    var focusedWorkspace: WorkspaceRef?
 
     var isCreateProjectPresented = false
     var createWorkspaceContext: CreateWorkspaceContext?
     var startSessionKind: StartSessionKind?
 
-    /// Opens a Workspace in the shell: records it on the AppModel (which
-    /// pins its sessions in the attachment budget) and routes the window.
-    func openWorkspace(_ ref: WorkspaceRef, in appModel: AppModel) {
-        appModel.openWorkspace = ref
-        hasOpenedWorkspaceShell = true
-        route = .workspace
+    @ObservationIgnored private let selectionMemory: WorkspaceSelectionMemory
+    @ObservationIgnored private var pendingRestore: WorkspaceRef?
+
+    init(selectionMemory: WorkspaceSelectionMemory = WorkspaceSelectionMemory()) {
+        self.selectionMemory = selectionMemory
+    }
+
+    var selectedSession: SessionRef? {
+        guard case .session(let ref) = selectedContent else { return nil }
+        return ref
+    }
+
+    var retentionContext: TerminalRetentionContext {
+        TerminalRetentionContext(
+            activeWorkspace: activeWorkspace,
+            selectedSession: selectedSession
+        )
+    }
+
+    /// The single Workspace activation transition used by every entry point.
+    /// A missing target is rejected without changing the current window.
+    @discardableResult
+    func activateWorkspace(_ ref: WorkspaceRef, in appModel: AppModel) -> Bool {
+        guard let runtime = appModel.runtime(id: ref.connectionID),
+              runtime.workspaces.workspace(id: ref.workspaceID) != nil
+        else { return false }
+
+        if activeWorkspace == ref { return true }
+
+        let restored = runtime.sessions.hasLoadedOnce
+            ? validRememberedSelection(for: ref, in: runtime.sessions.sessions)
+            : nil
+
+        activeWorkspace = ref
+        selectedContent = restored.map(MainContentSelection.session) ?? .workspace(ref)
+        isInspectorPresented = false
+        pendingRestore = runtime.sessions.hasLoadedOnce ? nil : ref
+
+        if let restored, let session = appModel.session(for: restored), session.attachable {
+            appModel.attachIfNeeded(
+                to: session,
+                connectionID: restored.connectionID,
+                retentionContext: retentionContext
+            )
+        }
+        return true
+    }
+
+    /// Selects content only when it belongs to the Active Workspace on the
+    /// same Connection. Invalid cross-Workspace references fail closed.
+    @discardableResult
+    func selectSession(_ ref: SessionRef, in appModel: AppModel) -> Bool {
+        guard let activeWorkspace,
+              activeWorkspace.connectionID == ref.connectionID,
+              let session = appModel.session(for: ref),
+              session.workspace?.id == activeWorkspace.workspaceID
+        else { return false }
+
+        selectedContent = .session(ref)
+        selectionMemory.remember(sessionID: ref.sessionID, for: activeWorkspace)
+        if session.attachable {
+            appModel.attachIfNeeded(
+                to: session,
+                connectionID: ref.connectionID,
+                retentionContext: retentionContext
+            )
+        } else {
+            appModel.touchTerminal(ref)
+        }
+        return true
     }
 
     func showDashboard() {
-        route = .dashboard
+        selectedContent = .dashboard
+        isInspectorPresented = false
     }
 
-    /// The open Workspace vanished (deleted remotely, or its Connection
-    /// was removed): back to the Dashboard.
-    func handleOpenWorkspaceGone(in appModel: AppModel) {
-        appModel.openWorkspace = nil
-        route = .dashboard
+    func showWorkspaceEmpty() {
+        guard let activeWorkspace else { return }
+        selectionMemory.forget(activeWorkspace)
+        selectedContent = .workspace(activeWorkspace)
+        isInspectorPresented = false
+    }
+
+    /// Reconciles store-driven removal and delayed restoration. An unloaded
+    /// store is unresolved and never clears the current Workspace.
+    func reconcile(in appModel: AppModel) {
+        guard let activeWorkspace else { return }
+        guard let runtime = appModel.runtime(id: activeWorkspace.connectionID) else {
+            selectionMemory.forget(connectionID: activeWorkspace.connectionID)
+            handleActiveWorkspaceGone(activeWorkspace)
+            return
+        }
+        guard runtime.workspaces.hasLoadedOnce else { return }
+        guard runtime.workspaces.workspace(id: activeWorkspace.workspaceID) != nil else {
+            handleActiveWorkspaceGone(activeWorkspace)
+            return
+        }
+
+        if pendingRestore == activeWorkspace, runtime.sessions.hasLoadedOnce {
+            pendingRestore = nil
+            if selectedContent == .workspace(activeWorkspace),
+               let restored = validRememberedSelection(
+                    for: activeWorkspace,
+                    in: runtime.sessions.sessions
+               ) {
+                selectedContent = .session(restored)
+                if let session = appModel.session(for: restored), session.attachable {
+                    appModel.attachIfNeeded(
+                        to: session,
+                        connectionID: restored.connectionID,
+                        retentionContext: retentionContext
+                    )
+                }
+            }
+        }
+
+        guard case .session(let selected) = selectedContent,
+              runtime.sessions.hasLoadedOnce
+        else { return }
+        let session = appModel.session(for: selected)
+        if selected.connectionID != activeWorkspace.connectionID
+            || session?.workspace?.id != activeWorkspace.workspaceID {
+            selectionMemory.forget(activeWorkspace)
+            selectedContent = .workspace(activeWorkspace)
+            isInspectorPresented = false
+        } else if let session {
+            if session.isArchived {
+                selectionMemory.forget(activeWorkspace)
+            }
+            if session.attachable, appModel.terminals[selected] == nil {
+                appModel.attachIfNeeded(
+                    to: session,
+                    connectionID: selected.connectionID,
+                    retentionContext: retentionContext
+                )
+            }
+        }
+    }
+
+    func forgetSelection(for ref: WorkspaceRef) {
+        selectionMemory.forget(ref)
+    }
+
+    func handleConnectionRemoved(_ connectionID: UUID) {
+        selectionMemory.forget(connectionID: connectionID)
+        if activeWorkspace?.connectionID == connectionID, let activeWorkspace {
+            handleActiveWorkspaceGone(activeWorkspace)
+        }
     }
 
     func toggleSidebar() {
         columnVisibility = columnVisibility == .detailOnly ? .all : .detailOnly
     }
 
-    // MARK: - Command availability
-
-    /// `session.new` / `terminal.new` need an active open Workspace: the
-    /// shell is the visible route, the Workspace is unarchived, and its
-    /// Connection is reachable.
     func canStartSession(in appModel: AppModel) -> Bool {
-        guard route == .workspace,
-              let ref = appModel.openWorkspace,
-              let runtime = appModel.runtime(id: ref.connectionID),
+        guard let activeWorkspace,
+              let runtime = appModel.runtime(id: activeWorkspace.connectionID),
               runtime.reachability == .connected,
-              let workspace = runtime.workspaces.workspace(id: ref.workspaceID),
+              let workspace = runtime.workspaces.workspace(id: activeWorkspace.workspaceID),
               !workspace.isArchived
         else { return false }
         return true
     }
 
-    /// `workspace.new` works everywhere: preselects the open Workspace's
-    /// Project (changeable) when the shell is visible, else the
-    /// context-free form with a required Project picker.
     func presentCreateWorkspace(in appModel: AppModel) {
-        if route == .workspace,
-           let ref = appModel.openWorkspace,
-           let runtime = appModel.runtime(id: ref.connectionID),
-           let workspace = runtime.workspaces.workspace(id: ref.workspaceID) {
+        if let activeWorkspace,
+           let runtime = appModel.runtime(id: activeWorkspace.connectionID),
+           runtime.reachability == .connected,
+           let workspace = runtime.workspaces.workspace(id: activeWorkspace.workspaceID),
+           let project = runtime.projects.project(id: workspace.projectId),
+           !project.isArchived {
             createWorkspaceContext = CreateWorkspaceContext(mode: .preselected(
-                ProjectRef(connectionID: ref.connectionID, projectID: workspace.projectId)
+                ProjectRef(connectionID: activeWorkspace.connectionID, projectID: project.id)
             ))
         } else {
             createWorkspaceContext = CreateWorkspaceContext(mode: .free)
         }
     }
+
+    private func validRememberedSelection(
+        for ref: WorkspaceRef,
+        in sessions: [Session]
+    ) -> SessionRef? {
+        let remembered = selectionMemory.sessionID(for: ref)
+        let restored = selectionMemory.restoredSelection(for: ref, in: sessions)
+        if remembered != nil, restored == nil {
+            selectionMemory.forget(ref)
+        }
+        return restored
+    }
+
+    private func handleActiveWorkspaceGone(_ ref: WorkspaceRef) {
+        selectionMemory.forget(ref)
+        activeWorkspace = nil
+        pendingRestore = nil
+        selectedNavigator = .projects
+        selectedContent = .dashboard
+        isInspectorPresented = false
+    }
 }
 
-/// Which creation sheet `startSessionKind` presents.
 enum StartSessionKind: String, Identifiable {
-    /// Agent Actions only — the sidebar's Sessions section.
     case agentSession
-    /// Interactive Shell or a general Action — the Terminals section.
     case terminal
 
     var id: String { rawValue }
 }
 
-/// Where the create-Workspace sheet was invoked from; decides how the
-/// Project field behaves (see the spec's three contexts).
 struct CreateWorkspaceContext: Identifiable, Hashable {
     enum Mode: Hashable {
-        /// Project card / row button: preselected and fixed.
         case fixed(ProjectRef)
-        /// `workspace.new` inside an open Workspace: preselected, changeable.
         case preselected(ProjectRef)
-        /// File menu: required picker over unarchived Projects.
         case free
     }
 

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -75,6 +75,11 @@ final class WindowState {
         )
     }
 
+    func hasInspectorTarget(in appModel: AppModel) -> Bool {
+        guard case .session(let ref) = selectedContent else { return false }
+        return appModel.session(for: ref) != nil && appModel.runtime(id: ref.connectionID) != nil
+    }
+
     /// The single Workspace activation transition used by every entry point.
     /// A missing target is rejected without changing the current window.
     @discardableResult
@@ -85,14 +90,15 @@ final class WindowState {
 
         if activeWorkspace == ref { return true }
 
-        let restored = runtime.sessions.hasLoadedOnce
+        let sessionsCurrent = runtime.sessions.hasLoadedOnce && runtime.sessions.lastError == nil
+        let restored = sessionsCurrent
             ? validRememberedSelection(for: ref, in: runtime.sessions.sessions)
             : nil
 
         activeWorkspace = ref
         selectedContent = restored.map(MainContentSelection.session) ?? .workspace(ref)
         isInspectorPresented = false
-        pendingRestore = runtime.sessions.hasLoadedOnce ? nil : ref
+        pendingRestore = sessionsCurrent ? nil : ref
 
         if let restored, let session = appModel.session(for: restored), session.attachable {
             appModel.attachIfNeeded(
@@ -115,7 +121,11 @@ final class WindowState {
         else { return false }
 
         selectedContent = .session(ref)
-        selectionMemory.remember(sessionID: ref.sessionID, for: activeWorkspace)
+        if session.isArchived {
+            selectionMemory.forget(activeWorkspace)
+        } else {
+            selectionMemory.remember(sessionID: ref.sessionID, for: activeWorkspace)
+        }
         if session.attachable {
             appModel.attachIfNeeded(
                 to: session,
@@ -149,13 +159,15 @@ final class WindowState {
             handleActiveWorkspaceGone(activeWorkspace)
             return
         }
-        guard runtime.workspaces.hasLoadedOnce else { return }
+        guard runtime.workspaces.hasLoadedOnce, runtime.workspaces.lastError == nil else { return }
         guard runtime.workspaces.workspace(id: activeWorkspace.workspaceID) != nil else {
             handleActiveWorkspaceGone(activeWorkspace)
             return
         }
 
-        if pendingRestore == activeWorkspace, runtime.sessions.hasLoadedOnce {
+        if pendingRestore == activeWorkspace,
+           runtime.sessions.hasLoadedOnce,
+           runtime.sessions.lastError == nil {
             pendingRestore = nil
             if selectedContent == .workspace(activeWorkspace),
                let restored = validRememberedSelection(
@@ -174,7 +186,8 @@ final class WindowState {
         }
 
         guard case .session(let selected) = selectedContent,
-              runtime.sessions.hasLoadedOnce
+              runtime.sessions.hasLoadedOnce,
+              runtime.sessions.lastError == nil
         else { return }
         let session = appModel.session(for: selected)
         if selected.connectionID != activeWorkspace.connectionID
@@ -205,24 +218,24 @@ final class WindowState {
     }
 
     func canStartSession(in appModel: AppModel) -> Bool {
-        guard let activeWorkspace,
-              let runtime = appModel.runtime(id: activeWorkspace.connectionID),
-              runtime.reachability == .connected,
-              let workspace = runtime.workspaces.workspace(id: activeWorkspace.workspaceID),
-              !workspace.isArchived
-        else { return false }
-        return true
+        activeWorkspace.map { appModel.canStartSession(in: $0) } ?? false
     }
 
     func presentCreateWorkspace(in appModel: AppModel) {
         if let activeWorkspace,
            let runtime = appModel.runtime(id: activeWorkspace.connectionID),
-           runtime.reachability == .connected,
            let workspace = runtime.workspaces.workspace(id: activeWorkspace.workspaceID),
-           let project = runtime.projects.project(id: workspace.projectId),
-           !project.isArchived {
+           let project = runtime.projects.project(id: workspace.projectId) {
+            let projectRef = ProjectRef(
+                connectionID: activeWorkspace.connectionID,
+                projectID: project.id
+            )
+            guard appModel.canCreateWorkspace(in: projectRef) else {
+                createWorkspaceContext = CreateWorkspaceContext(mode: .free)
+                return
+            }
             createWorkspaceContext = CreateWorkspaceContext(mode: .preselected(
-                ProjectRef(connectionID: activeWorkspace.connectionID, projectID: project.id)
+                projectRef
             ))
         } else {
             createWorkspaceContext = CreateWorkspaceContext(mode: .free)

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -49,8 +49,6 @@ final class WindowState {
     var isInspectorPresented = false
 
     var expandedProjects: Set<ProjectRef> = []
-    var focusedProject: ProjectRef?
-    var focusedWorkspace: WorkspaceRef?
 
     var isCreateProjectPresented = false
     var createWorkspaceContext: CreateWorkspaceContext?
@@ -85,8 +83,13 @@ final class WindowState {
     @discardableResult
     func activateWorkspace(_ ref: WorkspaceRef, in appModel: AppModel) -> Bool {
         guard let runtime = appModel.runtime(id: ref.connectionID),
-              runtime.workspaces.workspace(id: ref.workspaceID) != nil
+              let workspace = runtime.workspaces.workspace(id: ref.workspaceID)
         else { return false }
+
+        expandedProjects.insert(ProjectRef(
+            connectionID: ref.connectionID,
+            projectID: workspace.projectId
+        ))
 
         // Re-selecting the current Workspace is normally idempotent, but from
         // Dashboard it is also the expected way back into that Workspace.

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -125,7 +125,7 @@ final class WindowState {
         guard let activeWorkspace,
               activeWorkspace.connectionID == ref.connectionID,
               let session = appModel.session(for: ref),
-              session.workspace?.id == activeWorkspace.workspaceID
+              session.belongs(to: activeWorkspace)
         else { return false }
 
         selectedContent = .session(ref)
@@ -199,7 +199,7 @@ final class WindowState {
         else { return }
         let session = appModel.session(for: selected)
         if selected.connectionID != activeWorkspace.connectionID
-            || session?.workspace?.id != activeWorkspace.workspaceID {
+            || session?.belongs(to: activeWorkspace) != true {
             selectionMemory.forget(activeWorkspace)
             selectedContent = .workspace(activeWorkspace)
             isInspectorPresented = false

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -48,6 +48,9 @@ final class WindowState {
     var columnVisibility: NavigationSplitViewVisibility = .all
     var isInspectorPresented = false
 
+    var isProjectsSectionExpanded = true
+    var isSessionsSectionExpanded = true
+    var isTerminalsSectionExpanded = true
     var expandedProjects: Set<ProjectRef> = []
 
     var isCreateProjectPresented = false

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -200,13 +200,6 @@ final class WindowState {
         selectionMemory.forget(ref)
     }
 
-    func handleConnectionRemoved(_ connectionID: UUID) {
-        selectionMemory.forget(connectionID: connectionID)
-        if activeWorkspace?.connectionID == connectionID, let activeWorkspace {
-            handleActiveWorkspaceGone(activeWorkspace)
-        }
-    }
-
     func toggleSidebar() {
         columnVisibility = columnVisibility == .detailOnly ? .all : .detailOnly
     }

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -17,9 +17,9 @@ enum NavigatorID: String, CaseIterable, Sendable {
 
     var systemImage: String {
         switch self {
-        case .projects: "square.grid.2x2"
+        case .projects: "folder"
         case .workspace: "rectangle.stack"
-        case .file: "doc"
+        case .file: "doc.text"
         }
     }
 }
@@ -88,7 +88,9 @@ final class WindowState {
               runtime.workspaces.workspace(id: ref.workspaceID) != nil
         else { return false }
 
-        if activeWorkspace == ref { return true }
+        // Re-selecting the current Workspace is normally idempotent, but from
+        // Dashboard it is also the expected way back into that Workspace.
+        if activeWorkspace == ref, selectedContent != .dashboard { return true }
 
         let sessionsCurrent = runtime.sessions.hasLoadedOnce && runtime.sessions.lastError == nil
         let restored = sessionsCurrent

--- a/macos/ATCTests/AppModelRuntimeTests.swift
+++ b/macos/ATCTests/AppModelRuntimeTests.swift
@@ -206,26 +206,22 @@ struct AppModelRuntimeTests {
         #expect(model.runtime(id: a.id) !== runtime)
     }
 
-    @Test("deleting a connection removes its runtime and clears its selection")
-    func deleteClearsOwnSelection() throws {
+    @Test("deleting a connection removes only its runtime")
+    func deleteRemovesOwnRuntime() throws {
         let (model, _) = makeModel()
         let a = try model.addConnection(name: "A", urlString: "http://a:1", token: "")
         let b = try model.addConnection(name: "B", urlString: "http://b:1", token: "")
-        model.selection = SessionRef(connectionID: a.id, sessionID: "ses_running")
         model.removeConnection(id: a.id)
         #expect(model.runtimes.map(\.id) == [b.id])
-        #expect(model.selection == nil)
     }
 
-    @Test("deleting a connection keeps a selection on another connection")
-    func deleteKeepsForeignSelection() throws {
+    @Test("deleting a connection keeps the other runtime")
+    func deleteKeepsForeignRuntime() throws {
         let (model, _) = makeModel()
         let a = try model.addConnection(name: "A", urlString: "http://a:1", token: "")
         let b = try model.addConnection(name: "B", urlString: "http://b:1", token: "")
-        let kept = SessionRef(connectionID: b.id, sessionID: "ses_running")
-        model.selection = kept
         model.removeConnection(id: a.id)
-        #expect(model.selection == kept)
+        #expect(model.runtime(id: b.id) != nil)
     }
 
     @Test("reachability: unknown → connected → unreachable → connected")
@@ -287,16 +283,14 @@ struct AppModelRuntimeTests {
         #expect(model.runtimes.count == 1)
     }
 
-    @Test("deleting a connection clears an open workspace pointing into it")
-    func deleteClearsOpenWorkspace() throws {
+    @Test("navigation snapshot drops a deleted connection")
+    func snapshotDropsDeletedConnection() throws {
         let (model, _) = makeModel()
         let a = try model.addConnection(name: "A", urlString: "http://a:1", token: "")
         let b = try model.addConnection(name: "B", urlString: "http://b:1", token: "")
-        model.openWorkspace = WorkspaceRef(connectionID: a.id, workspaceID: "wsp_parser")
+        #expect(model.windowNavigationSnapshot().connections.map(\.id) == [a.id, b.id])
         model.removeConnection(id: b.id)
-        #expect(model.openWorkspace != nil)
-        model.removeConnection(id: a.id)
-        #expect(model.openWorkspace == nil)
+        #expect(model.windowNavigationSnapshot().connections.map(\.id) == [a.id])
     }
 
     @Test("runtime refresh loads workspaces and actions alongside projects and sessions")

--- a/macos/ATCTests/AttachmentBudgetTests.swift
+++ b/macos/ATCTests/AttachmentBudgetTests.swift
@@ -5,7 +5,7 @@ import ATCAPI
 
 /// The LRU attachment budget: attaching past the budget evicts the
 /// least-recently-used terminal through the standard disconnect path,
-/// while the selected session and the open Workspace's sessions are
+/// while the selected Session and the Active Workspace's Sessions are
 /// pinned.
 @MainActor
 @Suite("Attachment budget")
@@ -72,10 +72,8 @@ struct AttachmentBudgetTests {
 
         model.attachIfNeeded(to: session("s1"), connectionID: record.id)
         model.attachIfNeeded(to: session("s2"), connectionID: record.id)
-        // Re-selecting s1 makes s2 the LRU candidate...
-        model.selection = SessionRef(connectionID: record.id, sessionID: "s1")
-        // ...then s1 is deselected again so nothing is pinned.
-        model.selection = nil
+        // Touching s1 makes s2 the LRU candidate.
+        model.touchTerminal(SessionRef(connectionID: record.id, sessionID: "s1"))
         model.attachIfNeeded(to: session("s3"), connectionID: record.id)
         #expect(model.terminals[SessionRef(connectionID: record.id, sessionID: "s1")] != nil)
         #expect(model.terminals[SessionRef(connectionID: record.id, sessionID: "s2")] == nil)
@@ -89,17 +87,20 @@ struct AttachmentBudgetTests {
 
         let pinned = SessionRef(connectionID: record.id, sessionID: "s1")
         model.attachIfNeeded(to: session("s1"), connectionID: record.id)
-        model.selection = pinned
         model.attachIfNeeded(to: session("s2"), connectionID: record.id)
-        model.attachIfNeeded(to: session("s3"), connectionID: record.id)
+        model.attachIfNeeded(
+            to: session("s3"),
+            connectionID: record.id,
+            retentionContext: .init(activeWorkspace: nil, selectedSession: pinned)
+        )
         #expect(model.terminals.count == 2)
         #expect(model.terminals[pinned] != nil)
         // s2 (the oldest unpinned attach) was the eviction victim.
         #expect(model.terminals[SessionRef(connectionID: record.id, sessionID: "s2")] == nil)
     }
 
-    @Test("the open workspace's sessions are never evicted")
-    func openWorkspaceIsPinned() async throws {
+    @Test("the Active Workspace's Sessions are never evicted")
+    func activeWorkspaceIsPinned() async throws {
         let model = makeModel(budget: 1)
         let record = try model.addConnection(name: "A", urlString: "http://a:1", token: "")
         let runtime = model.runtime(id: record.id)!
@@ -107,12 +108,17 @@ struct AttachmentBudgetTests {
         await runtime.refresh()
 
         // ses_running belongs to wsp_parser in the fixtures.
-        model.openWorkspace = WorkspaceRef(connectionID: record.id, workspaceID: "wsp_parser")
+        let context = TerminalRetentionContext(
+            activeWorkspace: WorkspaceRef(connectionID: record.id, workspaceID: "wsp_parser"),
+            selectedSession: nil
+        )
         let pinned = SessionRef(connectionID: record.id, sessionID: "ses_running")
         let fixture = try #require(runtime.sessions.session(id: "ses_running"))
-        model.attachIfNeeded(to: fixture, connectionID: record.id)
+        model.attachIfNeeded(to: fixture, connectionID: record.id, retentionContext: context)
 
-        model.attachIfNeeded(to: session("s_other"), connectionID: record.id)
+        model.attachIfNeeded(
+            to: session("s_other"), connectionID: record.id, retentionContext: context
+        )
         #expect(model.terminals[pinned] != nil)
         #expect(model.terminals[SessionRef(connectionID: record.id, sessionID: "s_other")] != nil)
     }
@@ -125,16 +131,18 @@ struct AttachmentBudgetTests {
         runtime.stopPolling()
         await runtime.refresh()
 
-        model.openWorkspace = WorkspaceRef(connectionID: record.id, workspaceID: "wsp_parser")
+        let context = TerminalRetentionContext(
+            activeWorkspace: WorkspaceRef(connectionID: record.id, workspaceID: "wsp_parser"),
+            selectedSession: nil
+        )
         // Both fixtures are wsp_parser members: both pinned, budget 1.
         let running = try #require(runtime.sessions.session(id: "ses_running"))
         let shell = try #require(runtime.sessions.session(id: "ses_shell"))
-        model.attachIfNeeded(to: running, connectionID: record.id)
-        model.attachIfNeeded(to: shell, connectionID: record.id)
+        model.attachIfNeeded(to: running, connectionID: record.id, retentionContext: context)
+        model.attachIfNeeded(to: shell, connectionID: record.id, retentionContext: context)
         #expect(model.terminals.count == 2)
 
         // Closing the workspace unpins; the next attach evicts down.
-        model.openWorkspace = nil
         model.attachIfNeeded(to: session("s_new"), connectionID: record.id)
         #expect(model.terminals.count == 1)
     }
@@ -167,8 +175,7 @@ struct AttachmentBudgetTests {
         let ref = SessionRef(connectionID: record.id, sessionID: "s1")
         #expect(model.terminals[ref] == nil)
 
-        // The same path selection takes on a cold session.
-        model.selection = ref
+        // The same attach path used by window selection reconnects it.
         model.attachIfNeeded(to: session("s1"), connectionID: record.id)
         #expect(model.terminals[ref] != nil)
         #expect(model.terminals.count == 1)

--- a/macos/ATCTests/NavigationPresentationTests.swift
+++ b/macos/ATCTests/NavigationPresentationTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+import ATCAPI
+@testable import ATC
+
+@MainActor
+@Suite("Navigation presentation")
+struct NavigationPresentationTests {
+    @Test("Navigator selector exposes all states and Active Workspace gating")
+    func navigatorSelectorStates() {
+        let unavailable = NavigatorSelectorOption.all(hasActiveWorkspace: false)
+        #expect(unavailable.map(\.id) == [.projects, .workspace, .file])
+        #expect(unavailable.map(\.isEnabled) == [true, false, false])
+        #expect(unavailable[1].help == "Requires an Active Workspace")
+        #expect(unavailable[2].help == "Requires an Active Workspace")
+
+        let available = NavigatorSelectorOption.all(hasActiveWorkspace: true)
+        #expect(available.map(\.isEnabled) == [true, true, true])
+        #expect(available.map(\.help) == NavigatorID.allCases.map(\.label))
+        #expect(FileNavigatorView.unavailableMessage == "File navigation is not available yet")
+    }
+
+    @Test("Workspace Switcher projects no-active, connection, and archive context")
+    func workspaceSwitcherStates() {
+        let project = Project(
+            id: "prj", name: "Shared", workingDir: "/tmp",
+            createdAt: .now, updatedAt: .now
+        )
+        let workspace = Workspace(
+            id: "wsp", projectId: project.id, name: "Parser",
+            createdAt: .now, updatedAt: .now
+        )
+        let noActive = WorkspaceSwitcherPresentation.noActiveWorkspace
+        #expect(noActive.label == "Select Workspace…")
+        #expect(noActive.help == "Select an Active Workspace")
+
+        let connected = WorkspaceSwitcherPresentation(
+            project: project,
+            workspace: workspace,
+            connectionName: "Mac mini",
+            reachability: .connected
+        )
+        #expect(connected.label == "Shared › Parser")
+        #expect(connected.help.contains("Mac mini"))
+        #expect(connected.help.contains("Connected"))
+
+        let ambiguous = WorkspaceSwitcherPresentation(
+            project: project,
+            workspace: workspace,
+            connectionName: "Laptop",
+            reachability: .unreachable
+        )
+        #expect(ambiguous.label == connected.label)
+        #expect(ambiguous.help != connected.help)
+        #expect(ambiguous.help.contains("Disconnected"))
+
+        var archivedWorkspace = workspace
+        archivedWorkspace.archivedAt = .now
+        let archived = WorkspaceSwitcherPresentation(
+            project: project,
+            workspace: archivedWorkspace,
+            connectionName: "Mac mini",
+            reachability: .connected
+        )
+        #expect(archived.isArchived)
+        #expect(archived.help.contains("Archived"))
+    }
+}

--- a/macos/ATCTests/ProjectUIHostingSmokeTest.swift
+++ b/macos/ATCTests/ProjectUIHostingSmokeTest.swift
@@ -37,7 +37,12 @@ struct ProjectUIHostingSmokeTest {
     }
 
     private func dashboard(_ appModel: AppModel) -> some View {
-        DashboardView(onOpenWorkspace: { _ in }, onCreateWorkspace: { _ in }, onCreateProject: {})
+        DashboardView(
+            onOpenWorkspace: { _ in },
+            onCreateWorkspace: { _ in },
+            onCreateProject: {},
+            onWorkspaceDeleted: { _ in }
+        )
             .environment(appModel)
     }
 
@@ -79,7 +84,7 @@ struct ProjectUIHostingSmokeTest {
         let appModel = AppModel.preview()
         let runtime = try #require(appModel.runtimes.first)
         await waitForData(runtime)
-        let state = WindowState()
+        let state = WindowState.ephemeral()
         let sidebar = NavigatorSidebar()
             .environment(appModel)
             .environment(state)

--- a/macos/ATCTests/ProjectUIHostingSmokeTest.swift
+++ b/macos/ATCTests/ProjectUIHostingSmokeTest.swift
@@ -74,6 +74,28 @@ struct ProjectUIHostingSmokeTest {
         host(dashboard(appModel), width: 700, height: 560)
     }
 
+    @Test("all Navigator sidebar modes host without crashing")
+    func hostNavigatorSidebarModes() async throws {
+        let appModel = AppModel.preview()
+        let runtime = try #require(appModel.runtimes.first)
+        await waitForData(runtime)
+        let state = WindowState()
+        let sidebar = NavigatorSidebar()
+            .environment(appModel)
+            .environment(state)
+
+        host(sidebar, width: 280, height: 560)
+        let workspace = WorkspaceRef(
+            connectionID: runtime.id,
+            workspaceID: "wsp_parser"
+        )
+        #expect(state.activateWorkspace(workspace, in: appModel))
+        state.selectedNavigator = .workspace
+        host(sidebar, width: 280, height: 560)
+        state.selectedNavigator = .file
+        host(sidebar, width: 280, height: 560)
+    }
+
     @Test("create-project sheet hosts without crashing")
     func hostCreateProject() async throws {
         host(

--- a/macos/ATCTests/ProjectsNavigatorGroupsTests.swift
+++ b/macos/ATCTests/ProjectsNavigatorGroupsTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Testing
+import ATCAPI
+@testable import ATC
+
+@MainActor
+@Suite("Projects Navigator groups")
+struct ProjectsNavigatorGroupsTests {
+    private func connection(_ id: String, name: String) -> ConnectionRecord {
+        ConnectionRecord(
+            id: UUID(uuidString: id)!,
+            name: name,
+            urlString: "http://\(name.lowercased()):7331",
+            token: ""
+        )
+    }
+
+    private func project(_ id: String, name: String, archived: Bool = false) -> Project {
+        Project(
+            id: id,
+            name: name,
+            workingDir: "/tmp/\(id)",
+            createdAt: .now,
+            updatedAt: .now,
+            archivedAt: archived ? .now : nil
+        )
+    }
+
+    private func workspace(
+        _ id: String,
+        project: String,
+        age: TimeInterval,
+        archived: Bool = false
+    ) -> Workspace {
+        Workspace(
+            id: id,
+            projectId: project,
+            name: id,
+            createdAt: Date(timeIntervalSinceNow: -age),
+            updatedAt: .now,
+            archivedAt: archived ? .now : nil
+        )
+    }
+
+    private func input(
+        connection: ConnectionRecord,
+        projects: [Project],
+        workspaces: [Workspace],
+        reachability: Reachability = .connected
+    ) -> ProjectsNavigatorGroups.Input {
+        .init(
+            connection: connection,
+            reachability: reachability,
+            projects: projects,
+            workspaces: workspaces,
+            sessions: []
+        )
+    }
+
+    @Test("projects sort case-insensitively, then by Connection name and stable identity")
+    func projectOrdering() {
+        let z = connection("00000000-0000-0000-0000-000000000002", name: "Zulu")
+        let a = connection("00000000-0000-0000-0000-000000000001", name: "Alpha")
+        let result = ProjectsNavigatorGroups(inputs: [
+            input(connection: z, projects: [project("p2", name: "same")], workspaces: []),
+            input(connection: a, projects: [
+                project("p3", name: "Beta"),
+                project("p1", name: "Same")
+            ], workspaces: [])
+        ])
+        #expect(result.projects.map(\.project.id) == ["p3", "p1", "p2"])
+        #expect(result.projects.map(\.connectionName) == ["Alpha", "Alpha", "Zulu"])
+    }
+
+    @Test("workspaces sort newest-first and archived records are excluded")
+    func workspaceOrderingAndArchiveFiltering() {
+        let c = connection("00000000-0000-0000-0000-000000000001", name: "Alpha")
+        let result = ProjectsNavigatorGroups(inputs: [input(
+            connection: c,
+            projects: [
+                project("active", name: "Active"),
+                project("archived", name: "Archived", archived: true)
+            ],
+            workspaces: [
+                workspace("old", project: "active", age: 300),
+                workspace("new", project: "active", age: 10),
+                workspace("hidden", project: "active", age: 1, archived: true),
+                workspace("orphan", project: "archived", age: 1)
+            ]
+        )])
+        #expect(result.projects.map(\.project.id) == ["active"])
+        #expect(result.projects[0].workspaces.map(\.workspace.id) == ["new", "old"])
+        #expect(result.projects[0].totalWorkspaceCount == 3)
+    }
+
+    @Test("Connection context and reachability project onto same-named Projects")
+    func connectionContextProjection() {
+        let a = connection("00000000-0000-0000-0000-000000000001", name: "Alpha")
+        let b = connection("00000000-0000-0000-0000-000000000002", name: "Beta")
+        let result = ProjectsNavigatorGroups(inputs: [
+            input(
+                connection: a,
+                projects: [project("one", name: "Shared")],
+                workspaces: [],
+                reachability: .connected
+            ),
+            input(
+                connection: b,
+                projects: [project("two", name: "Shared")],
+                workspaces: [],
+                reachability: .unreachable
+            )
+        ])
+        #expect(result.projects.map(\.connectionName) == ["Alpha", "Beta"])
+        #expect(result.projects.map(\.reachability) == [.connected, .unreachable])
+        #expect(result.projects[0].ref.connectionID != result.projects[1].ref.connectionID)
+    }
+}

--- a/macos/ATCTests/SettingsHostingSmokeTest.swift
+++ b/macos/ATCTests/SettingsHostingSmokeTest.swift
@@ -12,7 +12,7 @@ struct SettingsHostingSmokeTest {
         RunLoop.main.run(until: Date(timeIntervalSinceNow: seconds))
     }
 
-    private func host(_ view: some View, width: CGFloat = 700, height: CGFloat = 450) {
+    private func host(_ view: some View, width: CGFloat = 720, height: CGFloat = 500) {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: width, height: height),
             styleMask: [.titled], backing: .buffered, defer: false
@@ -62,8 +62,7 @@ struct SettingsHostingSmokeTest {
         let store = makeStore(seeded: true)
         host(
             ActionsSettingsView()
-                .environment(AppModel(connections: store, clientFactory: { _ in MockATCClient() })),
-            width: 760, height: 540
+                .environment(AppModel(connections: store, clientFactory: { _ in MockATCClient() }))
         )
     }
 
@@ -72,8 +71,7 @@ struct SettingsHostingSmokeTest {
         let store = makeStore(seeded: false)
         host(
             ActionsSettingsView()
-                .environment(AppModel(connections: store, clientFactory: { _ in MockATCClient() })),
-            width: 760, height: 540
+                .environment(AppModel(connections: store, clientFactory: { _ in MockATCClient() }))
         )
     }
 }

--- a/macos/ATCTests/ShellHostingSmokeTest.swift
+++ b/macos/ATCTests/ShellHostingSmokeTest.swift
@@ -125,4 +125,42 @@ struct ShellHostingSmokeTest {
         ))
         host(RootView().environment(appModel).environment(windowState))
     }
+
+    @Test("Navigator and Dashboard transitions retain the hosted terminal surface")
+    func navigatorTransitionsRetainTerminal() async throws {
+        let appModel = AppModel.preview()
+        let runtime = try #require(appModel.runtimes.first)
+        await waitForData(runtime)
+        let windowState = WindowState()
+        let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
+        let session = SessionRef(connectionID: runtime.id, sessionID: "ses_running")
+        #expect(windowState.activateWorkspace(workspace, in: appModel))
+        #expect(windowState.selectSession(session, in: appModel))
+        let terminal = try #require(appModel.terminals[session])
+        #expect(windowState.hasInspectorTarget(in: appModel))
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 900, height: 600),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        window.contentView = NSHostingView(
+            rootView: RootView().environment(appModel).environment(windowState)
+        )
+        window.orderFront(nil)
+
+        for navigator in NavigatorID.allCases {
+            windowState.selectedNavigator = navigator
+            pump(seconds: 0.15)
+            #expect(windowState.selectedContent == .session(session))
+            #expect(appModel.terminals[session] === terminal)
+            #expect(windowState.hasInspectorTarget(in: appModel))
+        }
+
+        windowState.showDashboard()
+        pump(seconds: 0.15)
+        #expect(windowState.activeWorkspace == workspace)
+        #expect(appModel.terminals[session] === terminal)
+        #expect(!windowState.hasInspectorTarget(in: appModel))
+        window.orderOut(nil)
+    }
 }

--- a/macos/ATCTests/ShellHostingSmokeTest.swift
+++ b/macos/ATCTests/ShellHostingSmokeTest.swift
@@ -38,7 +38,7 @@ struct ShellHostingSmokeTest {
         let appModel = AppModel.preview()
         let runtime = try #require(appModel.runtimes.first)
         await waitForData(runtime)
-        host(RootView().environment(appModel).environment(WindowState()))
+        host(RootView().environment(appModel).environment(WindowState.ephemeral()))
     }
 
     @Test("root view hosts with data arriving after first render")
@@ -46,7 +46,7 @@ struct ShellHostingSmokeTest {
         // The app's real launch order: the window is up before the first
         // poll returns, then rows insert into the live List.
         let appModel = AppModel.preview()
-        host(RootView().environment(appModel).environment(WindowState()))
+        host(RootView().environment(appModel).environment(WindowState.ephemeral()))
     }
 
     @Test("root view hosts Workspace content inside the stable split view")
@@ -54,7 +54,7 @@ struct ShellHostingSmokeTest {
         let appModel = AppModel.preview()
         let runtime = try #require(appModel.runtimes.first)
         await waitForData(runtime)
-        let windowState = WindowState()
+        let windowState = WindowState.ephemeral()
         #expect(windowState.activateWorkspace(
             WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser"),
             in: appModel
@@ -69,7 +69,7 @@ struct ShellHostingSmokeTest {
         let appModel = AppModel.preview()
         let runtime = try #require(appModel.runtimes.first)
         await waitForData(runtime)
-        let windowState = WindowState()
+        let windowState = WindowState.ephemeral()
         #expect(windowState.activateWorkspace(
             WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser"),
             in: appModel
@@ -85,7 +85,7 @@ struct ShellHostingSmokeTest {
         let appModel = AppModel.preview()
         let runtime = try #require(appModel.runtimes.first)
         await waitForData(runtime)
-        let windowState = WindowState()
+        let windowState = WindowState.ephemeral()
         #expect(windowState.activateWorkspace(
             WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser"),
             in: appModel
@@ -118,7 +118,7 @@ struct ShellHostingSmokeTest {
         let appModel = AppModel.preview()
         let runtime = try #require(appModel.runtimes.first)
         await waitForData(runtime)
-        let windowState = WindowState()
+        let windowState = WindowState.ephemeral()
         #expect(windowState.activateWorkspace(
             WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_archived"),
             in: appModel
@@ -131,7 +131,7 @@ struct ShellHostingSmokeTest {
         let appModel = AppModel.preview()
         let runtime = try #require(appModel.runtimes.first)
         await waitForData(runtime)
-        let windowState = WindowState()
+        let windowState = WindowState.ephemeral()
         let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
         let session = SessionRef(connectionID: runtime.id, sessionID: "ses_running")
         #expect(windowState.activateWorkspace(workspace, in: appModel))

--- a/macos/ATCTests/ShellHostingSmokeTest.swift
+++ b/macos/ATCTests/ShellHostingSmokeTest.swift
@@ -4,12 +4,9 @@ import Testing
 import ATCAPI
 @testable import ATC
 
-/// Hosts the full window root (Dashboard cover, Workspace shell with
-/// NavigationSplitView + sidebar List + searchable + detail) in a real
-/// window and pumps the run loop. This is the hierarchy the app boots
-/// into, so it's where launch-time AppKit warnings (reentrant NSTableView
-/// delegate operations, invalid Picker selections) surface under a
-/// controlled model instead of the developer's live state.
+/// Hosts the full stable split-view window in a real window and pumps the
+/// run loop. This is the hierarchy the app boots into, so launch-time AppKit
+/// warnings surface under a controlled model instead of live user state.
 @Suite("Shell hosting smoke")
 struct ShellHostingSmokeTest {
     private func pump(seconds: TimeInterval) {
@@ -52,47 +49,47 @@ struct ShellHostingSmokeTest {
         host(RootView().environment(appModel).environment(WindowState()))
     }
 
-    @Test("root view hosts the Workspace shell after opening a workspace")
-    func hostRootWithOpenWorkspace() async throws {
+    @Test("root view hosts Workspace content inside the stable split view")
+    func hostRootWithActiveWorkspace() async throws {
         let appModel = AppModel.preview()
         let runtime = try #require(appModel.runtimes.first)
         await waitForData(runtime)
         let windowState = WindowState()
-        windowState.openWorkspace(
+        #expect(windowState.activateWorkspace(
             WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser"),
             in: appModel
-        )
+        ))
         host(RootView().environment(appModel).environment(windowState))
-        #expect(windowState.route == .workspace)
+        #expect(windowState.activeWorkspace?.workspaceID == "wsp_parser")
+        #expect(windowState.selectedContent != .dashboard)
     }
 
-    @Test("dashboard covers a mounted shell without tearing it down")
-    func hostRootDashboardCoveringShell() async throws {
+    @Test("Dashboard remains a main-content destination with an Active Workspace")
+    func hostDashboardWithActiveWorkspace() async throws {
         let appModel = AppModel.preview()
         let runtime = try #require(appModel.runtimes.first)
         await waitForData(runtime)
         let windowState = WindowState()
-        windowState.openWorkspace(
+        #expect(windowState.activateWorkspace(
             WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser"),
             in: appModel
-        )
+        ))
         windowState.showDashboard()
         host(RootView().environment(appModel).environment(windowState))
-        // The shell stays mounted (openWorkspace survives the cover).
-        #expect(windowState.hasOpenedWorkspaceShell)
-        #expect(appModel.openWorkspace != nil)
+        #expect(windowState.selectedContent == .dashboard)
+        #expect(windowState.activeWorkspace != nil)
     }
 
-    @Test("removing the open workspace's connection routes back to the dashboard")
-    func removedConnectionRoutesBack() async throws {
+    @Test("removing the Active Workspace's Connection returns to Dashboard")
+    func removedConnectionReturnsToDashboard() async throws {
         let appModel = AppModel.preview()
         let runtime = try #require(appModel.runtimes.first)
         await waitForData(runtime)
         let windowState = WindowState()
-        windowState.openWorkspace(
+        #expect(windowState.activateWorkspace(
             WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser"),
             in: appModel
-        )
+        ))
 
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 900, height: 600),
@@ -103,19 +100,18 @@ struct ShellHostingSmokeTest {
         )
         window.orderFront(nil)
         pump(seconds: 0.5)
-        #expect(windowState.route == .workspace)
+        #expect(windowState.activeWorkspace != nil)
 
-        // Teardown nils openWorkspace before the view sees the change; the
-        // route must still fall back to the Dashboard.
+        // Window reconciliation observes the AppModel's store projection.
         appModel.removeConnection(id: runtime.id)
         pump(seconds: 0.5)
         window.orderOut(nil)
-        #expect(windowState.route == .dashboard)
-        #expect(appModel.openWorkspace == nil)
+        #expect(windowState.selectedContent == .dashboard)
+        #expect(windowState.activeWorkspace == nil)
     }
 
-    @Test("workspace shell hosts an empty workspace with creation actions")
-    func hostShellEmptyWorkspace() async throws {
+    @Test("main content hosts an empty Workspace with creation actions")
+    func hostEmptyWorkspace() async throws {
         // prj_notes has zero workspaces; wsp_refactor has sessions — use a
         // workspace whose sessions are filtered to nothing instead: open
         // the archived workspace, which owns no sessions in the fixtures.
@@ -123,10 +119,10 @@ struct ShellHostingSmokeTest {
         let runtime = try #require(appModel.runtimes.first)
         await waitForData(runtime)
         let windowState = WindowState()
-        windowState.openWorkspace(
+        #expect(windowState.activateWorkspace(
             WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_archived"),
             in: appModel
-        )
+        ))
         host(RootView().environment(appModel).environment(windowState))
     }
 }

--- a/macos/ATCTests/TestSupport.swift
+++ b/macos/ATCTests/TestSupport.swift
@@ -1,0 +1,16 @@
+import Foundation
+@testable import ATC
+
+extension WindowState {
+    /// A WindowState whose selection memory lives in an ephemeral defaults
+    /// suite. Tests must use this over `WindowState()`, whose default
+    /// selection memory reads and writes the developer's real app defaults.
+    static func ephemeral() -> WindowState {
+        let suite = "WindowStateTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return WindowState(
+            selectionMemory: WorkspaceSelectionMemory(defaults: defaults)
+        )
+    }
+}

--- a/macos/ATCTests/WorkspaceFlowTests.swift
+++ b/macos/ATCTests/WorkspaceFlowTests.swift
@@ -117,6 +117,22 @@ struct WorkspaceFlowTests {
         #expect(state.isInspectorPresented)
     }
 
+    @Test("reselecting the Active Workspace returns from Dashboard")
+    func activeWorkspaceReturnsFromDashboard() async throws {
+        let (model, runtime) = try await makeLoadedModel()
+        let state = WindowState()
+        let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
+        let selected = SessionRef(connectionID: runtime.id, sessionID: "ses_running")
+        #expect(state.activateWorkspace(workspace, in: model))
+        #expect(state.selectSession(selected, in: model))
+
+        state.showDashboard()
+        #expect(state.activateWorkspace(workspace, in: model))
+
+        #expect(state.activeWorkspace == workspace)
+        #expect(state.selectedContent == .session(selected))
+    }
+
     @Test("cross-Workspace and cross-Connection session selections are rejected")
     func invalidSelectionsRejected() async throws {
         let (model, runtime) = try await makeLoadedModel()

--- a/macos/ATCTests/WorkspaceFlowTests.swift
+++ b/macos/ATCTests/WorkspaceFlowTests.swift
@@ -218,6 +218,44 @@ struct WorkspaceFlowTests {
         #expect(selectionMemory.sessionID(for: refactor) == nil)
     }
 
+    @Test("explicit Disconnect is not undone by reconcile")
+    func disconnectSurvivesReconcile() async throws {
+        let (model, runtime) = try await makeLoadedModel()
+        let (selectionMemory, _) = memory()
+        let state = WindowState(selectionMemory: selectionMemory)
+        let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
+        let selected = SessionRef(connectionID: runtime.id, sessionID: "ses_running")
+        #expect(state.activateWorkspace(workspace, in: model))
+        #expect(state.selectSession(selected, in: model))
+        #expect(model.terminals[selected] != nil)
+
+        model.disconnectTerminal(ref: selected)
+        state.reconcile(in: model)
+        #expect(model.terminals[selected] == nil)
+
+        // An explicit attach (Connect button, re-selection) reconnects and
+        // reconcile keeps it connected afterwards.
+        let session = try #require(model.session(for: selected))
+        model.attachIfNeeded(to: session, connectionID: selected.connectionID)
+        state.reconcile(in: model)
+        #expect(model.terminals[selected] != nil)
+    }
+
+    @Test("losing the Active Workspace dismisses the start-session sheet")
+    func startSheetDismissedWhenWorkspaceGone() async throws {
+        let (model, runtime) = try await makeLoadedModel()
+        let (selectionMemory, _) = memory()
+        let state = WindowState(selectionMemory: selectionMemory)
+        let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
+        #expect(state.activateWorkspace(workspace, in: model))
+        state.startSessionKind = .agentSession
+
+        model.removeConnection(id: runtime.id)
+        state.reconcile(in: model)
+        #expect(state.activeWorkspace == nil)
+        #expect(state.startSessionKind == nil)
+    }
+
     @Test("selecting archived content never writes restoration memory")
     func archivedSelectionIsNotRemembered() async throws {
         let (model, runtime) = try await makeLoadedModel()

--- a/macos/ATCTests/WorkspaceFlowTests.swift
+++ b/macos/ATCTests/WorkspaceFlowTests.swift
@@ -3,233 +3,371 @@ import Testing
 import ATCAPI
 @testable import ATC
 
-/// Window routing, command availability, selection memory, and the
-/// delete-confirmation copy — the state layer behind the Dashboard and
-/// Workspace shell flows.
 @MainActor
 @Suite("Workspace flows")
 struct WorkspaceFlowTests {
     private func makeModel(
         client: @escaping @autoclosure () -> any ATCClient = MockATCClient()
     ) -> AppModel {
-        let suite = "WorkspaceFlowTests.\(UUID().uuidString)"
+        let suite = "WorkspaceFlowTests.model.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
         defaults.removePersistentDomain(forName: suite)
-        let store = ConnectionsStore(defaults: defaults, credentials: InMemoryCredentialStore())
         return AppModel(
-            connections: store,
+            connections: ConnectionsStore(
+                defaults: defaults,
+                credentials: InMemoryCredentialStore()
+            ),
             clientFactory: { _ in client() },
             terminalRecoveryMonitor: .disabled()
         )
     }
 
-    /// A connected runtime with fixture data loaded and polling stopped.
-    private func makeOpenedModel() async throws -> (AppModel, WindowState, ConnectionRuntime) {
-        let model = makeModel()
+    private func makeLoadedModel(
+        client: @escaping @autoclosure () -> any ATCClient = MockATCClient()
+    ) async throws -> (AppModel, ConnectionRuntime) {
+        let model = makeModel(client: client())
         let record = try model.addConnection(name: "A", urlString: "http://a:1", token: "")
-        let runtime = model.runtime(id: record.id)!
+        let runtime = try #require(model.runtime(id: record.id))
         runtime.stopPolling()
         await runtime.refresh()
-        let windowState = WindowState()
-        windowState.openWorkspace(
-            WorkspaceRef(connectionID: record.id, workspaceID: "wsp_parser"),
-            in: model
-        )
-        return (model, windowState, runtime)
+        return (model, runtime)
     }
 
-    // MARK: - Routing
-
-    @Test("opening a workspace routes to the shell and mounts it for good")
-    func openRoutes() async throws {
-        let (model, windowState, _) = try await makeOpenedModel()
-        #expect(windowState.route == .workspace)
-        #expect(windowState.hasOpenedWorkspaceShell)
-        #expect(model.openWorkspace?.workspaceID == "wsp_parser")
-
-        // Back to the Dashboard covers the shell but keeps it open.
-        windowState.showDashboard()
-        #expect(windowState.route == .dashboard)
-        #expect(windowState.hasOpenedWorkspaceShell)
-        #expect(model.openWorkspace != nil)
-    }
-
-    @Test("a vanished open workspace routes back to the dashboard")
-    func vanishedWorkspaceRoutesBack() async throws {
-        let (model, windowState, runtime) = try await makeOpenedModel()
-        #expect(model.openWorkspaceExists)
-
-        // Simulate a remote delete: the store no longer lists it.
-        model.openWorkspace = WorkspaceRef(
-            connectionID: runtime.id, workspaceID: "wsp_deleted_elsewhere"
-        )
-        #expect(!model.openWorkspaceExists)
-        windowState.handleOpenWorkspaceGone(in: model)
-        #expect(windowState.route == .dashboard)
-        #expect(model.openWorkspace == nil)
-    }
-
-    @Test("removing the connection makes the open workspace not exist")
-    func removedConnectionRoutesBack() async throws {
-        let (model, _, runtime) = try await makeOpenedModel()
-        model.removeConnection(id: runtime.id)
-        // teardown already cleared openWorkspace; a cleared ref reads as gone.
-        #expect(model.openWorkspace == nil)
-        #expect(!model.openWorkspaceExists)
-    }
-
-    // MARK: - Command availability
-
-    @Test("session and terminal creation need the shell route")
-    func creationNeedsShellRoute() async throws {
-        let (model, windowState, _) = try await makeOpenedModel()
-        #expect(windowState.canStartSession(in: model))
-        windowState.showDashboard()
-        #expect(!windowState.canStartSession(in: model))
-    }
-
-    @Test("session creation is disabled in an archived workspace")
-    func creationDisabledWhenArchived() async throws {
-        let (model, windowState, runtime) = try await makeOpenedModel()
-        windowState.openWorkspace(
-            WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_archived"),
-            in: model
-        )
-        #expect(!windowState.canStartSession(in: model))
-    }
-
-    @Test("session creation is disabled on an unreachable connection")
-    func creationDisabledWhenUnreachable() async throws {
-        let client = StatefulWorkspacesClient()
-        let model = makeModel(client: client)
-        let record = try model.addConnection(name: "A", urlString: "http://a:1", token: "")
-        let runtime = model.runtime(id: record.id)!
-        runtime.stopPolling()
-        await runtime.refresh()
-        let windowState = WindowState()
-        windowState.openWorkspace(
-            WorkspaceRef(connectionID: record.id, workspaceID: "wsp_a"),
-            in: model
-        )
-        #expect(windowState.canStartSession(in: model))
-
-        // Flip the whole connection red: cached data stays, creation stops.
-        client.failSessions = true
-        await runtime.refresh()
-        #expect(runtime.reachability == .unreachable)
-        #expect(!windowState.canStartSession(in: model))
-    }
-
-    @Test("new-workspace preselects the open workspace's project, else runs context-free")
-    func createWorkspaceContexts() async throws {
-        let (model, windowState, runtime) = try await makeOpenedModel()
-        windowState.presentCreateWorkspace(in: model)
-        #expect(windowState.createWorkspaceContext?.mode == .preselected(
-            ProjectRef(connectionID: runtime.id, projectID: "prj_atelier")
-        ))
-
-        windowState.createWorkspaceContext = nil
-        windowState.showDashboard()
-        windowState.presentCreateWorkspace(in: model)
-        #expect(windowState.createWorkspaceContext?.mode == .free)
-    }
-
-    // MARK: - Selection memory
-
-    @Test("selection memory remembers, restores, and forgets per workspace")
-    func selectionMemory() {
+    private func memory() -> (WorkspaceSelectionMemory, UserDefaults) {
         let suite = "WorkspaceFlowTests.memory.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
         defaults.removePersistentDomain(forName: suite)
-        let memory = WorkspaceSelectionMemory(defaults: defaults)
-
-        #expect(memory.sessionID(for: "wsp_a") == nil)
-        memory.remember(sessionID: "ses_1", for: "wsp_a")
-        memory.remember(sessionID: "ses_2", for: "wsp_b")
-        #expect(memory.sessionID(for: "wsp_a") == "ses_1")
-        #expect(memory.sessionID(for: "wsp_b") == "ses_2")
-
-        memory.remember(sessionID: "ses_9", for: "wsp_a")
-        #expect(memory.sessionID(for: "wsp_a") == "ses_9")
-
-        memory.forget(workspaceID: "wsp_a")
-        #expect(memory.sessionID(for: "wsp_a") == nil)
-        #expect(memory.sessionID(for: "wsp_b") == "ses_2")
+        return (WorkspaceSelectionMemory(defaults: defaults), defaults)
     }
 
-    @Test("selection restore hits the surviving session and falls back to nil")
+    @Test("launch defaults select Projects and Dashboard with no Active Workspace")
+    func launchDefaults() {
+        let state = WindowState()
+        #expect(state.selectedNavigator == .projects)
+        #expect(state.selectedContent == .dashboard)
+        #expect(state.activeWorkspace == nil)
+        #expect(!state.isInspectorPresented)
+        #expect(state.columnVisibility == .all)
+    }
+
+    @Test("Navigator changes preserve main content and inspector")
+    func navigatorPreservesContent() async throws {
+        let (model, runtime) = try await makeLoadedModel()
+        let state = WindowState()
+        let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
+        #expect(state.activateWorkspace(workspace, in: model))
+        let session = SessionRef(connectionID: runtime.id, sessionID: "ses_running")
+        #expect(state.selectSession(session, in: model))
+        state.isInspectorPresented = true
+
+        state.selectedNavigator = .workspace
+        #expect(state.selectedContent == .session(session))
+        #expect(state.isInspectorPresented)
+        state.selectedNavigator = .file
+        #expect(state.selectedContent == .session(session))
+        #expect(state.isInspectorPresented)
+    }
+
+    @Test("Dashboard preserves Active Workspace, Navigator, and command availability")
+    func dashboardPreservesWorkspaceContext() async throws {
+        let (model, runtime) = try await makeLoadedModel()
+        let state = WindowState()
+        let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
+        #expect(state.activateWorkspace(workspace, in: model))
+        state.selectedNavigator = .file
+        state.isInspectorPresented = true
+
+        state.showDashboard()
+        #expect(state.selectedContent == .dashboard)
+        #expect(state.activeWorkspace == workspace)
+        #expect(state.selectedNavigator == .file)
+        #expect(!state.isInspectorPresented)
+        #expect(state.canStartSession(in: model))
+    }
+
+    @Test("activation preserves Navigator and restores valid remembered content")
+    func activationRestoresSelection() async throws {
+        let (model, runtime) = try await makeLoadedModel()
+        let (selectionMemory, _) = memory()
+        let state = WindowState(selectionMemory: selectionMemory)
+        state.selectedNavigator = .file
+        let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
+        selectionMemory.remember(sessionID: "ses_running", for: workspace)
+
+        #expect(state.activateWorkspace(workspace, in: model))
+        #expect(state.activeWorkspace == workspace)
+        #expect(state.selectedNavigator == .file)
+        #expect(state.selectedContent == .session(
+            SessionRef(connectionID: runtime.id, sessionID: "ses_running")
+        ))
+    }
+
+    @Test("same Workspace activation is idempotent")
+    func activationIsIdempotent() async throws {
+        let (model, runtime) = try await makeLoadedModel()
+        let state = WindowState()
+        let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
+        let selected = SessionRef(connectionID: runtime.id, sessionID: "ses_running")
+        #expect(state.activateWorkspace(workspace, in: model))
+        #expect(state.selectSession(selected, in: model))
+        state.isInspectorPresented = true
+
+        #expect(state.activateWorkspace(workspace, in: model))
+        #expect(state.selectedContent == .session(selected))
+        #expect(state.isInspectorPresented)
+    }
+
+    @Test("cross-Workspace and cross-Connection session selections are rejected")
+    func invalidSelectionsRejected() async throws {
+        let (model, runtime) = try await makeLoadedModel()
+        let other = try model.addConnection(name: "B", urlString: "http://b:1", token: "")
+        model.runtime(id: other.id)?.stopPolling()
+        await model.runtime(id: other.id)?.refresh()
+        let state = WindowState()
+        let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
+        #expect(state.activateWorkspace(workspace, in: model))
+
+        #expect(!state.selectSession(
+            SessionRef(connectionID: runtime.id, sessionID: "ses_ghost"), in: model
+        ))
+        #expect(!state.selectSession(
+            SessionRef(connectionID: other.id, sessionID: "ses_running"), in: model
+        ))
+        #expect(state.selectedContent == .workspace(workspace))
+    }
+
+    @Test("different Workspace activation closes inspector and never keeps stale content")
+    func switchingWorkspaceClearsStaleContent() async throws {
+        let (model, runtime) = try await makeLoadedModel()
+        let state = WindowState()
+        let first = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
+        let second = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_refactor")
+        #expect(state.activateWorkspace(first, in: model))
+        #expect(state.selectSession(
+            SessionRef(connectionID: runtime.id, sessionID: "ses_running"), in: model
+        ))
+        state.isInspectorPresented = true
+
+        #expect(state.activateWorkspace(second, in: model))
+        #expect(state.activeWorkspace == second)
+        #expect(state.selectedContent == .workspace(second))
+        #expect(!state.isInspectorPresented)
+    }
+
+    @Test("an open inspector follows a new Session in the same Workspace")
+    func inspectorFollowsSelection() async throws {
+        let (model, runtime) = try await makeLoadedModel()
+        let state = WindowState()
+        #expect(state.activateWorkspace(
+            WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser"), in: model
+        ))
+        #expect(state.selectSession(
+            SessionRef(connectionID: runtime.id, sessionID: "ses_running"), in: model
+        ))
+        state.isInspectorPresented = true
+        let next = SessionRef(connectionID: runtime.id, sessionID: "ses_shell")
+        #expect(state.selectSession(next, in: model))
+        #expect(state.selectedContent == .session(next))
+        #expect(state.isInspectorPresented)
+    }
+
+    @Test("clearing or archiving selected content clears remembered restoration")
+    func staleSelectionMemoryIsCleared() async throws {
+        let (model, runtime) = try await makeLoadedModel()
+        let (selectionMemory, _) = memory()
+        let state = WindowState(selectionMemory: selectionMemory)
+        let parser = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
+        #expect(state.activateWorkspace(parser, in: model))
+        #expect(state.selectSession(
+            SessionRef(connectionID: runtime.id, sessionID: "ses_running"), in: model
+        ))
+        #expect(selectionMemory.sessionID(for: parser) == "ses_running")
+        state.showWorkspaceEmpty()
+        #expect(selectionMemory.sessionID(for: parser) == nil)
+
+        let refactor = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_refactor")
+        #expect(state.activateWorkspace(refactor, in: model))
+        let ended = SessionRef(connectionID: runtime.id, sessionID: "ses_done")
+        #expect(state.selectSession(ended, in: model))
+        try await runtime.sessions.archive(id: ended.sessionID)
+        state.reconcile(in: model)
+        #expect(state.selectedContent == .session(ended))
+        #expect(selectionMemory.sessionID(for: refactor) == nil)
+    }
+
+    @Test("unresolved and disconnected stores preserve the Active Workspace")
+    func unresolvedAndDisconnectedPreserveWorkspace() async throws {
+        let client = StatefulWorkspacesClient()
+        let (model, runtime) = try await makeLoadedModel(client: client)
+        let state = WindowState()
+        let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_a")
+        #expect(state.activateWorkspace(workspace, in: model))
+
+        try model.updateConnection(
+            id: runtime.id, name: "A", urlString: "http://a:2", token: ""
+        )
+        state.reconcile(in: model)
+        #expect(state.activeWorkspace == workspace)
+
+        let rebuilt = try #require(model.runtime(id: runtime.id))
+        rebuilt.stopPolling()
+        await rebuilt.refresh()
+        state.reconcile(in: model)
+        #expect(state.activeWorkspace == workspace)
+    }
+
+    @Test("removed Connection clears window references and returns to Dashboard")
+    func removedConnectionClearsWindow() async throws {
+        let (model, runtime) = try await makeLoadedModel()
+        let state = WindowState()
+        let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
+        #expect(state.activateWorkspace(workspace, in: model))
+        state.selectedNavigator = .workspace
+        state.isInspectorPresented = true
+
+        model.removeConnection(id: runtime.id)
+        state.reconcile(in: model)
+        #expect(state.activeWorkspace == nil)
+        #expect(state.selectedNavigator == .projects)
+        #expect(state.selectedContent == .dashboard)
+        #expect(!state.isInspectorPresented)
+    }
+
+    @Test("confirmed Workspace removal clears window references")
+    func removedWorkspaceClearsWindow() async throws {
+        let client = StatefulWorkspacesClient()
+        let (model, runtime) = try await makeLoadedModel(client: client)
+        let state = WindowState()
+        let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_a")
+        #expect(state.activateWorkspace(workspace, in: model))
+        try await runtime.workspaces.delete(id: workspace.workspaceID)
+        state.reconcile(in: model)
+        #expect(state.activeWorkspace == nil)
+        #expect(state.selectedNavigator == .projects)
+        #expect(state.selectedContent == .dashboard)
+    }
+
+    @Test("archiving an Active Workspace preserves it and disables creation")
+    func archivedWorkspaceRemainsActive() async throws {
+        let client = StatefulWorkspacesClient()
+        let (model, runtime) = try await makeLoadedModel(client: client)
+        let state = WindowState()
+        let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_a")
+        #expect(state.activateWorkspace(workspace, in: model))
+        try await runtime.workspaces.archive(id: workspace.workspaceID)
+        state.reconcile(in: model)
+        #expect(state.activeWorkspace == workspace)
+        #expect(!state.canStartSession(in: model))
+    }
+
+    @Test("creation availability depends on Active Workspace, archive, and reachability")
+    func creationAvailability() async throws {
+        let client = StatefulWorkspacesClient()
+        let (model, runtime) = try await makeLoadedModel(client: client)
+        let state = WindowState()
+        #expect(state.activateWorkspace(
+            WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_a"), in: model
+        ))
+        state.showDashboard()
+        #expect(state.canStartSession(in: model))
+
+        client.failSessions = true
+        await runtime.refresh()
+        #expect(!state.canStartSession(in: model))
+
+        client.failSessions = false
+        await runtime.refresh()
+        let (archiveModel, archiveRuntime) = try await makeLoadedModel()
+        let archiveState = WindowState()
+        #expect(archiveState.activateWorkspace(
+            WorkspaceRef(connectionID: archiveRuntime.id, workspaceID: "wsp_archived"),
+            in: archiveModel
+        ))
+        #expect(!archiveState.canStartSession(in: archiveModel))
+    }
+
+    @Test("New Workspace uses Active Project even while Dashboard is visible")
+    func createWorkspaceContextUsesActiveWorkspace() async throws {
+        let (model, runtime) = try await makeLoadedModel()
+        let state = WindowState()
+        #expect(state.activateWorkspace(
+            WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser"), in: model
+        ))
+        state.showDashboard()
+        state.presentCreateWorkspace(in: model)
+        #expect(state.createWorkspaceContext?.mode == .preselected(
+            ProjectRef(connectionID: runtime.id, projectID: "prj_atelier")
+        ))
+    }
+
+    @Test("selection memory is Connection-qualified and discards the obsolete map")
+    func selectionMemoryIsComposite() {
+        let (selectionMemory, defaults) = memory()
+        defaults.set(["same": "old"], forKey: "workspaceSelections")
+        let memoryAfterOldData = WorkspaceSelectionMemory(defaults: defaults)
+        let a = WorkspaceRef(connectionID: UUID(), workspaceID: "same")
+        let b = WorkspaceRef(connectionID: UUID(), workspaceID: "same")
+
+        memoryAfterOldData.remember(sessionID: "ses_a", for: a)
+        memoryAfterOldData.remember(sessionID: "ses_b", for: b)
+        #expect(memoryAfterOldData.sessionID(for: a) == "ses_a")
+        #expect(memoryAfterOldData.sessionID(for: b) == "ses_b")
+        #expect(defaults.object(forKey: "workspaceSelections") == nil)
+
+        selectionMemory.forget(a)
+        #expect(selectionMemory.sessionID(for: a) == nil)
+        #expect(selectionMemory.sessionID(for: b) == "ses_b")
+    }
+
+    @Test("restoration rejects missing, moved, and archived sessions")
     func selectionRestoreFallbacks() {
-        let suite = "WorkspaceFlowTests.restore.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
-        let memory = WorkspaceSelectionMemory(defaults: defaults)
-        let connectionID = UUID()
-        let ref = WorkspaceRef(connectionID: connectionID, workspaceID: "wsp_a")
-        let survivor = Session(
+        let (memory, _) = memory()
+        let ref = WorkspaceRef(connectionID: UUID(), workspaceID: "wsp_a")
+        var session = Session(
             id: "ses_1", environment: "host", workingDir: "/home/dev",
-            status: .terminated, attachable: false,
+            status: .running, attachable: true,
             createdAt: .now, updatedAt: .now,
             workspace: SessionWorkspace(id: "wsp_a", name: "A")
         )
-
-        // Nothing remembered → empty state.
-        #expect(memory.restoredSelection(for: ref, in: [survivor]) == nil)
-
-        // Remembered and surviving (any lifecycle state) → restored.
-        memory.remember(sessionID: "ses_1", for: "wsp_a")
-        #expect(memory.restoredSelection(for: ref, in: [survivor])
-            == SessionRef(connectionID: connectionID, sessionID: "ses_1"))
-
-        // Remembered but gone from the store → empty state.
+        memory.remember(sessionID: session.id, for: ref)
+        for status in [SessionStatus.running, .terminated, .failed] {
+            session.status = status
+            #expect(memory.restoredSelection(for: ref, in: [session]) != nil)
+        }
         #expect(memory.restoredSelection(for: ref, in: []) == nil)
 
-        // Remembered but now in a different workspace → empty state.
-        var moved = survivor
-        moved.workspace = SessionWorkspace(id: "wsp_b", name: "B")
-        #expect(memory.restoredSelection(for: ref, in: [moved]) == nil)
+        session.workspace = SessionWorkspace(id: "wsp_b", name: "B")
+        #expect(memory.restoredSelection(for: ref, in: [session]) == nil)
+        session.workspace = SessionWorkspace(id: "wsp_a", name: "A")
+        session.archivedAt = .now
+        #expect(memory.restoredSelection(for: ref, in: [session]) == nil)
     }
 
-    // MARK: - Delete confirmations
-
-    @Test("every delete confirmation names its target and ends with the ADR sentence")
+    @Test("every delete confirmation names its target and preserves file copy")
     func deleteConfirmationCopy() {
         let session = DeleteConfirmation.sessionMessage(displayName: "Fix parser")
         #expect(session.contains("“Fix parser”"))
         #expect(session.hasSuffix(DeleteConfirmation.filesUntouched))
-
-        let quiet = DeleteConfirmation.workspaceMessage(name: "Spike", sessionCount: 1, activeCount: 0)
-        #expect(quiet.contains("“Spike” and its 1 session?"))
-        #expect(!quiet.contains("will be stopped"))
-        #expect(quiet.hasSuffix(DeleteConfirmation.filesUntouched))
-
-        let busy = DeleteConfirmation.workspaceMessage(name: "Spike", sessionCount: 3, activeCount: 2)
-        #expect(busy.contains("its 3 sessions?"))
-        #expect(busy.contains("2 running sessions will be stopped."))
-        #expect(busy.hasSuffix(DeleteConfirmation.filesUntouched))
-
-        let project = DeleteConfirmation.projectMessage(name: "Atelier")
-        #expect(project.contains("“Atelier”"))
-        #expect(project.hasSuffix(DeleteConfirmation.filesUntouched))
+        let workspace = DeleteConfirmation.workspaceMessage(
+            name: "Spike", sessionCount: 3, activeCount: 2
+        )
+        #expect(workspace.contains("2 running sessions will be stopped."))
+        #expect(workspace.hasSuffix(DeleteConfirmation.filesUntouched))
+        #expect(DeleteConfirmation.projectMessage(name: "Atelier")
+            .hasSuffix(DeleteConfirmation.filesUntouched))
     }
 
-    // MARK: - Session store wrappers
-
-    @Test("session delete removes the row; unarchive clears archivedAt")
+    @Test("session delete and unarchive wrappers update the store")
     func sessionWrappers() async throws {
-        // Stateful client: the store's follow-up refreshes must not
-        // resurrect the deleted/archived fixtures mid-test.
         let model = makeModel(client: StatefulWorkspacesClient())
         let record = try model.addConnection(name: "A", urlString: "http://a:1", token: "")
-        let runtime = model.runtime(id: record.id)!
+        let runtime = try #require(model.runtime(id: record.id))
         runtime.stopPolling()
         await runtime.refresh()
-
-        let store = runtime.sessions
-        #expect(store.session(id: "ses_archived")?.isArchived == true)
-        try await store.unarchive(id: "ses_archived")
-        #expect(store.session(id: "ses_archived")?.isArchived == false)
-
-        try await store.delete(id: "ses_done")
-        #expect(store.session(id: "ses_done") == nil)
+        #expect(runtime.sessions.session(id: "ses_archived")?.isArchived == true)
+        try await runtime.sessions.unarchive(id: "ses_archived")
+        #expect(runtime.sessions.session(id: "ses_archived")?.isArchived == false)
+        try await runtime.sessions.delete(id: "ses_done")
+        #expect(runtime.sessions.session(id: "ses_done") == nil)
     }
 }

--- a/macos/ATCTests/WorkspaceFlowTests.swift
+++ b/macos/ATCTests/WorkspaceFlowTests.swift
@@ -42,7 +42,7 @@ struct WorkspaceFlowTests {
 
     @Test("launch defaults select Projects and Dashboard with no Active Workspace")
     func launchDefaults() {
-        let state = WindowState()
+        let state = WindowState.ephemeral()
         #expect(state.selectedNavigator == .projects)
         #expect(state.selectedContent == .dashboard)
         #expect(state.activeWorkspace == nil)
@@ -56,7 +56,7 @@ struct WorkspaceFlowTests {
     @Test("Navigator changes preserve main content and inspector")
     func navigatorPreservesContent() async throws {
         let (model, runtime) = try await makeLoadedModel()
-        let state = WindowState()
+        let state = WindowState.ephemeral()
         let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
         #expect(state.activateWorkspace(workspace, in: model))
         let session = SessionRef(connectionID: runtime.id, sessionID: "ses_running")
@@ -74,7 +74,7 @@ struct WorkspaceFlowTests {
     @Test("Dashboard preserves Active Workspace, Navigator, and command availability")
     func dashboardPreservesWorkspaceContext() async throws {
         let (model, runtime) = try await makeLoadedModel()
-        let state = WindowState()
+        let state = WindowState.ephemeral()
         let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
         #expect(state.activateWorkspace(workspace, in: model))
         state.selectedNavigator = .file
@@ -112,7 +112,7 @@ struct WorkspaceFlowTests {
     @Test("same Workspace activation is idempotent")
     func activationIsIdempotent() async throws {
         let (model, runtime) = try await makeLoadedModel()
-        let state = WindowState()
+        let state = WindowState.ephemeral()
         let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
         let selected = SessionRef(connectionID: runtime.id, sessionID: "ses_running")
         #expect(state.activateWorkspace(workspace, in: model))
@@ -127,7 +127,7 @@ struct WorkspaceFlowTests {
     @Test("reselecting the Active Workspace returns from Dashboard")
     func activeWorkspaceReturnsFromDashboard() async throws {
         let (model, runtime) = try await makeLoadedModel()
-        let state = WindowState()
+        let state = WindowState.ephemeral()
         let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
         let selected = SessionRef(connectionID: runtime.id, sessionID: "ses_running")
         #expect(state.activateWorkspace(workspace, in: model))
@@ -146,7 +146,7 @@ struct WorkspaceFlowTests {
         let other = try model.addConnection(name: "B", urlString: "http://b:1", token: "")
         model.runtime(id: other.id)?.stopPolling()
         await model.runtime(id: other.id)?.refresh()
-        let state = WindowState()
+        let state = WindowState.ephemeral()
         let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
         #expect(state.activateWorkspace(workspace, in: model))
 
@@ -162,7 +162,7 @@ struct WorkspaceFlowTests {
     @Test("different Workspace activation closes inspector and never keeps stale content")
     func switchingWorkspaceClearsStaleContent() async throws {
         let (model, runtime) = try await makeLoadedModel()
-        let state = WindowState()
+        let state = WindowState.ephemeral()
         let first = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
         let second = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_refactor")
         #expect(state.activateWorkspace(first, in: model))
@@ -180,7 +180,7 @@ struct WorkspaceFlowTests {
     @Test("an open inspector follows a new Session in the same Workspace")
     func inspectorFollowsSelection() async throws {
         let (model, runtime) = try await makeLoadedModel()
-        let state = WindowState()
+        let state = WindowState.ephemeral()
         #expect(state.activateWorkspace(
             WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser"), in: model
         ))
@@ -328,7 +328,7 @@ struct WorkspaceFlowTests {
     func unresolvedAndDisconnectedPreserveWorkspace() async throws {
         let client = StatefulWorkspacesClient()
         let (model, runtime) = try await makeLoadedModel(client: client)
-        let state = WindowState()
+        let state = WindowState.ephemeral()
         let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_a")
         #expect(state.activateWorkspace(workspace, in: model))
 
@@ -348,7 +348,7 @@ struct WorkspaceFlowTests {
     @Test("removed Connection clears window references and returns to Dashboard")
     func removedConnectionClearsWindow() async throws {
         let (model, runtime) = try await makeLoadedModel()
-        let state = WindowState()
+        let state = WindowState.ephemeral()
         let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
         #expect(state.activateWorkspace(workspace, in: model))
         state.selectedNavigator = .workspace
@@ -366,7 +366,7 @@ struct WorkspaceFlowTests {
     func removedWorkspaceClearsWindow() async throws {
         let client = StatefulWorkspacesClient()
         let (model, runtime) = try await makeLoadedModel(client: client)
-        let state = WindowState()
+        let state = WindowState.ephemeral()
         let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_a")
         #expect(state.activateWorkspace(workspace, in: model))
         try await runtime.workspaces.delete(id: workspace.workspaceID)
@@ -380,7 +380,7 @@ struct WorkspaceFlowTests {
     func archivedWorkspaceRemainsActive() async throws {
         let client = StatefulWorkspacesClient()
         let (model, runtime) = try await makeLoadedModel(client: client)
-        let state = WindowState()
+        let state = WindowState.ephemeral()
         let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_a")
         #expect(state.activateWorkspace(workspace, in: model))
         try await runtime.workspaces.archive(id: workspace.workspaceID)
@@ -393,7 +393,7 @@ struct WorkspaceFlowTests {
     func creationAvailability() async throws {
         let client = StatefulWorkspacesClient()
         let (model, runtime) = try await makeLoadedModel(client: client)
-        let state = WindowState()
+        let state = WindowState.ephemeral()
         #expect(state.activateWorkspace(
             WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_a"), in: model
         ))
@@ -407,7 +407,7 @@ struct WorkspaceFlowTests {
         client.failSessions = false
         await runtime.refresh()
         let (archiveModel, archiveRuntime) = try await makeLoadedModel()
-        let archiveState = WindowState()
+        let archiveState = WindowState.ephemeral()
         #expect(archiveState.activateWorkspace(
             WorkspaceRef(connectionID: archiveRuntime.id, workspaceID: "wsp_archived"),
             in: archiveModel
@@ -418,7 +418,7 @@ struct WorkspaceFlowTests {
     @Test("New Workspace uses Active Project even while Dashboard is visible")
     func createWorkspaceContextUsesActiveWorkspace() async throws {
         let (model, runtime) = try await makeLoadedModel()
-        let state = WindowState()
+        let state = WindowState.ephemeral()
         #expect(state.activateWorkspace(
             WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser"), in: model
         ))
@@ -455,19 +455,16 @@ struct WorkspaceFlowTests {
         #expect(!model.canStartSession(in: workspace))
     }
 
-    @Test("selection memory is Connection-qualified and discards the obsolete map")
+    @Test("selection memory is Connection-qualified")
     func selectionMemoryIsComposite() {
-        let (selectionMemory, defaults) = memory()
-        defaults.set(["same": "old"], forKey: "workspaceSelections")
-        let memoryAfterOldData = WorkspaceSelectionMemory(defaults: defaults)
+        let (selectionMemory, _) = memory()
         let a = WorkspaceRef(connectionID: UUID(), workspaceID: "same")
         let b = WorkspaceRef(connectionID: UUID(), workspaceID: "same")
 
-        memoryAfterOldData.remember(sessionID: "ses_a", for: a)
-        memoryAfterOldData.remember(sessionID: "ses_b", for: b)
-        #expect(memoryAfterOldData.sessionID(for: a) == "ses_a")
-        #expect(memoryAfterOldData.sessionID(for: b) == "ses_b")
-        #expect(defaults.object(forKey: "workspaceSelections") == nil)
+        selectionMemory.remember(sessionID: "ses_a", for: a)
+        selectionMemory.remember(sessionID: "ses_b", for: b)
+        #expect(selectionMemory.sessionID(for: a) == "ses_a")
+        #expect(selectionMemory.sessionID(for: b) == "ses_b")
 
         selectionMemory.forget(a)
         #expect(selectionMemory.sessionID(for: a) == nil)

--- a/macos/ATCTests/WorkspaceFlowTests.swift
+++ b/macos/ATCTests/WorkspaceFlowTests.swift
@@ -97,6 +97,10 @@ struct WorkspaceFlowTests {
         #expect(state.activateWorkspace(workspace, in: model))
         #expect(state.activeWorkspace == workspace)
         #expect(state.selectedNavigator == .file)
+        #expect(state.expandedProjects.contains(ProjectRef(
+            connectionID: runtime.id,
+            projectID: "prj_atelier"
+        )))
         #expect(state.selectedContent == .session(
             SessionRef(connectionID: runtime.id, sessionID: "ses_running")
         ))

--- a/macos/ATCTests/WorkspaceFlowTests.swift
+++ b/macos/ATCTests/WorkspaceFlowTests.swift
@@ -48,6 +48,9 @@ struct WorkspaceFlowTests {
         #expect(state.activeWorkspace == nil)
         #expect(!state.isInspectorPresented)
         #expect(state.columnVisibility == .all)
+        #expect(state.isProjectsSectionExpanded)
+        #expect(state.isSessionsSectionExpanded)
+        #expect(state.isTerminalsSectionExpanded)
     }
 
     @Test("Navigator changes preserve main content and inspector")

--- a/macos/ATCTests/WorkspaceFlowTests.swift
+++ b/macos/ATCTests/WorkspaceFlowTests.swift
@@ -195,6 +195,74 @@ struct WorkspaceFlowTests {
         #expect(selectionMemory.sessionID(for: refactor) == nil)
     }
 
+    @Test("selecting archived content never writes restoration memory")
+    func archivedSelectionIsNotRemembered() async throws {
+        let (model, runtime) = try await makeLoadedModel()
+        let (selectionMemory, _) = memory()
+        let state = WindowState(selectionMemory: selectionMemory)
+        let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
+        let archived = SessionRef(connectionID: runtime.id, sessionID: "ses_archived")
+
+        #expect(state.activateWorkspace(workspace, in: model))
+        #expect(state.selectSession(archived, in: model))
+        #expect(state.selectedContent == .session(archived))
+        #expect(selectionMemory.sessionID(for: workspace) == nil)
+    }
+
+    @Test("a failed first Workspace load after rebuild preserves window context")
+    func failedWorkspaceLoadAfterRebuildPreservesContext() async throws {
+        let client = StatefulWorkspacesClient()
+        let (model, runtime) = try await makeLoadedModel(client: client)
+        let (selectionMemory, _) = memory()
+        let state = WindowState(selectionMemory: selectionMemory)
+        let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_a")
+        #expect(state.activateWorkspace(workspace, in: model))
+
+        client.failWorkspaces = true
+        try model.updateConnection(
+            id: runtime.id, name: "A", urlString: "http://a:2", token: ""
+        )
+        let rebuilt = try #require(model.runtime(id: runtime.id))
+        rebuilt.stopPolling()
+        await rebuilt.refresh()
+        state.reconcile(in: model)
+
+        #expect(rebuilt.workspaces.hasLoadedOnce)
+        #expect(rebuilt.workspaces.lastError != nil)
+        #expect(state.activeWorkspace == workspace)
+
+        client.failWorkspaces = false
+        await rebuilt.refresh()
+        state.reconcile(in: model)
+        #expect(state.activeWorkspace == workspace)
+    }
+
+    @Test("failed first Sessions load preserves memory and restores after recovery")
+    func failedSessionsLoadPreservesPendingRestore() async throws {
+        let client = StatefulWorkspacesClient()
+        client.failSessions = true
+        let model = makeModel(client: client)
+        let record = try model.addConnection(name: "A", urlString: "http://a:1", token: "")
+        let runtime = try #require(model.runtime(id: record.id))
+        runtime.stopPolling()
+        await runtime.refresh()
+
+        let (selectionMemory, _) = memory()
+        let state = WindowState(selectionMemory: selectionMemory)
+        let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_a")
+        selectionMemory.remember(sessionID: "ses_running", for: workspace)
+        #expect(state.activateWorkspace(workspace, in: model))
+        #expect(state.selectedContent == .workspace(workspace))
+        #expect(selectionMemory.sessionID(for: workspace) == "ses_running")
+
+        client.failSessions = false
+        await runtime.refresh()
+        state.reconcile(in: model)
+        #expect(state.selectedContent == .session(
+            SessionRef(connectionID: runtime.id, sessionID: "ses_running")
+        ))
+    }
+
     @Test("unresolved and disconnected stores preserve the Active Workspace")
     func unresolvedAndDisconnectedPreserveWorkspace() async throws {
         let client = StatefulWorkspacesClient()
@@ -298,6 +366,32 @@ struct WorkspaceFlowTests {
         #expect(state.createWorkspaceContext?.mode == .preselected(
             ProjectRef(connectionID: runtime.id, projectID: "prj_atelier")
         ))
+    }
+
+    @Test("captured creation targets revalidate reachability and archive state")
+    func mutationTargetsRevalidate() async throws {
+        let client = StatefulWorkspacesClient()
+        let (model, runtime) = try await makeLoadedModel(client: client)
+        let project = ProjectRef(connectionID: runtime.id, projectID: "prj_one")
+        let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_a")
+
+        #expect(model.canMutate(connectionID: runtime.id))
+        #expect(model.canCreateWorkspace(in: project))
+        #expect(model.canStartSession(in: workspace))
+
+        client.failSessions = true
+        await runtime.refresh()
+        #expect(!model.canMutate(connectionID: runtime.id))
+        #expect(!model.canCreateWorkspace(in: project))
+        #expect(!model.canStartSession(in: workspace))
+
+        client.failSessions = false
+        await runtime.refresh()
+        #expect(model.canCreateWorkspace(in: project))
+        #expect(model.canStartSession(in: workspace))
+
+        try await runtime.workspaces.archive(id: workspace.workspaceID)
+        #expect(!model.canStartSession(in: workspace))
     }
 
     @Test("selection memory is Connection-qualified and discards the obsolete map")

--- a/macos/ATCTests/WorkspacesStoreTests.swift
+++ b/macos/ATCTests/WorkspacesStoreTests.swift
@@ -107,6 +107,7 @@ final class StatefulWorkspacesClient: ATCClient, @unchecked Sendable {
     private let failAll: Bool
     private var _failDeletes = false
     private var _failSessions = false
+    private var _failWorkspaces = false
     /// Session mutations persist as overrides on the inner fixtures, so
     /// the store's follow-up refreshes converge instead of resurrecting
     /// pre-mutation state.
@@ -124,6 +125,11 @@ final class StatefulWorkspacesClient: ATCClient, @unchecked Sendable {
     var failSessions: Bool {
         get { lock.withLock { _failSessions } }
         set { lock.withLock { _failSessions = newValue } }
+    }
+
+    var failWorkspaces: Bool {
+        get { lock.withLock { _failWorkspaces } }
+        set { lock.withLock { _failWorkspaces = newValue } }
     }
 
     private let projects = [
@@ -161,7 +167,8 @@ final class StatefulWorkspacesClient: ATCClient, @unchecked Sendable {
     }
 
     func workspaces(projectID: String?, includeArchived: Bool) async throws -> [Workspace] {
-        try withState { state in
+        if failWorkspaces { throw ATCError.badStatus(500) }
+        return try withState { state in
             state.filter {
                 (projectID == nil || $0.projectId == projectID)
                     && (includeArchived || !$0.isArchived)
@@ -255,6 +262,10 @@ final class StatefulWorkspacesClient: ATCClient, @unchecked Sendable {
             .filter { !overrides.deleted.contains($0.id) }
             .map { session in
                 var session = session
+                if session.id == "ses_running" {
+                    session.workspace = SessionWorkspace(id: "wsp_a", name: "Alpha")
+                    session.project = SessionProject(id: "prj_one", name: "One")
+                }
                 if overrides.unarchived.contains(session.id) {
                     session.archivedAt = nil
                 }


### PR DESCRIPTION
## Summary

- replace Dashboard/Workspace routing with one stable window-root `NavigationSplitView`
- add Projects, Workspace, and File navigators plus an app-wide Workspace switcher
- move Active Workspace and main-content selection into per-window state while preserving terminal surfaces and attachment-budget behavior
- use connection-qualified restoration, resilient store reconciliation, and centralized mutation availability
- add state, grouping, persistence, retention, presentation, and hosted navigation regression coverage

## Review

A separate review agent audited the full implementation. Two review passes found lifecycle, disconnected-action, archived-memory, and UI-coverage issues; all findings were fixed. The final verification reported no remaining actionable findings.

## Validation

- `TMPDIR=/tmp mise run macos:test` (181 tests)
- `TMPDIR=/tmp mise run check` (server, ATCKit, and macOS gates)