### PR TITLE
Configurable keyboard shortcuts: command registry, keymap, per-window router, config.toml

### DIFF
--- a/docs/keyboard-shortcuts-spec.md
+++ b/docs/keyboard-shortcuts-spec.md
@@ -517,7 +517,7 @@ the router (injected via environment) and the config store. Per
 `CONTEXT.md`, user-visible copy says **Command Sequence** — never "leader".
 
 - **Hint** (`CommandSequenceHintView`): while `state == .pending`, a
-  compact bottom-center HUD (thin material capsule) generated from the
+  compact bottom-trailing HUD (thin material capsule) generated from the
   pending node: one row per continuation, sorted by key, showing a keycap
   glyph and the command title. Unavailable continuations stay listed but
   dimmed, annotated with the descriptor's short reason — availability is

--- a/macos/ATC/ATCApp.swift
+++ b/macos/ATC/ATCApp.swift
@@ -6,16 +6,28 @@ struct ATCApp: App {
     /// Single-window today; one WindowState per window is the seam a
     /// future multi-window pass builds on.
     @State private var windowState = WindowState()
+    @State private var keyboardConfigStore: KeyboardConfigStore
+
+    init() {
+        let store = KeyboardConfigStore()
+        store.loadAtLaunch()
+        _keyboardConfigStore = State(initialValue: store)
+    }
 
     var body: some Scene {
         WindowGroup {
-            RootView()
+            RootView(configStore: keyboardConfigStore)
                 .environment(appModel)
                 .environment(windowState)
+                .environment(keyboardConfigStore)
                 .preferredColorScheme(.dark)
         }
         .commands {
-            AppCommands(appModel: appModel, windowState: windowState)
+            AppCommands(
+                appModel: appModel,
+                windowState: windowState,
+                configStore: keyboardConfigStore
+            )
         }
         Settings {
             SettingsView()

--- a/macos/ATC/AppCommands.swift
+++ b/macos/ATC/AppCommands.swift
@@ -1,60 +1,64 @@
 import SwiftUI
 
-/// Menu placement from the keyboard-shortcuts brief. Each item is one
-/// closure-shaped command the future `session.new`/`workspace.new`/etc.
-/// registry entries will invoke — no per-menu logic. The full shortcut MVP
-/// (registry, config.toml, leader key) is a separate effort.
 struct AppCommands: Commands {
     let appModel: AppModel
     let windowState: WindowState
+    let configStore: KeyboardConfigStore
+
+    private var context: CommandContext {
+        CommandContext(
+            appModel: appModel,
+            windowState: windowState,
+            configStore: configStore
+        )
+    }
 
     var body: some Commands {
         CommandGroup(replacing: .newItem) {
-            // Availability is based on the Active Workspace, independent of
-            // the visible Navigator or main-content destination.
-            Button("New Session") {
-                windowState.startSessionKind = .agentSession
-            }
-            .keyboardShortcut("n", modifiers: .command)
-            .disabled(!windowState.canStartSession(in: appModel))
-
-            Button("New Terminal") {
-                windowState.startSessionKind = .terminal
-            }
-            .keyboardShortcut("t", modifiers: .command)
-            .disabled(!windowState.canStartSession(in: appModel))
+            commandButton(.newSession)
+            commandButton(.newTerminal)
 
             Divider()
 
-            // workspace.new works everywhere; context-free without an
-            // implied Project. ⌘⇧N is reassigned here from New Project.
-            Button("New Workspace…") {
-                windowState.presentCreateWorkspace(in: appModel)
-            }
-            .keyboardShortcut("n", modifiers: [.command, .shift])
-            .disabled(appModel.runtimes.isEmpty)
-
-            // project.new: menu-only (its old ⌘⇧N now creates Workspaces).
-            Button("New Project…") {
-                windowState.isCreateProjectPresented = true
-            }
-            .disabled(appModel.runtimes.isEmpty)
+            commandButton(.newWorkspace)
+            commandButton(.newProject)
         }
 
         CommandGroup(after: .sidebar) {
-            // The stable root split view makes this meaningful everywhere.
-            Button("Toggle Sidebar") {
-                windowState.toggleSidebar()
-            }
-            .keyboardShortcut("b", modifiers: .command)
-
-            // data.refresh: always available.
-            Button("Refresh") {
-                Task { await appModel.refreshAll() }
-            }
-            .keyboardShortcut("r", modifiers: .command)
-
+            commandButton(.toggleSidebar)
+            commandButton(.refresh)
             Divider()
         }
+
+        CommandGroup(after: .appSettings) {
+            commandButton(.reloadConfiguration)
+        }
+    }
+
+    @ViewBuilder
+    private func commandButton(_ id: CommandID) -> some View {
+        let descriptor = CommandRegistry.descriptor(for: id)
+        let button = Button(descriptor.title) {
+            CommandRegistry.execute(id, context: context)
+        }
+        .disabled(!descriptor.availability(context).isAvailable)
+
+        if let shortcut = configStore.keymap.menuShortcuts[id]?.menuShortcut {
+            button.keyboardShortcut(shortcut.key, modifiers: shortcut.modifiers)
+        } else {
+            button
+        }
+    }
+}
+
+private extension KeyStroke {
+    var menuShortcut: (key: KeyEquivalent, modifiers: EventModifiers)? {
+        guard key.count == 1, let character = key.first else { return nil }
+        var eventModifiers: EventModifiers = []
+        if modifiers.contains(.command) { eventModifiers.insert(.command) }
+        if modifiers.contains(.control) { eventModifiers.insert(.control) }
+        if modifiers.contains(.option) { eventModifiers.insert(.option) }
+        if modifiers.contains(.shift) { eventModifiers.insert(.shift) }
+        return (KeyEquivalent(character), eventModifiers)
     }
 }

--- a/macos/ATC/Commands/CommandFeedbackViews.swift
+++ b/macos/ATC/Commands/CommandFeedbackViews.swift
@@ -16,17 +16,16 @@ struct CommandFeedbackOverlay: View {
                 .padding(.top, 8)
             }
 
-            VStack {
-                Spacer()
+            Group {
                 if let flash = router.flash {
                     RouterFlashView(flash: flash)
-                        .allowsHitTesting(false)
                 } else if router.pendingNode != nil {
                     CommandSequenceHintView()
-                        .allowsHitTesting(false)
                 }
             }
-            .padding(.bottom, 24)
+            .allowsHitTesting(false)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+            .padding([.bottom, .trailing], 24)
         }
     }
 }

--- a/macos/ATC/Commands/CommandFeedbackViews.swift
+++ b/macos/ATC/Commands/CommandFeedbackViews.swift
@@ -1,0 +1,122 @@
+import SwiftUI
+
+struct CommandFeedbackOverlay: View {
+    @Environment(WindowKeyboardRouter.self) private var router
+    @Environment(KeyboardConfigStore.self) private var configStore
+
+    var body: some View {
+        ZStack {
+            if let notice = configStore.notice {
+                VStack {
+                    ConfigNoticeView(notice: notice) {
+                        configStore.dismissNotice()
+                    }
+                    Spacer()
+                }
+                .padding(.top, 8)
+            }
+
+            VStack {
+                Spacer()
+                if let flash = router.flash {
+                    RouterFlashView(flash: flash)
+                        .allowsHitTesting(false)
+                } else if router.pendingNode != nil {
+                    CommandSequenceHintView()
+                        .allowsHitTesting(false)
+                }
+            }
+            .padding(.bottom, 24)
+        }
+    }
+}
+
+struct CommandSequenceHintView: View {
+    @Environment(AppModel.self) private var appModel
+    @Environment(WindowState.self) private var windowState
+    @Environment(KeyboardConfigStore.self) private var configStore
+    @Environment(WindowKeyboardRouter.self) private var router
+
+    private var continuations: [(KeyStroke, CommandID)] {
+        guard let node = router.pendingNode else { return [] }
+        return node.compactMap { stroke, node in
+            guard case .command(let command) = node else { return nil }
+            return (stroke, command)
+        }.sorted { $0.0.description < $1.0.description }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Text("Command Sequence")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            ForEach(continuations, id: \.0) { stroke, command in
+                continuationRow(stroke: stroke, command: command)
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 11)
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.2), radius: 12, y: 4)
+    }
+
+    @ViewBuilder
+    private func continuationRow(stroke: KeyStroke, command: CommandID) -> some View {
+        let context = CommandContext(
+            appModel: appModel,
+            windowState: windowState,
+            configStore: configStore
+        )
+        let descriptor = CommandRegistry.descriptor(for: command)
+        let availability = descriptor.availability(context)
+        HStack(spacing: 9) {
+            Text(stroke.displayDescription)
+                .font(.caption.monospaced().weight(.semibold))
+                .padding(.horizontal, 6)
+                .padding(.vertical, 3)
+                .background(.quaternary, in: RoundedRectangle(cornerRadius: 5))
+            Text(descriptor.title)
+                .font(.caption)
+            if case .unavailable(let reason) = availability {
+                Text(reason)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .foregroundStyle(availability.isAvailable ? .primary : .secondary)
+        .opacity(availability.isAvailable ? 1 : 0.6)
+    }
+}
+
+struct RouterFlashView: View {
+    let flash: RouterFlash
+
+    var body: some View {
+        Text(flash.message)
+            .font(.callout.weight(.medium))
+            .padding(.horizontal, 14)
+            .padding(.vertical, 9)
+            .background(.thinMaterial, in: Capsule())
+            .shadow(color: .black.opacity(0.2), radius: 12, y: 4)
+    }
+}
+
+struct ConfigNoticeView: View {
+    let notice: ConfigNotice
+    let dismiss: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "keyboard.badge.exclamationmark")
+            Text(notice.message)
+                .font(.callout)
+            Button("Dismiss", action: dismiss)
+                .buttonStyle(.borderless)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 9)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
+        .shadow(color: .black.opacity(0.2), radius: 10, y: 3)
+        .padding(.horizontal, 16)
+    }
+}

--- a/macos/ATC/Commands/CommandID.swift
+++ b/macos/ATC/Commands/CommandID.swift
@@ -1,0 +1,9 @@
+enum CommandID: String, CaseIterable, Sendable {
+    case toggleSidebar = "view.toggle-sidebar"
+    case newSession = "session.new"
+    case newTerminal = "terminal.new"
+    case newProject = "project.new"
+    case newWorkspace = "workspace.new"
+    case refresh = "data.refresh"
+    case reloadConfiguration = "configuration.reload"
+}

--- a/macos/ATC/Commands/CommandRegistry.swift
+++ b/macos/ATC/Commands/CommandRegistry.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+@MainActor
+struct CommandContext {
+    let appModel: AppModel
+    let windowState: WindowState
+    let configStore: KeyboardConfigStore
+}
+
+enum CommandAvailability: Equatable {
+    case available
+    case unavailable(reason: String)
+
+    var isAvailable: Bool {
+        self == .available
+    }
+}
+
+@MainActor
+struct CommandDescriptor {
+    let id: CommandID
+    let title: String
+    let availability: (CommandContext) -> CommandAvailability
+    let perform: (CommandContext) -> Void
+}
+
+@MainActor
+enum CommandRegistry {
+    private static let sessionUnavailable =
+        "Requires an open Workspace on a reachable Connection"
+    private static let connectionUnavailable = "Requires a configured Connection"
+
+    static func descriptor(for id: CommandID) -> CommandDescriptor {
+        switch id {
+        case .toggleSidebar:
+            CommandDescriptor(
+                id: id,
+                title: "Toggle Sidebar",
+                availability: { _ in .available },
+                perform: { $0.windowState.toggleSidebar() }
+            )
+        case .newSession:
+            CommandDescriptor(
+                id: id,
+                title: "New Session",
+                availability: sessionAvailability,
+                perform: { $0.windowState.startSessionKind = .agentSession }
+            )
+        case .newTerminal:
+            CommandDescriptor(
+                id: id,
+                title: "New Terminal",
+                availability: sessionAvailability,
+                perform: { $0.windowState.startSessionKind = .terminal }
+            )
+        case .newProject:
+            CommandDescriptor(
+                id: id,
+                title: "New Project…",
+                availability: connectionAvailability,
+                perform: { $0.windowState.isCreateProjectPresented = true }
+            )
+        case .newWorkspace:
+            CommandDescriptor(
+                id: id,
+                title: "New Workspace…",
+                availability: connectionAvailability,
+                perform: { $0.windowState.presentCreateWorkspace(in: $0.appModel) }
+            )
+        case .refresh:
+            CommandDescriptor(
+                id: id,
+                title: "Refresh",
+                availability: { _ in .available },
+                perform: { context in Task { await context.appModel.refreshAll() } }
+            )
+        case .reloadConfiguration:
+            CommandDescriptor(
+                id: id,
+                title: "Reload Configuration",
+                availability: { _ in .available },
+                perform: { $0.configStore.reload() }
+            )
+        }
+    }
+
+    @discardableResult
+    static func execute(
+        _ id: CommandID,
+        context: CommandContext
+    ) -> CommandAvailability {
+        let descriptor = descriptor(for: id)
+        let availability = descriptor.availability(context)
+        guard availability.isAvailable else { return availability }
+        descriptor.perform(context)
+        return .available
+    }
+
+    private static func sessionAvailability(_ context: CommandContext) -> CommandAvailability {
+        context.windowState.canStartSession(in: context.appModel)
+            ? .available
+            : .unavailable(reason: sessionUnavailable)
+    }
+
+    private static func connectionAvailability(
+        _ context: CommandContext
+    ) -> CommandAvailability {
+        context.appModel.runtimes.isEmpty
+            ? .unavailable(reason: connectionUnavailable)
+            : .available
+    }
+}

