### PR TITLE
Command palette: list all Sessions, Terminals, or Workspaces by type keyword (ATC-26)

### DIFF
--- a/macos/ATC/Features/CommandPalette/CommandPaletteContent.swift
+++ b/macos/ATC/Features/CommandPalette/CommandPaletteContent.swift
@@ -47,6 +47,11 @@ struct SessionResult: Identifiable {
     var id: PaletteResultID { .session(ref) }
 }
 
+/// A whole-query type keyword: a trimmed query of three or more characters
+/// that is a case-insensitive prefix of one plural keyword ("sessions",
+/// "terminals", "workspaces") lists every target of that type, additively
+/// with ordinary matching. Anything else — shorter, longer than the keyword,
+/// or a composed query like "session parser" — matches only by title.
 enum PaletteTypeKeyword: CaseIterable, Equatable {
     case sessions
     case terminals

--- a/macos/ATC/Features/CommandPalette/CommandPaletteContent.swift
+++ b/macos/ATC/Features/CommandPalette/CommandPaletteContent.swift
@@ -47,6 +47,28 @@ struct SessionResult: Identifiable {
     var id: PaletteResultID { .session(ref) }
 }
 
+enum PaletteTypeKeyword: CaseIterable, Equatable {
+    case sessions
+    case terminals
+    case workspaces
+
+    static func match(_ query: String) -> PaletteTypeKeyword? {
+        let query = query
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        guard query.count >= 3 else { return nil }
+        return allCases.first { $0.keyword.hasPrefix(query) }
+    }
+
+    private var keyword: String {
+        switch self {
+        case .sessions: "sessions"
+        case .terminals: "terminals"
+        case .workspaces: "workspaces"
+        }
+    }
+}
+
 @MainActor
 enum CommandPaletteContent {
     static func results(
@@ -81,10 +103,12 @@ enum CommandPaletteContent {
         query: String,
         groups: ProjectsNavigatorGroups
     ) -> [WorkspaceResult] {
-        groups.projects.flatMap { group in
+        let expandsWorkspaces = PaletteTypeKeyword.match(query) == .workspaces
+        return groups.projects.flatMap { group in
             group.workspaces.compactMap { row in
                 let titleMatch = QueryMatcher.match(query, in: row.workspace.name)
-                guard titleMatch != nil
+                guard expandsWorkspaces
+                    || titleMatch != nil
                     || QueryMatcher.match(query, in: group.project.name) != nil
                     || QueryMatcher.match(query, in: group.connectionName) != nil
                 else { return nil }
@@ -108,18 +132,28 @@ enum CommandPaletteContent {
         sessions: [Session],
         actions: [ATCAction]
     ) -> [SessionResult] {
-        sessions.compactMap { session in
+        let keyword = PaletteTypeKeyword.match(query)
+        return sessions.compactMap { session in
             guard session.belongs(to: activeWorkspace), !session.isArchived else { return nil }
             let title = SessionKind.displayName(session: session, actions: actions)
-            guard let match = QueryMatcher.match(query, in: title) else { return nil }
+            let kind = SessionKind.classify(session: session, actions: actions)
+            let titleMatch = QueryMatcher.match(query, in: title)
+            let expandsKind: Bool
+            switch kind {
+            case .agent:
+                expandsKind = keyword == .sessions
+            case .terminal:
+                expandsKind = keyword == .terminals
+            }
+            guard titleMatch != nil || expandsKind else { return nil }
             return SessionResult(
                 ref: SessionRef(
                     connectionID: activeWorkspace.connectionID,
                     sessionID: session.id
                 ),
                 title: title,
-                kind: SessionKind.classify(session: session, actions: actions),
-                matchedRanges: match.ranges
+                kind: kind,
+                matchedRanges: titleMatch?.ranges ?? []
             )
         }.sorted(by: sessionComesFirst)
     }

--- a/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
+++ b/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
@@ -213,7 +213,11 @@ struct CommandPaletteView: View {
             }
         case .workspace(let row):
             VStack(alignment: .leading, spacing: 2) {
-                highlightedTitle(row.title, ranges: row.matchedRanges)
+                typedTitle(
+                    "Workspace",
+                    title: row.title,
+                    ranges: row.matchedRanges
+                )
                     .font(.callout)
                 Text("\(row.projectName) · \(row.connectionName)")
                     .font(.caption)
@@ -222,10 +226,25 @@ struct CommandPaletteView: View {
             }
             Spacer(minLength: 12)
         case .session(let row):
-            highlightedTitle(row.title, ranges: row.matchedRanges)
+            typedTitle(
+                row.kind == .agent ? "Session" : "Terminal",
+                title: row.title,
+                ranges: row.matchedRanges
+            )
                 .font(.callout)
             Spacer(minLength: 12)
-            trailingLabel(row.kind == .agent ? "Session" : "Terminal")
+        }
+    }
+
+    private func typedTitle(
+        _ type: String,
+        title: String,
+        ranges: [Range<String.Index>]
+    ) -> some View {
+        HStack(spacing: 0) {
+            Text("\(type): ")
+                .foregroundStyle(.secondary)
+            highlightedTitle(title, ranges: ranges)
         }
     }
 

--- a/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
+++ b/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
@@ -227,7 +227,7 @@ struct CommandPaletteView: View {
             Spacer(minLength: 12)
         case .session(let row):
             typedTitle(
-                row.kind == .agent ? "Session" : "Terminal",
+                row.kind.paletteTypeLabel,
                 title: row.title,
                 ranges: row.matchedRanges
             )
@@ -236,16 +236,17 @@ struct CommandPaletteView: View {
         }
     }
 
+    /// One flowing Text so a long name wraps as a unit with its prefix. The
+    /// prefix is dropped when the name already is the type label — an unnamed
+    /// shell reads "Terminal", not "Terminal: Terminal".
     private func typedTitle(
         _ type: String,
         title: String,
         ranges: [Range<String.Index>]
-    ) -> some View {
-        HStack(spacing: 0) {
-            Text("\(type): ")
-                .foregroundStyle(.secondary)
-            highlightedTitle(title, ranges: ranges)
-        }
+    ) -> Text {
+        let name = highlightedTitle(title, ranges: ranges)
+        guard title != type else { return name }
+        return Text("\(type): ").foregroundStyle(.secondary) + name
     }
 
     @ViewBuilder
@@ -294,7 +295,10 @@ struct CommandPaletteView: View {
                 parts.append("Unavailable — \(reason)")
             }
         case .session(let row):
-            parts = [row.title, row.kind == .agent ? "Session" : "Terminal"]
+            parts = [row.title]
+            if row.title != row.kind.paletteTypeLabel {
+                parts.append(row.kind.paletteTypeLabel)
+            }
         }
         return parts.joined(separator: ", ")
     }
@@ -381,6 +385,16 @@ struct CommandPaletteView: View {
         }
         self.selectedID = rows[(index + offset + rows.count) % rows.count].id
         return .handled
+    }
+}
+
+private extension SessionKind {
+    /// The one palette type label, shared by the row prefix and VoiceOver.
+    var paletteTypeLabel: String {
+        switch self {
+        case .agent: "Session"
+        case .terminal: "Terminal"
+        }
     }
 }
 

--- a/macos/ATCTests/CommandPaletteContentTests.swift
+++ b/macos/ATCTests/CommandPaletteContentTests.swift
@@ -618,6 +618,45 @@ struct CommandPaletteSessionResultTests {
         #expect(terminals.allSatisfy { $0.kind == .terminal && $0.matchedRanges.isEmpty })
     }
 
+    @Test("cross-kind title matches stay additive under keyword expansion")
+    func crossKindTitleMatches() throws {
+        let active = WorkspaceRef(connectionID: connectionID, workspaceID: "active")
+        let candidates = [
+            paletteSession("shell", name: "Session log", workspace: "active"),
+            paletteSession(
+                "agent", name: "Terminate run", action: "claude", workspace: "active"
+            ),
+        ]
+
+        let bySessionKeyword = results(query: "ses", active: active, sessions: candidates)
+        #expect(bySessionKeyword.map(\.ref.sessionID) == ["shell", "agent"])
+        let titleMatched = try #require(bySessionKeyword.first)
+        #expect(titleMatched.kind == .terminal)
+        #expect(titleMatched.matchedRanges.map {
+            String(titleMatched.title[$0])
+        } == ["Ses"])
+        #expect(try #require(bySessionKeyword.last).matchedRanges.isEmpty)
+
+        let byTerminalKeyword = results(query: "ter", active: active, sessions: candidates)
+        #expect(byTerminalKeyword.map(\.ref.sessionID) == ["shell", "agent"])
+        #expect(try #require(byTerminalKeyword.first).matchedRanges.isEmpty)
+        let agentMatch = try #require(byTerminalKeyword.last)
+        #expect(agentMatch.kind == .agent)
+        #expect(agentMatch.matchedRanges.map { String(agentMatch.title[$0]) } == ["Ter"])
+    }
+
+    @Test("a two-character keyword prefix never expands")
+    func shortPrefixDoesNotExpand() {
+        let active = WorkspaceRef(connectionID: connectionID, workspaceID: "active")
+        let projected = results(query: "se", active: active, sessions: [
+            paletteSession("shell", name: "Session log", workspace: "active"),
+            paletteSession(
+                "agent", name: "Unrelated", action: "claude", workspace: "active"
+            ),
+        ])
+        #expect(projected.map(\.ref.sessionID) == ["shell"])
+    }
+
     @Test("hidden Action, status, and raw identifiers never match")
     func hiddenFieldsDoNotMatch() {
         let active = WorkspaceRef(connectionID: connectionID, workspaceID: "active")
@@ -713,18 +752,27 @@ struct CommandPaletteScaleTests {
             connectionID: paletteConnectionID(1),
             workspaceID: "active"
         )
+        let sessions = (0..<2_000).map {
+            paletteSession(
+                "session-\($0)", name: "Scale Session \($0)",
+                workspace: active.workspaceID
+            )
+        }
         let sessionResults = CommandPaletteContent.sessionResults(
             query: "Scale",
             activeWorkspace: active,
-            sessions: (0..<2_000).map {
-                paletteSession(
-                    "session-\($0)", name: "Scale Session \($0)",
-                    workspace: active.workspaceID
-                )
-            },
+            sessions: sessions,
             actions: []
         )
         #expect(sessionResults.count == 2_000)
+
+        let keywordResults = CommandPaletteContent.sessionResults(
+            query: "ter",
+            activeWorkspace: active,
+            sessions: sessions,
+            actions: []
+        )
+        #expect(keywordResults.count == 2_000)
     }
 }
 

