### PR TITLE
macOS: indexed Session identity and navigation (ATC-51)

### DIFF
--- a/.memory/CONTEXT.md
+++ b/.memory/CONTEXT.md
@@ -25,7 +25,7 @@ The Navigator containing the file tree of the single Active Workspace.
 _Avoid_: Files Navigator, File browser Navigator
 
 **Workspace Switcher**:
-The toolbar control that identifies the Active Workspace as `Project › Workspace` and opens the app-wide Workspace selection menu. Its status indicator reflects the Active Workspace's Connection.
+The toolbar context pill whose Workspace region identifies the Active Workspace as `Project › Workspace` and opens the app-wide Workspace selection menu. When a Session is selected, a second region shows `› [index] Identity` with an optional ` · Custom Name` and opens the Active Workspace's Session picker, grouped into Sessions and Terminals.
 _Avoid_: Workspace Picker, Project picker, Breadcrumb
 
 **Command Palette**:

--- a/macos/ATC/Features/CommandPalette/CommandPaletteContent.swift
+++ b/macos/ATC/Features/CommandPalette/CommandPaletteContent.swift
@@ -41,10 +41,18 @@ struct WorkspaceResult: Identifiable {
 
 struct SessionResult: Identifiable {
     let ref: SessionRef
+    let identity: SessionIdentity
     let title: String
     let kind: SessionKind
     let matchedRanges: [Range<String.Index>]
+    fileprivate let matchQuality: SessionMatchQuality
     var id: PaletteResultID { .session(ref) }
+}
+
+fileprivate enum SessionMatchQuality: Int {
+    case index = 0
+    case title = 1
+    case typeExpansion = 2
 }
 
 /// A whole-query type keyword for the unscoped palette: a trimmed query of
@@ -182,12 +190,14 @@ enum CommandPaletteContent {
         keyword: PaletteTypeKeyword?,
         kind requiredKind: SessionKind? = nil
     ) -> [SessionResult] {
+        let sessionQuery = SessionQuery(query)
         return sessions.compactMap { session in
             guard session.belongs(to: activeWorkspace) else { return nil }
-            let title = SessionKind.displayName(session: session)
+            let identity = SessionIdentity(session: session)
+            let title = identity.fullLabel
             let kind = SessionKind.classify(session: session)
             guard requiredKind == nil || kind == requiredKind else { return nil }
-            let titleMatch = QueryMatcher.match(query, in: title)
+            let match = sessionQuery.match(identity: identity, title: title)
             let expandsKind: Bool
             switch kind {
             case .agent:
@@ -195,15 +205,17 @@ enum CommandPaletteContent {
             case .terminal:
                 expandsKind = keyword == .terminals
             }
-            guard titleMatch != nil || expandsKind else { return nil }
+            guard match != nil || expandsKind else { return nil }
             return SessionResult(
                 ref: SessionRef(
                     connectionID: activeWorkspace.connectionID,
                     sessionID: session.id
                 ),
+                identity: identity,
                 title: title,
                 kind: kind,
-                matchedRanges: titleMatch?.ranges ?? []
+                matchedRanges: match?.query?.ranges ?? [],
+                matchQuality: match?.quality ?? .typeExpansion
             )
         }.sorted(by: sessionComesFirst)
     }
@@ -258,10 +270,83 @@ enum CommandPaletteContent {
         _ lhs: SessionResult,
         _ rhs: SessionResult
     ) -> Bool {
+        if lhs.matchQuality != rhs.matchQuality {
+            return lhs.matchQuality.rawValue < rhs.matchQuality.rawValue
+        }
+        switch (lhs.identity.index, rhs.identity.index) {
+        case let (lhsIndex?, rhsIndex?) where lhsIndex != rhsIndex:
+            return lhsIndex < rhsIndex
+        case (_?, nil):
+            return true
+        case (nil, _?):
+            return false
+        default:
+            break
+        }
         let lhsTitle = lhs.title.lowercased()
         let rhsTitle = rhs.title.lowercased()
         return lhsTitle == rhsTitle
             ? lhs.ref.sessionID < rhs.ref.sessionID
             : lhsTitle < rhsTitle
+    }
+}
+
+private struct SessionQuery {
+    enum Kind {
+        case title(String)
+        case index(String)
+        case indexAndTitle(index: String, title: String)
+    }
+
+    struct Match {
+        let query: QueryMatch?
+        let quality: SessionMatchQuality
+    }
+
+    let kind: Kind
+
+    init(_ query: String) {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty, trimmed.allSatisfy(\.isNumber) {
+            kind = .index(trimmed)
+            return
+        }
+
+        if let separator = trimmed.firstIndex(where: \.isWhitespace) {
+            let index = String(trimmed[..<separator])
+            let title = trimmed[separator...]
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !index.isEmpty, index.allSatisfy(\.isNumber), !title.isEmpty {
+                kind = .indexAndTitle(index: index, title: title)
+                return
+            }
+        }
+
+        kind = .title(query)
+    }
+
+    func match(identity: SessionIdentity, title: String) -> Match? {
+        switch kind {
+        case .title(let query):
+            return QueryMatcher.match(query, in: title).map {
+                Match(query: $0, quality: .title)
+            }
+        case .index(let digits):
+            if index(digits, matches: identity.index) {
+                return Match(query: nil, quality: .index)
+            }
+            return QueryMatcher.match(digits, in: title).map {
+                Match(query: $0, quality: .title)
+            }
+        case .indexAndTitle(let digits, let query):
+            guard index(digits, matches: identity.index),
+                  let titleMatch = QueryMatcher.match(query, in: title)
+            else { return nil }
+            return Match(query: titleMatch, quality: .index)
+        }
+    }
+
+    private func index(_ digits: String, matches index: Int?) -> Bool {
+        index.map { String($0).hasPrefix(digits) } ?? false
     }
 }

--- a/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
+++ b/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
@@ -230,19 +230,22 @@ struct CommandPaletteView: View {
             }
             Spacer(minLength: 12)
         case .session(let row):
+            if let index = row.identity.index {
+                SessionIndexBadge(index)
+            }
             typedTitle(
                 row.kind.paletteTypeLabel,
                 title: row.title,
                 ranges: row.matchedRanges
             )
-                .font(.callout)
+            .font(.callout)
             Spacer(minLength: 12)
         }
     }
 