--- a/macos/ATC/Commands/KeyStroke.swift
+++ b/macos/ATC/Commands/KeyStroke.swift
@@ -103,7 +103,7 @@ struct KeyStroke: Hashable, Sendable, CustomStringConvertible {
         return .success(stroke)
     }
 
-    private static func isPrintable(_ scalar: UnicodeScalar) -> Bool {
+    static func isPrintable(_ scalar: UnicodeScalar) -> Bool {
         !CharacterSet.controlCharacters.contains(scalar)
             && !CharacterSet.illegalCharacters.contains(scalar)
             && !(0xF700...0xF8FF).contains(scalar.value)

--- a/macos/ATC/Commands/KeyStroke.swift
+++ b/macos/ATC/Commands/KeyStroke.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+struct KeyStroke: Hashable, Sendable, CustomStringConvertible {
+    struct Modifiers: OptionSet, Hashable, Sendable {
+        let rawValue: UInt8
+
+        static let command = Modifiers(rawValue: 1 << 0)
+        static let control = Modifiers(rawValue: 1 << 1)
+        static let option = Modifiers(rawValue: 1 << 2)
+        static let shift = Modifiers(rawValue: 1 << 3)
+
+        static let primary: Modifiers = [.command, .control, .option]
+    }
+
+    let key: String
+    let modifiers: Modifiers
+
+    static let escape = KeyStroke(key: "escape", modifiers: [])
+
+    var description: String {
+        var parts: [String] = []
+        if modifiers.contains(.command) { parts.append("cmd") }
+        if modifiers.contains(.control) { parts.append("ctrl") }
+        if modifiers.contains(.option) { parts.append("opt") }
+        if modifiers.contains(.shift) { parts.append("shift") }
+        parts.append(key)
+        return parts.joined(separator: "+")
+    }
+
+    var displayDescription: String {
+        var value = ""
+        if modifiers.contains(.control) { value += "⌃" }
+        if modifiers.contains(.option) { value += "⌥" }
+        if modifiers.contains(.shift) { value += "⇧" }
+        if modifiers.contains(.command) { value += "⌘" }
+        value += key == "escape" ? "Esc" : key.uppercased()
+        return value
+    }
+
+    var hasPrimaryModifier: Bool {
+        !modifiers.intersection(.primary).isEmpty
+    }
+
+    static func parse(_ text: String) -> Result<KeyStroke, TriggerError> {
+        parse(text, requiresPrimaryModifier: true)
+    }
+
+    static func parseContinuation(_ text: String) -> Result<KeyStroke, TriggerError> {
+        parse(text, requiresPrimaryModifier: false)
+    }
+
+    private static func parse(
+        _ text: String,
+        requiresPrimaryModifier: Bool
+    ) -> Result<KeyStroke, TriggerError> {
+        let tokens = text.split(separator: "+", omittingEmptySubsequences: false)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+        guard let keyToken = tokens.last, !keyToken.isEmpty else {
+            return .failure(.init(message: "Trigger has an empty key"))
+        }
+
+        var modifiers: Modifiers = []
+        for token in tokens.dropLast() {
+            guard !token.isEmpty else {
+                return .failure(.init(message: "Trigger contains an empty modifier token"))
+            }
+            let modifier: Modifiers
+            switch token {
+            case "cmd", "command", "super": modifier = .command
+            case "ctrl", "control": modifier = .control
+            case "opt", "option", "alt": modifier = .option
+            case "shift": modifier = .shift
+            default:
+                return .failure(.init(message: "Unknown modifier token '\(token)'"))
+            }
+            guard !modifiers.contains(modifier) else {
+                return .failure(.init(message: "Duplicate modifier token '\(token)'"))
+            }
+            modifiers.insert(modifier)
+        }
+
+        guard keyToken != "escape" else {
+            return .failure(.init(
+                message: "Named key 'escape' is deferred beyond the MVP"
+            ))
+        }
+        guard keyToken.count == 1,
+              let scalar = keyToken.unicodeScalars.first,
+              isPrintable(scalar)
+        else {
+            let kind = keyToken.hasPrefix("f") && Int(keyToken.dropFirst()) != nil
+                ? "Function key '\(keyToken)'"
+                : "Key '\(keyToken)'"
+            return .failure(.init(message: "\(kind) is deferred beyond the MVP"))
+        }
+        let stroke = KeyStroke(key: keyToken, modifiers: modifiers)
+        guard !requiresPrimaryModifier || stroke.hasPrimaryModifier else {
+            let detail = modifiers == [.shift] ? "shift-only" : "unmodified"
+            return .failure(.init(
+                message: "A \(detail) direct trigger is deferred beyond the MVP"
+            ))
+        }
+        return .success(stroke)
+    }
+
+    private static func isPrintable(_ scalar: UnicodeScalar) -> Bool {
+        !CharacterSet.controlCharacters.contains(scalar)
+            && !CharacterSet.illegalCharacters.contains(scalar)
+            && !(0xF700...0xF8FF).contains(scalar.value)
+    }
+}
+
+typealias KeySequence = [KeyStroke]
+
+struct TriggerError: Error, Equatable, CustomStringConvertible {
+    let message: String
+    var description: String { message }
+}
+
+enum ParsedKeySequence: Equatable {
+    case direct(KeyStroke)
+    case leader(continuation: KeyStroke)
+
+    static func parse(_ text: String) -> Result<ParsedKeySequence, TriggerError> {
+        let steps = text.split(separator: ">", omittingEmptySubsequences: false)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        switch steps.count {
+        case 1:
+            guard steps[0].lowercased() != "leader" else {
+                return .failure(.init(
+                    message: "'leader' is reserved for the first step of leader>X"
+                ))
+            }
+            return KeyStroke.parse(steps[0]).map(ParsedKeySequence.direct)
+        case 2:
+            guard steps[0].lowercased() == "leader" else {
+                return .failure(.init(
+                    message: "Only leader>X sequences are supported in the MVP"
+                ))
+            }
+            guard steps[1].lowercased() != "leader" else {
+                return .failure(.init(
+                    message: "'leader' is only valid as the first sequence step"
+                ))
+            }
+            return KeyStroke.parseContinuation(steps[1]).map {
+                .leader(continuation: $0)
+            }
+        default:
+            return .failure(.init(
+                message: "Only two-step leader>X sequences are supported in the MVP"
+            ))
+        }
+    }
+}

--- a/macos/ATC/Commands/KeyboardConfig.swift
+++ b/macos/ATC/Commands/KeyboardConfig.swift
@@ -1,0 +1,342 @@
+import Foundation
+
+struct ConfigDiagnostic: Error, Equatable, CustomStringConvertible, Sendable {
+    enum Severity: Equatable, Sendable {
+        case error
+        case warning
+    }
+
+    let severity: Severity
+    let line: Int?
+    let message: String
+
+    var description: String {
+        let location = line.map { "line \($0): " } ?? ""
+        return "\(severity == .error ? "error" : "warning"): \(location)\(message)"
+    }
+}
+
+struct ConfigDiagnostics: Error, Equatable, RandomAccessCollection, Sendable {
+    private(set) var diagnostics: [ConfigDiagnostic]
+
+    init(_ diagnostics: [ConfigDiagnostic]) {
+        self.diagnostics = diagnostics
+    }
+
+    var startIndex: Int { diagnostics.startIndex }
+    var endIndex: Int { diagnostics.endIndex }
+    subscript(position: Int) -> ConfigDiagnostic { diagnostics[position] }
+}
+
+struct ParsedConfig: Sendable {
+    enum Value: Equatable, Sendable {
+        case string(String)
+        case integer(Int)
+        case boolean(Bool)
+    }
+
+    struct Entry: Equatable, Sendable {
+        let key: String
+        let value: Value
+        let line: Int
+    }
+
+    let tables: [String: [Entry]]
+    let diagnostics: [ConfigDiagnostic]
+
+    static let empty = ParsedConfig(tables: [:], diagnostics: [])
+}
+
+enum KeyboardConfigParser {
+    private static let recognizedTables = ["keyboard", "keybindings"]
+    private static let keyboardKeys = [
+        "leader", "leader_timeout_ms", "clear_default_keybindings",
+    ]
+
+    static func parse(data: Data) -> ParsedConfig {
+        guard let text = String(data: data, encoding: .utf8) else {
+            return ParsedConfig(
+                tables: [:],
+                diagnostics: [.init(
+                    severity: .error,
+                    line: nil,
+                    message: "config.toml is not valid UTF-8"
+                )]
+            )
+        }
+        return parse(text)
+    }
+
+    static func parse(_ text: String) -> ParsedConfig {
+        var tables: [String: [ParsedConfig.Entry]] = [:]
+        var diagnostics: [ConfigDiagnostic] = []
+        var currentTable: String?
+        var seen: [String: Set<String>] = [:]
+
+        for (offset, rawLine) in text.split(
+            separator: "\n",
+            omittingEmptySubsequences: false
+        ).enumerated() {
+            let lineNumber = offset + 1
+            let uncommented = removingComment(from: String(rawLine))
+            let line = uncommented.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty else { continue }
+
+            if line.hasPrefix("[") {
+                guard line.hasSuffix("]"),
+                      !line.hasPrefix("[["),
+                      !line.hasSuffix("]]"),
+                      line.filter({ $0 == "[" }).count == 1,
+                      line.filter({ $0 == "]" }).count == 1
+                else {
+                    diagnostics.append(error(lineNumber, "Unsupported table construct '\(line)'"))
+                    currentTable = nil
+                    continue
+                }
+                let name = String(line.dropFirst().dropLast())
+                    .trimmingCharacters(in: .whitespaces)
+                guard isBareKey(name) else {
+                    diagnostics.append(error(
+                        lineNumber,
+                        "Table name '\(name)' must be a bare name"
+                    ))
+                    currentTable = nil
+                    continue
+                }
+                currentTable = name
+                continue
+            }
+
+            if let currentTable, !recognizedTables.contains(currentTable) {
+                // Unknown top-level tables and their contents belong to
+                // other subsystems sharing config.toml.
+                continue
+            }
+
+            guard let equals = firstUnquotedEquals(in: line) else {
+                diagnostics.append(error(lineNumber, "Expected key = value"))
+                continue
+            }
+            let keyText = String(line[..<equals]).trimmingCharacters(in: .whitespaces)
+            let valueText = String(line[line.index(after: equals)...])
+                .trimmingCharacters(in: .whitespaces)
+            guard let table = currentTable else {
+                diagnostics.append(error(
+                    lineNumber,
+                    "Top-level values are unsupported; place the key in a table"
+                ))
+                continue
+            }
+
+            let keyResult = parseKey(keyText, line: lineNumber)
+            let valueResult = parseValue(valueText, line: lineNumber)
+            guard case .success(let key) = keyResult,
+                  case .success(let value) = valueResult
+            else {
+                if case .failure(let diagnostic) = keyResult { diagnostics.append(diagnostic) }
+                if case .failure(let diagnostic) = valueResult { diagnostics.append(diagnostic) }
+                continue
+            }
+
+            guard recognizedTables.contains(table) else {
+                // Other subsystems own unknown tables in this shared config file.
+                continue
+            }
+            if seen[table, default: []].contains(key) {
+                diagnostics.append(.init(
+                    severity: .warning,
+                    line: lineNumber,
+                    message: "Duplicate key '\(key)' in [\(table)]; the later entry wins"
+                ))
+            }
+            seen[table, default: []].insert(key)
+            tables[table, default: []].append(.init(
+                key: key,
+                value: value,
+                line: lineNumber
+            ))
+            if table == "keyboard", !keyboardKeys.contains(key) {
+                diagnostics.append(.init(
+                    severity: .warning,
+                    line: lineNumber,
+                    message: "Unknown [keyboard] key '\(key)' was ignored"
+                ))
+            }
+        }
+
+        return ParsedConfig(tables: tables, diagnostics: diagnostics)
+    }
+
+    private static func parseKey(
+        _ text: String,
+        line: Int
+    ) -> Result<String, ConfigDiagnostic> {
+        guard !text.isEmpty else {
+            return .failure(error(line, "Key cannot be empty"))
+        }
+        if text.hasPrefix("\"") {
+            return parseBasicString(text, line: line)
+        }
+        if text.hasPrefix("'") {
+            return .failure(error(
+                line,
+                "Literal strings are unsupported; use a basic quoted string"
+            ))
+        }
+        if text.contains(".") {
+            return .failure(error(
+                line,
+                "Dotted keys are unsupported: '\(text)'"
+            ))
+        }
+        guard isBareKey(text) else {
+            return .failure(error(
+                line,
+                "Invalid bare key '\(text)'"
+            ))
+        }
+        return .success(text)
+    }
+
+    private static func parseValue(
+        _ text: String,
+        line: Int
+    ) -> Result<ParsedConfig.Value, ConfigDiagnostic> {
+        guard !text.isEmpty else {
+            return .failure(error(line, "Value cannot be empty"))
+        }
+        if text.hasPrefix("\"\"\"") || text.hasPrefix("'''") {
+            return .failure(error(line, "Multiline strings are unsupported"))
+        }
+        if text.hasPrefix("\"") {
+            return parseBasicString(text, line: line)
+                .map(ParsedConfig.Value.string)
+        }
+        if text.hasPrefix("'") {
+            return .failure(error(
+                line,
+                "Literal strings are unsupported; use a basic quoted string"
+            ))
+        }
+        if text.hasPrefix("[") {
+            return .failure(error(line, "Arrays are unsupported"))
+        }
+        if text.hasPrefix("{") {
+            return .failure(error(line, "Inline tables are unsupported"))
+        }
+        if text == "true" { return .success(.boolean(true)) }
+        if text == "false" { return .success(.boolean(false)) }
+        if text.range(of: #"^[+-]?[0-9]+$"#, options: .regularExpression) != nil,
+           let value = Int(text) {
+            return .success(.integer(value))
+        }
+        if text.range(of: #"^[+-]?[0-9]+\.[0-9]+$"#, options: .regularExpression) != nil {
+            return .failure(error(line, "Floats are unsupported"))
+        }
+        if text.range(of: #"^[0-9]{4}-[0-9]{2}-[0-9]{2}"#, options: .regularExpression) != nil {
+            return .failure(error(line, "Dates are unsupported"))
+        }
+        return .failure(error(
+            line,
+            "Unsupported value construct '\(text)'"
+        ))
+    }
+
+    private static func parseBasicString(
+        _ text: String,
+        line: Int
+    ) -> Result<String, ConfigDiagnostic> {
+        guard text.count >= 2, text.first == "\"", text.last == "\"" else {
+            return .failure(error(line, "Unterminated basic quoted string"))
+        }
+        let body = text.dropFirst().dropLast()
+        var result = ""
+        var index = body.startIndex
+        while index < body.endIndex {
+            let character = body[index]
+            guard character == "\\" else {
+                if character == "\"" {
+                    return .failure(error(line, "Unescaped quote in basic string"))
+                }
+                result.append(character)
+                index = body.index(after: index)
+                continue
+            }
+            index = body.index(after: index)
+            guard index < body.endIndex else {
+                return .failure(error(line, "Incomplete escape in basic string"))
+            }
+            let escape = body[index]
+            switch escape {
+            case "\"": result.append("\"")
+            case "\\": result.append("\\")
+            case "n": result.append("\n")
+            case "t": result.append("\t")
+            case "u":
+                let start = body.index(after: index)
+                guard let end = body.index(start, offsetBy: 4, limitedBy: body.endIndex),
+                      body.distance(from: start, to: end) == 4,
+                      let scalarValue = UInt32(body[start..<end], radix: 16),
+                      let scalar = UnicodeScalar(scalarValue)
+                else {
+                    return .failure(error(line, "Invalid \\uXXXX escape"))
+                }
+                result.unicodeScalars.append(scalar)
+                index = body.index(before: end)
+            default:
+                return .failure(error(line, "Unsupported escape '\\\(escape)'"))
+            }
+            index = body.index(after: index)
+        }
+        return .success(result)
+    }
+
+    private static func removingComment(from line: String) -> String {
+        var quoted = false
+        var escaped = false
+        for index in line.indices {
+            let character = line[index]
+            if escaped {
+                escaped = false
+                continue
+            }
+            if quoted, character == "\\" {
+                escaped = true
+            } else if character == "\"" {
+                quoted.toggle()
+            } else if character == "#", !quoted {
+                return String(line[..<index])
+            }
+        }
+        return line
+    }
+
+    private static func firstUnquotedEquals(in line: String) -> String.Index? {
+        var quoted = false
+        var escaped = false
+        for index in line.indices {
+            let character = line[index]
+            if escaped {
+                escaped = false
+            } else if quoted, character == "\\" {
+                escaped = true
+            } else if character == "\"" {
+                quoted.toggle()
+            } else if character == "=", !quoted {
+                return index
+            }
+        }
+        return nil
+    }
+
+    private static func isBareKey(_ text: String) -> Bool {
+        !text.isEmpty && text.utf8.allSatisfy {
+            (48...57).contains($0) || (65...90).contains($0)
+                || (97...122).contains($0) || $0 == 95 || $0 == 45
+        }
+    }
+
+    private static func error(_ line: Int, _ message: String) -> ConfigDiagnostic {
+        ConfigDiagnostic(severity: .error, line: line, message: message)
+    }
+}

--- a/macos/ATC/Commands/KeyboardConfig.swift
+++ b/macos/ATC/Commands/KeyboardConfig.swift
@@ -138,10 +138,6 @@ enum KeyboardConfigParser {
                 continue
             }
 
-            guard recognizedTables.contains(table) else {
-                // Other subsystems own unknown tables in this shared config file.
-                continue
-            }
             if seen[table, default: []].contains(key) {
                 diagnostics.append(.init(
                     severity: .warning,

--- a/macos/ATC/Commands/KeyboardConfigStore.swift
+++ b/macos/ATC/Commands/KeyboardConfigStore.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Observation
+import OSLog
+
+struct ConfigNotice: Equatable {
+    let message: String
+}
+
+@MainActor
+@Observable
+final class KeyboardConfigStore {
+    private(set) var keymap: ResolvedKeymap
+    private(set) var notice: ConfigNotice?
+    private(set) var diagnostics: [ConfigDiagnostic] = []
+
+    @ObservationIgnored private let configURL: URL
+    @ObservationIgnored private let fileManager: FileManager
+    @ObservationIgnored private let logger = Logger(
+        subsystem: "ElevenIdeas.atc",
+        category: "keyboard"
+    )
+
+    init(
+        configURL: URL = KeyboardConfigStore.defaultConfigURL(),
+        fileManager: FileManager = .default
+    ) {
+        self.configURL = configURL
+        self.fileManager = fileManager
+        switch Keymap.resolve(generation: 0) {
+        case .success(let keymap): self.keymap = keymap
+        case .failure: preconditionFailure("Compiled keyboard defaults must be valid")
+        }
+    }
+
+    func loadAtLaunch() {
+        load(isLaunch: true)
+    }
+
+    func reload() {
+        load(isLaunch: false)
+    }
+
+    func dismissNotice() {
+        notice = nil
+    }
+
+    nonisolated static func defaultConfigURL(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> URL {
+        let base: URL
+        if let xdg = environment["XDG_CONFIG_HOME"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !xdg.isEmpty {
+            base = URL(fileURLWithPath: xdg, isDirectory: true)
+        } else {
+            base = homeDirectory.appending(path: ".config", directoryHint: .isDirectory)
+        }
+        return base
+            .appending(path: "atc", directoryHint: .isDirectory)
+            .appending(path: "config.toml", directoryHint: .notDirectory)
+    }
+
+    private func load(isLaunch: Bool) {
+        let nextGeneration = keymap.generation + 1
+        guard fileManager.fileExists(atPath: configURL.path) else {
+            apply(parsed: .empty, generation: nextGeneration, isLaunch: isLaunch)
+            return
+        }
+
+        let parsed: ParsedConfig
+        do {
+            parsed = KeyboardConfigParser.parse(data: try Data(contentsOf: configURL))
+        } catch {
+            fail(
+                diagnostics: [.init(
+                    severity: .error,
+                    line: nil,
+                    message: "Could not read config.toml: \(error.localizedDescription)"
+                )],
+                isLaunch: isLaunch
+            )
+            return
+        }
+        apply(parsed: parsed, generation: nextGeneration, isLaunch: isLaunch)
+    }
+
+    private func apply(parsed: ParsedConfig, generation: Int, isLaunch: Bool) {
+        switch Keymap.resolve(user: parsed, generation: generation) {
+        case .success(let candidate):
+            keymap = candidate
+            diagnostics = parsed.diagnostics
+            notice = nil
+            log(parsed.diagnostics)
+        case .failure(let failure):
+            fail(diagnostics: failure.diagnostics, isLaunch: isLaunch)
+        }
+    }
+
+    private func fail(diagnostics: [ConfigDiagnostic], isLaunch: Bool) {
+        self.diagnostics = diagnostics
+        log(diagnostics)
+        let errorCount = diagnostics.count { $0.severity == .error }
+        let disposition = isLaunch
+            ? "using default keybindings"
+            : "keeping the previous keybindings"
+        notice = ConfigNotice(
+            message: "Keyboard configuration was not loaded (\(errorCount) \(errorCount == 1 ? "error" : "errors")) — \(disposition). See log for details."
+        )
+    }
+
+    private func log(_ diagnostics: [ConfigDiagnostic]) {
+        for diagnostic in diagnostics {
+            let message = "\(configURL.path): \(diagnostic.description)"
+            switch diagnostic.severity {
+            case .error: logger.error("\(message, privacy: .public)")
+            case .warning: logger.warning("\(message, privacy: .public)")
+            }
+        }
+    }
+}

--- a/macos/ATC/Commands/KeyboardMonitorHost.swift
+++ b/macos/ATC/Commands/KeyboardMonitorHost.swift
@@ -1,0 +1,170 @@
+import AppKit
+import SwiftUI
+
+struct KeyboardMonitorHost: NSViewRepresentable {
+    let router: WindowKeyboardRouter
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(router: router)
+    }
+
+    func makeNSView(context: Context) -> HostView {
+        let view = HostView()
+        view.onWindowChange = { [weak coordinator = context.coordinator] window in
+            coordinator?.install(for: window)
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: HostView, context: Context) {
+        context.coordinator.router = router
+        if nsView.window !== context.coordinator.hostWindow {
+            context.coordinator.install(for: nsView.window)
+        }
+    }
+
+    static func dismantleNSView(_ nsView: HostView, coordinator: Coordinator) {
+        nsView.onWindowChange = nil
+        coordinator.stop()
+    }
+
+    final class HostView: NSView {
+        var onWindowChange: ((NSWindow?) -> Void)?
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            onWindowChange?(window)
+        }
+    }
+
+    @MainActor
+    final class Coordinator {
+        var router: WindowKeyboardRouter
+        private(set) weak var hostWindow: NSWindow?
+        private var monitor: Any?
+        private var observers: [NSObjectProtocol] = []
+
+        init(router: WindowKeyboardRouter) {
+            self.router = router
+        }
+
+        func install(for window: NSWindow?) {
+            guard window !== hostWindow || monitor == nil else { return }
+            stop()
+            guard let window else { return }
+            hostWindow = window
+            monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) {
+                [weak self, weak window] event in
+                guard let self, let window,
+                      event.window === window,
+                      window.isKeyWindow,
+                      let stroke = KeyStroke.normalize(event: event)
+                else { return event }
+                return self.router.handle(stroke, isRepeat: event.isARepeat) ? nil : event
+            }
+
+            let center = NotificationCenter.default
+            observers.append(center.addObserver(
+                forName: NSWindow.didResignKeyNotification,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated { self?.router.cancel() }
+            })
+            observers.append(center.addObserver(
+                forName: NSApplication.didResignActiveNotification,
+                object: NSApp,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated { self?.router.cancel() }
+            })
+        }
+
+        func stop() {
+            if let monitor {
+                NSEvent.removeMonitor(monitor)
+                self.monitor = nil
+            }
+            for observer in observers {
+                NotificationCenter.default.removeObserver(observer)
+            }
+            observers.removeAll()
+            hostWindow = nil
+            router.cancel()
+        }
+
+        deinit {
+            if let monitor { NSEvent.removeMonitor(monitor) }
+            for observer in observers {
+                NotificationCenter.default.removeObserver(observer)
+            }
+        }
+    }
+}
+
+struct KeyboardRoutingContainer<Content: View>: View {
+    let appModel: AppModel
+    let windowState: WindowState
+    let configStore: KeyboardConfigStore
+    @ViewBuilder let content: Content
+
+    @State private var router: WindowKeyboardRouter
+
+    init(
+        appModel: AppModel,
+        windowState: WindowState,
+        configStore: KeyboardConfigStore,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.appModel = appModel
+        self.windowState = windowState
+        self.configStore = configStore
+        self.content = content()
+        let context = CommandContext(
+            appModel: appModel,
+            windowState: windowState,
+            configStore: configStore
+        )
+        _router = State(initialValue: WindowKeyboardRouter(
+            keymap: configStore.keymap,
+            context: context
+        ))
+    }
+
+    var body: some View {
+        content
+            .overlay {
+                CommandFeedbackOverlay()
+            }
+            .environment(configStore)
+            .environment(router)
+            .background(KeyboardMonitorHost(router: router))
+            .onChange(of: configStore.keymap.generation, initial: true) {
+                router.keymap = configStore.keymap
+            }
+    }
+}
+
+extension KeyStroke {
+    static func normalize(event: NSEvent) -> KeyStroke? {
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        var modifiers: Modifiers = []
+        if flags.contains(.command) { modifiers.insert(.command) }
+        if flags.contains(.control) { modifiers.insert(.control) }
+        if flags.contains(.option) { modifiers.insert(.option) }
+        if flags.contains(.shift) { modifiers.insert(.shift) }
+
+        if event.keyCode == 53 {
+            return KeyStroke(key: "escape", modifiers: modifiers)
+        }
+        guard let characters = event.characters(byApplyingModifiers: [])
+                ?? event.charactersIgnoringModifiers,
+              characters.count == 1,
+              let scalar = characters.lowercased().unicodeScalars.first,
+              !CharacterSet.controlCharacters.contains(scalar),
+              !CharacterSet.illegalCharacters.contains(scalar),
+              !(0xF700...0xF8FF).contains(scalar.value)
+        else { return nil }
+        return KeyStroke(key: characters.lowercased(), modifiers: modifiers)
+    }
+}

--- a/macos/ATC/Commands/KeyboardMonitorHost.swift
+++ b/macos/ATC/Commands/KeyboardMonitorHost.swift
@@ -154,16 +154,16 @@ extension KeyStroke {
         if flags.contains(.option) { modifiers.insert(.option) }
         if flags.contains(.shift) { modifiers.insert(.shift) }
 
+        // Escape normalizes to the bare stroke regardless of held modifiers
+        // so a pending sequence always cancels silently.
         if event.keyCode == 53 {
-            return KeyStroke(key: "escape", modifiers: modifiers)
+            return .escape
         }
         guard let characters = event.characters(byApplyingModifiers: [])
                 ?? event.charactersIgnoringModifiers,
               characters.count == 1,
               let scalar = characters.lowercased().unicodeScalars.first,
-              !CharacterSet.controlCharacters.contains(scalar),
-              !CharacterSet.illegalCharacters.contains(scalar),
-              !(0xF700...0xF8FF).contains(scalar.value)
+              isPrintable(scalar)
         else { return nil }
         return KeyStroke(key: characters.lowercased(), modifiers: modifiers)
     }

--- a/macos/ATC/Commands/Keymap.swift
+++ b/macos/ATC/Commands/Keymap.swift
@@ -160,14 +160,9 @@ enum Keymap {
             )
         }
 
-        for (sequence, binding) in folded where !sequence[0].hasPrimaryModifier {
-            diagnostics.append(.init(
-                severity: .error,
-                line: binding.line,
-                message: "Step-one trigger '\(sequence[0])' must include cmd, ctrl, or option"
-            ))
-        }
-
+        // The step-one modifier rule (cmd/ctrl/option required) is enforced
+        // when triggers parse: direct bindings and the leader go through
+        // KeyStroke.parse, so every sequence[0] here already satisfies it.
         let directTriggers = Set(folded.keys.filter { $0.count == 1 }.map { $0[0] })
         let prefixTriggers = Set(folded.keys.filter { $0.count > 1 }.map { $0[0] })
         func sourceLine(for trigger: KeyStroke) -> Int? {

--- a/macos/ATC/Commands/Keymap.swift
+++ b/macos/ATC/Commands/Keymap.swift
@@ -1,0 +1,254 @@
+import Foundation
+
+struct ResolvedKeymap: Sendable {
+    indirect enum Node: Sendable {
+        case command(CommandID)
+        case prefix([KeyStroke: Node])
+    }
+
+    let root: [KeyStroke: Node]
+    let menuShortcuts: [CommandID: KeyStroke]
+    let leaderTimeout: Duration
+    let generation: Int
+}
+
+enum Keymap {
+    static let defaultLeader = "cmd+k"
+    static let defaultLeaderTimeoutMilliseconds = 1_800
+
+    static let compiledDefaults: [(sequence: String, command: CommandID)] = [
+        ("cmd+b", .toggleSidebar), ("leader>b", .toggleSidebar),
+        ("cmd+n", .newSession), ("leader>n", .newSession),
+        ("cmd+r", .refresh), ("leader>r", .refresh),
+        ("cmd+t", .newTerminal),
+        ("cmd+shift+n", .newWorkspace),
+    ]
+
+    static func resolve(
+        defaults: [(sequence: String, command: CommandID)] = compiledDefaults,
+        user: ParsedConfig = .empty,
+        generation: Int = 1
+    ) -> Result<ResolvedKeymap, ConfigDiagnostics> {
+        var diagnostics = user.diagnostics
+        var leader = requiredStroke(defaultLeader)
+        var leaderLine: Int?
+        var timeoutMilliseconds = defaultLeaderTimeoutMilliseconds
+        var clearDefaults = false
+
+        for entry in user.tables["keyboard", default: []] {
+            switch entry.key {
+            case "leader":
+                guard case .string(let text) = entry.value else {
+                    diagnostics.append(.init(
+                        severity: .error,
+                        line: entry.line,
+                        message: "[keyboard].leader must be a quoted trigger string"
+                    ))
+                    continue
+                }
+                switch KeyStroke.parse(text) {
+                case .success(let stroke):
+                    leader = stroke
+                    leaderLine = entry.line
+                case .failure(let error):
+                    diagnostics.append(.init(
+                        severity: .error,
+                        line: entry.line,
+                        message: "Invalid leader '\(text)': \(error.message)"
+                    ))
+                }
+            case "leader_timeout_ms":
+                guard case .integer(let value) = entry.value, value > 0 else {
+                    diagnostics.append(.init(
+                        severity: .error,
+                        line: entry.line,
+                        message: "[keyboard].leader_timeout_ms must be a positive integer"
+                    ))
+                    continue
+                }
+                timeoutMilliseconds = value
+            case "clear_default_keybindings":
+                guard case .boolean(let value) = entry.value else {
+                    diagnostics.append(.init(
+                        severity: .error,
+                        line: entry.line,
+                        message: "[keyboard].clear_default_keybindings must be a boolean"
+                    ))
+                    continue
+                }
+                clearDefaults = value
+            default:
+                continue
+            }
+        }
+
+        struct OrderedEntry {
+            let sequenceText: String
+            let commandText: String
+            let line: Int?
+            let order: Int
+        }
+        var ordered: [OrderedEntry] = []
+        if !clearDefaults {
+            ordered = defaults.enumerated().map { offset, binding in
+                OrderedEntry(
+                    sequenceText: binding.sequence,
+                    commandText: binding.command.rawValue,
+                    line: nil,
+                    order: offset
+                )
+            }
+        }
+        let userOffset = ordered.count
+        for (offset, entry) in user.tables["keybindings", default: []].enumerated() {
+            guard case .string(let command) = entry.value else {
+                diagnostics.append(.init(
+                    severity: .error,
+                    line: entry.line,
+                    message: "Binding '\(entry.key)' must map to a quoted command id or \"unbind\""
+                ))
+                continue
+            }
+            ordered.append(.init(
+                sequenceText: entry.key,
+                commandText: command,
+                line: entry.line,
+                order: userOffset + offset
+            ))
+        }
+
+        struct FoldedBinding {
+            let command: CommandID
+            let order: Int
+            let line: Int?
+        }
+        var folded: [KeySequence: FoldedBinding] = [:]
+        for entry in ordered {
+            let parsed: ParsedKeySequence
+            switch ParsedKeySequence.parse(entry.sequenceText) {
+            case .success(let value): parsed = value
+            case .failure(let error):
+                diagnostics.append(.init(
+                    severity: .error,
+                    line: entry.line,
+                    message: "Invalid binding trigger '\(entry.sequenceText)': \(error.message)"
+                ))
+                continue
+            }
+            let sequence: KeySequence
+            switch parsed {
+            case .direct(let stroke): sequence = [stroke]
+            case .leader(let continuation): sequence = [leader, continuation]
+            }
+
+            if entry.commandText == "unbind" {
+                folded.removeValue(forKey: sequence)
+                continue
+            }
+            guard let command = CommandID(rawValue: entry.commandText) else {
+                diagnostics.append(.init(
+                    severity: .error,
+                    line: entry.line,
+                    message: "Unknown command id '\(entry.commandText)' for '\(entry.sequenceText)'"
+                ))
+                continue
+            }
+            folded[sequence] = FoldedBinding(
+                command: command,
+                order: entry.order,
+                line: entry.line
+            )
+        }
+
+        for (sequence, binding) in folded where !sequence[0].hasPrimaryModifier {
+            diagnostics.append(.init(
+                severity: .error,
+                line: binding.line,
+                message: "Step-one trigger '\(sequence[0])' must include cmd, ctrl, or option"
+            ))
+        }
+
+        let directTriggers = Set(folded.keys.filter { $0.count == 1 }.map { $0[0] })
+        let prefixTriggers = Set(folded.keys.filter { $0.count > 1 }.map { $0[0] })
+        func sourceLine(for trigger: KeyStroke) -> Int? {
+            if trigger == leader, let leaderLine { return leaderLine }
+            return folded.first { sequence, _ in sequence[0] == trigger }?.value.line
+        }
+        for trigger in directTriggers.intersection(prefixTriggers).sorted(by: descriptionOrder) {
+            diagnostics.append(.init(
+                severity: .error,
+                line: sourceLine(for: trigger),
+                message: "Trigger '\(trigger)' is both a direct shortcut and a sequence prefix; unbind the direct shortcut or choose another leader"
+            ))
+        }
+
+        let protected = protectedTriggers
+        let protectedCandidates = directTriggers.union(prefixTriggers).union([leader])
+        for trigger in protectedCandidates.sorted(by: descriptionOrder) {
+            if let name = protected[trigger] {
+                diagnostics.append(.init(
+                    severity: .error,
+                    line: sourceLine(for: trigger),
+                    message: "\(trigger) is reserved for \(name)"
+                ))
+            }
+        }
+
+        guard !diagnostics.contains(where: { $0.severity == .error }) else {
+            return .failure(ConfigDiagnostics(diagnostics))
+        }
+
+        var root: [KeyStroke: ResolvedKeymap.Node] = [:]
+        for (sequence, binding) in folded {
+            if sequence.count == 1 {
+                root[sequence[0]] = .command(binding.command)
+            } else {
+                var continuations: [KeyStroke: ResolvedKeymap.Node]
+                if case .prefix(let existing)? = root[sequence[0]] {
+                    continuations = existing
+                } else {
+                    continuations = [:]
+                }
+                continuations[sequence[1]] = .command(binding.command)
+                root[sequence[0]] = .prefix(continuations)
+            }
+        }
+
+        var menuCandidates: [CommandID: (stroke: KeyStroke, order: Int)] = [:]
+        for (sequence, binding) in folded where sequence.count == 1 {
+            let candidate = menuCandidates[binding.command]
+            if candidate == nil || binding.order > candidate!.order {
+                menuCandidates[binding.command] = (sequence[0], binding.order)
+            }
+        }
+        return .success(ResolvedKeymap(
+            root: root,
+            menuShortcuts: menuCandidates.mapValues(\.stroke),
+            leaderTimeout: .milliseconds(timeoutMilliseconds),
+            generation: generation
+        ))
+    }
+
+    private static let protectedTriggers: [KeyStroke: String] = {
+        let values: [(String, String)] = [
+            ("cmd+q", "Quit"), ("cmd+h", "Hide atc"),
+            ("cmd+opt+h", "Hide Others"), ("cmd+,", "Settings"),
+            ("cmd+w", "Close Window"), ("cmd+shift+w", "Close All Windows"),
+            ("cmd+z", "Undo"), ("cmd+shift+z", "Redo"),
+            ("cmd+x", "Cut"), ("cmd+c", "Copy"), ("cmd+v", "Paste"),
+            ("cmd+a", "Select All"), ("cmd+m", "Minimize"),
+        ]
+        return Dictionary(uniqueKeysWithValues: values.map { (requiredStroke($0.0), $0.1) })
+    }()
+
+    private static func requiredStroke(_ text: String) -> KeyStroke {
+        switch KeyStroke.parse(text) {
+        case .success(let stroke): stroke
+        case .failure(let error): preconditionFailure("Invalid compiled trigger: \(error)")
+        }
+    }
+
+    private static func descriptionOrder(_ lhs: KeyStroke, _ rhs: KeyStroke) -> Bool {
+        lhs.description < rhs.description
+    }
+}

--- a/macos/ATC/Commands/WindowKeyboardRouter.swift
+++ b/macos/ATC/Commands/WindowKeyboardRouter.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Observation
+
+struct RouterFlash: Equatable {
+    let message: String
+}
+
+@MainActor
+@Observable
+final class WindowKeyboardRouter {
+    enum State {
+        case idle
+        case pending(node: [KeyStroke: ResolvedKeymap.Node])
+    }
+
+    private(set) var state: State = .idle
+    private(set) var flash: RouterFlash?
+    var keymap: ResolvedKeymap {
+        didSet {
+            if oldValue.generation != keymap.generation {
+                cancel()
+            }
+        }
+    }
+
+    @ObservationIgnored private let executeCommand: @MainActor (CommandID) -> CommandAvailability
+    @ObservationIgnored private var timeoutTask: Task<Void, Never>?
+    @ObservationIgnored private var flashTask: Task<Void, Never>?
+    @ObservationIgnored private var flashToken = 0
+
+    init(keymap: ResolvedKeymap, context: CommandContext) {
+        self.keymap = keymap
+        self.executeCommand = { CommandRegistry.execute($0, context: context) }
+    }
+
+    init(
+        keymap: ResolvedKeymap,
+        execute: @escaping @MainActor (CommandID) -> CommandAvailability
+    ) {
+        self.keymap = keymap
+        self.executeCommand = execute
+    }
+
+    var pendingNode: [KeyStroke: ResolvedKeymap.Node]? {
+        guard case .pending(let node) = state else { return nil }
+        return node
+    }
+
+    @discardableResult
+    func handle(_ stroke: KeyStroke, isRepeat: Bool) -> Bool {
+        switch state {
+        case .idle:
+            guard let node = keymap.root[stroke] else { return false }
+            if isRepeat { return true }
+            return handle(node)
+        case .pending(let continuations):
+            if isRepeat { return true }
+            if stroke == .escape {
+                cancel()
+                return true
+            }
+            guard let node = continuations[stroke] else {
+                cancel()
+                showFlash("No matching command")
+                return true
+            }
+            return handle(node)
+        }
+    }
+
+    func cancel() {
+        timeoutTask?.cancel()
+        timeoutTask = nil
+        state = .idle
+    }
+
+    func handleTimeout(generation: Int) {
+        guard generation == keymap.generation,
+              case .pending = state
+        else { return }
+        cancel()
+    }
+
+    private func handle(_ node: ResolvedKeymap.Node) -> Bool {
+        switch node {
+        case .command(let command):
+            cancel()
+            if case .unavailable(let reason) = executeCommand(command) {
+                showFlash(reason)
+            }
+        case .prefix(let continuations):
+            state = .pending(node: continuations)
+            startTimeout()
+        }
+        return true
+    }
+
+    private func startTimeout() {
+        timeoutTask?.cancel()
+        let generation = keymap.generation
+        let duration = keymap.leaderTimeout
+        timeoutTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: duration)
+            } catch {
+                return
+            }
+            self?.handleTimeout(generation: generation)
+        }
+    }
+
+    private func showFlash(_ message: String) {
+        flashToken += 1
+        let token = flashToken
+        flash = RouterFlash(message: message)
+        flashTask?.cancel()
+        flashTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: .milliseconds(800))
+            } catch {
+                return
+            }
+            guard let self, token == self.flashToken else { return }
+            self.flash = nil
+        }
+    }
+}

