### PR TITLE
macos: restore live/ended session lifecycle integration

### DIFF
--- a/macos/ATC/AppModel.swift
+++ b/macos/ATC/AppModel.swift
@@ -16,8 +16,7 @@ struct WindowNavigationSnapshot: Equatable {
         struct SessionRecord: Equatable {
             let id: String
             let workspaceID: String?
-            let isArchived: Bool
-            let attachable: Bool
+            let status: SessionStatus
         }
 
         let id: UUID
@@ -148,8 +147,7 @@ final class AppModel {
                     .init(
                         id: $0.id,
                         workspaceID: $0.workspace?.id,
-                        isArchived: $0.isArchived,
-                        attachable: $0.attachable
+                        status: $0.status
                     )
                 }
             )
@@ -241,9 +239,13 @@ final class AppModel {
             markRecentlyUsed(ref)
             return
         }
-        guard session.attachable,
+        guard session.status == .live,
               let runtime = runtime(id: connectionID) else { return }
-        terminals[ref] = terminalControllerFactory(session.id, runtime.client)
+        let controller = terminalControllerFactory(session.id, runtime.client)
+        controller.onSessionEnded = { [weak self] in
+            self?.reconcileEndedSession(ref)
+        }
+        terminals[ref] = controller
         markRecentlyUsed(ref)
         evictOverBudget(retentionContext: retentionContext)
     }
@@ -272,6 +274,34 @@ final class AppModel {
         for controller in terminals.values {
             controller.recoverAfterInterruption()
         }
+    }
+
+    /// Tears down interaction for sessions the latest successful poll says
+    /// are Ended or deleted. Failed refreshes are deliberately ignored so
+    /// connection loss never manufactures a lifecycle transition.
+    func reconcileTerminalLifecycle() {
+        for ref in Array(terminals.keys) {
+            guard let runtime = runtime(id: ref.connectionID),
+                  runtime.sessions.hasLoadedOnce,
+                  runtime.sessions.lastError == nil
+            else { continue }
+            guard runtime.sessions.session(id: ref.sessionID)?.status == .live else {
+                disconnectTerminal(ref: ref)
+                continue
+            }
+        }
+    }
+
+    /// Central stale-interaction reconciliation. Returns true when the
+    /// error is the expected `session_ended` response and was consumed.
+    @discardableResult
+    func handleSessionInteractionError(_ error: any Error, connectionID: UUID) -> Bool {
+        guard let error = error as? ATCError,
+              error.apiCode == "session_ended",
+              let sessionID = error.sessionID
+        else { return false }
+        reconcileEndedSession(SessionRef(connectionID: connectionID, sessionID: sessionID))
+        return true
     }
 
     // MARK: - Attachment budget
@@ -310,6 +340,13 @@ final class AppModel {
               activeWorkspace.connectionID == ref.connectionID
         else { return false }
         return session(for: ref)?.belongs(to: activeWorkspace) == true
+    }
+
+    private func reconcileEndedSession(_ ref: SessionRef) {
+        runtime(id: ref.connectionID)?.sessions.reconcileEnded(id: ref.sessionID)
+        if terminals[ref] != nil {
+            disconnectTerminal(ref: ref)
+        }
     }
 
     // MARK: - Private

