### PR TITLE
Make terminal focus ownership deterministic

### DIFF
--- a/macos/ATC/Features/Sessions/SessionContentView.swift
+++ b/macos/ATC/Features/Sessions/SessionContentView.swift
@@ -19,6 +19,7 @@ struct SessionContentView: View {
     @Environment(AppModel.self) private var appModel
     let selectedRef: SessionRef?
     let selectedSession: Session?
+    let terminalFocusRequest: UInt
     var emptyState: EmptyStateActions?
 
     @Environment(WindowState.self) private var windowState
@@ -37,7 +38,10 @@ struct SessionContentView: View {
                 Divider()
             }
             ZStack {
-                TerminalPane(visibleRef: selectedRef)
+                TerminalPane(
+                    visibleRef: selectedRef,
+                    focusRequest: terminalFocusRequest
+                )
                 cover
             }
         }

--- a/macos/ATC/Features/Terminal/TerminalHostView.swift
+++ b/macos/ATC/Features/Terminal/TerminalHostView.swift
@@ -1,6 +1,9 @@
 import AppKit
+import OSLog
 import SwiftUI
 import GhosttyTerminal
+
+private let logger = Logger(subsystem: "ElevenIdeas.atc", category: "terminal")
 
 /// The one view that hosts a Ghostty surface. Each retained terminal owns an
 /// AppKit container so focus can be transferred directly between the actual