--- a/macos/ATC/Commands/WindowKeyboardRouter.swift
+++ b/macos/ATC/Commands/WindowKeyboardRouter.swift
@@ -82,6 +82,9 @@ final class WindowKeyboardRouter {
     }
 
     private func handle(_ node: ResolvedKeymap.Node) -> Bool {
+        // A recognized binding supersedes lingering feedback; without this a
+        // fresh flash would hide the hint of a sequence started within 800 ms.
+        clearFlash()
         switch node {
         case .command(let command):
             cancel()
@@ -107,6 +110,13 @@ final class WindowKeyboardRouter {
             }
             self?.handleTimeout(generation: generation)
         }
+    }
+
+    private func clearFlash() {
+        flashToken += 1
+        flashTask?.cancel()
+        flashTask = nil
+        flash = nil
     }
 
     private func showFlash(_ message: String) {

--- a/macos/ATC/RootView.swift
+++ b/macos/ATC/RootView.swift
@@ -7,15 +7,9 @@ import ATCAPI
 struct RootView: View {
     @Environment(AppModel.self) private var appModel
     @Environment(WindowState.self) private var windowState
-    private let configStore: KeyboardConfigStore
-
-    init(configStore: KeyboardConfigStore) {
-        self.configStore = configStore
-    }
-
-    init() {
-        self.configStore = KeyboardConfigStore()
-    }
+    /// The one store ATCApp creates and loads; previews and hosting tests
+    /// pass an unloaded throwaway explicitly.
+    let configStore: KeyboardConfigStore
 
     var body: some View {
         KeyboardRoutingContainer(
@@ -143,7 +137,7 @@ struct RootView: View {
 }
 
 #Preview {
-    RootView()
+    RootView(configStore: KeyboardConfigStore())
         .environment(AppModel.preview())
         .environment(WindowState())
         .preferredColorScheme(.dark)

--- a/macos/ATC/RootView.swift
+++ b/macos/ATC/RootView.swift
@@ -3,13 +3,33 @@ import ATCAPI
 
 /// One stable window-root split view. Navigators replace only the leading
 /// column while the terminal stack remains mounted in the detail column.
+@MainActor
 struct RootView: View {
     @Environment(AppModel.self) private var appModel
     @Environment(WindowState.self) private var windowState
+    private let configStore: KeyboardConfigStore
+
+    init(configStore: KeyboardConfigStore) {
+        self.configStore = configStore
+    }
+
+    init() {
+        self.configStore = KeyboardConfigStore()
+    }
 
     var body: some View {
+        KeyboardRoutingContainer(
+            appModel: appModel,
+            windowState: windowState,
+            configStore: configStore
+        ) {
+            rootContent
+        }
+    }
+
+    private var rootContent: some View {
         @Bindable var windowState = windowState
-        NavigationSplitView(columnVisibility: $windowState.columnVisibility) {
+        return NavigationSplitView(columnVisibility: $windowState.columnVisibility) {
             NavigatorSidebar()
         } detail: {
             mainContent

--- a/macos/ATCTests/CommandRegistryTests.swift
+++ b/macos/ATCTests/CommandRegistryTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+import SwiftUI
+import Testing
+import ATCAPI
+@testable import ATC
+
+@MainActor
+@Suite("Command registry")
+struct CommandRegistryTests {
+    private func makeModel() -> AppModel {
+        let suite = "CommandRegistryTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return AppModel(
+            connections: ConnectionsStore(
+                defaults: defaults,
+                credentials: InMemoryCredentialStore()
+            ),
+            clientFactory: { _ in MockATCClient() },
+            terminalRecoveryMonitor: .disabled()
+        )
+    }
+
+    private func makeContext(
+        model: AppModel,
+        state: WindowState,
+        store: KeyboardConfigStore? = nil
+    ) -> CommandContext {
+        CommandContext(
+            appModel: model,
+            windowState: state,
+            configStore: store ?? KeyboardConfigStore(
+                configURL: FileManager.default.temporaryDirectory
+                    .appending(path: UUID().uuidString)
+            )
+        )
+    }
+
+    private func loadedContext() async throws -> (CommandContext, ConnectionRuntime) {
+        let model = makeModel()
+        let record = try model.addConnection(
+            name: "A", urlString: "http://a:1", token: ""
+        )
+        let runtime = try #require(model.runtime(id: record.id))
+        runtime.stopPolling()
+        await runtime.refresh()
+        let state = WindowState.ephemeral()
+        #expect(state.activateWorkspace(
+            WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser"),
+            in: model
+        ))
+        return (makeContext(model: model, state: state), runtime)
+    }
+
+    @Test("descriptors expose stable ids and titles")
+    func descriptors() {
+        #expect(CommandID.allCases.map(\.rawValue) == [
+            "view.toggle-sidebar", "session.new", "terminal.new", "project.new",
+            "workspace.new", "data.refresh", "configuration.reload",
+        ])
+        for id in CommandID.allCases {
+            let descriptor = CommandRegistry.descriptor(for: id)
+            #expect(descriptor.id == id)
+            #expect(!descriptor.title.isEmpty)
+        }
+    }
+
+    @Test("availability follows the complete command truth table")
+    func availability() async throws {
+        let emptyModel = makeModel()
+        let emptyState = WindowState.ephemeral()
+        let empty = makeContext(model: emptyModel, state: emptyState)
+        #expect(CommandRegistry.descriptor(for: .toggleSidebar).availability(empty) == .available)
+        #expect(CommandRegistry.descriptor(for: .refresh).availability(empty) == .available)
+        #expect(CommandRegistry.descriptor(for: .reloadConfiguration).availability(empty)
+            == .available)
+        let sessionAvailability = CommandRegistry.descriptor(for: .newSession)
+            .availability(empty)
+        #expect(sessionAvailability == .unavailable(
+            reason: "Requires an open Workspace on a reachable Connection"
+        ))
+        for id in [CommandID.newWorkspace, .newProject] {
+            #expect(CommandRegistry.descriptor(for: id).availability(empty)
+                == .unavailable(reason: "Requires a configured Connection"))
+        }
+
+        let (loaded, _) = try await loadedContext()
+        for id in [CommandID.newSession, .newTerminal, .newWorkspace, .newProject] {
+            #expect(CommandRegistry.descriptor(for: id).availability(loaded) == .available)
+        }
+    }
+
+    @Test("unavailable execution returns its reason and performs nothing")
+    func unavailableExecution() {
+        let model = makeModel()
+        let state = WindowState.ephemeral()
+        let context = makeContext(model: model, state: state)
+        let outcome = CommandRegistry.execute(.newSession, context: context)
+        #expect(outcome == .unavailable(
+            reason: "Requires an open Workspace on a reachable Connection"
+        ))
+        #expect(state.startSessionKind == nil)
+    }
+
+    @Test("window and creation commands perform the original menu mutations")
+    func windowMutations() async throws {
+        let (context, _) = try await loadedContext()
+        let state = context.windowState
+
+        #expect(state.columnVisibility == .all)
+        CommandRegistry.execute(.toggleSidebar, context: context)
+        #expect(state.columnVisibility == .detailOnly)
+
+        CommandRegistry.execute(.newSession, context: context)
+        #expect(state.startSessionKind?.rawValue == StartSessionKind.agentSession.rawValue)
+        state.startSessionKind = nil
+        CommandRegistry.execute(.newTerminal, context: context)
+        #expect(state.startSessionKind?.rawValue == StartSessionKind.terminal.rawValue)
+
+        CommandRegistry.execute(.newWorkspace, context: context)
+        #expect(state.createWorkspaceContext != nil)
+        CommandRegistry.execute(.newProject, context: context)
+        #expect(state.isCreateProjectPresented)
+    }
+
+    @Test("reload and refresh use the registry's always-available path")
+    func appCommands() {
+        let model = makeModel()
+        let state = WindowState.ephemeral()
+        let store = KeyboardConfigStore(
+            configURL: FileManager.default.temporaryDirectory
+                .appending(path: UUID().uuidString)
+        )
+        let context = makeContext(model: model, state: state, store: store)
+        #expect(CommandRegistry.execute(.refresh, context: context) == .available)
+        #expect(CommandRegistry.execute(.reloadConfiguration, context: context) == .available)
+        #expect(store.keymap.generation == 1)
+    }
+}