-    /// One flowing Text so a long name wraps as a unit with its prefix. The
-    /// prefix is dropped when the name already is the type label — an unnamed
-    /// shell reads "Terminal", not "Terminal: Terminal".
+    /// One flowing Text so a long identity wraps as a unit with its category
+    /// prefix. "Terminal" remains a category; an Interactive Shell's identity
+    /// is "Shell".
     private func typedTitle(
         _ type: String,
         title: String,
@@ -299,7 +302,7 @@ struct CommandPaletteView: View {
                 parts.append("Unavailable — \(reason)")
             }
         case .session(let row):
-            parts = [row.title]
+            parts = [row.identity.accessibilityLabel]
             if row.title != row.kind.paletteTypeLabel {
                 parts.append(row.kind.paletteTypeLabel)
             }

--- a/macos/ATC/Features/Sessions/SessionContentView.swift
+++ b/macos/ATC/Features/Sessions/SessionContentView.swift
@@ -100,7 +100,7 @@ private struct SessionEndedView: View {
     @State private var actionError: String?
 
     private var displayName: String {
-        SessionKind.displayName(session: session)
+        SessionIdentity(session: session).indexedLabel
     }
 
     var body: some View {

--- a/macos/ATC/Features/Sessions/SessionDetailView.swift
+++ b/macos/ATC/Features/Sessions/SessionDetailView.swift
@@ -6,9 +6,13 @@ struct SessionDetailView: View {
     let session: Session
 
     var body: some View {
+        let identity = SessionIdentity(session: session)
         Form {
             Section("Session") {
-                LabeledContent("Name", value: SessionKind.displayName(session: session))
+                LabeledContent("Identity", value: identity.indexedLabel)
+                if let customName = identity.customName {
+                    LabeledContent("Custom Name", value: customName)
+                }
                 LabeledContent("ID", value: session.id)
                 LabeledContent("Status") {
                     StatusBadge(session: session, showLabel: true)

--- a/macos/ATC/Features/Sessions/SessionIdentity.swift
+++ b/macos/ATC/Features/Sessions/SessionIdentity.swift
@@ -1,0 +1,96 @@
+import Foundation
+import ATCAPI
+
+/// The one user-facing identity projection for a Session.
+///
+/// A custom name is supporting context. It never replaces the launch
+/// identity copied onto the Session.
+struct SessionIdentity: Equatable, Sendable {
+    let index: Int?
+    let identityText: String
+    let customName: String?
+
+    init(session: Session) {
+        index = session.sessionIndex
+        if session.actionId == nil {
+            identityText = "Shell"
+        } else {
+            // An Action-backed Session should always carry its copied name.
+            // Keep a useful non-category fallback for malformed legacy data.
+            identityText = session.actionName?.nonemptyTrimmed ?? "Action"
+        }
+        customName = session.name?.nonemptyTrimmed
+    }
+
+    /// Identity plus optional supporting name, without the index badge.
+    var fullLabel: String {
+        customName.map { "\(identityText) · \($0)" } ?? identityText
+    }
+
+    /// Plain-text equivalent of the badge and label used in dialogs/help.
+    var indexedLabel: String {
+        index.map { "[\($0)] \(fullLabel)" } ?? fullLabel
+    }
+
+    var accessibilityLabel: String {
+        var parts: [String] = []
+        if let index {
+            parts.append("Session \(index)")
+        }
+        parts.append(identityText)
+        if let customName {
+            parts.append(customName)
+        }
+        return parts.joined(separator: ", ")
+    }
+}
+
+/// The shared Workspace grouping and ordering used by both navigation
+/// surfaces. Session indexes share one namespace, so gaps within either
+/// visible group are intentional.
+struct WorkspaceSessionGroups: Equatable, Sendable {
+    struct Row: Identifiable, Equatable, Sendable {
+        let ref: SessionRef
+        let session: Session
+        let identity: SessionIdentity
+        let kind: SessionKind
+
+        var id: SessionRef { ref }
+    }
+
+    let sessions: [Row]
+    let terminals: [Row]
+
+    static let empty = WorkspaceSessionGroups(sessions: [], terminals: [])
+
+    init(workspace: WorkspaceRef, sessions allSessions: [Session]) {
+        let rows = allSessions
+            .filter { $0.belongs(to: workspace) }
+            .sortedBySessionIndex()
+            .map { session in
+                Row(
+                    ref: SessionRef(
+                        connectionID: workspace.connectionID,
+                        sessionID: session.id
+                    ),
+                    session: session,
+                    identity: SessionIdentity(session: session),
+                    kind: SessionKind.classify(session: session)
+                )
+            }
+        sessions = rows.filter { $0.kind == .agent }
+        terminals = rows.filter { $0.kind == .terminal }
+    }
+
+    private init(sessions: [Row], terminals: [Row]) {
+        self.sessions = sessions
+        self.terminals = terminals
+    }
+}
+
+private extension String {
+    var nonemptyTrimmed: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/macos/ATC/Features/Sessions/SessionIndexBadge.swift
+++ b/macos/ATC/Features/Sessions/SessionIndexBadge.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// Workspace-local Session address. This is identity, never status, so its
+/// appearance deliberately does not vary with lifecycle or selection.
+struct SessionIndexBadge: View {
+    let index: Int
+
+    init(_ index: Int) {
+        self.index = index
+    }
+
+    var body: some View {
+        Text(String(index))
+            .font(.caption2.monospaced().weight(.semibold))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, Spacing.xs)
+            .frame(minWidth: 18, minHeight: 16)
+            .background(
+                .quaternary,
+                in: RoundedRectangle(cornerRadius: Spacing.xs)
+            )
+            .accessibilityHidden(true)
+    }
+}

--- a/macos/ATC/Features/Sessions/SessionKind.swift
+++ b/macos/ATC/Features/Sessions/SessionKind.swift
@@ -4,16 +4,12 @@ import ATCAPI
 /// Presentation classification copied onto each Session at launch. It never
 /// depends on the current Actions list, so later Action changes cannot alter
 /// an existing session's identity.
-enum SessionKind: Equatable {
+enum SessionKind: Equatable, Sendable {
     case agent
     case terminal
 
     static func classify(session: Session) -> SessionKind {
         guard session.actionId != nil else { return .terminal }
         return session.isAgent ? .agent : .terminal
-    }
-
-    static func displayName(session: Session) -> String {
-        session.name ?? session.actionName ?? "Terminal"
     }
 }

--- a/macos/ATC/Features/Sessions/SessionsStore.swift
+++ b/macos/ATC/Features/Sessions/SessionsStore.swift
@@ -79,7 +79,7 @@ final class SessionsStore {
     }
 
     @discardableResult
-    func rename(id: String, name: String) async throws -> Session {
+    func rename(id: String, name: String?) async throws -> Session {
         let session = try await client.renameSession(id: id, name: name)
         merge(session)
         scheduleRefresh()

--- a/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
+++ b/macos/ATC/Features/Workspaces/WorkspaceShellView.swift
@@ -8,16 +8,8 @@ struct WorkspaceNavigatorView: View {
     @Environment(WindowState.self) private var windowState
 
     @State private var actionError: String?
-    @State private var deletingSession: Row?
+    @State private var deletingSession: WorkspaceSessionGroups.Row?
     @State private var renameRequest: SessionRenameRequest?
-
-    private struct Row: Identifiable {
-        let ref: SessionRef
-        let session: Session
-        let title: String
-        let kind: SessionKind
-        var id: SessionRef { ref }
-    }
 
     var body: some View {
         if workspaceRef == nil {
@@ -35,9 +27,7 @@ struct WorkspaceNavigatorView: View {
     @ViewBuilder
     private var navigatorContent: some View {
         @Bindable var windowState = windowState
-        let rows = sidebarRows()
-        let agents = rows.filter { kind(of: $0.session) == .agent }
-        let terminals = rows.filter { kind(of: $0.session) == .terminal }
+        let groups = sessionGroups()
 
         NavigatorList {
             if runtime?.reachability == .unreachable {
@@ -55,7 +45,7 @@ struct WorkspaceNavigatorView: View {
                 onAdd: { windowState.startSessionKind = .agentSession }
             )
             if windowState.isSessionsSectionExpanded {
-                sessionRows(agents, emptyText: "No sessions")
+                sessionRows(groups.sessions, emptyText: "No sessions")
             }
 
             NavigatorDisclosureHeader(
@@ -66,11 +56,11 @@ struct WorkspaceNavigatorView: View {
                 onAdd: { windowState.startSessionKind = .terminal }
             )
             if windowState.isTerminalsSectionExpanded {
-                sessionRows(terminals, emptyText: "No terminals")
+                sessionRows(groups.terminals, emptyText: "No terminals")
             }
         }
         .confirmationDialog(
-            "Delete Session “\(deletingSession?.title ?? "")”?",
+            "Delete Session “\(deletingSession?.identity.indexedLabel ?? "")”?",
             isPresented: Binding(
                 get: { deletingSession != nil },
                 set: { if !$0 { deletingSession = nil } }
@@ -83,7 +73,7 @@ struct WorkspaceNavigatorView: View {
         } message: {
             if let row = deletingSession {
                 Text(DeleteConfirmation.sessionMessage(
-                    displayName: row.title,
+                    displayName: row.identity.indexedLabel,
                     status: row.session.status
                 ))
             }
@@ -104,7 +94,7 @@ struct WorkspaceNavigatorView: View {
 
     @ViewBuilder
     private func sessionRows(
-        _ rows: [Row],
+        _ rows: [WorkspaceSessionGroups.Row],
         emptyText: String
     ) -> some View {
         ForEach(rows) { row in
@@ -113,7 +103,10 @@ struct WorkspaceNavigatorView: View {
                 action: { _ = windowState.selectSession(row.ref, in: appModel) }
             ) { _ in
                 HStack(spacing: Spacing.xs) {
-                    Text(row.title)
+                    if let index = row.identity.index {
+                        SessionIndexBadge(index)
+                    }
+                    Text(row.identity.fullLabel)
                         .lineLimit(1)
                     if row.session.status == .ended {
                         StatusDot(color: .red)
@@ -124,6 +117,13 @@ struct WorkspaceNavigatorView: View {
             } actions: {
                 EmptyView()
             }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(
+                row.session.status == .ended
+                    ? "\(row.identity.accessibilityLabel), Ended"
+                    : row.identity.accessibilityLabel
+            )
+            .help(row.identity.indexedLabel)
             .contextMenu { sessionMenu(row) }
         }
         if rows.isEmpty {
@@ -135,12 +135,12 @@ struct WorkspaceNavigatorView: View {
     }
 
     @ViewBuilder
-    private func sessionMenu(_ row: Row) -> some View {
+    private func sessionMenu(_ row: WorkspaceSessionGroups.Row) -> some View {
         if row.session.status == .live {
             Button("Rename…", systemImage: "pencil") {
                 renameRequest = SessionRenameRequest(
                     ref: row.ref,
-                    title: row.title,
+                    identity: row.identity,
                     kind: row.kind
                 )
             }
@@ -172,26 +172,12 @@ struct WorkspaceNavigatorView: View {
         return runtime.sessions.sessions.filter { $0.belongs(to: ref) }
     }
 
-    private func kind(of session: Session) -> SessionKind {
-        SessionKind.classify(session: session)
+    private func sessionGroups() -> WorkspaceSessionGroups {
+        guard let ref = workspaceRef else { return .empty }
+        return WorkspaceSessionGroups(workspace: ref, sessions: workspaceSessions())
     }
 
-    /// Ordered sidebar rows: the Active Workspace's sessions, newest-first.
-    private func sidebarRows() -> [Row] {
-        guard let ref = workspaceRef else { return [] }
-        return workspaceSessions()
-            .sortedNewestFirst()
-            .map { session in
-                return Row(
-                    ref: SessionRef(connectionID: ref.connectionID, sessionID: session.id),
-                    session: session,
-                    title: SessionKind.displayName(session: session),
-                    kind: SessionKind.classify(session: session)
-                )
-            }
-    }
-
-    private func deleteSession(_ row: Row) {
+    private func deleteSession(_ row: WorkspaceSessionGroups.Row) {
         appModel.deleteSession(ref: row.ref, windowState: windowState, reporting: $actionError)
     }
 
@@ -216,23 +202,29 @@ struct WorkspaceNavigatorView: View {
 struct SessionRenameRequest: Equatable {
     let ref: SessionRef
     let kind: SessionKind
+    let identity: SessionIdentity
+    private let originalName: String?
     var draft: String
 
-    init(ref: SessionRef, title: String, kind: SessionKind) {
+    init(ref: SessionRef, identity: SessionIdentity, kind: SessionKind) {
         self.ref = ref
         self.kind = kind
-        self.draft = title
+        self.identity = identity
+        originalName = identity.customName
+        draft = identity.customName ?? ""
     }
 
     var dialogTitle: String {
-        kind == .agent ? "Rename Session" : "Rename Terminal"
+        let category = kind == .agent ? "Session" : "Terminal"
+        return "Rename \(category) “\(identity.indexedLabel)”"
     }
 
-    var normalizedName: String {
-        draft.trimmingCharacters(in: .whitespacesAndNewlines)
+    var normalizedName: String? {
+        let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     var canSubmit: Bool {
-        !normalizedName.isEmpty
+        normalizedName != originalName
     }
 }

--- a/macos/ATC/Features/Workspaces/WorkspaceSwitcher.swift
+++ b/macos/ATC/Features/Workspaces/WorkspaceSwitcher.swift
@@ -1,90 +1,124 @@
 import SwiftUI
 import ATCAPI
 
-/// The toolbar's workspace pill, styled like Xcode's scheme picker: a
-/// static project prefix, then the workspace name as the one interactive
-/// segment — it alone highlights on hover and reveals the dropdown
-/// chevron. A plain Button + popover, NOT a Menu — toolbar Menus bridge
-/// to a native item that flattens custom labels to text, so composite
-/// content (the badge) never renders inside one. The toolbar already
-/// wraps the item in Liquid Glass, so the label draws no container of
-/// its own — a second glassEffect here nests two capsule outlines.
+/// The toolbar's continuous context pill. Plain Buttons + popovers are used
+/// instead of toolbar Menus because native toolbar Menu labels flatten
+/// composite SwiftUI content such as the Session index badge.
 struct WorkspaceSwitcher: View {
     @Environment(AppModel.self) private var appModel
     @Environment(WindowState.self) private var windowState
 
-    @State private var isPickerPresented = false
-    @State private var isHovering = false
+    @State private var isWorkspacePickerPresented = false
+    @State private var isSessionPickerPresented = false
+    @State private var isWorkspaceHovering = false
+    @State private var isSessionHovering = false
 
     var body: some View {
         let presentation = activeContext.map {
             WorkspaceSwitcherPresentation(
                 project: $0.project,
-                workspace: $0.workspace
+                workspace: $0.workspace,
+                session: selectedSession
             )
         } ?? .noActiveWorkspace
-        // Highlight persists while the picker is open, matching Xcode.
-        let isHighlighted = isHovering || isPickerPresented
-        HStack(spacing: Spacing.xs) {
-            if let project = presentation.projectName {
-                Text(project)
-                    .foregroundStyle(.secondary)
-                Text("›")
-                    .foregroundStyle(.tertiary)
-            }
-            Button {
-                isPickerPresented.toggle()
-            } label: {
-                HStack(spacing: Spacing.xs) {
-                    Text(presentation.workspaceName)
-                        .fontWeight(.medium)
-                    // Opacity, not removal: the reserved width keeps the
-                    // pill from shifting as the chevron fades in.
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 9, weight: .semibold))
-                        .foregroundStyle(.tertiary)
-                        .opacity(isHighlighted ? 1 : 0)
-                }
-                .padding(.horizontal, Spacing.sm)
-                .padding(.vertical, 2)
-                .background(
-                    .quaternary.opacity(isHighlighted ? 1 : 0),
-                    in: RoundedRectangle(cornerRadius: 5)
-                )
-                .contentShape(RoundedRectangle(cornerRadius: 5))
-            }
-            .buttonStyle(.plain)
-            .onHover { isHovering = $0 }
-            .popover(isPresented: $isPickerPresented, arrowEdge: .bottom) {
-                WorkspacePicker()
-            }
-            .help(presentation.help)
-            .accessibilityLabel(
-                sessionBadgeLabel.map { "\(presentation.help), \($0)" }
-                    ?? presentation.help
-            )
-            if let sessionBadgeLabel {
-                TagBadge(text: sessionBadgeLabel)
+
+        HStack(spacing: 0) {
+            workspaceRegion(presentation)
+            if let session = presentation.session {
+                sessionRegion(session, help: presentation.help)
             }
         }
         .lineLimit(1)
-        // The toolbar offers custom principal views less than their
-        // natural width, which SwiftUI resolves by squeezing the Texts
-        // into "…" — even short names. fixedSize makes the pill's
-        // intrinsic width non-negotiable.
-        .fixedSize()
-        // Inset the content from the toolbar item's glass capsule so the
-        // hover highlight and badge never crowd its rounded ends.
         .padding(.horizontal, Spacing.md)
     }
 
-    /// The visible session's Agent name or Terminal session name; nil
-    /// whenever no session is the selected content.
-    private var sessionBadgeLabel: String? {
-        guard let ref = windowState.selectedSession,
-              let session = appModel.session(for: ref)
+    private func workspaceRegion(
+        _ presentation: WorkspaceSwitcherPresentation
+    ) -> some View {
+        let isHighlighted = isWorkspaceHovering || isWorkspacePickerPresented
+        return Button {
+            isWorkspacePickerPresented.toggle()
+        } label: {
+            HStack(spacing: Spacing.xs) {
+                if let project = presentation.projectName {
+                    Text(project)
+                        .foregroundStyle(.secondary)
+                        .layoutPriority(1)
+                    Text("›")
+                        .foregroundStyle(.tertiary)
+                }
+                Text(presentation.workspaceName)
+                    .fontWeight(.medium)
+                    .layoutPriority(3)
+                regionChevron(isHighlighted: isHighlighted)
+            }
+            .regionChrome(isHighlighted: isHighlighted)
+        }
+        .buttonStyle(.plain)
+        .onHover { isWorkspaceHovering = $0 }
+        .popover(isPresented: $isWorkspacePickerPresented, arrowEdge: .bottom) {
+            WorkspacePicker()
+        }
+        .help(presentation.workspaceHelp)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Choose Workspace, \(presentation.label)")
+    }
+
+    private func sessionRegion(
+        _ identity: SessionIdentity,
+        help: String
+    ) -> some View {
+        let isHighlighted = isSessionHovering || isSessionPickerPresented
+        return Button {
+            isSessionPickerPresented.toggle()
+        } label: {
+            HStack(spacing: Spacing.xs) {
+                Text("›")
+                    .foregroundStyle(.tertiary)
+                if let index = identity.index {
+                    SessionIndexBadge(index)
+                        .layoutPriority(4)
+                }
+                Text(identity.identityText)
+                    .fontWeight(.medium)
+                    .layoutPriority(4)
+                if let customName = identity.customName {
+                    Text("·")
+                        .foregroundStyle(.tertiary)
+                        .layoutPriority(2)
+                    Text(customName)
+                        .foregroundStyle(.secondary)
+                        .layoutPriority(2)
+                }
+                regionChevron(isHighlighted: isHighlighted)
+            }
+            .regionChrome(isHighlighted: isHighlighted)
+        }
+        .buttonStyle(.plain)
+        .onHover { isSessionHovering = $0 }
+        .popover(isPresented: $isSessionPickerPresented, arrowEdge: .bottom) {
+            WorkspaceSessionPicker()
+        }
+        .help(help)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Choose Session, \(identity.accessibilityLabel)")
+    }
+
+    private func regionChevron(isHighlighted: Bool) -> some View {
+        Image(systemName: "chevron.down")
+            .font(.system(size: 9, weight: .semibold))
+            .foregroundStyle(.tertiary)
+            .opacity(isHighlighted ? 1 : 0)
+    }
+
+    private var selectedSession: Session? {
+        guard let workspace = windowState.activeWorkspace,
+              let ref = windowState.selectedSession,
+              ref.connectionID == workspace.connectionID,
+              let session = appModel.session(for: ref),
+              session.belongs(to: workspace)
         else { return nil }
-        return SessionKind.displayName(session: session)
+        return session
     }
 
     private var activeContext: (project: Project, workspace: Workspace)? {
@@ -94,6 +128,116 @@ struct WorkspaceSwitcher: View {
               let project = runtime.projects.project(id: workspace.projectId)
         else { return nil }
         return (project, workspace)
+    }
+}
+
+/// Pure projection for the Workspace-scoped Session picker.
+struct SessionPickerPresentation: Equatable, Sendable {
+    let groups: WorkspaceSessionGroups
+    let selectedSession: SessionRef?
+
+    init(
+        workspace: WorkspaceRef,
+        sessions: [Session],
+        selectedSession: SessionRef?
+    ) {
+        groups = WorkspaceSessionGroups(workspace: workspace, sessions: sessions)
+        self.selectedSession = selectedSession
+    }
+
+    func isSelected(_ row: WorkspaceSessionGroups.Row) -> Bool {
+        row.ref == selectedSession
+    }
+}
+
+/// Picker for existing Sessions and Terminals in the Active Workspace.
+/// Selection is immediate; creation and filtering intentionally live
+/// elsewhere.
+struct WorkspaceSessionPicker: View {
+    @Environment(AppModel.self) private var appModel
+    @Environment(WindowState.self) private var windowState
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        if let presentation {
+            List {
+                sessionSection(
+                    "Sessions",
+                    rows: presentation.groups.sessions,
+                    emptyText: "No Sessions",
+                    presentation: presentation
+                )
+                sessionSection(
+                    "Terminals",
+                    rows: presentation.groups.terminals,
+                    emptyText: "No Terminals",
+                    presentation: presentation
+                )
+            }
+            .listStyle(.sidebar)
+            .scrollContentBackground(.hidden)
+            .frame(width: 300, height: 300)
+        } else {
+            Text("No Active Workspace")
+                .foregroundStyle(.secondary)
+                .frame(width: 300, height: 160)
+        }
+    }
+
+    @ViewBuilder
+    private func sessionSection(
+        _ title: String,
+        rows: [WorkspaceSessionGroups.Row],
+        emptyText: String,
+        presentation: SessionPickerPresentation
+    ) -> some View {
+        Section(title) {
+            if rows.isEmpty {
+                Text(emptyText)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            } else {
+                ForEach(rows) { row in
+                    Button {
+                        if windowState.selectSession(row.ref, in: appModel) {
+                            dismiss()
+                        }
+                    } label: {
+                        HStack(spacing: Spacing.xs) {
+                            if let index = row.identity.index {
+                                SessionIndexBadge(index)
+                            }
+                            Text(row.identity.fullLabel)
+                                .lineLimit(1)
+                            Spacer()
+                            if presentation.isSelected(row) {
+                                Image(systemName: "checkmark")
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .help(row.identity.indexedLabel)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(row.identity.accessibilityLabel)
+                    .accessibilityAddTraits(
+                        presentation.isSelected(row) ? .isSelected : []
+                    )
+                }
+            }
+        }
+    }
+
+    private var presentation: SessionPickerPresentation? {
+        guard let workspace = windowState.activeWorkspace,
+              let runtime = appModel.runtime(id: workspace.connectionID)
+        else { return nil }
+        return SessionPickerPresentation(
+            workspace: workspace,
+            sessions: runtime.sessions.sessions,
+            selectedSession: windowState.selectedSession
+        )
     }
 }
 
@@ -179,12 +323,27 @@ private struct WorkspacePicker: View {
     }
 }
 
+private extension View {
+    /// Shared hover chrome for each pill region: its own subtle rounded
+    /// highlight while the two regions still read as one continuous path.
+    func regionChrome(isHighlighted: Bool) -> some View {
+        padding(.horizontal, Spacing.sm)
+            .padding(.vertical, 2)
+            .background(
+                .quaternary.opacity(isHighlighted ? 1 : 0),
+                in: RoundedRectangle(cornerRadius: 5)
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 5))
+    }
+}
+
 struct WorkspaceSwitcherPresentation: Equatable {
     /// nil when no Active Workspace is selected — the pill then shows
     /// only `workspaceName` (the placeholder prompt).
     let projectName: String?
     let workspaceName: String
-    let help: String
+    let session: SessionIdentity?
+    let workspaceHelp: String
 
     /// Flat "project › workspace" string for accessibility.
     var label: String {
@@ -194,18 +353,30 @@ struct WorkspaceSwitcherPresentation: Equatable {
     static let noActiveWorkspace = WorkspaceSwitcherPresentation(
         projectName: nil,
         workspaceName: "Select Workspace…",
-        help: "Select an Active Workspace"
+        session: nil,
+        workspaceHelp: "Select an Active Workspace"
     )
 
-    private init(projectName: String?, workspaceName: String, help: String) {
-        self.projectName = projectName
-        self.workspaceName = workspaceName
-        self.help = help
+    var help: String {
+        session.map { "\(workspaceHelp) › \($0.indexedLabel)" } ?? workspaceHelp
     }
 
-    init(project: Project, workspace: Workspace) {
+    private init(
+        projectName: String?,
+        workspaceName: String,
+        session: SessionIdentity?,
+        workspaceHelp: String
+    ) {
+        self.projectName = projectName
+        self.workspaceName = workspaceName
+        self.session = session
+        self.workspaceHelp = workspaceHelp
+    }
+
+    init(project: Project, workspace: Workspace, session: Session? = nil) {
         projectName = project.name
         workspaceName = workspace.name
-        help = "\(project.name) › \(workspace.name)"
+        self.session = session.map(SessionIdentity.init(session:))
+        workspaceHelp = "\(project.name) › \(workspace.name)"
     }
 }

--- a/macos/ATC/PreviewSupport/MockATCClient.swift
+++ b/macos/ATC/PreviewSupport/MockATCClient.swift
@@ -121,6 +121,7 @@ nonisolated struct MockATCClient: ATCClient {
     var mockSessions: [Session] = [
         Session(
             id: "ses_running",
+            sessionIndex: 1,
             name: "Fix the parser",
             actionId: "act_vpj2tlg9viqd8ms52ptuvao5c4",
             actionName: "Claude",
@@ -134,6 +135,7 @@ nonisolated struct MockATCClient: ATCClient {
         ),
         Session(
             id: "ses_starting",
+            sessionIndex: 1,
             actionId: "act_fh9g7e6571qo53r0t647ughtfg",
             actionName: "Codex",
             isAgent: true,
@@ -156,6 +158,7 @@ nonisolated struct MockATCClient: ATCClient {
         ),
         Session(
             id: "ses_done",
+            sessionIndex: 1,
             name: "Yesterday's refactor",
             actionId: "act_vpj2tlg9viqd8ms52ptuvao5c4",
             actionName: "Claude",
@@ -170,6 +173,7 @@ nonisolated struct MockATCClient: ATCClient {
         // Interactive Shell (nil action ID) → classified as a Terminal.
         Session(
             id: "ses_shell",
+            sessionIndex: 2,
             isAgent: false,
             workingDir: "/home/dev/Projects/atelier",
             status: .live,
@@ -181,6 +185,7 @@ nonisolated struct MockATCClient: ATCClient {
         // General (non-agent) action → classified as a Terminal.
         Session(
             id: "ses_lazygit",
+            sessionIndex: 3,
             actionId: "act_00000000000000000000000000",
             actionName: "LazyGit",
             isAgent: false,
@@ -194,6 +199,7 @@ nonisolated struct MockATCClient: ATCClient {
         // Action deleted after the session ended; copied identity remains.
         Session(
             id: "ses_ghost",
+            sessionIndex: 2,
             actionId: "act_11111111111111111111111111",
             actionName: "Deleted Tool",
             isAgent: false,
@@ -207,6 +213,7 @@ nonisolated struct MockATCClient: ATCClient {
         // Another ended agent session.
         Session(
             id: "ses_abandoned",
+            sessionIndex: 4,
             name: "Abandoned attempt",
             actionId: "act_vpj2tlg9viqd8ms52ptuvao5c4",
             actionName: "Claude",
@@ -263,6 +270,11 @@ nonisolated struct MockATCClient: ATCClient {
         }
         let session = Session(
             id: "ses_" + String(UUID().uuidString.lowercased().prefix(8)),
+            sessionIndex: mockSessions
+                .filter { $0.workspace?.id == workspace.id }
+                .compactMap(\.sessionIndex)
+                .max()
+                .map { $0 + 1 } ?? 1,
             name: request.name,
             actionId: action?.id,
             actionName: action?.name,

--- a/macos/ATC/Shared/DomainRules.swift
+++ b/macos/ATC/Shared/DomainRules.swift
@@ -1,9 +1,8 @@
 import Foundation
 import ATCAPI
 
-/// The one display order for Workspace and Session lists: newest-created
-/// first, with a stable id tiebreak so equal timestamps keep a
-/// deterministic order across renders.
+/// Shared creation metadata used by Workspace ordering and the legacy
+/// fallback for index-less Sessions.
 protocol CreatedOrdered {
     var createdAt: Date { get }
     var id: String { get }
@@ -17,6 +16,28 @@ extension Sequence where Element: CreatedOrdered {
         sorted {
             if $0.createdAt != $1.createdAt { return $0.createdAt > $1.createdAt }
             return $0.id < $1.id
+        }
+    }
+}
+
+extension Sequence where Element == Session {
+    /// Workspace Session address order: indexed Sessions first and ascending,
+    /// then legacy index-less Sessions by creation time and stable ID.
+    func sortedBySessionIndex() -> [Session] {
+        sorted {
+            switch ($0.sessionIndex, $1.sessionIndex) {
+            case let (lhs?, rhs?) where lhs != rhs:
+                return lhs < rhs
+            case (_?, nil):
+                return true
+            case (nil, _?):
+                return false
+            default:
+                if $0.createdAt != $1.createdAt {
+                    return $0.createdAt < $1.createdAt
+                }
+                return $0.id < $1.id
+            }
         }
     }
 }

--- a/macos/ATCTests/CommandPaletteContentTests.swift
+++ b/macos/ATCTests/CommandPaletteContentTests.swift
@@ -134,7 +134,11 @@ struct CommandPaletteContentTests {
         } == ["Alpha:wsp_b", "same:wsp_a", "Same:wsp_z"])
         #expect(projected.compactMap(\.sessionRow).map {
             "\($0.title):\($0.ref.sessionID)"
-        } == ["Alpha:ses_b", "same:ses_a", "Same:ses_z"])
+        } == [
+            "Shell · Alpha:ses_b",
+            "Shell · same:ses_a",
+            "Shell · Same:ses_z",
+        ])
     }
 
     @Test("keyword expansion keeps bucket and alphabetical ordering")
@@ -161,7 +165,9 @@ struct CommandPaletteContentTests {
         #expect(projected.compactMap(\.workspaceRow).map(\.title) == [
             "Session Alpha", "Session Zoo",
         ])
-        #expect(projected.compactMap(\.sessionRow).map(\.title) == ["Alpha", "Zulu"])
+        #expect(projected.compactMap(\.sessionRow).map(\.title) == [
+            "Claude · Alpha", "Claude · Zulu",
+        ])
         #expect(projected.map { result in
             switch result {
             case .command: "command"
@@ -194,7 +200,7 @@ struct CommandPaletteContentTests {
         let sessionRows = projected.compactMap(\.sessionRow)
 
         #expect(projected.compactMap(\.commandRow).map(\.title).contains("New Terminal"))
-        #expect(sessionRows.map(\.ref.sessionID) == ["category-only", "title-match"])
+        #expect(sessionRows.map(\.ref.sessionID) == ["title-match", "category-only"])
         #expect(sessionRows.filter { $0.ref.sessionID == "title-match" }.count == 1)
         let titleMatch = try #require(sessionRows.first {
             $0.ref.sessionID == "title-match"
@@ -245,7 +251,7 @@ struct CommandPaletteContentTests {
         #expect(workspaceRows.allSatisfy { !$0.availability.isAvailable })
         #expect(!projected.compactMap(\.sessionRow).isEmpty)
         #expect(projected.compactMap(\.sessionRow).allSatisfy {
-            $0.title == "Fix the parser"
+            $0.title == "Claude · Fix the parser"
         })
     }
 
@@ -278,13 +284,15 @@ struct CommandPaletteContentTests {
 
         let sessions = results(query: "", presentation: .sessions, fixture: fixture)
         #expect(sessions.count == 2)
-        #expect(sessions.compactMap(\.sessionRow).map(\.title) == ["Alpha Agent", "Zulu Agent"])
+        #expect(sessions.compactMap(\.sessionRow).map(\.title) == [
+            "Claude · Alpha Agent", "Claude · Zulu Agent",
+        ])
         #expect(sessions.compactMap(\.sessionRow).allSatisfy { $0.kind == .agent })
 
         let terminals = results(query: "", presentation: .terminals, fixture: fixture)
         #expect(terminals.count == 2)
         #expect(terminals.compactMap(\.sessionRow).map(\.title) == [
-            "Beta Terminal", "Delta Tool",
+            "LazyGit · Delta Tool", "Shell · Beta Terminal",
         ])
         #expect(terminals.compactMap(\.sessionRow).allSatisfy { $0.kind == .terminal })
     }
@@ -354,7 +362,7 @@ struct CommandPaletteContentTests {
 
         let unscoped = results(query: "ses", presentation: .all, fixture: fixture)
             .compactMap(\.sessionRow)
-        #expect(unscoped.map(\.ref.sessionID) == ["session-other", "session-match"])
+        #expect(unscoped.map(\.ref.sessionID) == ["session-match", "session-other"])
         #expect(unscoped.allSatisfy { $0.kind == .agent })
     }
 
@@ -692,9 +700,9 @@ struct CommandPaletteSessionResultTests {
             paletteSession("tool", actionName: "LazyGit", workspace: "active"),
         ])
         let byID = Dictionary(uniqueKeysWithValues: projected.map { ($0.ref.sessionID, $0) })
-        #expect(byID["named"]?.title == "Fix parser")
+        #expect(byID["named"]?.title == "Claude · Fix parser")
         #expect(byID["named"]?.kind == .agent)
-        #expect(byID["shell"]?.title == "Terminal")
+        #expect(byID["shell"]?.title == "Shell")
         #expect(byID["shell"]?.kind == .terminal)
         #expect(byID["agent"]?.title == "Claude")
         #expect(byID["agent"]?.kind == .agent)
@@ -738,7 +746,7 @@ struct CommandPaletteSessionResultTests {
 
         let terminals = results(query: "ter", active: active, sessions: candidates)
         #expect(terminals.map(\.ref.sessionID) == [
-            "shell-starting", "action-terminated", "unresolved-running",
+            "action-terminated", "unresolved-running", "shell-starting",
         ])
         #expect(terminals.allSatisfy { $0.kind == .terminal && $0.matchedRanges.isEmpty })
     }
@@ -763,11 +771,11 @@ struct CommandPaletteSessionResultTests {
         #expect(try #require(bySessionKeyword.last).matchedRanges.isEmpty)
 
         let byTerminalKeyword = results(query: "ter", active: active, sessions: candidates)
-        #expect(byTerminalKeyword.map(\.ref.sessionID) == ["shell", "agent"])
-        #expect(try #require(byTerminalKeyword.first).matchedRanges.isEmpty)
-        let agentMatch = try #require(byTerminalKeyword.last)
+        #expect(byTerminalKeyword.map(\.ref.sessionID) == ["agent", "shell"])
+        let agentMatch = try #require(byTerminalKeyword.first)
         #expect(agentMatch.kind == .agent)
         #expect(agentMatch.matchedRanges.map { String(agentMatch.title[$0]) } == ["Ter"])
+        #expect(try #require(byTerminalKeyword.last).matchedRanges.isEmpty)
     }
 
     @Test("a two-character keyword prefix never expands")
@@ -782,16 +790,71 @@ struct CommandPaletteSessionResultTests {
         #expect(projected.map(\.ref.sessionID) == ["shell"])
     }
 
-    @Test("hidden Action, status, and raw identifiers never match")
+    @Test("numeric, identity, custom-name, and combined Session queries are additive")
+    func indexedQueries() {
+        let active = WorkspaceRef(connectionID: connectionID, workspaceID: "active")
+        let candidates = [
+            paletteSession(
+                "claude-two", index: 2, name: "API migration",
+                actionName: "Claude", workspace: "active"
+            ),
+            paletteSession(
+                "codex-three", index: 3, name: "Parser cleanup",
+                actionName: "Codex", workspace: "active"
+            ),
+            paletteSession(
+                "title-digit", index: 9, name: "Version 2 shell",
+                workspace: "active"
+            ),
+        ]
+
+        #expect(results(
+            query: "2", active: active, sessions: candidates
+        ).map(\.ref.sessionID) == ["claude-two", "title-digit"])
+        #expect(results(
+            query: "claude", active: active, sessions: candidates
+        ).map(\.ref.sessionID) == ["claude-two"])
+        #expect(results(
+            query: "migration", active: active, sessions: candidates
+        ).map(\.ref.sessionID) == ["claude-two"])
+        #expect(results(
+            query: "2 claude", active: active, sessions: candidates
+        ).map(\.ref.sessionID) == ["claude-two"])
+        #expect(results(
+            query: "2 codex", active: active, sessions: candidates
+        ).isEmpty)
+    }
+
+    @Test("index is the default Session tie-break ahead of title and legacy IDs")
+    func indexTieBreak() {
+        let active = WorkspaceRef(connectionID: connectionID, workspaceID: "active")
+        let projected = results(query: "claude", active: active, sessions: [
+            paletteSession(
+                "legacy", name: "Alpha", actionName: "Claude", workspace: "active"
+            ),
+            paletteSession(
+                "seven", index: 7, name: "Beta", actionName: "Claude", workspace: "active"
+            ),
+            paletteSession(
+                "two", index: 2, name: "Zulu", actionName: "Claude", workspace: "active"
+            ),
+        ])
+
+        #expect(projected.map(\.ref.sessionID) == ["two", "seven", "legacy"])
+        #expect(projected.map(\.identity.index) == [2, 7, nil])
+    }
+
+    @Test("identity and custom names match while status and raw identifiers stay hidden")
     func hiddenFieldsDoNotMatch() {
         let active = WorkspaceRef(connectionID: connectionID, workspaceID: "active")
         let session = paletteSession(
             "raw-identifier", name: "Public Name", actionName: "Claude",
             workspace: "active", status: .ended
         )
-        for query in ["claude", "failed", "raw-identifier"] {
+        for query in ["failed", "raw-identifier"] {
             #expect(results(query: query, active: active, sessions: [session]).isEmpty)
         }
+        #expect(results(query: "claude", active: active, sessions: [session]).count == 1)
         #expect(results(query: "Public", active: active, sessions: [session]).count == 1)
     }
 
@@ -829,7 +892,7 @@ struct CommandPaletteSessionResultTests {
             context: fixture.context,
             presentation: .all
         ).compactMap(\.sessionRow)
-        #expect(projected.map(\.title) == ["Only Active Connection"])
+        #expect(projected.map(\.title) == ["Shell · Only Active Connection"])
     }
 
     private func results(
@@ -987,6 +1050,7 @@ private func paletteWorkspace(
 
 private func paletteSession(
     _ id: String,
+    index: Int? = nil,
     name: String? = nil,
     actionName: String? = nil,
     workspace: String,
@@ -994,6 +1058,7 @@ private func paletteSession(
 ) -> Session {
     return Session(
         id: id,
+        sessionIndex: index,
         name: name,
         actionId: actionName.map { "act_\($0.lowercased())" },
         actionName: actionName,

--- a/macos/ATCTests/NavigationPresentationTests.swift
+++ b/macos/ATCTests/NavigationPresentationTests.swift
@@ -36,6 +36,7 @@ struct NavigationPresentationTests {
         #expect(noActive.projectName == nil)
         #expect(noActive.label == "Select Workspace…")
         #expect(noActive.help == "Select an Active Workspace")
+        #expect(noActive.session == nil)
 
         let active = WorkspaceSwitcherPresentation(
             project: project,
@@ -45,23 +46,100 @@ struct NavigationPresentationTests {
         #expect(active.workspaceName == "Parser")
         #expect(active.label == "Shared › Parser")
         #expect(active.help == active.label)
+        #expect(active.session == nil)
+
+        let session = navigationSession(
+            "ses", index: 7, name: "Migration", actionName: "Codex",
+            isAgent: true
+        )
+        let selected = WorkspaceSwitcherPresentation(
+            project: project,
+            workspace: workspace,
+            session: session
+        )
+        #expect(selected.session?.indexedLabel == "[7] Codex · Migration")
+        #expect(selected.help == "Shared › Parser › [7] Codex · Migration")
     }
 
-    @Test("Session rename request starts with the current display name")
+    @Test("Session rename request edits only the custom name and supports clearing")
     func sessionRenameRequest() {
         let ref = SessionRef(connectionID: UUID(), sessionID: "ses_123")
-        var request = SessionRenameRequest(ref: ref, title: "Current name", kind: .agent)
+        let identity = SessionIdentity(session: navigationSession(
+            ref.sessionID,
+            index: 2,
+            name: "Current name",
+            actionName: "Claude",
+            isAgent: true
+        ))
+        var request = SessionRenameRequest(ref: ref, identity: identity, kind: .agent)
 
         #expect(request.ref == ref)
-        #expect(request.dialogTitle == "Rename Session")
+        #expect(request.dialogTitle == "Rename Session “[2] Claude · Current name”")
         #expect(request.draft == "Current name")
-        #expect(request.canSubmit)
-
-        request.draft = " \n "
         #expect(!request.canSubmit)
 
-        request = SessionRenameRequest(ref: ref, title: "  New name\n", kind: .terminal)
-        #expect(request.dialogTitle == "Rename Terminal")
+        request.draft = " \n "
+        #expect(request.canSubmit)
+        #expect(request.normalizedName == nil)
+
+        request.draft = "  New name\n"
         #expect(request.normalizedName == "New name")
+        #expect(request.canSubmit)
+
+        let unnamed = SessionIdentity(session: navigationSession(
+            ref.sessionID,
+            index: 3,
+            actionName: nil,
+            isAgent: false
+        ))
+        request = SessionRenameRequest(ref: ref, identity: unnamed, kind: .terminal)
+        #expect(request.dialogTitle == "Rename Terminal “[3] Shell”")
+        #expect(request.draft.isEmpty)
+        #expect(!request.canSubmit)
     }
+
+    @Test("Session picker groups rows and marks the current selection")
+    func sessionPickerPresentation() throws {
+        let connectionID = UUID()
+        let workspace = WorkspaceRef(connectionID: connectionID, workspaceID: "wsp")
+        let terminal = navigationSession(
+            "terminal", index: 1, actionName: nil, isAgent: false
+        )
+        let agent = navigationSession(
+            "agent", index: 2, actionName: "Codex", isAgent: true
+        )
+        let selected = SessionRef(connectionID: connectionID, sessionID: terminal.id)
+        let presentation = SessionPickerPresentation(
+            workspace: workspace,
+            sessions: [agent, terminal],
+            selectedSession: selected
+        )
+
+        #expect(presentation.groups.sessions.map(\.ref.sessionID) == ["agent"])
+        #expect(presentation.groups.terminals.map(\.ref.sessionID) == ["terminal"])
+        #expect(presentation.isSelected(try #require(presentation.groups.terminals.first)))
+        #expect(!presentation.isSelected(try #require(presentation.groups.sessions.first)))
+    }
+}
+
+private func navigationSession(
+    _ id: String,
+    index: Int?,
+    name: String? = nil,
+    actionName: String?,
+    isAgent: Bool
+) -> Session {
+    Session(
+        id: id,
+        sessionIndex: index,
+        name: name,
+        actionId: actionName.map { _ in "act_\(id)" },
+        actionName: actionName,
+        isAgent: isAgent,
+        workingDir: "/tmp",
+        status: .live,
+        createdAt: .now,
+        updatedAt: .now,
+        workspace: SessionWorkspace(id: "wsp", name: "Workspace")
+    )
 }

--- a/macos/ATCTests/PickerHostingSmokeTest.swift
+++ b/macos/ATCTests/PickerHostingSmokeTest.swift
@@ -36,4 +36,34 @@ struct PickerHostingSmokeTest {
         pump(seconds: 0.5)
         window.orderOut(nil)
     }
+
+    @MainActor
+    @Test("indexed toolbar context pill hosts without crashing")
+    func hostWorkspaceSwitcher() async throws {
+        let model = AppModel.preview()
+        await model.refreshAll()
+        let state = WindowState.ephemeral()
+        let connectionID = try #require(model.runtimes.first?.id)
+        let workspace = WorkspaceRef(
+            connectionID: connectionID,
+            workspaceID: "wsp_parser"
+        )
+        #expect(state.activateWorkspace(workspace, in: model))
+        #expect(state.selectSession(
+            SessionRef(connectionID: connectionID, sessionID: "ses_running"),
+            in: model
+        ))
+
+        let switcher = WorkspaceSwitcher()
+            .environment(model)
+            .environment(state)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 560, height: 80),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        window.contentView = NSHostingView(rootView: switcher)
+        window.orderFront(nil)
+        pump(seconds: 0.25)
+        window.orderOut(nil)
+    }
 }

--- a/macos/ATCTests/SessionKindTests.swift
+++ b/macos/ATCTests/SessionKindTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 import ATCAPI
 @testable import ATC
@@ -5,6 +6,7 @@ import ATCAPI
 @Suite("SessionKind")
 struct SessionKindTests {
     private func session(
+        index: Int? = nil,
         name: String? = nil,
         actionId: String? = "act_x",
         actionName: String? = "Action",
@@ -12,6 +14,7 @@ struct SessionKindTests {
     ) -> Session {
         Session(
             id: "ses_x",
+            sessionIndex: index,
             name: name,
             actionId: actionId,
             actionName: actionName,
@@ -45,15 +48,94 @@ struct SessionKindTests {
         )
 
         #expect(SessionKind.classify(session: deletedAgent) == .agent)
-        #expect(SessionKind.displayName(session: deletedAgent) == "Deleted Agent")
+        #expect(SessionIdentity(session: deletedAgent).identityText == "Deleted Agent")
     }
 
-    @Test("display name uses session name, copied action name, then Terminal")
-    func displayNameFallbacks() {
-        #expect(SessionKind.displayName(session: session(name: "Fix parser")) == "Fix parser")
-        #expect(SessionKind.displayName(session: session(name: "")) == "")
-        #expect(SessionKind.displayName(
-            session: session(actionId: nil, actionName: nil)
-        ) == "Terminal")
+    @Test("identity keeps launch identity ahead of the optional custom name")
+    func identityProjection() {
+        let agent = SessionIdentity(session: session(
+            index: 2,
+            name: "API migration",
+            actionName: "Codex",
+            isAgent: true
+        ))
+        #expect(agent.index == 2)
+        #expect(agent.identityText == "Codex")
+        #expect(agent.customName == "API migration")
+        #expect(agent.fullLabel == "Codex · API migration")
+        #expect(agent.indexedLabel == "[2] Codex · API migration")
+        #expect(agent.accessibilityLabel == "Session 2, Codex, API migration")
+
+        let action = SessionIdentity(session: session(actionName: "Editor"))
+        #expect(action.identityText == "Editor")
+        #expect(action.fullLabel == "Editor")
+
+        let shell = SessionIdentity(session: session(
+            name: "Scratch",
+            actionId: nil,
+            actionName: nil
+        ))
+        #expect(shell.identityText == "Shell")
+        #expect(shell.fullLabel == "Shell · Scratch")
+    }
+
+    @Test("legacy identity omits the index and blank custom names")
+    func legacyIdentity() {
+        let identity = SessionIdentity(session: session(
+            name: " \n ",
+            actionName: "Claude",
+            isAgent: true
+        ))
+        #expect(identity.index == nil)
+        #expect(identity.customName == nil)
+        #expect(identity.indexedLabel == "Claude")
+        #expect(identity.accessibilityLabel == "Claude")
+    }
+}
+
+@Suite("Workspace Session groups")
+struct WorkspaceSessionGroupsTests {
+    @Test("groups ascend by shared index and place legacy Sessions last")
+    func indexedOrdering() {
+        let workspace = WorkspaceRef(connectionID: UUID(), workspaceID: "wsp")
+        let base = Date(timeIntervalSince1970: 1_000)
+        let groups = WorkspaceSessionGroups(workspace: workspace, sessions: [
+            groupedSession("agent-legacy-new", createdAt: base.addingTimeInterval(20), isAgent: true),
+            groupedSession("terminal-six", index: 6, createdAt: base, isAgent: false),
+            groupedSession("agent-four", index: 4, createdAt: base, isAgent: true),
+            groupedSession("terminal-two", index: 2, createdAt: base, isAgent: false),
+            groupedSession("agent-one", index: 1, createdAt: base, isAgent: true),
+            groupedSession("terminal-legacy", createdAt: base.addingTimeInterval(10), isAgent: false),
+            groupedSession("agent-legacy-old", createdAt: base.addingTimeInterval(10), isAgent: true),
+        ])
+
+        #expect(groups.sessions.map(\.identity.index) == [1, 4, nil, nil])
+        #expect(groups.sessions.map(\.ref.sessionID) == [
+            "agent-one", "agent-four", "agent-legacy-old", "agent-legacy-new",
+        ])
+        #expect(groups.terminals.map(\.identity.index) == [2, 6, nil])
+        #expect(groups.terminals.map(\.ref.sessionID) == [
+            "terminal-two", "terminal-six", "terminal-legacy",
+        ])
+    }
+
+    private func groupedSession(
+        _ id: String,
+        index: Int? = nil,
+        createdAt: Date,
+        isAgent: Bool
+    ) -> Session {
+        Session(
+            id: id,
+            sessionIndex: index,
+            actionId: "act_\(id)",
+            actionName: isAgent ? "Codex" : "Editor",
+            isAgent: isAgent,
+            workingDir: "/tmp",
+            status: .live,
+            createdAt: createdAt,
+            updatedAt: createdAt,
+            workspace: SessionWorkspace(id: "wsp", name: "Workspace")
+        )
     }
 }

--- a/macos/ATCTests/SessionsStoreTests.swift
+++ b/macos/ATCTests/SessionsStoreTests.swift
@@ -16,6 +16,7 @@ struct SessionsStoreTests {
         #expect(started.actionId == "act_vpj2tlg9viqd8ms52ptuvao5c4")
         #expect(started.actionName == "Claude")
         #expect(started.isAgent)
+        #expect(started.sessionIndex == 5)
     }
 
     @Test("start without an Action ID returns an Interactive Shell Session")
@@ -29,6 +30,7 @@ struct SessionsStoreTests {
         #expect(started.actionId == nil)
         #expect(started.actionName == nil)
         #expect(!started.isAgent)
+        #expect(started.sessionIndex == 5)
     }
 
     @Test("rename merges the authoritative Session immediately")
@@ -46,5 +48,19 @@ struct SessionsStoreTests {
         #expect(renamed.actionId == target.actionId)
         #expect(renamed.actionName == target.actionName)
         #expect(renamed.isAgent == target.isAgent)
+    }
+
+    @Test("rename passes nil through to clear the custom name")
+    func renameClears() async throws {
+        let store = SessionsStore(client: MockATCClient())
+        await store.refresh()
+        let target = try #require(store.session(id: "ses_running"))
+        #expect(target.name != nil)
+
+        let renamed = try await store.rename(id: target.id, name: nil)
+
+        #expect(renamed.name == nil)
+        #expect(store.session(id: target.id)?.name == nil)
+        #expect(SessionIdentity(session: renamed).fullLabel == "Claude")
     }
 }

--- a/macos/CONTEXT.md
+++ b/macos/CONTEXT.md
@@ -1,6 +1,6 @@
 # atc
 
-atc is a native client for working with atc Terminal Sessions on a remote workstation.
+atc is a native client for working with atc Sessions on a remote workstation.
 
 ## Language
 
@@ -21,22 +21,28 @@ _Avoid_: Local project, app project
 A Server-owned task context within one Project. In the initial version, every Workspace uses its Project's default folder, owns its Sessions, and persists after they end. Its name is user-owned, renameable, and need not be unique. Deleting a Workspace never changes its working directory or other filesystem state, but stops and deletes all of its associated Sessions only after every stop succeeds.
 _Avoid_: Checkout, worktree
 
-**Terminal Session**:
-A Server-owned terminal process created on a particular atc server. A Terminal Session belongs to its Workspace, except for legacy Project-scoped sessions. Its lifecycle is Live or Ended; Ended is a retained read-only tombstone shown only after the server confirms the backing zmx session is absent. Transport and attach failures remain retryable and do not end it.
-_Avoid_: Terminal, shell
+**Session**:
+A Server-owned terminal process created on a particular atc server. A Session belongs to its Workspace, except for legacy Project-scoped Sessions. Its lifecycle is Live or Ended; Ended is a retained read-only tombstone shown only after the server confirms the backing zmx session is absent. Transport and attach failures remain retryable and do not end it.
+_Avoid_: Terminal Session, shell
 
-**Agent Session**:
-A Terminal Session configured to run a coding agent such as Codex or Claude Code. A Workspace may have multiple Agent Sessions.
-_Avoid_: Agent
-A Workspace Session that opens the server's default Interactive Shell or runs an Action from the Terminal creation flow. The macOS sidebar labels this group Terminals; the server treats it as a generic Session.
-_Avoid_: Shell, generic Session
+**Session Identity**:
+The macOS user-facing identity copied onto a Session at launch: its Agent or Action name, or `Shell` for the Interactive Shell. An indexed Session presents as `[index] Identity`, followed by ` · Custom Name` when set; the optional Custom Name supplements and never replaces the identity.
+_Avoid_: Session name, Terminal
+
+**Session Index**:
+An immutable positive Workspace-local address allocated by the server in one namespace shared by Sessions and Terminals. The Workspace Navigator and Session picker sort each group by ascending Session Index; gaps are expected, and legacy index-less Sessions sort last.
+_Avoid_: Session ID, row number
+
+**Terminal**:
+The macOS category for a Workspace Session that opens the server's default Interactive Shell or runs a non-Agent Action from the Terminal creation flow. It appears in the Terminals group, but its Session Identity is `Shell` or the Action name, never `Terminal`.
+_Avoid_: Terminal Session, Shell Session
 
 **Agent Session**:
 A Workspace Session started from an Agent Action, such as Codex or Claude Code. The macOS sidebar labels this group Sessions; it remains a generic server Session and may later report Agent Activity.
 _Avoid_: Agent
 
 **Focused Sidebar Row**:
-The Workspace, Agent Session, or Terminal Session row currently targeted by keyboard navigation in the sidebar. A Focused Sidebar Row is distinct from the selected Session because Workspaces can be focused without becoming the active detail content.
+The Workspace, Agent Session, or Terminal row currently targeted by keyboard navigation in the sidebar. A Focused Sidebar Row is distinct from the selected Session because Workspaces can be focused without becoming the active detail content.
 _Avoid_: Highlighted Entry, selected row
 
 **Remote Workspace Root**:
@@ -52,5 +58,5 @@ The current viewed remote directory that atc will use as a session working direc
 _Avoid_: Selected file, selected row
 
 **Command Sequence**:
-A two-step atc interaction that starts with the configured leader (`Cmd-K` by default), waits for one continuation key (modified or unmodified), and targets atc itself, including when a Terminal Session has focus. A Command Sequence is not a Keyboard Shortcut.
+A two-step atc interaction that starts with the configured leader (`Cmd-K` by default), waits for one continuation key (modified or unmodified), and targets atc itself, including when a Session has focus. A Command Sequence is not a Keyboard Shortcut.
 _Avoid_: Keyboard Shortcut, terminal prefix, command chord


### PR DESCRIPTION
## Summary

Implements [ATC-51](https://linear.app/elevenideas/issue/ATC-51/adopt-indexed-session-identity-and-navigation-in-macos): the macOS app adopts the server-owned Session index everywhere a Session is presented or navigated.

**Stacked on #117 (ATC-50)** — merge that first; this PR's base is `atc-50-session-indexes`.

### Shared identity
- New `SessionIdentity` projection: identity text is the agent/Action name, or `Shell` for the Interactive Shell; the optional custom name renders after a middle dot and never replaces identity. `SessionKind.displayName` is removed — every surface consumes the one projection.
- New reusable `SessionIndexBadge` (rounded square, monospaced semibold, quaternary fill); omitted gracefully for legacy index-less Sessions.

### Navigation
- Workspace Navigator and the new Session picker group rows via one shared `WorkspaceSessionGroups` projection, sorted by ascending Session index (legacy Sessions last by createdAt, id); agent/terminal groups keep gaps from the shared namespace.
- The separate toolbar Session badge is replaced by a continuous two-region context pill: `Project › Workspace › [n] Identity`. Region 1 opens the existing Workspace picker; region 2 opens a Workspace-scoped Session picker (grouped, checkmark on current, immediate switch, no search/creation) and disappears when no Session is selected. Truncation priority: index+identity, workspace, custom name, project; full path in hover help.

### Command Palette
- Session results render the index badge separately. Matching is additive: `2` matches index 2, `claude` matches identity, custom names match, `2 claude` combines both. Ordering: index match > title match > type-keyword expansion, then ascending index, then existing tie-breaks. Buckets, type keywords, and scoped palettes unchanged.

### Rename
- The rename dialog edits only the custom name and clears it on empty submit (explicit-null rename from ATC-50); unchanged drafts can't submit.

### Docs
- `macos/CONTEXT.md` gains Session Identity / Session Index vocabulary (and drops stale `Terminal Session` wording); `.memory/CONTEXT.md`'s Workspace Switcher entry now describes the two-region context pill.

### Tests
- Identity projection, shared-group ordering, indexed palette matching/tie-breaks, picker presentation, rename set/clear, plus a hosting smoke test for the new pill. Full `mise run macos:test` green.

Part of the ATC-48 series.