### PR TITLE
macOS: add safe terminal padding defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,7 @@ theme = "Catppuccin Mocha"
 font_family = "Berkeley Mono"
 font_size = 14.0
 padding_x = 8
-padding_y = 8
-background = "1e1e2e"
-background_opacity = 0.95
+padding_y = 6
 ```
 
 Binding keys are either direct triggers such as `cmd+b` or two-step leader
@@ -87,17 +85,21 @@ The scoped Command Palette commands search within a specific navigation type:
 | `view.search-workspaces` | `cmd+shift+o`, `leader>w` |
 
 All `[terminal]` keys are optional. Terminal presentation starts from
-libghostty's compiled defaults, then applies only the values explicitly set in
-this table. `theme` must name a bundled Ghostty theme; `font_family` must be
-non-empty; `font_size` must be positive; padding values must be non-negative integers;
-`background` is a six-digit RGB hex value with an optional leading `#`; and
-`background_opacity` ranges from `0` (fully transparent) through `1` (opaque).
+libghostty's compiled defaults, then applies the values set in this table.
+`theme` must name a bundled Ghostty theme; `font_family` must be non-empty; and
+`font_size` must be positive. `padding_x` and `padding_y` are non-negative
+integers and default to `8` and `6`, respectively. Set either padding value to
+`0` for an intentional edge-to-edge layout, which may place content beneath a
+window's rounded corners.
 
 Use **Reload Configuration** in the app menu after editing the file. A valid
 reload replaces the complete application configuration; an invalid reload
 keeps the last-known-good configuration. Deleting the file and reloading
-restores defaults. Terminal presentation changes apply live to every retained
-surface without recreating terminal sessions or reconnecting WebSockets.
+restores defaults. Most terminal presentation changes apply live to every
+retained surface without recreating terminal sessions or reconnecting
+WebSockets. Padding changes are guaranteed for new terminal surfaces or after
+restarting the app; retained surfaces may not recalculate their padding on
+reload.
 **Reveal Configuration** selects `macos.toml` in Finder when it exists, or
 reveals its expected directory without creating anything.
 

--- a/macos/ATC/TerminalBridge/TerminalPresentation.swift
+++ b/macos/ATC/TerminalBridge/TerminalPresentation.swift
@@ -3,6 +3,9 @@ import GhosttyTheme
 
 @MainActor
 enum TerminalPresentation {
+    private static let defaultPaddingX = 8
+    private static let defaultPaddingY = 6
+
     static func makeController(preferences: TerminalPreferences) -> TerminalController {
         // An empty generated base is libghostty's compiled defaults;
         // .none would substitute the wrapper's TerminalConfiguration.default
@@ -45,12 +48,8 @@ enum TerminalPresentation {
             if let fontSize = preferences.fontSize {
                 builder.withFontSize(fontSize)
             }
-            if let paddingX = preferences.paddingX {
-                builder.withWindowPaddingX(paddingX)
-            }
-            if let paddingY = preferences.paddingY {
-                builder.withWindowPaddingY(paddingY)
-            }
+            builder.withWindowPaddingX(preferences.paddingX ?? defaultPaddingX)
+            builder.withWindowPaddingY(preferences.paddingY ?? defaultPaddingY)
             // background is rendered through the theme (themes render after
             // this configuration, so only a theme-level value wins).
         }

--- a/macos/ATCTests/TerminalPresentationTests.swift
+++ b/macos/ATCTests/TerminalPresentationTests.swift
@@ -4,20 +4,35 @@ import Testing
 @MainActor
 @Suite("Terminal presentation")
 struct TerminalPresentationTests {
-    @Test("unset preferences render no wrapper-selected configuration")
-    func emptyRendering() {
+    @Test("unset preferences render safe padding defaults")
+    func defaultPaddingRendering() {
         #expect(TerminalPresentation.renderedConfiguration(
             preferences: TerminalPreferences()
-        ).isEmpty)
+        ) == """
+        window-padding-x = 8
+        window-padding-y = 6
+        """)
     }
 
-    @Test("each generated preference renders only its Ghostty key")
+    @Test("generated preferences render with padding defaults or overrides")
     func individualRendering() {
         let cases: [(TerminalPreferences, String)] = [
-            (.init(fontFamily: "Berkeley Mono"), "font-family = Berkeley Mono"),
-            (.init(fontSize: 14), "font-size = 14"),
-            (.init(paddingX: 8), "window-padding-x = 8"),
-            (.init(paddingY: 9), "window-padding-y = 9"),
+            (
+                .init(fontFamily: "Berkeley Mono"),
+                "font-family = Berkeley Mono\nwindow-padding-x = 8\nwindow-padding-y = 6"
+            ),
+            (
+                .init(fontSize: 14),
+                "font-size = 14\nwindow-padding-x = 8\nwindow-padding-y = 6"
+            ),
+            (
+                .init(paddingX: 12),
+                "window-padding-x = 12\nwindow-padding-y = 6"
+            ),
+            (
+                .init(paddingY: 9),
+                "window-padding-x = 8\nwindow-padding-y = 9"
+            ),
         ]
 
         for (preferences, expected) in cases {
@@ -27,21 +42,39 @@ struct TerminalPresentationTests {
         }
     }
 
+    @Test("explicit zero padding renders edge-to-edge overrides")
+    func zeroPaddingRendering() {
+        #expect(TerminalPresentation.renderedConfiguration(
+            preferences: TerminalPreferences(paddingX: 0, paddingY: 0)
+        ) == """
+        window-padding-x = 0
+        window-padding-y = 0
+        """)
+    }
+
     @Test("theme is resolved separately and does not emit a config key")
     func themeRendering() {
         let rendered = TerminalPresentation.renderedConfiguration(
             preferences: TerminalPreferences(theme: "Catppuccin Mocha")
         )
-        #expect(rendered.isEmpty)
+        #expect(rendered == """
+        window-padding-x = 8
+        window-padding-y = 6
+        """)
         #expect(!rendered.contains("theme"))
     }
 
-    @Test("unset preferences apply only the app-owned canvas background")
+    @Test("unset preferences apply safe padding and the app-owned canvas background")
     func compiledDefaultsController() {
         // Unset preferences keep libghostty's compiled defaults except for
-        // the app-owned background shared with every other surface.
+        // safe content padding and the app-owned background.
         let controller = TerminalPresentation.makeController(preferences: .init())
-        #expect(controller.renderedConfig == "background = 141416\n")
+        #expect(controller.renderedConfig == """
+        window-padding-x = 8
+        window-padding-y = 6
+        background = 141416
+
+        """)
     }
 
     @Test("a selected theme keeps its palette but the canvas background wins")


### PR DESCRIPTION
## Summary

- apply ATC defaults of 8 points horizontal and 6 points vertical through Ghostty's native window padding configuration
- preserve custom `padding_x` and `padding_y` overrides, including explicit `0` for edge-to-edge content
- document defaults and the new-surface/restart behavior, and remove obsolete terminal background settings from the example

## Why

Libghostty's compiled 2-point padding allows terminal content to intersect the macOS window's rounded bottom corners. Supplying safer app defaults keeps content visible without adding SwiftUI/AppKit insets around the terminal surface.

Users who have not configured padding get safe spacing automatically. Existing non-negative overrides continue to work unchanged.

## Validation

- `xcodebuildmcp macos test --project-path macos/atc.xcodeproj --scheme atc --progress` — 318 passed
- `mise run check` — server, web, ATCKit, and macOS gates passed

Linear: https://linear.app/elevenideas/issue/ATC-42/terminal-content-gets-cut-off-by-bottom-rounded-corner