--- a/macos/ATCTests/EventNormalizationTests.swift
+++ b/macos/ATCTests/EventNormalizationTests.swift
@@ -41,6 +41,13 @@ struct EventNormalizationTests {
         ))
         #expect(KeyStroke.normalize(event: escape) == .escape)
 
+        // Held modifiers never produce a distinct escape stroke; a pending
+        // sequence cancels silently for shift+esc just like bare esc.
+        let shiftedEscape = try #require(event(
+            flags: .shift, characters: "\u{1b}", ignoringModifiers: "\u{1b}", keyCode: 53
+        ))
+        #expect(KeyStroke.normalize(event: shiftedEscape) == .escape)
+
         let functionCharacter = String(UnicodeScalar(NSF1FunctionKey)!)
         let function = try #require(event(
             flags: [],

--- a/macos/ATCTests/EventNormalizationTests.swift
+++ b/macos/ATCTests/EventNormalizationTests.swift
@@ -1,0 +1,73 @@
+import AppKit
+import Testing
+@testable import ATC
+
+@Suite("Keyboard event normalization")
+struct EventNormalizationTests {
+    @Test("layout-resolved command, shift, and option events normalize")
+    func printableEvents() throws {
+        let commandB = try #require(event(
+            flags: .command,
+            characters: "b",
+            ignoringModifiers: "b",
+            keyCode: 11
+        ))
+        #expect(KeyStroke.normalize(event: commandB)
+            == KeyStroke(key: "b", modifiers: .command))
+
+        let shiftedOne = try #require(event(
+            flags: [.command, .shift],
+            characters: "!",
+            ignoringModifiers: "1",
+            keyCode: 18
+        ))
+        #expect(KeyStroke.normalize(event: shiftedOne)
+            == KeyStroke(key: "1", modifiers: [.command, .shift]))
+
+        let optionB = try #require(event(
+            flags: .option,
+            characters: "∫",
+            ignoringModifiers: "b",
+            keyCode: 11
+        ))
+        #expect(KeyStroke.normalize(event: optionB)
+            == KeyStroke(key: "b", modifiers: .option))
+    }
+
+    @Test("escape normalizes and function keys forward as unmappable")
+    func specialEvents() throws {
+        let escape = try #require(event(
+            flags: [], characters: "\u{1b}", ignoringModifiers: "\u{1b}", keyCode: 53
+        ))
+        #expect(KeyStroke.normalize(event: escape) == .escape)
+
+        let functionCharacter = String(UnicodeScalar(NSF1FunctionKey)!)
+        let function = try #require(event(
+            flags: [],
+            characters: functionCharacter,
+            ignoringModifiers: functionCharacter,
+            keyCode: 122
+        ))
+        #expect(KeyStroke.normalize(event: function) == nil)
+    }
+
+    private func event(
+        flags: NSEvent.ModifierFlags,
+        characters: String,
+        ignoringModifiers: String,
+        keyCode: UInt16
+    ) -> NSEvent? {
+        NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: flags,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: ignoringModifiers,
+            isARepeat: false,
+            keyCode: keyCode
+        )
+    }
+}

