### PR TITLE
server: move config to atc/server/config.toml with strict TOML schema (ATC-5)

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -70,12 +70,12 @@ There are two ways to run the project:
   real backend. Logs from both processes stream in the same terminal. Stop both
   with `Ctrl-C`.
 
-  Dev is a hermetic profile: it generates `tmp/dev/atc.toml` and keeps its
+  Dev is a hermetic profile: it generates `tmp/dev/config.toml` and keeps its
   socket, database, and actions file under `tmp/dev/`, on a dedicated port.
-  Your personal `~/.config/atc/atc.toml` and `ATC_*` overrides
+  Your personal `~/.config/atc/server/config.toml` and `ATC_*` overrides
   never apply, and it runs cleanly alongside an installed background service.
   Delete `tmp/dev` for a fresh dev state; to point the CLI at the dev service,
-  pass its config: `go run ./cmd/atc --config tmp/dev/atc.toml sessions list`.
+  pass its config: `go run ./cmd/atc --config tmp/dev/config.toml sessions list`.
 - **`mise run serve`** builds the web app, embeds it into the binary, and runs
   the service in the foreground. This is the development/debug/supervisor path;
   `atc start` is the normal operator path for a background service.
@@ -218,14 +218,20 @@ gh workflow run release.yml --ref main -f channel=stable -f release_type=minor
 
 atc reads an optional TOML config file. Every setting also has a built-in default, so the file is never required.
 
-The default location is `$XDG_CONFIG_HOME/atc/atc.toml` (i.e. `~/.config/atc/atc.toml`). Override it with the `--config` flag or the `ATC_CONFIG` environment variable:
+The default location is `$XDG_CONFIG_HOME/atc/server/config.toml` (falling back
+to `~/.config/atc/server/config.toml`). Override it with the `--config` flag or
+the `ATC_CONFIG` environment variable:
 
 ```sh
-go run ./cmd/atc serve --config ./atc.toml
-ATC_CONFIG=./atc.toml go run ./cmd/atc serve
+go run ./cmd/atc serve --config ./config.toml
+ATC_CONFIG=./config.toml go run ./cmd/atc serve
 ```
 
-A missing config file at the default location is fine — atc falls back to defaults. A file passed explicitly via `--config` or `ATC_CONFIG` that is missing or malformed is an error.
+A missing config file at the default location is fine — atc falls back to
+defaults. A file passed explicitly via `--config` or `ATC_CONFIG` that is
+missing or malformed is an error. Config decoding is strict: unknown tables,
+unknown keys, and malformed values fail startup with the file path and position
+of the problem.
 
 Settings resolve with the precedence **flag > environment variable > config file > built-in default**, so a more specific source always wins. `http_addr` has a CLI flag (`--http-addr`) and environment override (`ATC_HTTP_ADDR`). `zmx.bin`, `auth.token`, and `store.db_path` can be overridden with `ATC_ZMX_BIN`, `ATC_API_TOKEN`, and `ATC_DB_PATH`.
 
@@ -293,11 +299,12 @@ Do not use recursive deletion or broad `atc-*` globs for this reset.
 
 The config file applies to background mode too: `atc start` forwards an explicit `--config` path to the detached service so it resolves the same file.
 
-Actions are managed in `actions.json` beside `atc.toml` by default, or at
-`ATC_ACTIONS_PATH` when that environment variable is set. The file is a
-sparse overlay: built-in `claude` and `codex` are always present underneath, and
-file entries add custom Actions or override built-ins by name. `[actions]` in
-`atc.toml` is rejected.
+Actions are managed in `actions.json` beside the resolved config file (by
+default `~/.config/atc/server/actions.json`), or at `ATC_ACTIONS_PATH` when that
+environment variable is set. The file is a sparse overlay: built-in `claude`
+and `codex` are always present underneath, and file entries add custom Actions
+or override built-ins by name. `[actions]` in TOML is rejected because the
+schema is strict; actions are managed through the API in `actions.json`.
 
 Pre-release files that use `bin` and `kind` still load, but new API writes use
 `command` and omit `kind`.
