### PR TITLE
Add the Command Palette

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,7 +26,19 @@ _Avoid_: Files Navigator, File browser Navigator
 
 **Workspace Switcher**:
 The toolbar control that identifies the Active Workspace as `Project › Workspace` and opens the app-wide Workspace selection menu. Its status indicator reflects the Active Workspace's Connection.
-_Avoid_: Workspace picker, Project picker, Breadcrumb
+_Avoid_: Project picker, Breadcrumb
+
+**Workspace Picker**:
+The keyboard-driven selection surface for finding and activating a Workspace from anywhere in a window. It is separate from the toolbar Workspace Switcher even though both change the Active Workspace.
+_Avoid_: Workspace Switcher, Workspace search
+
+**Keyboard Shortcut**:
+A one-step key binding that directly invokes an atc command, such as `Cmd-B`.
+_Avoid_: Command Sequence, key chord
+
+**Command Sequence**:
+A two-step atc interaction that begins with the configured leader and invokes a command after a continuation key, such as `Cmd-K, B`. A Command Sequence is not a Keyboard Shortcut.
+_Avoid_: Keyboard Shortcut, key chord, terminal prefix
 
 **Dashboard**:
 The app-wide main-content destination for viewing and managing work across Connections, Projects, and Workspaces. Showing the Dashboard does not clear the Active Workspace or change the selected Navigator.

