### PR TITLE
Server-owned Workspace Session indexes and name clearing (ATC-50)

### DIFF
--- a/macos/ATC/PreviewSupport/MockATCClient.swift
+++ b/macos/ATC/PreviewSupport/MockATCClient.swift
@@ -277,9 +277,9 @@ nonisolated struct MockATCClient: ATCClient {
         return session
     }
 
-    func renameSession(id: String, name: String) async throws -> Session {
-        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
+    func renameSession(id: String, name: String?) async throws -> Session {
+        let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let trimmed, trimmed.isEmpty {
             throw ATCError.api(code: "invalid_request", message: "name is required", sessionID: nil)
         }
         var session = try await session(id: id)

--- a/macos/ATCTests/CreateProjectFlowTests.swift
+++ b/macos/ATCTests/CreateProjectFlowTests.swift
@@ -31,7 +31,7 @@ private nonisolated final class RecordingClient: ATCClient, @unchecked Sendable 
         try await inner.sessions(status: status)
     }
     func session(id: String) async throws -> Session { try await inner.session(id: id) }
-    func renameSession(id: String, name: String) async throws -> Session {
+    func renameSession(id: String, name: String?) async throws -> Session {
         try await inner.renameSession(id: id, name: name)
     }
     func deleteSession(id: String) async throws { try await inner.deleteSession(id: id) }

--- a/macos/ATCTests/ProjectsStoreTests.swift
+++ b/macos/ATCTests/ProjectsStoreTests.swift
@@ -117,7 +117,7 @@ final class GatedProjectsClient: ATCClient, @unchecked Sendable {
     func sessions(status: SessionStatus?) async throws -> [Session] { [] }
     func session(id: String) async throws -> Session { throw ATCError.badStatus(500) }
     func startSession(_ request: StartSessionRequest) async throws -> Session { throw ATCError.badStatus(500) }
-    func renameSession(id: String, name: String) async throws -> Session { throw ATCError.badStatus(500) }
+    func renameSession(id: String, name: String?) async throws -> Session { throw ATCError.badStatus(500) }
     func deleteSession(id: String) async throws { throw ATCError.badStatus(500) }
     func sendText(sessionID: String, text: String) async throws {}
     func sendKey(sessionID: String, key: String) async throws {}
@@ -222,7 +222,7 @@ final class StatefulProjectsClient: ATCClient, @unchecked Sendable {
     func sessions(status: SessionStatus?) async throws -> [Session] { [] }
     func session(id: String) async throws -> Session { throw ATCError.badStatus(500) }
     func startSession(_ request: StartSessionRequest) async throws -> Session { throw ATCError.badStatus(500) }
-    func renameSession(id: String, name: String) async throws -> Session { throw ATCError.badStatus(500) }
+    func renameSession(id: String, name: String?) async throws -> Session { throw ATCError.badStatus(500) }
     func deleteSession(id: String) async throws { throw ATCError.badStatus(500) }
     func sendText(sessionID: String, text: String) async throws {}
     func sendKey(sessionID: String, key: String) async throws {}

--- a/macos/ATCTests/ScriptableClient.swift
+++ b/macos/ATCTests/ScriptableClient.swift
@@ -41,7 +41,7 @@ nonisolated final class ScriptableClient: ATCClient, @unchecked Sendable {
     func startSession(_ request: StartSessionRequest) async throws -> Session {
         try await gate(); return try await inner.startSession(request)
     }
-    func renameSession(id: String, name: String) async throws -> Session {
+    func renameSession(id: String, name: String?) async throws -> Session {
         try await gate(); return try await inner.renameSession(id: id, name: name)
     }
     func deleteSession(id: String) async throws {

--- a/macos/ATCTests/WorkspacesStoreTests.swift
+++ b/macos/ATCTests/WorkspacesStoreTests.swift
@@ -248,7 +248,7 @@ final class StatefulWorkspacesClient: ATCClient, @unchecked Sendable {
     func startSession(_ request: StartSessionRequest) async throws -> Session {
         try await inner.startSession(request)
     }
-    func renameSession(id: String, name: String) async throws -> Session {
+    func renameSession(id: String, name: String?) async throws -> Session {
         var detail = try await inner.renameSession(id: id, name: name)
         lock.withLock { renamedSessions[id] = detail.name }
         detail.updatedAt = .now

--- a/packages/ATCKit/Sources/ATCAPI/ATCClient.swift
+++ b/packages/ATCKit/Sources/ATCAPI/ATCClient.swift
@@ -9,7 +9,7 @@ public protocol ATCClient: Sendable {
     func sessions(status: SessionStatus?) async throws -> [Session]
     func session(id: String) async throws -> Session
     func startSession(_ request: StartSessionRequest) async throws -> Session
-    func renameSession(id: String, name: String) async throws -> Session
+    func renameSession(id: String, name: String?) async throws -> Session
     /// Deletes a session's metadata, ending it first if Live. Files
     /// are never touched.
     func deleteSession(id: String) async throws

--- a/packages/ATCKit/Sources/ATCAPI/HTTPATCClient.swift
+++ b/packages/ATCKit/Sources/ATCAPI/HTTPATCClient.swift
@@ -39,9 +39,10 @@ public struct HTTPATCClient: ATCClient {
         try await post("sessions/start", body: request)
     }
 
-    public func renameSession(id: String, name: String) async throws -> Session {
-        struct Body: Encodable { var name: String }
-        return try await patch("sessions/\(id)", body: Body(name: name))
+    public func renameSession(id: String, name: String?) async throws -> Session {
+        // A dictionary value encodes nil as an explicit JSON null, which the
+        // server requires to clear the name; a struct property would be omitted.
+        try await patch("sessions/\(id)", body: ["name": name])
     }
 
     public func deleteSession(id: String) async throws {

--- a/packages/ATCKit/Sources/ATCAPI/Models/SessionModels.swift
+++ b/packages/ATCKit/Sources/ATCAPI/Models/SessionModels.swift
@@ -31,6 +31,9 @@ public struct SessionProject: Codable, Sendable, Hashable, Identifiable {
 /// The shared shape returned by session list, detail, start, and rename APIs.
 public struct Session: Codable, Sendable, Hashable, Identifiable {
     public var id: String
+    /// Workspace-local human-facing address. Nil when the server predates
+    /// session indexes.
+    public var sessionIndex: Int?
     public var name: String?
     /// Copied launch identity. Both fields are nil for the Interactive Shell.
     public var actionId: String?
@@ -45,6 +48,7 @@ public struct Session: Codable, Sendable, Hashable, Identifiable {
 
     public init(
         id: String,
+        sessionIndex: Int? = nil,
         name: String? = nil,
         actionId: String? = nil,
         actionName: String? = nil,
@@ -57,6 +61,7 @@ public struct Session: Codable, Sendable, Hashable, Identifiable {
         project: SessionProject? = nil
     ) {
         self.id = id
+        self.sessionIndex = sessionIndex
         self.name = name
         self.actionId = actionId
         self.actionName = actionName

--- a/packages/ATCKit/Tests/ATCAPITests/ContractFixtureTests.swift
+++ b/packages/ATCKit/Tests/ATCAPITests/ContractFixtureTests.swift
@@ -31,6 +31,7 @@ struct ContractFixtureTests {
     func sessionsList() throws {
         let sessions = try decodeResponse("sessions-list", as: SessionsEnvelope.self).sessions
         #expect(sessions.count == 1)
+        #expect(sessions[0].sessionIndex == 3)
         #expect(sessions[0].status == .live)
         #expect(sessions[0].actionName == "Claude")
         #expect(sessions[0].isAgent)
@@ -42,6 +43,7 @@ struct ContractFixtureTests {
     func session(fixture: String) throws {
         let session = try decodeResponse(fixture, as: Session.self)
         #expect(!session.id.isEmpty)
+        #expect(session.sessionIndex != nil)
         #expect(session.workspace != nil)
         #expect(session.project != nil)
         if fixture == "session-detail" {
@@ -63,6 +65,7 @@ struct ContractFixtureTests {
     func workspaceSessions() throws {
         let sessions = try decodeResponse("workspace-sessions", as: SessionsEnvelope.self).sessions
         #expect(sessions.count == 1)
+        #expect(sessions[0].sessionIndex == 3)
         #expect(sessions[0].workspace?.id == "wsp_fixture01")
     }
 

--- a/packages/ATCKit/Tests/ATCAPITests/SessionDecodingTests.swift
+++ b/packages/ATCKit/Tests/ATCAPITests/SessionDecodingTests.swift
@@ -4,8 +4,8 @@ import Testing
 
 private let sessionsFixture = Data(#"""
 {"sessions":[
-  {"id":"ses_ended","actionId":"act_vpj2tlg9viqd8ms52ptuvao5c4","actionName":"Claude","isAgent":true,"workingDir":"/tmp","status":"ended","createdAt":"2026-06-30T03:30:53.536616153Z","updatedAt":"2026-07-01T20:09:31.517106561Z"},
-  {"id":"ses_live","name":"Live One","actionId":"act_editor123456789abcdefghijkl","actionName":"Neovim","isAgent":false,"workingDir":"/tmp","status":"live","createdAt":"2026-06-30T01:44:53.678613522Z","updatedAt":"2026-06-30T01:44:53.678613522Z"},
+  {"id":"ses_ended","sessionIndex":1,"actionId":"act_vpj2tlg9viqd8ms52ptuvao5c4","actionName":"Claude","isAgent":true,"workingDir":"/tmp","status":"ended","createdAt":"2026-06-30T03:30:53.536616153Z","updatedAt":"2026-07-01T20:09:31.517106561Z"},
+  {"id":"ses_live","sessionIndex":2,"name":"Live One","actionId":"act_editor123456789abcdefghijkl","actionName":"Neovim","isAgent":false,"workingDir":"/tmp","status":"live","createdAt":"2026-06-30T01:44:53.678613522Z","updatedAt":"2026-06-30T01:44:53.678613522Z"},
   {"id":"ses_shell","isAgent":false,"workingDir":"/tmp","status":"live","createdAt":"2026-06-30T01:45:00Z","updatedAt":"2026-06-30T01:45:00Z","workspace":{"id":"wsp_shell","name":"Scratch"},"project":{"id":"prj_tmp","name":"Tmp"}}
 ]}
 """#.utf8)
@@ -19,6 +19,7 @@ struct SessionDecodingTests {
 
         let ended = envelope.sessions[0]
         #expect(ended.status == .ended)
+        #expect(ended.sessionIndex == 1)
         #expect(ended.name == nil)
         #expect(ended.actionId == "act_vpj2tlg9viqd8ms52ptuvao5c4")
         #expect(ended.actionName == "Claude")
@@ -27,11 +28,13 @@ struct SessionDecodingTests {
 
         let live = envelope.sessions[1]
         #expect(live.status == .live)
+        #expect(live.sessionIndex == 2)
         #expect(!live.isAgent)
         #expect(live.displayName == "Live One")
 
         let shell = envelope.sessions[2]
         #expect(shell.actionId == nil)
+        #expect(shell.sessionIndex == nil)
         #expect(shell.actionName == nil)
         #expect(!shell.isAgent)
         #expect(shell.displayName == "Shell")

--- a/packages/ATCKit/Tests/ATCAPITests/SessionRenameRequestTests.swift
+++ b/packages/ATCKit/Tests/ATCAPITests/SessionRenameRequestTests.swift
@@ -14,7 +14,7 @@ private final class SessionRenameURLProtocol: URLProtocol {
         Self.lastBody = request.httpBody ?? request.httpBodyStream.flatMap(readAll)
         let body = Data(#"""
         {
-          "id":"ses_123","name":"Renamed","actionId":"act_123456789abcdefghijklmnopq",
+          "id":"ses_123","sessionIndex":4,"name":"Renamed","actionId":"act_123456789abcdefghijklmnopq",
           "actionName":"Editor","isAgent":false,"workingDir":"/repo","status":"ended",
           "createdAt":"2026-07-18T10:00:00Z","updatedAt":"2026-07-18T11:00:00Z"
         }
@@ -62,7 +62,17 @@ struct SessionRenameRequestTests {
         let json = try JSONSerialization.jsonObject(with: body) as? [String: String]
         #expect(json == ["name": "Renamed"])
         #expect(detail.id == "ses_123")
+        #expect(detail.sessionIndex == 4)
         #expect(detail.name == "Renamed")
         #expect(detail.status == .ended)
+    }
+
+    @Test("renameSession encodes an explicit null when clearing")
+    func clearSessionName() async throws {
+        _ = try await makeClient().renameSession(id: "ses_123", name: nil)
+        let body = try #require(SessionRenameURLProtocol.lastBody)
+        let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        #expect(json.keys.sorted() == ["name"])
+        #expect(json["name"] is NSNull)
     }
 }

--- a/packages/contracts/fixtures/session-detail.json
+++ b/packages/contracts/fixtures/session-detail.json
@@ -4,6 +4,7 @@
   ],
   "response": {
     "id": "ses_fixture02",
+    "sessionIndex": 1,
     "name": "Ended shell",
     "isAgent": false,
     "workingDir": "/home/dev/projects/experiment",

--- a/packages/contracts/fixtures/session-rename.json
+++ b/packages/contracts/fixtures/session-rename.json
@@ -3,11 +3,11 @@
     "PATCH /sessions/{id}"
   ],
   "request": {
-    "name": "Review login fix"
+    "name": null
   },
   "response": {
     "id": "ses_fixture01",
-    "name": "Review login fix",
+    "sessionIndex": 3,
     "actionId": "act_fh9g7e6571qo53r0t647ughtfg",
     "actionName": "Codex",
     "isAgent": true,

--- a/packages/contracts/fixtures/session-start.json
+++ b/packages/contracts/fixtures/session-start.json
@@ -9,6 +9,7 @@
   },
   "response": {
     "id": "ses_fixture01",
+    "sessionIndex": 3,
     "name": "Fix the login bug",
     "actionId": "act_vpj2tlg9viqd8ms52ptuvao5c4",
     "actionName": "Claude",

--- a/packages/contracts/fixtures/sessions-list.json
+++ b/packages/contracts/fixtures/sessions-list.json
@@ -7,6 +7,7 @@
     "sessions": [
       {
         "id": "ses_fixture01",
+        "sessionIndex": 3,
         "name": "Fix the login bug",
         "actionId": "act_vpj2tlg9viqd8ms52ptuvao5c4",
         "actionName": "Claude",

--- a/packages/contracts/fixtures/workspace-sessions.json
+++ b/packages/contracts/fixtures/workspace-sessions.json
@@ -6,6 +6,7 @@
     "sessions": [
       {
         "id": "ses_fixture01",
+        "sessionIndex": 3,
         "name": "Fix the login bug",
         "actionId": "act_vpj2tlg9viqd8ms52ptuvao5c4",
         "actionName": "Claude",

--- a/server/CONTEXT.md
+++ b/server/CONTEXT.md
@@ -15,11 +15,14 @@ server-selected Interactive Shell in a Workspace working directory, then living
 independently of the atc service. Its public lifecycle is Live or Ended; the
 provisional Launch Attempt used during startup is not a Session. atc starts it,
 injects input, and can re-attach while it is Live. Its atc identity is
-independent of its multiplexer handle. Ended is a retained, read-only tombstone
-whose backing zmx session was confirmed absent by a successful, complete zmx
-inventory. Attach EOF, PTY/input failures, and failed inventories are never
-evidence of ending; unavailable inventory changes no state and operations that
-require it return `zmx_unavailable`. Chosen
+independent of its multiplexer handle. Each Session also has an immutable
+positive index in a Workspace-local namespace shared by agent and terminal
+Sessions. While Live, its optional custom name is supporting context that can
+be set or cleared; it never replaces Action or Agent identity. Ended is a
+retained, read-only tombstone whose backing zmx session was confirmed absent by a
+successful, complete zmx inventory. Attach EOF, PTY/input failures, and failed
+inventories are never evidence of ending; unavailable inventory changes no
+state and operations that require it return `zmx_unavailable`. Chosen
 over "Run"/"Agent Run" deliberately, despite "session" being the underlying zmx
 term. Delete ends a Live process when necessary and removes its atc record.
 _Avoid_: terminal, tab, pane, job, task, run, agent run.

--- a/server/README.md
+++ b/server/README.md
@@ -387,6 +387,7 @@ go run ./cmd/atc sessions start --workspace <id>
 go run ./cmd/atc sessions list
 go run ./cmd/atc sessions show <id>
 go run ./cmd/atc sessions rename <id> "New name"
+go run ./cmd/atc sessions rename <id> --clear
 go run ./cmd/atc sessions attach <id>
 go run ./cmd/atc sessions send-text <id> "hello"
 go run ./cmd/atc sessions send-key <id> enter
@@ -413,10 +414,16 @@ listed closes with `attach_failed`; an inventory failure closes with
 Session to Ended.
 
 `PATCH /api/sessions/{id}` renames only Live Sessions and accepts a strict
-`{"name":"New name"}` body. The server trims the name, rejects blank names with
-`400 invalid_request`, returns `409 session_ended` for an Ended Session, and
-otherwise returns the updated Session detail. Rename changes only the persisted
-display name.
+`{"name":"New name"}` body, or `{"name":null}` to clear the custom name. The
+server trims the name, rejects blank names with `400 invalid_request`, returns
+`409 session_ended` for an Ended Session, and otherwise returns the updated
+Session detail. Rename changes only the persisted display name.
+
+Every Workspace Session carries a server-owned `sessionIndex`: the smallest
+unused positive integer in its Workspace at start time, shared across agent and
+terminal Sessions, immutable for the record's lifetime, retained by Ended
+tombstones, and released only when the record is deleted. It is a human-facing
+Workspace-local address; the Session ID remains the API identity.
 
 Session deletion is stop-and-forget: a Live process confirmed present is
 terminated before its record is removed; an Ended Session or a Live process

--- a/server/cli/sessions.go
+++ b/server/cli/sessions.go
@@ -135,7 +135,7 @@ func sessionsListCommand(lookup envLookup) *cobra.Command {
 				if actionName == "" {
 					actionName = "(interactive shell)"
 				}
-				fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\t%t\t%s\t%s\n", s.ID, s.Status, actionName, s.IsAgent, s.WorkingDir, s.Name)
+				fmt.Fprintf(cmd.OutOrStdout(), "%d\t%s\t%s\t%s\t%t\t%s\t%s\n", s.SessionIndex, s.ID, s.Status, actionName, s.IsAgent, s.WorkingDir, s.Name)
 			}
 			return nil
 		},
@@ -184,21 +184,32 @@ func sessionsShowCommand(lookup envLookup) *cobra.Command {
 
 func sessionsRenameCommand(lookup envLookup) *cobra.Command {
 	var output string
+	var clearName bool
 
 	cmd := &cobra.Command{
-		Use:   "rename <id> <name>",
-		Short: "Rename a session",
-		Args:  cobra.ExactArgs(2),
+		Use:   "rename <id> [name]",
+		Short: "Set or clear a session name",
+		Args:  cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := validateOutput(output); err != nil {
 				return err
+			}
+			if clearName && len(args) == 2 {
+				return errors.New("--clear cannot be used with a name")
+			}
+			if !clearName && len(args) != 2 {
+				return errors.New("a name is required unless --clear is used")
+			}
+			var name any
+			if !clearName {
+				name = args[1]
 			}
 			client, err := commandAPIClient(cmd, lookup)
 			if err != nil {
 				return err
 			}
 			body, err := client.patch(cmd.Context(), sessionEndpoint(args[0]), map[string]any{
-				"name": args[1],
+				"name": name,
 			})
 			if err != nil {
 				return err
@@ -216,6 +227,7 @@ func sessionsRenameCommand(lookup envLookup) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&output, "output", "o", outputText, "Output format: text or json")
+	cmd.Flags().BoolVar(&clearName, "clear", false, "Clear the custom session name")
 	return cmd
 }
 
@@ -337,6 +349,7 @@ func writeSessionDetailText(cmd *cobra.Command, s api.SessionDetail) error {
 	}
 	out := cmd.OutOrStdout()
 	fmt.Fprintf(out, "id\t%s\n", s.ID)
+	fmt.Fprintf(out, "sessionIndex\t%d\n", s.SessionIndex)
 	fmt.Fprintf(out, "status\t%s\n", s.Status)
 	if s.ActionID != "" {
 		fmt.Fprintf(out, "actionId\t%s\n", s.ActionID)

--- a/server/cli/sessions_test.go
+++ b/server/cli/sessions_test.go
@@ -121,7 +121,7 @@ func TestSessionsListJSONUsesQuery(t *testing.T) {
 func TestSessionsListTextShowsCopiedActionIdentity(t *testing.T) {
 	lookup := testRuntimeLookup(t)
 	serveUnixAPI(t, lookup, func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(`{"sessions":[{"id":"ses_agent","actionId":"act_codex","actionName":"Codex","isAgent":true,"workingDir":"/repo","status":"live","createdAt":"2026-06-25T15:04:05Z","updatedAt":"2026-06-25T15:04:06Z"},{"id":"ses_shell","isAgent":false,"workingDir":"/repo","status":"ended","createdAt":"2026-06-25T15:04:05Z","updatedAt":"2026-06-25T15:04:06Z"}]}`))
+		_, _ = w.Write([]byte(`{"sessions":[{"id":"ses_agent","sessionIndex":1,"actionId":"act_codex","actionName":"Codex","isAgent":true,"workingDir":"/repo","status":"live","createdAt":"2026-06-25T15:04:05Z","updatedAt":"2026-06-25T15:04:06Z"},{"id":"ses_shell","sessionIndex":2,"isAgent":false,"workingDir":"/repo","status":"ended","createdAt":"2026-06-25T15:04:05Z","updatedAt":"2026-06-25T15:04:06Z"}]}`))
 	})
 
 	cmd := sessionsCommand(lookup)
@@ -132,7 +132,7 @@ func TestSessionsListTextShowsCopiedActionIdentity(t *testing.T) {
 		t.Fatalf("Execute: %v", err)
 	}
 	got := out.String()
-	if !strings.Contains(got, "ses_agent\tlive\tCodex\ttrue") || !strings.Contains(got, "ses_shell\tended\t(interactive shell)\tfalse") {
+	if !strings.Contains(got, "1\tses_agent\tlive\tCodex\ttrue") || !strings.Contains(got, "2\tses_shell\tended\t(interactive shell)\tfalse") {
 		t.Fatalf("output = %q", got)
 	}
 }
@@ -143,7 +143,7 @@ func TestSessionsShowTextIncludesFullDetail(t *testing.T) {
 		if r.Method != http.MethodGet || r.URL.Path != "/api/sessions/ses_show" {
 			t.Fatalf("request = %s %s, want GET /api/sessions/ses_show", r.Method, r.URL.Path)
 		}
-		_, _ = w.Write([]byte(`{"id":"ses_show","name":"Review","actionId":"act_codex","actionName":"Codex","isAgent":true,"workingDir":"/repo","status":"live","createdAt":"2026-06-25T15:04:05Z","updatedAt":"2026-06-25T15:04:06Z"}`))
+		_, _ = w.Write([]byte(`{"id":"ses_show","sessionIndex":7,"name":"Review","actionId":"act_codex","actionName":"Codex","isAgent":true,"workingDir":"/repo","status":"live","createdAt":"2026-06-25T15:04:05Z","updatedAt":"2026-06-25T15:04:06Z"}`))
 	})
 
 	cmd := sessionsCommand(lookup)
@@ -157,6 +157,7 @@ func TestSessionsShowTextIncludesFullDetail(t *testing.T) {
 	got := out.String()
 	for _, want := range []string{
 		"id\tses_show\n",
+		"sessionIndex\t7\n",
 		"actionId\tact_codex\n",
 		"actionName\tCodex\n",
 		"isAgent\ttrue\n",
@@ -192,6 +193,43 @@ func TestSessionsRenamePatchesName(t *testing.T) {
 	}
 	if got := out.String(); got != "ses_123\tRenamed\n" {
 		t.Fatalf("output = %q", got)
+	}
+}
+
+func TestSessionsRenameClearSendsExplicitNull(t *testing.T) {
+	lookup := testRuntimeLookup(t)
+	serveUnixAPI(t, lookup, func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		name, present := req["name"]
+		if !present || name != nil {
+			t.Fatalf("name = %#v, present=%t; want explicit null", name, present)
+		}
+		_, _ = w.Write([]byte(`{"id":"ses_123","sessionIndex":1,"isAgent":false,"workingDir":"/repo","status":"live","createdAt":"2026-07-09T12:30:00Z","updatedAt":"2026-07-09T14:00:00Z"}`))
+	})
+
+	cmd := sessionsCommand(lookup)
+	cmd.SetOut(io.Discard)
+	cmd.SetArgs([]string{"rename", "ses_123", "--clear"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute clear: %v", err)
+	}
+}
+
+func TestSessionsRenameValidatesClearUsage(t *testing.T) {
+	for _, args := range [][]string{
+		{"rename", "ses_123"},
+		{"rename", "ses_123", "Name", "--clear"},
+	} {
+		cmd := sessionsCommand(testRuntimeLookup(t))
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+		cmd.SetArgs(args)
+		if err := cmd.Execute(); err == nil {
+			t.Fatalf("Execute(%v) succeeded", args)
+		}
 	}
 }
 

--- a/server/docs/adr/0005-sqlite-for-atc-state.md
+++ b/server/docs/adr/0005-sqlite-for-atc-state.md
@@ -9,6 +9,11 @@
 > longer persisted; a provisional Launch Attempt is deleted unless it becomes
 > Live.
 
+> **Session-index amendment (2026-07):** SQLite also owns each Session's
+> immutable positive Workspace-local index. It is allocated with the
+> provisional Launch Attempt, retained by an Ended tombstone, and released only
+> when the record is deleted.
+
 atc will use a local SQLite database for atc-owned application state,
 starting with the persistent session registry. Earlier specs deliberately
 avoided persistence for the terminal-session proof loop, but the next backend

--- a/server/docs/adr/0006-atc-owned-session-identity.md
+++ b/server/docs/adr/0006-atc-owned-session-identity.md
@@ -8,6 +8,12 @@
 > only after a successful, complete zmx inventory confirms absence. Inventory
 > failure changes no Session state.
 
+> **Identity amendment (2026-07):** `Session.id` remains the global API
+> identity. Each Session also exposes an immutable positive Workspace-local
+> index as a human-facing address. Its optional custom name is supporting
+> context and can be set or cleared while Live; neither the index nor name
+> replaces Action or Agent identity.
+
 Supersedes [ADR 0002](0002-session-identity-in-zmx-name.md).
 
 atc sessions will expose a stable atc-owned `Session.id` as their public

--- a/server/docs/adr/0010-workspace-session-index.md
+++ b/server/docs/adr/0010-workspace-session-index.md
@@ -1,0 +1,3 @@
+# Workspace Sessions have server-owned indexes
+
+Each Session has an immutable positive integer index allocated by the server in one Workspace-local namespace shared by agent and terminal Sessions, while its stable Session ID remains the API identity. Allocation atomically selects the smallest currently unused integer, including provisional Launch Attempts, with a SQLite uniqueness constraint on `(workspace_id, session_index)` as the concurrency backstop. Ended tombstones retain their indexes, and an index is released only when its Session record is deleted, including failed-launch cleanup and Workspace deletion; remaining Sessions are never renumbered.

--- a/server/docs/adr/0010-workspace-session-index.md
+++ b/server/docs/adr/0010-workspace-session-index.md
@@ -1,3 +1,15 @@
 # Workspace Sessions have server-owned indexes
 
-Each Session has an immutable positive integer index allocated by the server in one Workspace-local namespace shared by agent and terminal Sessions, while its stable Session ID remains the API identity. Allocation atomically selects the smallest currently unused integer, including provisional Launch Attempts, with a SQLite uniqueness constraint on `(workspace_id, session_index)` as the concurrency backstop. Ended tombstones retain their indexes, and an index is released only when its Session record is deleted, including failed-launch cleanup and Workspace deletion; remaining Sessions are never renumbered.
+Each Workspace Session exposes `sessionIndex`, an immutable positive integer in
+one Workspace-local namespace shared by agent and terminal Sessions. It is a
+human-facing address; the stable Session ID remains the API identity.
+
+The server allocates the smallest unused index atomically when it creates the
+provisional Launch Attempt. Provisional records reserve their indexes, with a
+SQLite uniqueness constraint on `(workspace_id, session_index)` as the
+concurrency backstop. Ended tombstones retain their indexes. Record deletion,
+including failed-launch cleanup and Workspace deletion, releases them for
+reuse; remaining Sessions are never renumbered.
+
+Existing Sessions are backfilled per Workspace, oldest first by `created_at`
+with Session ID as the tie-break.

--- a/server/internal/api/sessions.go
+++ b/server/internal/api/sessions.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"strconv"
@@ -27,7 +29,7 @@ type sendKeyRequest struct {
 }
 
 type renameSessionRequest struct {
-	Name string `json:"name"`
+	Name json.RawMessage `json:"name"`
 }
 
 // SessionListResponse is the wire envelope for session list endpoints. It is
@@ -40,17 +42,18 @@ type SessionListResponse struct {
 // SessionResponse is the wire shape shared by session list and detail
 // endpoints. Action identity is omitted for Interactive Shell sessions.
 type SessionResponse struct {
-	ID         string            `json:"id"`
-	Name       string            `json:"name,omitempty"`
-	ActionID   string            `json:"actionId,omitempty"`
-	ActionName string            `json:"actionName,omitempty"`
-	IsAgent    bool              `json:"isAgent"`
-	WorkingDir string            `json:"workingDir"`
-	Status     session.Status    `json:"status"`
-	CreatedAt  string            `json:"createdAt"`
-	UpdatedAt  string            `json:"updatedAt"`
-	Workspace  *SessionWorkspace `json:"workspace,omitempty"`
-	Project    *SessionProject   `json:"project,omitempty"`
+	ID           string            `json:"id"`
+	SessionIndex int               `json:"sessionIndex"`
+	Name         string            `json:"name,omitempty"`
+	ActionID     string            `json:"actionId,omitempty"`
+	ActionName   string            `json:"actionName,omitempty"`
+	IsAgent      bool              `json:"isAgent"`
+	WorkingDir   string            `json:"workingDir"`
+	Status       session.Status    `json:"status"`
+	CreatedAt    string            `json:"createdAt"`
+	UpdatedAt    string            `json:"updatedAt"`
+	Workspace    *SessionWorkspace `json:"workspace,omitempty"`
+	Project      *SessionProject   `json:"project,omitempty"`
 }
 
 // SessionWorkspace is the workspace object nested on sessions.
@@ -133,7 +136,11 @@ func (routes apiRoutes) patchSession(w http.ResponseWriter, r *http.Request) {
 	if !decodeRenameJSON(w, r, &req) {
 		return
 	}
-	renamed, err := routes.sessions.Rename(r.Context(), r.PathValue("id"), req.Name)
+	name, ok := decodeSessionName(w, req.Name)
+	if !ok {
+		return
+	}
+	renamed, err := routes.sessions.Rename(r.Context(), r.PathValue("id"), name)
 	if err != nil {
 		writeSessionError(w, err)
 		return
@@ -246,18 +253,35 @@ func writeSessionError(w http.ResponseWriter, err error) {
 
 func listItemResponse(s session.Session) SessionResponse {
 	return SessionResponse{
-		ID:         s.ID,
-		Name:       s.Name,
-		ActionID:   s.ActionID,
-		ActionName: s.ActionName,
-		IsAgent:    s.IsAgent,
-		WorkingDir: s.WorkingDir,
-		Status:     s.Status,
-		CreatedAt:  formatTime(s.CreatedAt),
-		UpdatedAt:  formatTime(s.UpdatedAt),
-		Workspace:  sessionWorkspaceResponse(s.Workspace),
-		Project:    sessionProjectResponse(s.Project),
+		ID:           s.ID,
+		SessionIndex: s.SessionIndex,
+		Name:         s.Name,
+		ActionID:     s.ActionID,
+		ActionName:   s.ActionName,
+		IsAgent:      s.IsAgent,
+		WorkingDir:   s.WorkingDir,
+		Status:       s.Status,
+		CreatedAt:    formatTime(s.CreatedAt),
+		UpdatedAt:    formatTime(s.UpdatedAt),
+		Workspace:    sessionWorkspaceResponse(s.Workspace),
+		Project:      sessionProjectResponse(s.Project),
 	}
+}
+
+func decodeSessionName(w http.ResponseWriter, raw json.RawMessage) (*string, bool) {
+	if len(raw) == 0 {
+		writeError(w, http.StatusBadRequest, "invalid_request", "name is required")
+		return nil, false
+	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, true
+	}
+	var name string
+	if err := json.Unmarshal(raw, &name); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", "name must be a string or null")
+		return nil, false
+	}
+	return &name, true
 }
 
 func detailResponse(s session.Session) SessionResponse {

--- a/server/internal/api/sessions_test.go
+++ b/server/internal/api/sessions_test.go
@@ -329,12 +329,30 @@ func TestPatchSessionRenamesAndDecodesStrictly(t *testing.T) {
 	if renamed.Status != original.Status || renamed.WorkingDir != original.WorkingDir || len(mux.sessions) != 1 || mux.sessions[0].Name != zmx.NameForID(original.ID) {
 		t.Fatalf("rename changed session identity/config: before=%+v after=%+v", original, renamed)
 	}
+	if renamed.SessionIndex != original.SessionIndex || renamed.SessionIndex == 0 {
+		t.Fatalf("rename changed or omitted session index: before=%+v after=%+v", original, renamed)
+	}
+
+	rec = do(t, env.handler, http.MethodPatch, "/sessions/"+original.ID, `{"name":null}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("clear status = %d, want 200 (%s)", rec.Code, rec.Body)
+	}
+	var cleared SessionDetail
+	if err := json.NewDecoder(rec.Body).Decode(&cleared); err != nil {
+		t.Fatalf("decode clear: %v", err)
+	}
+	if cleared.Name != "" || cleared.SessionIndex != original.SessionIndex {
+		t.Fatalf("cleared = %+v", cleared)
+	}
 
 	for _, tc := range []struct {
 		name, id, body, code string
 		status               int
 	}{
+		{name: "empty", id: original.ID, body: `{"name":""}`, status: http.StatusBadRequest, code: "invalid_request"},
 		{name: "blank", id: original.ID, body: `{"name":"   "}`, status: http.StatusBadRequest, code: "invalid_request"},
+		{name: "absent name", id: original.ID, body: `{}`, status: http.StatusBadRequest, code: "invalid_request"},
+		{name: "wrong type", id: original.ID, body: `{"name":42}`, status: http.StatusBadRequest, code: "invalid_request"},
 		{name: "unknown field", id: original.ID, body: `{"name":"X","status":"ended"}`, status: http.StatusBadRequest, code: "invalid_request"},
 		{name: "trailing data", id: original.ID, body: `{"name":"X"}{"name":"Y"}`, status: http.StatusBadRequest, code: "invalid_request"},
 		{name: "missing", id: "ses_missing", body: `{"name":"X"}`, status: http.StatusNotFound, code: "session_not_found"},

--- a/server/internal/session/session.go
+++ b/server/internal/session/session.go
@@ -108,15 +108,16 @@ type StartInput struct {
 // Session is atc's full domain model for a session. API list/detail
 // serializers decide which fields are exposed on each endpoint.
 type Session struct {
-	ID          string
-	Name        string
-	ActionID    string
-	ActionName  string
-	IsAgent     bool
-	WorkingDir  string
-	Status      Status
-	WorkspaceID string
-	Workspace   *WorkspaceRef
+	ID           string
+	SessionIndex int
+	Name         string
+	ActionID     string
+	ActionName   string
+	IsAgent      bool
+	WorkingDir   string
+	Status       Status
+	WorkspaceID  string
+	Workspace    *WorkspaceRef
 	// Project is the derived project reference, reached through the
 	// workspace, kept so clients that group sessions by project keep working.
 	Project   *ProjectRef
@@ -348,10 +349,13 @@ func (s *Service) Read(ctx context.Context, id string) (Session, error) {
 }
 
 // Rename updates only a Live session's persisted display name.
-func (s *Service) Rename(ctx context.Context, id, name string) (Session, error) {
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return Session{}, fmt.Errorf("%w: name is required", ErrInvalidSessionName)
+func (s *Service) Rename(ctx context.Context, id string, name *string) (Session, error) {
+	if name != nil {
+		trimmed := strings.TrimSpace(*name)
+		if trimmed == "" {
+			return Session{}, fmt.Errorf("%w: name is required", ErrInvalidSessionName)
+		}
+		name = &trimmed
 	}
 	current, err := s.store.Get(ctx, id)
 	if err != nil {
@@ -735,18 +739,19 @@ func domainSession(record store.Session) (Session, error) {
 		return Session{}, err
 	}
 	return Session{
-		ID:          record.ID,
-		Name:        record.Name,
-		ActionID:    record.ActionID,
-		ActionName:  record.ActionName,
-		IsAgent:     record.IsAgent,
-		WorkingDir:  record.WorkingDir,
-		Status:      status,
-		WorkspaceID: record.WorkspaceID,
-		Workspace:   workspaceRef,
-		Project:     projectRef,
-		CreatedAt:   record.CreatedAt,
-		UpdatedAt:   record.UpdatedAt,
+		ID:           record.ID,
+		SessionIndex: record.SessionIndex,
+		Name:         record.Name,
+		ActionID:     record.ActionID,
+		ActionName:   record.ActionName,
+		IsAgent:      record.IsAgent,
+		WorkingDir:   record.WorkingDir,
+		Status:       status,
+		WorkspaceID:  record.WorkspaceID,
+		Workspace:    workspaceRef,
+		Project:      projectRef,
+		CreatedAt:    record.CreatedAt,
+		UpdatedAt:    record.UpdatedAt,
 	}, nil
 }
 

--- a/server/internal/session/session_test.go
+++ b/server/internal/session/session_test.go
@@ -235,6 +235,14 @@ func TestLaunchFailureDeletesProvisionalSession(t *testing.T) {
 	if len(records) != 0 {
 		t.Fatalf("persistent sessions after failure = %+v", records)
 	}
+	mux.startErr = nil
+	started, err := svc.Start(ctx, StartInput{WorkspaceID: testWorkspaceID, ActionID: action.ID})
+	if err != nil {
+		t.Fatalf("Start after failed launch: %v", err)
+	}
+	if started.SessionIndex != 1 {
+		t.Fatalf("index after failed launch = %d, want released index 1", started.SessionIndex)
+	}
 }
 
 func TestNewIDUsesSessionPrefix(t *testing.T) {
@@ -310,11 +318,11 @@ func TestRenameLiveSessionAndRejectEnded(t *testing.T) {
 		t.Fatalf("MarkEnded: %v", err)
 	}
 
-	renamedLive, err := svc.Rename(ctx, live.ID, "  Shared  ")
+	renamedLive, err := svc.Rename(ctx, live.ID, sessionName("  Shared  "))
 	if err != nil {
 		t.Fatalf("Rename live: %v", err)
 	}
-	_, err = svc.Rename(ctx, ended.ID, "Shared")
+	_, err = svc.Rename(ctx, ended.ID, sessionName("Shared"))
 	var endedErr *EndedError
 	if !errors.As(err, &endedErr) || endedErr.SessionID != ended.ID {
 		t.Fatalf("Rename ended err = %#v", err)
@@ -325,12 +333,20 @@ func TestRenameLiveSessionAndRejectEnded(t *testing.T) {
 	if renamedLive.Workspace == nil || renamedLive.Project == nil {
 		t.Fatalf("renamed live missing refs: %+v", renamedLive)
 	}
-	if _, err := svc.Rename(ctx, live.ID, "   "); !errors.Is(err, ErrInvalidSessionName) {
+	clearedLive, err := svc.Rename(ctx, live.ID, nil)
+	if err != nil || clearedLive.Name != "" {
+		t.Fatalf("clear live = %+v err=%v", clearedLive, err)
+	}
+	if _, err := svc.Rename(ctx, live.ID, sessionName("   ")); !errors.Is(err, ErrInvalidSessionName) {
 		t.Fatalf("blank err = %v, want ErrInvalidSessionName", err)
 	}
-	if _, err := svc.Rename(ctx, "ses_missing", "Name"); !errors.Is(err, ErrSessionNotFound) {
+	if _, err := svc.Rename(ctx, "ses_missing", sessionName("Name")); !errors.Is(err, ErrSessionNotFound) {
 		t.Fatalf("missing err = %v, want ErrSessionNotFound", err)
 	}
+}
+
+func sessionName(name string) *string {
+	return &name
 }
 
 func TestStartPromotionLostRaceTerminatesLaunchedProcess(t *testing.T) {

--- a/server/internal/store/migrations/0002_session_index.sql
+++ b/server/internal/store/migrations/0002_session_index.sql
@@ -1,0 +1,25 @@
+-- +goose Up
+ALTER TABLE sessions ADD COLUMN session_index INTEGER;
+
+WITH ranked AS (
+	SELECT
+		id,
+		ROW_NUMBER() OVER (
+			PARTITION BY workspace_id
+			ORDER BY created_at, id
+		) AS session_index
+	FROM sessions
+)
+UPDATE sessions
+SET session_index = (
+	SELECT ranked.session_index
+	FROM ranked
+	WHERE ranked.id = sessions.id
+);
+
+CREATE UNIQUE INDEX sessions_workspace_session_index_idx
+	ON sessions(workspace_id, session_index);
+
+-- +goose Down
+DROP INDEX sessions_workspace_session_index_idx;
+ALTER TABLE sessions DROP COLUMN session_index;

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -66,8 +66,9 @@ const (
 // domain value; the API layer owns its own wire types and serialization, so this
 // struct carries no JSON tags.
 type Session struct {
-	ID   string
-	Name string
+	ID           string
+	SessionIndex int
+	Name         string
 	// ActionID and ActionName are immutable launch provenance. Both are empty
 	// for the Interactive Shell.
 	ActionID    string
@@ -231,9 +232,14 @@ func (s *Store) MarkEnded(ctx context.Context, id string) (Session, error) {
 
 // RenameSession updates a Live session's display name. It does not affect
 // process identity or lifecycle state.
-func (s *Store) RenameSession(ctx context.Context, id, name string) (Session, error) {
-	if strings.TrimSpace(name) == "" {
-		return Session{}, errors.New("rename session: name is required")
+func (s *Store) RenameSession(ctx context.Context, id string, name *string) (Session, error) {
+	var storedName any
+	if name != nil {
+		trimmed := strings.TrimSpace(*name)
+		if trimmed == "" {
+			return Session{}, errors.New("rename session: name is required")
+		}
+		storedName = trimmed
 	}
 	q := s.queries()
 	now := q.nowUTC()
@@ -242,7 +248,7 @@ func (s *Store) RenameSession(ctx context.Context, id, name string) (Session, er
 	SET name = ?, updated_at = ?
 	WHERE id = ? AND status = ?
 	RETURNING`+sessionColumnsSQL,
-		name, formatTime(now), id, StatusLive,
+		storedName, formatTime(now), id, StatusLive,
 	)
 }
 
@@ -318,12 +324,33 @@ func (q queries) CreateStarting(ctx context.Context, input CreateSessionInput) (
 	// session under a missing workspace.
 	created, err := q.scanOne(q.runner.QueryRowContext(ctx, `
 	INSERT INTO sessions (
-		id, name, action_id, action_name, is_agent, working_dir, status, workspace_id, created_at, updated_at
+		id, session_index, name, action_id, action_name, is_agent, working_dir, status, workspace_id, created_at, updated_at
 	)
-	SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+	SELECT ?,
+		CASE
+			WHEN NOT EXISTS (
+				SELECT 1
+				FROM sessions
+				WHERE workspace_id = ? AND session_index = 1
+			) THEN 1
+			ELSE (
+				SELECT MIN(current.session_index + 1)
+				FROM sessions AS current
+				WHERE current.workspace_id = ?
+					AND NOT EXISTS (
+						SELECT 1
+						FROM sessions AS successor
+						WHERE successor.workspace_id = current.workspace_id
+							AND successor.session_index = current.session_index + 1
+					)
+			)
+		END,
+		?, ?, ?, ?, ?, ?, ?, ?, ?
 	WHERE EXISTS (SELECT 1 FROM workspaces WHERE id = ?)
 	RETURNING`+sessionColumnsSQL,
 		input.ID,
+		input.WorkspaceID,
+		input.WorkspaceID,
 		nullableString(input.Name),
 		nullableString(input.ActionID),
 		nullableString(input.ActionName),
@@ -519,6 +546,7 @@ func (q queries) nowUTC() time.Time {
 // and project columns) used by reads, which JOIN workspaces and projects.
 const sessionColumnsSQL = `
 		id,
+		COALESCE(session_index, 0),
 		COALESCE(name, ''),
 		COALESCE(action_id, ''),
 		COALESCE(action_name, ''),
@@ -531,6 +559,7 @@ const sessionColumnsSQL = `
 
 const sessionJoinColumnsSQL = `
 		s.id,
+		COALESCE(s.session_index, 0),
 		COALESCE(s.name, ''),
 		COALESCE(s.action_id, ''),
 		COALESCE(s.action_name, ''),
@@ -578,6 +607,7 @@ func scanSessionColumns(row scanner, extra ...any) (Session, error) {
 	var createdAt, updatedAt string
 	dests := []any{
 		&session.ID,
+		&session.SessionIndex,
 		&session.Name,
 		&session.ActionID,
 		&session.ActionName,

--- a/server/internal/store/store_test.go
+++ b/server/internal/store/store_test.go
@@ -2,12 +2,18 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"errors"
+	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/pressly/goose/v3"
 )
 
 func TestOpenCreatesParentAndMigrates(t *testing.T) {
@@ -61,6 +67,71 @@ func TestOpenCreatesParentAndMigrates(t *testing.T) {
 	}
 	if busyTimeout <= 0 {
 		t.Fatalf("busy_timeout = %d, want positive", busyTimeout)
+	}
+}
+
+func TestSessionIndexMigrationBackfillsOldestFirstPerWorkspace(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open(sqliteDriver, sqliteDSN(filepath.Join(t.TempDir(), "atc.db")))
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+
+	migrationFS, err := fs.Sub(migrations, "migrations")
+	if err != nil {
+		t.Fatalf("migration fs: %v", err)
+	}
+	provider, err := goose.NewProvider(goose.DialectSQLite3, db, migrationFS, goose.WithLogger(goose.NopLogger()))
+	if err != nil {
+		t.Fatalf("new migration provider: %v", err)
+	}
+	if _, err := provider.UpTo(ctx, 1); err != nil {
+		t.Fatalf("apply baseline: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO projects (id, name, working_dir, created_at, updated_at)
+		VALUES ('prj_backfill', 'Backfill', '/work', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+		INSERT INTO workspaces (id, project_id, name, created_at, updated_at)
+		VALUES
+			('wsp_a', 'prj_backfill', 'A', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+			('wsp_b', 'prj_backfill', 'B', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+		INSERT INTO sessions (
+			id, is_agent, working_dir, status, workspace_id, created_at, updated_at
+		) VALUES
+			('ses_b', 1, '/work', 'live', 'wsp_a', '2026-01-02T00:00:00Z', '2026-01-02T00:00:00Z'),
+			('ses_oldest', 0, '/work', 'ended', 'wsp_a', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+			('ses_a', 0, '/work', 'live', 'wsp_a', '2026-01-02T00:00:00Z', '2026-01-02T00:00:00Z'),
+			('ses_other_workspace', 0, '/work', 'live', 'wsp_b', '2026-01-03T00:00:00Z', '2026-01-03T00:00:00Z')
+	`); err != nil {
+		t.Fatalf("seed pre-migration rows: %v", err)
+	}
+	if _, err := provider.UpTo(ctx, 2); err != nil {
+		t.Fatalf("apply session index migration: %v", err)
+	}
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT id, session_index
+		FROM sessions
+		ORDER BY workspace_id, session_index
+	`)
+	if err != nil {
+		t.Fatalf("query backfill: %v", err)
+	}
+	defer rows.Close()
+	var got []string
+	for rows.Next() {
+		var id string
+		var index int
+		if err := rows.Scan(&id, &index); err != nil {
+			t.Fatalf("scan backfill: %v", err)
+		}
+		got = append(got, id+":"+fmt.Sprint(index))
+	}
+	want := []string{"ses_oldest:1", "ses_a:2", "ses_b:3", "ses_other_workspace:1"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("backfill = %v, want %v", got, want)
 	}
 }
 
@@ -295,7 +366,7 @@ func TestRenameSessionPersistsAndReturnsHydratedRecord(t *testing.T) {
 	if _, err := st.PromoteToLive(ctx, created.ID); err != nil {
 		t.Fatalf("PromoteToLive: %v", err)
 	}
-	renamed, err := st.RenameSession(ctx, created.ID, "After")
+	renamed, err := st.RenameSession(ctx, created.ID, storeSessionName("After"))
 	if err != nil {
 		t.Fatalf("RenameSession: %v", err)
 	}
@@ -309,14 +380,125 @@ func TestRenameSessionPersistsAndReturnsHydratedRecord(t *testing.T) {
 	if err != nil || got.Name != "After" {
 		t.Fatalf("Get = %+v err=%v", got, err)
 	}
+	cleared, err := st.RenameSession(ctx, created.ID, nil)
+	if err != nil {
+		t.Fatalf("clear RenameSession: %v", err)
+	}
+	if cleared.Name != "" {
+		t.Fatalf("cleared name = %q, want empty domain value", cleared.Name)
+	}
+	var storedName any
+	if err := st.db.QueryRowContext(ctx, `SELECT name FROM sessions WHERE id = ?`, created.ID).Scan(&storedName); err != nil {
+		t.Fatalf("query cleared name: %v", err)
+	}
+	if storedName != nil {
+		t.Fatalf("stored cleared name = %#v, want NULL", storedName)
+	}
 	if _, err := st.MarkEnded(ctx, created.ID); err != nil {
 		t.Fatalf("MarkEnded: %v", err)
 	}
-	if _, err := st.RenameSession(ctx, created.ID, "After ending"); !errors.Is(err, ErrSessionNotFound) {
+	if _, err := st.RenameSession(ctx, created.ID, storeSessionName("After ending")); !errors.Is(err, ErrSessionNotFound) {
 		t.Fatalf("rename ended err = %v, want ErrSessionNotFound", err)
 	}
-	if _, err := st.RenameSession(ctx, "ses_missing", "After"); !errors.Is(err, ErrSessionNotFound) {
+	if _, err := st.RenameSession(ctx, "ses_missing", storeSessionName("After")); !errors.Is(err, ErrSessionNotFound) {
 		t.Fatalf("missing err = %v, want ErrSessionNotFound", err)
+	}
+}
+
+func TestSessionIndexesUseSmallestAvailableWorkspaceNumber(t *testing.T) {
+	ctx := context.Background()
+	st := openTestStore(t)
+	defer st.Close()
+	seedWorkspace(t, st, "prj_main", "wsp_main")
+	if _, err := st.CreateWorkspace(ctx, CreateWorkspaceInput{ID: "wsp_other", ProjectID: "prj_main", Name: "Other"}); err != nil {
+		t.Fatalf("CreateWorkspace other: %v", err)
+	}
+
+	create := func(id, workspaceID string) Session {
+		t.Helper()
+		created, err := st.CreateStarting(ctx, CreateSessionInput{
+			ID: id, IsAgent: id == "ses_2", WorkingDir: "/work", WorkspaceID: workspaceID,
+		})
+		if err != nil {
+			t.Fatalf("CreateStarting(%s): %v", id, err)
+		}
+		return created
+	}
+
+	first := create("ses_1", "wsp_main")
+	second := create("ses_2", "wsp_main")
+	third := create("ses_3", "wsp_main")
+	if first.SessionIndex != 1 || second.SessionIndex != 2 || third.SessionIndex != 3 {
+		t.Fatalf("sequential indexes = %d, %d, %d", first.SessionIndex, second.SessionIndex, third.SessionIndex)
+	}
+	other := create("ses_other", "wsp_other")
+	if other.SessionIndex != 1 {
+		t.Fatalf("other workspace index = %d, want 1", other.SessionIndex)
+	}
+
+	for _, id := range []string{first.ID, second.ID, third.ID} {
+		if _, err := st.PromoteToLive(ctx, id); err != nil {
+			t.Fatalf("PromoteToLive(%s): %v", id, err)
+		}
+	}
+	if err := st.ForgetSession(ctx, second.ID); err != nil {
+		t.Fatalf("ForgetSession second: %v", err)
+	}
+	reused := create("ses_reused", "wsp_main")
+	if reused.SessionIndex != 2 {
+		t.Fatalf("reused index = %d, want 2", reused.SessionIndex)
+	}
+	if _, err := st.MarkEnded(ctx, first.ID); err != nil {
+		t.Fatalf("MarkEnded first: %v", err)
+	}
+	next := create("ses_next", "wsp_main")
+	if next.SessionIndex != 4 {
+		t.Fatalf("index after ended tombstone = %d, want 4", next.SessionIndex)
+	}
+}
+
+func TestConcurrentSessionIndexAllocationIsUniqueAndGapFree(t *testing.T) {
+	ctx := context.Background()
+	st := openTestStore(t)
+	defer st.Close()
+	seedWorkspace(t, st, "prj_main", "wsp_main")
+
+	const count = 20
+	results := make(chan Session, count)
+	errs := make(chan error, count)
+	var wg sync.WaitGroup
+	for i := 0; i < count; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			created, err := st.CreateStarting(ctx, CreateSessionInput{
+				ID: fmt.Sprintf("ses_concurrent_%02d", i), WorkingDir: "/work", WorkspaceID: "wsp_main",
+			})
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- created
+		}(i)
+	}
+	wg.Wait()
+	close(results)
+	close(errs)
+	for err := range errs {
+		t.Fatalf("CreateStarting: %v", err)
+	}
+
+	indexes := make(map[int]bool, count)
+	for created := range results {
+		if indexes[created.SessionIndex] {
+			t.Fatalf("duplicate session index %d", created.SessionIndex)
+		}
+		indexes[created.SessionIndex] = true
+	}
+	for index := 1; index <= count; index++ {
+		if !indexes[index] {
+			t.Fatalf("missing session index %d; got %v", index, indexes)
+		}
 	}
 }
 
@@ -689,6 +871,10 @@ func assertSessionIDs(t *testing.T, sessions []Session, want []string) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("session ids = %v, want %v", got, want)
 	}
+}
+
+func storeSessionName(name string) *string {
+	return &name
 }
 
 type testClock struct {

--- a/server/web/src/lib/api.contract.test.ts
+++ b/server/web/src/lib/api.contract.test.ts
@@ -83,7 +83,7 @@ const sessionRenameContract = {
   ...sessionRename.response,
   status: sessionStatus(sessionRename.response.status)
 } satisfies SessionDetail;
-sessionRename.request satisfies { name: string };
+sessionRename.request satisfies { name: string | null };
 sessionStart.request satisfies StartSessionRequest;
 projectsList.response satisfies { projects: Project[] };
 projectCreate.response satisfies Project;
@@ -129,6 +129,7 @@ describe('api client unwraps fixture responses', () => {
 	mockFetch(sessionsContract);
     const sessions = await listSessions();
     expect(sessions.map((s) => s.id)).toEqual(['ses_fixture01']);
+    expect(sessions[0].sessionIndex).toBe(3);
     expect(sessions[0].project?.id).toBe('prj_fixture01');
     expect(sessions[0].workspace?.id).toBe('wsp_fixture01');
   });
@@ -137,6 +138,7 @@ describe('api client unwraps fixture responses', () => {
 	mockFetch(sessionStartContract);
     const detail = await startSession(sessionStart.request);
 	expect(detail.status).toBe('live');
+    expect(detail.sessionIndex).toBe(3);
     expect(detail.actionName).toBe('Claude');
     expect(detail.isAgent).toBe(true);
     expect(detail.workspace?.id).toBe('wsp_fixture01');
@@ -145,6 +147,7 @@ describe('api client unwraps fixture responses', () => {
   it('getSession returns an Interactive Shell session without action identity', async () => {
     mockFetch(sessionDetailContract);
     const detail = await getSession('ses/fixture 02');
+    expect(detail.sessionIndex).toBe(1);
     expect(detail.actionId).toBeUndefined();
     expect(detail.actionName).toBeUndefined();
     expect(detail.isAgent).toBe(false);
@@ -154,7 +157,7 @@ describe('api client unwraps fixture responses', () => {
   it('renameSession patches the encoded session path and returns updated detail', async () => {
     mockFetch(sessionRenameContract);
     const detail = await renameSession('ses/fixture 01', sessionRename.request.name);
-    expect(detail.name).toBe('Review login fix');
+    expect(detail.name).toBeUndefined();
     expect(fetch).toHaveBeenCalledWith(
       '/api/sessions/ses%2Ffixture%2001',
       expect.objectContaining({

--- a/server/web/src/lib/api.ts
+++ b/server/web/src/lib/api.ts
@@ -65,6 +65,7 @@ export type SessionProject = {
 
 export type SessionListItem = {
   id: string;
+  sessionIndex: number;
   name?: string;
   // Absent actionId/actionName means the session is an Interactive Shell.
   actionId?: string;
@@ -189,7 +190,7 @@ export async function startSession(body: StartSessionRequest): Promise<SessionDe
   return (await res.json()) as SessionDetail;
 }
 
-export async function renameSession(id: string, name: string): Promise<SessionDetail> {
+export async function renameSession(id: string, name: string | null): Promise<SessionDetail> {
   const res = await apiFetch(
     `/api/sessions/${encodeURIComponent(id)}`,
     jsonInit('PATCH', { name })

--- a/server/web/src/lib/docs/endpoints.ts
+++ b/server/web/src/lib/docs/endpoints.ts
@@ -68,7 +68,7 @@ export const ENDPOINTS: Endpoint[] = [
       { key: 'name', label: 'name', kind: 'text', placeholder: 'optional' }
     ],
     returns:
-      '{\n  "id": "ses_8f3a2c",\n  "actionId": "act_fh9g7e6571qo53r0t647ughtfg",\n  "actionName": "Codex",\n  "isAgent": true,\n  "status": "live"\n}',
+      '{\n  "id": "ses_8f3a2c",\n  "sessionIndex": 3,\n  "actionId": "act_fh9g7e6571qo53r0t647ughtfg",\n  "actionName": "Codex",\n  "isAgent": true,\n  "status": "live"\n}',
     cli: {
       cmd: 'atc sessions start',
       example:
@@ -103,7 +103,7 @@ export const ENDPOINTS: Endpoint[] = [
     desc: 'Fetch one session after demand-driven zmx reconciliation, including its copied launch-time action name and agent classification. If inventory is unavailable, stored state is returned unchanged. Interactive Shell sessions omit actionId and actionName and return isAgent false.',
     params: [{ name: 'id', type: 'string', required: true, desc: 'Session id (path).' }],
     fields: [{ key: 'id', label: 'id', kind: 'text', placeholder: 'ses_…', required: true }],
-	returns: '{ "id": "ses_…", "status": "live", … }',
+	returns: '{ "id": "ses_…", "sessionIndex": 3, "status": "live", … }',
     cli: { cmd: 'atc sessions show', example: 'atc sessions show ses_8f3a2c' }
   },
   {
@@ -130,16 +130,16 @@ export const ENDPOINTS: Endpoint[] = [
     method: 'PATCH',
     path: '/api/sessions/{id}',
     title: 'Rename session',
-    desc: 'Change only a Live Session’s persisted display name. Names are trimmed, must not be blank, and need not be unique; an Ended Session returns 409 session_ended.',
+    desc: 'Change only a Live Session’s persisted display name. Names are trimmed, must not be blank, and need not be unique; send null to clear the custom name. An Ended Session returns 409 session_ended.',
     params: [
       { name: 'id', type: 'string', required: true, desc: 'Session id (path).' },
-      { name: 'name', type: 'string', required: true, desc: 'New display name.' }
+      { name: 'name', type: 'string | null', required: true, desc: 'New display name, or null to clear it.' }
     ],
     fields: [
       { key: 'id', label: 'id', kind: 'text', placeholder: 'ses_…', required: true },
       { key: 'name', label: 'name', kind: 'text', placeholder: 'New name', required: true }
     ],
-    returns: '{ "id": "ses_…", "name": "New name", "status": "live", … }',
+    returns: '{ "id": "ses_…", "sessionIndex": 3, "name": "New name", "status": "live", … }',
     cli: { cmd: 'atc sessions rename', example: 'atc sessions rename ses_8f3a2c "New name"' }
   },
   {

--- a/server/web/src/lib/sessions/session-rename.test.ts
+++ b/server/web/src/lib/sessions/session-rename.test.ts
@@ -10,6 +10,7 @@ import {
 
 const session: SessionListItem = {
   id: 'ses_123',
+  sessionIndex: 3,
   name: 'Before',
   actionId: 'act_123',
   actionName: 'Codex',
@@ -27,17 +28,19 @@ const renamed: SessionDetail = {
 };
 
 describe('shared session rename interaction', () => {
-  it('prefills the displayed name and falls back to the displayed id', () => {
+  it('prefills the custom name and leaves unnamed sessions blank', () => {
     expect(sessionRenameDraft(session)).toBe('Before');
-    expect(sessionRenameDraft({ ...session, name: '   ' })).toBe('ses_123');
+    expect(sessionRenameDraft({ ...session, name: '   ' })).toBe('');
   });
 
-  it('disables blank drafts and trims before submitting', async () => {
-    expect(canRenameSession('   ')).toBe(false);
+  it('trims set names and sends null to clear an existing name', async () => {
+    expect(canRenameSession(session, '   ')).toBe(true);
+    expect(canRenameSession({ ...session, name: undefined }, '   ')).toBe(false);
     const rename = vi.fn(async () => renamed);
     await expect(submitSessionRename(session, '  After  ', rename)).resolves.toBe(renamed);
     expect(rename).toHaveBeenCalledWith('ses_123', 'After');
-    await expect(submitSessionRename(session, '   ', rename)).rejects.toThrow('Name is required');
+    await expect(submitSessionRename(session, '   ', rename)).resolves.toBe(renamed);
+    expect(rename).toHaveBeenLastCalledWith('ses_123', null);
   });
 
   it('replaces the authoritative list item returned by rename', () => {

--- a/server/web/src/lib/sessions/session-rename.ts
+++ b/server/web/src/lib/sessions/session-rename.ts
@@ -1,11 +1,11 @@
 import type { SessionDetail, SessionListItem } from '$lib/api';
 
 export function sessionRenameDraft(session: SessionListItem): string {
-  return session.name?.trim() || session.id;
+  return session.name?.trim() ?? '';
 }
 
-export function canRenameSession(draft: string): boolean {
-  return draft.trim() !== '';
+export function canRenameSession(session: SessionListItem, draft: string): boolean {
+  return draft.trim() !== (session.name?.trim() ?? '');
 }
 
 export function replaceRenamedSession(
@@ -18,9 +18,8 @@ export function replaceRenamedSession(
 export async function submitSessionRename(
   session: SessionListItem,
   draft: string,
-  rename: (id: string, name: string) => Promise<SessionDetail>
+  rename: (id: string, name: string | null) => Promise<SessionDetail>
 ): Promise<SessionDetail> {
   const name = draft.trim();
-  if (!name) throw new Error('Name is required');
-  return rename(session.id, name);
+  return rename(session.id, name || null);
 }

--- a/server/web/src/lib/sessions/session-row-actions.svelte
+++ b/server/web/src/lib/sessions/session-row-actions.svelte
@@ -25,7 +25,7 @@
   let draft = $state('');
   let saving = $state(false);
   let saveError = $state('');
-  let canSave = $derived(canRenameSession(draft));
+  let canSave = $derived(canRenameSession(session, draft));
 
   function beginRename() {
     draft = sessionRenameDraft(session);
@@ -79,7 +79,7 @@
         value={draft}
         oninput={(e) => (draft = e.currentTarget.value)}
       />
-      <p class="hint">Changes only the display name.</p>
+      <p class="hint">Changes only the display name. Leave empty to clear it.</p>
       {#if saveError}
         <div
           class="card"

--- a/server/web/src/routes/sessions/+page.svelte
+++ b/server/web/src/routes/sessions/+page.svelte
@@ -109,6 +109,7 @@
         {:else}
           <span class="sdot" aria-hidden="true"></span>
         {/if}
+        <span class="badge">[{s.sessionIndex}]</span>
         <div class="sident">
           {#if s.name?.trim()}
             <span class="sname">{s.name}</span>

--- a/server/web/src/routes/sessions/[id]/+page.svelte
+++ b/server/web/src/routes/sessions/[id]/+page.svelte
@@ -148,6 +148,7 @@
         {session?.name ?? id}
       </a>
       {#if session}
+        <span class="badge">[{session.sessionIndex}]</span>
         <span class="badge">{sessionActionLabel(session)}</span>
         {#if session.isAgent}<span class="badge">Agent</span>{/if}
       {/if}


### PR DESCRIPTION
## Summary

Implements [ATC-50](https://linear.app/elevenideas/issue/ATC-50/add-server-owned-session-indexes-and-update-server-surfaces): every Workspace Session gets a durable, server-owned numeric index, and the Session rename API supports clearing a custom name with explicit null.

### Session index
- Migration `0002_session_index.sql`: adds `session_index`, backfills existing sessions per Workspace oldest-first by `created_at` (id tie-break), and enforces uniqueness on `(workspace_id, session_index)`.
- Allocation picks the smallest unused positive integer atomically inside the existing guarded `CreateStarting` insert, so provisional Launch Attempts participate and failed launches release their index. Ended tombstones retain their index; only record deletion releases one; sessions are never renumbered.
- `sessionIndex` exposed in all session API responses, contract fixtures, ATCKit (`Int?`, tolerant of older servers per spec), CLI `sessions list`/`show`, and the web UI list/detail badges.

### Rename clearing
- `PATCH /api/sessions/{id}` accepts `{"name": null}` to clear the custom name; blank/absent names still 400. CLI adds `atc sessions rename <id> --clear`; the web rename dialog clears on empty submit.

### Docs
- New ADR `server/docs/adr/0010-workspace-session-index.md`; amendments to ADRs 0005/0006; server CONTEXT.md and README updated.

### Tests
- Migration backfill determinism, sequential + gap-reuse allocation, Ended retention, failed-launch index release, 20-way concurrent allocation, rename set/clear/validation across store, domain, API, CLI, ATCKit, and web contract suites.

Verified with `mise run -C server check`, `swift test` (ATCKit), and `mise run macos:test` — all green.

Part of the ATC-48 series; the macOS adoption of indexed identity ships separately (ATC-51, stacked on this branch).