--- a/macos/ATC/Features/CommandPalette/CommandPaletteContent.swift
+++ b/macos/ATC/Features/CommandPalette/CommandPaletteContent.swift
@@ -139,7 +139,7 @@ enum CommandPaletteContent {
     ) -> [SessionResult] {
         let keyword = PaletteTypeKeyword.match(query)
         return sessions.compactMap { session in
-            guard session.belongs(to: activeWorkspace), !session.isArchived else { return nil }
+            guard session.belongs(to: activeWorkspace) else { return nil }
             let title = SessionKind.displayName(session: session, actions: actions)
             let kind = SessionKind.classify(session: session, actions: actions)
             let titleMatch = QueryMatcher.match(query, in: title)

--- a/macos/ATC/Features/Dashboard/DashboardGroups.swift
+++ b/macos/ATC/Features/Dashboard/DashboardGroups.swift
@@ -23,7 +23,7 @@ struct DashboardGroups {
     struct WorkspaceRow: Identifiable {
         let ref: WorkspaceRef
         let workspace: Workspace
-        /// Any known session is `starting`/`running` — gates Archive.
+        /// Any known session is Live — gates Archive.
         let hasActiveSessions: Bool
         /// Local-store counts for the delete confirmation.
         let sessionCount: Int
@@ -81,9 +81,7 @@ struct DashboardGroups {
                     .sortedNewestFirst()
                     .map { workspace in
                         let members = sessionsByWorkspace[workspace.id] ?? []
-                        let active = members.filter {
-                            $0.status == .starting || $0.status == .running
-                        }
+                        let active = members.filter(\.isActive)
                         return WorkspaceRow(
                             ref: WorkspaceRef(
                                 connectionID: input.connection.id,

--- a/macos/ATC/Features/Sessions/SessionContentView.swift
+++ b/macos/ATC/Features/Sessions/SessionContentView.swift
@@ -50,12 +50,15 @@ struct SessionContentView: View {
     @ViewBuilder
     private var cover: some View {
         if let ref = selectedRef, let session = selectedSession {
-            if let controller = appModel.terminals[ref] {
+            if session.status == .ended {
+                SessionEndedView(sessionRef: ref, session: session)
+                    .background()
+            } else if let controller = appModel.terminals[ref] {
                 // Terminal visible; only the phase banner floats on top.
                 TerminalStatusBanner(controller: controller) {
                     appModel.disconnectTerminal(ref: ref)
                 }
-            } else if session.attachable {
+            } else if session.status == .live {
                 // Normally auto-attach creates the controller in the same
                 // update; this cover only lingers after an explicit
                 // Disconnect, so offer the way back in.
@@ -74,9 +77,6 @@ struct SessionContentView: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background()
-            } else if let client = appModel.runtime(id: ref.connectionID)?.client {
-                SessionDetailView(session: session, client: client)
-                    .background()
             }
         } else if let emptyState {
             ContentUnavailableView {
@@ -111,8 +111,6 @@ struct SessionHeaderBar: View {
     let session: Session
     @Binding var showInspector: Bool
 
-    @State private var confirmStop = false
-    @State private var confirmArchive = false
     @State private var confirmDelete = false
     @State private var actionError: String?
 
@@ -122,19 +120,6 @@ struct SessionHeaderBar: View {
 
     private var canMutate: Bool {
         appModel.canMutate(connectionID: sessionRef.connectionID)
-    }
-
-    private var canStop: Bool {
-        session.status == .running || session.status == .starting
-    }
-
-    /// Mirror the server rule: archive only after the session ended.
-    private var canArchive: Bool {
-        !session.isArchived && (session.status == .terminated || session.status == .failed)
-    }
-
-    private var sessionsStore: SessionsStore? {
-        appModel.runtime(id: sessionRef.connectionID)?.sessions
     }
 
     private var actions: [ATCAction] {
@@ -160,33 +145,11 @@ struct SessionHeaderBar: View {
                 .lineLimit(1)
                 .truncationMode(.head)
             Spacer()
-            if isConnected {
+            if session.status == .live && isConnected {
                 Button("Disconnect", systemImage: "cable.connector.slash") {
                     appModel.disconnectTerminal(ref: sessionRef)
                 }
                 .help("Detach from the session (it keeps running)")
-            }
-            if canStop {
-                Button("Stop", systemImage: "stop.circle") {
-                    confirmStop = true
-                }
-                .disabled(!canMutate)
-                .help("Terminate this session")
-            }
-            if session.isArchived {
-                Button("Unarchive", systemImage: "archivebox") {
-                    appModel.run(on: sessionRef.connectionID, reporting: $actionError) {
-                        try await sessionsStore?.unarchive(id: session.id)
-                    }
-                }
-                .disabled(!canMutate)
-                .help("Unarchive this session")
-            } else {
-                Button("Archive", systemImage: "archivebox") {
-                    confirmArchive = true
-                }
-                .disabled(!canArchive || !canMutate)
-                .help(canArchive ? "Archive this session" : "Stop the session before archiving")
             }
             Button("Delete", systemImage: "trash") {
                 confirmDelete = true
@@ -205,32 +168,6 @@ struct SessionHeaderBar: View {
         .padding(.horizontal, Spacing.md)
         .padding(.vertical, Spacing.sm)
         .confirmationDialog(
-            "Stop “\(displayName)”?",
-            isPresented: $confirmStop
-        ) {
-            Button("Stop Session", role: .destructive) {
-                appModel.run(on: sessionRef.connectionID, reporting: $actionError) {
-                    try await sessionsStore?.terminate(id: session.id)
-                }
-            }
-            .disabled(!canMutate)
-        } message: {
-            Text("The process will be terminated. The session record is kept until archived.")
-        }
-        .confirmationDialog(
-            "Archive “\(displayName)”?",
-            isPresented: $confirmArchive
-        ) {
-            Button("Archive Session") {
-                appModel.run(on: sessionRef.connectionID, reporting: $actionError) {
-                    try await sessionsStore?.archive(id: session.id)
-                }
-            }
-            .disabled(!canMutate)
-        } message: {
-            Text("Archived sessions are hidden behind the archived filter.")
-        }
-        .confirmationDialog(
             "Delete Session “\(displayName)”?",
             isPresented: $confirmDelete
         ) {
@@ -239,19 +176,66 @@ struct SessionHeaderBar: View {
             }
             .disabled(!canMutate)
         } message: {
-            Text(DeleteConfirmation.sessionMessage(displayName: displayName))
+            Text(DeleteConfirmation.sessionMessage(
+                displayName: displayName,
+                status: session.status
+            ))
         }
         .actionErrorAlert($actionError, title: "Session Action Failed")
     }
 
-    /// Failure (stop error, 502) leaves the session and surfaces the alert.
+    /// Failure leaves the session and surfaces the alert.
     private func deleteSession() {
-        appModel.run(on: sessionRef.connectionID, reporting: $actionError) {
-            try await sessionsStore?.delete(id: session.id)
-            appModel.disconnectTerminal(ref: sessionRef)
-            if windowState.selectedSession == sessionRef {
-                windowState.showWorkspaceEmpty()
+        appModel.deleteSession(ref: sessionRef, windowState: windowState, reporting: $actionError)
+    }
+}
+
+/// Non-interactive presentation for an Ended session. Selection remains in
+/// place so metadata and explicit record deletion stay available.
+private struct SessionEndedView: View {
+    @Environment(AppModel.self) private var appModel
+    @Environment(WindowState.self) private var windowState
+    let sessionRef: SessionRef
+    let session: Session
+
+    @State private var confirmDelete = false
+    @State private var actionError: String?
+
+    private var displayName: String {
+        let actions = appModel.runtime(id: sessionRef.connectionID)?.actions.actions ?? []
+        return SessionKind.displayName(session: session, actions: actions)
+    }
+
+    var body: some View {
+        ContentUnavailableView {
+            Label("Session Ended", systemImage: "checkmark.circle")
+        } description: {
+            Text("This session is no longer interactive.")
+        } actions: {
+            Button("Delete Session", role: .destructive) {
+                confirmDelete = true
             }
+            .disabled(!appModel.canMutate(connectionID: sessionRef.connectionID))
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .confirmationDialog(
+            "Delete Session “\(displayName)”?",
+            isPresented: $confirmDelete
+        ) {
+            Button("Delete Session", role: .destructive) {
+                deleteSession()
+            }
+            .disabled(!appModel.canMutate(connectionID: sessionRef.connectionID))
+        } message: {
+            Text(DeleteConfirmation.sessionMessage(
+                displayName: displayName,
+                status: session.status
+            ))
+        }
+        .actionErrorAlert($actionError, title: "Session Action Failed")
+    }
+
+    private func deleteSession() {
+        appModel.deleteSession(ref: sessionRef, windowState: windowState, reporting: $actionError)
     }
 }

--- a/macos/ATC/Features/Sessions/SessionDetailView.swift
+++ b/macos/ATC/Features/Sessions/SessionDetailView.swift
@@ -1,9 +1,10 @@
 import SwiftUI
 import ATCAPI
 
-/// Metadata view for non-attachable sessions, and the inspector content
-/// for live ones.
+/// Session metadata and inspector content.
 struct SessionDetailView: View {
+    @Environment(AppModel.self) private var appModel
+    let sessionRef: SessionRef
     let session: Session
     /// The owning Connection's client — details load from the same server
     /// the session lives on.
@@ -26,25 +27,9 @@ struct SessionDetailView: View {
                 }
                 LabeledContent("Working Directory", value: session.workingDir)
             }
-            if session.failureReason != nil || session.failureCode != nil {
-                Section("Failure") {
-                    if let code = session.failureCode {
-                        LabeledContent("Code", value: code)
-                    }
-                    if let reason = session.failureReason {
-                        LabeledContent("Reason", value: reason)
-                    }
-                }
-            }
             Section("Timestamps") {
                 LabeledContent("Created", value: session.createdAt.formatted(date: .abbreviated, time: .shortened))
                 LabeledContent("Updated", value: session.updatedAt.formatted(date: .abbreviated, time: .shortened))
-                if let terminatedAt = session.terminatedAt {
-                    LabeledContent("Terminated", value: terminatedAt.formatted(date: .abbreviated, time: .shortened))
-                }
-                if let archivedAt = session.archivedAt {
-                    LabeledContent("Archived", value: archivedAt.formatted(date: .abbreviated, time: .shortened))
-                }
             }
             if let detail {
                 if let prompt = detail.prompt, !prompt.isEmpty {
@@ -65,7 +50,14 @@ struct SessionDetailView: View {
         }
         .formStyle(.grouped)
         .task(id: session.id) {
-            detail = try? await client.session(id: session.id)
+            do {
+                detail = try await client.session(id: session.id)
+            } catch {
+                _ = appModel.handleSessionInteractionError(
+                    error,
+                    connectionID: sessionRef.connectionID
+                )
+            }
         }
     }
 }

--- a/macos/ATC/Features/Sessions/SessionsStore.swift
+++ b/macos/ATC/Features/Sessions/SessionsStore.swift
@@ -18,8 +18,7 @@ final class SessionsStore {
         }
     }
 
-    /// Always includes archived sessions; surfaces filter locally (the
-    /// Workspace Navigator's Archived toggle).
+    /// Complete server list, including both Live and Ended sessions.
     private(set) var sessions: [Session] = []
     private(set) var isLoading = false
     private(set) var hasLoadedOnce = false
@@ -51,7 +50,7 @@ final class SessionsStore {
             }
         }
         do {
-            let fetched = try await client.sessions(includeArchived: true, status: nil)
+            let fetched = try await client.sessions(status: nil)
             guard generation == refreshGeneration else { return }
             sessions = fetched
             lastError = nil
@@ -79,32 +78,8 @@ final class SessionsStore {
         return detail
     }
 
-    @discardableResult
-    func terminate(id: String) async throws -> SessionDetail {
-        let detail = try await client.terminateSession(id: id)
-        merge(detail)
-        scheduleRefresh()
-        return detail
-    }
-
-    @discardableResult
-    func archive(id: String) async throws -> SessionDetail {
-        let detail = try await client.archiveSession(id: id)
-        merge(detail)
-        scheduleRefresh()
-        return detail
-    }
-
-    @discardableResult
-    func unarchive(id: String) async throws -> SessionDetail {
-        let detail = try await client.unarchiveSession(id: id)
-        merge(detail)
-        scheduleRefresh()
-        return detail
-    }
-
-    /// Deletes a session's metadata (the server terminates it first if
-    /// active — files are never touched). Removes the row locally on
+    /// Deletes a session's metadata (the server ends it first if Live —
+    /// files are never touched). Removes the row locally on
     /// success instead of merging.
     func delete(id: String) async throws {
         try await client.deleteSession(id: id)
@@ -114,6 +89,14 @@ final class SessionsStore {
 
     func session(id: String) -> Session? {
         sessions.first { $0.id == id }
+    }
+
+    /// Applies the server's authoritative stale-interaction result without
+    /// waiting for the next poll. A follow-up refresh fills in server time.
+    func reconcileEnded(id: String) {
+        guard let index = sessions.firstIndex(where: { $0.id == id }) else { return }
+        sessions[index].status = .ended
+        scheduleRefresh()
     }
 
     private func merge(_ detail: SessionDetail) {

--- a/macos/ATC/Features/Terminal/TerminalSessionController.swift
+++ b/macos/ATC/Features/Terminal/TerminalSessionController.swift
@@ -74,6 +74,7 @@ final class TerminalSessionController: Identifiable {
     let sessionID: String
     let viewState: TerminalViewState
     private(set) var phase: Phase = .connecting
+    @ObservationIgnored var onSessionEnded: (() -> Void)?
 
     var id: String { sessionID }
 
@@ -233,6 +234,9 @@ final class TerminalSessionController: Identifiable {
                 retryAttempt = 0
                 cancelRetry()
                 phase = .ended(reason)
+                if reason == .sessionEnded {
+                    onSessionEnded?()
+                }
             }
         }
     }

--- a/macos/ATC/Features/Workspaces/DeleteConfirmation.swift
+++ b/macos/ATC/Features/Workspaces/DeleteConfirmation.swift
@@ -1,13 +1,19 @@
 import Foundation
+import ATCAPI
 
 /// The one source of delete-confirmation copy, so every dialog names its
 /// target and ends with the ADR 0008 sentence: files are never touched.
 enum DeleteConfirmation {
     static let filesUntouched = "Files on disk are not touched."
 
-    static func sessionMessage(displayName: String) -> String {
-        "Delete Session “\(displayName)”? This stops the session if it is "
-            + "running and removes its atc history. \(filesUntouched)"
+    static func sessionMessage(displayName: String, status: SessionStatus) -> String {
+        let consequence = switch status {
+        case .live:
+            "The running process will end and the session record will be removed."
+        case .ended:
+            "The session record will be permanently removed."
+        }
+        return "Delete Session “\(displayName)”? \(consequence) \(filesUntouched)"
     }
 
     /// Counts come from the local store at confirmation time.

--- a/macos/ATC/Features/Workspaces/WorkspaceSelectionMemory.swift
+++ b/macos/ATC/Features/Workspaces/WorkspaceSelectionMemory.swift
@@ -48,8 +48,7 @@ struct WorkspaceSelectionMemory {
     func restoredSelection(for ref: WorkspaceRef, in sessions: [Session]) -> SessionRef? {
         guard let saved = sessionID(for: ref),
               let session = sessions.first(where: { $0.id == saved }),
-              session.workspace?.id == ref.workspaceID,
-              !session.isArchived
+              session.workspace?.id == ref.workspaceID
         else { return nil }
         return SessionRef(connectionID: ref.connectionID, sessionID: session.id)
     }

--- a/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
+++ b/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
@@ -9,7 +9,6 @@ struct WorkspaceNavigatorView: View {
 
     @State private var actionError: String?
     @State private var deletingSession: Row?
-    @State private var showArchived = false
 
     private struct Row: Identifiable {
         let ref: SessionRef
@@ -68,17 +67,6 @@ struct WorkspaceNavigatorView: View {
                 sessionRows(terminals, emptyText: "No terminals")
             }
         }
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            HStack {
-                Toggle("Show Archived", isOn: $showArchived)
-                    .toggleStyle(.checkbox)
-                    .font(.caption)
-                Spacer()
-            }
-            .padding(.horizontal, Spacing.md)
-            .padding(.vertical, Spacing.sm)
-            .background(.bar)
-        }
         .confirmationDialog(
             "Delete Session “\(deletingSession?.title ?? "")”?",
             isPresented: Binding(
@@ -92,7 +80,10 @@ struct WorkspaceNavigatorView: View {
             .disabled(!isConnected)
         } message: {
             if let row = deletingSession {
-                Text(DeleteConfirmation.sessionMessage(displayName: row.title))
+                Text(DeleteConfirmation.sessionMessage(
+                    displayName: row.title,
+                    status: row.session.status
+                ))
             }
         }
         .actionErrorAlert($actionError, title: "Workspace Action Failed")
@@ -113,7 +104,6 @@ struct WorkspaceNavigatorView: View {
             } actions: {
                 EmptyView()
             }
-            .opacity(row.session.isArchived ? Dimming.archived : 1)
             .contextMenu { sessionMenu(row) }
         }
         if rows.isEmpty {
@@ -126,26 +116,6 @@ struct WorkspaceNavigatorView: View {
 
     @ViewBuilder
     private func sessionMenu(_ row: Row) -> some View {
-        let session = row.session
-        if session.isArchived {
-            Button("Unarchive", systemImage: "archivebox") {
-                if let store = runtime?.sessions {
-                    appModel.run(on: row.ref.connectionID, reporting: $actionError) {
-                        try await store.unarchive(id: session.id)
-                    }
-                }
-            }
-            .disabled(!isConnected)
-        } else if session.status == .terminated || session.status == .failed {
-            Button("Archive", systemImage: "archivebox") {
-                if let store = runtime?.sessions {
-                    appModel.run(on: row.ref.connectionID, reporting: $actionError) {
-                        try await store.archive(id: session.id)
-                    }
-                }
-            }
-            .disabled(!isConnected)
-        }
         Button("Delete…", systemImage: "trash", role: .destructive) {
             deletingSession = row
         }
@@ -175,13 +145,11 @@ struct WorkspaceNavigatorView: View {
         SessionKind.classify(session: session, actions: runtime?.actions.actions ?? [])
     }
 
-    /// Filtered, ordered sidebar rows: the Active Workspace's sessions,
-    /// newest-first, archived behind the footer toggle.
+    /// Ordered sidebar rows: the Active Workspace's sessions, newest-first.
     private func sidebarRows() -> [Row] {
         guard let ref = workspaceRef else { return [] }
         let actions = runtime?.actions.actions ?? []
         return workspaceSessions()
-            .filter { showArchived || !$0.isArchived }
             .sortedNewestFirst()
             .map { session in
                 return Row(
@@ -193,14 +161,7 @@ struct WorkspaceNavigatorView: View {
     }
 
     private func deleteSession(_ row: Row) {
-        guard let store = runtime?.sessions else { return }
-        appModel.run(on: row.ref.connectionID, reporting: $actionError) {
-            try await store.delete(id: row.session.id)
-            appModel.disconnectTerminal(ref: row.ref)
-            if windowState.selectedSession == row.ref {
-                windowState.showWorkspaceEmpty()
-            }
-        }
+        appModel.deleteSession(ref: row.ref, windowState: windowState, reporting: $actionError)
     }
 }
 
@@ -310,8 +271,4 @@ struct WorkspaceActionsMenu: View {
             windowState.forgetSelection(for: ref)
         }
     }
-}
-
-extension Session {
-    var isActive: Bool { status == .starting || status == .running }
 }

--- a/macos/ATC/PreviewSupport/MockATCClient.swift
+++ b/macos/ATC/PreviewSupport/MockATCClient.swift
@@ -127,8 +127,7 @@ nonisolated struct MockATCClient: ATCClient {
             action: "claude",
             environment: "host-login-shell",
             workingDir: "/home/dev/Projects/atelier",
-            status: .running,
-            attachable: true,
+            status: .live,
             createdAt: Date(timeIntervalSinceNow: -3600),
             updatedAt: Date(timeIntervalSinceNow: -60),
             workspace: MockATCClient.parserRef,
@@ -139,8 +138,7 @@ nonisolated struct MockATCClient: ATCClient {
             action: "codex",
             environment: "host-login-shell",
             workingDir: "/home/dev/Projects/huge",
-            status: .starting,
-            attachable: false,
+            status: .live,
             createdAt: Date(timeIntervalSinceNow: -30),
             updatedAt: Date(timeIntervalSinceNow: -30),
             workspace: MockATCClient.blazerrWorkspaceRef,
@@ -151,10 +149,7 @@ nonisolated struct MockATCClient: ATCClient {
             action: "lazygit",
             environment: "host-login-shell",
             workingDir: "/home/dev",
-            status: .failed,
-            attachable: false,
-            failureReason: "command not found: lazygit",
-            failureCode: "spawn_failed",
+            status: .ended,
             createdAt: Date(timeIntervalSinceNow: -7200),
             updatedAt: Date(timeIntervalSinceNow: -7100)
         ),
@@ -164,11 +159,9 @@ nonisolated struct MockATCClient: ATCClient {
             action: "claude",
             environment: "host-login-shell",
             workingDir: "/home/dev/Projects/atelier",
-            status: .terminated,
-            attachable: false,
+            status: .ended,
             createdAt: Date(timeIntervalSinceNow: -90000),
             updatedAt: Date(timeIntervalSinceNow: -86400),
-            terminatedAt: Date(timeIntervalSinceNow: -86400),
             workspace: MockATCClient.refactorRef,
             project: MockATCClient.atelierRef
         ),
@@ -178,8 +171,7 @@ nonisolated struct MockATCClient: ATCClient {
             action: nil,
             environment: "host-login-shell",
             workingDir: "/home/dev/Projects/atelier",
-            status: .running,
-            attachable: true,
+            status: .live,
             createdAt: Date(timeIntervalSinceNow: -1800),
             updatedAt: Date(timeIntervalSinceNow: -120),
             workspace: MockATCClient.parserRef,
@@ -191,8 +183,7 @@ nonisolated struct MockATCClient: ATCClient {
             action: "lazygit",
             environment: "host-login-shell",
             workingDir: "/home/dev/Projects/atelier",
-            status: .running,
-            attachable: true,
+            status: .live,
             createdAt: Date(timeIntervalSinceNow: -900),
             updatedAt: Date(timeIntervalSinceNow: -60),
             workspace: MockATCClient.parserRef,
@@ -204,27 +195,22 @@ nonisolated struct MockATCClient: ATCClient {
             action: "ghost",
             environment: "host-login-shell",
             workingDir: "/home/dev/Projects/atelier",
-            status: .terminated,
-            attachable: false,
+            status: .ended,
             createdAt: Date(timeIntervalSinceNow: -50000),
             updatedAt: Date(timeIntervalSinceNow: -49000),
-            terminatedAt: Date(timeIntervalSinceNow: -49000),
             workspace: MockATCClient.refactorRef,
             project: MockATCClient.atelierRef
         ),
-        // Archived agent session, behind the shell's Archived filter.
+        // Another ended agent session.
         Session(
             id: "ses_archived",
             name: "Abandoned attempt",
             action: "claude",
             environment: "host-login-shell",
             workingDir: "/home/dev/Projects/atelier",
-            status: .terminated,
-            attachable: false,
+            status: .ended,
             createdAt: Date(timeIntervalSinceNow: -200000),
             updatedAt: Date(timeIntervalSinceNow: -190000),
-            terminatedAt: Date(timeIntervalSinceNow: -195000),
-            archivedAt: Date(timeIntervalSinceNow: -190000),
             workspace: MockATCClient.parserRef,
             project: MockATCClient.atelierRef
         ),
@@ -236,8 +222,8 @@ nonisolated struct MockATCClient: ATCClient {
         Version(name: "atc", version: "dev", commit: "unknown")
     }
 
-    func sessions(includeArchived: Bool, status: SessionStatus?) async throws -> [Session] {
-        mockSessions.filter { includeArchived || !$0.isArchived }
+    func sessions(status: SessionStatus?) async throws -> [Session] {
+        mockSessions.filter { status == nil || $0.status == status }
     }
 
     func session(id: String) async throws -> SessionDetail {
@@ -269,37 +255,13 @@ nonisolated struct MockATCClient: ATCClient {
             action: request.action,
             environment: request.environment ?? "host-login-shell",
             workingDir: project.workingDir,
-            status: .starting,
-            attachable: false,
+            status: .live,
             createdAt: Date(),
             updatedAt: Date(),
             workspace: SessionWorkspace(id: workspace.id, name: workspace.name),
             project: SessionProject(id: project.id, name: project.name)
         )
         return detail(from: session)
-    }
-
-    func terminateSession(id: String) async throws -> SessionDetail {
-        var session = try await self.session(id: id)
-        session.status = .terminated
-        session.attachable = false
-        session.terminatedAt = Date()
-        return session
-    }
-
-    func archiveSession(id: String) async throws -> SessionDetail {
-        var session = try await self.session(id: id)
-        guard session.status == .terminated || session.status == .failed else {
-            throw ATCError.api(code: "session_live", message: "session is still running", sessionID: id)
-        }
-        session.archivedAt = Date()
-        return session
-    }
-
-    func unarchiveSession(id: String) async throws -> SessionDetail {
-        var session = try await self.session(id: id)
-        session.archivedAt = nil
-        return session
     }
 
     func deleteSession(id: String) async throws {
@@ -392,13 +354,11 @@ nonisolated struct MockATCClient: ATCClient {
 
     func projectSessions(
         projectID: String,
-        includeArchived: Bool,
         status: SessionStatus?
     ) async throws -> [Session] {
         _ = try lookupProject(projectID)
         return mockSessions.filter { session in
             session.project?.id == projectID
-                && (includeArchived || !session.isArchived)
                 && (status == nil || session.status == status)
         }
     }
@@ -471,13 +431,11 @@ nonisolated struct MockATCClient: ATCClient {
 
     func workspaceSessions(
         workspaceID: String,
-        includeArchived: Bool,
         status: SessionStatus?
     ) async throws -> [Session] {
         _ = try lookupWorkspace(workspaceID)
         return mockSessions.filter { session in
             session.workspace?.id == workspaceID
-                && (includeArchived || !session.isArchived)
                 && (status == nil || session.status == status)
         }
     }

--- a/macos/ATC/RootView.swift
+++ b/macos/ATC/RootView.swift
@@ -75,6 +75,7 @@ struct RootView: View {
             }
         }
         .onChange(of: appModel.windowNavigationSnapshot(), initial: true) {
+            appModel.reconcileTerminalLifecycle()
             windowState.reconcile(in: appModel)
         }
     }
@@ -107,7 +108,7 @@ struct RootView: View {
            let ref = visibleSessionRef,
            let session = visibleSession,
            let client = appModel.runtime(id: ref.connectionID)?.client {
-            SessionDetailView(session: session, client: client)
+            SessionDetailView(sessionRef: ref, session: session, client: client)
                 .inspectorColumnWidth(min: 260, ideal: 320)
         }
     }

--- a/macos/ATC/Shared/ConnectionMutations.swift
+++ b/macos/ATC/Shared/ConnectionMutations.swift
@@ -4,6 +4,25 @@ import SwiftUI
 /// Connection's model isn't current and routes failures into the caller's
 /// alert state. Views must not hand-roll this guard.
 extension AppModel {
+    /// The one shared session delete flow (header, Session Ended state, and
+    /// navigator context menu): remove the record, tear down the terminal,
+    /// and return the window to the Workspace empty state when the deleted
+    /// session was selected.
+    func deleteSession(
+        ref: SessionRef,
+        windowState: WindowState,
+        reporting actionError: Binding<String?>
+    ) {
+        guard let store = runtime(id: ref.connectionID)?.sessions else { return }
+        run(on: ref.connectionID, reporting: actionError) {
+            try await store.delete(id: ref.sessionID)
+            self.disconnectTerminal(ref: ref)
+            if windowState.selectedSession == ref {
+                windowState.showWorkspaceEmpty()
+            }
+        }
+    }
+
     func run(
         on connectionID: UUID,
         reporting actionError: Binding<String?>,
@@ -17,6 +36,10 @@ extension AppModel {
             do {
                 try await operation()
             } catch {
+                if handleSessionInteractionError(error, connectionID: connectionID) {
+                    actionError.wrappedValue = nil
+                    return
+                }
                 actionError.wrappedValue = error.localizedDescription
             }
         }

--- a/macos/ATC/Shared/DomainRules.swift
+++ b/macos/ATC/Shared/DomainRules.swift
@@ -22,6 +22,8 @@ extension Sequence where Element: CreatedOrdered {
 }
 
 extension Session {
+    var isActive: Bool { status == .live }
+
     /// Whether this Session belongs to the Workspace. Server IDs are only
     /// unique within a Connection, so callers compare same-Connection refs.
     func belongs(to ref: WorkspaceRef) -> Bool {

--- a/macos/ATC/Shared/StatusBadge.swift
+++ b/macos/ATC/Shared/StatusBadge.swift
@@ -19,16 +19,11 @@ struct StatusBadge: View {
     }
 
     private var color: Color {
-        if session.isArchived { return .gray.opacity(0.5) }
         switch session.status {
-        case .running: return .green
-        case .starting: return .yellow
-        case .failed: return .red
-        case .terminated: return .gray
+        case .live: return .green
+        case .ended: return .gray
         }
     }
 
-    private var label: String {
-        session.isArchived ? "archived" : session.status.rawValue
-    }
+    private var label: String { session.status.rawValue.capitalized }
 }

--- a/macos/ATC/TerminalBridge/AttachConnection.swift
+++ b/macos/ATC/TerminalBridge/AttachConnection.swift
@@ -151,6 +151,11 @@ actor AttachConnection {
         if closedByClient {
             return .closedByClient
         }
+        // A stale attach is rejected before WebSocket upgrade. URLSession
+        // exposes the HTTP response even though there is no close frame.
+        if (task.response as? HTTPURLResponse)?.statusCode == 409 {
+            return .sessionEnded
+        }
         switch task.closeCode {
         case .normalClosure:
             return .sessionEnded

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -104,7 +104,7 @@ final class WindowState {
         isInspectorPresented = false
         pendingRestore = sessionsCurrent ? nil : ref
 
-        if let restored, let session = appModel.session(for: restored), session.attachable {
+        if let restored, let session = appModel.session(for: restored), session.status == .live {
             appModel.attachIfNeeded(
                 to: session,
                 connectionID: restored.connectionID,
@@ -125,12 +125,8 @@ final class WindowState {
         else { return false }
 
         selectedContent = .session(ref)
-        if session.isArchived {
-            selectionMemory.forget(activeWorkspace)
-        } else {
-            selectionMemory.remember(sessionID: ref.sessionID, for: activeWorkspace)
-        }
-        if session.attachable {
+        selectionMemory.remember(sessionID: ref.sessionID, for: activeWorkspace)
+        if session.status == .live {
             appModel.attachIfNeeded(
                 to: session,
                 connectionID: ref.connectionID,
@@ -187,7 +183,7 @@ final class WindowState {
                     in: runtime.sessions.sessions
                ) {
                 selectedContent = .session(restored)
-                if let session = appModel.session(for: restored), session.attachable {
+                if let session = appModel.session(for: restored), session.status == .live {
                     appModel.attachIfNeeded(
                         to: session,
                         connectionID: restored.connectionID,
@@ -208,18 +204,17 @@ final class WindowState {
             selectedContent = .workspace(activeWorkspace)
             isInspectorPresented = false
         } else if let session {
-            if session.isArchived {
-                selectionMemory.forget(activeWorkspace)
-            }
             // Never undo an explicit Disconnect: reconcile runs on every
             // store change, not just selection changes.
-            if session.attachable, appModel.terminals[selected] == nil,
+            if session.status == .live, appModel.terminals[selected] == nil,
                !appModel.isDetached(selected) {
                 appModel.attachIfNeeded(
                     to: session,
                     connectionID: selected.connectionID,
                     retentionContext: retentionContext
                 )
+            } else if session.status == .ended, appModel.terminals[selected] != nil {
+                appModel.disconnectTerminal(ref: selected)
             }
         }
     }

--- a/macos/ATCTests/AppModelRuntimeTests.swift
+++ b/macos/ATCTests/AppModelRuntimeTests.swift
@@ -170,9 +170,9 @@ struct AppModelRuntimeTests {
         await runtime.refresh()
         #expect(!runtime.workspaces.workspaces.isEmpty)
         #expect(!runtime.actions.actions.isEmpty)
-        // Archived rows are always fetched; filtering is view-local now.
+        // Project and Workspace archives are fetched; Sessions include both states.
         #expect(runtime.workspaces.workspaces.contains { $0.isArchived })
         #expect(runtime.projects.projects.contains { $0.isArchived })
-        #expect(runtime.sessions.sessions.contains { $0.isArchived })
+        #expect(runtime.sessions.sessions.contains { $0.status == .ended })
     }
 }

--- a/macos/ATCTests/AttachmentBudgetTests.swift
+++ b/macos/ATCTests/AttachmentBudgetTests.swift
@@ -42,7 +42,7 @@ struct AttachmentBudgetTests {
     private func session(_ id: String, workspace: String? = nil) -> Session {
         Session(
             id: id, environment: "host", workingDir: "/home/dev",
-            status: .running, attachable: true,
+            status: .live,
             createdAt: .now, updatedAt: .now,
             workspace: workspace.map { SessionWorkspace(id: $0, name: $0) }
         )

--- a/macos/ATCTests/CommandPaletteContentTests.swift
+++ b/macos/ATCTests/CommandPaletteContentTests.swift
@@ -525,20 +525,18 @@ struct CommandPaletteSessionResultTests {
         ),
     ]
 
-    @Test("only the Active Workspace's unarchived Sessions appear")
+    @Test("the Active Workspace's Live and Ended Sessions appear")
     func workspaceAndArchiveFiltering() {
         let active = WorkspaceRef(connectionID: connectionID, workspaceID: "active")
         let projected = results(query: "", active: active, sessions: [
             paletteSession("active", name: "Active", workspace: "active"),
             paletteSession("other", name: "Other", workspace: "other"),
-            paletteSession(
-                "archived", name: "Archived", workspace: "active", archived: true
-            ),
+            paletteSession("ended", name: "Ended", workspace: "active", status: .ended),
         ])
-        #expect(projected.map(\.ref.sessionID) == ["active"])
+        #expect(projected.map(\.ref.sessionID) == ["active", "ended"])
     }
 
-    @Test("an archived Active Workspace still yields unarchived Sessions")
+    @Test("an archived Active Workspace still yields its Sessions")
     func archivedActiveWorkspace() {
         let archivedWorkspace = WorkspaceRef(
             connectionID: connectionID,
@@ -579,31 +577,27 @@ struct CommandPaletteSessionResultTests {
         let candidates = [
             paletteSession(
                 "agent-failed", name: "Agent Failed", action: "claude",
-                workspace: "active", status: .failed
+                workspace: "active", status: .ended
             ),
             paletteSession(
                 "agent-terminated", name: "Finished Agent", action: "claude",
-                workspace: "active", status: .terminated
+                workspace: "active", status: .ended
             ),
             paletteSession(
                 "shell-starting", name: "Shell Starting",
-                workspace: "active", status: .starting
+                workspace: "active", status: .live
             ),
             paletteSession(
                 "action-terminated", name: "Tool Done", action: "lazygit",
-                workspace: "active", status: .terminated
+                workspace: "active", status: .ended
             ),
             paletteSession(
                 "unresolved-running", name: "Unknown Action", action: "missing",
-                workspace: "active", status: .running
+                workspace: "active", status: .live
             ),
             paletteSession(
                 "other-workspace", name: "Other Agent", action: "claude",
                 workspace: "other"
-            ),
-            paletteSession(
-                "archived", name: "Archived Agent", action: "claude",
-                workspace: "active", archived: true
             ),
         ]
 
@@ -662,7 +656,7 @@ struct CommandPaletteSessionResultTests {
         let active = WorkspaceRef(connectionID: connectionID, workspaceID: "active")
         let session = paletteSession(
             "raw-identifier", name: "Public Name", action: "claude",
-            workspace: "active", status: .failed
+            workspace: "active", status: .ended
         )
         for query in ["claude", "failed", "raw-identifier"] {
             #expect(results(query: query, active: active, sessions: [session]).isEmpty)
@@ -867,8 +861,7 @@ private func paletteSession(
     name: String? = nil,
     action: String? = nil,
     workspace: String,
-    archived: Bool = false,
-    status: SessionStatus = .running
+    status: SessionStatus = .live
 ) -> Session {
     Session(
         id: id,
@@ -877,10 +870,8 @@ private func paletteSession(
         environment: "host",
         workingDir: "/tmp",
         status: status,
-        attachable: false,
         createdAt: .now,
         updatedAt: .now,
-        archivedAt: archived ? .now : nil,
         workspace: SessionWorkspace(id: workspace, name: workspace)
     )
 }

--- a/macos/ATCTests/CreateProjectFlowTests.swift
+++ b/macos/ATCTests/CreateProjectFlowTests.swift
@@ -27,13 +27,10 @@ private nonisolated final class RecordingClient: ATCClient, @unchecked Sendable 
     // Everything else is a straight passthrough.
     func health() async throws -> Health { try await inner.health() }
     func version() async throws -> Version { try await inner.version() }
-    func sessions(includeArchived: Bool, status: SessionStatus?) async throws -> [Session] {
-        try await inner.sessions(includeArchived: includeArchived, status: status)
+    func sessions(status: SessionStatus?) async throws -> [Session] {
+        try await inner.sessions(status: status)
     }
     func session(id: String) async throws -> SessionDetail { try await inner.session(id: id) }
-    func terminateSession(id: String) async throws -> SessionDetail { try await inner.terminateSession(id: id) }
-    func archiveSession(id: String) async throws -> SessionDetail { try await inner.archiveSession(id: id) }
-    func unarchiveSession(id: String) async throws -> SessionDetail { try await inner.unarchiveSession(id: id) }
     func deleteSession(id: String) async throws { try await inner.deleteSession(id: id) }
     func sendText(sessionID: String, text: String) async throws {}
     func sendKey(sessionID: String, key: String) async throws {}
@@ -62,8 +59,8 @@ private nonisolated final class RecordingClient: ATCClient, @unchecked Sendable 
     }
     func archiveProject(id: String) async throws -> Project { try await inner.archiveProject(id: id) }
     func unarchiveProject(id: String) async throws -> Project { try await inner.unarchiveProject(id: id) }
-    func projectSessions(projectID: String, includeArchived: Bool, status: SessionStatus?) async throws -> [Session] {
-        try await inner.projectSessions(projectID: projectID, includeArchived: includeArchived, status: status)
+    func projectSessions(projectID: String, status: SessionStatus?) async throws -> [Session] {
+        try await inner.projectSessions(projectID: projectID, status: status)
     }
     func deleteProject(id: String) async throws { try await inner.deleteProject(id: id) }
     func workspaces(projectID: String?, includeArchived: Bool) async throws -> [Workspace] {
@@ -79,8 +76,8 @@ private nonisolated final class RecordingClient: ATCClient, @unchecked Sendable 
     func archiveWorkspace(id: String) async throws -> Workspace { try await inner.archiveWorkspace(id: id) }
     func unarchiveWorkspace(id: String) async throws -> Workspace { try await inner.unarchiveWorkspace(id: id) }
     func deleteWorkspace(id: String) async throws { try await inner.deleteWorkspace(id: id) }
-    func workspaceSessions(workspaceID: String, includeArchived: Bool, status: SessionStatus?) async throws -> [Session] {
-        try await inner.workspaceSessions(workspaceID: workspaceID, includeArchived: includeArchived, status: status)
+    func workspaceSessions(workspaceID: String, status: SessionStatus?) async throws -> [Session] {
+        try await inner.workspaceSessions(workspaceID: workspaceID, status: status)
     }
     func attachURL(sessionID: String) -> URL { inner.attachURL(sessionID: sessionID) }
     func attachHeaders() -> [String: String] { inner.attachHeaders() }

--- a/macos/ATCTests/DashboardGroupsTests.swift
+++ b/macos/ATCTests/DashboardGroupsTests.swift
@@ -35,7 +35,7 @@ struct DashboardGroupsTests {
     ) -> Session {
         Session(
             id: id, environment: "host", workingDir: "/home/dev",
-            status: status, attachable: status == .running,
+            status: status,
             createdAt: .now, updatedAt: .now,
             workspace: SessionWorkspace(id: workspace, name: workspace)
         )
@@ -114,9 +114,9 @@ struct DashboardGroupsTests {
             projects: [project("p1")],
             workspaces: [workspace("w1", project: "p1", createdAgo: 10)],
             sessions: [
-                session("s1", workspace: "w1", status: .running),
-                session("s2", workspace: "w1", status: .terminated),
-                session("s3", workspace: "other", status: .running),
+                session("s1", workspace: "w1", status: .live),
+                session("s2", workspace: "w1", status: .ended),
+                session("s3", workspace: "other", status: .live),
             ]
         )
         let row = result.sections[0].cards[0].rows[0]

--- a/macos/ATCTests/ProjectsNavigatorGroupsTests.swift
+++ b/macos/ATCTests/ProjectsNavigatorGroupsTests.swift
@@ -46,6 +46,7 @@ struct ProjectsNavigatorGroupsTests {
         connection: ConnectionRecord,
         projects: [Project],
         workspaces: [Workspace],
+        sessions: [Session] = [],
         reachability: Reachability = .connected
     ) -> ProjectsNavigatorGroups.Input {
         .init(
@@ -53,8 +54,28 @@ struct ProjectsNavigatorGroupsTests {
             reachability: reachability,
             projects: projects,
             workspaces: workspaces,
-            sessions: []
+            sessions: sessions
         )
+    }
+
+    @Test("Ended sessions count as records but do not block Workspace archive")
+    func endedSessionsDoNotBlockArchive() {
+        let c = connection("00000000-0000-0000-0000-000000000001", name: "Alpha")
+        let session = Session(
+            id: "ended", environment: "host", workingDir: "/tmp", status: .ended,
+            createdAt: .now, updatedAt: .now,
+            workspace: SessionWorkspace(id: "workspace", name: "Workspace")
+        )
+        let result = ProjectsNavigatorGroups(inputs: [input(
+            connection: c,
+            projects: [project("project", name: "Project")],
+            workspaces: [workspace("workspace", project: "project", age: 1)],
+            sessions: [session]
+        )])
+        let row = result.projects[0].workspaces[0]
+        #expect(row.sessionCount == 1)
+        #expect(row.activeSessionCount == 0)
+        #expect(!row.hasActiveSessions)
     }
 
     @Test("projects sort case-insensitively, then by Connection name and stable identity")

--- a/macos/ATCTests/ProjectsStoreTests.swift
+++ b/macos/ATCTests/ProjectsStoreTests.swift
@@ -125,12 +125,9 @@ final class GatedProjectsClient: ATCClient, @unchecked Sendable {
 
     func health() async throws -> Health { throw ATCError.badStatus(500) }
     func version() async throws -> Version { throw ATCError.badStatus(500) }
-    func sessions(includeArchived: Bool, status: SessionStatus?) async throws -> [Session] { [] }
+    func sessions(status: SessionStatus?) async throws -> [Session] { [] }
     func session(id: String) async throws -> SessionDetail { throw ATCError.badStatus(500) }
     func startSession(_ request: StartSessionRequest) async throws -> SessionDetail { throw ATCError.badStatus(500) }
-    func terminateSession(id: String) async throws -> SessionDetail { throw ATCError.badStatus(500) }
-    func archiveSession(id: String) async throws -> SessionDetail { throw ATCError.badStatus(500) }
-    func unarchiveSession(id: String) async throws -> SessionDetail { throw ATCError.badStatus(500) }
     func deleteSession(id: String) async throws { throw ATCError.badStatus(500) }
     func sendText(sessionID: String, text: String) async throws {}
     func sendKey(sessionID: String, key: String) async throws {}
@@ -147,7 +144,7 @@ final class GatedProjectsClient: ATCClient, @unchecked Sendable {
     func renameProject(id: String, name: String) async throws -> Project { throw ATCError.badStatus(500) }
     func archiveProject(id: String) async throws -> Project { throw ATCError.badStatus(500) }
     func unarchiveProject(id: String) async throws -> Project { throw ATCError.badStatus(500) }
-    func projectSessions(projectID: String, includeArchived: Bool, status: SessionStatus?) async throws -> [Session] { [] }
+    func projectSessions(projectID: String, status: SessionStatus?) async throws -> [Session] { [] }
     func deleteProject(id: String) async throws { throw ATCError.badStatus(500) }
     func workspaces(projectID: String?, includeArchived: Bool) async throws -> [Workspace] { [] }
     func workspace(id: String) async throws -> Workspace { throw ATCError.badStatus(500) }
@@ -156,7 +153,7 @@ final class GatedProjectsClient: ATCClient, @unchecked Sendable {
     func archiveWorkspace(id: String) async throws -> Workspace { throw ATCError.badStatus(500) }
     func unarchiveWorkspace(id: String) async throws -> Workspace { throw ATCError.badStatus(500) }
     func deleteWorkspace(id: String) async throws { throw ATCError.badStatus(500) }
-    func workspaceSessions(workspaceID: String, includeArchived: Bool, status: SessionStatus?) async throws -> [Session] { [] }
+    func workspaceSessions(workspaceID: String, status: SessionStatus?) async throws -> [Session] { [] }
     func attachURL(sessionID: String) -> URL { URL(string: "ws://127.0.0.1:1/attach")! }
     func attachHeaders() -> [String: String] { [:] }
 }
@@ -246,12 +243,9 @@ final class StatefulProjectsClient: ATCClient, @unchecked Sendable {
 
     func health() async throws -> Health { throw ATCError.badStatus(500) }
     func version() async throws -> Version { throw ATCError.badStatus(500) }
-    func sessions(includeArchived: Bool, status: SessionStatus?) async throws -> [Session] { [] }
+    func sessions(status: SessionStatus?) async throws -> [Session] { [] }
     func session(id: String) async throws -> SessionDetail { throw ATCError.badStatus(500) }
     func startSession(_ request: StartSessionRequest) async throws -> SessionDetail { throw ATCError.badStatus(500) }
-    func terminateSession(id: String) async throws -> SessionDetail { throw ATCError.badStatus(500) }
-    func archiveSession(id: String) async throws -> SessionDetail { throw ATCError.badStatus(500) }
-    func unarchiveSession(id: String) async throws -> SessionDetail { throw ATCError.badStatus(500) }
     func deleteSession(id: String) async throws { throw ATCError.badStatus(500) }
     func sendText(sessionID: String, text: String) async throws {}
     func sendKey(sessionID: String, key: String) async throws {}
@@ -263,7 +257,7 @@ final class StatefulProjectsClient: ATCClient, @unchecked Sendable {
     func deleteAction(name: String) async throws { throw ATCError.badStatus(500) }
     func environments() async throws -> [ATCEnvironment] { [] }
     func listDirectory(path: String, showHidden: Bool) async throws -> DirectoryListing { throw ATCError.badStatus(500) }
-    func projectSessions(projectID: String, includeArchived: Bool, status: SessionStatus?) async throws -> [Session] { [] }
+    func projectSessions(projectID: String, status: SessionStatus?) async throws -> [Session] { [] }
     func workspaces(projectID: String?, includeArchived: Bool) async throws -> [Workspace] { [] }
     func workspace(id: String) async throws -> Workspace { throw ATCError.badStatus(500) }
     func createWorkspace(projectID: String, name: String) async throws -> Workspace { throw ATCError.badStatus(500) }
@@ -271,7 +265,7 @@ final class StatefulProjectsClient: ATCClient, @unchecked Sendable {
     func archiveWorkspace(id: String) async throws -> Workspace { throw ATCError.badStatus(500) }
     func unarchiveWorkspace(id: String) async throws -> Workspace { throw ATCError.badStatus(500) }
     func deleteWorkspace(id: String) async throws { throw ATCError.badStatus(500) }
-    func workspaceSessions(workspaceID: String, includeArchived: Bool, status: SessionStatus?) async throws -> [Session] { [] }
+    func workspaceSessions(workspaceID: String, status: SessionStatus?) async throws -> [Session] { [] }
     func attachURL(sessionID: String) -> URL { URL(string: "ws://127.0.0.1:1/attach")! }
     func attachHeaders() -> [String: String] { [:] }
 }

--- a/macos/ATCTests/ScriptableClient.swift
+++ b/macos/ATCTests/ScriptableClient.swift
@@ -31,24 +31,15 @@ nonisolated final class ScriptableClient: ATCClient, @unchecked Sendable {
 
     func health() async throws -> Health { try await gate(); return try await inner.health() }
     func version() async throws -> Version { try await gate(); return try await inner.version() }
-    func sessions(includeArchived: Bool, status: SessionStatus?) async throws -> [Session] {
+    func sessions(status: SessionStatus?) async throws -> [Session] {
         try await gate()
-        return try await inner.sessions(includeArchived: includeArchived, status: status)
+        return try await inner.sessions(status: status)
     }
     func session(id: String) async throws -> SessionDetail {
         try await gate(); return try await inner.session(id: id)
     }
     func startSession(_ request: StartSessionRequest) async throws -> SessionDetail {
         try await gate(); return try await inner.startSession(request)
-    }
-    func terminateSession(id: String) async throws -> SessionDetail {
-        try await gate(); return try await inner.terminateSession(id: id)
-    }
-    func archiveSession(id: String) async throws -> SessionDetail {
-        try await gate(); return try await inner.archiveSession(id: id)
-    }
-    func unarchiveSession(id: String) async throws -> SessionDetail {
-        try await gate(); return try await inner.unarchiveSession(id: id)
     }
     func deleteSession(id: String) async throws {
         try await gate(); try await inner.deleteSession(id: id)
@@ -93,10 +84,10 @@ nonisolated final class ScriptableClient: ATCClient, @unchecked Sendable {
     func unarchiveProject(id: String) async throws -> Project {
         try await gate(); return try await inner.unarchiveProject(id: id)
     }
-    func projectSessions(projectID: String, includeArchived: Bool, status: SessionStatus?) async throws -> [Session] {
+    func projectSessions(projectID: String, status: SessionStatus?) async throws -> [Session] {
         try await gate()
         return try await inner.projectSessions(
-            projectID: projectID, includeArchived: includeArchived, status: status
+            projectID: projectID, status: status
         )
     }
     func deleteProject(id: String) async throws {
@@ -124,10 +115,10 @@ nonisolated final class ScriptableClient: ATCClient, @unchecked Sendable {
     func deleteWorkspace(id: String) async throws {
         try await gate(); try await inner.deleteWorkspace(id: id)
     }
-    func workspaceSessions(workspaceID: String, includeArchived: Bool, status: SessionStatus?) async throws -> [Session] {
+    func workspaceSessions(workspaceID: String, status: SessionStatus?) async throws -> [Session] {
         try await gate()
         return try await inner.workspaceSessions(
-            workspaceID: workspaceID, includeArchived: includeArchived, status: status
+            workspaceID: workspaceID, status: status
         )
     }
     func attachURL(sessionID: String) -> URL { inner.attachURL(sessionID: sessionID) }

--- a/macos/ATCTests/SessionKindTests.swift
+++ b/macos/ATCTests/SessionKindTests.swift
@@ -16,7 +16,7 @@ struct SessionKindTests {
     private func session(name: String? = nil, action: String?) -> Session {
         Session(
             id: "ses_x", name: name, action: action, environment: "host",
-            workingDir: "/home/dev", status: .running, attachable: true,
+            workingDir: "/home/dev", status: .live,
             createdAt: .now, updatedAt: .now
         )
     }

--- a/macos/ATCTests/TerminalLivenessTests.swift
+++ b/macos/ATCTests/TerminalLivenessTests.swift
@@ -31,7 +31,7 @@ struct TerminalLivenessTests {
         for _ in 0..<100 where runtime.sessions.sessions.isEmpty {
             try await Task.sleep(for: .milliseconds(20))
         }
-        let session = try #require(runtime.sessions.sessions.first { $0.attachable })
+        let session = try #require(runtime.sessions.sessions.first { $0.status == .live })
         let ref = SessionRef(connectionID: runtime.id, sessionID: session.id)
 
         appModel.attachIfNeeded(to: session, connectionID: runtime.id)
@@ -50,6 +50,29 @@ struct TerminalLivenessTests {
     }
 
     @MainActor
+    @Test("a socket-reported session end reconciles the store and removes the terminal")
+    func socketEndReconcilesStoreAndRemovesTerminal() async throws {
+        let appModel = AppModel.preview()
+        let runtime = try #require(appModel.runtimes.first)
+        for _ in 0..<100 where runtime.sessions.sessions.isEmpty {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        let session = try #require(runtime.sessions.sessions.first { $0.status == .live })
+        let ref = SessionRef(connectionID: runtime.id, sessionID: session.id)
+
+        appModel.attachIfNeeded(to: session, connectionID: runtime.id)
+        let controller = try #require(appModel.terminals[ref])
+
+        // The controller reporting an authoritative end (409 stale attach or
+        // a normal WebSocket closure) must flip the stored session to Ended
+        // and tear the terminal down so input is impossible.
+        controller.onSessionEnded?()
+        let reconciled = try #require(runtime.sessions.sessions.first { $0.id == session.id })
+        #expect(reconciled.status == .ended)
+        #expect(appModel.terminals[ref] == nil)
+    }
+
+    @MainActor
     @Test("explicit disconnect removes the controller from the registry")
     func explicitDisconnectRemoves() async throws {
         let appModel = AppModel.preview()
@@ -57,7 +80,7 @@ struct TerminalLivenessTests {
         for _ in 0..<100 where runtime.sessions.sessions.isEmpty {
             try await Task.sleep(for: .milliseconds(20))
         }
-        let session = try #require(runtime.sessions.sessions.first { $0.attachable })
+        let session = try #require(runtime.sessions.sessions.first { $0.status == .live })
         let ref = SessionRef(connectionID: runtime.id, sessionID: session.id)
 
         appModel.attachIfNeeded(to: session, connectionID: runtime.id)

--- a/macos/ATCTests/TerminalReconnectTests.swift
+++ b/macos/ATCTests/TerminalReconnectTests.swift
@@ -284,7 +284,7 @@ struct TerminalReconnectTests {
         let runtime = try #require(model.runtime(id: record.id))
         runtime.stopPolling()
         await runtime.refresh()
-        let session = try #require(runtime.sessions.sessions.first { $0.attachable })
+        let session = try #require(runtime.sessions.sessions.first { $0.status == .live })
         model.attachIfNeeded(to: session, connectionID: record.id)
         let ref = SessionRef(connectionID: record.id, sessionID: session.id)
         let controller = try #require(model.terminals[ref])

--- a/macos/ATCTests/WorkspaceFlowTests.swift
+++ b/macos/ATCTests/WorkspaceFlowTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import Testing
 import ATCAPI
 @testable import ATC
@@ -230,7 +231,7 @@ struct WorkspaceFlowTests {
         #expect(state.isInspectorPresented)
     }
 
-    @Test("clearing or archiving selected content clears remembered restoration")
+    @Test("clearing selected content clears remembered restoration")
     func staleSelectionMemoryIsCleared() async throws {
         let (model, runtime) = try await makeLoadedModel()
         let (selectionMemory, _) = memory()
@@ -244,14 +245,6 @@ struct WorkspaceFlowTests {
         state.showWorkspaceEmpty()
         #expect(selectionMemory.sessionID(for: parser) == nil)
 
-        let refactor = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_refactor")
-        #expect(state.activateWorkspace(refactor, in: model))
-        let ended = SessionRef(connectionID: runtime.id, sessionID: "ses_done")
-        #expect(state.selectSession(ended, in: model))
-        try await runtime.sessions.archive(id: ended.sessionID)
-        state.reconcile(in: model)
-        #expect(state.selectedContent == .session(ended))
-        #expect(selectionMemory.sessionID(for: refactor) == nil)
     }
 
     @Test("explicit Disconnect is not undone by reconcile")
@@ -277,6 +270,82 @@ struct WorkspaceFlowTests {
         #expect(model.terminals[selected] != nil)
     }
 
+    @Test("Live to Ended refresh tears down interaction and preserves selection")
+    func liveToEndedRefresh() async throws {
+        let client = StatefulWorkspacesClient()
+        let (model, runtime) = try await makeLoadedModel(client: client)
+        let state = WindowState.ephemeral()
+        let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_a")
+        let selected = SessionRef(connectionID: runtime.id, sessionID: "ses_running")
+        #expect(state.activateWorkspace(workspace, in: model))
+        #expect(state.selectSession(selected, in: model))
+        #expect(model.terminals[selected] != nil)
+
+        client.endSession(id: selected.sessionID)
+        await runtime.sessions.refresh()
+        model.reconcileTerminalLifecycle()
+        state.reconcile(in: model)
+
+        #expect(model.session(for: selected)?.status == .ended)
+        #expect(model.terminals[selected] == nil)
+        #expect(state.selectedContent == .session(selected))
+    }
+
+    @Test("failed session refresh preserves last-known Live state and interaction")
+    func failedRefreshPreservesLiveState() async throws {
+        let client = StatefulWorkspacesClient()
+        let (model, runtime) = try await makeLoadedModel(client: client)
+        let state = WindowState.ephemeral()
+        let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_a")
+        let selected = SessionRef(connectionID: runtime.id, sessionID: "ses_running")
+        #expect(state.activateWorkspace(workspace, in: model))
+        #expect(state.selectSession(selected, in: model))
+
+        client.failSessions = true
+        await runtime.sessions.refresh()
+        model.reconcileTerminalLifecycle()
+        state.reconcile(in: model)
+
+        #expect(runtime.sessions.lastError != nil)
+        #expect(model.session(for: selected)?.status == .live)
+        #expect(model.terminals[selected] != nil)
+        #expect(state.selectedContent == .session(selected))
+    }
+
+    @Test("session_ended error reconciles without becoming a generic failure")
+    func staleInteractionReconciles() async throws {
+        let client = StatefulWorkspacesClient()
+        let (model, runtime) = try await makeLoadedModel(client: client)
+        let state = WindowState.ephemeral()
+        let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_a")
+        let selected = SessionRef(connectionID: runtime.id, sessionID: "ses_running")
+        #expect(state.activateWorkspace(workspace, in: model))
+        #expect(state.selectSession(selected, in: model))
+
+        client.endSession(id: selected.sessionID)
+        var actionError: String? = "old error"
+        let errorBinding = Binding<String?>(
+            get: { actionError },
+            set: { actionError = $0 }
+        )
+        model.run(on: runtime.id, reporting: errorBinding) {
+            throw ATCError.api(
+                code: "session_ended",
+                message: "session has ended",
+                sessionID: selected.sessionID
+            )
+        }
+        for _ in 0..<100 where model.session(for: selected)?.status != .ended {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        state.reconcile(in: model)
+
+        #expect(actionError == nil)
+        #expect(model.session(for: selected)?.status == .ended)
+        #expect(model.terminals[selected] == nil)
+        #expect(state.selectedContent == .session(selected))
+    }
+
     @Test("losing the Active Workspace dismisses the start-session sheet")
     func startSheetDismissedWhenWorkspaceGone() async throws {
         let (model, runtime) = try await makeLoadedModel()
@@ -292,18 +361,19 @@ struct WorkspaceFlowTests {
         #expect(state.startSessionKind == nil)
     }
 
-    @Test("selecting archived content never writes restoration memory")
-    func archivedSelectionIsNotRemembered() async throws {
+    @Test("selecting an Ended session writes restoration memory")
+    func endedSelectionIsRemembered() async throws {
         let (model, runtime) = try await makeLoadedModel()
         let (selectionMemory, _) = memory()
         let state = WindowState(selectionMemory: selectionMemory)
         let workspace = WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser")
-        let archived = SessionRef(connectionID: runtime.id, sessionID: "ses_archived")
+        let ended = SessionRef(connectionID: runtime.id, sessionID: "ses_archived")
 
         #expect(state.activateWorkspace(workspace, in: model))
-        #expect(state.selectSession(archived, in: model))
-        #expect(state.selectedContent == .session(archived))
-        #expect(selectionMemory.sessionID(for: workspace) == nil)
+        #expect(state.selectSession(ended, in: model))
+        #expect(state.selectedContent == .session(ended))
+        #expect(selectionMemory.sessionID(for: workspace) == "ses_archived")
+        #expect(model.terminals[ended] == nil)
     }
 
     @Test("a failed first Workspace load after rebuild preserves window context")
@@ -507,18 +577,18 @@ struct WorkspaceFlowTests {
         #expect(selectionMemory.sessionID(for: b) == "ses_b")
     }
 
-    @Test("restoration rejects missing, moved, and archived sessions")
+    @Test("restoration accepts Live and Ended sessions but rejects missing or moved sessions")
     func selectionRestoreFallbacks() {
         let (memory, _) = memory()
         let ref = WorkspaceRef(connectionID: UUID(), workspaceID: "wsp_a")
         var session = Session(
             id: "ses_1", environment: "host", workingDir: "/home/dev",
-            status: .running, attachable: true,
+            status: .live,
             createdAt: .now, updatedAt: .now,
             workspace: SessionWorkspace(id: "wsp_a", name: "A")
         )
         memory.remember(sessionID: session.id, for: ref)
-        for status in [SessionStatus.running, .terminated, .failed] {
+        for status in [SessionStatus.live, .ended] {
             session.status = status
             #expect(memory.restoredSelection(for: ref, in: [session]) != nil)
         }
@@ -527,15 +597,17 @@ struct WorkspaceFlowTests {
         session.workspace = SessionWorkspace(id: "wsp_b", name: "B")
         #expect(memory.restoredSelection(for: ref, in: [session]) == nil)
         session.workspace = SessionWorkspace(id: "wsp_a", name: "A")
-        session.archivedAt = .now
-        #expect(memory.restoredSelection(for: ref, in: [session]) == nil)
+        #expect(memory.restoredSelection(for: ref, in: [session]) != nil)
     }
 
     @Test("every delete confirmation names its target and preserves file copy")
     func deleteConfirmationCopy() {
-        let session = DeleteConfirmation.sessionMessage(displayName: "Fix parser")
-        #expect(session.contains("“Fix parser”"))
-        #expect(session.hasSuffix(DeleteConfirmation.filesUntouched))
+        let live = DeleteConfirmation.sessionMessage(displayName: "Fix parser", status: .live)
+        #expect(live.contains("running process will end"))
+        #expect(live.hasSuffix(DeleteConfirmation.filesUntouched))
+        let ended = DeleteConfirmation.sessionMessage(displayName: "Fix parser", status: .ended)
+        #expect(ended.contains("permanently removed"))
+        #expect(ended.hasSuffix(DeleteConfirmation.filesUntouched))
         let workspace = DeleteConfirmation.workspaceMessage(
             name: "Spike", sessionCount: 3, activeCount: 2
         )
@@ -545,16 +617,13 @@ struct WorkspaceFlowTests {
             .hasSuffix(DeleteConfirmation.filesUntouched))
     }
 
-    @Test("session delete and unarchive wrappers update the store")
+    @Test("session delete wrapper updates the store")
     func sessionWrappers() async throws {
         let model = makeModel(client: StatefulWorkspacesClient())
         let record = try model.addConnection(name: "A", urlString: "http://a:1", token: "")
         let runtime = try #require(model.runtime(id: record.id))
         runtime.stopPolling()
         await runtime.refresh()
-        #expect(runtime.sessions.session(id: "ses_archived")?.isArchived == true)
-        try await runtime.sessions.unarchive(id: "ses_archived")
-        #expect(runtime.sessions.session(id: "ses_archived")?.isArchived == false)
         try await runtime.sessions.delete(id: "ses_done")
         #expect(runtime.sessions.session(id: "ses_done") == nil)
     }

--- a/macos/ATCTests/WorkspacesStoreTests.swift
+++ b/macos/ATCTests/WorkspacesStoreTests.swift
@@ -72,7 +72,7 @@ struct WorkspacesStoreTests {
         #expect(store.workspace(id: target.id) == nil)
     }
 
-    @Test("a failed delete (scripted stop error) leaves every row intact")
+    @Test("a failed delete leaves every row intact")
     func failedDeleteKeepsRows() async throws {
         let client = StatefulWorkspacesClient()
         client.failDeletes = true
@@ -108,11 +108,9 @@ final class StatefulWorkspacesClient: ATCClient, @unchecked Sendable {
     private var _failDeletes = false
     private var _failSessions = false
     private var _failWorkspaces = false
-    /// Session mutations persist as overrides on the inner fixtures, so
-    /// the store's follow-up refreshes converge instead of resurrecting
-    /// pre-mutation state.
+    /// Session deletes persist so follow-up refreshes converge.
     private var deletedSessions: Set<String> = []
-    private var unarchivedSessions: Set<String> = []
+    private var endedSessions: Set<String> = []
 
     var failDeletes: Bool {
         get { lock.withLock { _failDeletes } }
@@ -130,6 +128,10 @@ final class StatefulWorkspacesClient: ATCClient, @unchecked Sendable {
     var failWorkspaces: Bool {
         get { lock.withLock { _failWorkspaces } }
         set { lock.withLock { _failWorkspaces = newValue } }
+    }
+
+    func endSession(id: String) {
+        lock.withLock { _ = endedSessions.insert(id) }
     }
 
     private let projects = [
@@ -255,38 +257,27 @@ final class StatefulWorkspacesClient: ATCClient, @unchecked Sendable {
 
     func health() async throws -> Health { try await inner.health() }
     func version() async throws -> Version { try await inner.version() }
-    func sessions(includeArchived: Bool, status: SessionStatus?) async throws -> [Session] {
+    func sessions(status: SessionStatus?) async throws -> [Session] {
         if failAll || failSessions { throw ATCError.badStatus(500) }
-        let overrides = lock.withLock { (deleted: deletedSessions, unarchived: unarchivedSessions) }
-        return try await inner.sessions(includeArchived: true, status: status)
-            .filter { !overrides.deleted.contains($0.id) }
+        let overrides = lock.withLock { (deletedSessions, endedSessions) }
+        return try await inner.sessions(status: status)
+            .filter { !overrides.0.contains($0.id) }
             .map { session in
                 var session = session
                 if session.id == "ses_running" {
                     session.workspace = SessionWorkspace(id: "wsp_a", name: "Alpha")
                     session.project = SessionProject(id: "prj_one", name: "One")
                 }
-                if overrides.unarchived.contains(session.id) {
-                    session.archivedAt = nil
+                if overrides.1.contains(session.id) {
+                    session.status = .ended
                 }
                 return session
             }
-            .filter { includeArchived || !$0.isArchived }
+            .filter { status == nil || $0.status == status }
     }
     func session(id: String) async throws -> SessionDetail { try await inner.session(id: id) }
     func startSession(_ request: StartSessionRequest) async throws -> SessionDetail {
         try await inner.startSession(request)
-    }
-    func terminateSession(id: String) async throws -> SessionDetail {
-        try await inner.terminateSession(id: id)
-    }
-    func archiveSession(id: String) async throws -> SessionDetail {
-        try await inner.archiveSession(id: id)
-    }
-    func unarchiveSession(id: String) async throws -> SessionDetail {
-        let detail = try await inner.unarchiveSession(id: id)
-        lock.withLock { _ = unarchivedSessions.insert(id) }
-        return detail
     }
     func deleteSession(id: String) async throws {
         try await inner.deleteSession(id: id)
@@ -321,12 +312,12 @@ final class StatefulWorkspacesClient: ATCClient, @unchecked Sendable {
     }
     func archiveProject(id: String) async throws -> Project { try await inner.archiveProject(id: id) }
     func unarchiveProject(id: String) async throws -> Project { try await inner.unarchiveProject(id: id) }
-    func projectSessions(projectID: String, includeArchived: Bool, status: SessionStatus?) async throws -> [Session] {
-        try await inner.projectSessions(projectID: projectID, includeArchived: includeArchived, status: status)
+    func projectSessions(projectID: String, status: SessionStatus?) async throws -> [Session] {
+        try await inner.projectSessions(projectID: projectID, status: status)
     }
     func deleteProject(id: String) async throws { try await inner.deleteProject(id: id) }
-    func workspaceSessions(workspaceID: String, includeArchived: Bool, status: SessionStatus?) async throws -> [Session] {
-        try await inner.workspaceSessions(workspaceID: workspaceID, includeArchived: includeArchived, status: status)
+    func workspaceSessions(workspaceID: String, status: SessionStatus?) async throws -> [Session] {
+        try await inner.workspaceSessions(workspaceID: workspaceID, status: status)
     }
     func attachURL(sessionID: String) -> URL { inner.attachURL(sessionID: sessionID) }
     func attachHeaders() -> [String: String] { inner.attachHeaders() }

--- a/packages/ATCKit/Sources/ATCAPI/ATCClient.swift
+++ b/packages/ATCKit/Sources/ATCAPI/ATCClient.swift
@@ -6,13 +6,10 @@ import Foundation
 public protocol ATCClient: Sendable {
     func health() async throws -> Health
     func version() async throws -> Version
-    func sessions(includeArchived: Bool, status: SessionStatus?) async throws -> [Session]
+    func sessions(status: SessionStatus?) async throws -> [Session]
     func session(id: String) async throws -> SessionDetail
     func startSession(_ request: StartSessionRequest) async throws -> SessionDetail
-    func terminateSession(id: String) async throws -> SessionDetail
-    func archiveSession(id: String) async throws -> SessionDetail
-    func unarchiveSession(id: String) async throws -> SessionDetail
-    /// Deletes a session's metadata, terminating it first if active. Files
+    /// Deletes a session's metadata, ending it first if Live. Files
     /// are never touched.
     func deleteSession(id: String) async throws
     func sendText(sessionID: String, text: String) async throws
@@ -35,7 +32,7 @@ public protocol ATCClient: Sendable {
     func unarchiveProject(id: String) async throws -> Project
     /// Deletes a project record; allowed only once it has zero workspaces.
     func deleteProject(id: String) async throws
-    func projectSessions(projectID: String, includeArchived: Bool, status: SessionStatus?) async throws -> [Session]
+    func projectSessions(projectID: String, status: SessionStatus?) async throws -> [Session]
     /// Lists workspaces newest-first; a nil `projectID` spans every project.
     func workspaces(projectID: String?, includeArchived: Bool) async throws -> [Workspace]
     func workspace(id: String) async throws -> Workspace
@@ -43,10 +40,10 @@ public protocol ATCClient: Sendable {
     func renameWorkspace(id: String, name: String) async throws -> Workspace
     func archiveWorkspace(id: String) async throws -> Workspace
     func unarchiveWorkspace(id: String) async throws -> Workspace
-    /// Deletes a workspace and its sessions' metadata, stopping active
-    /// sessions first. Files are never touched.
+    /// Deletes a workspace and its sessions' metadata, ending Live sessions
+    /// first. Files are never touched.
     func deleteWorkspace(id: String) async throws
-    func workspaceSessions(workspaceID: String, includeArchived: Bool, status: SessionStatus?) async throws -> [Session]
+    func workspaceSessions(workspaceID: String, status: SessionStatus?) async throws -> [Session]
 
     /// WebSocket URL for `GET /api/sessions/{id}/attach`.
     func attachURL(sessionID: String) -> URL
@@ -56,7 +53,7 @@ public protocol ATCClient: Sendable {
 
 public extension ATCClient {
     func sessions() async throws -> [Session] {
-        try await sessions(includeArchived: false, status: nil)
+        try await sessions(status: nil)
     }
 
     func listDirectory(path: String) async throws -> DirectoryListing {
@@ -68,7 +65,7 @@ public extension ATCClient {
     }
 
     func projectSessions(projectID: String) async throws -> [Session] {
-        try await projectSessions(projectID: projectID, includeArchived: false, status: nil)
+        try await projectSessions(projectID: projectID, status: nil)
     }
 
     func workspaces(projectID: String? = nil) async throws -> [Workspace] {
@@ -76,6 +73,6 @@ public extension ATCClient {
     }
 
     func workspaceSessions(workspaceID: String) async throws -> [Session] {
-        try await workspaceSessions(workspaceID: workspaceID, includeArchived: false, status: nil)
+        try await workspaceSessions(workspaceID: workspaceID, status: nil)
     }
 }

--- a/packages/ATCKit/Sources/ATCAPI/ATCError.swift
+++ b/packages/ATCKit/Sources/ATCAPI/ATCError.swift
@@ -32,6 +32,12 @@ extension ATCError: LocalizedError {
         if case .api(let code, _, _) = self { return code }
         return nil
     }
+
+    /// The related session ID, when the server sent one.
+    public var sessionID: String? {
+        if case .api(_, _, let sessionID) = self { return sessionID }
+        return nil
+    }
 }
 
 /// Wire format of atc server error responses.

--- a/packages/ATCKit/Sources/ATCAPI/HTTPATCClient.swift
+++ b/packages/ATCKit/Sources/ATCAPI/HTTPATCClient.swift
@@ -22,11 +22,8 @@ public struct HTTPATCClient: ATCClient {
         try await get("version")
     }
 
-    public func sessions(includeArchived: Bool, status: SessionStatus?) async throws -> [Session] {
+    public func sessions(status: SessionStatus?) async throws -> [Session] {
         var query: [URLQueryItem] = []
-        if includeArchived {
-            query.append(URLQueryItem(name: "includeArchived", value: "true"))
-        }
         if let status {
             query.append(URLQueryItem(name: "status", value: status.rawValue))
         }
@@ -40,18 +37,6 @@ public struct HTTPATCClient: ATCClient {
 
     public func startSession(_ request: StartSessionRequest) async throws -> SessionDetail {
         try await post("sessions/start", body: request)
-    }
-
-    public func terminateSession(id: String) async throws -> SessionDetail {
-        try await post("sessions/\(id)/terminate")
-    }
-
-    public func archiveSession(id: String) async throws -> SessionDetail {
-        try await post("sessions/\(id)/archive")
-    }
-
-    public func unarchiveSession(id: String) async throws -> SessionDetail {
-        try await post("sessions/\(id)/unarchive")
     }
 
     public func deleteSession(id: String) async throws {
@@ -182,13 +167,9 @@ public struct HTTPATCClient: ATCClient {
 
     public func workspaceSessions(
         workspaceID: String,
-        includeArchived: Bool,
         status: SessionStatus?
     ) async throws -> [Session] {
         var query: [URLQueryItem] = []
-        if includeArchived {
-            query.append(URLQueryItem(name: "includeArchived", value: "true"))
-        }
         if let status {
             query.append(URLQueryItem(name: "status", value: status.rawValue))
         }
@@ -198,13 +179,9 @@ public struct HTTPATCClient: ATCClient {
 
     public func projectSessions(
         projectID: String,
-        includeArchived: Bool,
         status: SessionStatus?
     ) async throws -> [Session] {
         var query: [URLQueryItem] = []
-        if includeArchived {
-            query.append(URLQueryItem(name: "includeArchived", value: "true"))
-        }
         if let status {
             query.append(URLQueryItem(name: "status", value: status.rawValue))
         }

--- a/packages/ATCKit/Sources/ATCAPI/Models/SessionModels.swift
+++ b/packages/ATCKit/Sources/ATCAPI/Models/SessionModels.swift
@@ -1,10 +1,8 @@
 import Foundation
 
 public enum SessionStatus: String, Codable, Sendable, CaseIterable, Hashable {
-    case starting
-    case running
-    case failed
-    case terminated
+    case live
+    case ended
 }
 
 /// Workspace reference nested on sessions.
@@ -39,13 +37,8 @@ public struct Session: Codable, Sendable, Hashable, Identifiable {
     public var environment: String
     public var workingDir: String
     public var status: SessionStatus
-    public var attachable: Bool
-    public var failureReason: String?
-    public var failureCode: String?
     public var createdAt: Date
     public var updatedAt: Date
-    public var terminatedAt: Date?
-    public var archivedAt: Date?
     /// The workspace this session belongs to.
     public var workspace: SessionWorkspace?
     /// The workspace's project, derived server-side.
@@ -58,13 +51,8 @@ public struct Session: Codable, Sendable, Hashable, Identifiable {
         environment: String,
         workingDir: String,
         status: SessionStatus,
-        attachable: Bool,
-        failureReason: String? = nil,
-        failureCode: String? = nil,
         createdAt: Date,
         updatedAt: Date,
-        terminatedAt: Date? = nil,
-        archivedAt: Date? = nil,
         workspace: SessionWorkspace? = nil,
         project: SessionProject? = nil
     ) {
@@ -74,19 +62,11 @@ public struct Session: Codable, Sendable, Hashable, Identifiable {
         self.environment = environment
         self.workingDir = workingDir
         self.status = status
-        self.attachable = attachable
-        self.failureReason = failureReason
-        self.failureCode = failureCode
         self.createdAt = createdAt
         self.updatedAt = updatedAt
-        self.terminatedAt = terminatedAt
-        self.archivedAt = archivedAt
         self.workspace = workspace
         self.project = project
     }
-
-    /// Archived is not a status — it's a non-null `archivedAt`.
-    public var isArchived: Bool { archivedAt != nil }
 
     /// Human label for what the session launched: the action name, or
     /// "Shell" for the Interactive Shell.
@@ -99,8 +79,7 @@ public struct Session: Codable, Sendable, Hashable, Identifiable {
     }
 }
 
-/// `GET /api/sessions/{id}` and the response of start/terminate/archive/
-/// unarchive.
+/// `GET /api/sessions/{id}` and the response of starting a session.
 public struct SessionDetail: Codable, Sendable, Hashable, Identifiable {
     public var id: String
     public var name: String?
@@ -111,22 +90,15 @@ public struct SessionDetail: Codable, Sendable, Hashable, Identifiable {
     public var workingDir: String
     public var prompt: String?
     public var status: SessionStatus
-    public var attachable: Bool
-    public var failureReason: String?
-    public var failureCode: String?
     public var createdAt: Date
     public var updatedAt: Date
-    public var terminatedAt: Date?
-    public var archivedAt: Date?
     /// The workspace this session belongs to.
     public var workspace: SessionWorkspace?
     /// The workspace's project, derived server-side.
     public var project: SessionProject?
 
-    public var isArchived: Bool { archivedAt != nil }
-
-    /// The list-shaped projection of this detail, for merging into a
-    /// sessions array after a mutation.
+    /// The list-shaped projection of this detail, for merging a get/start
+    /// response into a sessions array.
     public var asSession: Session {
         Session(
             id: id,
@@ -135,13 +107,8 @@ public struct SessionDetail: Codable, Sendable, Hashable, Identifiable {
             environment: environment,
             workingDir: workingDir,
             status: status,
-            attachable: attachable,
-            failureReason: failureReason,
-            failureCode: failureCode,
             createdAt: createdAt,
             updatedAt: updatedAt,
-            terminatedAt: terminatedAt,
-            archivedAt: archivedAt,
             workspace: workspace,
             project: project
         )

--- a/packages/ATCKit/Tests/ATCAPITests/ATCServerTests.swift
+++ b/packages/ATCKit/Tests/ATCAPITests/ATCServerTests.swift
@@ -9,8 +9,8 @@ struct ATCServerTests {
     @Test("REST URLs live under /api")
     func restURL() {
         #expect(server.restURL("sessions").absoluteString == "http://workstation.tail1f9a09.ts.net:7331/api/sessions")
-        let filtered = server.restURL("sessions", query: [URLQueryItem(name: "includeArchived", value: "true")])
-        #expect(filtered.absoluteString == "http://workstation.tail1f9a09.ts.net:7331/api/sessions?includeArchived=true")
+        let filtered = server.restURL("sessions", query: [URLQueryItem(name: "status", value: "live")])
+        #expect(filtered.absoluteString == "http://workstation.tail1f9a09.ts.net:7331/api/sessions?status=live")
     }
 
     @Test("attach URL swaps scheme to ws")

--- a/packages/ATCKit/Tests/ATCAPITests/ContractFixtureTests.swift
+++ b/packages/ATCKit/Tests/ATCAPITests/ContractFixtureTests.swift
@@ -32,18 +32,16 @@ struct ContractFixtureTests {
     func sessionsList() throws {
         let sessions = try decodeResponse("sessions-list", as: SessionsEnvelope.self).sessions
         #expect(sessions.count == 2)
-        #expect(sessions[0].status == .running)
+        #expect(sessions[0].status == .live)
         #expect(sessions[0].workspace?.id == "wsp_fixture01")
         #expect(sessions[0].project?.id == "prj_fixture01")
         // The second session is an Interactive Shell: no action on the wire.
         #expect(sessions[1].action == nil)
         #expect(sessions[1].displayName == "Shell")
-        #expect(sessions[1].status == .failed)
-        #expect(sessions[1].failureCode == "launch_failed")
-        #expect(sessions[1].isArchived)
+        #expect(sessions[1].status == .ended)
     }
 
-    @Test("session detail", arguments: ["session-detail", "session-start", "session-unarchive"])
+    @Test("session detail", arguments: ["session-detail", "session-start"])
     func sessionDetail(fixture: String) throws {
         let detail = try decodeResponse(fixture, as: SessionDetail.self)
         #expect(!detail.id.isEmpty)
@@ -131,6 +129,7 @@ struct ContractFixtureTests {
     func errorEnvelope() throws {
         let envelope = try decodeResponse("error", as: ErrorEnvelope.self)
         #expect(envelope.error == "session_not_found")
+        #expect(envelope.sessionId == "ses_fixture01")
     }
 
     @Test("health and version")

--- a/packages/ATCKit/Tests/ATCAPITests/ErrorEnvelopeTests.swift
+++ b/packages/ATCKit/Tests/ATCAPITests/ErrorEnvelopeTests.swift
@@ -14,16 +14,17 @@ struct ErrorEnvelopeTests {
 
     @Test("envelope with sessionId")
     func withSessionID() throws {
-        let body = Data(#"{"error":"session_live","message":"session is still running","sessionId":"ses_abc"}"#.utf8)
+        let body = Data(#"{"error":"session_ended","message":"session has ended","sessionId":"ses_abc"}"#.utf8)
         let envelope = try JSONDecoder.atc().decode(ErrorEnvelope.self, from: body)
-        #expect(envelope.error == "session_live")
+        #expect(envelope.error == "session_ended")
         #expect(envelope.sessionId == "ses_abc")
     }
 
     @Test("ATCError surfaces message and code")
     func errorSurface() {
-        let error = ATCError.api(code: "session_live", message: "still running", sessionID: nil)
-        #expect(error.apiCode == "session_live")
-        #expect(error.errorDescription == "still running")
+        let error = ATCError.api(code: "session_ended", message: "session has ended", sessionID: "ses_abc")
+        #expect(error.apiCode == "session_ended")
+        #expect(error.sessionID == "ses_abc")
+        #expect(error.errorDescription == "session has ended")
     }
 }

--- a/packages/ATCKit/Tests/ATCAPITests/ProjectDecodingTests.swift
+++ b/packages/ATCKit/Tests/ATCAPITests/ProjectDecodingTests.swift
@@ -18,12 +18,12 @@ private let projectFixture = Data(#"""
 
 /// A session detail carrying nested workspace and derived project references.
 private let sessionWithProjectFixture = Data(#"""
-{"id":"ses_scoped","action":"claude","environment":"host-login-shell","workingDir":"/home/dev/Projects/atelier","status":"running","attachable":true,"createdAt":"2026-07-05T12:00:00Z","updatedAt":"2026-07-05T12:00:00Z","workspace":{"id":"wsp_login","name":"Login bug"},"project":{"id":"prj_atelier","name":"Atelier"}}
+{"id":"ses_scoped","action":"claude","environment":"host-login-shell","workingDir":"/home/dev/Projects/atelier","status":"live","createdAt":"2026-07-05T12:00:00Z","updatedAt":"2026-07-05T12:00:00Z","workspace":{"id":"wsp_login","name":"Login bug"},"project":{"id":"prj_atelier","name":"Atelier"}}
 """#.utf8)
 
 /// A session detail with no refs (defensive: the server always sends both).
 private let sessionWithoutProjectFixture = Data(#"""
-{"id":"ses_unscoped","action":"codex","environment":"host-login-shell","workingDir":"/tmp","status":"running","attachable":true,"createdAt":"2026-07-05T12:00:00Z","updatedAt":"2026-07-05T12:00:00Z"}
+{"id":"ses_unscoped","action":"codex","environment":"host-login-shell","workingDir":"/tmp","status":"live","createdAt":"2026-07-05T12:00:00Z","updatedAt":"2026-07-05T12:00:00Z"}
 """#.utf8)
 
 @Suite("Project decoding")

--- a/packages/ATCKit/Tests/ATCAPITests/SessionDecodingTests.swift
+++ b/packages/ATCKit/Tests/ATCAPITests/SessionDecodingTests.swift
@@ -2,20 +2,17 @@ import Foundation
 import Testing
 @testable import ATCAPI
 
-/// Fixture captured from the live server on 2026-07-03
-/// (`GET /api/sessions?includeArchived=true`).
+/// Representative fixtures for the closed Live/Ended session contract.
 private let sessionsFixture = Data(#"""
 {"sessions":[
-  {"id":"ses_p6p7ma7hu7gs7gf6us9k97434g","action":"claude","environment":"host-login-shell","workingDir":"/home/jeremytondo/Projects/atc","status":"terminated","attachable":false,"createdAt":"2026-06-30T03:30:53.536616153Z","updatedAt":"2026-07-01T20:09:31.517106561Z","terminatedAt":"2026-07-01T19:29:02.141995752Z","archivedAt":"2026-07-01T20:09:31.517106561Z"},
-  {"id":"ses_n7ka7ajhjlt0hfi0n466aa5mg4","name":"atc Claude Test","action":"claude","environment":"host-login-shell","workingDir":"/home/jeremytondo/Projects/atc/server","status":"terminated","attachable":false,"createdAt":"2026-06-30T02:59:17.697575859Z","updatedAt":"2026-07-01T19:29:02.16375741Z","terminatedAt":"2026-07-01T19:29:02.16375741Z"},
-  {"id":"ses_live","name":"Live One","action":"codex","environment":"host-login-shell","workingDir":"/tmp","status":"running","attachable":true,"createdAt":"2026-06-30T01:44:53.678613522Z","updatedAt":"2026-06-30T01:44:53.678613522Z"},
-  {"id":"ses_failed","action":"codex","environment":"host-login-shell","workingDir":"/tmp","status":"failed","attachable":false,"failureReason":"command not found","failureCode":"spawn_failed","createdAt":"2026-06-30T01:43:06.504785282Z","updatedAt":"2026-06-30T01:44:28.228109473Z"},
-  {"id":"ses_shell","environment":"host-login-shell","workingDir":"/tmp","status":"running","attachable":true,"createdAt":"2026-06-30T01:45:00Z","updatedAt":"2026-06-30T01:45:00Z","workspace":{"id":"wsp_shell","name":"Scratch"},"project":{"id":"prj_tmp","name":"Tmp"}}
+  {"id":"ses_ended","action":"claude","environment":"host-login-shell","workingDir":"/tmp","status":"ended","createdAt":"2026-06-30T03:30:53.536616153Z","updatedAt":"2026-07-01T20:09:31.517106561Z"},
+  {"id":"ses_live","name":"Live One","action":"codex","environment":"host-login-shell","workingDir":"/tmp","status":"live","createdAt":"2026-06-30T01:44:53.678613522Z","updatedAt":"2026-06-30T01:44:53.678613522Z"},
+  {"id":"ses_shell","environment":"host-login-shell","workingDir":"/tmp","status":"live","createdAt":"2026-06-30T01:45:00Z","updatedAt":"2026-06-30T01:45:00Z","workspace":{"id":"wsp_shell","name":"Scratch"},"project":{"id":"prj_tmp","name":"Tmp"}}
 ]}
 """#.utf8)
 
 private let detailFixture = Data(#"""
-{"id":"ses_live","name":"Live One","action":"codex","environment":"host-login-shell","params":{"model":"gpt-5","yolo":true},"workingDir":"/tmp","prompt":"do the thing","status":"running","attachable":true,"createdAt":"2026-06-30T01:44:53.678613522Z","updatedAt":"2026-06-30T01:44:53.678613522Z"}
+{"id":"ses_live","name":"Live One","action":"codex","environment":"host-login-shell","params":{"model":"gpt-5","yolo":true},"workingDir":"/tmp","prompt":"do the thing","status":"live","createdAt":"2026-06-30T01:44:53.678613522Z","updatedAt":"2026-06-30T01:44:53.678613522Z"}
 """#.utf8)
 
 @Suite("Session decoding")
@@ -23,29 +20,18 @@ struct SessionDecodingTests {
     @Test("wrapped list decodes with real server shapes")
     func listDecodes() throws {
         let envelope = try JSONDecoder.atc().decode(SessionsEnvelope.self, from: sessionsFixture)
-        #expect(envelope.sessions.count == 5)
+        #expect(envelope.sessions.count == 3)
 
-        let archived = envelope.sessions[0]
-        #expect(archived.isArchived)
-        #expect(archived.status == .terminated)
-        #expect(archived.name == nil)
-        #expect(archived.displayName == "claude")
+        let ended = envelope.sessions[0]
+        #expect(ended.status == .ended)
+        #expect(ended.name == nil)
+        #expect(ended.displayName == "claude")
 
-        let named = envelope.sessions[1]
-        #expect(!named.isArchived)
-        #expect(named.displayName == "atc Claude Test")
-        #expect(named.terminatedAt != nil)
-
-        let live = envelope.sessions[2]
-        #expect(live.status == .running)
-        #expect(live.attachable)
-
-        let failed = envelope.sessions[3]
-        #expect(failed.status == .failed)
-        #expect(failed.failureCode == "spawn_failed")
+        let live = envelope.sessions[1]
+        #expect(live.status == .live)
 
         // An Interactive Shell session has no action and carries its refs.
-        let shell = envelope.sessions[4]
+        let shell = envelope.sessions[2]
         #expect(shell.action == nil)
         #expect(shell.displayName == "Shell")
         #expect(shell.workspace?.id == "wsp_shell")
@@ -59,6 +45,14 @@ struct SessionDecodingTests {
         #expect(detail.params?["model"] == .string("gpt-5"))
         #expect(detail.params?["yolo"] == .bool(true))
         #expect(detail.asSession.id == detail.id)
-        #expect(detail.asSession.status == .running)
+        #expect(detail.asSession.status == .live)
+    }
+
+    @Test("legacy statuses do not decode", arguments: ["starting", "running", "failed", "terminated"])
+    func legacyStatusDoesNotDecode(status: String) {
+        let body = Data("\"\(status)\"".utf8)
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder.atc().decode(SessionStatus.self, from: body)
+        }
     }
 }


### PR DESCRIPTION
## Summary

- restores the complete ATCKit and macOS `live | ended` Session lifecycle integration from PR #100
- rebases that exact client patch onto current `main`, which already contains the incompatible server-side contract from PR #99
- restores `session_ended` reconciliation, Live-to-Ended terminal teardown, and the unified Session delete flow

## Root cause

PR #100 was merged while its base still pointed to PR #99's feature branch rather than `main`. Because PR #99 had already merged, the macOS integration never reached `main`. The server therefore emitted `live | ended` while released clients still decoded the legacy four-state lifecycle.

This commit was recovered from PR #100 commit `4fc58ac68935d14f7e1f1811ebd94643d1d0086c`; its patch matches the original commit exactly.

## User impact

Remote macOS clients can decode Session responses from the current server again, so Connections no longer become unreachable merely because Session refresh encounters the new lifecycle values.

## Validation

- `CI=true mise run check`
- ATCKit contract suite passed, including strict `live | ended` decoding
- macOS suite passed: 287 tests across 35 suites


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session states are now represented as **Live** or **Ended**, with clearer status badges and lifecycle behavior.
  * Ended sessions remain visible, can be restored in navigation, and offer deletion without connection controls.
  * Added automatic handling when sessions end, including terminal disconnection and stale-session reconciliation.
  * Archived-session filtering and archive/unarchive actions were removed; session lists now include ended sessions.
  * Delete confirmations now explain consequences based on whether a session is live or ended.

* **Bug Fixes**
  * Improved handling of session-ended errors and stale terminal connections.
  * Session details now surface relevant interaction errors instead of silently ignoring them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->