--- a/docs/command-palette-plan.md
+++ b/docs/command-palette-plan.md
@@ -1,0 +1,270 @@
+# Command Palette Plan
+
+Status: Specified in [command-palette-spec.md](command-palette-spec.md);
+that spec's Resolved Decisions record the deltas from this draft.
+
+Related: [command-palette-spec.md](command-palette-spec.md),
+[keyboard-shortcuts-plan.md](keyboard-shortcuts-plan.md),
+[keyboard-shortcuts-spec.md](keyboard-shortcuts-spec.md), and
+[keyboard-shortcut-reference-plan.md](keyboard-shortcut-reference-plan.md).
+
+## Summary
+
+Add a small, Ghostty-style Command Palette to the macOS app. The palette is a
+flat, searchable list of actions from atc's existing command registry. It opens
+with `Shift-Cmd-P`, executes one command, and dismisses.
+
+This plan covers only the Command Palette. Workspace, Session, Agent Action,
+file, symbol, task, source-control, and mixed-result pickers are separate future
+features and are not architectural inputs to this implementation.
+
+## Reference
+
+Follow Ghostty's macOS Command Palette unless an existing atc command or focus
+boundary requires a small deliberate difference.
+
+Reference implementation:
+
+- [Ghostty `CommandPaletteView`](https://github.com/ghostty-org/ghostty/blob/main/macos/Sources/Features/Command%20Palette/CommandPalette.swift)
+- [Ghostty terminal integration](https://github.com/ghostty-org/ghostty/blob/main/macos/Sources/Features/Command%20Palette/TerminalCommandPalette.swift)
+
+The useful Ghostty shape is:
+
+- One in-window SwiftUI overlay.
+- One flat array of command options.
+- Local query, selection, and hover state.
+- Simple title filtering with highlighted matches.
+- Direct Keyboard Shortcut symbols on the trailing edge.
+- Arrow-key, Return, Escape, and pointer interaction.
+- Dismissal before command execution.
+- Focus restoration to the terminal after dismissal.
+
+atc keeps its existing `CommandRegistry`, `CommandAvailability`, resolved
+keymap, and terminal-safe keyboard router rather than copying Ghostty's action
+model.
+
+## Goals
+
+- Let users discover and execute atc commands without leaving the keyboard.
+- Work while an embedded Ghostty terminal has focus.
+- Reuse the same command identifiers, titles, availability, and execution paths
+  as menus, toolbar controls, Keyboard Shortcuts, and Command Sequences.
+- Display the current resolved direct Keyboard Shortcut where one exists.
+- Keep the implementation small enough to understand in one pass.
+- Preserve normal terminal input whenever the palette is closed.
+
+## Non-Goals
+
+- A reusable picker framework or provider protocol.
+- Workspace, Session, Agent Action, file, symbol, task, source-control, or
+  mixed-result search.
+- Launching another picker from the Command Palette.
+- Picker stacks, provider switching, back buttons, prefixes, or query handoff.
+- Fuzzy scoring, typo correction, ranking weights, ranking fixtures, or an
+  external matching dependency.
+- Command history, usage ranking, recency, personalization, previews, or
+  persisted palette state.
+- A graphical keybinding editor.
+- Displaying Command Sequences as Keyboard Shortcuts.
+- Server, API contract, ATCKit, or GhosttyTerminal changes.
+
+## Existing Foundation
+
+The keyboard-shortcut implementation already provides the required seams:
+
+- `CommandID` identifies each command.
+- `CommandRegistry` owns titles, availability, and execution.
+- `CommandContext` supplies the current `AppModel`, `WindowState`, and keyboard
+  configuration.
+- `ResolvedKeymap.menuShortcuts` supplies the one resolved direct Keyboard
+  Shortcut already selected for native-menu display.
+- `WindowKeyboardRouter` handles registered shortcuts before the embedded
+  terminal consumes them.
+- `CommandFeedbackOverlay` already renders brief command feedback; expose one
+  small router method so the palette can present an unavailable-command reason
+  through the same path.
+
+The palette extends these seams rather than creating a second command system.
+
+## Command Catalog
+
+Extend `CommandDescriptor` with only the presentation metadata required by the
+palette and Keyboard Shortcuts reference:
+
+- A broad `CommandCategory`.
+- Whether the command is eligible for the Command Palette.
+
+Use these initial categories:
+
+1. General.
+2. Projects & Workspaces.
+3. Sessions & Terminals.
+4. View.
+
+Add deterministic command enumeration to `CommandRegistry`. Registry tests must
+verify that every `CommandID` has exactly one descriptor, identifiers are
+unique, titles are nonempty, and enumeration order is stable.
+
+The palette includes every palette-eligible command even when it has a familiar
+shortcut. Toggle Sidebar therefore remains discoverable despite its `Cmd-B`
+default. The `view.toggle-command-palette` opener itself is not
+palette-eligible because executing it from the open palette would only close
+the palette. Commands whose only purpose is opening another focused picker are
+also not palette-eligible. The opener gets a View-menu item like every other
+registered command, so the palette and its shortcut stay discoverable from the
+menu bar.
+
+## Presentation
+
+Mirror Ghostty's compact presentation:
+
+- Render an upper-center overlay inside the active atc window.
+- Keep the terminal and current content mounted behind it.
+- Use a compact material-backed surface with rounded corners, border, and
+  shadow.
+- Target a maximum width of roughly 500 points and a result-list height of
+  roughly 200 points; adapt down for smaller windows.
+- Do not add a separate window, `NSPanel`, sheet, popover, or modal scrim.
+- Use one transparent outside-click layer to dismiss and consume the initiating
+  click. This is a deliberate atc difference because content behind the palette
+  includes navigation controls, not only a terminal surface.
+- Place a plain query field at the top with an action-oriented placeholder such
+  as `Execute a command…`.
+- Render one flat result list. Do not group rows by category.
+
+Each row contains:
+
+- Command title.
+- The resolved direct Keyboard Shortcut on the trailing edge, when present.
+- Dimmed treatment and the existing availability reason when unavailable.
+
+Command Sequences never appear as shortcut labels. A command bound only through
+a Command Sequence has no trailing shortcut in the palette.
+
+## Matching and Ordering
+
+Use the same deliberately small matching behavior as Ghostty:
+
+1. Try a case-insensitive substring match against the command title.
+2. If that fails, match the query against the first letters of title words.
+3. Return the matching character positions for highlighting.
+4. Exclude commands that do not match.
+
+Do not calculate scores or reorder matches by perceived quality. Empty and
+filtered results preserve one deterministic alphabetical title order, with the
+stable command identifier breaking ties.
+
+Put the matcher in a small UI-independent atc type. The Keyboard Shortcuts
+reference may reuse it for filtering, but the matcher does not become a generic
+search framework.
+
+## Interaction
+
+- `Shift-Cmd-P` toggles the palette: it opens with the query field focused,
+  and a second press dismisses.
+- Do not ship a compiled Command Sequence for opening the palette.
+- Typing filters the list.
+- Up and Down move selection and wrap at the list boundaries.
+- `Control-P` and `Control-N` mirror Ghostty's previous/next movement as aliases
+  of the same selection actions.
+- With an empty query, no row is selected until the user moves selection.
+- Typing a nonempty query selects the first matching row.
+- Return executes the selected available command.
+- Return with no selected row dismisses without executing anything.
+- Escape dismisses.
+- Clicking an available row executes it; clicking an unavailable row selects
+  it and shows its reason.
+- Clicking outside dismisses and consumes that click; it does not activate
+  content behind the palette.
+- App or window deactivation dismisses the palette; do not preserve its query
+  or introduce a suspended state.
+- Dismissal clears the query for the next opening.
+
+For an available result, dismiss the palette before calling
+`CommandRegistry.execute`. For an unavailable result, keep the palette open and
+show the existing registry-owned availability reason through the current
+command feedback path.
+
+## State and Integration
+
+Add one per-window presentation Boolean to `WindowState`. Keep query, selected
+row, and hover state local to `CommandPaletteView`.
+
+Do not add a picker coordinator, provider protocol, candidate framework,
+type-erased payload, generic action model, loading state, error state, async
+stream, cancellation generation, or background search task.
+
+Overlay `CommandPaletteView` at the existing stable window root. While it is
+visible, its query field owns text and navigation input, and palette keystrokes
+must not reach the terminal. When it dismisses, restore the previous first
+responder when still valid, with the selected terminal as the practical
+fallback. Do not create a generalized focus coordinator.
+
+## Accessibility
+
+- Give the overlay and query field clear accessible names.
+- Expose command title, availability, reason, and direct Keyboard Shortcut to
+  assistive technology.
+- Provide spoken shortcut labels rather than only glyphs.
+- Keep match highlighting supplemental; the full title remains readable.
+- Support keyboard and pointer operation.
+- Respect Reduce Motion and increased contrast without adding custom animation
+  machinery.
+
+## Testing
+
+### Unit Tests
+
+- Registry enumeration is complete, unique, and deterministic.
+- Palette eligibility excludes the palette opener.
+- Substring matching is case-insensitive.
+- Word-initial matching handles representative atc command titles.
+- Nonmatches are excluded and match positions are correct.
+- Alphabetical order and identifier tie-breaking are stable.
+- Direct Keyboard Shortcuts appear; Command Sequences do not.
+- Availability is evaluated against the current `CommandContext`.
+
+### Presentation and Manual Checks
+
+- Open with `Shift-Cmd-P` while Ghostty has focus.
+- Confirm the query receives focus and input never reaches the terminal.
+- Dismiss with Escape, outside click, app deactivation, and Return with no
+  selection.
+- Confirm an outside click does not activate underlying navigation or terminal
+  content.
+- Execute with Return and pointer selection.
+- Confirm available commands execute exactly once after dismissal.
+- Confirm unavailable commands keep the palette open and show their reason.
+- Confirm dismissal restores terminal focus when the terminal was previously
+  focused.
+- Confirm remapping or unbinding a direct shortcut updates the open palette.
+- Verify VoiceOver labels, increased contrast, and Reduce Motion.
+
+## Implementation Sequence
+
+1. Extend command descriptors with category and palette eligibility, add stable
+   enumeration, and add registry tests.
+2. Add the small matcher and its focused tests.
+3. Implement `CommandPaletteView` and its result rows using local state.
+4. Add `view.toggle-command-palette`, the `cmd+shift+p` compiled binding, the
+   View-menu item, and the per-window presentation Boolean.
+5. Overlay the palette at the window root, verify terminal-safe input and focus
+   restoration, and complete the manual checks.
+
+This is one vertical feature. It does not establish an abstraction that future
+pickers must adopt.
+
+## Success Criteria
+
+- `Shift-Cmd-P` opens a compact Command Palette from any main-window focus,
+  including the embedded terminal.
+- Users can filter and execute every palette-eligible registered command.
+- Direct Keyboard Shortcuts are accurate; Command Sequences are never presented
+  as shortcuts.
+- Unavailable commands remain visible and explain why they cannot run.
+- Query and navigation input never leak into the terminal.
+- Selection dismisses before executing and commands run exactly once.
+- Escape, outside click, app deactivation, and empty Return dismiss cleanly.
+- Terminal focus is restored after dismissal when appropriate.
+- The implementation adds no external search dependency or speculative picker
+  framework.

--- a/docs/command-palette-spec.md
+++ b/docs/command-palette-spec.md
@@ -1,0 +1,575 @@
+# Command Palette Implementation Spec
+
+Status: Draft v1 — reconciled against the current `macos/` sources
+
+Scope: the Command Palette described in
+[command-palette-plan.md](command-palette-plan.md) — a flat, searchable,
+Ghostty-style overlay over the existing command registry. All work lands in
+`macos/`; no server, ATCKit, or GhosttyTerminal package change is required.
+This is one vertical feature: no picker framework, provider protocol, or
+generic search infrastructure is introduced.
+
+Related: [command-palette-plan.md](command-palette-plan.md) (the brief this
+spec implements), [keyboard-shortcuts-spec.md](keyboard-shortcuts-spec.md)
+(the registry, keymap, and router this feature extends),
+[keyboard-shortcut-reference-plan.md](keyboard-shortcut-reference-plan.md)
+(the future second consumer of `CommandCategory` and the matcher),
+`macos/CONTEXT.md` (terminology — a Command Sequence is not a Keyboard
+Shortcut and never appears as one).
+
+Reference implementation, followed unless an atc seam requires a deliberate
+difference (each difference is recorded in Resolved Decisions):
+
+- [Ghostty `CommandPaletteView`](https://github.com/ghostty-org/ghostty/blob/main/macos/Sources/Features/Command%20Palette/CommandPalette.swift)
+- [Ghostty terminal integration](https://github.com/ghostty-org/ghostty/blob/main/macos/Sources/Features/Command%20Palette/TerminalCommandPalette.swift)
+
+## 1. Module Layout
+
+New feature folder (file-system synchronized groups pick the files up
+without project edits):
+
+```text
+macos/ATC/Features/CommandPalette/
+├── CommandPaletteView.swift     — overlay chrome, query field, rows, local state
+├── CommandPaletteContent.swift  — pure row projection: eligibility, match, order
+└── QueryMatcher.swift           — substring / word-initial matcher (UI-independent)
+```
+
+Changed files, all small:
+
+- `Commands/CommandID.swift` — one new case.
+- `Commands/CommandRegistry.swift` — `CommandCategory`, descriptor metadata,
+  stable enumeration, the new descriptor.
+- `Commands/Keymap.swift` — one new compiled default binding.
+- `Commands/WindowKeyboardRouter.swift` — suspension check and a public
+  unavailable-reason flash method.
+- `Commands/KeyboardMonitorHost.swift` — `KeyboardRoutingContainer` mounts the
+  palette overlay and wires suspension; the coordinator gains a deactivation
+  callback.
+- `Commands/KeyStroke.swift` — `spokenDescription` for assistive technology.
+- `WindowState.swift` — one presentation Boolean and one sheet-presence
+  computed property.
+- `AppCommands.swift` — one View-menu item.
+
+`QueryMatcher` stays with the feature until the Keyboard Shortcuts reference
+becomes its second consumer; its API is already UI- and `CommandID`-independent
+so that move is a file relocation, not a rewrite.
+
+## 2. Command Catalog
+
+### Category and palette eligibility
+
+`CommandDescriptor` gains exactly the presentation metadata the palette and
+the future Keyboard Shortcuts reference need — nothing else:
+
+```swift
+enum CommandCategory: CaseIterable, Sendable {
+    case general              // "General"
+    case projectsAndWorkspaces // "Projects & Workspaces"
+    case sessionsAndTerminals  // "Sessions & Terminals"
+    case view                  // "View"
+
+    var title: String
+}
+
+@MainActor
+struct CommandDescriptor {
+    let id: CommandID
+    let title: String
+    let category: CommandCategory
+    var isPaletteEligible = true
+    let availability: (CommandContext) -> CommandAvailability
+    let perform: (CommandContext) -> Void
+}
+```
+
+`CommandCategory` declaration order is the stable presentation order for
+grouped surfaces. The palette itself renders one flat list and ignores
+grouping; the category ships now so menus, the palette, and the reference
+window never invent competing organization schemes.
+
+| Command | Category | Palette-eligible |
+|---|---|---|
+| `view.toggle-sidebar` | View | yes |
+| `view.toggle-command-palette` | View | **no** — executing it from the open palette would only close the palette |
+| `session.new` | Sessions & Terminals | yes |
+| `terminal.new` | Sessions & Terminals | yes |
+| `project.new` | Projects & Workspaces | yes |
+| `workspace.new` | Projects & Workspaces | yes |
+| `data.refresh` | General | yes |
+| `configuration.reload` | General | yes |
+
+Every eligible command appears even when it has a familiar shortcut — Toggle
+Sidebar stays discoverable despite `Cmd-B`.
+
+### Stable enumeration
+
+```swift
+@MainActor
+enum CommandRegistry {
+    static var allDescriptors: [CommandDescriptor] {
+        CommandID.allCases.map(descriptor(for:))
+    }
+    // descriptor(for:) and execute(_:context:) unchanged
+}
+```
+
+Enumeration order is `CommandID.allCases` declaration order and therefore
+stable across launches. Registry tests pin completeness (every `CommandID`
+yields a descriptor whose `id` matches), identifier uniqueness, nonempty
+titles, and stable order (§9).
+
+### The opener command
+
+```swift
+case toggleCommandPalette = "view.toggle-command-palette"
+```
+
+| Field | Value |
+|---|---|
+| Title | `Toggle Command Palette` |
+| Category | View |
+| Palette-eligible | No |
+| Perform | `windowState.isCommandPalettePresented.toggle()` |
+| Availability | `.unavailable(reason: "Not available while a dialog is open")` while `windowState.isSheetPresented`; otherwise available |
+
+`WindowState.isSheetPresented` is a computed property over the three existing
+sheet drivers (`isCreateProjectPresented`, `createWorkspaceContext != nil`,
+`startSessionKind != nil`). The guard exists because menu key equivalents
+fire even while a sheet is the key window (keyboard-shortcuts-spec §7); a
+palette presented underneath a sheet could neither take focus nor dismiss
+itself. The router path never encounters this case — a sheet is its own key
+window, so the monitor is already out of the path.
+
+Compiled default, added to `Keymap.compiledDefaults`:
+
+```swift
+("cmd+shift+p", .toggleCommandPalette),
+```
+
+No compiled Command Sequence is shipped for the palette (per the brief).
+`cmd+shift+p` conflicts with no protected trigger and no existing default;
+users can rebind or unbind it in `[keybindings]` like any other command.
+
+Menu item: `AppCommands` adds `commandButton(.toggleCommandPalette)` to the
+existing `CommandGroup(after: .sidebar)`, after Refresh and before the
+divider. This gives the command the same menu home every other registered
+command has, shows the resolved shortcut in the menu bar, and — because menu
+equivalents remain live while the router is suspended (§7) — is the mechanism
+that makes a second `Shift-Cmd-P` close the open palette.
+
+## 3. QueryMatcher
+
+One small UI-independent type; deliberately not a search framework:
+
+```swift
+struct QueryMatch: Equatable {
+    /// Ranges within the matched title, for supplemental highlighting.
+    let ranges: [Range<String.Index>]
+}
+
+enum QueryMatcher {
+    static func match(_ query: String, in title: String) -> QueryMatch?
+}
+```
+
+Behavior, in order:
+
+1. Trim whitespace from the query. An empty trimmed query matches every
+   title with no highlight ranges.
+2. **Substring**: `title.range(of: trimmed, options: .caseInsensitive)` —
+   on a hit, return that single range.
+3. **Word-initial**: split the title into words — maximal runs of
+   alphanumeric characters, so `New Project…` yields `["New", "Project"]`
+   and punctuation never becomes a word. Lowercase each word's first
+   character to form the initials string (`"np"`). If the initials string
+   contains the lowercased trimmed query as a substring, return one
+   single-character range per matched word's first character.
+4. Otherwise return `nil`; the command is excluded from results.
+
+No scores, no reordering by match quality, no typo tolerance, no external
+dependency. Matching is deterministic for a given query and title.
+
+## 4. Row Projection (`CommandPaletteContent`)
+
+A pure `@MainActor` function the view calls from `body`, so SwiftUI
+observation of `AppModel`, `WindowState`, and the keymap re-evaluates rows
+automatically (live availability changes and config reloads update the open
+palette without extra machinery):
+
+```swift
+struct CommandPaletteRow: Identifiable {
+    let id: CommandID
+    let title: String
+    let matchedRanges: [Range<String.Index>]
+    let shortcut: KeyStroke?              // keymap.menuShortcuts[id]
+    let availability: CommandAvailability
+}
+
+@MainActor
+enum CommandPaletteContent {
+    static func rows(
+        query: String,
+        keymap: ResolvedKeymap,
+        context: CommandContext
+    ) -> [CommandPaletteRow]
+}
+```
+
+Rules:
+
+- Start from `CommandRegistry.allDescriptors`, keeping only
+  `isPaletteEligible` descriptors.
+- Apply `QueryMatcher`; drop nonmatches.
+- Order alphabetically by lowercased title (plain Unicode comparison, not
+  locale-dependent), breaking ties with the raw `CommandID` value. The same
+  order holds for the empty query and every filtered result.
+- `shortcut` comes from `keymap.menuShortcuts` only. That map is built solely
+  from direct bindings, so a command bound only through a Command Sequence
+  gets `nil` and shows no trailing shortcut — Command Sequences are never
+  presented as Keyboard Shortcuts.
+- `availability` is the descriptor's closure evaluated against the current
+  `CommandContext` at projection time. Unavailable commands stay in the list.
+
+## 5. Presentation
+
+### State
+
+`WindowState` gains one per-window Boolean:
+
+```swift
+var isCommandPalettePresented = false
+```
+
+Query text, selected row, and hover state are `@State` local to
+`CommandPaletteView`. The overlay is mounted conditionally
+(`if windowState.isCommandPalettePresented`), so dismissal destroys the view
+identity and every next opening starts with a cleared query and no selection —
+no explicit reset code and no suspended state.
+
+### Placement
+
+`KeyboardRoutingContainer` (the existing stable window root) mounts the
+palette between the content and the feedback overlay, so router flashes stay
+visible above the open palette:
+
+```swift
+content
+    .overlay {
+        if windowState.isCommandPalettePresented { CommandPaletteView() }
+    }
+    .overlay { CommandFeedbackOverlay() }
+```
+
+No separate window, `NSPanel`, sheet, popover, or modal scrim. The terminal
+and current content stay mounted behind the overlay.
+
+### Layout
+
+- Upper-center: top-aligned with a fixed ~48 pt top inset below the toolbar
+  edge.
+- One transparent full-window layer behind the panel
+  (`Color.clear.contentShape(Rectangle())` with a tap gesture) dismisses and
+  consumes the initiating click, so the click never activates navigation or
+  terminal content behind the palette. This is the deliberate atc difference
+  from Ghostty: content behind the palette includes navigation controls, not
+  only a terminal surface.
+- Panel: material background (`.regularMaterial`), rounded corners
+  (~10–12 pt), hairline border stroke, shadow. Maximum width 500 pt, adapting
+  down with ~20 pt side margins in smaller windows.
+- A plain borderless query field at the top with placeholder
+  `Execute a command…`, then a divider, then the result list.
+- Result list: one flat scrollable list, maximum height ~200 pt, shrinking to
+  fit fewer rows; no category grouping, no section headers. The selected row
+  is kept scrolled into view (`ScrollViewReader`).
+- Empty result set (nonempty query, no matches): a single non-interactive
+  secondary-styled `No matching commands` label in the list area.
+
+### Rows
+
+Each row renders:
+
+- The command title, with matched ranges emphasized (e.g. bold or primary
+  color). Highlighting is supplemental — the full title stays readable.
+- The resolved direct Keyboard Shortcut from `row.shortcut` on the trailing
+  edge as `KeyStroke.displayDescription` glyphs, when present.
+- Unavailable commands: dimmed treatment (mirroring
+  `CommandSequenceHintView`'s secondary style and reduced opacity) with the
+  registry-owned reason inline in tertiary text.
+- Selection: prominent background highlight. Hover: a lighter highlight that
+  never moves keyboard selection.
+
+Reduce Motion and increased contrast are respected by using system materials,
+semantic colors, and default (or no) transitions — no custom animation
+machinery.
+
+## 6. Interaction
+
+Selection is tracked by `CommandID`, not index. On every query change the
+selection resets: first matching row for a nonempty query, no selection for
+an empty query.
+
+| Input | Behavior |
+|---|---|
+| Typing | Filters the list; selection resets per the rule above |
+| Down / `Control-N` | Next row, wrapping at the end; with no selection, selects the first row |
+| Up / `Control-P` | Previous row, wrapping at the start; with no selection, selects the last row |
+| Return, available row selected | Dismiss, then execute (below) |
+| Return, unavailable row selected | Keep the palette open; flash the reason via the router (below) |
+| Return, no selection | Dismiss without executing |
+| Escape | Dismiss |
+| Click on an available row | Same as selecting it and pressing Return: dismiss, then execute |
+| Click on an unavailable row | Selects it and flashes its reason; stays open |
+| Pointer hover | Visual highlight only |
+| Click outside the panel | Dismiss; the click is consumed |
+| Window resigns key / app deactivates | Dismiss (query is not preserved) |
+| `Shift-Cmd-P` (the resolved opener binding) | Dismisses via the menu key equivalent (§7) |
+
+Keys are handled in SwiftUI on the focused query field: `.onSubmit` for
+Return, `.onKeyPress` for Up/Down/Escape and `Control-P`/`Control-N`. The
+control-modified presses must move selection without inserting control
+characters into the query; the palette root also carries `.onExitCommand` as
+an Escape backstop if focus ever leaves the field while the palette is open.
+
+### Execution
+
+For an available command:
+
+1. Set `isCommandPalettePresented = false` (dismissal first).
+2. Call `CommandRegistry.execute(id, context:)` synchronously in the same
+   MainActor turn.
+
+One code path serves Return and click, so a command executes exactly once per
+activation. Dismissing first means a command that presents a sheet or moves
+focus never fights the open palette.
+
+For an unavailable command, the palette stays open and the reason surfaces
+through the existing feedback path. `WindowKeyboardRouter` exposes its
+private flash as one small public method:
+
+```swift
+func showUnavailable(reason: String)   // wraps the existing showFlash(_:)
+```
+
+The palette calls it with the row's availability reason;
+`CommandFeedbackOverlay` renders it exactly as it renders an unavailable
+binding fired from the keyboard.
+
+## 7. Input Routing and Focus
+
+### Router suspension
+
+The `NSEvent` local monitor sees every key-down in the key window before the
+responder chain, so without a check the router would keep executing
+registered bindings (and swallowing them) while the palette is open. The
+suspension lives on the router so it is unit-testable without `NSEvent`:
+
+```swift
+// WindowKeyboardRouter
+@ObservationIgnored var isSuspended: @MainActor () -> Bool = { false }
+
+func handle(_ stroke: KeyStroke, isRepeat: Bool) -> Bool {
+    guard !isSuspended() else { return false }   // forward untouched
+    ...
+}
+```
+
+`KeyboardRoutingContainer` wires `router.isSuspended = {
+windowState.isCommandPalettePresented }` and cancels any pending Command
+Sequence when the palette presents (reachable only via the menu item while a
+sequence is pending, but cheap to make deterministic):
+
+```swift
+.onChange(of: windowState.isCommandPalettePresented) { _, presented in
+    if presented { router.cancel() }
+}
+```
+
+Consequences while the palette is open, all deliberate:
+
+- Unmodified typing, arrows, Return, and Escape forward through the monitor
+  to the responder chain and land in the focused query field.
+- Registered bindings are not routed; native menu key equivalents still
+  apply, which is standard macOS text-field behavior and matches Ghostty.
+  In particular the opener's own menu equivalent fires, executes
+  `toggleCommandPalette`, and closes the palette — the toggle needs no
+  second dispatch path. A binding like `Cmd-N` may likewise fire through its
+  menu item; if it presents a sheet, the window resigns key and the palette
+  dismisses cleanly.
+- Nothing reaches the terminal: the terminal view is not first responder
+  while the palette owns focus, and the responder handoff below closes the
+  presentation race.
+
+### Focus transfer and restoration
+
+`CommandPaletteView` hosts a minimal `NSViewRepresentable` window accessor
+(no generalized focus coordinator):
+
+- **On attach to the window**: capture `window.firstResponder` weakly, then
+  immediately `window.makeFirstResponder(nil)` so no keystroke can reach the
+  terminal in the gap before SwiftUI focuses the query field; then request
+  field focus via `@FocusState`.
+- **On dismissal**: if the captured responder is still valid (same window,
+  still in the view hierarchy, accepts first responder), restore it;
+  otherwise fall back to `windowState.requestTerminalFocus()` — the existing
+  seam sheets already use, a no-op when no Terminal Session is selected. If
+  teardown ordering proves to steal focus back after restoration (verified in
+  build step 5), defer the restoration by one runloop turn rather than adding
+  machinery.
+
+### Deactivation dismissal
+
+`KeyboardMonitorHost.Coordinator` already observes
+`NSWindow.didResignKeyNotification` (host window) and
+`NSApplication.didResignActiveNotification` to cancel pending sequences. It
+gains one callback, `var onDeactivate: (() -> Void)?`, invoked from both
+handlers; `KeyboardRoutingContainer` sets it to clear
+`isCommandPalettePresented`. One observation site keeps sheet presentation,
+window switching, and app switching all dismissing the palette through the
+same path.
+
+### Invariants
+
+- Palette closed: routing, Command Sequences, and terminal input behave
+  exactly as today; the suspension check is one closure call on the
+  hot path.
+- Palette open: no palette keystroke — query text, navigation, Return,
+  Escape — is ever delivered to the terminal.
+- A command activated from the palette executes exactly once, after
+  dismissal.
+
+## 8. Accessibility
+
+- The panel is an accessibility container named `Command Palette` with
+  `.isModal` so assistive technology stays within it while open.
+- The query field has an accessible label (`Command query`) in addition to
+  its placeholder.
+- Each row's accessibility label combines the full title (highlighting is
+  visual-only), availability (`Unavailable — <reason>` when applicable), and
+  the shortcut via a new `KeyStroke.spokenDescription` — e.g.
+  `Shift Command P`, modifiers in `⌃⌥⇧⌘` order, then the uppercased key —
+  so VoiceOver never reads bare glyphs.
+- Rows are reachable and activatable by keyboard and pointer; selection state
+  is exposed with `.isSelected`.
+- Reduce Motion and increased contrast per §5 (system materials and semantic
+  colors, no custom animation).
+
+## 9. Test Plan
+
+All in `macos/ATCTests` (Swift Testing), reusing the `CommandRegistryTests` /
+`WorkspaceFlowTests` fixture pattern. Projection, matcher, and router logic
+are pure enough to run without a window server.
+
+**CommandRegistryTests (extended)** — enumeration covers every `CommandID`
+with matching ids; ids unique; titles nonempty; enumeration order equals
+declaration order; category assignments match §2's table; palette
+eligibility excludes exactly `toggleCommandPalette`; opener perform toggles
+the Boolean both directions; opener availability is unavailable with the §2
+reason while each sheet driver is active and available otherwise.
+
+**QueryMatcherTests** — empty and whitespace-only queries match with no
+ranges; case-insensitive substring with correct range (`sid` →
+`Toggle Sidebar`); word-initial hits on representative titles (`np` →
+`New Project…`, `nt` → `New Terminal`, `ts` → `Toggle Sidebar`, `rc` →
+`Reload Configuration`); punctuation never forms a word; substring wins over
+word-initial when both apply; nonmatches return `nil`; returned ranges
+identify the exact matched characters.
+
+**CommandPaletteContentTests** — ineligible commands never appear;
+alphabetical order with identifier tie-breaking is stable for empty and
+filtered queries; nonmatches are excluded; `shortcut` reflects
+`menuShortcuts` (rebinds and unbinds change it; a keymap where a command is
+bound only via `leader>x` yields `nil`); availability rows match fixtures
+configured available and unavailable.
+
+**KeymapResolutionTests (extended)** — compiled defaults resolve
+`cmd+shift+p` → `toggleCommandPalette` in both the routing tree and
+`menuShortcuts`; the binding can be rebound and unbound by user config.
+
+**KeyboardRouterTests (extended)** — with `isSuspended` returning true, a
+registered direct binding is forwarded (returns `false`) and executes
+nothing; the same stroke routes again once unsuspended; `showUnavailable`
+sets and auto-clears the flash like an unavailable binding.
+
+**CommandPaletteHostingSmokeTest** — hosts `CommandPaletteView` with preview
+fixtures (pattern of `ShellHostingSmokeTest`) to catch layout and environment
+crashes.
+
+**Manual checks** (build step 5 exit list):
+
+- Open with `Shift-Cmd-P` while the embedded Ghostty terminal has focus; the
+  query field takes focus and no keystroke reaches the terminal, including
+  fast typing immediately after opening.
+- View menu shows `Toggle Command Palette` with the resolved shortcut; the
+  item opens and closes the palette; a second `Shift-Cmd-P` closes it.
+- Dismiss with Escape, outside click, app deactivation, and Return with no
+  selection; the outside click activates nothing behind the palette; the
+  query is cleared on the next opening.
+- Execute via Return and via click; commands run exactly once, after
+  dismissal.
+- Unavailable commands render dimmed with their reason, and activating one
+  keeps the palette open and flashes the reason.
+- Dismissal restores terminal focus when the terminal was previously focused,
+  and restores a non-terminal responder (e.g. the sidebar) when that was
+  focused.
+- Remapping or unbinding `cmd+shift+p` and reloading configuration updates
+  both opening behavior and the open palette's trailing shortcuts.
+- The opener menu item is disabled while a creation sheet is open.
+- VoiceOver reads container, query field, and rows with spoken shortcuts;
+  verify increased contrast and Reduce Motion.
+
+## 10. Build Order
+
+Each step lands green (`mise run macos:test`) with a `jj` checkpoint.
+
+1. **Catalog metadata** — `CommandCategory`, `isPaletteEligible`,
+   `allDescriptors`, extended registry tests. Pure metadata; no behavior
+   change.
+2. **Matcher** — `QueryMatcher` with its full test suite.
+3. **Palette view** — `CommandPaletteContent` projection and
+   `CommandPaletteView` with local state, plus content tests and the hosting
+   smoke test. Not yet mounted.
+4. **Command and binding** — `toggleCommandPalette` id + descriptor,
+   `WindowState.isCommandPalettePresented` and `isSheetPresented`, the
+   `cmd+shift+p` compiled default, the View-menu item, router
+   `isSuspended`/`showUnavailable`, keymap and router test extensions.
+5. **Integration** — mount the overlay in `KeyboardRoutingContainer`, wire
+   suspension, pending-sequence cancellation, focus capture/transfer/restore,
+   and deactivation dismissal; run the manual checklist.
+
+## Resolved Decisions
+
+Differences from and clarifications to the brief, recorded per its
+instruction; the brief has been updated to match.
+
+1. **Command id `view.toggle-command-palette`, not
+   `navigation.show-command-palette`.** Raw values are permanent config API.
+   Every existing id lives in an established namespace (`view.`, `session.`,
+   `terminal.`, `project.`, `workspace.`, `data.`, `configuration.`), and the
+   palette is a view-layer presentation command exactly like
+   `view.toggle-sidebar`; minting a one-command `navigation.` namespace adds
+   a second spelling convention for no benefit. `toggle` (not `show`)
+   because the command genuinely toggles (decision 3), matching both its
+   sibling `view.toggle-sidebar` and Ghostty's `toggle_command_palette`.
+2. **A View-menu item is added.** The brief was silent on menus. Every other
+   registered command has a menu home; the item costs one `commandButton`
+   line, makes the palette discoverable and its shortcut visible, and — with
+   the router suspended while the palette is open — its key equivalent is
+   what lets `Shift-Cmd-P` close the palette without a second dispatch path.
+3. **The opener toggles.** Pressing `Shift-Cmd-P` with the palette open
+   closes it instead of doing nothing. It remains palette-ineligible.
+4. **Clicking an available row executes it.** The brief's interaction list
+   said clicking only selects, but its own manual checks required "execute
+   with … pointer selection", and click-to-execute is the universal palette
+   convention (Ghostty, VS Code). Clicking an unavailable row selects it and
+   shows its reason.
+5. **Router suspension is a router-level check**, not monitor logic, so the
+   forward-while-open guarantee is unit-testable; menu key equivalents
+   staying live while the palette is open is documented, deliberate, and
+   native behavior.
+6. **The opener is unavailable while a sheet is presented**, because menu
+   equivalents fire even when a sheet is the key window and a palette opened
+   under a sheet could neither focus nor dismiss.
+7. **Small presentation additions**: a `No matching commands` empty-state
+   label, and matcher words defined as maximal alphanumeric runs so
+   punctuation (`…`, `&`) never breaks word-initial matching.

--- a/docs/keyboard-shortcut-reference-plan.md
+++ b/docs/keyboard-shortcut-reference-plan.md
@@ -9,7 +9,7 @@ Related: [DEV-46](https://linear.app/elevenideas/issue/DEV-46/keyboard-shortcut-
 ## Purpose
 
 Give people a searchable, always-current reference for every configured atc
-keyboard shortcut without taking space from the terminal, competing with
+Keyboard Shortcut without taking space from the terminal, competing with
 Session Details, or duplicating keybinding configuration in the UI.
 
 ## Confirmed Decisions
@@ -20,8 +20,8 @@ Session Details, or duplicating keybinding configuration in the UI.
 - Use native SwiftUI window, menu, search, list, section, and empty-state
   behavior. The Linear screenshot is inspiration for content, not a layout
   requirement.
-- Provide fuzzy search and group the unfiltered and filtered results under
-  meaningful headings.
+- Provide simple searchable filtering and group the unfiltered and filtered
+  results under meaningful headings.
 
 ## Recommended Experience
 
@@ -35,18 +35,20 @@ Session Details, or duplicating keybinding configuration in the UI.
   behavior supplied by `UtilityWindow`.
 - A native search field receives focus when the window opens. Below it, a
   sectioned `List` shows command titles on the leading edge and their resolved
-  direct shortcuts or Command Sequences on the trailing edge.
-- A command with multiple configured bindings appears once with all of its
-  bindings. A two-step Command Sequence renders as two distinct key groups in
-  execution order rather than as one opaque string.
+  Keyboard Shortcuts on the trailing edge.
+- A command with multiple configured direct shortcuts appears once with all of
+  those shortcuts.
+- Command Sequences do not appear. They are a distinct interaction model, not
+  Keyboard Shortcuts.
 - With no query, commands use stable category and command ordering. With a
-  query, empty sections disappear and matches rank within their category.
+  query, empty sections disappear and matching rows preserve that ordering.
 - `ContentUnavailableView.search` handles a query with no matches. If the user
   clears every default binding, a separate empty state explains that no
   keyboard shortcuts are configured.
 - The window displays the active resolved keymap. Reloading `config.toml`
-  updates it immediately, including remaps, unbinds, a changed leader, and
-  `clear_default_keybindings`.
+  updates it immediately, including direct-shortcut remaps, unbinds, and
+  `clear_default_keybindings`. Changing the leader affects Command Sequences
+  only and therefore does not change this window.
 
 ## Command and Binding Model
 
@@ -56,42 +58,44 @@ The reference must not maintain a second hard-coded shortcut table.
 - Add a stable `CommandCategory` to `CommandDescriptor`. Category titles and
   ordering belong to command metadata so menus, this reference, and the future
   command palette do not invent separate organization schemes.
-- Add an ordered flat collection of `ResolvedBinding` values to
+- Add an ordered flat collection of `ResolvedShortcut` values to
   `ResolvedKeymap` alongside its routing tree and `menuShortcuts`. Each value
-  contains the resolved `KeySequence` and `CommandID`.
+  contains one resolved direct `KeyStroke` and `CommandID`.
 - Build that collection during keymap resolution, after defaults, user
-  replacements, unbinds, and leader expansion have been applied. Do not
-  reconstruct display data by walking the prefix tree.
-- Project resolved bindings into one reference item per bound command by
-  joining them with `CommandRegistry` metadata.
-- Exclude commands with no resolved binding. This is a shortcut reference, not
-  a catalog of every app command; menu-only and unbound commands remain
-  discoverable through their normal menus.
+  replacements, and unbinds have been applied. Exclude Command Sequences. Do
+  not reconstruct display data by walking the prefix tree.
+- Project resolved shortcuts into one reference item per directly bound command
+  by joining them with `CommandRegistry` metadata.
+- Exclude commands with no resolved direct shortcut, including commands bound
+  only through Command Sequences. This is a shortcut reference, not a catalog
+  of every app command; menu-only, sequence-only, and unbound commands remain
+  discoverable through their appropriate surfaces.
 - Reuse `KeyStroke.displayDescription` as the base display formatter and add a
-  sequence-level formatter that also provides a spoken accessibility label.
+  spoken accessibility label for each direct shortcut.
 
 Initial categories should cover the current registry without introducing
 feature-specific UI logic:
 
 - **Projects & Workspaces**: project and Workspace creation commands.
-- **Sessions**: Agent Session and Terminal Session commands.
+- **Sessions & Terminals**: Session and Terminal commands.
 - **View**: sidebar and other presentation commands.
 - **General**: app-wide operations such as refresh and configuration reload.
 
 Only categories containing at least one bound command are displayed.
 
-## Fuzzy Search
+## Search
 
-- Implement matching as a small, deterministic, Swift-only value type with no
-  production dependency.
-- Normalize case and diacritics, require query characters to occur in order,
-  and reward exact prefixes, word-boundary matches, and contiguous runs.
+- Use the same small atc-owned matcher as the Command Palette: first try a
+  case-insensitive substring, then fall back to matching the first letters of
+  words.
+- Return matching character positions for highlighting. Do not calculate fuzzy
+  scores or reorder results by perceived match quality.
 - Search command title, category title, stable command identifier, and both
-  human-readable and configuration-style binding text.
-- Keep matching independent of SwiftUI and of `CommandID` so DEV-37 can reuse
-  it for the command palette and session search without copying ranking logic.
-- Preserve stable command order as the tie-breaker so results do not jump
-  unpredictably while typing.
+  human-readable and configuration-style direct-shortcut text.
+- Keep matching independent of SwiftUI and `CommandID` so the reference and
+  Command Palette can reuse it without copying logic.
+- Preserve stable category and command order while filtering so results do not
+  jump unpredictably while typing.
 
 ## System Shape
 
@@ -101,13 +105,14 @@ Only categories containing at least one bound command are displayed.
 - **`AppCommands`**: Add the Help-menu `WindowVisibilityToggle` for the utility
   window. The existing registry-driven app commands remain unchanged.
 - **Command registry**: Own category metadata and stable presentation order.
-- **Keymap resolver**: Publish the final ordered bindings in addition to the
-  routing tree and selected menu equivalents.
-- **Shortcut reference model**: Join descriptors to resolved bindings, group
+- **Keymap resolver**: Publish the final ordered direct shortcuts in addition to
+  the routing tree and selected menu equivalents.
+- **Shortcut reference model**: Join descriptors to resolved shortcuts, group
   and order items, and expose filtered sections.
 - **Shortcut reference views**: Render the searchable native list, section
   headings, shortcut labels, accessibility descriptions, and empty states.
-- **Fuzzy matcher**: Provide reusable, UI-independent matching and scoring.
+- **Search matcher**: Provide the small shared, UI-independent substring and
+  word-initial matching behavior without an external dependency.
 
 The feature belongs under a focused macOS feature directory such as
 `macos/ATC/Features/KeyboardShortcuts/`. Generic matching may live in
@@ -117,9 +122,10 @@ generic but its file can remain with the feature.
 ## Implementation Sequence
 
 1. Extend command descriptors with categories and stable presentation order.
-2. Preserve the final ordered bindings in `ResolvedKeymap` and cover overrides,
-   unbinding, leader expansion, cleared defaults, and reload behavior in tests.
-3. Add the reference projection and fuzzy matcher with focused unit tests.
+2. Preserve the final ordered direct shortcuts in `ResolvedKeymap` and cover
+   overrides, unbinding, cleared defaults, sequence exclusion, and reload
+   behavior in tests.
+3. Add the reference projection and small matcher with focused unit tests.
 4. Build the sectioned, searchable `KeyboardShortcutsView` from the projection.
 5. Add the singleton `UtilityWindow` and Help-menu visibility toggle.
 6. Add hosting or presentation smoke coverage, then verify menu opening, window
@@ -129,7 +135,7 @@ generic but its file can remain with the feature.
 ## Accessibility and Keyboard Behavior
 
 - The window and every result must be navigable with Full Keyboard Access.
-- Shortcut symbols need spoken labels such as “Command K, then B”; VoiceOver
+- Shortcut symbols need spoken labels such as “Shift Command N”; VoiceOver
   must not receive only glyphs like `⌘` or `⇧`.
 - Search must not activate the main window's terminal keyboard router because
   the utility window is a separate key window.
@@ -143,25 +149,25 @@ generic but its file can remain with the feature.
 - Replacing native menu shortcut labels.
 - Executing commands from the reference list; DEV-46 is reference and search,
   not the DEV-37 command palette.
+- Showing Command Sequences; they are not Keyboard Shortcuts.
 - Adding a custom right-side overlay, sheet, popover, or second inspector.
-- Adding a third-party fuzzy-search dependency.
 
 ## Success Criteria
 
 - Help → Keyboard Shortcuts opens one reusable utility window and never alters
   the main window's inspector or navigation state.
-- The reference shows every and only currently resolved binding, grouped by
-  registry-owned categories.
-- Direct shortcuts, multiple bindings, and Command Sequences are legible and
-  accessible.
-- Fuzzy search returns useful, deterministic results and preserves headings.
+- The reference shows every and only currently resolved direct Keyboard
+  Shortcut, grouped by registry-owned categories.
+- Multiple direct shortcuts for one command are legible and accessible.
+- Commands bound only through Command Sequences do not appear.
+- Search returns useful, deterministic filtered results and preserves headings.
 - Reloading valid configuration updates the open window; invalid reloads keep
   showing the previous working keymap.
 - Clearing or unbinding defaults never leaves stale shortcut rows behind.
 - The window remains usable when the Dashboard or a terminal is active, and
   opening or closing it does not send keystrokes to the terminal.
-- Automated tests cover binding projection, ordering, grouping, fuzzy ranking,
-  empty states, and configuration changes.
+- Automated tests cover binding projection, ordering, grouping, search
+  filtering, empty states, and configuration changes.
 
 ## Open Question
 

--- a/docs/keyboard-shortcut-reference-plan.md
+++ b/docs/keyboard-shortcut-reference-plan.md
@@ -1,0 +1,171 @@
+# Keyboard Shortcut Reference Plan
+
+Status: Draft
+
+Related: [DEV-46](https://linear.app/elevenideas/issue/DEV-46/keyboard-shortcut-reference),
+[keyboard-shortcuts-plan.md](keyboard-shortcuts-plan.md), and
+[keyboard-shortcuts-spec.md](keyboard-shortcuts-spec.md)
+
+## Purpose
+
+Give people a searchable, always-current reference for every configured atc
+keyboard shortcut without taking space from the terminal, competing with
+Session Details, or duplicating keybinding configuration in the UI.
+
+## Confirmed Decisions
+
+- Present the reference in a singleton SwiftUI `UtilityWindow` titled
+  **Keyboard Shortcuts** rather than in the main window's trailing inspector.
+- Keep the existing inspector dedicated to contextual Session Details.
+- Use native SwiftUI window, menu, search, list, section, and empty-state
+  behavior. The Linear screenshot is inspiration for content, not a layout
+  requirement.
+- Provide fuzzy search and group the unfiltered and filtered results under
+  meaningful headings.
+
+## Recommended Experience
+
+- Add **Keyboard Shortcuts** to the Help menu. Selecting it opens the utility
+  window or brings the existing instance forward.
+- Remove the `UtilityWindow`'s automatic View-menu command and place a
+  `WindowVisibilityToggle` in SwiftUI's `.help` command group so the feature has
+  one canonical menu location.
+- The window opens at a useful compact size, remains resizable, floats while
+  atc is active, hides with the app, and supports the native Escape-to-dismiss
+  behavior supplied by `UtilityWindow`.
+- A native search field receives focus when the window opens. Below it, a
+  sectioned `List` shows command titles on the leading edge and their resolved
+  direct shortcuts or Command Sequences on the trailing edge.
+- A command with multiple configured bindings appears once with all of its
+  bindings. A two-step Command Sequence renders as two distinct key groups in
+  execution order rather than as one opaque string.
+- With no query, commands use stable category and command ordering. With a
+  query, empty sections disappear and matches rank within their category.
+- `ContentUnavailableView.search` handles a query with no matches. If the user
+  clears every default binding, a separate empty state explains that no
+  keyboard shortcuts are configured.
+- The window displays the active resolved keymap. Reloading `config.toml`
+  updates it immediately, including remaps, unbinds, a changed leader, and
+  `clear_default_keybindings`.
+
+## Command and Binding Model
+
+The command registry and resolved keymap remain the only sources of truth.
+The reference must not maintain a second hard-coded shortcut table.
+
+- Add a stable `CommandCategory` to `CommandDescriptor`. Category titles and
+  ordering belong to command metadata so menus, this reference, and the future
+  command palette do not invent separate organization schemes.
+- Add an ordered flat collection of `ResolvedBinding` values to
+  `ResolvedKeymap` alongside its routing tree and `menuShortcuts`. Each value
+  contains the resolved `KeySequence` and `CommandID`.
+- Build that collection during keymap resolution, after defaults, user
+  replacements, unbinds, and leader expansion have been applied. Do not
+  reconstruct display data by walking the prefix tree.
+- Project resolved bindings into one reference item per bound command by
+  joining them with `CommandRegistry` metadata.
+- Exclude commands with no resolved binding. This is a shortcut reference, not
+  a catalog of every app command; menu-only and unbound commands remain
+  discoverable through their normal menus.
+- Reuse `KeyStroke.displayDescription` as the base display formatter and add a
+  sequence-level formatter that also provides a spoken accessibility label.
+
+Initial categories should cover the current registry without introducing
+feature-specific UI logic:
+
+- **Projects & Workspaces**: project and Workspace creation commands.
+- **Sessions**: Agent Session and Terminal Session commands.
+- **View**: sidebar and other presentation commands.
+- **General**: app-wide operations such as refresh and configuration reload.
+
+Only categories containing at least one bound command are displayed.
+
+## Fuzzy Search
+
+- Implement matching as a small, deterministic, Swift-only value type with no
+  production dependency.
+- Normalize case and diacritics, require query characters to occur in order,
+  and reward exact prefixes, word-boundary matches, and contiguous runs.
+- Search command title, category title, stable command identifier, and both
+  human-readable and configuration-style binding text.
+- Keep matching independent of SwiftUI and of `CommandID` so DEV-37 can reuse
+  it for the command palette and session search without copying ranking logic.
+- Preserve stable command order as the tie-breaker so results do not jump
+  unpredictably while typing.
+
+## System Shape
+
+- **`ATCApp`**: Own the singleton `UtilityWindow` scene, inject the existing
+  `KeyboardConfigStore`, set a reasonable default size, and remove the scene's
+  automatic commands.
+- **`AppCommands`**: Add the Help-menu `WindowVisibilityToggle` for the utility
+  window. The existing registry-driven app commands remain unchanged.
+- **Command registry**: Own category metadata and stable presentation order.
+- **Keymap resolver**: Publish the final ordered bindings in addition to the
+  routing tree and selected menu equivalents.
+- **Shortcut reference model**: Join descriptors to resolved bindings, group
+  and order items, and expose filtered sections.
+- **Shortcut reference views**: Render the searchable native list, section
+  headings, shortcut labels, accessibility descriptions, and empty states.
+- **Fuzzy matcher**: Provide reusable, UI-independent matching and scoring.
+
+The feature belongs under a focused macOS feature directory such as
+`macos/ATC/Features/KeyboardShortcuts/`. Generic matching may live in
+`macos/ATC/Shared/` once it has a second consumer; until then its API should be
+generic but its file can remain with the feature.
+
+## Implementation Sequence
+
+1. Extend command descriptors with categories and stable presentation order.
+2. Preserve the final ordered bindings in `ResolvedKeymap` and cover overrides,
+   unbinding, leader expansion, cleared defaults, and reload behavior in tests.
+3. Add the reference projection and fuzzy matcher with focused unit tests.
+4. Build the sectioned, searchable `KeyboardShortcutsView` from the projection.
+5. Add the singleton `UtilityWindow` and Help-menu visibility toggle.
+6. Add hosting or presentation smoke coverage, then verify menu opening, window
+   reuse, search focus, live configuration reload, Escape dismissal, and
+   terminal focus behavior manually.
+
+## Accessibility and Keyboard Behavior
+
+- The window and every result must be navigable with Full Keyboard Access.
+- Shortcut symbols need spoken labels such as “Command K, then B”; VoiceOver
+  must not receive only glyphs like `⌘` or `⇧`.
+- Search must not activate the main window's terminal keyboard router because
+  the utility window is a separate key window.
+- Closing the utility window should return naturally to the previous main
+  window without mutating Workspace, selection, terminal, or inspector state.
+
+## Non-Goals
+
+- Editing, recording, resetting, or resolving keybinding conflicts in a GUI.
+- Moving the reference into Settings.
+- Replacing native menu shortcut labels.
+- Executing commands from the reference list; DEV-46 is reference and search,
+  not the DEV-37 command palette.
+- Adding a custom right-side overlay, sheet, popover, or second inspector.
+- Adding a third-party fuzzy-search dependency.
+
+## Success Criteria
+
+- Help → Keyboard Shortcuts opens one reusable utility window and never alters
+  the main window's inspector or navigation state.
+- The reference shows every and only currently resolved binding, grouped by
+  registry-owned categories.
+- Direct shortcuts, multiple bindings, and Command Sequences are legible and
+  accessible.
+- Fuzzy search returns useful, deterministic results and preserves headings.
+- Reloading valid configuration updates the open window; invalid reloads keep
+  showing the previous working keymap.
+- Clearing or unbinding defaults never leaves stale shortcut rows behind.
+- The window remains usable when the Dashboard or a terminal is active, and
+  opening or closing it does not send keystrokes to the terminal.
+- Automated tests cover binding projection, ordering, grouping, fuzzy ranking,
+  empty states, and configuration changes.
+
+## Open Question
+
+- Should the Keyboard Shortcuts window receive a compiled default shortcut in
+  this issue? Recommendation: ship the Help-menu entry first and defer a default
+  until the command can participate in the same configurable registry and
+  terminal-safe routing path as every other atc shortcut.

--- a/macos/ATC/AppCommands.swift
+++ b/macos/ATC/AppCommands.swift
@@ -27,6 +27,7 @@ struct AppCommands: Commands {
         CommandGroup(after: .sidebar) {
             commandButton(.toggleSidebar)
             commandButton(.refresh)
+            commandButton(.toggleCommandPalette)
             Divider()
         }
 

--- a/macos/ATC/Commands/CommandID.swift
+++ b/macos/ATC/Commands/CommandID.swift
@@ -1,5 +1,6 @@
 enum CommandID: String, CaseIterable, Sendable {
     case toggleSidebar = "view.toggle-sidebar"
+    case toggleCommandPalette = "view.toggle-command-palette"
     case newSession = "session.new"
     case newTerminal = "terminal.new"
     case newProject = "project.new"

--- a/macos/ATC/Commands/CommandRegistry.swift
+++ b/macos/ATC/Commands/CommandRegistry.swift
@@ -16,10 +16,28 @@ enum CommandAvailability: Equatable {
     }
 }
 
+enum CommandCategory: CaseIterable, Sendable {
+    case general
+    case projectsAndWorkspaces
+    case sessionsAndTerminals
+    case view
+
+    var title: String {
+        switch self {
+        case .general: "General"
+        case .projectsAndWorkspaces: "Projects & Workspaces"
+        case .sessionsAndTerminals: "Sessions & Terminals"
+        case .view: "View"
+        }
+    }
+}
+
 @MainActor
 struct CommandDescriptor {
     let id: CommandID
     let title: String
+    let category: CommandCategory
+    var isPaletteEligible = true
     let availability: (CommandContext) -> CommandAvailability
     let perform: (CommandContext) -> Void
 }
@@ -30,12 +48,17 @@ enum CommandRegistry {
         "Requires an open Workspace on a reachable Connection"
     private static let connectionUnavailable = "Requires a configured Connection"
 
+    static var allDescriptors: [CommandDescriptor] {
+        CommandID.allCases.map(descriptor(for:))
+    }
+
     static func descriptor(for id: CommandID) -> CommandDescriptor {
         switch id {
         case .toggleSidebar:
             CommandDescriptor(
                 id: id,
                 title: "Toggle Sidebar",
+                category: .view,
                 availability: { _ in .available },
                 perform: { $0.windowState.toggleSidebar() }
             )
@@ -43,6 +66,7 @@ enum CommandRegistry {
             CommandDescriptor(
                 id: id,
                 title: "New Session",
+                category: .sessionsAndTerminals,
                 availability: sessionAvailability,
                 perform: { $0.windowState.startSessionKind = .agentSession }
             )
@@ -50,6 +74,7 @@ enum CommandRegistry {
             CommandDescriptor(
                 id: id,
                 title: "New Terminal",
+                category: .sessionsAndTerminals,
                 availability: sessionAvailability,
                 perform: { $0.windowState.startSessionKind = .terminal }
             )
@@ -57,6 +82,7 @@ enum CommandRegistry {
             CommandDescriptor(
                 id: id,
                 title: "New Project…",
+                category: .projectsAndWorkspaces,
                 availability: connectionAvailability,
                 perform: { $0.windowState.isCreateProjectPresented = true }
             )
@@ -64,6 +90,7 @@ enum CommandRegistry {
             CommandDescriptor(
                 id: id,
                 title: "New Workspace…",
+                category: .projectsAndWorkspaces,
                 availability: connectionAvailability,
                 perform: { $0.windowState.presentCreateWorkspace(in: $0.appModel) }
             )
@@ -71,6 +98,7 @@ enum CommandRegistry {
             CommandDescriptor(
                 id: id,
                 title: "Refresh",
+                category: .general,
                 availability: { _ in .available },
                 perform: { context in Task { await context.appModel.refreshAll() } }
             )
@@ -78,6 +106,7 @@ enum CommandRegistry {
             CommandDescriptor(
                 id: id,
                 title: "Reload Configuration",
+                category: .general,
                 availability: { _ in .available },
                 perform: { $0.configStore.reload() }
             )

--- a/macos/ATC/Commands/CommandRegistry.swift
+++ b/macos/ATC/Commands/CommandRegistry.swift
@@ -62,6 +62,19 @@ enum CommandRegistry {
                 availability: { _ in .available },
                 perform: { $0.windowState.toggleSidebar() }
             )
+        case .toggleCommandPalette:
+            CommandDescriptor(
+                id: id,
+                title: "Toggle Command Palette",
+                category: .view,
+                isPaletteEligible: false,
+                availability: {
+                    $0.windowState.isSheetPresented
+                        ? .unavailable(reason: "Not available while a dialog is open")
+                        : .available
+                },
+                perform: { $0.windowState.isCommandPalettePresented.toggle() }
+            )
         case .newSession:
             CommandDescriptor(
                 id: id,

--- a/macos/ATC/Commands/KeyStroke.swift
+++ b/macos/ATC/Commands/KeyStroke.swift
@@ -37,6 +37,16 @@ struct KeyStroke: Hashable, Sendable, CustomStringConvertible {
         return value
     }
 
+    var spokenDescription: String {
+        var parts: [String] = []
+        if modifiers.contains(.control) { parts.append("Control") }
+        if modifiers.contains(.option) { parts.append("Option") }
+        if modifiers.contains(.shift) { parts.append("Shift") }
+        if modifiers.contains(.command) { parts.append("Command") }
+        parts.append(key == "escape" ? "Escape" : key.uppercased())
+        return parts.joined(separator: " ")
+    }
+
     var hasPrimaryModifier: Bool {
         !modifiers.intersection(.primary).isEmpty
     }

--- a/macos/ATC/Commands/KeyboardMonitorHost.swift
+++ b/macos/ATC/Commands/KeyboardMonitorHost.swift
@@ -64,7 +64,19 @@ struct KeyboardMonitorHost: NSViewRepresentable {
                       window.isKeyWindow,
                       let stroke = KeyStroke.normalize(event: event)
                 else { return event }
-                return self.router.handle(stroke, isRepeat: event.isARepeat) ? nil : event
+                let wasSuspended = self.router.isSuspended()
+                let handled = self.router.handle(stroke, isRepeat: event.isARepeat)
+                // The palette opener flips suspension synchronously, but the
+                // palette's focus accessor only mounts on the next SwiftUI
+                // commit; keystrokes already queued behind the opener would
+                // land in the still-focused terminal. Clearing focus at the
+                // flip closes that gap, stashing the responder so dismissal
+                // can still restore it.
+                if handled, !wasSuspended, self.router.isSuspended() {
+                    self.router.responderBeforeSuspension = window.firstResponder
+                    window.makeFirstResponder(nil)
+                }
+                return handled ? nil : event
             }
 
             let center = NotificationCenter.default

--- a/macos/ATC/Commands/KeyboardMonitorHost.swift
+++ b/macos/ATC/Commands/KeyboardMonitorHost.swift
@@ -3,9 +3,10 @@ import SwiftUI
 
 struct KeyboardMonitorHost: NSViewRepresentable {
     let router: WindowKeyboardRouter
+    let onDeactivate: () -> Void
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(router: router)
+        Coordinator(router: router, onDeactivate: onDeactivate)
     }
 
     func makeNSView(context: Context) -> HostView {
@@ -18,6 +19,7 @@ struct KeyboardMonitorHost: NSViewRepresentable {
 
     func updateNSView(_ nsView: HostView, context: Context) {
         context.coordinator.router = router
+        context.coordinator.onDeactivate = onDeactivate
         if nsView.window !== context.coordinator.hostWindow {
             context.coordinator.install(for: nsView.window)
         }
@@ -40,12 +42,14 @@ struct KeyboardMonitorHost: NSViewRepresentable {
     @MainActor
     final class Coordinator {
         var router: WindowKeyboardRouter
+        var onDeactivate: () -> Void
         private(set) weak var hostWindow: NSWindow?
         private var monitor: Any?
         private var observers: [NSObjectProtocol] = []
 
-        init(router: WindowKeyboardRouter) {
+        init(router: WindowKeyboardRouter, onDeactivate: @escaping () -> Void) {
             self.router = router
+            self.onDeactivate = onDeactivate
         }
 
         func install(for window: NSWindow?) {
@@ -69,14 +73,20 @@ struct KeyboardMonitorHost: NSViewRepresentable {
                 object: window,
                 queue: .main
             ) { [weak self] _ in
-                MainActor.assumeIsolated { self?.router.cancel() }
+                MainActor.assumeIsolated {
+                    self?.router.cancel()
+                    self?.onDeactivate()
+                }
             })
             observers.append(center.addObserver(
                 forName: NSApplication.didResignActiveNotification,
                 object: NSApp,
                 queue: .main
             ) { [weak self] _ in
-                MainActor.assumeIsolated { self?.router.cancel() }
+                MainActor.assumeIsolated {
+                    self?.router.cancel()
+                    self?.onDeactivate()
+                }
             })
         }
 
@@ -125,22 +135,36 @@ struct KeyboardRoutingContainer<Content: View>: View {
             windowState: windowState,
             configStore: configStore
         )
-        _router = State(initialValue: WindowKeyboardRouter(
+        let router = WindowKeyboardRouter(
             keymap: configStore.keymap,
             context: context
-        ))
+        )
+        router.isSuspended = { windowState.isCommandPalettePresented }
+        _router = State(initialValue: router)
     }
 
     var body: some View {
         content
             .overlay {
+                if windowState.isCommandPalettePresented {
+                    CommandPaletteView()
+                }
+            }
+            .overlay {
                 CommandFeedbackOverlay()
             }
             .environment(configStore)
             .environment(router)
-            .background(KeyboardMonitorHost(router: router))
+            .background(KeyboardMonitorHost(router: router) {
+                windowState.isCommandPalettePresented = false
+            })
             .onChange(of: configStore.keymap.generation, initial: true) {
                 router.keymap = configStore.keymap
+            }
+            .onChange(of: windowState.isCommandPalettePresented) {
+                if windowState.isCommandPalettePresented {
+                    router.cancel()
+                }
             }
     }
 }

--- a/macos/ATC/Commands/KeyboardMonitorHost.swift
+++ b/macos/ATC/Commands/KeyboardMonitorHost.swift
@@ -4,9 +4,14 @@ import SwiftUI
 struct KeyboardMonitorHost: NSViewRepresentable {
     let router: WindowKeyboardRouter
     let onDeactivate: () -> Void
+    let focusFallback: () -> Void
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(router: router, onDeactivate: onDeactivate)
+        Coordinator(
+            router: router,
+            onDeactivate: onDeactivate,
+            focusFallback: focusFallback
+        )
     }
 
     func makeNSView(context: Context) -> HostView {
@@ -20,6 +25,7 @@ struct KeyboardMonitorHost: NSViewRepresentable {
     func updateNSView(_ nsView: HostView, context: Context) {
         context.coordinator.router = router
         context.coordinator.onDeactivate = onDeactivate
+        context.coordinator.focusFallback = focusFallback
         if nsView.window !== context.coordinator.hostWindow {
             context.coordinator.install(for: nsView.window)
         }
@@ -43,13 +49,19 @@ struct KeyboardMonitorHost: NSViewRepresentable {
     final class Coordinator {
         var router: WindowKeyboardRouter
         var onDeactivate: () -> Void
+        var focusFallback: () -> Void
         private(set) weak var hostWindow: NSWindow?
         private var monitor: Any?
         private var observers: [NSObjectProtocol] = []
 
-        init(router: WindowKeyboardRouter, onDeactivate: @escaping () -> Void) {
+        init(
+            router: WindowKeyboardRouter,
+            onDeactivate: @escaping () -> Void,
+            focusFallback: @escaping () -> Void
+        ) {
             self.router = router
             self.onDeactivate = onDeactivate
+            self.focusFallback = focusFallback
         }
 
         func install(for window: NSWindow?) {
@@ -88,6 +100,7 @@ struct KeyboardMonitorHost: NSViewRepresentable {
                 MainActor.assumeIsolated {
                     self?.router.cancel()
                     self?.onDeactivate()
+                    self?.restoreOrphanedResponder()
                 }
             })
             observers.append(center.addObserver(
@@ -98,8 +111,26 @@ struct KeyboardMonitorHost: NSViewRepresentable {
                 MainActor.assumeIsolated {
                     self?.router.cancel()
                     self?.onDeactivate()
+                    self?.restoreOrphanedResponder()
                 }
             })
+        }
+
+        // Dismissal normally restores focus through the palette's window
+        // accessor, but deactivation can dismiss the palette before the
+        // accessor's first mount consumes the stash; the responder captured
+        // at the suspension flip would then stay lost.
+        private func restoreOrphanedResponder() {
+            guard let stashed = router.responderBeforeSuspension else { return }
+            router.responderBeforeSuspension = nil
+            if let window = hostWindow,
+               let view = stashed as? NSView,
+               view.window === window,
+               view.acceptsFirstResponder,
+               window.makeFirstResponder(view) {
+                return
+            }
+            focusFallback()
         }
 
         func stop() {
@@ -167,9 +198,11 @@ struct KeyboardRoutingContainer<Content: View>: View {
             }
             .environment(configStore)
             .environment(router)
-            .background(KeyboardMonitorHost(router: router) {
-                windowState.isCommandPalettePresented = false
-            })
+            .background(KeyboardMonitorHost(
+                router: router,
+                onDeactivate: { windowState.isCommandPalettePresented = false },
+                focusFallback: { windowState.requestTerminalFocus() }
+            ))
             .onChange(of: configStore.keymap.generation, initial: true) {
                 router.keymap = configStore.keymap
             }

--- a/macos/ATC/Commands/Keymap.swift
+++ b/macos/ATC/Commands/Keymap.swift
@@ -18,6 +18,7 @@ enum Keymap {
 
     static let compiledDefaults: [(sequence: String, command: CommandID)] = [
         ("cmd+b", .toggleSidebar), ("leader>b", .toggleSidebar),
+        ("cmd+shift+p", .toggleCommandPalette),
         ("cmd+n", .newSession), ("leader>n", .newSession),
         ("cmd+r", .refresh), ("leader>r", .refresh),
         ("cmd+t", .newTerminal),

--- a/macos/ATC/Commands/WindowKeyboardRouter.swift
+++ b/macos/ATC/Commands/WindowKeyboardRouter.swift
@@ -24,6 +24,10 @@ final class WindowKeyboardRouter {
     }
 
     @ObservationIgnored var isSuspended: @MainActor () -> Bool = { false }
+    /// The responder that held focus when suspension began. The key monitor
+    /// stashes it before clearing window focus so the palette can restore it
+    /// on dismissal; AnyObject keeps AppKit out of this file.
+    @ObservationIgnored weak var responderBeforeSuspension: AnyObject?
     @ObservationIgnored private let executeCommand: @MainActor (CommandID) -> CommandAvailability
     @ObservationIgnored private var timeoutTask: Task<Void, Never>?
     @ObservationIgnored private var flashTask: Task<Void, Never>?

--- a/macos/ATC/Commands/WindowKeyboardRouter.swift
+++ b/macos/ATC/Commands/WindowKeyboardRouter.swift
@@ -23,6 +23,7 @@ final class WindowKeyboardRouter {
         }
     }
 
+    @ObservationIgnored var isSuspended: @MainActor () -> Bool = { false }
     @ObservationIgnored private let executeCommand: @MainActor (CommandID) -> CommandAvailability
     @ObservationIgnored private var timeoutTask: Task<Void, Never>?
     @ObservationIgnored private var flashTask: Task<Void, Never>?
@@ -48,6 +49,7 @@ final class WindowKeyboardRouter {
 
     @discardableResult
     func handle(_ stroke: KeyStroke, isRepeat: Bool) -> Bool {
+        guard !isSuspended() else { return false }
         switch state {
         case .idle:
             guard let node = keymap.root[stroke] else { return false }
@@ -79,6 +81,10 @@ final class WindowKeyboardRouter {
               case .pending = state
         else { return }
         cancel()
+    }
+
+    func showUnavailable(reason: String) {
+        showFlash(reason)
     }
 
     private func handle(_ node: ResolvedKeymap.Node) -> Bool {

--- a/macos/ATC/Features/CommandPalette/CommandPaletteContent.swift
+++ b/macos/ATC/Features/CommandPalette/CommandPaletteContent.swift
@@ -1,0 +1,43 @@
+struct CommandPaletteRow: Identifiable {
+    let id: CommandID
+    let title: String
+    let matchedRanges: [Range<String.Index>]
+    let shortcut: KeyStroke?
+    let availability: CommandAvailability
+}
+
+@MainActor
+enum CommandPaletteContent {
+    static func rows(
+        query: String,
+        keymap: ResolvedKeymap,
+        context: CommandContext
+    ) -> [CommandPaletteRow] {
+        CommandRegistry.allDescriptors.compactMap { descriptor in
+            guard descriptor.isPaletteEligible,
+                  let match = QueryMatcher.match(query, in: descriptor.title)
+            else { return nil }
+            return CommandPaletteRow(
+                id: descriptor.id,
+                title: descriptor.title,
+                matchedRanges: match.ranges,
+                shortcut: keymap.menuShortcuts[descriptor.id],
+                availability: descriptor.availability(context)
+            )
+        }.sorted { isOrderedBefore(
+            title: $0.title, id: $0.id,
+            thanTitle: $1.title, id: $1.id
+        ) }
+    }
+
+    static func isOrderedBefore(
+        title lhsTitle: String,
+        id lhsID: CommandID,
+        thanTitle rhsTitle: String,
+        id rhsID: CommandID
+    ) -> Bool {
+        let lhs = lhsTitle.lowercased()
+        let rhs = rhsTitle.lowercased()
+        return lhs == rhs ? lhsID.rawValue < rhsID.rawValue : lhs < rhs
+    }
+}

--- a/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
+++ b/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
@@ -38,7 +38,10 @@ struct CommandPaletteView: View {
         .accessibilityLabel("Command Palette")
         .accessibilityAddTraits(.isModal)
         .onExitCommand { dismissPalette() }
-        .task { queryIsFocused = true }
+        .background(PaletteWindowAccessor(
+            onAttach: { queryIsFocused = true },
+            fallback: { windowState.requestTerminalFocus() }
+        ))
         .onChange(of: query) {
             selectedID = query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 ? nil
@@ -75,6 +78,7 @@ struct CommandPaletteView: View {
                 }
 
             Divider()
+
             resultList(rows: rows, context: context)
         }
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 11))
@@ -225,5 +229,79 @@ struct CommandPaletteView: View {
         }
         self.selectedID = rows[(index + offset + rows.count) % rows.count].id
         return .handled
+    }
+}
+
+private struct PaletteWindowAccessor: NSViewRepresentable {
+    let onAttach: @MainActor () -> Void
+    let fallback: @MainActor () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onAttach: onAttach, fallback: fallback)
+    }
+
+    func makeNSView(context: Context) -> HostView {
+        let view = HostView()
+        view.onWindowChange = { [weak coordinator = context.coordinator] window in
+            coordinator?.attach(to: window)
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: HostView, context: Context) {
+        context.coordinator.onAttach = onAttach
+        context.coordinator.fallback = fallback
+        if nsView.window !== context.coordinator.hostWindow {
+            context.coordinator.attach(to: nsView.window)
+        }
+    }
+
+    static func dismantleNSView(_ nsView: HostView, coordinator: Coordinator) {
+        nsView.onWindowChange = nil
+        coordinator.restore()
+    }
+
+    final class HostView: NSView {
+        var onWindowChange: ((NSWindow?) -> Void)?
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            onWindowChange?(window)
+        }
+    }
+
+    @MainActor
+    final class Coordinator {
+        var onAttach: @MainActor () -> Void
+        var fallback: @MainActor () -> Void
+        private(set) weak var hostWindow: NSWindow?
+        private weak var previousResponder: NSResponder?
+
+        init(
+            onAttach: @escaping @MainActor () -> Void,
+            fallback: @escaping @MainActor () -> Void
+        ) {
+            self.onAttach = onAttach
+            self.fallback = fallback
+        }
+
+        func attach(to window: NSWindow?) {
+            guard let window, window !== hostWindow else { return }
+            hostWindow = window
+            previousResponder = window.firstResponder
+            window.makeFirstResponder(nil)
+            Task { @MainActor [weak self] in self?.onAttach() }
+        }
+
+        func restore() {
+            guard let window = hostWindow else { return }
+            if let view = previousResponder as? NSView,
+               view.window === window,
+               view.acceptsFirstResponder,
+               window.makeFirstResponder(view) {
+                return
+            }
+            fallback()
+        }
     }
 }

--- a/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
+++ b/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
@@ -64,11 +64,11 @@ struct CommandPaletteView: View {
                 .onSubmit { activateSelection(in: rows, context: context) }
                 .onKeyPress(.downArrow) { moveSelection(1, through: rows) }
                 .onKeyPress(.upArrow) { moveSelection(-1, through: rows) }
-                .onKeyPress("n") { press in
+                .onKeyPress(keys: ["n"], phases: .down) { press in
                     guard press.modifiers == .control else { return .ignored }
                     return moveSelection(1, through: rows)
                 }
-                .onKeyPress("p") { press in
+                .onKeyPress(keys: ["p"], phases: .down) { press in
                     guard press.modifiers == .control else { return .ignored }
                     return moveSelection(-1, through: rows)
                 }

--- a/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
+++ b/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
@@ -5,7 +5,7 @@ struct CommandPaletteView: View {
     @Environment(AppModel.self) private var appModel
     @Environment(WindowState.self) private var windowState
     @Environment(KeyboardConfigStore.self) private var configStore
-    @Environment(\.dismiss) private var dismiss
+    @Environment(WindowKeyboardRouter.self) private var router
 
     @State private var query = ""
     @State private var selectedID: CommandID?
@@ -27,7 +27,7 @@ struct CommandPaletteView: View {
         ZStack(alignment: .top) {
             Color.clear
                 .contentShape(Rectangle())
-                .onTapGesture { dismiss() }
+                .onTapGesture { dismissPalette() }
 
             palettePanel(rows: rows, context: context)
                 .frame(maxWidth: 500)
@@ -37,7 +37,7 @@ struct CommandPaletteView: View {
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Command Palette")
         .accessibilityAddTraits(.isModal)
-        .onExitCommand { dismiss() }
+        .onExitCommand { dismissPalette() }
         .task { queryIsFocused = true }
         .onChange(of: query) {
             selectedID = query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -70,7 +70,7 @@ struct CommandPaletteView: View {
                     return moveSelection(-1, through: rows)
                 }
                 .onKeyPress(.escape) {
-                    dismiss()
+                    dismissPalette()
                     return .handled
                 }
 
@@ -179,7 +179,7 @@ struct CommandPaletteView: View {
             parts.append("Unavailable — \(reason)")
         }
         if let shortcut = row.shortcut {
-            parts.append(shortcut.displayDescription)
+            parts.append(shortcut.spokenDescription)
         }
         return parts.joined(separator: ", ")
     }
@@ -191,16 +191,25 @@ struct CommandPaletteView: View {
         guard let selectedID,
               let row = rows.first(where: { $0.id == selectedID })
         else {
-            dismiss()
+            dismissPalette()
             return
         }
         activate(row, context: context)
     }
 
     private func activate(_ row: CommandPaletteRow, context: CommandContext) {
-        guard row.availability.isAvailable else { return }
-        dismiss()
+        guard row.availability.isAvailable else {
+            if case .unavailable(let reason) = row.availability {
+                router.showUnavailable(reason: reason)
+            }
+            return
+        }
+        dismissPalette()
         CommandRegistry.execute(row.id, context: context)
+    }
+
+    private func dismissPalette() {
+        windowState.isCommandPalettePresented = false
     }
 
     private func moveSelection(

--- a/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
+++ b/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
@@ -47,9 +47,20 @@ struct CommandPaletteView: View {
             fallback: { windowState.requestTerminalFocus() }
         ))
         .onChange(of: query) {
-            selectedID = query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                ? nil
-                : rows.first?.id
+            let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+            selectedID = trimmed.isEmpty ? nil : rows.first?.id
+            if !trimmed.isEmpty, rows.isEmpty {
+                AccessibilityNotification.Announcement("No matching commands").post()
+            }
+        }
+        // Keyboard focus stays on the query field while arrows move the
+        // selection, so VoiceOver never lands on the rows; announce the
+        // active row instead.
+        .onChange(of: selectedID) {
+            guard let selectedID,
+                  let row = rows.first(where: { $0.id == selectedID })
+            else { return }
+            AccessibilityNotification.Announcement(accessibilityLabel(for: row)).post()
         }
     }
 

--- a/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
+++ b/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
@@ -1,0 +1,220 @@
+import AppKit
+import SwiftUI
+
+struct CommandPaletteView: View {
+    @Environment(AppModel.self) private var appModel
+    @Environment(WindowState.self) private var windowState
+    @Environment(KeyboardConfigStore.self) private var configStore
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var query = ""
+    @State private var selectedID: CommandID?
+    @State private var hoveredID: CommandID?
+    @FocusState private var queryIsFocused: Bool
+
+    var body: some View {
+        let context = CommandContext(
+            appModel: appModel,
+            windowState: windowState,
+            configStore: configStore
+        )
+        let rows = CommandPaletteContent.rows(
+            query: query,
+            keymap: configStore.keymap,
+            context: context
+        )
+
+        ZStack(alignment: .top) {
+            Color.clear
+                .contentShape(Rectangle())
+                .onTapGesture { dismiss() }
+
+            palettePanel(rows: rows, context: context)
+                .frame(maxWidth: 500)
+                .padding(.horizontal, 20)
+                .padding(.top, 48)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Command Palette")
+        .accessibilityAddTraits(.isModal)
+        .onExitCommand { dismiss() }
+        .task { queryIsFocused = true }
+        .onChange(of: query) {
+            selectedID = query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? nil
+                : rows.first?.id
+        }
+    }
+
+    private func palettePanel(
+        rows: [CommandPaletteRow],
+        context: CommandContext
+    ) -> some View {
+        VStack(spacing: 0) {
+            TextField("Execute a command…", text: $query)
+                .textFieldStyle(.plain)
+                .font(.title3)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 12)
+                .focused($queryIsFocused)
+                .accessibilityLabel("Command query")
+                .onSubmit { activateSelection(in: rows, context: context) }
+                .onKeyPress(.downArrow) { moveSelection(1, through: rows) }
+                .onKeyPress(.upArrow) { moveSelection(-1, through: rows) }
+                .onKeyPress("n") { press in
+                    guard press.modifiers == .control else { return .ignored }
+                    return moveSelection(1, through: rows)
+                }
+                .onKeyPress("p") { press in
+                    guard press.modifiers == .control else { return .ignored }
+                    return moveSelection(-1, through: rows)
+                }
+                .onKeyPress(.escape) {
+                    dismiss()
+                    return .handled
+                }
+
+            Divider()
+            resultList(rows: rows, context: context)
+        }
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 11))
+        .overlay {
+            RoundedRectangle(cornerRadius: 11)
+                .stroke(Color(nsColor: .separatorColor).opacity(0.7), lineWidth: 0.5)
+        }
+        .shadow(color: .black.opacity(0.28), radius: 18, y: 7)
+    }
+
+    @ViewBuilder
+    private func resultList(
+        rows: [CommandPaletteRow],
+        context: CommandContext
+    ) -> some View {
+        if rows.isEmpty {
+            Text("No matching commands")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, minHeight: 44)
+                .accessibilityHidden(true)
+        } else {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(spacing: 2) {
+                        ForEach(rows) { row in
+                            commandRow(row, rows: rows, context: context)
+                                .id(row.id)
+                        }
+                    }
+                    .padding(5)
+                }
+                .frame(height: min(200, CGFloat(rows.count * 42 + 10)))
+                .onChange(of: selectedID) {
+                    if let selectedID {
+                        proxy.scrollTo(selectedID, anchor: .center)
+                    }
+                }
+            }
+        }
+    }
+
+    private func commandRow(
+        _ row: CommandPaletteRow,
+        rows: [CommandPaletteRow],
+        context: CommandContext
+    ) -> some View {
+        let isSelected = selectedID == row.id
+        let isHovered = hoveredID == row.id
+        return HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                highlightedTitle(row)
+                    .font(.callout)
+                if case .unavailable(let reason) = row.availability {
+                    Text(reason)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            Spacer(minLength: 12)
+            if let shortcut = row.shortcut {
+                Text(shortcut.displayDescription)
+                    .font(.caption.monospaced().weight(.medium))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .foregroundStyle(row.availability.isAvailable ? .primary : .secondary)
+        .opacity(row.availability.isAvailable ? 1 : 0.6)
+        .background {
+            RoundedRectangle(cornerRadius: 6)
+                .fill(isSelected ? Color.accentColor.opacity(0.65) :
+                    isHovered ? Color.primary.opacity(0.08) : .clear)
+        }
+        .contentShape(Rectangle())
+        .onHover { hovering in hoveredID = hovering ? row.id : nil }
+        .onTapGesture {
+            selectedID = row.id
+            activate(row, context: context)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel(for: row))
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityAction { activate(row, context: context) }
+    }
+
+    private func highlightedTitle(_ row: CommandPaletteRow) -> Text {
+        var text = Text("")
+        var cursor = row.title.startIndex
+        for range in row.matchedRanges.sorted(by: { $0.lowerBound < $1.lowerBound }) {
+            text = text + Text(String(row.title[cursor..<range.lowerBound]))
+            text = text + Text(String(row.title[range])).bold()
+            cursor = range.upperBound
+        }
+        return text + Text(String(row.title[cursor...]))
+    }
+
+    private func accessibilityLabel(for row: CommandPaletteRow) -> String {
+        var parts = [row.title]
+        if case .unavailable(let reason) = row.availability {
+            parts.append("Unavailable — \(reason)")
+        }
+        if let shortcut = row.shortcut {
+            parts.append(shortcut.displayDescription)
+        }
+        return parts.joined(separator: ", ")
+    }
+
+    private func activateSelection(
+        in rows: [CommandPaletteRow],
+        context: CommandContext
+    ) {
+        guard let selectedID,
+              let row = rows.first(where: { $0.id == selectedID })
+        else {
+            dismiss()
+            return
+        }
+        activate(row, context: context)
+    }
+
+    private func activate(_ row: CommandPaletteRow, context: CommandContext) {
+        guard row.availability.isAvailable else { return }
+        dismiss()
+        CommandRegistry.execute(row.id, context: context)
+    }
+
+    private func moveSelection(
+        _ offset: Int,
+        through rows: [CommandPaletteRow]
+    ) -> KeyPress.Result {
+        guard !rows.isEmpty else { return .handled }
+        guard let selectedID,
+              let index = rows.firstIndex(where: { $0.id == selectedID })
+        else {
+            self.selectedID = offset > 0 ? rows.first?.id : rows.last?.id
+            return .handled
+        }
+        self.selectedID = rows[(index + offset + rows.count) % rows.count].id
+        return .handled
+    }
+}

--- a/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
+++ b/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
@@ -39,6 +39,10 @@ struct CommandPaletteView: View {
         .accessibilityAddTraits(.isModal)
         .onExitCommand { dismissPalette() }
         .background(PaletteWindowAccessor(
+            takeCapturedResponder: {
+                defer { router.responderBeforeSuspension = nil }
+                return router.responderBeforeSuspension as? NSResponder
+            },
             onAttach: { queryIsFocused = true },
             fallback: { windowState.requestTerminalFocus() }
         ))
@@ -99,7 +103,6 @@ struct CommandPaletteView: View {
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: .infinity, minHeight: 44)
-                .accessibilityHidden(true)
         } else {
             ScrollViewReader { proxy in
                 ScrollView {
@@ -233,11 +236,16 @@ struct CommandPaletteView: View {
 }
 
 private struct PaletteWindowAccessor: NSViewRepresentable {
+    let takeCapturedResponder: @MainActor () -> NSResponder?
     let onAttach: @MainActor () -> Void
     let fallback: @MainActor () -> Void
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onAttach: onAttach, fallback: fallback)
+        Coordinator(
+            takeCapturedResponder: takeCapturedResponder,
+            onAttach: onAttach,
+            fallback: fallback
+        )
     }
 
     func makeNSView(context: Context) -> HostView {
@@ -249,6 +257,7 @@ private struct PaletteWindowAccessor: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: HostView, context: Context) {
+        context.coordinator.takeCapturedResponder = takeCapturedResponder
         context.coordinator.onAttach = onAttach
         context.coordinator.fallback = fallback
         if nsView.window !== context.coordinator.hostWindow {
@@ -272,15 +281,18 @@ private struct PaletteWindowAccessor: NSViewRepresentable {
 
     @MainActor
     final class Coordinator {
+        var takeCapturedResponder: @MainActor () -> NSResponder?
         var onAttach: @MainActor () -> Void
         var fallback: @MainActor () -> Void
         private(set) weak var hostWindow: NSWindow?
         private weak var previousResponder: NSResponder?
 
         init(
+            takeCapturedResponder: @escaping @MainActor () -> NSResponder?,
             onAttach: @escaping @MainActor () -> Void,
             fallback: @escaping @MainActor () -> Void
         ) {
+            self.takeCapturedResponder = takeCapturedResponder
             self.onAttach = onAttach
             self.fallback = fallback
         }
@@ -288,7 +300,10 @@ private struct PaletteWindowAccessor: NSViewRepresentable {
         func attach(to window: NSWindow?) {
             guard let window, window !== hostWindow else { return }
             hostWindow = window
-            previousResponder = window.firstResponder
+            // A keyboard-opened palette already had its focus cleared (and
+            // the responder stashed) by the key monitor; a menu-opened one
+            // still holds the responder to capture here.
+            previousResponder = takeCapturedResponder() ?? window.firstResponder
             window.makeFirstResponder(nil)
             Task { @MainActor [weak self] in self?.onAttach() }
         }

--- a/macos/ATC/Features/CommandPalette/QueryMatcher.swift
+++ b/macos/ATC/Features/CommandPalette/QueryMatcher.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+struct QueryMatch: Equatable {
+    let ranges: [Range<String.Index>]
+}
+
+enum QueryMatcher {
+    static func match(_ query: String, in title: String) -> QueryMatch? {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return QueryMatch(ranges: []) }
+
+        if let range = title.range(of: trimmed, options: .caseInsensitive) {
+            return QueryMatch(ranges: [range])
+        }
+
+        let wordStarts = wordStartIndices(in: title)
+        let initials = String(wordStarts.compactMap {
+            String(title[$0]).lowercased().first
+        })
+        guard let match = initials.range(of: trimmed.lowercased()) else { return nil }
+
+        let offset = initials.distance(from: initials.startIndex, to: match.lowerBound)
+        let length = initials.distance(from: match.lowerBound, to: match.upperBound)
+        let ranges = wordStarts[offset..<(offset + length)].map { start in
+            start..<title.index(after: start)
+        }
+        return QueryMatch(ranges: ranges)
+    }
+
+    private static func wordStartIndices(in title: String) -> [String.Index] {
+        var starts: [String.Index] = []
+        var isInsideWord = false
+
+        for index in title.indices {
+            let isAlphanumeric = title[index].unicodeScalars.allSatisfy {
+                CharacterSet.alphanumerics.contains($0)
+            }
+            if isAlphanumeric, !isInsideWord {
+                starts.append(index)
+            }
+            isInsideWord = isAlphanumeric
+        }
+        return starts
+    }
+}

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -31,6 +31,7 @@ final class WindowState {
     private(set) var selectedContent: MainContentSelection = .dashboard
     var columnVisibility: NavigationSplitViewVisibility = .all
     var isInspectorPresented = false
+    var isCommandPalettePresented = false
 
     var isProjectsSectionExpanded = true
     var isSessionsSectionExpanded = true
@@ -40,6 +41,12 @@ final class WindowState {
     var isCreateProjectPresented = false
     var createWorkspaceContext: CreateWorkspaceContext?
     var startSessionKind: StartSessionKind?
+
+    var isSheetPresented: Bool {
+        isCreateProjectPresented
+            || createWorkspaceContext != nil
+            || startSessionKind != nil
+    }
 
     /// Advances for every explicit request to type in the selected Terminal
     /// Session. Unlike `selectedSession`, this also changes when the user

--- a/macos/ATCTests/CommandPaletteContentTests.swift
+++ b/macos/ATCTests/CommandPaletteContentTests.swift
@@ -5,6 +5,13 @@ import Testing
 @MainActor
 @Suite("Command palette content")
 struct CommandPaletteContentTests {
+    @Test("palette-ineligible commands never appear")
+    func eligibility() {
+        let fixture = makeFixture()
+        #expect(!rows(query: "", fixture: fixture).map(\.id)
+            .contains(.toggleCommandPalette))
+    }
+
     @Test("rows use stable alphabetical order for empty and filtered queries")
     func stableOrdering() throws {
         let fixture = makeFixture()

--- a/macos/ATCTests/CommandPaletteContentTests.swift
+++ b/macos/ATCTests/CommandPaletteContentTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+@testable import ATC
+
+@MainActor
+@Suite("Command palette content")
+struct CommandPaletteContentTests {
+    @Test("rows use stable alphabetical order for empty and filtered queries")
+    func stableOrdering() throws {
+        let fixture = makeFixture()
+        #expect(rows(query: "", fixture: fixture).map(\.title) == [
+            "New Project…", "New Session", "New Terminal", "New Workspace…",
+            "Refresh", "Reload Configuration", "Toggle Sidebar",
+        ])
+        #expect(rows(query: "new", fixture: fixture).map(\.title) == [
+            "New Project…", "New Session", "New Terminal", "New Workspace…",
+        ])
+        #expect(CommandPaletteContent.isOrderedBefore(
+            title: "Same", id: .newProject,
+            thanTitle: "same", id: .newSession
+        ))
+        #expect(!CommandPaletteContent.isOrderedBefore(
+            title: "same", id: .newSession,
+            thanTitle: "Same", id: .newProject
+        ))
+    }
+
+    @Test("nonmatching commands are excluded")
+    func filtering() throws {
+        let fixture = makeFixture()
+        #expect(rows(query: "sidebar", fixture: fixture).map(\.id) == [.toggleSidebar])
+        #expect(rows(query: "missing", fixture: fixture).isEmpty)
+    }
+
+    @Test("shortcuts follow direct rebinds and unbinds")
+    func directShortcuts() throws {
+        let rebound = makeFixture(config: #"""
+        [keybindings]
+        "ctrl+shift+r" = "data.refresh"
+        """#)
+        let reboundShortcut = try stroke("ctrl+shift+r")
+        #expect(row(.refresh, fixture: rebound).shortcut == reboundShortcut)
+
+        let unbound = makeFixture(config: #"""
+        [keybindings]
+        "cmd+r" = "unbind"
+        """#)
+        #expect(row(.refresh, fixture: unbound).shortcut == nil)
+    }
+
+    @Test("a command bound only through a Command Sequence has no shortcut")
+    func sequenceIsNotAShortcut() throws {
+        let fixture = makeFixture(config: #"""
+        [keyboard]
+        clear_default_keybindings = true
+        [keybindings]
+        "leader>x" = "project.new"
+        """#)
+        #expect(row(.newProject, fixture: fixture).shortcut == nil)
+    }
+
+    @Test("availability is evaluated from the current command context")
+    func availability() throws {
+        let fixture = makeFixture()
+        #expect(row(.refresh, fixture: fixture).availability == .available)
+        #expect(row(.newSession, fixture: fixture).availability == .unavailable(
+            reason: "Requires an open Workspace on a reachable Connection"
+        ))
+    }
+
+    private func makeFixture(config: String = "") -> Fixture {
+        let suite = "CommandPaletteContentTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let model = AppModel(
+            connections: ConnectionsStore(
+                defaults: defaults,
+                credentials: InMemoryCredentialStore()
+            ),
+            clientFactory: { _ in MockATCClient() },
+            terminalRecoveryMonitor: .disabled()
+        )
+        let state = WindowState.ephemeral()
+        let store = KeyboardConfigStore(
+            configURL: FileManager.default.temporaryDirectory
+                .appending(path: UUID().uuidString)
+        )
+        let keymap = try! Keymap.resolve(
+            user: KeyboardConfigParser.parse(config)
+        ).get()
+        return Fixture(
+            keymap: keymap,
+            context: CommandContext(
+                appModel: model,
+                windowState: state,
+                configStore: store
+            )
+        )
+    }
+
+    private func rows(query: String, fixture: Fixture) -> [CommandPaletteRow] {
+        CommandPaletteContent.rows(
+            query: query,
+            keymap: fixture.keymap,
+            context: fixture.context
+        )
+    }
+
+    private func row(_ id: CommandID, fixture: Fixture) -> CommandPaletteRow {
+        try! #require(rows(query: "", fixture: fixture).first { $0.id == id })
+    }
+
+    private func stroke(_ text: String) throws -> KeyStroke {
+        try KeyStroke.parse(text).get()
+    }
+
+    private struct Fixture {
+        let keymap: ResolvedKeymap
+        let context: CommandContext
+    }
+}

--- a/macos/ATCTests/CommandPaletteHostingSmokeTest.swift
+++ b/macos/ATCTests/CommandPaletteHostingSmokeTest.swift
@@ -1,0 +1,30 @@
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+@testable import ATC
+
+@MainActor
+@Suite("Command palette hosting smoke")
+struct CommandPaletteHostingSmokeTest {
+    @Test("palette hosts with preview fixtures without crashing")
+    func hostPalette() {
+        let store = KeyboardConfigStore(
+            configURL: FileManager.default.temporaryDirectory
+                .appending(path: UUID().uuidString)
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 900, height: 600),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        window.contentView = NSHostingView(
+            rootView: CommandPaletteView()
+                .environment(AppModel.preview())
+                .environment(WindowState.ephemeral())
+                .environment(store)
+        )
+        window.makeKeyAndOrderFront(nil)
+        pump(seconds: 0.5)
+        window.orderOut(nil)
+    }
+}

--- a/macos/ATCTests/CommandPaletteHostingSmokeTest.swift
+++ b/macos/ATCTests/CommandPaletteHostingSmokeTest.swift
@@ -13,15 +13,26 @@ struct CommandPaletteHostingSmokeTest {
             configURL: FileManager.default.temporaryDirectory
                 .appending(path: UUID().uuidString)
         )
+        let appModel = AppModel.preview()
+        let windowState = WindowState.ephemeral()
+        let router = WindowKeyboardRouter(
+            keymap: store.keymap,
+            context: CommandContext(
+                appModel: appModel,
+                windowState: windowState,
+                configStore: store
+            )
+        )
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 900, height: 600),
             styleMask: [.titled], backing: .buffered, defer: false
         )
         window.contentView = NSHostingView(
             rootView: CommandPaletteView()
-                .environment(AppModel.preview())
-                .environment(WindowState.ephemeral())
+                .environment(appModel)
+                .environment(windowState)
                 .environment(store)
+                .environment(router)
         )
         window.makeKeyAndOrderFront(nil)
         pump(seconds: 0.5)

--- a/macos/ATCTests/CommandPaletteHostingSmokeTest.swift
+++ b/macos/ATCTests/CommandPaletteHostingSmokeTest.swift
@@ -38,4 +38,79 @@ struct CommandPaletteHostingSmokeTest {
         pump(seconds: 0.5)
         window.orderOut(nil)
     }
+
+    @Test("routing container mounts the presented palette without crashing")
+    func hostIntegratedPalette() {
+        let store = KeyboardConfigStore(
+            configURL: FileManager.default.temporaryDirectory
+                .appending(path: UUID().uuidString)
+        )
+        let appModel = AppModel.preview()
+        let windowState = WindowState.ephemeral()
+        windowState.isCommandPalettePresented = true
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 900, height: 600),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        window.contentView = NSHostingView(
+            rootView: KeyboardRoutingContainer(
+                appModel: appModel,
+                windowState: windowState,
+                configStore: store
+            ) {
+                Color.clear
+            }
+            .environment(appModel)
+            .environment(windowState)
+        )
+        window.makeKeyAndOrderFront(nil)
+        pump(seconds: 0.5)
+        #expect(windowState.isCommandPalettePresented)
+        window.orderOut(nil)
+    }
+
+    @Test("palette dismissal restores a valid previous responder")
+    func restoresPreviousResponder() {
+        let store = KeyboardConfigStore(
+            configURL: FileManager.default.temporaryDirectory
+                .appending(path: UUID().uuidString)
+        )
+        let appModel = AppModel.preview()
+        let windowState = WindowState.ephemeral()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 900, height: 600),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        let hostingView = NSHostingView(
+            rootView: KeyboardRoutingContainer(
+                appModel: appModel,
+                windowState: windowState,
+                configStore: store
+            ) {
+                Color.clear
+            }
+            .environment(appModel)
+            .environment(windowState)
+        )
+        window.contentView = hostingView
+        window.makeKeyAndOrderFront(nil)
+        pump(seconds: 0.2)
+
+        let previousResponder = FocusProbeView(frame: .zero)
+        hostingView.addSubview(previousResponder)
+        #expect(window.makeFirstResponder(previousResponder))
+
+        windowState.isCommandPalettePresented = true
+        pump(until: { window.firstResponder !== previousResponder })
+        #expect(window.firstResponder !== previousResponder)
+
+        windowState.isCommandPalettePresented = false
+        pump(until: { window.firstResponder === previousResponder })
+        #expect(window.firstResponder === previousResponder)
+        window.orderOut(nil)
+    }
+}
+
+private final class FocusProbeView: NSView {
+    override var acceptsFirstResponder: Bool { true }
 }

--- a/macos/ATCTests/CommandPaletteHostingSmokeTest.swift
+++ b/macos/ATCTests/CommandPaletteHostingSmokeTest.swift
@@ -109,6 +109,58 @@ struct CommandPaletteHostingSmokeTest {
         #expect(window.firstResponder === previousResponder)
         window.orderOut(nil)
     }
+
+    @Test("deactivation before the palette mounts restores the stashed responder")
+    func restoresResponderWhenDeactivationBeatsMounting() {
+        let store = KeyboardConfigStore(
+            configURL: FileManager.default.temporaryDirectory
+                .appending(path: UUID().uuidString)
+        )
+        let appModel = AppModel.preview()
+        let windowState = WindowState.ephemeral()
+        let router = WindowKeyboardRouter(
+            keymap: store.keymap,
+            context: CommandContext(
+                appModel: appModel,
+                windowState: windowState,
+                configStore: store
+            )
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 900, height: 600),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        let probe = FocusProbeView(frame: .zero)
+        window.contentView?.addSubview(probe)
+        window.makeKeyAndOrderFront(nil)
+        #expect(window.makeFirstResponder(probe))
+
+        let coordinator = KeyboardMonitorHost.Coordinator(
+            router: router,
+            onDeactivate: { windowState.isCommandPalettePresented = false },
+            focusFallback: {}
+        )
+        coordinator.install(for: window)
+
+        // Simulate the keyboard opener mid-flight: suspension has flipped and
+        // the key monitor stashed the responder and cleared focus, but the
+        // palette's window accessor has not mounted yet.
+        windowState.isCommandPalettePresented = true
+        router.responderBeforeSuspension = probe
+        window.makeFirstResponder(nil)
+
+        NotificationCenter.default.post(
+            name: NSWindow.didResignKeyNotification,
+            object: window
+        )
+        pump(until: { window.firstResponder === probe })
+
+        #expect(!windowState.isCommandPalettePresented)
+        #expect(window.firstResponder === probe)
+        #expect(router.responderBeforeSuspension == nil)
+        coordinator.stop()
+        window.orderOut(nil)
+    }
 }
 
 private final class FocusProbeView: NSView {

--- a/macos/ATCTests/CommandRegistryTests.swift
+++ b/macos/ATCTests/CommandRegistryTests.swift
@@ -55,7 +55,8 @@ struct CommandRegistryTests {
     @Test("descriptor enumeration is complete, unique, and stable")
     func descriptors() {
         let expectedIDs = [
-            "view.toggle-sidebar", "session.new", "terminal.new", "project.new",
+            "view.toggle-sidebar", "view.toggle-command-palette", "session.new",
+            "terminal.new", "project.new",
             "workspace.new", "data.refresh", "configuration.reload",
         ]
         let descriptors = CommandRegistry.allDescriptors
@@ -64,7 +65,8 @@ struct CommandRegistryTests {
         #expect(descriptors.map(\.id) == CommandID.allCases)
         #expect(Set(descriptors.map { $0.id.rawValue }).count == descriptors.count)
         #expect(descriptors.allSatisfy { !$0.title.isEmpty })
-        #expect(descriptors.allSatisfy(\.isPaletteEligible))
+        #expect(descriptors.filter { !$0.isPaletteEligible }.map(\.id)
+            == [.toggleCommandPalette])
     }
 
     @Test("categories use the shared presentation order and assignments")
@@ -76,6 +78,7 @@ struct CommandRegistryTests {
             ($0.id, $0.category)
         }) == [
             .toggleSidebar: .view,
+            .toggleCommandPalette: .view,
             .newSession: .sessionsAndTerminals,
             .newTerminal: .sessionsAndTerminals,
             .newProject: .projectsAndWorkspaces,
@@ -83,6 +86,40 @@ struct CommandRegistryTests {
             .refresh: .general,
             .reloadConfiguration: .general,
         ])
+    }
+
+    @Test("the palette opener toggles and is unavailable for every sheet driver")
+    func paletteOpener() {
+        let model = makeModel()
+        let state = WindowState.ephemeral()
+        let context = makeContext(model: model, state: state)
+        let descriptor = CommandRegistry.descriptor(for: .toggleCommandPalette)
+        let unavailable = CommandAvailability.unavailable(
+            reason: "Not available while a dialog is open"
+        )
+
+        #expect(descriptor.availability(context) == .available)
+        CommandRegistry.execute(.toggleCommandPalette, context: context)
+        #expect(state.isCommandPalettePresented)
+        CommandRegistry.execute(.toggleCommandPalette, context: context)
+        #expect(!state.isCommandPalettePresented)
+
+        state.isCreateProjectPresented = true
+        #expect(state.isSheetPresented)
+        #expect(descriptor.availability(context) == unavailable)
+        state.isCreateProjectPresented = false
+
+        state.createWorkspaceContext = .init(mode: .free)
+        #expect(state.isSheetPresented)
+        #expect(descriptor.availability(context) == unavailable)
+        state.createWorkspaceContext = nil
+
+        state.startSessionKind = .terminal
+        #expect(state.isSheetPresented)
+        #expect(descriptor.availability(context) == unavailable)
+        state.startSessionKind = nil
+        #expect(!state.isSheetPresented)
+        #expect(descriptor.availability(context) == .available)
     }
 
     @Test("availability follows the complete command truth table")

--- a/macos/ATCTests/CommandRegistryTests.swift
+++ b/macos/ATCTests/CommandRegistryTests.swift
@@ -52,17 +52,37 @@ struct CommandRegistryTests {
         return (makeContext(model: model, state: state), runtime)
     }
 
-    @Test("descriptors expose stable ids and titles")
+    @Test("descriptor enumeration is complete, unique, and stable")
     func descriptors() {
-        #expect(CommandID.allCases.map(\.rawValue) == [
+        let expectedIDs = [
             "view.toggle-sidebar", "session.new", "terminal.new", "project.new",
             "workspace.new", "data.refresh", "configuration.reload",
+        ]
+        let descriptors = CommandRegistry.allDescriptors
+
+        #expect(CommandID.allCases.map(\.rawValue) == expectedIDs)
+        #expect(descriptors.map(\.id) == CommandID.allCases)
+        #expect(Set(descriptors.map { $0.id.rawValue }).count == descriptors.count)
+        #expect(descriptors.allSatisfy { !$0.title.isEmpty })
+        #expect(descriptors.allSatisfy(\.isPaletteEligible))
+    }
+
+    @Test("categories use the shared presentation order and assignments")
+    func categories() {
+        #expect(CommandCategory.allCases.map(\.title) == [
+            "General", "Projects & Workspaces", "Sessions & Terminals", "View",
         ])
-        for id in CommandID.allCases {
-            let descriptor = CommandRegistry.descriptor(for: id)
-            #expect(descriptor.id == id)
-            #expect(!descriptor.title.isEmpty)
-        }
+        #expect(Dictionary(uniqueKeysWithValues: CommandRegistry.allDescriptors.map {
+            ($0.id, $0.category)
+        }) == [
+            .toggleSidebar: .view,
+            .newSession: .sessionsAndTerminals,
+            .newTerminal: .sessionsAndTerminals,
+            .newProject: .projectsAndWorkspaces,
+            .newWorkspace: .projectsAndWorkspaces,
+            .refresh: .general,
+            .reloadConfiguration: .general,
+        ])
     }
 
     @Test("availability follows the complete command truth table")

--- a/macos/ATCTests/KeyboardRouterTests.swift
+++ b/macos/ATCTests/KeyboardRouterTests.swift
@@ -170,11 +170,15 @@ struct KeyboardRouterTests {
     }
 
     @Test("external unavailable feedback uses the router flash lifecycle")
-    func showUnavailable() throws {
+    func showUnavailable() async throws {
         let router = WindowKeyboardRouter(keymap: try keymap()) { _ in .available }
         router.showUnavailable(reason: "Unavailable now")
         #expect(router.flash == RouterFlash(message: "Unavailable now"))
-        pump(seconds: 0.9)
+        // Awaiting releases the main actor so the router's clearing task can
+        // run; a run-loop pump would hold the actor and dead-lock the clear.
+        for _ in 0..<100 where router.flash != nil {
+            try await Task.sleep(for: .milliseconds(50))
+        }
         #expect(router.flash == nil)
     }
 }

--- a/macos/ATCTests/KeyboardRouterTests.swift
+++ b/macos/ATCTests/KeyboardRouterTests.swift
@@ -150,4 +150,31 @@ struct KeyboardRouterTests {
         let router = WindowKeyboardRouter(keymap: map) { _ in .available }
         #expect(!router.handle(try stroke("ctrl+j"), isRepeat: false))
     }
+
+    @Test("suspension forwards registered bindings until routing resumes")
+    func suspension() throws {
+        var isSuspended = true
+        var executions: [CommandID] = []
+        let router = WindowKeyboardRouter(keymap: try keymap()) {
+            executions.append($0)
+            return .available
+        }
+        router.isSuspended = { isSuspended }
+        let refresh = try stroke("cmd+r")
+
+        #expect(!router.handle(refresh, isRepeat: false))
+        #expect(executions.isEmpty)
+        isSuspended = false
+        #expect(router.handle(refresh, isRepeat: false))
+        #expect(executions == [.refresh])
+    }
+
+    @Test("external unavailable feedback uses the router flash lifecycle")
+    func showUnavailable() throws {
+        let router = WindowKeyboardRouter(keymap: try keymap()) { _ in .available }
+        router.showUnavailable(reason: "Unavailable now")
+        #expect(router.flash == RouterFlash(message: "Unavailable now"))
+        pump(seconds: 0.9)
+        #expect(router.flash == nil)
+    }
 }

--- a/macos/ATCTests/KeymapResolutionTests.swift
+++ b/macos/ATCTests/KeymapResolutionTests.swift
@@ -21,6 +21,10 @@ struct KeymapResolutionTests {
         #expect(keymap.generation == 1)
         #expect(keymap.leaderTimeout == .milliseconds(1_800))
         #expect(command(at: try stroke("cmd+b"), in: keymap) == .toggleSidebar)
+        #expect(command(at: try stroke("cmd+shift+p"), in: keymap)
+            == .toggleCommandPalette)
+        let paletteShortcut = try stroke("cmd+shift+p")
+        #expect(keymap.menuShortcuts[.toggleCommandPalette] == paletteShortcut)
         #expect(command(at: try stroke("cmd+n"), in: keymap) == .newSession)
         #expect(command(at: try stroke("cmd+r"), in: keymap) == .refresh)
         #expect(command(at: try stroke("cmd+t"), in: keymap) == .newTerminal)
@@ -31,6 +35,25 @@ struct KeymapResolutionTests {
         #expect(command(in: leader[KeyStroke(key: "b", modifiers: [])]) == .toggleSidebar)
         #expect(command(in: leader[KeyStroke(key: "n", modifiers: [])]) == .newSession)
         #expect(command(in: leader[KeyStroke(key: "r", modifiers: [])]) == .refresh)
+    }
+
+    @Test("the palette binding can be rebound and unbound")
+    func paletteBindingLayering() throws {
+        let rebound = try resolve(#"""
+        [keybindings]
+        "ctrl+shift+p" = "view.toggle-command-palette"
+        """#)
+        #expect(command(at: try stroke("ctrl+shift+p"), in: rebound)
+            == .toggleCommandPalette)
+        let reboundShortcut = try stroke("ctrl+shift+p")
+        #expect(rebound.menuShortcuts[.toggleCommandPalette] == reboundShortcut)
+
+        let unbound = try resolve(#"""
+        [keybindings]
+        "cmd+shift+p" = "unbind"
+        """#)
+        #expect(unbound.root[try stroke("cmd+shift+p")] == nil)
+        #expect(unbound.menuShortcuts[.toggleCommandPalette] == nil)
     }
 
     @Test("user entries replace, unbind, and can rebind defaults")

--- a/macos/ATCTests/KeymapResolutionTests.swift
+++ b/macos/ATCTests/KeymapResolutionTests.swift
@@ -24,7 +24,8 @@ struct KeymapResolutionTests {
         #expect(command(at: try stroke("cmd+shift+p"), in: keymap)
             == .toggleCommandPalette)
         let paletteShortcut = try stroke("cmd+shift+p")
-        #expect(keymap.menuShortcuts[.toggleCommandPalette] == paletteShortcut)
+        #expect(keymap.menuShortcuts[.toggleCommandPalette]
+            == paletteShortcut)
         #expect(command(at: try stroke("cmd+n"), in: keymap) == .newSession)
         #expect(command(at: try stroke("cmd+r"), in: keymap) == .refresh)
         #expect(command(at: try stroke("cmd+t"), in: keymap) == .newTerminal)
@@ -46,7 +47,8 @@ struct KeymapResolutionTests {
         #expect(command(at: try stroke("ctrl+shift+p"), in: rebound)
             == .toggleCommandPalette)
         let reboundShortcut = try stroke("ctrl+shift+p")
-        #expect(rebound.menuShortcuts[.toggleCommandPalette] == reboundShortcut)
+        #expect(rebound.menuShortcuts[.toggleCommandPalette]
+            == reboundShortcut)
 
         let unbound = try resolve(#"""
         [keybindings]

--- a/macos/ATCTests/QueryMatcherTests.swift
+++ b/macos/ATCTests/QueryMatcherTests.swift
@@ -1,0 +1,55 @@
+import Testing
+@testable import ATC
+
+@Suite("Command palette query matcher")
+struct QueryMatcherTests {
+    @Test("empty and whitespace-only queries match without highlights")
+    func emptyQueries() throws {
+        #expect(try #require(QueryMatcher.match("", in: "Toggle Sidebar")).ranges.isEmpty)
+        #expect(try #require(QueryMatcher.match("  \n", in: "New Project…")).ranges.isEmpty)
+    }
+
+    @Test("substring matching is case-insensitive and returns the exact range")
+    func substring() throws {
+        let title = "Toggle Sidebar"
+        let match = try #require(QueryMatcher.match("SID", in: title))
+        #expect(strings(for: match, in: title) == ["Sid"])
+    }
+
+    @Test("word-initial matching covers representative command titles")
+    func wordInitials() throws {
+        for (query, title, expected) in [
+            ("np", "New Project…", ["N", "P"]),
+            ("nt", "New Terminal", ["N", "T"]),
+            ("ts", "Toggle Sidebar", ["T", "S"]),
+            ("rc", "Reload Configuration", ["R", "C"]),
+        ] {
+            let match = try #require(QueryMatcher.match(query, in: title))
+            #expect(strings(for: match, in: title) == expected)
+        }
+    }
+
+    @Test("punctuation does not form words")
+    func punctuation() throws {
+        let title = "New & Project…"
+        let match = try #require(QueryMatcher.match("np", in: title))
+        #expect(strings(for: match, in: title) == ["N", "P"])
+        #expect(QueryMatcher.match("n&p", in: title) == nil)
+    }
+
+    @Test("substring matching wins when both strategies match")
+    func substringPrecedence() throws {
+        let title = "To Optimize"
+        let match = try #require(QueryMatcher.match("to", in: title))
+        #expect(strings(for: match, in: title) == ["To"])
+    }
+
+    @Test("nonmatches return nil")
+    func nonmatch() {
+        #expect(QueryMatcher.match("xyz", in: "Toggle Sidebar") == nil)
+    }
+
+    private func strings(for match: QueryMatch, in title: String) -> [String] {
+        match.ranges.map { String(title[$0]) }
+    }
+}

--- a/macos/ATCTests/TriggerParsingTests.swift
+++ b/macos/ATCTests/TriggerParsingTests.swift
@@ -24,6 +24,15 @@ struct TriggerParsingTests {
         #expect(stroke.description == "cmd+opt+shift+n")
     }
 
+    @Test("spoken shortcuts name modifiers in glyph order")
+    func spokenDescription() {
+        #expect(KeyStroke(
+            key: "p",
+            modifiers: [.control, .option, .shift, .command]
+        ).spokenDescription == "Control Option Shift Command P")
+        #expect(KeyStroke.escape.spokenDescription == "Escape")
+    }
+
     @Test("sequence parsing reserves leader for step one")
     func sequences() throws {
         #expect(try ParsedKeySequence.parse("cmd+b").get()

--- a/macos/CONTEXT.md
+++ b/macos/CONTEXT.md
@@ -55,6 +55,6 @@ _Avoid_: Selected row
 The current viewed remote directory that atc will use as a session working directory when the user confirms a folder picker.
 _Avoid_: Selected file, selected row
 
-**Atelier Command Sequence**:
-A keyboard sequence that starts with the configured leader key (`Cmd-K` by default), waits for one continuation key (modified or unmodified), and targets atc itself, including when a Terminal Session has focus.
-_Avoid_: Leader key, terminal prefix, command chord
+**Command Sequence**:
+A two-step atc interaction that starts with the configured leader (`Cmd-K` by default), waits for one continuation key (modified or unmodified), and targets atc itself, including when a Terminal Session has focus. A Command Sequence is not a Keyboard Shortcut.
+_Avoid_: Keyboard Shortcut, terminal prefix, command chord


### PR DESCRIPTION
Implements [docs/command-palette-spec.md](docs/command-palette-spec.md): a flat, searchable, Ghostty-style overlay over the existing command registry, opened with `Shift-Cmd-P` (rebindable via `[keybindings]`) or View → Toggle Command Palette.

## What's included

- **Catalog metadata** — `CommandCategory`, `isPaletteEligible`, and stable `CommandRegistry.allDescriptors` enumeration; the opener command `view.toggle-command-palette` (palette-ineligible, unavailable while a sheet is presented).
- **QueryMatcher** — case-insensitive substring with word-initial fallback (`np` → **N**ew **P**roject…), words as maximal alphanumeric runs, exact highlight ranges, no scoring/typo machinery.
- **CommandPaletteContent** — pure row projection: eligibility filter, match, alphabetical order with `CommandID` tie-break, shortcuts from `menuShortcuts` only (Command Sequences never render as shortcuts), unavailable rows kept with their reason.
- **CommandPaletteView** — material panel overlay in `KeyboardRoutingContainer` (below the feedback overlay), local `@State` so every opening starts fresh, full §6 interaction table (wrapping arrow/Ctrl-N/P navigation, dismiss-then-execute-exactly-once, unavailable rows flash their reason via the router), VoiceOver container/labels with spoken shortcuts.
- **Routing** — `WindowKeyboardRouter.isSuspended` forwards everything untouched while the palette is open (menu key equivalents stay live, which is what lets a second `Shift-Cmd-P` close it); pending Command Sequences cancel on present; window-resign/app-deactivate dismisses through the existing coordinator.
- **Focus** — the key monitor clears window focus the instant suspension flips on (stashing the responder), so keystrokes queued behind a fast `Shift-Cmd-P` can never reach the terminal; dismissal restores the prior responder or falls back to `requestTerminalFocus()`.

## Review process

Implemented per the spec's five-step build order, then adversarially reviewed by two independent agents (spec conformance + runtime edge cases). Findings addressed: a pre-mount focus gap where queued keystrokes could reach the terminal, an `onKeyPress` API misuse that broke Ctrl-N/P, empty-state visibility to assistive tech, and a timing-flaky flash test.

## Testing

- `mise run macos:test` green: 256 tests in 32 suites.
- New/extended suites per spec §9: registry enumeration/categories/opener, QueryMatcher, palette content projection, keymap resolution for `cmd+shift+p`, router suspension + `showUnavailable`, and palette hosting smoke tests (including responder restoration).
- Manual checklist (spec §9) still to be run interactively — focus behavior with the embedded Ghostty terminal, VoiceOver, Reduce Motion/contrast.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a searchable Command Palette with deterministic, keyboard-driven navigation and result highlighting.
  * Added default `Cmd+Shift+P` and a sidebar/menu entry to open it.
  * Unavailable commands stay visible with immediate “unavailable” feedback; executing an available command dismisses the palette and restores focus appropriately.

* **Documentation**
  * Added Command Palette and keyboard shortcut reference plan/spec docs, including clearer command-input terminology.

* **Tests**
  * Added/expanded coverage for palette searching and ordering, shortcut binding/rebinding, availability behavior, keyboard routing/suspension, accessibility descriptions, and focus/deactivation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->