### PR TITLE
Label navigator selector buttons

### DIFF
--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -47,11 +47,6 @@ struct NavigatorSelector: View {
         .labelsHidden()
         .controlSize(.large)
         .tint(.accentColor)
-        .padding(2)
-        .background(.quaternary, in: RoundedRectangle(
-            cornerRadius: Radius.control,
-            style: .continuous
-        ))
         .padding(.horizontal, Spacing.md)
         .padding(.bottom, NavigatorMetrics.selectorToContentSpacing)
     }

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -21,6 +21,32 @@ struct NavigatorSidebar: View {
     }
 }
 
+extension NavigatorID {
+    var selectorLabel: String {
+        switch self {
+        case .projects: "Projects"
+        case .workspace: "Workspace"
+        case .file: "Files"
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .projects: "Projects Navigator"
+        case .workspace: "Workspace Navigator"
+        case .file: "File Navigator"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .projects: "folder"
+        case .workspace: "rectangle.stack"
+        case .file: "doc.text"
+        }
+    }
+}
+
 /// Native segmented navigation in an inset system surface, matching the
 /// hierarchy and interaction model of Xcode's Navigator selector.
 struct NavigatorSelector: View {

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -33,7 +33,8 @@ struct NavigatorSelector: View {
         )
         Picker("Navigator", selection: $selection) {
             ForEach(options) { option in
-                Image(systemName: option.id.systemImage)
+                Label(option.id.selectorLabel, systemImage: option.id.systemImage)
+                    .labelStyle(.titleAndIcon)
                     .accessibilityLabel(option.id.label)
                     .help(option.help)
                     .tag(option.id)
@@ -44,7 +45,7 @@ struct NavigatorSelector: View {
         }
         .pickerStyle(.segmented)
         .labelsHidden()
-        .controlSize(.regular)
+        .controlSize(.large)
         .tint(.accentColor)
         .padding(2)
         .background(.quaternary, in: RoundedRectangle(

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -7,6 +7,14 @@ enum NavigatorID: String, CaseIterable, Sendable {
     case workspace
     case file
 
+    var selectorLabel: String {
+        switch self {
+        case .projects: "Projects"
+        case .workspace: "Workspace"
+        case .file: "Files"
+        }
+    }
+
     var label: String {
         switch self {
         case .projects: "Projects Navigator"

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -6,30 +6,6 @@ enum NavigatorID: String, CaseIterable, Sendable {
     case projects
     case workspace
     case file
-
-    var selectorLabel: String {
-        switch self {
-        case .projects: "Projects"
-        case .workspace: "Workspace"
-        case .file: "Files"
-        }
-    }
-
-    var label: String {
-        switch self {
-        case .projects: "Projects Navigator"
-        case .workspace: "Workspace Navigator"
-        case .file: "File Navigator"
-        }
-    }
-
-    var systemImage: String {
-        switch self {
-        case .projects: "folder"
-        case .workspace: "rectangle.stack"
-        case .file: "doc.text"
-        }
-    }
 }
 
 enum MainContentSelection: Equatable, Sendable {

--- a/macos/ATCTests/NavigationPresentationTests.swift
+++ b/macos/ATCTests/NavigationPresentationTests.swift
@@ -8,6 +8,8 @@ import ATCAPI
 struct NavigationPresentationTests {
     @Test("Navigator selector exposes all states and Active Workspace gating")
     func navigatorSelectorStates() {
+        #expect(NavigatorID.allCases.map(\.selectorLabel) == ["Projects", "Workspace", "Files"])
+
         let unavailable = NavigatorSelectorOption.all(hasActiveWorkspace: false)
         #expect(unavailable.map(\.id) == [.projects, .workspace, .file])
         #expect(unavailable.map(\.isEnabled) == [true, false, false])


### PR DESCRIPTION
## Summary

- show icons and text in the existing segmented navigator picker
- label the three navigator modes as Projects, Workspace, and Files
- use the larger native control size
- remove the redundant custom backing surface so only the native pill-shaped picker background remains
- keep navigator labels and SF Symbol mappings beside the sidebar UI instead of in window state

## Why

The icon-only selector was compact but made each navigator harder to identify at a glance. Adding concise labels improves discoverability while preserving the existing native control and navigation behavior.

The previous custom quaternary background duplicated the segmented picker's native surface and produced a rectangular edge behind it. Removing that wrapper leaves a single clean picker surface.

Navigator identity remains part of window state, while its presentation metadata now lives with the sidebar that consumes it. This keeps the state file focused without introducing another component or strings abstraction.

## Validation

- `CI=true TMPDIR=/tmp mise run check`
- `TMPDIR=/tmp mise run macos:test` (185 tests passed after the final cleanup)