--- a/macos/ATCTests/CommandPaletteContentTests.swift
+++ b/macos/ATCTests/CommandPaletteContentTests.swift
@@ -6,6 +6,19 @@ import ATCAPI
 @MainActor
 @Suite("Command palette content")
 struct CommandPaletteContentTests {
+    @Test("type keywords require a complete three-character-or-longer prefix")
+    func typeKeywordBoundaries() {
+        #expect(PaletteTypeKeyword.match("se") == nil)
+        for query in ["ses", "sess", "sessions"] {
+            #expect(PaletteTypeKeyword.match(query) == .sessions)
+        }
+        #expect(PaletteTypeKeyword.match("sessionsx") == nil)
+        #expect(PaletteTypeKeyword.match("session parser") == nil)
+        #expect(PaletteTypeKeyword.match("SES") == .sessions)
+        #expect(PaletteTypeKeyword.match("Ter") == .terminals)
+        #expect(PaletteTypeKeyword.match(" \n work \t") == .workspaces)
+    }
+
     @Test("palette-ineligible commands never appear")
     func eligibility() {
         let fixture = makeFixture()
@@ -121,6 +134,74 @@ struct CommandPaletteContentTests {
         #expect(projected.compactMap(\.sessionRow).map {
             "\($0.title):\($0.ref.sessionID)"
         } == ["Alpha:ses_b", "same:ses_a", "Same:ses_z"])
+    }
+
+    @Test("keyword expansion keeps bucket and alphabetical ordering")
+    func keywordBucketOrdering() async throws {
+        var client = MockATCClient()
+        client.mockProjects = [paletteProject("project", name: "Project")]
+        client.mockWorkspaces = [
+            paletteWorkspace("wsp_z", project: "project", name: "Session Zoo"),
+            paletteWorkspace("wsp_a", project: "project", name: "Session Alpha"),
+        ]
+        client.mockSessions = [
+            paletteSession(
+                "ses_z", name: "Zulu", action: "claude", workspace: "wsp_a"
+            ),
+            paletteSession(
+                "ses_a", name: "Alpha", action: "claude", workspace: "wsp_a"
+            ),
+            paletteSession("terminal", name: "Shell Tools", workspace: "wsp_a"),
+        ]
+        let fixture = try await makeLiveFixture(client: client, workspaceID: "wsp_a")
+        let projected = results(query: "ses", fixture: fixture)
+
+        #expect(projected.compactMap(\.commandRow).map(\.title) == ["New Session"])
+        #expect(projected.compactMap(\.workspaceRow).map(\.title) == [
+            "Session Alpha", "Session Zoo",
+        ])
+        #expect(projected.compactMap(\.sessionRow).map(\.title) == ["Alpha", "Zulu"])
+        #expect(projected.map { result in
+            switch result {
+            case .command: "command"
+            case .workspace: "workspace"
+            case .session: "session"
+            }
+        } == ["command", "workspace", "workspace", "session", "session"])
+    }
+
+    @Test("type expansion is additive and preserves title matches without duplicates")
+    func keywordAdditivityAndDeduplication() async throws {
+        var client = MockATCClient()
+        client.mockProjects = [paletteProject("project", name: "Project")]
+        client.mockWorkspaces = [
+            paletteWorkspace("workspace", project: "project", name: "Workspace")
+        ]
+        client.mockSessions = [
+            paletteSession(
+                "title-match", name: "Terminal cleanup", workspace: "workspace"
+            ),
+            paletteSession(
+                "category-only", name: "Shell tools", workspace: "workspace"
+            ),
+            paletteSession(
+                "agent", name: "Agent work", action: "claude", workspace: "workspace"
+            ),
+        ]
+        let fixture = try await makeLiveFixture(client: client, workspaceID: "workspace")
+        let projected = results(query: "ter", fixture: fixture)
+        let sessionRows = projected.compactMap(\.sessionRow)
+
+        #expect(projected.compactMap(\.commandRow).map(\.title).contains("New Terminal"))
+        #expect(sessionRows.map(\.ref.sessionID) == ["category-only", "title-match"])
+        #expect(sessionRows.filter { $0.ref.sessionID == "title-match" }.count == 1)
+        let titleMatch = try #require(sessionRows.first {
+            $0.ref.sessionID == "title-match"
+        })
+        #expect(titleMatch.matchedRanges.map { String(titleMatch.title[$0]) } == ["Ter"])
+        #expect(try #require(sessionRows.first {
+            $0.ref.sessionID == "category-only"
+        }).matchedRanges.isEmpty)
     }
 
     @Test("no Active Workspace omits Sessions and an unmatched query is empty")
