### PR TITLE
macos: scoped Command Palette commands for Sessions, Terminals, Workspaces (ATC-35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ When a command has several direct triggers, the menu bar shows one of them,
 chosen deterministically (user bindings beat defaults; ties resolve
 alphabetically).
 
+The scoped Command Palette commands search within a specific navigation type:
+
+| Command ID | Default bindings |
+| --- | --- |
+| `view.search-sessions` | `cmd+shift+s`, `leader>s` |
+| `view.search-terminals` | `cmd+shift+t`, `leader>t` |
+| `view.search-workspaces` | `cmd+shift+o`, `leader>w` |
+
 All `[terminal]` keys are optional. Terminal presentation starts from
 libghostty's compiled defaults, then applies only the values explicitly set in
 this table. `theme` must name a bundled Ghostty theme; `font_family` must be

--- a/macos/ATC/AppCommands.swift
+++ b/macos/ATC/AppCommands.swift
@@ -29,6 +29,9 @@ struct AppCommands: Commands {
             commandButton(.showDashboard)
             commandButton(.refresh)
             commandButton(.toggleCommandPalette)
+            commandButton(.searchSessions)
+            commandButton(.searchTerminals)
+            commandButton(.searchWorkspaces)
             Divider()
         }
 

--- a/macos/ATC/Commands/CommandID.swift
+++ b/macos/ATC/Commands/CommandID.swift
@@ -1,6 +1,9 @@
 enum CommandID: String, CaseIterable, Sendable {
     case toggleSidebar = "view.toggle-sidebar"
     case toggleCommandPalette = "view.toggle-command-palette"
+    case searchSessions = "view.search-sessions"
+    case searchTerminals = "view.search-terminals"
+    case searchWorkspaces = "view.search-workspaces"
     case showDashboard = "view.show-dashboard"
     case newSession = "session.new"
     case newTerminal = "terminal.new"

--- a/macos/ATC/Commands/CommandRegistry.swift
+++ b/macos/ATC/Commands/CommandRegistry.swift
@@ -48,6 +48,7 @@ enum CommandRegistry {
     private static let sessionUnavailable =
         "Requires an open Workspace on a reachable Connection"
     private static let connectionUnavailable = "Requires a configured Connection"
+    private static let dialogUnavailable = "Not available while a dialog is open"
 
     static var allDescriptors: [CommandDescriptor] {
         CommandID.allCases.map(descriptor(for:))
@@ -71,10 +72,40 @@ enum CommandRegistry {
                 isPaletteEligible: false,
                 availability: {
                     $0.windowState.isSheetPresented
-                        ? .unavailable(reason: "Not available while a dialog is open")
+                        ? .unavailable(reason: dialogUnavailable)
                         : .available
                 },
-                perform: { $0.windowState.isCommandPalettePresented.toggle() }
+                perform: {
+                    $0.windowState.commandPalettePresentation =
+                        $0.windowState.commandPalettePresentation == nil ? .all : nil
+                }
+            )
+        case .searchSessions:
+            CommandDescriptor(
+                id: id,
+                title: "Search Sessions…",
+                category: .view,
+                isPaletteEligible: false,
+                availability: { scopedPaletteAvailability($0, requiresWorkspace: true) },
+                perform: { $0.windowState.commandPalettePresentation = .sessions }
+            )
+        case .searchTerminals:
+            CommandDescriptor(
+                id: id,
+                title: "Search Terminals…",
+                category: .view,
+                isPaletteEligible: false,
+                availability: { scopedPaletteAvailability($0, requiresWorkspace: true) },
+                perform: { $0.windowState.commandPalettePresentation = .terminals }
+            )
+        case .searchWorkspaces:
+            CommandDescriptor(
+                id: id,
+                title: "Search Workspaces…",
+                category: .view,
+                isPaletteEligible: false,
+                availability: { scopedPaletteAvailability($0, requiresWorkspace: false) },
+                perform: { $0.windowState.commandPalettePresentation = .workspaces }
             )
         case .showDashboard:
             CommandDescriptor(
@@ -166,6 +197,22 @@ enum CommandRegistry {
         context.windowState.canStartSession(in: context.appModel)
             ? .available
             : .unavailable(reason: sessionUnavailable)
+    }
+
+    private static func scopedPaletteAvailability(
+        _ context: CommandContext,
+        requiresWorkspace: Bool
+    ) -> CommandAvailability {
+        if context.windowState.isSheetPresented {
+            return .unavailable(reason: dialogUnavailable)
+        }
+        if context.windowState.commandPalettePresentation != nil {
+            return .unavailable(reason: "Not available while the Command Palette is open")
+        }
+        if requiresWorkspace, context.windowState.activeWorkspace == nil {
+            return .unavailable(reason: "Requires an Active Workspace")
+        }
+        return .available
     }
 
     private static func connectionAvailability(

--- a/macos/ATC/Commands/KeyboardMonitorHost.swift
+++ b/macos/ATC/Commands/KeyboardMonitorHost.swift
@@ -182,14 +182,14 @@ struct KeyboardRoutingContainer<Content: View>: View {
             keymap: configStore.configuration.keymap,
             context: context
         )
-        router.isSuspended = { windowState.isCommandPalettePresented }
+        router.isSuspended = { windowState.commandPalettePresentation != nil }
         _router = State(initialValue: router)
     }
 
     var body: some View {
         content
             .overlay {
-                if windowState.isCommandPalettePresented {
+                if windowState.commandPalettePresentation != nil {
                     CommandPaletteView()
                 }
             }
@@ -200,14 +200,14 @@ struct KeyboardRoutingContainer<Content: View>: View {
             .environment(router)
             .background(KeyboardMonitorHost(
                 router: router,
-                onDeactivate: { windowState.isCommandPalettePresented = false },
+                onDeactivate: { windowState.commandPalettePresentation = nil },
                 focusFallback: { windowState.requestTerminalFocus() }
             ))
             .onChange(of: configStore.configuration.keymap.generation, initial: true) {
                 router.keymap = configStore.configuration.keymap
             }
-            .onChange(of: windowState.isCommandPalettePresented) {
-                if windowState.isCommandPalettePresented {
+            .onChange(of: windowState.commandPalettePresentation) {
+                if windowState.commandPalettePresentation != nil {
                     router.cancel()
                 }
             }

--- a/macos/ATC/Commands/Keymap.swift
+++ b/macos/ATC/Commands/Keymap.swift
@@ -24,6 +24,9 @@ enum Keymap {
         ("cmd+r", .refresh), ("leader>r", .refresh),
         ("cmd+t", .newTerminal),
         ("cmd+shift+n", .newWorkspace),
+        ("cmd+shift+s", .searchSessions), ("leader>s", .searchSessions),
+        ("cmd+shift+t", .searchTerminals), ("leader>t", .searchTerminals),
+        ("cmd+shift+o", .searchWorkspaces), ("leader>w", .searchWorkspaces),
     ]
 
     static func resolve(

--- a/macos/ATC/Features/CommandPalette/CommandPaletteContent.swift
+++ b/macos/ATC/Features/CommandPalette/CommandPaletteContent.swift
@@ -47,11 +47,12 @@ struct SessionResult: Identifiable {
     var id: PaletteResultID { .session(ref) }
 }
 
-/// A whole-query type keyword: a trimmed query of three or more characters
-/// that is a case-insensitive prefix of one plural keyword ("sessions",
-/// "terminals", "workspaces") lists every target of that type, additively
-/// with ordinary matching. Anything else — shorter, longer than the keyword,
-/// or a composed query like "session parser" — matches only by title.
+/// A whole-query type keyword for the unscoped palette: a trimmed query of
+/// three or more characters that is a case-insensitive prefix of one plural
+/// keyword ("sessions", "terminals", "workspaces") lists every target of that
+/// type, additively with ordinary matching. Anything else — shorter, longer
+/// than the keyword, or a composed query like "session parser" — matches only
+/// by title.
 enum PaletteTypeKeyword: CaseIterable, Equatable {
     case sessions
     case terminals
@@ -79,6 +80,28 @@ enum CommandPaletteContent {
     static func results(
         query: String,
         keymap: ResolvedKeymap,
+        context: CommandContext,
+        presentation: CommandPalettePresentation
+    ) -> [PaletteResult] {
+        switch presentation {
+        case .all:
+            return allResults(query: query, keymap: keymap, context: context)
+        case .sessions:
+            return scopedSessionResults(query: query, kind: .agent, context: context)
+        case .terminals:
+            return scopedSessionResults(query: query, kind: .terminal, context: context)
+        case .workspaces:
+            return workspaceResults(
+                query: query,
+                groups: ProjectsNavigatorGroups(runtimes: context.appModel.runtimes),
+                keyword: nil
+            ).map(PaletteResult.workspace)
+        }
+    }
+
+    private static func allResults(
+        query: String,
+        keymap: ResolvedKeymap,
         context: CommandContext
     ) -> [PaletteResult] {
         let commands = commandRows(query: query, keymap: keymap, context: context)
@@ -87,9 +110,12 @@ enum CommandPaletteContent {
             return commands
         }
 
+        let keyword = PaletteTypeKeyword.match(query)
+
         let workspaces = workspaceResults(
             query: query,
-            groups: ProjectsNavigatorGroups(runtimes: context.appModel.runtimes)
+            groups: ProjectsNavigatorGroups(runtimes: context.appModel.runtimes),
+            keyword: keyword
         ).map(PaletteResult.workspace)
 
         guard let activeWorkspace = context.windowState.activeWorkspace,
@@ -99,16 +125,36 @@ enum CommandPaletteContent {
             query: query,
             activeWorkspace: activeWorkspace,
             sessions: runtime.sessions.sessions,
-            actions: runtime.actions.actions
+            actions: runtime.actions.actions,
+            keyword: keyword
         ).map(PaletteResult.session)
         return commands + workspaces + sessions
     }
 
+    private static func scopedSessionResults(
+        query: String,
+        kind: SessionKind,
+        context: CommandContext
+    ) -> [PaletteResult] {
+        guard let activeWorkspace = context.windowState.activeWorkspace,
+              let runtime = context.appModel.runtime(id: activeWorkspace.connectionID)
+        else { return [] }
+        return sessionResults(
+            query: query,
+            activeWorkspace: activeWorkspace,
+            sessions: runtime.sessions.sessions,
+            actions: runtime.actions.actions,
+            keyword: nil,
+            kind: kind
+        ).map(PaletteResult.session)
+    }
+
     static func workspaceResults(
         query: String,
-        groups: ProjectsNavigatorGroups
+        groups: ProjectsNavigatorGroups,
+        keyword: PaletteTypeKeyword?
     ) -> [WorkspaceResult] {
-        let expandsWorkspaces = PaletteTypeKeyword.match(query) == .workspaces
+        let expandsWorkspaces = keyword == .workspaces
         return groups.projects.flatMap { group in
             group.workspaces.compactMap { row in
                 let titleMatch = QueryMatcher.match(query, in: row.workspace.name)
@@ -135,13 +181,15 @@ enum CommandPaletteContent {
         query: String,
         activeWorkspace: WorkspaceRef,
         sessions: [Session],
-        actions: [ATCAction]
+        actions: [ATCAction],
+        keyword: PaletteTypeKeyword?,
+        kind requiredKind: SessionKind? = nil
     ) -> [SessionResult] {
-        let keyword = PaletteTypeKeyword.match(query)
         return sessions.compactMap { session in
             guard session.belongs(to: activeWorkspace) else { return nil }
             let title = SessionKind.displayName(session: session, actions: actions)
             let kind = SessionKind.classify(session: session, actions: actions)
+            guard requiredKind == nil || kind == requiredKind else { return nil }
             let titleMatch = QueryMatcher.match(query, in: title)
             let expandsKind: Bool
             switch kind {

--- a/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
+++ b/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
@@ -18,6 +18,7 @@ struct CommandPaletteView: View {
     }
 
     var body: some View {
+        let presentation = windowState.commandPalettePresentation ?? .all
         let context = CommandContext(
             appModel: appModel,
             windowState: windowState,
@@ -26,7 +27,8 @@ struct CommandPaletteView: View {
         let rows = CommandPaletteContent.results(
             query: query,
             keymap: configStore.configuration.keymap,
-            context: context
+            context: context,
+            presentation: presentation
         )
 
         ZStack(alignment: .top) {
@@ -34,7 +36,7 @@ struct CommandPaletteView: View {
                 .contentShape(Rectangle())
                 .onTapGesture { dismissPalette() }
 
-            palettePanel(rows: rows, context: context)
+            palettePanel(rows: rows, context: context, presentation: presentation)
                 .frame(maxWidth: 500)
                 .padding(.horizontal, 20)
                 .padding(.top, 48)
@@ -54,9 +56,9 @@ struct CommandPaletteView: View {
             },
             fallback: { windowState.requestTerminalFocus() }
         ))
-        .onAppear { resetSelection(for: rows) }
+        .onAppear { resetSelection(for: rows, presentation: presentation) }
         .onChange(of: query) {
-            resetSelection(for: rows)
+            resetSelection(for: rows, presentation: presentation)
             let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
             if !trimmed.isEmpty, rows.isEmpty {
                 AccessibilityNotification.Announcement("No matching results").post()
@@ -66,7 +68,7 @@ struct CommandPaletteView: View {
         // selection that no longer resolves falls back to the standard rule.
         .onChange(of: rows.map(\.id)) {
             if let selectedID, rows.contains(where: { $0.id == selectedID }) { return }
-            resetSelection(for: rows)
+            resetSelection(for: rows, presentation: presentation)
         }
         // Keyboard focus stays on the query field while arrows move the
         // selection, so VoiceOver never lands on the rows; announce the
@@ -81,10 +83,11 @@ struct CommandPaletteView: View {
 
     private func palettePanel(
         rows: [PaletteResult],
-        context: CommandContext
+        context: CommandContext,
+        presentation: CommandPalettePresentation
     ) -> some View {
         VStack(spacing: 0) {
-            TextField("Search commands and navigation…", text: $query)
+            TextField(placeholder(for: presentation), text: $query)
                 .textFieldStyle(.plain)
                 .font(.title3)
                 .padding(.horizontal, 14)
@@ -109,7 +112,7 @@ struct CommandPaletteView: View {
 
             Divider()
 
-            resultList(rows: rows, context: context)
+            resultList(rows: rows, context: context, presentation: presentation)
         }
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 11))
         .overlay {
@@ -122,10 +125,11 @@ struct CommandPaletteView: View {
     @ViewBuilder
     private func resultList(
         rows: [PaletteResult],
-        context: CommandContext
+        context: CommandContext,
+        presentation: CommandPalettePresentation
     ) -> some View {
         if rows.isEmpty {
-            Text("No matching results")
+            Text(emptyStateText(for: presentation))
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: .infinity, minHeight: 44)
@@ -361,15 +365,39 @@ struct CommandPaletteView: View {
     }
 
     private func dismissPalette() {
-        windowState.isCommandPalettePresented = false
+        windowState.commandPalettePresentation = nil
     }
 
-    /// The one selection rule: first row for a nonempty query, none for an
-    /// empty one. Applied on appearance too, so a palette hosted with a
-    /// prefilled query starts with a live selection.
-    private func resetSelection(for rows: [PaletteResult]) {
+    /// Scoped palettes always select the first row; the unscoped palette does
+    /// so only for a nonempty query. Applied on appearance too, so a palette
+    /// hosted with a prefilled query starts with a live selection.
+    private func resetSelection(
+        for rows: [PaletteResult],
+        presentation: CommandPalettePresentation
+    ) {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        selectedID = trimmed.isEmpty ? nil : rows.first?.id
+        selectedID = presentation == .all && trimmed.isEmpty ? nil : rows.first?.id
+    }
+
+    private func placeholder(for presentation: CommandPalettePresentation) -> String {
+        switch presentation {
+        case .all: "Search commands and navigation…"
+        case .sessions: "Search Sessions…"
+        case .terminals: "Search Terminals…"
+        case .workspaces: "Search Workspaces…"
+        }
+    }
+
+    private func emptyStateText(for presentation: CommandPalettePresentation) -> String {
+        guard query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return "No matching results"
+        }
+        return switch presentation {
+        case .all: "No matching results"
+        case .sessions: "No Sessions"
+        case .terminals: "No Terminals"
+        case .workspaces: "No Workspaces"
+        }
     }
 
     private func moveSelection(

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -14,6 +14,13 @@ enum MainContentSelection: Equatable, Sendable {
     case session(SessionRef)
 }
 
+enum CommandPalettePresentation: Equatable, Sendable {
+    case all
+    case sessions
+    case terminals
+    case workspaces
+}
+
 struct TerminalRetentionContext: Equatable, Sendable {
     let activeWorkspace: WorkspaceRef?
     let selectedSession: SessionRef?
@@ -31,7 +38,7 @@ final class WindowState {
     private(set) var selectedContent: MainContentSelection = .dashboard
     var columnVisibility: NavigationSplitViewVisibility = .all
     var isInspectorPresented = false
-    var isCommandPalettePresented = false
+    var commandPalettePresentation: CommandPalettePresentation?
 
     var isProjectsSectionExpanded = true
     var isSessionsSectionExpanded = true

--- a/macos/ATCTests/CommandPaletteContentTests.swift
+++ b/macos/ATCTests/CommandPaletteContentTests.swift
@@ -249,6 +249,154 @@ struct CommandPaletteContentTests {
         })
     }
 
+    @Test("scoped blank queries list only the Active Workspace's classified Sessions")
+    func scopedSessionKinds() async throws {
+        var client = MockATCClient()
+        client.mockProjects = [paletteProject("project", name: "Project")]
+        client.mockWorkspaces = [
+            paletteWorkspace("active", project: "project", name: "Active"),
+            paletteWorkspace("other", project: "project", name: "Other"),
+        ]
+        client.mockSessions = [
+            paletteSession(
+                "agent-live", name: "Zulu Agent", action: "claude", workspace: "active"
+            ),
+            paletteSession(
+                "agent-ended", name: "Alpha Agent", action: "claude",
+                workspace: "active", status: .ended
+            ),
+            paletteSession("terminal-live", name: "Beta Terminal", workspace: "active"),
+            paletteSession(
+                "terminal-ended", name: "Delta Tool", action: "lazygit",
+                workspace: "active", status: .ended
+            ),
+            paletteSession(
+                "outside", name: "Outside Agent", action: "claude", workspace: "other"
+            ),
+        ]
+        let fixture = try await makeLiveFixture(client: client, workspaceID: "active")
+
+        let sessions = results(query: "", presentation: .sessions, fixture: fixture)
+        #expect(sessions.count == 2)
+        #expect(sessions.compactMap(\.sessionRow).map(\.title) == ["Alpha Agent", "Zulu Agent"])
+        #expect(sessions.compactMap(\.sessionRow).allSatisfy { $0.kind == .agent })
+
+        let terminals = results(query: "", presentation: .terminals, fixture: fixture)
+        #expect(terminals.count == 2)
+        #expect(terminals.compactMap(\.sessionRow).map(\.title) == [
+            "Beta Terminal", "Delta Tool",
+        ])
+        #expect(terminals.compactMap(\.sessionRow).allSatisfy { $0.kind == .terminal })
+    }
+
+    @Test("scoped typed queries never admit another result type")
+    func scopedTypeIsolation() async throws {
+        var client = MockATCClient()
+        client.mockProjects = [paletteProject("project", name: "Project")]
+        client.mockWorkspaces = [
+            paletteWorkspace("active", project: "project", name: "Active Workspace")
+        ]
+        client.mockSessions = [
+            paletteSession(
+                "agent", name: "Agent Result", action: "claude", workspace: "active"
+            ),
+            paletteSession("terminal", name: "Terminal Result", workspace: "active"),
+        ]
+        let fixture = try await makeLiveFixture(client: client, workspaceID: "active")
+
+        #expect(results(
+            query: "Refresh", presentation: .sessions, fixture: fixture
+        ).isEmpty)
+        #expect(results(
+            query: "Terminal Result", presentation: .sessions, fixture: fixture
+        ).isEmpty)
+        #expect(results(
+            query: "Agent Result", presentation: .terminals, fixture: fixture
+        ).isEmpty)
+        #expect(results(
+            query: "Agent Result", presentation: .workspaces, fixture: fixture
+        ).isEmpty)
+    }
+
+    @Test("type keywords expand only in the unscoped palette")
+    func scopedKeywordsDoNotExpand() async throws {
+        var client = MockATCClient()
+        client.mockProjects = [paletteProject("project", name: "Project")]
+        client.mockWorkspaces = [
+            paletteWorkspace("alpha", project: "project", name: "Alpha"),
+            paletteWorkspace("working", project: "project", name: "Workspace Notes"),
+        ]
+        client.mockSessions = [
+            paletteSession(
+                "session-match", name: "Session Notes", action: "claude",
+                workspace: "alpha"
+            ),
+            paletteSession(
+                "session-other", name: "Agent Notes", action: "claude",
+                workspace: "alpha"
+            ),
+            paletteSession("terminal-match", name: "Terminal Notes", workspace: "alpha"),
+            paletteSession("terminal-other", name: "Shell Notes", workspace: "alpha"),
+        ]
+        let fixture = try await makeLiveFixture(client: client, workspaceID: "alpha")
+
+        #expect(results(
+            query: "ses", presentation: .sessions, fixture: fixture
+        ).compactMap(\.sessionRow).map(\.ref.sessionID) == ["session-match"])
+        #expect(results(
+            query: "ter", presentation: .terminals, fixture: fixture
+        ).compactMap(\.sessionRow).map(\.ref.sessionID) == ["terminal-match"])
+        // "worksp" is still a keyword prefix, but avoids the preview
+        // Connection name "Workstation", which every scoped row may match.
+        #expect(results(
+            query: "worksp", presentation: .workspaces, fixture: fixture
+        ).compactMap(\.workspaceRow).map(\.ref.workspaceID) == ["working"])
+
+        let unscoped = results(query: "ses", presentation: .all, fixture: fixture)
+            .compactMap(\.sessionRow)
+        #expect(unscoped.map(\.ref.sessionID) == ["session-other", "session-match"])
+        #expect(unscoped.allSatisfy { $0.kind == .agent })
+    }
+
+    @Test("Workspace scope includes unarchived Workspaces from unreachable Connections")
+    func scopedWorkspacesAcrossConnections() async throws {
+        let connectedClient = ScriptableClient()
+        let disconnectedClient = ScriptableClient()
+        let model = AppModel.preview(connections: [
+            (name: "Connected", client: connectedClient),
+            (name: "Disconnected", client: disconnectedClient),
+        ])
+        await model.refreshAll()
+        let disconnectedRuntime = try #require(model.runtimes.first {
+            $0.record.name == "Disconnected"
+        })
+        disconnectedRuntime.stopPolling()
+        disconnectedClient.shouldFail = true
+        await disconnectedRuntime.refresh()
+
+        let fixture = makeFixture(appModel: model)
+        let rows = results(query: "", presentation: .workspaces, fixture: fixture)
+            .compactMap(\.workspaceRow)
+        #expect(rows.count == 6)
+        #expect(rows.map(\.title) == rows.map(\.title).sorted {
+            $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
+        })
+        #expect(!rows.map(\.title).contains("Old experiment"))
+        #expect(Set(rows.map(\.connectionName)) == ["Connected", "Disconnected"])
+        #expect(rows.filter { $0.connectionName == "Disconnected" }.allSatisfy {
+            $0.availability == .unavailable(reason: "Requires a reachable Connection")
+        })
+    }
+
+    @Test("Session scopes are empty without an Active Workspace")
+    func scopedSessionsWithoutActiveWorkspace() async {
+        let model = AppModel.preview()
+        await model.refreshAll()
+        let fixture = makeFixture(appModel: model)
+        #expect(results(query: "", presentation: .sessions, fixture: fixture).isEmpty)
+        #expect(results(query: "", presentation: .terminals, fixture: fixture).isEmpty)
+    }
+
     private func makeFixture(
         config: String = "",
         appModel: AppModel? = nil,
@@ -295,11 +443,16 @@ struct CommandPaletteContentTests {
         return makeFixture(appModel: model, windowState: state)
     }
 
-    private func results(query: String, fixture: Fixture) -> [PaletteResult] {
+    private func results(
+        query: String,
+        presentation: CommandPalettePresentation = .all,
+        fixture: Fixture
+    ) -> [PaletteResult] {
         CommandPaletteContent.results(
             query: query,
             keymap: fixture.keymap,
-            context: fixture.context
+            context: fixture.context,
+            presentation: presentation
         )
     }
 
@@ -502,7 +655,11 @@ struct CommandPaletteWorkspaceResultTests {
         query: String,
         groups: ProjectsNavigatorGroups
     ) -> [WorkspaceResult] {
-        CommandPaletteContent.workspaceResults(query: query, groups: groups)
+        CommandPaletteContent.workspaceResults(
+            query: query,
+            groups: groups,
+            keyword: PaletteTypeKeyword.match(query)
+        )
     }
 
     private func groups(inputs: [ProjectsNavigatorGroups.Input]) -> ProjectsNavigatorGroups {
@@ -696,7 +853,8 @@ struct CommandPaletteSessionResultTests {
         let projected = CommandPaletteContent.results(
             query: "Only",
             keymap: fixture.keymap,
-            context: fixture.context
+            context: fixture.context,
+            presentation: .all
         ).compactMap(\.sessionRow)
         #expect(projected.map(\.title) == ["Only Active Connection"])
     }
@@ -710,7 +868,8 @@ struct CommandPaletteSessionResultTests {
             query: query,
             activeWorkspace: active,
             sessions: sessions,
-            actions: actions
+            actions: actions,
+            keyword: PaletteTypeKeyword.match(query)
         )
     }
 }
@@ -739,7 +898,8 @@ struct CommandPaletteScaleTests {
         }
         let workspaceResults = CommandPaletteContent.workspaceResults(
             query: "Scale",
-            groups: ProjectsNavigatorGroups(inputs: workspaceInputs)
+            groups: ProjectsNavigatorGroups(inputs: workspaceInputs),
+            keyword: nil
         )
         #expect(workspaceResults.count == 2_000)
 
@@ -757,7 +917,8 @@ struct CommandPaletteScaleTests {
             query: "Scale",
             activeWorkspace: active,
             sessions: sessions,
-            actions: []
+            actions: [],
+            keyword: nil
         )
         #expect(sessionResults.count == 2_000)
 
@@ -765,7 +926,8 @@ struct CommandPaletteScaleTests {
             query: "ter",
             activeWorkspace: active,
             sessions: sessions,
-            actions: []
+            actions: [],
+            keyword: .terminals
         )
         #expect(keywordResults.count == 2_000)
     }

--- a/macos/ATCTests/CommandPaletteHostingSmokeTest.swift
+++ b/macos/ATCTests/CommandPaletteHostingSmokeTest.swift
@@ -77,6 +77,50 @@ struct CommandPaletteHostingSmokeTest {
         window.orderOut(nil)
     }
 
+    @Test("scoped palettes host their blank-query listings without crashing")
+    func hostScopedPalettes() async throws {
+        let store = ConfigurationStore(
+            configURL: FileManager.default.temporaryDirectory
+                .appending(path: UUID().uuidString)
+        )
+        let appModel = AppModel.preview()
+        await appModel.refreshAll()
+        let windowState = WindowState.ephemeral()
+        let connectionID = try #require(appModel.runtimes.first?.id)
+        #expect(windowState.activateWorkspace(
+            WorkspaceRef(connectionID: connectionID, workspaceID: "wsp_parser"),
+            in: appModel
+        ))
+        let router = WindowKeyboardRouter(
+            keymap: store.configuration.keymap,
+            context: CommandContext(
+                appModel: appModel,
+                windowState: windowState,
+                configStore: store
+            )
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 900, height: 600),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        for presentation in [
+            CommandPalettePresentation.sessions, .terminals, .workspaces,
+        ] {
+            windowState.commandPalettePresentation = presentation
+            window.contentView = NSHostingView(
+                rootView: CommandPaletteView()
+                    .environment(appModel)
+                    .environment(windowState)
+                    .environment(store)
+                    .environment(router)
+            )
+            window.makeKeyAndOrderFront(nil)
+            pump(seconds: 0.2)
+            #expect(windowState.commandPalettePresentation == presentation)
+        }
+        window.orderOut(nil)
+    }
+
     @Test("routing container mounts the presented palette without crashing")
     func hostIntegratedPalette() {
         let store = ConfigurationStore(
@@ -85,7 +129,7 @@ struct CommandPaletteHostingSmokeTest {
         )
         let appModel = AppModel.preview()
         let windowState = WindowState.ephemeral()
-        windowState.isCommandPalettePresented = true
+        windowState.commandPalettePresentation = .all
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 900, height: 600),
             styleMask: [.titled], backing: .buffered, defer: false
@@ -103,7 +147,7 @@ struct CommandPaletteHostingSmokeTest {
         )
         window.makeKeyAndOrderFront(nil)
         pump(seconds: 0.5)
-        #expect(windowState.isCommandPalettePresented)
+        #expect(windowState.commandPalettePresentation == .all)
         window.orderOut(nil)
     }
 
@@ -138,11 +182,11 @@ struct CommandPaletteHostingSmokeTest {
         hostingView.addSubview(previousResponder)
         #expect(window.makeFirstResponder(previousResponder))
 
-        windowState.isCommandPalettePresented = true
+        windowState.commandPalettePresentation = .all
         pump(until: { window.firstResponder !== previousResponder })
         #expect(window.firstResponder !== previousResponder)
 
-        windowState.isCommandPalettePresented = false
+        windowState.commandPalettePresentation = nil
         pump(until: { window.firstResponder === previousResponder })
         #expect(window.firstResponder === previousResponder)
         window.orderOut(nil)
@@ -175,7 +219,7 @@ struct CommandPaletteHostingSmokeTest {
 
         let coordinator = KeyboardMonitorHost.Coordinator(
             router: router,
-            onDeactivate: { windowState.isCommandPalettePresented = false },
+            onDeactivate: { windowState.commandPalettePresentation = nil },
             focusFallback: {}
         )
         coordinator.install(for: window)
@@ -183,7 +227,7 @@ struct CommandPaletteHostingSmokeTest {
         // Simulate the keyboard opener mid-flight: suspension has flipped and
         // the key monitor stashed the responder and cleared focus, but the
         // palette's window accessor has not mounted yet.
-        windowState.isCommandPalettePresented = true
+        windowState.commandPalettePresentation = .all
         router.responderBeforeSuspension = probe
         window.makeFirstResponder(nil)
 
@@ -193,7 +237,7 @@ struct CommandPaletteHostingSmokeTest {
         )
         pump(until: { window.firstResponder === probe })
 
-        #expect(!windowState.isCommandPalettePresented)
+        #expect(windowState.commandPalettePresentation == nil)
         #expect(window.firstResponder === probe)
         #expect(router.responderBeforeSuspension == nil)
         coordinator.stop()

--- a/macos/ATCTests/CommandRegistryTests.swift
+++ b/macos/ATCTests/CommandRegistryTests.swift
@@ -56,7 +56,8 @@ struct CommandRegistryTests {
     func descriptors() {
         let expectedIDs = [
             "view.toggle-sidebar", "view.toggle-command-palette",
-            "view.show-dashboard", "session.new",
+            "view.search-sessions", "view.search-terminals",
+            "view.search-workspaces", "view.show-dashboard", "session.new",
             "terminal.new", "project.new",
             "workspace.new", "data.refresh", "configuration.reload",
             "configuration.reveal",
@@ -68,7 +69,7 @@ struct CommandRegistryTests {
         #expect(Set(descriptors.map { $0.id.rawValue }).count == descriptors.count)
         #expect(descriptors.allSatisfy { !$0.title.isEmpty })
         #expect(descriptors.filter { !$0.isPaletteEligible }.map(\.id)
-            == [.toggleCommandPalette])
+            == [.toggleCommandPalette, .searchSessions, .searchTerminals, .searchWorkspaces])
     }
 
     @Test("categories use the shared presentation order and assignments")
@@ -81,6 +82,9 @@ struct CommandRegistryTests {
         }) == [
             .toggleSidebar: .view,
             .toggleCommandPalette: .view,
+            .searchSessions: .view,
+            .searchTerminals: .view,
+            .searchWorkspaces: .view,
             .showDashboard: .view,
             .newSession: .sessionsAndTerminals,
             .newTerminal: .sessionsAndTerminals,
@@ -104,9 +108,13 @@ struct CommandRegistryTests {
 
         #expect(descriptor.availability(context) == .available)
         CommandRegistry.execute(.toggleCommandPalette, context: context)
-        #expect(state.isCommandPalettePresented)
+        #expect(state.commandPalettePresentation == .all)
         CommandRegistry.execute(.toggleCommandPalette, context: context)
-        #expect(!state.isCommandPalettePresented)
+        #expect(state.commandPalettePresentation == nil)
+
+        state.commandPalettePresentation = .sessions
+        CommandRegistry.execute(.toggleCommandPalette, context: context)
+        #expect(state.commandPalettePresentation == nil)
 
         state.isCreateProjectPresented = true
         #expect(state.isSheetPresented)
@@ -124,6 +132,66 @@ struct CommandRegistryTests {
         state.startSessionKind = nil
         #expect(!state.isSheetPresented)
         #expect(descriptor.availability(context) == .available)
+    }
+
+    @Test("scoped palette commands execute into their presentation")
+    func scopedPaletteExecution() async throws {
+        let (context, _) = try await loadedContext()
+        let state = context.windowState
+
+        for (id, presentation) in [
+            (CommandID.searchSessions, CommandPalettePresentation.sessions),
+            (.searchTerminals, .terminals),
+            (.searchWorkspaces, .workspaces),
+        ] {
+            #expect(CommandRegistry.execute(id, context: context) == .available)
+            #expect(state.commandPalettePresentation == presentation)
+            state.commandPalettePresentation = nil
+        }
+    }
+
+    @Test("scoped palette availability follows dialog, palette, and Workspace state")
+    func scopedPaletteAvailability() async throws {
+        let model = makeModel()
+        let state = WindowState.ephemeral()
+        let context = makeContext(model: model, state: state)
+        let workspaceRequired = CommandAvailability.unavailable(
+            reason: "Requires an Active Workspace"
+        )
+        #expect(CommandRegistry.descriptor(for: .searchSessions).availability(context)
+            == workspaceRequired)
+        #expect(CommandRegistry.descriptor(for: .searchTerminals).availability(context)
+            == workspaceRequired)
+        #expect(CommandRegistry.descriptor(for: .searchWorkspaces).availability(context)
+            == .available)
+
+        let scopedIDs = [
+            CommandID.searchSessions, .searchTerminals, .searchWorkspaces,
+        ]
+        state.commandPalettePresentation = .all
+        for id in scopedIDs {
+            #expect(CommandRegistry.descriptor(for: id).availability(context) == .unavailable(
+                reason: "Not available while the Command Palette is open"
+            ))
+        }
+        state.commandPalettePresentation = .workspaces
+        for id in scopedIDs {
+            #expect(CommandRegistry.descriptor(for: id).availability(context) == .unavailable(
+                reason: "Not available while the Command Palette is open"
+            ))
+        }
+
+        state.isCreateProjectPresented = true
+        for id in scopedIDs {
+            #expect(CommandRegistry.descriptor(for: id).availability(context) == .unavailable(
+                reason: "Not available while a dialog is open"
+            ))
+        }
+
+        let (loaded, _) = try await loadedContext()
+        for id in scopedIDs {
+            #expect(CommandRegistry.descriptor(for: id).availability(loaded) == .available)
+        }
     }
 
     @Test("availability follows the complete command truth table")

--- a/macos/ATCTests/KeymapResolutionTests.swift
+++ b/macos/ATCTests/KeymapResolutionTests.swift
@@ -26,6 +26,16 @@ struct KeymapResolutionTests {
         let paletteShortcut = try stroke("cmd+shift+p")
         #expect(keymap.menuShortcuts[.toggleCommandPalette]
             == paletteShortcut)
+        let scopedBindings: [(String, CommandID)] = [
+            ("cmd+shift+s", .searchSessions),
+            ("cmd+shift+t", .searchTerminals),
+            ("cmd+shift+o", .searchWorkspaces),
+        ]
+        for (trigger, commandID) in scopedBindings {
+            let trigger = try stroke(trigger)
+            #expect(command(at: trigger, in: keymap) == commandID)
+            #expect(keymap.menuShortcuts[commandID] == trigger)
+        }
         #expect(command(at: try stroke("cmd+d"), in: keymap) == .showDashboard)
         #expect(command(at: try stroke("cmd+n"), in: keymap) == .newSession)
         #expect(command(at: try stroke("cmd+r"), in: keymap) == .refresh)
@@ -33,11 +43,14 @@ struct KeymapResolutionTests {
         #expect(command(at: try stroke("cmd+shift+n"), in: keymap) == .newWorkspace)
 
         let leader = try #require(prefix(at: try stroke("cmd+k"), in: keymap))
-        #expect(leader.count == 4)
+        #expect(leader.count == 7)
         #expect(command(in: leader[KeyStroke(key: "b", modifiers: [])]) == .toggleSidebar)
         #expect(command(in: leader[KeyStroke(key: "d", modifiers: [])]) == .showDashboard)
         #expect(command(in: leader[KeyStroke(key: "n", modifiers: [])]) == .newSession)
         #expect(command(in: leader[KeyStroke(key: "r", modifiers: [])]) == .refresh)
+        #expect(command(in: leader[KeyStroke(key: "s", modifiers: [])]) == .searchSessions)
+        #expect(command(in: leader[KeyStroke(key: "t", modifiers: [])]) == .searchTerminals)
+        #expect(command(in: leader[KeyStroke(key: "w", modifiers: [])]) == .searchWorkspaces)
     }
 
     @Test("the palette binding can be rebound and unbound")
@@ -58,6 +71,26 @@ struct KeymapResolutionTests {
         """#)
         #expect(unbound.root[try stroke("cmd+shift+p")] == nil)
         #expect(unbound.menuShortcuts[.toggleCommandPalette] == nil)
+    }
+
+    @Test("a scoped search command can be rebound and unbound")
+    func scopedSearchBindingLayering() throws {
+        let rebound = try resolve(#"""
+        [keybindings]
+        "ctrl+shift+s" = "view.search-sessions"
+        """#)
+        let reboundShortcut = try stroke("ctrl+shift+s")
+        #expect(command(at: reboundShortcut, in: rebound) == .searchSessions)
+        #expect(rebound.menuShortcuts[.searchSessions] == reboundShortcut)
+
+        let unbound = try resolve(#"""
+        [keybindings]
+        "cmd+shift+s" = "unbind"
+        """#)
+        #expect(unbound.root[try stroke("cmd+shift+s")] == nil)
+        #expect(unbound.menuShortcuts[.searchSessions] == nil)
+        let leader = try #require(prefix(at: try stroke("cmd+k"), in: unbound))
+        #expect(command(in: leader[KeyStroke(key: "s", modifiers: [])]) == .searchSessions)
     }
 
     @Test("user entries replace, unbind, and can rebind defaults")


### PR DESCRIPTION
Implements [ATC-35](https://linear.app/elevenideas/issue/ATC-35/keyboard-shortcuts-to-specific-command-palette-results): three first-class commands that open the existing Command Palette directly into a strict navigation scope.

## Commands and defaults

| Command ID | Title | Direct shortcut | Command Sequence |
| --- | --- | --- | --- |
| `view.search-sessions` | Search Sessions… | `cmd+shift+s` | `leader>s` |
| `view.search-terminals` | Search Terminals… | `cmd+shift+t` | `leader>t` |
| `view.search-workspaces` | Search Workspaces… | `cmd+shift+o` | `leader>w` |

All six bindings are compiled defaults, rebindable and unbindable through the existing `[keybindings]` configuration.

## Design

- **One presentation value.** `WindowState.isCommandPalettePresented: Bool` is replaced by `commandPalettePresentation: CommandPalettePresentation?` (`nil` closed, `.all` ordinary palette, `.sessions`/`.terminals`/`.workspaces` scopes). One presentation path, one palette view; dismissal always clears the value so a scope can never leak into a later opening.
- **One projection.** `CommandPaletteContent.results` takes the presentation. Scoped paths reuse the existing `sessionResults`/`workspaceResults` with the type-keyword expansion disabled — `ses…`/`ter…`/`wor…` expansion stays exclusive to the unscoped palette. Blank queries list the complete scoped set (existing `QueryMatcher` empty-query behavior), ordering and tie-breakers unchanged, no caps, synchronous in-memory projection only.
- **Registry, menu, hints.** The three commands live in the shared `CommandRegistry` (palette-ineligible, like Toggle Command Palette), appear in the View menu with resolved shortcuts, and show up in the Command Sequence hint with live availability. Sessions/Terminals require an Active Workspace and flash `Requires an Active Workspace` through the existing router feedback; all three are unavailable while any palette or dialog is open.
- **Scoped view states.** Scope-specific placeholders, `No Sessions`/`No Terminals`/`No Workspaces` for an untouched empty scope, existing `No matching results` after typing, and first-row preselection so Return navigates immediately.

## Tests

318 tests pass (`mise run macos:test`). New coverage: keymap defaults/rebinding/unbinding for the six bindings, command availability and execution, scoped projection (blank-query listings, live+ended inclusion, strict scope isolation, no keyword expansion in scopes, cross-Connection workspaces with unavailable styling, no-Active-Workspace emptiness), plus a hosting smoke test for the scoped palettes and regressions on the ordinary palette.