### PR TITLE
macOS: enlarge leader key menu and keep it open until dismissed (ATC-43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ The app never creates the configuration directory or file.
 ```toml
 [keyboard]
 leader = "cmd+k"                       # default: "cmd+k"
-leader_timeout_ms = 1800               # default: 1800
 clear_default_keybindings = false      # default: false
 
 [keybindings]

--- a/macos/ATC/Commands/CommandFeedbackViews.swift
+++ b/macos/ATC/Commands/CommandFeedbackViews.swift
@@ -45,17 +45,15 @@ struct CommandSequenceHintView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 7) {
-            Text("Command Sequence")
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
+        VStack(alignment: .leading, spacing: 10) {
             ForEach(continuations, id: \.0) { stroke, command in
                 continuationRow(stroke: stroke, command: command)
             }
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 11)
-        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .frame(minWidth: 280, alignment: .leading)
+        .padding(.horizontal, 18)
+        .padding(.vertical, 16)
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 14))
         .shadow(color: .black.opacity(0.2), radius: 12, y: 4)
     }
 
@@ -68,17 +66,17 @@ struct CommandSequenceHintView: View {
         )
         let descriptor = CommandRegistry.descriptor(for: command)
         let availability = descriptor.availability(context)
-        HStack(spacing: 9) {
+        HStack(spacing: 11) {
             Text(stroke.displayDescription)
-                .font(.caption.monospaced().weight(.semibold))
-                .padding(.horizontal, 6)
-                .padding(.vertical, 3)
-                .background(.quaternary, in: RoundedRectangle(cornerRadius: 5))
+                .font(.callout.monospaced().weight(.semibold))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
             Text(descriptor.title)
-                .font(.caption)
+                .font(.callout)
             if case .unavailable(let reason) = availability {
                 Text(reason)
-                    .font(.caption2)
+                    .font(.caption)
                     .foregroundStyle(.tertiary)
             }
         }

--- a/macos/ATC/Commands/Keymap.swift
+++ b/macos/ATC/Commands/Keymap.swift
@@ -8,13 +8,11 @@ struct ResolvedKeymap: Sendable {
 
     let root: [KeyStroke: Node]
     let menuShortcuts: [CommandID: KeyStroke]
-    let leaderTimeout: Duration
     let generation: Int
 }
 
 enum Keymap {
     static let defaultLeader = "cmd+k"
-    static let defaultLeaderTimeoutMilliseconds = 1_800
 
     static let compiledDefaults: [(sequence: String, command: CommandID)] = [
         ("cmd+b", .toggleSidebar), ("leader>b", .toggleSidebar),
@@ -36,7 +34,6 @@ enum Keymap {
     ) -> Result<ResolvedKeymap, ConfigDiagnostics> {
         var diagnostics = user.diagnostics
         var leader = requiredStroke(defaultLeader)
-        var timeoutMilliseconds = defaultLeaderTimeoutMilliseconds
         var clearDefaults = false
 
         for entry in user.tables["keyboard", default: []] {
@@ -58,15 +55,6 @@ enum Keymap {
                         message: "[keyboard].leader has invalid trigger '\(text)': \(error.message)"
                     ))
                 }
-            case "leader_timeout_ms":
-                guard case .integer(let value) = entry.value, value > 0 else {
-                    diagnostics.append(.init(
-                        severity: .error,
-                        message: "[keyboard].leader_timeout_ms must be a positive integer"
-                    ))
-                    continue
-                }
-                timeoutMilliseconds = value
             case "clear_default_keybindings":
                 guard case .boolean(let value) = entry.value else {
                     diagnostics.append(.init(
@@ -207,7 +195,6 @@ enum Keymap {
         return .success(ResolvedKeymap(
             root: root,
             menuShortcuts: menuCandidates.mapValues(\.stroke),
-            leaderTimeout: .milliseconds(timeoutMilliseconds),
             generation: generation
         ))
     }

--- a/macos/ATC/Commands/WindowKeyboardRouter.swift
+++ b/macos/ATC/Commands/WindowKeyboardRouter.swift
@@ -29,7 +29,6 @@ final class WindowKeyboardRouter {
     /// on dismissal; AnyObject keeps AppKit out of this file.
     @ObservationIgnored weak var responderBeforeSuspension: AnyObject?
     @ObservationIgnored private let executeCommand: @MainActor (CommandID) -> CommandAvailability
-    @ObservationIgnored private var timeoutTask: Task<Void, Never>?
     @ObservationIgnored private var flashTask: Task<Void, Never>?
     @ObservationIgnored private var flashToken = 0
 
@@ -75,16 +74,7 @@ final class WindowKeyboardRouter {
     }
 
     func cancel() {
-        timeoutTask?.cancel()
-        timeoutTask = nil
         state = .idle
-    }
-
-    func handleTimeout(generation: Int) {
-        guard generation == keymap.generation,
-              case .pending = state
-        else { return }
-        cancel()
     }
 
     func showUnavailable(reason: String) {
@@ -103,23 +93,8 @@ final class WindowKeyboardRouter {
             }
         case .prefix(let continuations):
             state = .pending(node: continuations)
-            startTimeout()
         }
         return true
-    }
-
-    private func startTimeout() {
-        timeoutTask?.cancel()
-        let generation = keymap.generation
-        let duration = keymap.leaderTimeout
-        timeoutTask = Task { [weak self] in
-            do {
-                try await Task.sleep(for: duration)
-            } catch {
-                return
-            }
-            self?.handleTimeout(generation: generation)
-        }
     }
 
     private func clearFlash() {

--- a/macos/ATC/Configuration/ConfigurationLoader.swift
+++ b/macos/ATC/Configuration/ConfigurationLoader.swift
@@ -23,7 +23,7 @@ struct ParsedConfig: Sendable {
 enum ConfigurationLoader {
     private static let recognizedTables = Set(["keyboard", "keybindings", "terminal"])
     private static let keyboardKeys = Set([
-        "leader", "leader_timeout_ms", "clear_default_keybindings",
+        "leader", "clear_default_keybindings",
     ])
     private static let terminalKeys = Set([
         "theme", "font_family", "font_size", "padding_x", "padding_y",
@@ -120,15 +120,6 @@ enum ConfigurationLoader {
                     ))
                 } catch {
                     diagnostics.append(diagnostic("[keyboard].leader must be a string"))
-                }
-            case "leader_timeout_ms":
-                do {
-                    let value = try table.integer(forKey: key)
-                    entries.append(.init(key: key, value: .integer(Int(value))))
-                } catch {
-                    diagnostics.append(diagnostic(
-                        "[keyboard].leader_timeout_ms must be an integer"
-                    ))
                 }
             case "clear_default_keybindings":
                 do {

--- a/macos/ATCTests/ConfigurationLoaderTests.swift
+++ b/macos/ATCTests/ConfigurationLoaderTests.swift
@@ -9,7 +9,6 @@ struct ConfigurationLoaderTests {
         let parsed = ConfigurationLoader.parse(#"""
           [keyboard]
           leader = 'cmd+k'
-          leader_timeout_ms=1_800
           clear_default_keybindings = false
 
           [keybindings]
@@ -18,7 +17,7 @@ struct ConfigurationLoaderTests {
         """#)
 
         #expect(parsed.diagnostics.isEmpty)
-        #expect(parsed.tables["keyboard"]?.count == 3)
+        #expect(parsed.tables["keyboard"]?.count == 2)
         #expect(parsed.tables["keybindings"]?.map(\.key) == ["cmd+b", "leader>b"])
         #expect(try Keymap.resolve(user: parsed).get().menuShortcuts[.toggleSidebar]
             == KeyStroke(key: "b", modifiers: .command))
@@ -64,7 +63,6 @@ struct ConfigurationLoaderTests {
         let parsed = ConfigurationLoader.parse(#"""
         [keyboard]
         leader = false
-        leader_timeout_ms = 1.5
         clear_default_keybindings = "no"
 
         [keybindings]
@@ -74,9 +72,6 @@ struct ConfigurationLoaderTests {
 
         #expect(messages.contains {
             $0.contains("[keyboard].leader") && $0.contains("string")
-        })
-        #expect(messages.contains {
-            $0.contains("[keyboard].leader_timeout_ms") && $0.contains("integer")
         })
         #expect(messages.contains {
             $0.contains("[keyboard].clear_default_keybindings")

--- a/macos/ATCTests/ConfigurationStoreTests.swift
+++ b/macos/ATCTests/ConfigurationStoreTests.swift
@@ -118,7 +118,7 @@ struct ConfigurationStoreTests {
 
         try write(#"""
         [keyboard]
-        leader_timeout_ms = 0
+        leader = false
         mystery = true
         """#, to: fixture.config)
         store.reload()
@@ -128,7 +128,7 @@ struct ConfigurationStoreTests {
         #expect(store.notice?.message.contains("keeping the previous configuration") == true)
         #expect(store.notice?.message.contains("[keyboard]") == true)
         #expect(store.diagnostics.contains {
-            $0.severity == .error && $0.message.contains("[keyboard].leader_timeout_ms")
+            $0.severity == .error && $0.message.contains("[keyboard].leader")
         })
         #expect(store.diagnostics.contains {
             $0.severity == .error && $0.message.contains("[keyboard].mystery")

--- a/macos/ATCTests/KeyboardRouterTests.swift
+++ b/macos/ATCTests/KeyboardRouterTests.swift
@@ -105,18 +105,6 @@ struct KeyboardRouterTests {
         #expect(router.flash == nil)
     }
 
-    @Test("only a timeout for the current generation cancels")
-    func timeoutGeneration() throws {
-        let router = WindowKeyboardRouter(
-            keymap: try keymap(generation: 7)
-        ) { _ in .available }
-        #expect(router.handle(try stroke("cmd+k"), isRepeat: false))
-        router.handleTimeout(generation: 6)
-        #expect(router.pendingNode != nil)
-        router.handleTimeout(generation: 7)
-        #expect(router.pendingNode == nil)
-    }
-
     @Test("unavailable commands consume and surface their reason")
     func unavailableCommand() throws {
         var executions = 0

--- a/macos/ATCTests/KeymapResolutionTests.swift
+++ b/macos/ATCTests/KeymapResolutionTests.swift
@@ -19,7 +19,6 @@ struct KeymapResolutionTests {
     func defaults() throws {
         let keymap = try resolve()
         #expect(keymap.generation == 1)
-        #expect(keymap.leaderTimeout == .milliseconds(1_800))
         #expect(command(at: try stroke("cmd+b"), in: keymap) == .toggleSidebar)
         #expect(command(at: try stroke("cmd+shift+p"), in: keymap)
             == .toggleCommandPalette)
@@ -187,31 +186,6 @@ struct KeymapResolutionTests {
         #expect(diagnostics.contains {
             $0.message.contains(#"[keybindings]."cmd+shift+b""#)
                 && $0.message.contains("missing.command")
-        })
-    }
-
-    @Test("timeout must be a positive integer and defaults when omitted")
-    func timeoutValidation() throws {
-        #expect(try resolve().leaderTimeout == .milliseconds(1_800))
-        // 0 and -1 fail range validation in the resolver; a string fails the
-        // loader's type check first. Both name the key and want an integer.
-        for value in ["0", "-1", "\"1800\""] {
-            let result = Keymap.resolve(user: ConfigurationLoader.parse("""
-            [keyboard]
-            leader_timeout_ms = \(value)
-            """))
-            #expect(try failure(result).contains {
-                $0.message.contains("[keyboard].leader_timeout_ms")
-                    && $0.message.contains("integer")
-            })
-        }
-        let floatResult = Keymap.resolve(user: ConfigurationLoader.parse("""
-        [keyboard]
-        leader_timeout_ms = 1.5
-        """))
-        #expect(try failure(floatResult).contains {
-            $0.message.contains("[keyboard].leader_timeout_ms")
-                && $0.message.contains("integer")
         })
     }
 


### PR DESCRIPTION
Implements [ATC-43](https://linear.app/elevenideas/issue/ATC-43/make-leader-key-menu-larger).

## Changes

- **Larger menu**: bumped the leader hint from caption-sized text to callout, with bigger key chips, more generous spacing/padding, and a 280pt minimum width.
- **No title**: removed the "Command Sequence" header.
- **Stays open**: the menu no longer auto-dismisses on a timer. It stays up until a continuation key is pressed or the user cancels with Escape (or focus loss).
- **Config cleanup**: removed the now-meaningless `leader_timeout_ms` setting from the config schema, keymap resolution, and README.

## Testing

- `mise run macos:test` — all 308 tests pass.
- Removed/updated the tests covering the timeout and the `leader_timeout_ms` key.