@@ -332,6 +413,37 @@ struct CommandPaletteWorkspaceResultTests {
         #expect(Set(projected.map(\.connectionName)) == ["First", "Second"])
     }
 
+    @Test("Workspace keywords include every unarchived Workspace across Connections")
+    func keywordExpansionAcrossConnections() {
+        let projected = results(query: "  WoR  ", inputs: [
+            input(
+                connection: paletteConnection(1, name: "First"),
+                projects: [paletteProject("p1", name: "Atlas")],
+                workspaces: [
+                    paletteWorkspace("alpha", project: "p1", name: "Alpha"),
+                    paletteWorkspace(
+                        "archived", project: "p1", name: "Archived", archived: true
+                    ),
+                ]
+            ),
+            input(
+                connection: paletteConnection(2, name: "Second"),
+                projects: [paletteProject("p2", name: "Beacon")],
+                workspaces: [
+                    paletteWorkspace("beta", project: "p2", name: "Beta")
+                ],
+                reachability: .unreachable
+            ),
+        ])
+
+        #expect(projected.map(\.ref.workspaceID) == ["alpha", "beta"])
+        #expect(projected.allSatisfy { $0.matchedRanges.isEmpty })
+        #expect(projected[0].availability == .available)
+        #expect(projected[1].availability == .unavailable(
+            reason: "Requires a reachable Connection"
+        ))
+    }
+
     @Test("only connected Workspaces are available")
     func availability() {
         let projected = results(query: "Workspace", inputs: [
@@ -459,6 +571,51 @@ struct CommandPaletteSessionResultTests {
         #expect(byID["agent"]?.kind == .agent)
         #expect(byID["tool"]?.title == "LazyGit")
         #expect(byID["tool"]?.kind == .terminal)
+    }
+
+    @Test("Session and Terminal keywords expand only their classified kind")
+    func keywordExpansionByKind() {
+        let active = WorkspaceRef(connectionID: connectionID, workspaceID: "active")
+        let candidates = [
+            paletteSession(
+                "agent-failed", name: "Agent Failed", action: "claude",
+                workspace: "active", status: .failed
+            ),
+            paletteSession(
+                "agent-terminated", name: "Finished Agent", action: "claude",
+                workspace: "active", status: .terminated
+            ),
+            paletteSession(
+                "shell-starting", name: "Shell Starting",
+                workspace: "active", status: .starting
+            ),
+            paletteSession(
+                "action-terminated", name: "Tool Done", action: "lazygit",
+                workspace: "active", status: .terminated
+            ),
+            paletteSession(
+                "unresolved-running", name: "Unknown Action", action: "missing",
+                workspace: "active", status: .running
+            ),
+            paletteSession(
+                "other-workspace", name: "Other Agent", action: "claude",
+                workspace: "other"
+            ),
+            paletteSession(
+                "archived", name: "Archived Agent", action: "claude",
+                workspace: "active", archived: true
+            ),
+        ]
+
+        let sessions = results(query: "ses", active: active, sessions: candidates)
+        #expect(sessions.map(\.ref.sessionID) == ["agent-failed", "agent-terminated"])
+        #expect(sessions.allSatisfy { $0.kind == .agent && $0.matchedRanges.isEmpty })
+
+        let terminals = results(query: "ter", active: active, sessions: candidates)
+        #expect(terminals.map(\.ref.sessionID) == [
+            "shell-starting", "action-terminated", "unresolved-running",
+        ])
+        #expect(terminals.allSatisfy { $0.kind == .terminal && $0.matchedRanges.isEmpty })
     }
 
     @Test("hidden Action, status, and raw identifiers never match")


### PR DESCRIPTION
Implements [ATC-26](https://linear.app/elevenideas/issue/ATC-26/command-palette-allow-listing-all-terminals-sessions-or-workspaces): the Command Palette can now enumerate navigation targets by type keyword, even when you can't remember a target's name.

## What changed

**Matching** (`CommandPaletteContent.swift`)
- New `PaletteTypeKeyword`: a trimmed query of ≥3 characters that is a case-insensitive prefix of `sessions`, `terminals`, or `workspaces` (`ses…`/`ter…`/`wor…`) expands that type.
- `ses…` lists every unarchived agent Session in the Active Workspace; `ter…` every unarchived Terminal (reusing `SessionKind.classify`, so the palette agrees with the Workspace Navigator); `wor…` every unarchived Workspace across all Connections, with unreachable ones keeping the existing dimmed/unavailable treatment.
- Expansion is purely additive: command matches and ordinary title/project/connection matches remain, bucket order (Commands → Workspaces → Sessions/Terminals) and alphabetical ordering are unchanged, and title matches keep their highlight ranges while category-only rows carry none. All lifecycle statuses are included; no eligibility, activation, or navigation rules changed.

**Presentation** (`CommandPaletteView.swift`)
- Navigation rows now read `Session: <name>` / `Terminal: <name>` / `Workspace: <name>` with the type prefix in secondary styling and the name primary (one concatenated `Text`, so long names wrap as a unit). The session row's old trailing kind badge is gone; Workspace rows keep their `Project · Connection` caption; command rows are untouched.
- Deliberate deviation from the ticket's literal presentation text: when the name already *is* the type label (an unnamed interactive shell is displayed as "Terminal"), the prefix is dropped so the row reads `Terminal` rather than `Terminal: Terminal`. VoiceOver labels apply the same rule via a shared `paletteTypeLabel`.

**Tests** (`CommandPaletteContentTests.swift`)
- Keyword boundaries (2-char no-op, prefix/whole-query rule, case/whitespace), kind separation across lifecycle statuses, cross-connection workspace expansion with unavailable state, additivity + dedup with preserved highlights, cross-kind title matches under expansion, bucket/alphabetical ordering, and an uncapped 2,000-row keyword-expansion scale assertion.

## Notes
- Workspaces inside archived Projects remain hidden under `wor…` — the shared navigator projection already excludes them, and keyword expansion deliberately changes matching only. Flagging in case the ticket's "every unarchived Workspace" intended otherwise.
- Full macOS suite passes (283 tests): `mise run macos:test`.

## Process
Initial implementation drafted with codex (GPT 5.6 Sol, high reasoning), then two adversarial reviews (correctness/spec + SwiftUI/a11y/maintainability) whose accepted findings were applied: `Text` concatenation instead of an `HStack` in `typedTitle`, the redundant-prefix rule above, a shared type-label source for visual + spoken copy, a constraint comment on `PaletteTypeKeyword`, and the added test coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Command Palette searches now recognize workspace, agent, and terminal type keywords.
  - Workspace results can be found across available connections using plural type keywords.
  - Session results can be filtered by agent or terminal type while retaining title-based matches.
  - Result labels and VoiceOver descriptions now present item types more consistently.

- **Bug Fixes**
  - Improved keyword matching behavior, including case handling, minimum prefix length, and accurate highlighting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->