@@ -75,8 +78,12 @@ final class TerminalContainerView: NSView {
         if controllerID != newControllerID {
             controllerID = newControllerID
             hostingView.rootView = TerminalSurfaceView(context: controller.viewState)
+            // A replaced controller brings a fresh surface; treat it as a
+            // first appearance so a visible terminal regains focus.
+            wasVisible = false
         }
 
+        let becameHidden = wasVisible && !isVisible
         let shouldFocus = isVisible && (!wasVisible || lastFocusRequest != focusRequest)
         wasVisible = isVisible
         lastFocusRequest = focusRequest
@@ -85,7 +92,10 @@ final class TerminalContainerView: NSView {
 
         if !isVisible {
             cancelPendingFocus()
-            scheduleTerminalFocusResignation()
+            // Only the visible→hidden transition can leave this terminal as
+            // the stale first responder; steady-state hidden updates would
+            // just schedule no-op timers.
+            if becameHidden { scheduleTerminalFocusResignation() }
         } else if shouldFocus {
             focusResignTimer?.invalidate()
             focusResignTimer = nil
@@ -156,6 +166,9 @@ final class TerminalContainerView: NSView {
         guard focusAttempt < Self.focusRetryLimit else {
             wantsFocus = false
             focusRetryTimer = nil
+            logger.error(
+                "Abandoned terminal focus transfer after \(Self.focusRetryLimit) attempts; the surface never produced an input view"
+            )
             return
         }
         schedulePendingFocus()
@@ -182,11 +195,12 @@ final class TerminalContainerView: NSView {
         RunLoop.main.add(timer, forMode: .common)
     }
 
-    /// `TerminalSurfaceView` intentionally keeps its AppKit view internal.
-    /// This hosting hierarchy contains only that surface, so its sole
-    /// first-responder descendant is the terminal input view.
+    /// This hosting hierarchy contains exactly one Ghostty surface. Matching
+    /// its concrete input view type (rather than any first-responder-capable
+    /// view) keeps the transfer correct even if SwiftUI hosting or the
+    /// surface ever grows other focusable descendants.
     private func terminalInputView() -> NSView? {
-        hostingView.firstDescendant { $0.acceptsFirstResponder }
+        hostingView.firstDescendant { $0 is TerminalView }
     }
 }
 

--- a/macos/ATC/Features/Terminal/TerminalHostView.swift
+++ b/macos/ATC/Features/Terminal/TerminalHostView.swift
@@ -1,16 +1,203 @@
+import AppKit
 import SwiftUI
 import GhosttyTerminal
 
-/// The one view that hosts a Ghostty surface. Keeping the GhosttyTerminal
-/// dependency contained here (plus the controller/bridge) keeps a future
-/// swap to a source-built GhosttyKit cheap.
-struct TerminalHostView: View {
-    let ref: SessionRef
+/// The one view that hosts a Ghostty surface. Each retained terminal owns an
+/// AppKit container so focus can be transferred directly between the actual
+/// terminal input views without shared SwiftUI focus state.
+struct TerminalHostView: NSViewRepresentable {
     let controller: TerminalSessionController
-    var focus: FocusState<SessionRef?>.Binding
+    let isVisible: Bool
+    let focusRequest: UInt
 
-    var body: some View {
-        TerminalSurfaceView(context: controller.viewState)
-            .terminalFocused(focus, equals: ref)
+    func makeNSView(context: Context) -> TerminalContainerView {
+        TerminalContainerView(controller: controller)
+    }
+
+    func updateNSView(_ view: TerminalContainerView, context: Context) {
+        view.update(
+            controller: controller,
+            isVisible: isVisible,
+            focusRequest: focusRequest
+        )
+    }
+
+    static func dismantleNSView(_ view: TerminalContainerView, coordinator: ()) {
+        view.tearDown()
+    }
+}
+
+/// Owns exactly one Ghostty view hierarchy. Scoping the first-responder lookup
+/// to this container prevents one retained terminal from focusing another.
+final class TerminalContainerView: NSView {
+    private static let focusRetryDelay = 0.01
+    private static let focusRetryLimit = 100
+
+    private let hostingView: NSHostingView<TerminalSurfaceView>
+    private var wasVisible = false
+    private var lastFocusRequest: UInt?
+    private var focusRetryTimer: Timer?
+    private var focusResignTimer: Timer?
+    private var focusAttempt = 0
+    private var wantsFocus = false
+    private var controllerID: ObjectIdentifier
+    private var acceptsPointerInput = false
+
+    init(controller: TerminalSessionController) {
+        hostingView = NSHostingView(
+            rootView: TerminalSurfaceView(context: controller.viewState)
+        )
+        controllerID = ObjectIdentifier(controller)
+        super.init(frame: .zero)
+        alphaValue = 0
+
+        hostingView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(hostingView)
+        NSLayoutConstraint.activate([
+            hostingView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            hostingView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            hostingView.topAnchor.constraint(equalTo: topAnchor),
+            hostingView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func update(
+        controller: TerminalSessionController,
+        isVisible: Bool,
+        focusRequest: UInt
+    ) {
+        let newControllerID = ObjectIdentifier(controller)
+        if controllerID != newControllerID {
+            controllerID = newControllerID
+            hostingView.rootView = TerminalSurfaceView(context: controller.viewState)
+        }
+
+        let shouldFocus = isVisible && (!wasVisible || lastFocusRequest != focusRequest)
+        wasVisible = isVisible
+        lastFocusRequest = focusRequest
+        acceptsPointerInput = isVisible
+        alphaValue = isVisible ? 1 : 0
+
+        if !isVisible {
+            cancelPendingFocus()
+            scheduleTerminalFocusResignation()
+        } else if shouldFocus {
+            focusResignTimer?.invalidate()
+            focusResignTimer = nil
+            // Visibility and focus are intentionally ordered in the same
+            // AppKit update. The transparent retained views remain mounted,
+            // so switching back never waits for SwiftUI to rebuild Ghostty.
+            requestTerminalFocus()
+        }
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard acceptsPointerInput else { return nil }
+        return super.hitTest(point)
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if wantsFocus { schedulePendingFocus() }
+    }
+
+    private func requestTerminalFocus() {
+        wantsFocus = true
+        focusAttempt = 0
+        schedulePendingFocus()
+    }
+
+    private func cancelPendingFocus() {
+        wantsFocus = false
+        focusRetryTimer?.invalidate()
+        focusRetryTimer = nil
+    }
+
+    private func schedulePendingFocus() {
+        guard wantsFocus else { return }
+        focusRetryTimer?.invalidate()
+        let timer = Timer(timeInterval: Self.focusRetryDelay, repeats: false) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.applyPendingFocus()
+            }
+        }
+        focusRetryTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
+    }
+
+    private func applyPendingFocus() {
+        guard wantsFocus else { return }
+        hostingView.layoutSubtreeIfNeeded()
+
+        guard let window, let terminalView = terminalInputView() else {
+            retryPendingFocus()
+            return
+        }
+
+        if window.firstResponder === terminalView || window.makeFirstResponder(terminalView) {
+            wantsFocus = false
+            focusRetryTimer = nil
+        } else {
+            retryPendingFocus()
+        }
+    }
+
+    /// SwiftUI can materialize the hosted AppKit terminal a few run-loop
+    /// turns after this representable becomes visible. Keep the request
+    /// alive until that concrete input view exists, with a bounded retry so
+    /// a broken hierarchy cannot schedule work indefinitely.
+    private func retryPendingFocus() {
+        focusAttempt += 1
+        guard focusAttempt < Self.focusRetryLimit else {
+            wantsFocus = false
+            focusRetryTimer = nil
+            return
+        }
+        schedulePendingFocus()
+    }
+
+    func tearDown() {
+        cancelPendingFocus()
+        scheduleTerminalFocusResignation()
+    }
+
+    private func scheduleTerminalFocusResignation() {
+        focusResignTimer?.invalidate()
+        guard let window, let terminalView = terminalInputView() else { return }
+        let timer = Timer(timeInterval: Self.focusRetryDelay, repeats: false) {
+            [weak window, weak terminalView] _ in
+            MainActor.assumeIsolated {
+                guard let window, let terminalView,
+                      window.firstResponder === terminalView
+                else { return }
+                window.makeFirstResponder(nil)
+            }
+        }
+        focusResignTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
+    }
+
+    /// `TerminalSurfaceView` intentionally keeps its AppKit view internal.
+    /// This hosting hierarchy contains only that surface, so its sole
+    /// first-responder descendant is the terminal input view.
+    private func terminalInputView() -> NSView? {
+        hostingView.firstDescendant { $0.acceptsFirstResponder }
+    }
+}
+
+private extension NSView {
+    func firstDescendant(matching predicate: (NSView) -> Bool) -> NSView? {
+        for subview in subviews {
+            if predicate(subview) { return subview }
+            if let match = subview.firstDescendant(matching: predicate) {
+                return match
+            }
+        }
+        return nil
     }
 }

--- a/macos/ATC/Features/Terminal/TerminalHostView.swift
+++ b/macos/ATC/Features/Terminal/TerminalHostView.swift
@@ -5,11 +5,12 @@ import GhosttyTerminal
 /// dependency contained here (plus the controller/bridge) keeps a future
 /// swap to a source-built GhosttyKit cheap.
 struct TerminalHostView: View {
+    let ref: SessionRef
     let controller: TerminalSessionController
-    var focus: FocusState<String?>.Binding
+    var focus: FocusState<SessionRef?>.Binding
 
     var body: some View {
         TerminalSurfaceView(context: controller.viewState)
-            .terminalFocused(focus, equals: controller.sessionID)
+            .terminalFocused(focus, equals: ref)
     }
 }

--- a/macos/ATC/Features/Terminal/TerminalPane.swift
+++ b/macos/ATC/Features/Terminal/TerminalPane.swift
@@ -6,7 +6,8 @@ import SwiftUI
 struct TerminalPane: View {
     @Environment(AppModel.self) private var appModel
     let visibleRef: SessionRef?
-    @FocusState private var focusedTerminal: String?
+    let focusRequest: UInt
+    @FocusState private var focusedTerminal: SessionRef?
 
     var body: some View {
         ZStack {
@@ -15,15 +16,28 @@ struct TerminalPane: View {
             Color(red: 0.117, green: 0.117, blue: 0.180)
             ForEach(refs, id: \.self) { ref in
                 if let controller = appModel.terminals[ref] {
-                    TerminalHostView(controller: controller, focus: $focusedTerminal)
+                    TerminalHostView(
+                        ref: ref,
+                        controller: controller,
+                        focus: $focusedTerminal
+                    )
                         .opacity(ref == visibleRef ? 1 : 0)
                         .allowsHitTesting(ref == visibleRef)
                 }
             }
         }
-        .onChange(of: visibleRef, initial: true) {
-            focusedTerminal = visibleRef?.sessionID
+        .onChange(of: focusTarget, initial: true) {
+            focusedTerminal = focusTarget.ref
         }
+    }
+
+    /// Includes attachment availability so a just-created or explicitly
+    /// reconnected controller gets focus as soon as its surface exists.
+    private var focusTarget: TerminalFocusTarget {
+        TerminalFocusTarget(
+            ref: visibleRef.flatMap { appModel.terminals[$0] == nil ? nil : $0 },
+            request: focusRequest
+        )
     }
 
     private var refs: [SessionRef] {
@@ -31,6 +45,11 @@ struct TerminalPane: View {
             ($0.sessionID, $0.connectionID.uuidString) < ($1.sessionID, $1.connectionID.uuidString)
         }
     }
+}
+
+private struct TerminalFocusTarget: Equatable {
+    let ref: SessionRef?
+    let request: UInt
 }
 
 /// Phase-driven banner shown over the terminal.

--- a/macos/ATC/Features/Terminal/TerminalPane.swift
+++ b/macos/ATC/Features/Terminal/TerminalPane.swift
@@ -7,7 +7,6 @@ struct TerminalPane: View {
     @Environment(AppModel.self) private var appModel
     let visibleRef: SessionRef?
     let focusRequest: UInt
-    @FocusState private var focusedTerminal: SessionRef?
 
     var body: some View {
         ZStack {
@@ -17,27 +16,13 @@ struct TerminalPane: View {
             ForEach(refs, id: \.self) { ref in
                 if let controller = appModel.terminals[ref] {
                     TerminalHostView(
-                        ref: ref,
                         controller: controller,
-                        focus: $focusedTerminal
+                        isVisible: ref == visibleRef,
+                        focusRequest: focusRequest
                     )
-                        .opacity(ref == visibleRef ? 1 : 0)
-                        .allowsHitTesting(ref == visibleRef)
                 }
             }
         }
-        .onChange(of: focusTarget, initial: true) {
-            focusedTerminal = focusTarget.ref
-        }
-    }
-
-    /// Includes attachment availability so a just-created or explicitly
-    /// reconnected controller gets focus as soon as its surface exists.
-    private var focusTarget: TerminalFocusTarget {
-        TerminalFocusTarget(
-            ref: visibleRef.flatMap { appModel.terminals[$0] == nil ? nil : $0 },
-            request: focusRequest
-        )
     }
 
     private var refs: [SessionRef] {
@@ -45,11 +30,6 @@ struct TerminalPane: View {
             ($0.sessionID, $0.connectionID.uuidString) < ($1.sessionID, $1.connectionID.uuidString)
         }
     }
-}
-
-private struct TerminalFocusTarget: Equatable {
-    let ref: SessionRef?
-    let request: UInt
 }
 
 /// Phase-driven banner shown over the terminal.

--- a/macos/ATC/RootView.swift
+++ b/macos/ATC/RootView.swift
@@ -65,7 +65,9 @@ struct RootView: View {
                 _ = windowState.activateWorkspace(ref, in: appModel)
             }
         }
-        .sheet(item: $windowState.startSessionKind) { kind in
+        .sheet(item: $windowState.startSessionKind, onDismiss: {
+            windowState.requestTerminalFocus()
+        }) { kind in
             if let ref = windowState.activeWorkspace {
                 StartWorkspaceSessionSheet(kind: kind, workspaceRef: ref) { newRef in
                     _ = windowState.selectSession(newRef, in: appModel)
@@ -82,6 +84,7 @@ struct RootView: View {
             SessionContentView(
                 selectedRef: visibleSessionRef,
                 selectedSession: visibleSession,
+                terminalFocusRequest: windowState.terminalFocusRequest,
                 emptyState: workspaceEmptyActions
             )
             if windowState.selectedContent == .dashboard {

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -41,6 +41,11 @@ final class WindowState {
     var createWorkspaceContext: CreateWorkspaceContext?
     var startSessionKind: StartSessionKind?
 
+    /// Advances for every explicit request to type in the selected Terminal
+    /// Session. Unlike `selectedSession`, this also changes when the user
+    /// re-selects the same sidebar row.
+    private(set) var terminalFocusRequest: UInt = 0
+
     @ObservationIgnored private let selectionMemory: WorkspaceSelectionMemory
     @ObservationIgnored private var pendingRestore: WorkspaceRef?
 
@@ -127,7 +132,15 @@ final class WindowState {
         } else {
             appModel.touchTerminal(ref)
         }
+        requestTerminalFocus()
         return true
+    }
+
+    /// Reasserts terminal focus after transient UI (notably a creation
+    /// sheet) has finished handing first-responder ownership back.
+    func requestTerminalFocus() {
+        guard selectedSession != nil else { return }
+        terminalFocusRequest &+= 1
     }
 
     func showDashboard() {

--- a/macos/ATCTests/PickerHostingSmokeTest.swift
+++ b/macos/ATCTests/PickerHostingSmokeTest.swift
@@ -8,10 +8,6 @@ import ATCAPI
 /// actually lays out — catches row-diff crashes previews can't attribute.
 @Suite("RemoteFolderPickerSheet hosting smoke")
 struct PickerHostingSmokeTest {
-    private func pump(seconds: TimeInterval) {
-        RunLoop.main.run(until: Date(timeIntervalSinceNow: seconds))
-    }
-
     @Test("sheet hosts, loads default directory without crashing")
     func hostAndNavigate() async throws {
         let sheet = RemoteFolderPickerSheet(client: MockATCClient()) { _ in }

--- a/macos/ATCTests/ProjectUIHostingSmokeTest.swift
+++ b/macos/ATCTests/ProjectUIHostingSmokeTest.swift
@@ -9,10 +9,6 @@ import ATCAPI
 /// previews can't attribute (same rationale as PickerHostingSmokeTest).
 @Suite("Dashboard and sheet hosting smoke")
 struct ProjectUIHostingSmokeTest {
-    private func pump(seconds: TimeInterval) {
-        RunLoop.main.run(until: Date(timeIntervalSinceNow: seconds))
-    }
-
     private func host(_ view: some View, width: CGFloat = 460, height: CGFloat = 480) {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: width, height: height),

--- a/macos/ATCTests/SettingsHostingSmokeTest.swift
+++ b/macos/ATCTests/SettingsHostingSmokeTest.swift
@@ -8,10 +8,6 @@ import ATCAPI
 /// catching crashes previews can't attribute.
 @Suite("Settings UI hosting smoke")
 struct SettingsHostingSmokeTest {
-    private func pump(seconds: TimeInterval) {
-        RunLoop.main.run(until: Date(timeIntervalSinceNow: seconds))
-    }
-
     private func host(_ view: some View, width: CGFloat = 720, height: CGFloat = 500) {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: width, height: height),

--- a/macos/ATCTests/ShellHostingSmokeTest.swift
+++ b/macos/ATCTests/ShellHostingSmokeTest.swift
@@ -9,10 +9,6 @@ import ATCAPI
 /// warnings surface under a controlled model instead of live user state.
 @Suite("Shell hosting smoke")
 struct ShellHostingSmokeTest {
-    private func pump(seconds: TimeInterval) {
-        RunLoop.main.run(until: Date(timeIntervalSinceNow: seconds))
-    }
-
     private func host(_ view: some View) {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 900, height: 600),
@@ -186,27 +182,30 @@ struct ShellHostingSmokeTest {
                 .environment(windowState)
         )
         window.makeKeyAndOrderFront(nil)
-        pump(seconds: 0.5)
 
+        // Condition-based waits: the focus transfer retries for up to a
+        // second while SwiftUI materializes the surface, so fixed pumps
+        // shorter than that budget would flake on a slow machine.
         let first = try #require(appModel.terminals[firstRef])
+        pump(until: { first.viewState.isFocused })
         #expect(first.viewState.isFocused)
 
         #expect(windowState.selectSession(secondRef, in: appModel))
-        pump(seconds: 0.5)
         let second = try #require(appModel.terminals[secondRef])
+        pump(until: { second.viewState.isFocused && !first.viewState.isFocused })
         #expect(!first.viewState.isFocused)
         #expect(second.viewState.isFocused)
 
         #expect(windowState.selectSession(firstRef, in: appModel))
-        pump(seconds: 0.5)
+        pump(until: { first.viewState.isFocused && !second.viewState.isFocused })
         #expect(first.viewState.isFocused)
         #expect(!second.viewState.isFocused)
 
         window.makeFirstResponder(nil)
-        pump(seconds: 0.1)
+        pump(until: { !first.viewState.isFocused })
         #expect(!first.viewState.isFocused)
         #expect(windowState.selectSession(firstRef, in: appModel))
-        pump(seconds: 0.5)
+        pump(until: { first.viewState.isFocused })
         #expect(first.viewState.isFocused)
         #expect(!second.viewState.isFocused)
         window.orderOut(nil)

--- a/macos/ATCTests/ShellHostingSmokeTest.swift
+++ b/macos/ATCTests/ShellHostingSmokeTest.swift
@@ -163,4 +163,52 @@ struct ShellHostingSmokeTest {
         #expect(!windowState.hasInspectorTarget(in: appModel))
         window.orderOut(nil)
     }
+
+    @Test("Session selection moves first-responder focus between terminal surfaces")
+    func sessionSelectionMovesTerminalFocus() async throws {
+        let appModel = AppModel.preview()
+        let runtime = try #require(appModel.runtimes.first)
+        await waitForData(runtime)
+        let windowState = WindowState.ephemeral()
+        let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
+        let firstRef = SessionRef(connectionID: runtime.id, sessionID: "ses_running")
+        let secondRef = SessionRef(connectionID: runtime.id, sessionID: "ses_shell")
+        #expect(windowState.activateWorkspace(workspace, in: appModel))
+        #expect(windowState.selectSession(firstRef, in: appModel))
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 900, height: 600),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        window.contentView = NSHostingView(
+            rootView: RootView(configStore: KeyboardConfigStore())
+                .environment(appModel)
+                .environment(windowState)
+        )
+        window.makeKeyAndOrderFront(nil)
+        pump(seconds: 0.5)
+
+        let first = try #require(appModel.terminals[firstRef])
+        #expect(first.viewState.isFocused)
+
+        #expect(windowState.selectSession(secondRef, in: appModel))
+        pump(seconds: 0.5)
+        let second = try #require(appModel.terminals[secondRef])
+        #expect(!first.viewState.isFocused)
+        #expect(second.viewState.isFocused)
+
+        #expect(windowState.selectSession(firstRef, in: appModel))
+        pump(seconds: 0.5)
+        #expect(first.viewState.isFocused)
+        #expect(!second.viewState.isFocused)
+
+        window.makeFirstResponder(nil)
+        pump(seconds: 0.1)
+        #expect(!first.viewState.isFocused)
+        #expect(windowState.selectSession(firstRef, in: appModel))
+        pump(seconds: 0.5)
+        #expect(first.viewState.isFocused)
+        #expect(!second.viewState.isFocused)
+        window.orderOut(nil)
+    }
 }

--- a/macos/ATCTests/TestSupport.swift
+++ b/macos/ATCTests/TestSupport.swift
@@ -1,5 +1,25 @@
+import AppKit
 import Foundation
 @testable import ATC
+
+/// Pumps the main run loop for a fixed duration so hosted SwiftUI/AppKit
+/// hierarchies can process layout, timers, and focus changes.
+@MainActor
+func pump(seconds: TimeInterval) {
+    RunLoop.main.run(until: Date(timeIntervalSinceNow: seconds))
+}
+
+/// Pumps the main run loop in short slices until `condition` holds or
+/// `timeout` elapses. Prefer this over a fixed pump when waiting on
+/// asynchronous work such as focus transfer: it outlasts a slow CI machine
+/// without slowing the common case.
+@MainActor
+func pump(until condition: () -> Bool, timeout: TimeInterval = 2) {
+    let deadline = Date(timeIntervalSinceNow: timeout)
+    while !condition(), Date() < deadline {
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.02))
+    }
+}
 
 extension WindowState {
     /// A WindowState whose selection memory lives in an ephemeral defaults

--- a/macos/ATCTests/WorkspaceFlowTests.swift
+++ b/macos/ATCTests/WorkspaceFlowTests.swift
@@ -71,6 +71,42 @@ struct WorkspaceFlowTests {
         #expect(state.isInspectorPresented)
     }
 
+    @Test("selecting and reselecting a Session requests terminal focus")
+    func sessionSelectionRequestsTerminalFocus() async throws {
+        let (model, runtime) = try await makeLoadedModel()
+        let state = WindowState.ephemeral()
+        let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
+        let session = SessionRef(connectionID: runtime.id, sessionID: "ses_running")
+        #expect(state.activateWorkspace(workspace, in: model))
+
+        #expect(state.terminalFocusRequest == 0)
+        #expect(state.selectSession(session, in: model))
+        let firstRequest = state.terminalFocusRequest
+        #expect(firstRequest > 0)
+
+        #expect(state.selectSession(session, in: model))
+        #expect(state.terminalFocusRequest > firstRequest)
+    }
+
+    @Test("dismissed transient UI can re-request focus for the selected Session")
+    func selectedSessionCanRequestFocusAgain() async throws {
+        let (model, runtime) = try await makeLoadedModel()
+        let state = WindowState.ephemeral()
+        #expect(state.activateWorkspace(
+            WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser"),
+            in: model
+        ))
+        #expect(state.selectSession(
+            SessionRef(connectionID: runtime.id, sessionID: "ses_running"),
+            in: model
+        ))
+        let selectionRequest = state.terminalFocusRequest
+
+        state.requestTerminalFocus()
+
+        #expect(state.terminalFocusRequest > selectionRequest)
+    }
+
     @Test("Dashboard preserves Active Workspace, Navigator, and command availability")
     func dashboardPreservesWorkspaceContext() async throws {
         let (model, runtime) = try await makeLoadedModel()


### PR DESCRIPTION
## Summary

- focus a newly created Session or Terminal as soon as its creation sheet closes
- transfer AppKit first-responder ownership whenever a Session or Terminal is selected or reselected
- keep retained background terminal surfaces mounted while preventing them from receiving pointer or keyboard input
- add integration coverage for initial focus, switching in both directions, and restoring focus after it is lost

## Root cause

Retained Ghostty surfaces shared a SwiftUI focus binding. Focus and resignation callbacks from different surfaces could race, allowing a previously selected terminal to remain the first responder after navigation.

Each retained terminal now owns an isolated AppKit container that locates its concrete Ghostty input view and transfers first-responder ownership directly. Focus requests are retried for a bounded period while SwiftUI materializes the hosted AppKit surface.

Closes DEV-39.

## Validation

- `CI=true mise run check`
- 235 macOS tests across 29 suites passed
- server and kit checks passed