### PR TITLE
macos: pin window base layer to app canvas so sidebar glass stays consistent (ATC-45)

### DIFF
--- a/macos/ATC/RootView.swift
+++ b/macos/ATC/RootView.swift
@@ -32,6 +32,12 @@ struct RootView: View {
                 }
         }
         .navigationTitle("atc")
+        // The sidebar's glass composites over the window's base layer, which
+        // otherwise varies with what the window contains (it brightens when a
+        // Metal-backed terminal surface is visible — ATC-45). Pinning the
+        // base layer to the canvas keeps the glass itself but gives it one
+        // constant color to rest on.
+        .containerBackground(AppColors.canvas, for: .window)
         .toolbar(removing: .title)
         .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
         .toolbar {


### PR DESCRIPTION
Fixes [ATC-45](https://linear.app/elevenideas/issue/ATC-45/background-under-sidebar-is-inconsisitent).

## Problem
With a terminal open, the background behind the sidebar rendered lighter (with a slight blue cast) than on the dashboard. Pixel comparison of the two states shows the detail canvas and the window base area are `#141416`/`#131315` in both — only the sidebar's glass pane shifts (`#181819` on the dashboard vs `#1B1F23` with a terminal open).

## Cause
ATC-41 pinned every detail surface (covers, dashboard, terminal) to `AppColors.canvas`, but never the window's base layer — the thing the sidebar's Liquid Glass actually composites over. That base layer was left to system defaults, and its composite changes once the Ghostty surface (a non-opaque `CAMetalLayer` that can swap to IOSurface-backed compositing) becomes visible. The sidebar backdrop was therefore a function of what content was open.

## Fix
`.containerBackground(AppColors.canvas, for: .window)` on the split view pins the window's base layer to the app canvas. The sidebar keeps its Liquid Glass material — blur and vibrancy intact — but now always rests on the one canvas color, so it cannot shift with the detail content. Darkness is controlled by `AppColors.canvasHex`, the same single source everything else derives from.

## Testing
- `mise run macos:test`: 322 tests in 38 suites passed.
- Needs a visual check of dashboard vs. terminal states before merge (screenshots unavailable on the dev machine).