### PR TITLE
Reduce navigator sidebar padding

### DIFF
--- a/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
+++ b/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
@@ -39,7 +39,7 @@ struct WorkspaceNavigatorView: View {
         let agents = rows.filter { kind(of: $0.session) == .agent }
         let terminals = rows.filter { kind(of: $0.session) == .terminal }
 
-        List {
+        NavigatorList {
             if runtime?.reachability == .unreachable {
                 Label("Disconnected", systemImage: "cable.connector.slash")
                     .font(.caption)
@@ -69,7 +69,6 @@ struct WorkspaceNavigatorView: View {
                 sessionRows(terminals, emptyText: "No terminals")
             }
         }
-        .navigatorList()
         .safeAreaInset(edge: .bottom, spacing: 0) {
             HStack {
                 Toggle("Show Archived", isOn: $showArchived)

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -109,7 +109,7 @@ struct ProjectsNavigatorView: View {
     var body: some View {
         @Bindable var windowState = windowState
         let groups = ProjectsNavigatorGroups(runtimes: appModel.runtimes)
-        List {
+        NavigatorList {
             NavigatorRow(
                 isSelected: windowState.selectedContent == .dashboard,
                 action: { windowState.showDashboard() }
@@ -145,7 +145,6 @@ struct ProjectsNavigatorView: View {
                 }
             }
         }
-        .navigatorList()
         .alert("Rename Project", isPresented: Binding(
             get: { renamingProject != nil },
             set: { if !$0 { renamingProject = nil } }

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -73,7 +73,7 @@ struct NavigatorSelector: View {
         .labelsHidden()
         .controlSize(.large)
         .tint(.accentColor)
-        .padding(.horizontal, Spacing.md)
+        .padding(.horizontal, NavigatorMetrics.horizontalPadding)
         .padding(.bottom, NavigatorMetrics.selectorToContentSpacing)
     }
 }

--- a/macos/ATC/Shared/NavigatorComponents.swift
+++ b/macos/ATC/Shared/NavigatorComponents.swift
@@ -6,7 +6,7 @@ enum NavigatorMetrics {
     static let rowHeight: CGFloat = 28
     static let iconWidth: CGFloat = 18
     static let actionSize: CGFloat = 22
-    static let rowHorizontalInset = Spacing.xs
+    static let horizontalPadding = Spacing.md
     static let contentHorizontalPadding = Spacing.sm
     static let rowVerticalInset: CGFloat = 1
     static let selectorToContentSpacing = Spacing.lg
@@ -182,6 +182,11 @@ struct NavigatorDisclosureHeader: View {
 extension View {
     func navigatorList() -> some View {
         listStyle(.sidebar)
+            .contentMargins(
+                .horizontal,
+                NavigatorMetrics.horizontalPadding,
+                for: .scrollContent
+            )
             .environment(\.defaultMinListRowHeight, NavigatorMetrics.rowHeight)
     }
 
@@ -191,9 +196,9 @@ extension View {
     ) -> some View {
         listRowInsets(EdgeInsets(
             top: top,
-            leading: NavigatorMetrics.rowHorizontalInset,
+            leading: 0,
             bottom: bottom,
-            trailing: NavigatorMetrics.rowHorizontalInset
+            trailing: 0
         ))
         .listRowBackground(Color.clear)
     }

--- a/macos/ATC/Shared/NavigatorComponents.swift
+++ b/macos/ATC/Shared/NavigatorComponents.swift
@@ -13,6 +13,27 @@ enum NavigatorMetrics {
     static let nestedIndent: CGFloat = iconWidth + Spacing.sm
 }
 
+/// A Navigator-owned scrolling container. A native sidebar `List` applies
+/// outline-row margins outside our view hierarchy, which prevents custom row
+/// surfaces and hit targets from using the full available width.
+struct NavigatorList<Content: View>: View {
+    let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                content
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, NavigatorMetrics.horizontalPadding)
+        }
+    }
+}
+
 /// The standard interactive row used by all Navigators. Actions stay out of
 /// sight until hover while the primary hit target remains full width.
 struct NavigatorRow<Content: View, Actions: View>: View {
@@ -180,27 +201,13 @@ struct NavigatorDisclosureHeader: View {
 }
 
 extension View {
-    func navigatorList() -> some View {
-        listStyle(.sidebar)
-            .contentMargins(
-                .horizontal,
-                NavigatorMetrics.horizontalPadding,
-                for: .scrollContent
-            )
-            .environment(\.defaultMinListRowHeight, NavigatorMetrics.rowHeight)
-    }
-
     func navigatorListRow(
         top: CGFloat = NavigatorMetrics.rowVerticalInset,
         bottom: CGFloat = NavigatorMetrics.rowVerticalInset
     ) -> some View {
-        listRowInsets(EdgeInsets(
-            top: top,
-            leading: 0,
-            bottom: bottom,
-            trailing: 0
-        ))
-        .listRowBackground(Color.clear)
+        padding(.top, top)
+            .padding(.bottom, bottom)
+            .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     func navigatorSurface(isActive: Bool) -> some View {

--- a/macos/ATC/Shared/NavigatorComponents.swift
+++ b/macos/ATC/Shared/NavigatorComponents.swift
@@ -6,6 +6,7 @@ enum NavigatorMetrics {
     static let rowHeight: CGFloat = 28
     static let iconWidth: CGFloat = 18
     static let actionSize: CGFloat = 22
+    static let rowHorizontalInset = Spacing.xs
     static let contentHorizontalPadding = Spacing.sm
     static let rowVerticalInset: CGFloat = 1
     static let selectorToContentSpacing = Spacing.lg
@@ -190,9 +191,9 @@ extension View {
     ) -> some View {
         listRowInsets(EdgeInsets(
             top: top,
-            leading: Spacing.sm,
+            leading: NavigatorMetrics.rowHorizontalInset,
             bottom: bottom,
-            trailing: Spacing.sm
+            trailing: NavigatorMetrics.rowHorizontalInset
         ))
         .listRowBackground(Color.clear)
     }

--- a/macos/ATC/Shared/NavigatorComponents.swift
+++ b/macos/ATC/Shared/NavigatorComponents.swift
@@ -6,7 +6,7 @@ enum NavigatorMetrics {
     static let rowHeight: CGFloat = 28
     static let iconWidth: CGFloat = 18
     static let actionSize: CGFloat = 22
-    static let horizontalPadding = Spacing.md
+    static let horizontalPadding = Spacing.sm
     static let contentHorizontalPadding = Spacing.sm
     static let rowVerticalInset: CGFloat = 1
     static let selectorToContentSpacing = Spacing.lg
@@ -205,6 +205,7 @@ extension View {
 
     func navigatorSurface(isActive: Bool) -> some View {
         padding(.horizontal, NavigatorMetrics.contentHorizontalPadding)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .background {
                 if isActive {
                     RoundedRectangle(cornerRadius: Radius.control, style: .continuous)


### PR DESCRIPTION
## Summary

- use one 8pt horizontal gutter for the Navigator selector and row surfaces
- replace the native sidebar `List` with a shared Navigator-owned scrolling container
- make selection, hover, and hit targets fill the available width in both Projects and Workspace Navigators

## Root cause

SwiftUI's macOS sidebar `List` applies AppKit outline-row margins outside the custom row view. Adjusting the row's internal padding could not make its interactive surface span the sidebar. The Navigator now owns its scrolling and row geometry directly through a shared `ScrollView` and `LazyVStack`.

## Validation

- `CI=true mise run check`
- verified the picker and all Navigator buttons resolve to the same x-position and width in the rebuilt app

Linear: [DEV-44](https://linear.app/elevenideas/issue/DEV-44/reduce-sidebar-left-and-right-padding)