@@ -354,7 +361,7 @@ documents the `params` shape; it is not the default Codex definition:
 }
 ```
 
-Environments still live in `atc.toml`:
+Environments still live in `config.toml`:
 
 ```toml
 

--- a/server/cli/root.go
+++ b/server/cli/root.go
@@ -41,7 +41,7 @@ func rootCommand() *cobra.Command {
 		SilenceErrors: true,
 	}
 
-	cmd.PersistentFlags().String("config", "", "Config file path (default $XDG_CONFIG_HOME/atc/atc.toml, or ATC_CONFIG)")
+	cmd.PersistentFlags().String("config", "", "Config file path (default $XDG_CONFIG_HOME/atc/server/config.toml, or ATC_CONFIG)")
 
 	cmd.AddCommand(serveCommand(os.Getenv, os.Stderr))
 	cmd.AddCommand(startCommand(os.Getenv))

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -3,13 +3,14 @@
 // runs flag > env > file > built-in default, so the most specific source wins.
 //
 // The config file is optional. Its default location is
-// $XDG_CONFIG_HOME/atc/atc.toml (falling back to
-// ~/.config/atc/atc.toml), overridable with the --config flag or the
+// $XDG_CONFIG_HOME/atc/server/config.toml (falling back to
+// ~/.config/atc/server/config.toml), overridable with the --config flag or the
 // ATC_CONFIG environment variable. A missing default file is not an error;
 // an explicitly requested file that is missing or malformed is.
 package config
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"maps"
@@ -142,11 +143,10 @@ func Load(opts Options) (Config, error) {
 		data, err := os.ReadFile(path)
 		switch {
 		case err == nil:
-			if err := rejectLegacyActionTables(data); err != nil {
-				return Config{}, err
-			}
-			if err := toml.Unmarshal(data, &cfg); err != nil {
-				return Config{}, fmt.Errorf("parse config file %s: %w", path, err)
+			dec := toml.NewDecoder(bytes.NewReader(data))
+			dec.DisallowUnknownFields()
+			if err := dec.Decode(&cfg); err != nil {
+				return Config{}, fmt.Errorf("parse config file %s: %s", path, decodeDetail(err))
 			}
 		case errors.Is(err, os.ErrNotExist) && !explicit:
 			// A missing default config file is fine; keep defaults.
@@ -203,10 +203,10 @@ func resolveConfigPath(opts Options, env func(string) string) (path string, expl
 
 func defaultConfigPath(env func(string) string) string {
 	if dir := env("XDG_CONFIG_HOME"); dir != "" {
-		return filepath.Join(dir, "atc", "atc.toml")
+		return filepath.Join(dir, "atc", "server", "config.toml")
 	}
 	if home := env("HOME"); home != "" {
-		return filepath.Join(home, ".config", "atc", "atc.toml")
+		return filepath.Join(home, ".config", "atc", "server", "config.toml")
 	}
 	return ""
 }
@@ -221,18 +221,16 @@ func defaultActionsPath(configPath string, env func(string) string) string {
 	return filepath.Join(filepath.Dir(configPath), "actions.json")
 }
 
-func rejectLegacyActionTables(data []byte) error {
-	var raw map[string]any
-	if err := toml.Unmarshal(data, &raw); err != nil {
-		return nil
+// decodeDetail renders a decode failure with go-toml's line/column excerpt
+// when one is available; Error() alone omits the position.
+func decodeDetail(err error) string {
+	if sme, ok := errors.AsType[*toml.StrictMissingError](err); ok {
+		return "unrecognized tables or keys:\n" + sme.String()
 	}
-	if _, ok := raw["agents"]; ok {
-		return fmt.Errorf("invalid config: [agents] has been renamed to [actions]")
+	if de, ok := errors.AsType[*toml.DecodeError](err); ok {
+		return de.Error() + "\n" + de.String()
 	}
-	if _, ok := raw["actions"]; ok {
-		return fmt.Errorf("invalid config: actions are now managed in actions.json or through the API")
-	}
-	return nil
+	return err.Error()
 }
 
 func (c Config) validate() error {

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -39,7 +39,7 @@ func TestLoadDefaults(t *testing.T) {
 }
 
 func TestLoadFromFile(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "atc.toml")
+	path := filepath.Join(t.TempDir(), "config.toml")
 	contents := "" +
 		"[server]\nhttp_addr = \"127.0.0.1:9000\"\n" +
 		"[log]\nlevel = \"debug\"\nformat = \"json\"\n" +
@@ -68,7 +68,7 @@ func TestLoadFromFile(t *testing.T) {
 }
 
 func TestLoadPrecedence(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "atc.toml")
+	path := filepath.Join(t.TempDir(), "config.toml")
 	if err := os.WriteFile(path, []byte("[server]\nhttp_addr = \"127.0.0.1:1111\"\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +119,7 @@ func TestLoadPrecedence(t *testing.T) {
 }
 
 func TestLoadDBPathPrecedence(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "atc.toml")
+	path := filepath.Join(t.TempDir(), "config.toml")
 	if err := os.WriteFile(path, []byte("[store]\ndb_path = \"/from/file/atc.db\"\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +165,7 @@ func TestLoadDBPathPrecedence(t *testing.T) {
 }
 
 func TestLoadZmxBinPrecedence(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "atc.toml")
+	path := filepath.Join(t.TempDir(), "config.toml")
 	if err := os.WriteFile(path, []byte("[zmx]\nbin = \"/from/file/zmx\"\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -233,12 +233,29 @@ func TestLoadMissingExplicitFileErrors(t *testing.T) {
 }
 
 func TestLoadParseError(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "atc.toml")
-	if err := os.WriteFile(path, []byte("this is = not valid = toml"), 0o600); err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name     string
+		contents string
+	}{
+		{name: "syntax error", contents: "this is = not valid = toml"},
+		{name: "type mismatch", contents: "[server]\nhttp_addr = 5\n"},
 	}
-	if _, err := Load(Options{ConfigPath: path, ConfigChanged: true, Env: envFunc(nil)}); err == nil {
-		t.Fatal("expected parse error")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.toml")
+			if err := os.WriteFile(path, []byte(tt.contents), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			_, err := Load(Options{ConfigPath: path, ConfigChanged: true, Env: envFunc(nil)})
+			if err == nil {
+				t.Fatal("expected parse error")
+			}
+			// The diagnostic must carry the file path and go-toml's
+			// line-annotated excerpt (rendered as "N| <line>").
+			if !strings.Contains(err.Error(), path) || !strings.Contains(err.Error(), "1|") {
+				t.Fatalf("Load err = %v, want config path and line position", err)
+			}
+		})
 	}
 }
 
@@ -253,7 +270,7 @@ func TestLoadValidation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			path := filepath.Join(t.TempDir(), "atc.toml")
+			path := filepath.Join(t.TempDir(), "config.toml")
 			if err := os.WriteFile(path, []byte(tt.contents), 0o600); err != nil {
 				t.Fatal(err)
 			}
@@ -267,12 +284,12 @@ func TestLoadValidation(t *testing.T) {
 func TestResolveConfigPathDefault(t *testing.T) {
 	xdg := "/home/u/.config"
 	got := defaultConfigPath(envFunc(map[string]string{"XDG_CONFIG_HOME": xdg}))
-	if want := filepath.Join(xdg, "atc", "atc.toml"); got != want {
+	if want := filepath.Join(xdg, "atc", "server", "config.toml"); got != want {
 		t.Errorf("xdg path = %q, want %q", got, want)
 	}
 
 	got = defaultConfigPath(envFunc(map[string]string{"HOME": "/home/u"}))
-	if want := filepath.Join("/home/u", ".config", "atc", "atc.toml"); got != want {
+	if want := filepath.Join("/home/u", ".config", "atc", "server", "config.toml"); got != want {
 		t.Errorf("home path = %q, want %q", got, want)
 	}
 }
@@ -283,7 +300,7 @@ func TestLoadDefaultActionsPathAndEnvironments(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if want := filepath.Join(xdg, "atc", "actions.json"); cfg.ActionsPath != want {
+	if want := filepath.Join(xdg, "atc", "server", "actions.json"); cfg.ActionsPath != want {
 		t.Fatalf("actions path = %q, want %q", cfg.ActionsPath, want)
 	}
 	env, ok := cfg.Environments["host-login-shell"]
@@ -293,7 +310,7 @@ func TestLoadDefaultActionsPathAndEnvironments(t *testing.T) {
 }
 
 func TestLoadActionsPathPrecedence(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "nested", "atc.toml")
+	path := filepath.Join(t.TempDir(), "nested", "config.toml")
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		t.Fatal(err)
 	}
@@ -334,32 +351,54 @@ func TestLoadActionsPathFallsBackToTMPDIR(t *testing.T) {
 	}
 }
 
-func TestLoadRejectsActionsTable(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "atc.toml")
-	if err := os.WriteFile(path, []byte("[actions.claude]\nbin = \"claude\"\n"), 0o600); err != nil {
-		t.Fatal(err)
+func TestLoadRejectsUnknownTopLevelTable(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+		want     string
+	}{
+		{name: "arbitrary table", contents: "[nonsense]\nvalue = 1\n", want: "nonsense"},
+		// Actions are managed via the API in actions.json; strict decoding
+		// rejects the retired [actions] and [agents] tables with no
+		// bespoke handling.
+		{name: "actions table", contents: "[actions.claude]\ncommand = \"claude\"\n", want: "actions"},
+		{name: "agents table", contents: "[agents.codex]\ncommand = \"codex\"\n", want: "agents"},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.toml")
+			if err := os.WriteFile(path, []byte(tt.contents), 0o600); err != nil {
+				t.Fatal(err)
+			}
 
-	_, err := Load(Options{ConfigPath: path, ConfigChanged: true, Env: envFunc(nil)})
-	if err == nil || !strings.Contains(err.Error(), "actions are now managed in actions.json") {
-		t.Fatalf("Load err = %v, want actions table error", err)
+			_, err := Load(Options{ConfigPath: path, ConfigChanged: true, Env: envFunc(nil)})
+			if err == nil {
+				t.Fatal("Load returned nil error, want unknown table error")
+			}
+			if !strings.Contains(err.Error(), path) || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Load err = %v, want config path and offending table %q", err, tt.want)
+			}
+		})
 	}
 }
 
-func TestLoadRejectsLegacyAgentsTable(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "atc.toml")
-	if err := os.WriteFile(path, []byte("[agents.codex]\nbin = \"codex\"\n"), 0o600); err != nil {
+func TestLoadRejectsUnknownKeyInKnownTable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte("[server]\nbogus = 1\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
 	_, err := Load(Options{ConfigPath: path, ConfigChanged: true, Env: envFunc(nil)})
-	if err == nil || !strings.Contains(err.Error(), "[agents] has been renamed to [actions]") {
-		t.Fatalf("Load err = %v, want legacy agents table error", err)
+	if err == nil {
+		t.Fatal("Load returned nil error, want unknown key error")
+	}
+	if !strings.Contains(err.Error(), path) || !strings.Contains(err.Error(), "bogus") {
+		t.Fatalf("Load err = %v, want config path and offending key", err)
 	}
 }
 
 func TestLoadEnvironmentsFromFileOverlaysDefaults(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "atc.toml")
+	path := filepath.Join(t.TempDir(), "config.toml")
 	contents := "" +
 		"[environments.custom]\n" +
 		"kind = \"host-login-shell\"\n" +
@@ -381,7 +420,7 @@ func TestLoadEnvironmentsFromFileOverlaysDefaults(t *testing.T) {
 }
 
 func TestLoadAuthTokenPrecedence(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "atc.toml")
+	path := filepath.Join(t.TempDir(), "config.toml")
 	if err := os.WriteFile(path, []byte("[auth]\ntoken = \"from-file\"\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/server/tools/dev.sh
+++ b/server/tools/dev.sh
@@ -5,11 +5,11 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Dev runs a hermetic profile under tmp/dev/: its own config, loopback bind,
 # Unix socket, database, and actions file. Your personal atc config
-# (~/.config/atc/atc.toml) and ATC_* environment overrides never
+# (~/.config/atc/server/config.toml) and ATC_* environment overrides never
 # apply here, and the dedicated port keeps dev clear of a background service
 # on the default 7331. Delete tmp/dev for a fresh dev state.
 DEV_DIR="$ROOT/tmp/dev"
-DEV_CONFIG="$DEV_DIR/atc.toml"
+DEV_CONFIG="$DEV_DIR/config.toml"
 API_ADDR="127.0.0.1:7332"
 API_PORT="${API_ADDR##*:}"
 API_URL="http://$API_ADDR"
@@ -287,7 +287,7 @@ atc dev ready
 UI:    $WEB_URL
 API:   $API_URL
 State: tmp/dev (delete for a fresh dev database)
-CLI:   go run ./cmd/atc --config tmp/dev/atc.toml sessions list
+CLI:   go run ./cmd/atc --config tmp/dev/config.toml sessions list
 Stop:  Ctrl-C
 
 Logs:

--- a/server/web/vite.config.ts
+++ b/server/web/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 
 // In dev, the SvelteKit dev server serves the UI on :5173 while the Go API runs
 // on the dev profile's fixed address (see tools/dev.sh, which generates
-// tmp/dev/atc.toml with the same value). Proxy /api to it so the frontend
+// tmp/dev/config.toml with the same value). Proxy /api to it so the frontend
 // stays same-origin (no CORS).
 const apiTarget = 'http://127.0.0.1:7332';
 


### PR DESCRIPTION
Part 1 of 3 for [ATC-5 Configuration system](https://linear.app/elevenideas/issue/ATC-5/configuration-system).

## What

- Default server config path moves from `$XDG_CONFIG_HOME/atc/atc.toml` to `$XDG_CONFIG_HOME/atc/server/config.toml` (fallback `~/.config/atc/server/config.toml`). Clean break — no legacy fallback or migration.
- Default `actions.json` colocates beside the resolved config file (`~/.config/atc/server/actions.json`); `ATC_ACTIONS_PATH` still overrides.
- TOML decoding is now strict via go-toml v2 `DisallowUnknownFields`: unknown tables/keys, syntax errors, and type mismatches fail startup with the file path plus go-toml's line-annotated excerpt.
- Deleted `rejectLegacyActionTables` — strict decoding rejects `[agents]`/`[actions]` naturally (covered by tests).
- Updated `tools/dev.sh` (generates `tmp/dev/config.toml`), server README, CLI flag help, and the vite dev-proxy comment.

Precedence is unchanged: CLI flag > environment variable > config file > built-in defaults. A missing default file remains valid; an explicitly selected missing file is an error.

## Example diagnostics

```text
parse config file ~/.config/atc/server/config.toml: unrecognized tables or keys:
1| [server]
2| bogus = 1
 | ~~~~~ unknown field
```

## Validation

- `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- `go test ./...` green (two pre-existing unix-socket test failures reproduce only under long TMPDIR paths, unrelated to this change)
- Two independent adversarial reviews; findings (positional detail lost for syntax/type errors, weak parse-error tests, dropped `[actions]`/`[agents]` coverage) all addressed