### PR TITLE
macos: seamless canvas with floating glass toolbar, dark treatment (ATC-41)

### DIFF
--- a/macos/ATC/Features/Dashboard/DashboardView.swift
+++ b/macos/ATC/Features/Dashboard/DashboardView.swift
@@ -486,7 +486,7 @@ struct DashboardView: View {
                 Text("Open Settings")
             }
         }
-        .background()
+        .background(AppColors.canvas)
     }
 
     private var emptyState: some View {
@@ -500,7 +500,7 @@ struct DashboardView: View {
                     appModel.canMutate(connectionID: $0.id)
                 })
         }
-        .background()
+        .background(AppColors.canvas)
     }
 
     private var allLoadedOnce: Bool {

--- a/macos/ATC/Features/Sessions/DetailCanvas.swift
+++ b/macos/ATC/Features/Sessions/DetailCanvas.swift
@@ -1,0 +1,26 @@
+import ATCAPI
+
+/// Owns the detail-area canvas color: the terminal's backing color when a
+/// terminal is the visible content, the app canvas for any cover.
+@MainActor
+enum DetailCanvas {
+    /// A terminal is the visible content only when a live selected session
+    /// has a retained controller and the dashboard is not covering it — the
+    /// same conditions under which SessionContentView draws no opaque cover.
+    static func showsTerminal(
+        isDashboard: Bool,
+        session: Session?,
+        hasController: Bool
+    ) -> Bool {
+        !isDashboard && session?.status == .live && hasController
+    }
+
+    static func backingColor(
+        showsTerminal: Bool,
+        preferences: TerminalPreferences
+    ) -> TerminalBackingColor {
+        showsTerminal
+            ? TerminalPresentation.backingColor(preferences: preferences)
+            : AppColors.canvasBackingColor
+    }
+}

--- a/macos/ATC/Features/Sessions/SessionContentView.swift
+++ b/macos/ATC/Features/Sessions/SessionContentView.swift
@@ -19,7 +19,6 @@ struct SessionContentView: View {
     let selectedRef: SessionRef?
     let selectedSession: Session?
     let terminalFocusRequest: UInt
-    let terminalPreferences: TerminalPreferences
     var emptyState: EmptyStateActions?
 
     @Environment(WindowState.self) private var windowState
@@ -28,8 +27,7 @@ struct SessionContentView: View {
         ZStack {
             TerminalPane(
                 visibleRef: selectedRef,
-                focusRequest: terminalFocusRequest,
-                preferences: terminalPreferences
+                focusRequest: terminalFocusRequest
             )
             cover
         }
@@ -40,7 +38,7 @@ struct SessionContentView: View {
         if let ref = selectedRef, let session = selectedSession {
             if session.status == .ended {
                 SessionEndedView(sessionRef: ref, session: session)
-                    .background()
+                    .background(AppColors.canvas)
             } else if let controller = appModel.terminals[ref] {
                 // Terminal visible; only the phase banner floats on top.
                 TerminalStatusBanner(controller: controller) {
@@ -64,7 +62,7 @@ struct SessionContentView: View {
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background()
+                .background(AppColors.canvas)
             }
         } else if let emptyState {
             ContentUnavailableView {
@@ -78,7 +76,7 @@ struct SessionContentView: View {
                     .disabled(!emptyState.creationEnabled)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background()
+            .background(AppColors.canvas)
         } else {
             ContentUnavailableView(
                 "No Session Selected",
@@ -86,7 +84,7 @@ struct SessionContentView: View {
                 description: Text("Select a session in the sidebar.")
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background()
+            .background(AppColors.canvas)
         }
     }
 }

--- a/macos/ATC/Features/Terminal/TerminalPane.swift
+++ b/macos/ATC/Features/Terminal/TerminalPane.swift
@@ -7,24 +7,15 @@ struct TerminalPane: View {
     @Environment(AppModel.self) private var appModel
     let visibleRef: SessionRef?
     let focusRequest: UInt
-    let preferences: TerminalPreferences
 
     var body: some View {
-        ZStack {
-            let backingColor = TerminalPresentation.backingColor(preferences: preferences)
-            Color(
-                red: backingColor.red,
-                green: backingColor.green,
-                blue: backingColor.blue
-            )
-            ForEach(refs, id: \.self) { ref in
-                if let controller = appModel.terminals[ref] {
-                    TerminalHostView(
-                        controller: controller,
-                        isVisible: ref == visibleRef,
-                        focusRequest: focusRequest
-                    )
-                }
+        ForEach(refs, id: \.self) { ref in
+            if let controller = appModel.terminals[ref] {
+                TerminalHostView(
+                    controller: controller,
+                    isVisible: ref == visibleRef,
+                    focusRequest: focusRequest
+                )
             }
         }
     }

--- a/macos/ATC/RootView.swift
+++ b/macos/ATC/RootView.swift
@@ -33,6 +33,7 @@ struct RootView: View {
         }
         .navigationTitle("atc")
         .toolbar(removing: .title)
+        .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
         .toolbar {
             ToolbarItem(placement: .principal) {
                 WorkspaceSwitcher()
@@ -78,7 +79,6 @@ struct RootView: View {
                 selectedRef: visibleSessionRef,
                 selectedSession: visibleSession,
                 terminalFocusRequest: windowState.terminalFocusRequest,
-                terminalPreferences: configStore.configuration.terminal,
                 emptyState: workspaceEmptyActions
             )
             if windowState.selectedContent == .dashboard {
@@ -90,8 +90,14 @@ struct RootView: View {
                     onCreateProject: { windowState.isCreateProjectPresented = true },
                     onWorkspaceDeleted: { windowState.forgetSelection(for: $0) }
                 )
-                .background()
+                .background(AppColors.canvas)
             }
+        }
+        .background {
+            let backingColor = detailBackingColor
+            backingColor.color
+                .ignoresSafeArea(.container, edges: .top)
+                .animation(.easeInOut(duration: 0.2), value: backingColor)
         }
     }
 
@@ -112,6 +118,19 @@ struct RootView: View {
 
     private var visibleSession: Session? {
         visibleSessionRef.flatMap { appModel.session(for: $0) }
+    }
+
+    private var detailBackingColor: TerminalBackingColor {
+        let hasController = visibleSessionRef.map { appModel.terminals[$0] != nil } ?? false
+        let showsTerminal = DetailCanvas.showsTerminal(
+            isDashboard: windowState.selectedContent == .dashboard,
+            session: visibleSession,
+            hasController: hasController
+        )
+        return DetailCanvas.backingColor(
+            showsTerminal: showsTerminal,
+            preferences: configStore.configuration.terminal
+        )
     }
 
     private var workspaceEmptyActions: SessionContentView.EmptyStateActions? {

--- a/macos/ATC/Shared/DesignTokens.swift
+++ b/macos/ATC/Shared/DesignTokens.swift
@@ -1,5 +1,20 @@
 import SwiftUI
 
+/// The app-wide dark canvas. `canvasHex` is the single source; the SwiftUI
+/// color and the terminal's default background both derive from it so covers
+/// and terminal rest on one color.
+enum AppColors {
+    static let canvasHex = "141416"
+    static let canvasBackingColor = TerminalBackingColor(hex: canvasHex)
+    static let canvas = canvasBackingColor.color
+}
+
+extension TerminalBackingColor {
+    var color: Color {
+        Color(red: red, green: green, blue: blue)
+    }
+}
+
 /// The app-wide spacing scale (4pt grid). Use these instead of literal
 /// spacing/padding values; keep literal `2` only for tight two-line text
 /// stacks and pill interiors.

--- a/macos/ATC/TerminalBridge/TerminalPresentation.swift
+++ b/macos/ATC/TerminalBridge/TerminalPresentation.swift
@@ -12,7 +12,9 @@ struct TerminalBackingColor: Equatable, Sendable {
         self.blue = blue
     }
 
-    fileprivate init(hex: String) {
+    /// Expects a compile-time-trusted RGB hex literal, not user input;
+    /// user-supplied values are validated by ConfigurationLoader first.
+    init(hex: String) {
         let normalized = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
         precondition(normalized.utf8.count == 6, "Terminal background must be RGB hex")
         red = Double(UInt8(normalized.prefix(2), radix: 16)!) / 255
@@ -62,8 +64,7 @@ enum TerminalPresentation {
            let theme = GhosttyThemeCatalog.theme(named: themeName) {
             return TerminalBackingColor(hex: theme.background)
         }
-        // libghostty's compiled default background (ghostty Config.zig).
-        return TerminalBackingColor(hex: "282C34")
+        return AppColors.canvasBackingColor
     }
 
     private static func configuration(
@@ -99,13 +100,16 @@ enum TerminalPresentation {
             }
             theme = definition.toTerminalTheme()
         } else {
-            // An empty theme renders no keys, so libghostty's compiled
-            // defaults stand; TerminalTheme.default would inject the
-            // wrapper's Alabaster/Afterglow palettes.
+            // Start empty so libghostty's compiled defaults stand except for
+            // the app-owned background injected below.
             theme = TerminalTheme(light: .init(), dark: .init())
         }
 
-        guard let background = preferences.background else { return theme }
+        // A selected theme owns its background unless the user explicitly
+        // overrides it. With no theme, ATC owns the default canvas color.
+        let background = preferences.background
+            ?? (preferences.theme == nil ? AppColors.canvasHex : nil)
+        guard let background else { return theme }
         return TerminalTheme(
             light: TerminalConfiguration(startingFrom: theme.light) {
                 $0.withBackground(background)

--- a/macos/ATCTests/DetailCanvasTests.swift
+++ b/macos/ATCTests/DetailCanvasTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+import ATCAPI
+@testable import ATC
+
+@MainActor
+@Suite("Detail canvas")
+struct DetailCanvasTests {
+    private func session(status: SessionStatus) -> Session {
+        Session(
+            id: "session",
+            environment: "host",
+            workingDir: "/home/dev",
+            status: status,
+            createdAt: .now,
+            updatedAt: .now
+        )
+    }
+
+    @Test("terminal visibility matches every cover state")
+    func showsTerminal() {
+        let live = session(status: .live)
+        let ended = session(status: .ended)
+
+        #expect(!DetailCanvas.showsTerminal(
+            isDashboard: true,
+            session: live,
+            hasController: true
+        ))
+        #expect(!DetailCanvas.showsTerminal(
+            isDashboard: false,
+            session: nil,
+            hasController: true
+        ))
+        #expect(!DetailCanvas.showsTerminal(
+            isDashboard: false,
+            session: ended,
+            hasController: true
+        ))
+        #expect(!DetailCanvas.showsTerminal(
+            isDashboard: false,
+            session: live,
+            hasController: false
+        ))
+        #expect(DetailCanvas.showsTerminal(
+            isDashboard: false,
+            session: live,
+            hasController: true
+        ))
+    }
+
+    @Test("covers use the app canvas and terminals use preference resolution")
+    func backingColor() {
+        let preferences = TerminalPreferences(background: "ff0000")
+
+        #expect(DetailCanvas.backingColor(
+            showsTerminal: false,
+            preferences: preferences
+        ) == TerminalBackingColor(
+            red: 20.0 / 255,
+            green: 20.0 / 255,
+            blue: 22.0 / 255
+        ))
+        #expect(DetailCanvas.backingColor(
+            showsTerminal: true,
+            preferences: preferences
+        ) == TerminalBackingColor(red: 1, green: 0, blue: 0))
+    }
+}

--- a/macos/ATCTests/TerminalPresentationTests.swift
+++ b/macos/ATCTests/TerminalPresentationTests.swift
@@ -37,13 +37,12 @@ struct TerminalPresentationTests {
         #expect(!rendered.contains("theme"))
     }
 
-    @Test("a fresh controller with no preferences applies no configuration keys")
+    @Test("unset preferences apply only the app-owned default background")
     func compiledDefaultsController() {
-        // Pins the ATC-5 requirement: unset preferences mean libghostty's
-        // compiled defaults — neither the wrapper's default config nor its
-        // default theme may leak into the applied configuration.
+        // Unset preferences keep libghostty's compiled defaults except for
+        // the app-owned background shared with the detail canvas.
         let controller = TerminalPresentation.makeController(preferences: .init())
-        #expect(controller.renderedConfig.isEmpty)
+        #expect(controller.renderedConfig == "background = 141416\n")
     }
 
     @Test("explicit background outranks the selected theme's background")
@@ -56,7 +55,25 @@ struct TerminalPresentationTests {
         #expect(lines.last { $0.hasPrefix("background =") } == "background = ff0000")
     }
 
-    @Test("backing color prefers explicit background, then theme, then black")
+    @Test("a selected theme keeps its own background, not the injected app default")
+    func themeKeepsItsBackground() {
+        let controller = TerminalPresentation.makeController(preferences: .init(
+            theme: "Catppuccin Mocha"
+        ))
+        #expect(controller.renderedConfig.contains("background = 1e1e2e"))
+        #expect(!controller.renderedConfig.contains("background = 141416"))
+    }
+
+    @Test("background opacity alone still injects the app default background")
+    func opacityKeepsDefaultBackground() {
+        let controller = TerminalPresentation.makeController(preferences: .init(
+            backgroundOpacity: 0.95
+        ))
+        #expect(controller.renderedConfig.contains("background-opacity = 0.95"))
+        #expect(controller.renderedConfig.contains("background = 141416"))
+    }
+
+    @Test("backing color prefers explicit background, then theme, then app canvas")
     func backingColorResolution() {
         let explicit = TerminalPresentation.backingColor(preferences: .init(
             theme: "Catppuccin Mocha",
@@ -74,9 +91,9 @@ struct TerminalPresentationTests {
         ))
         #expect(TerminalPresentation.backingColor(preferences: .init())
             == TerminalBackingColor(
-                red: 40.0 / 255,
-                green: 44.0 / 255,
-                blue: 52.0 / 255
+                red: 20.0 / 255,
+                green: 20.0 / 255,
+                blue: 22.0 / 255
             ))
     }
 }


### PR DESCRIPTION
Implements [ATC-41](https://linear.app/elevenideas/issue/ATC-41/decide-and-stabilize-terminal-and-toolbar-background-treatment): Option 1 — seamless canvas with floating glass controls, plus the darker T3Code-style treatment.

## What changed

- **Chrome policy**: `.toolbarBackgroundVisibility(.hidden, for: .windowToolbar)` applied unconditionally at the `NavigationSplitView` in `RootView`, so no automatic heuristic remains to flip the toolbar material/separator on resize. Public API only — no AppKit fallbacks were needed.
- **Single canvas owner**: new `DetailCanvas` resolver decides the detail-area fill — the terminal's backing color when a live session with a retained controller is visible, the app canvas otherwise. `RootView` paints it once with `.ignoresSafeArea(.container, edges: .top)` so the color (never the Ghostty surface) extends under the toolbar, with a brief crossfade on change.
- **Dark treatment**: new `AppColors` token — `canvasHex = "141416"` is the single source; the SwiftUI `canvas` color and the terminal's default background both derive from it. The default terminal background replaces libghostty's compiled `#282C34` via an injected theme background. Explicit `[terminal]` `theme`/`background`/`background_opacity` still win, unchanged.
- **Cover fills**: the scattered semantic `.background()` calls in `SessionContentView`, `DashboardView`, and `RootView` became `AppColors.canvas`; `TerminalPane` lost its solid `Color` layer and `preferences` parameter (the detail canvas owns that now).
- No terminal surface lifecycle changes: no recreation, scrollback loss, or reconnects.

## Tests

- `DetailCanvasTests`: `showsTerminal` truth table and cover-vs-terminal color resolution.
- `TerminalPresentationTests`: default backing/injected background is `141416`; theme keeps its own background (positive + negative assertion); `background_opacity` alone still gets the injected default; explicit background still outranks theme.
- Full suite: 322 tests, 38 suites, all passing.

## Manual checklist (from the issue — needs on-screen verification)

- [ ] Cold launch with no `macos.toml`: no separator, one surface
- [ ] Repeated narrow/wide resize past the split-view adaptation point
- [ ] Sidebar and inspector show/hide (note: the strip above the inspector column uses the inspector's own material — eyeball for a seam)
- [ ] Active vs inactive window; fullscreen entry/exit
- [ ] Dashboard: dark canvas, scroll edge effect, no terminal-colored strip
- [ ] Custom `[terminal]` background: whole canvas follows it; removing returns to app default
- [ ] Dashboard ↔ terminal crossfade (Color animation may snap on some SwiftUI versions — cosmetic)