--- a/macos/ATCTests/KeyboardConfigParserTests.swift
+++ b/macos/ATCTests/KeyboardConfigParserTests.swift
@@ -1,0 +1,100 @@
+import Testing
+@testable import ATC
+
+@Suite("Keyboard config parser")
+struct KeyboardConfigParserTests {
+    @Test("keyboard and keybinding scalars parse with comments")
+    func happyPath() {
+        let parsed = KeyboardConfigParser.parse(#"""
+        # general comment
+        [keyboard]
+        leader = "cmd+k" # trailing comment
+        leader_timeout_ms = 1800
+        clear_default_keybindings = false
+
+        [keybindings]
+        "cmd+b" = "view.toggle-sidebar"
+        "leader>b" = "view.toggle-sidebar"
+        """#)
+        #expect(parsed.diagnostics.isEmpty)
+        #expect(parsed.tables["keyboard"]?.count == 3)
+        #expect(parsed.tables["keybindings"]?.map(\.key) == ["cmd+b", "leader>b"])
+    }
+
+    @Test("source order, quoted and bare keys, and escapes are preserved")
+    func orderAndEscapes() {
+        let parsed = KeyboardConfigParser.parse(#"""
+        [keyboard]
+        leader = "cmd+\u006b"
+        [keybindings]
+        bare-key = "data.refresh"
+        "cmd+\u0062" = "view.toggle-\u0073idebar"
+        "cmd+#" = "data.refresh" # hash inside quotes
+        """#)
+        let entries = parsed.tables["keybindings", default: []]
+        #expect(entries.map(\.key) == ["bare-key", "cmd+b", "cmd+#"])
+        #expect(entries.map(\.line) == [4, 5, 6])
+        #expect(entries[1].value == .string("view.toggle-sidebar"))
+    }
+
+    @Test("duplicate keys warn and retain ordered replacement entries")
+    func duplicateKey() {
+        let parsed = KeyboardConfigParser.parse(#"""
+        [keybindings]
+        "cmd+b" = "data.refresh"
+        "cmd+b" = "view.toggle-sidebar"
+        """#)
+        #expect(parsed.tables["keybindings"]?.count == 2)
+        #expect(parsed.diagnostics == [.init(
+            severity: .warning,
+            line: 3,
+            message: "Duplicate key 'cmd+b' in [keybindings]; the later entry wins"
+        )])
+    }
+
+    @Test("unsupported TOML constructs report their exact lines")
+    func unsupportedConstructs() {
+        let parsed = KeyboardConfigParser.parse(#"""
+        [keyboard]
+        array = [1]
+        inline = { x = 1 }
+        dotted.key = "x"
+        float = 1.5
+        literal = 'x'
+        multiline = """x"""
+        date = 2026-07-15
+        """#)
+        #expect(parsed.diagnostics.filter { $0.severity == .error }.map(\.line)
+            == [2, 3, 4, 5, 6, 7, 8])
+        let messages = parsed.diagnostics.map(\.message).joined(separator: " ")
+        #expect(messages.contains("Arrays"))
+        #expect(messages.contains("Inline tables"))
+        #expect(messages.contains("Dotted keys"))
+        #expect(messages.contains("Floats"))
+        #expect(messages.contains("Literal strings"))
+        #expect(messages.contains("Multiline strings"))
+        #expect(messages.contains("Dates"))
+    }
+
+    @Test("unknown keyboard keys warn while unknown tables are silent")
+    func unknownKeysAndTables() {
+        let parsed = KeyboardConfigParser.parse(#"""
+        [future]
+        setting = ["a construct this parser otherwise rejects"]
+        setting = "replacement"
+        [keyboard]
+        future_setting = true
+        """#)
+        #expect(parsed.tables["future"] == nil)
+        #expect(parsed.diagnostics.count == 1)
+        #expect(parsed.diagnostics[0].severity == .warning)
+        #expect(parsed.diagnostics[0].line == 5)
+        #expect(parsed.diagnostics[0].message.contains("future_setting"))
+    }
+
+    @Test("empty text and blank comments produce an empty config")
+    func emptyConfig() {
+        #expect(KeyboardConfigParser.parse("").tables.isEmpty)
+        #expect(KeyboardConfigParser.parse("\n # comment\n").diagnostics.isEmpty)
+    }
+}

--- a/macos/ATCTests/KeyboardConfigParserTests.swift
+++ b/macos/ATCTests/KeyboardConfigParserTests.swift
@@ -92,6 +92,21 @@ struct KeyboardConfigParserTests {
         #expect(parsed.diagnostics[0].message.contains("future_setting"))
     }
 
+    @Test("malformed lines report errors without derailing the table")
+    func malformedLines() {
+        let parsed = KeyboardConfigParser.parse(#"""
+        top = "before any table"
+        [keyboard]
+        leader "cmd+k"
+        leader = "cmd+k
+        = "data.refresh"
+        leader = "cmd+k"
+        """#)
+        #expect(parsed.diagnostics.filter { $0.severity == .error }.map(\.line)
+            == [1, 3, 4, 5])
+        #expect(parsed.tables["keyboard"]?.map(\.line) == [6])
+    }
+
     @Test("empty text and blank comments produce an empty config")
     func emptyConfig() {
         #expect(KeyboardConfigParser.parse("").tables.isEmpty)

--- a/macos/ATCTests/KeyboardConfigStoreTests.swift
+++ b/macos/ATCTests/KeyboardConfigStoreTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Testing
+@testable import ATC
+
+@MainActor
+@Suite("Keyboard config store")
+struct KeyboardConfigStoreTests {
+    private func fixture() throws -> (directory: URL, config: URL) {
+        let directory = FileManager.default.temporaryDirectory
+            .appending(path: "KeyboardConfigStoreTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        return (directory, directory.appending(path: "config.toml"))
+    }
+
+    private func write(_ text: String, to url: URL) throws {
+        try Data(text.utf8).write(to: url, options: .atomic)
+    }
+
+    @Test("launch with a missing file silently resolves compiled defaults")
+    func missingLaunch() throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let store = KeyboardConfigStore(configURL: fixture.config)
+        store.loadAtLaunch()
+        #expect(store.keymap.generation == 1)
+        #expect(store.notice == nil)
+        #expect(store.diagnostics.isEmpty)
+        #expect(store.keymap.menuShortcuts[.toggleSidebar]
+            == KeyStroke(key: "b", modifiers: .command))
+    }
+
+    @Test("launch with a valid file publishes its complete keymap")
+    func validLaunch() throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        try write(#"""
+        [keyboard]
+        clear_default_keybindings = true
+        [keybindings]
+        "ctrl+b" = "view.toggle-sidebar"
+        """#, to: fixture.config)
+        let store = KeyboardConfigStore(configURL: fixture.config)
+        store.loadAtLaunch()
+        #expect(store.keymap.generation == 1)
+        #expect(store.keymap.menuShortcuts[.toggleSidebar]
+            == KeyStroke(key: "b", modifiers: .control))
+        #expect(store.notice == nil)
+    }
+
+    @Test("invalid launch config retains compiled defaults and one notice")
+    func invalidLaunch() throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        try write(#"""
+        [keybindings]
+        "cmd+c" = "data.refresh"
+        "cmd+shift+x" = "unknown.command"
+        """#, to: fixture.config)
+        let store = KeyboardConfigStore(configURL: fixture.config)
+        store.loadAtLaunch()
+        #expect(store.keymap.generation == 0)
+        #expect(store.keymap.menuShortcuts[.toggleSidebar]
+            == KeyStroke(key: "b", modifiers: .command))
+        #expect(store.notice?.message.contains("using default keybindings") == true)
+        #expect(store.diagnostics.count { $0.severity == .error } == 2)
+    }
+
+    @Test("successful reload swaps atomically, bumps generation, and clears notice")
+    func successfulReload() throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let store = KeyboardConfigStore(configURL: fixture.config)
+        store.loadAtLaunch()
+        try write(#"""
+        [keyboard]
+        clear_default_keybindings = true
+        [keybindings]
+        "ctrl+r" = "data.refresh"
+        """#, to: fixture.config)
+        store.reload()
+        #expect(store.keymap.generation == 2)
+        #expect(store.keymap.menuShortcuts[.refresh]
+            == KeyStroke(key: "r", modifiers: .control))
+        #expect(store.notice == nil)
+    }
+
+    @Test("failed reload retains the previous generation and exposes diagnostics once")
+    func failedReload() throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        try write(#"""
+        [keybindings]
+        "ctrl+r" = "data.refresh"
+        """#, to: fixture.config)
+        let store = KeyboardConfigStore(configURL: fixture.config)
+        store.loadAtLaunch()
+        let previousGeneration = store.keymap.generation
+        let previousShortcut = store.keymap.menuShortcuts[.refresh]
+
+        try write(#"""
+        [keyboard]
+        leader_timeout_ms = 0
+        mystery = true
+        """#, to: fixture.config)
+        store.reload()
+        #expect(store.keymap.generation == previousGeneration)
+        #expect(store.keymap.menuShortcuts[.refresh] == previousShortcut)
+        #expect(store.notice?.message.contains("keeping the previous keybindings") == true)
+        #expect(store.diagnostics.contains { $0.severity == .error && $0.line == 2 })
+        #expect(store.diagnostics.contains { $0.severity == .warning && $0.line == 3 })
+
+        store.dismissNotice()
+        #expect(store.notice == nil)
+    }
+
+    @Test("configuration location honors non-empty XDG_CONFIG_HOME")
+    func configLocation() {
+        let home = URL(fileURLWithPath: "/tmp/example-home")
+        #expect(KeyboardConfigStore.defaultConfigURL(
+            environment: ["XDG_CONFIG_HOME": "/tmp/xdg"],
+            homeDirectory: home
+        ).path == "/tmp/xdg/atc/config.toml")
+        #expect(KeyboardConfigStore.defaultConfigURL(
+            environment: ["XDG_CONFIG_HOME": "  "],
+            homeDirectory: home
+        ).path == "/tmp/example-home/.config/atc/config.toml")
+    }
+}

--- a/macos/ATCTests/KeyboardRouterTests.swift
+++ b/macos/ATCTests/KeyboardRouterTests.swift
@@ -1,0 +1,141 @@
+import Testing
+@testable import ATC
+
+@MainActor
+@Suite("Window keyboard router")
+struct KeyboardRouterTests {
+    private func keymap(_ config: String = "", generation: Int = 1) throws -> ResolvedKeymap {
+        try Keymap.resolve(
+            user: KeyboardConfigParser.parse(config),
+            generation: generation
+        ).get()
+    }
+
+    private func stroke(_ text: String) throws -> KeyStroke {
+        try KeyStroke.parse(text).get()
+    }
+
+    @Test("a direct hit executes once and consumes repeats")
+    func directAndRepeat() throws {
+        var executions: [CommandID] = []
+        let router = WindowKeyboardRouter(keymap: try keymap()) {
+            executions.append($0)
+            return .available
+        }
+        let refresh = try stroke("cmd+r")
+        #expect(router.handle(refresh, isRepeat: false))
+        #expect(router.handle(refresh, isRepeat: true))
+        #expect(executions == [.refresh])
+    }
+
+    @Test("unrelated strokes and idle escape forward unchanged")
+    func idleForwarding() throws {
+        let router = WindowKeyboardRouter(keymap: try keymap()) { _ in .available }
+        #expect(!router.handle(KeyStroke(key: "x", modifiers: []), isRepeat: false))
+        #expect(!router.handle(.escape, isRepeat: false))
+    }
+
+    @Test("leader activation pends and a continuation executes")
+    func leaderContinuation() throws {
+        var executions: [CommandID] = []
+        let router = WindowKeyboardRouter(keymap: try keymap()) {
+            executions.append($0)
+            return .available
+        }
+        #expect(router.handle(try stroke("cmd+k"), isRepeat: false))
+        #expect(router.pendingNode != nil)
+        #expect(router.handle(KeyStroke(key: "b", modifiers: []), isRepeat: false))
+        #expect(router.pendingNode == nil)
+        #expect(executions == [.toggleSidebar])
+    }
+
+    @Test("modified continuations are never retried against root")
+    func continuationDoesNotRetryRoot() throws {
+        var executions: [CommandID] = []
+        let map = try keymap(#"""
+        [keyboard]
+        clear_default_keybindings = true
+        [keybindings]
+        "cmd+shift+y" = "data.refresh"
+        "leader>x" = "view.toggle-sidebar"
+        """#)
+        let router = WindowKeyboardRouter(keymap: map) {
+            executions.append($0)
+            return .available
+        }
+        #expect(router.handle(try stroke("cmd+k"), isRepeat: false))
+        #expect(router.handle(try stroke("cmd+shift+y"), isRepeat: false))
+        #expect(executions.isEmpty)
+        #expect(router.flash?.message == "No matching command")
+        #expect(router.pendingNode == nil)
+    }
+
+    @Test("an unknown continuation is consumed, flashes, and returns idle")
+    func unknownContinuation() throws {
+        let router = WindowKeyboardRouter(keymap: try keymap()) { _ in .available }
+        #expect(router.handle(try stroke("cmd+k"), isRepeat: false))
+        #expect(router.handle(KeyStroke(key: "x", modifiers: []), isRepeat: false))
+        #expect(router.flash == RouterFlash(message: "No matching command"))
+        #expect(router.pendingNode == nil)
+    }
+
+    @Test("escape and focus loss cancel pending sequences silently")
+    func cancellation() throws {
+        let router = WindowKeyboardRouter(keymap: try keymap()) { _ in .available }
+        #expect(router.handle(try stroke("cmd+k"), isRepeat: false))
+        #expect(router.handle(.escape, isRepeat: false))
+        #expect(router.pendingNode == nil)
+        #expect(router.flash == nil)
+
+        #expect(router.handle(try stroke("cmd+k"), isRepeat: false))
+        router.cancel()
+        #expect(router.pendingNode == nil)
+        #expect(router.flash == nil)
+    }
+
+    @Test("only a timeout for the current generation cancels")
+    func timeoutGeneration() throws {
+        let router = WindowKeyboardRouter(
+            keymap: try keymap(generation: 7)
+        ) { _ in .available }
+        #expect(router.handle(try stroke("cmd+k"), isRepeat: false))
+        router.handleTimeout(generation: 6)
+        #expect(router.pendingNode != nil)
+        router.handleTimeout(generation: 7)
+        #expect(router.pendingNode == nil)
+    }
+
+    @Test("unavailable commands consume and surface their reason")
+    func unavailableCommand() throws {
+        var executions = 0
+        let reason = "Requires a configured Connection"
+        let router = WindowKeyboardRouter(keymap: try keymap()) { _ in
+            executions += 1
+            return .unavailable(reason: reason)
+        }
+        #expect(router.handle(try stroke("cmd+b"), isRepeat: false))
+        #expect(executions == 1)
+        #expect(router.flash == RouterFlash(message: reason))
+    }
+
+    @Test("replacing a keymap cancels pending before using the new tree")
+    func replacementCancelsPending() throws {
+        let router = WindowKeyboardRouter(
+            keymap: try keymap(generation: 1)
+        ) { _ in .available }
+        #expect(router.handle(try stroke("cmd+k"), isRepeat: false))
+        router.keymap = try keymap(generation: 2)
+        #expect(router.pendingNode == nil)
+    }
+
+    @Test("a configured leader with no surviving sequences forwards")
+    func unreservedLeader() throws {
+        let map = try keymap(#"""
+        [keyboard]
+        clear_default_keybindings = true
+        leader = "ctrl+j"
+        """#)
+        let router = WindowKeyboardRouter(keymap: map) { _ in .available }
+        #expect(!router.handle(try stroke("ctrl+j"), isRepeat: false))
+    }
+}

--- a/macos/ATCTests/KeyboardRouterTests.swift
+++ b/macos/ATCTests/KeyboardRouterTests.swift
@@ -79,6 +79,18 @@ struct KeyboardRouterTests {
         #expect(router.pendingNode == nil)
     }
 
+    @Test("a lingering flash clears when a new sequence starts")
+    func flashClearsOnNewSequence() throws {
+        let router = WindowKeyboardRouter(keymap: try keymap()) { _ in .available }
+        #expect(router.handle(try stroke("cmd+k"), isRepeat: false))
+        #expect(router.handle(KeyStroke(key: "x", modifiers: []), isRepeat: false))
+        #expect(router.flash != nil)
+
+        #expect(router.handle(try stroke("cmd+k"), isRepeat: false))
+        #expect(router.flash == nil)
+        #expect(router.pendingNode != nil)
+    }
+
     @Test("escape and focus loss cancel pending sequences silently")
     func cancellation() throws {
         let router = WindowKeyboardRouter(keymap: try keymap()) { _ in .available }

--- a/macos/ATCTests/KeymapResolutionTests.swift
+++ b/macos/ATCTests/KeymapResolutionTests.swift
@@ -1,0 +1,228 @@
+import Foundation
+import Testing
+@testable import ATC
+
+@Suite("Keyboard keymap resolution")
+struct KeymapResolutionTests {
+    private func resolve(_ config: String = "", generation: Int = 1) throws -> ResolvedKeymap {
+        try Keymap.resolve(
+            user: KeyboardConfigParser.parse(config),
+            generation: generation
+        ).get()
+    }
+
+    private func stroke(_ text: String) throws -> KeyStroke {
+        try KeyStroke.parse(text).get()
+    }
+
+    @Test("compiled defaults build the specified direct and leader tree")
+    func defaults() throws {
+        let keymap = try resolve()
+        #expect(keymap.generation == 1)
+        #expect(keymap.leaderTimeout == .milliseconds(1_800))
+        #expect(command(at: try stroke("cmd+b"), in: keymap) == .toggleSidebar)
+        #expect(command(at: try stroke("cmd+n"), in: keymap) == .newSession)
+        #expect(command(at: try stroke("cmd+r"), in: keymap) == .refresh)
+        #expect(command(at: try stroke("cmd+t"), in: keymap) == .newTerminal)
+        #expect(command(at: try stroke("cmd+shift+n"), in: keymap) == .newWorkspace)
+
+        let leader = try #require(prefix(at: try stroke("cmd+k"), in: keymap))
+        #expect(leader.count == 3)
+        #expect(command(in: leader[KeyStroke(key: "b", modifiers: [])]) == .toggleSidebar)
+        #expect(command(in: leader[KeyStroke(key: "n", modifiers: [])]) == .newSession)
+        #expect(command(in: leader[KeyStroke(key: "r", modifiers: [])]) == .refresh)
+    }
+
+    @Test("user entries replace, unbind, and can rebind defaults")
+    func layering() throws {
+        let replaced = try resolve(#"""
+        [keybindings]
+        "cmd+b" = "data.refresh"
+        "cmd+n" = "unbind"
+        "cmd+n" = "terminal.new"
+        """#)
+        #expect(command(at: try stroke("cmd+b"), in: replaced) == .refresh)
+        #expect(command(at: try stroke("cmd+n"), in: replaced) == .newTerminal)
+
+        let unbound = try resolve(#"""
+        [keybindings]
+        "cmd+b" = "unbind"
+        """#)
+        #expect(unbound.root[try stroke("cmd+b")] == nil)
+    }
+
+    @Test("clearing defaults leaves no leader reservation without sequences")
+    func clearDefaults() throws {
+        let keymap = try resolve(#"""
+        [keyboard]
+        clear_default_keybindings = true
+        """#)
+        #expect(keymap.root.isEmpty)
+        #expect(keymap.menuShortcuts.isEmpty)
+        #expect(keymap.root[try stroke("cmd+k")] == nil)
+    }
+
+    @Test("custom leaders expand all symbolic sequences")
+    func customLeader() throws {
+        let keymap = try resolve(#"""
+        [keyboard]
+        leader = "ctrl+j"
+        [keybindings]
+        "leader>x" = "project.new"
+        """#)
+        let node = try #require(prefix(at: try stroke("ctrl+j"), in: keymap))
+        #expect(command(in: node[KeyStroke(key: "x", modifiers: [])]) == .newProject)
+        #expect(keymap.root[try stroke("cmd+k")] == nil)
+    }
+
+    @Test("direct and expanded-prefix conflicts invalidate the candidate")
+    func prefixConflicts() throws {
+        let directConflict = Keymap.resolve(user: KeyboardConfigParser.parse(#"""
+        [keybindings]
+        "cmd+k" = "data.refresh"
+        """#))
+        let directDiagnostics = try failure(directConflict)
+        #expect(directDiagnostics.contains {
+            $0.message.contains("cmd+k") && $0.message.contains("both")
+        })
+
+        let expandedConflict = Keymap.resolve(user: KeyboardConfigParser.parse(#"""
+        [keyboard]
+        leader = "cmd+b"
+        """#))
+        let expandedDiagnostics = try failure(expandedConflict)
+        #expect(expandedDiagnostics.contains {
+            $0.message.contains("cmd+b") && $0.message.contains("unbind")
+        })
+    }
+
+    @Test("protected shortcuts and leaders name the native command")
+    func protectedShortcuts() throws {
+        let direct = Keymap.resolve(user: KeyboardConfigParser.parse(#"""
+        [keyboard]
+        clear_default_keybindings = true
+        [keybindings]
+        "cmd+c" = "data.refresh"
+        """#))
+        #expect(try failure(direct).contains {
+            $0.message.contains("cmd+c") && $0.message.contains("Copy")
+        })
+
+        let leader = Keymap.resolve(user: KeyboardConfigParser.parse(#"""
+        [keyboard]
+        clear_default_keybindings = true
+        leader = "cmd+q"
+        """#))
+        #expect(try failure(leader).contains {
+            $0.message.contains("cmd+q") && $0.message.contains("Quit")
+        })
+    }
+
+    @Test("unknown command ids invalidate the entire candidate")
+    func unknownCommand() throws {
+        let result = Keymap.resolve(user: KeyboardConfigParser.parse(#"""
+        [keybindings]
+        "cmd+shift+b" = "missing.command"
+        """#))
+        let diagnostics = try failure(result)
+        #expect(diagnostics.contains { $0.message.contains("missing.command") })
+    }
+
+    @Test("timeout must be a positive integer and defaults when omitted")
+    func timeoutValidation() throws {
+        #expect(try resolve().leaderTimeout == .milliseconds(1_800))
+        for value in ["0", "-1", "\"1800\""] {
+            let result = Keymap.resolve(user: KeyboardConfigParser.parse("""
+            [keyboard]
+            leader_timeout_ms = \(value)
+            """))
+            #expect(try failure(result).contains {
+                $0.message.contains("positive integer")
+            })
+        }
+        let floatResult = Keymap.resolve(user: KeyboardConfigParser.parse("""
+        [keyboard]
+        leader_timeout_ms = 1.5
+        """))
+        #expect(try failure(floatResult).contains { $0.message.contains("Floats") })
+    }
+
+    @Test("menu selection uses the latest remaining direct binding")
+    func menuSelection() throws {
+        let latest = try resolve(#"""
+        [keybindings]
+        "cmd+shift+b" = "view.toggle-sidebar"
+        "ctrl+b" = "view.toggle-sidebar"
+        """#)
+        let latestStroke = try stroke("ctrl+b")
+        #expect(latest.menuShortcuts[.toggleSidebar] == latestStroke)
+
+        let fallback = try resolve(#"""
+        [keybindings]
+        "cmd+shift+b" = "view.toggle-sidebar"
+        "ctrl+b" = "view.toggle-sidebar"
+        "ctrl+b" = "unbind"
+        """#)
+        let fallbackStroke = try stroke("cmd+shift+b")
+        #expect(fallback.menuShortcuts[.toggleSidebar] == fallbackStroke)
+    }
+
+    @Test("leader-only commands have no menu shortcut and commands may have many triggers")
+    func menuEligibility() throws {
+        let keymap = try resolve(#"""
+        [keyboard]
+        clear_default_keybindings = true
+        [keybindings]
+        "leader>p" = "project.new"
+        "cmd+b" = "data.refresh"
+        "ctrl+b" = "data.refresh"
+        """#)
+        #expect(keymap.menuShortcuts[.newProject] == nil)
+        let latestStroke = try stroke("ctrl+b")
+        #expect(keymap.menuShortcuts[.refresh] == latestStroke)
+        #expect(command(at: try stroke("cmd+b"), in: keymap) == .refresh)
+        #expect(command(at: try stroke("ctrl+b"), in: keymap) == .refresh)
+    }
+
+    @Test("one error prevents every otherwise-valid binding from publishing")
+    func atomicFailure() throws {
+        let result = Keymap.resolve(user: KeyboardConfigParser.parse(#"""
+        [keybindings]
+        "cmd+shift+b" = "data.refresh"
+        "cmd+shift+x" = "unknown"
+        """#))
+        if case .success = result {
+            Issue.record("Expected the complete candidate to fail")
+        }
+        #expect(try failure(result).count >= 1)
+    }
+
+    private func command(at stroke: KeyStroke, in keymap: ResolvedKeymap) -> CommandID? {
+        command(in: keymap.root[stroke])
+    }
+
+    private func command(in node: ResolvedKeymap.Node?) -> CommandID? {
+        guard case .command(let command) = node else { return nil }
+        return command
+    }
+
+    private func prefix(
+        at stroke: KeyStroke,
+        in keymap: ResolvedKeymap
+    ) -> [KeyStroke: ResolvedKeymap.Node]? {
+        guard case .prefix(let node) = keymap.root[stroke] else { return nil }
+        return node
+    }
+
+    private func failure(
+        _ result: Result<ResolvedKeymap, ConfigDiagnostics>
+    ) throws -> ConfigDiagnostics {
+        guard case .failure(let diagnostics) = result else {
+            Issue.record("Expected resolution failure")
+            throw TestFailure.expectedFailure
+        }
+        return diagnostics
+    }
+
+    private enum TestFailure: Error { case expectedFailure }
+}

--- a/macos/ATCTests/ShellHostingSmokeTest.swift
+++ b/macos/ATCTests/ShellHostingSmokeTest.swift
@@ -38,7 +38,7 @@ struct ShellHostingSmokeTest {
         let appModel = AppModel.preview()
         let runtime = try #require(appModel.runtimes.first)
         await waitForData(runtime)
-        host(RootView().environment(appModel).environment(WindowState.ephemeral()))
+        host(RootView(configStore: KeyboardConfigStore()).environment(appModel).environment(WindowState.ephemeral()))
     }
 
     @Test("root view hosts with data arriving after first render")
@@ -46,7 +46,7 @@ struct ShellHostingSmokeTest {
         // The app's real launch order: the window is up before the first
         // poll returns, then rows insert into the live List.
         let appModel = AppModel.preview()
-        host(RootView().environment(appModel).environment(WindowState.ephemeral()))
+        host(RootView(configStore: KeyboardConfigStore()).environment(appModel).environment(WindowState.ephemeral()))
     }
 
     @Test("root view hosts Workspace content inside the stable split view")
@@ -59,7 +59,7 @@ struct ShellHostingSmokeTest {
             WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser"),
             in: appModel
         ))
-        host(RootView().environment(appModel).environment(windowState))
+        host(RootView(configStore: KeyboardConfigStore()).environment(appModel).environment(windowState))
         #expect(windowState.activeWorkspace?.workspaceID == "wsp_parser")
         #expect(windowState.selectedContent != .dashboard)
     }
@@ -75,7 +75,7 @@ struct ShellHostingSmokeTest {
             in: appModel
         ))
         windowState.showDashboard()
-        host(RootView().environment(appModel).environment(windowState))
+        host(RootView(configStore: KeyboardConfigStore()).environment(appModel).environment(windowState))
         #expect(windowState.selectedContent == .dashboard)
         #expect(windowState.activeWorkspace != nil)
     }
@@ -96,7 +96,7 @@ struct ShellHostingSmokeTest {
             styleMask: [.titled], backing: .buffered, defer: false
         )
         window.contentView = NSHostingView(
-            rootView: RootView().environment(appModel).environment(windowState)
+            rootView: RootView(configStore: KeyboardConfigStore()).environment(appModel).environment(windowState)
         )
         window.orderFront(nil)
         pump(seconds: 0.5)
@@ -123,7 +123,7 @@ struct ShellHostingSmokeTest {
             WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_archived"),
             in: appModel
         ))
-        host(RootView().environment(appModel).environment(windowState))
+        host(RootView(configStore: KeyboardConfigStore()).environment(appModel).environment(windowState))
     }
 
     @Test("Navigator and Dashboard transitions retain the hosted terminal surface")
@@ -144,7 +144,7 @@ struct ShellHostingSmokeTest {
             styleMask: [.titled], backing: .buffered, defer: false
         )
         window.contentView = NSHostingView(
-            rootView: RootView().environment(appModel).environment(windowState)
+            rootView: RootView(configStore: KeyboardConfigStore()).environment(appModel).environment(windowState)
         )
         window.orderFront(nil)
 

--- a/macos/ATCTests/TriggerParsingTests.swift
+++ b/macos/ATCTests/TriggerParsingTests.swift
@@ -1,0 +1,69 @@
+import Testing
+@testable import ATC
+
+@Suite("Keyboard trigger parsing")
+struct TriggerParsingTests {
+    @Test("modifier aliases are case-insensitive and normalized")
+    func modifierAliases() throws {
+        let aliases = ["CMD+b", "Command+b", "SUPER+b"]
+        for alias in aliases {
+            let stroke = try #require(try? KeyStroke.parse(alias).get())
+            #expect(stroke == KeyStroke(key: "b", modifiers: .command))
+        }
+        #expect(try KeyStroke.parse("Control+B").get()
+            == KeyStroke(key: "b", modifiers: .control))
+        #expect(try KeyStroke.parse("ALT+B").get()
+            == KeyStroke(key: "b", modifiers: .option))
+    }
+
+    @Test("shift and multiple modifiers normalize independently of spelling")
+    func multipleModifiers() throws {
+        let stroke = try KeyStroke.parse(" shift + option + CMD + N ").get()
+        #expect(stroke.key == "n")
+        #expect(stroke.modifiers == [.command, .option, .shift])
+        #expect(stroke.description == "cmd+opt+shift+n")
+    }
+
+    @Test("sequence parsing reserves leader for step one")
+    func sequences() throws {
+        #expect(try ParsedKeySequence.parse("cmd+b").get()
+            == .direct(KeyStroke(key: "b", modifiers: .command)))
+        #expect(try ParsedKeySequence.parse(" leader > b ").get()
+            == .leader(continuation: KeyStroke(key: "b", modifiers: [])))
+        #expect(try ParsedKeySequence.parse("leader>cmd+shift+b").get()
+            == .leader(continuation: KeyStroke(
+                key: "b", modifiers: [.command, .shift]
+            )))
+    }
+
+    @Test("invalid direct triggers are rejected with actionable tokens")
+    func invalidDirectTriggers() {
+        let invalid = [
+            "b", "shift+b", "cmd+hyper+b", "cmd+cmd+b", "cmd+",
+            "cmd+return", "cmd+escape", "cmd+f12",
+        ]
+        for trigger in invalid {
+            guard case .failure(let error) = KeyStroke.parse(trigger) else {
+                Issue.record("Expected \(trigger) to fail")
+                continue
+            }
+            #expect(!error.message.isEmpty)
+        }
+    }
+
+    @Test("unsupported sequence shapes are rejected")
+    func invalidSequences() {
+        let invalid = [
+            "leader>a>b", "cmd+k>b", "x>leader", "leader>leader", "leader",
+        ]
+        for sequence in invalid {
+            #expect(ParsedKeySequence.parse(sequence).isFailure)
+        }
+    }
+}
+
+private extension Result {
+    var isFailure: Bool {
+        if case .failure = self { true } else { false }
+    }
+}

--- a/macos/CONTEXT.md
+++ b/macos/CONTEXT.md
@@ -56,5 +56,5 @@ The current viewed remote directory that atc will use as a session working direc
 _Avoid_: Selected file, selected row
 
 **Atelier Command Sequence**:
-A keyboard sequence that starts with `Cmd-K`, waits for one unmodified next key, and targets atc itself, including when a Terminal Session has focus.
+A keyboard sequence that starts with the configured leader key (`Cmd-K` by default), waits for one continuation key (modified or unmodified), and targets atc itself, including when a Terminal Session has focus.
 _Avoid_: Leader key, terminal prefix, command chord


### PR DESCRIPTION
Implements docs/keyboard-shortcuts-spec.md — the full configurable-shortcuts MVP from the keyboard-shortcuts brief.

## What's included

- **Command registry** (`CommandID`, `CommandRegistry`): the seven stable command identifiers with descriptors owning title, availability, and execution. Menus, the keyboard router, and future surfaces all execute through one path. Pure refactor of the old `AppCommands` closures — no behavior change.
- **Triggers and keymap** (`KeyStroke`, `Keymap`): Ghostty-style trigger parsing (`cmd+b`, `leader>b`), compiled defaults layered under user config, prefix-tree `ResolvedKeymap` with menu-shortcut selection (last eligible direct binding wins).
- **Configuration** (`KeyboardConfig`, `KeyboardConfigStore`): ordered, line-diagnostic TOML-subset parser for `~/.config/atc/config.toml` (`[keyboard]` + `[keybindings]`, `unbind`, `clear_default_keybindings`, leader + timeout). Invalid config never breaks the keymap: launch failures keep compiled defaults, reload failures keep the previous keymap, one dismissible notice either way.
- **Per-window routing** (`WindowKeyboardRouter`, `KeyboardMonitorHost`): a local NSEvent key-down monitor filtered to the key window resolves every registered binding before the Ghostty terminal can consume it. Leader sequences (`Cmd-K, B` etc.) with timeout, Esc cancel, and a non-modal Command Sequence hint HUD; sequence keystrokes never leak into the terminal. Idle path is one dictionary lookup.
- **Menu synchronization**: `AppCommands` is now a thin registry projection; shortcut labels derive from the resolved keymap and update on reload. Reload Configuration lives in the app menu.
- **Tests**: 7 new suites (trigger parsing, config parser, keymap resolution, router state machine, registry behavior/availability, store load/reload, NSEvent normalization).

## Process

Implementation was drafted by Codex (gpt-5.6-sol, high reasoning) against the spec, then adversarially reviewed by two independent reviewers. Neither found critical or major defects; the six minor findings were all addressed:

- Modified Esc (e.g. Shift-Esc) now cancels a pending sequence silently instead of flashing "No matching command" (normalization returns the bare escape stroke).
- A lingering flash no longer hides the hint of a sequence started within its 800 ms window.
- `KeyStroke.isPrintable` is shared between trigger parsing and event normalization instead of duplicated.
- Removed an unreachable modifier-rule validation loop in `Keymap.resolve` and a dead unknown-table guard in the parser.
- Removed the parameterless `RootView.init()` that silently created a second, unloaded config store; previews and hosting tests pass one explicitly.
- Added parser edge-case tests (unterminated string, missing `=`, top-level value) and regression tests for the two behavior fixes.

Also updates `macos/CONTEXT.md`'s Command Sequence definition per the spec's Resolved Decision 6 (continuations may be modified; leader is configurable).

## Testing

- `mise run macos:test`: 232 tests in 29 suites, all passing.
- Manual items from the spec's test plan (feel of held-key passthrough, menu labels after reload while a terminal has focus) still deserve a hands-on pass.