### PR TITLE
macOS: local Workspace startup configuration and editor (ATC-49)

### DIFF
--- a/.memory/adr/0003-workspace-startup-is-local-app-state.md
+++ b/.memory/adr/0003-workspace-startup-is-local-app-state.md
@@ -1,0 +1,3 @@
+# Workspace Startup Configuration is local app state
+
+The macOS app stores Workspace Startup Configuration as versioned UserDefaults state keyed by local Connection UUID, with Project overrides keyed by Connection UUID and stable server Project ID. A Project uses Connection defaults with live inheritance unless changed to Custom, which copies the current defaults once and remains independent, including when explicitly empty. This preference belongs to the app installation rather than the server or `macos.toml`; removing a Connection clears all of its startup state, and an app-initiated successful Project deletion clears that Project's override.

--- a/macos/ATC/AppModel.swift
+++ b/macos/ATC/AppModel.swift
@@ -34,6 +34,7 @@ struct WindowNavigationSnapshot: Equatable {
 @Observable
 final class AppModel {
     let connections: ConnectionsStore
+    let workspaceStartup: WorkspaceStartupStore
     private(set) var runtimes: [ConnectionRuntime] = []
 
     /// Live terminal attaches by composite ref. Connections and surfaces
@@ -65,10 +66,12 @@ final class AppModel {
         clientFactory: ((ConnectionRecord) -> any ATCClient)? = nil,
         terminalControllerFactory: ((String, any ATCClient) -> TerminalSessionController)? = nil,
         terminalRecoveryMonitor: TerminalRecoveryMonitor? = nil,
+        workspaceStartupDefaults: UserDefaults = .standard,
         attachmentBudget: Int = 12
     ) {
         self.attachmentBudget = attachmentBudget
         self.connections = connections ?? ConnectionsStore()
+        self.workspaceStartup = WorkspaceStartupStore(defaults: workspaceStartupDefaults)
         self.clientFactory = clientFactory ?? { record in
             // makeRuntime rejects records whose urlString doesn't parse, so
             // the unwrap here can't be reached with a corrupted record.
@@ -214,9 +217,27 @@ final class AppModel {
     /// navigation references are reconciled by `WindowState`.
     func removeConnection(id: UUID) {
         connections.remove(id: id)
+        workspaceStartup.removeConnection(connectionID: id)
         guard let index = runtimes.firstIndex(where: { $0.id == id }) else { return }
         teardown(runtimes[index])
         runtimes.remove(at: index)
+    }
+
+    /// Deletes a Project on its server, then removes its local startup
+    /// override only after the server mutation succeeds.
+    func deleteProject(_ ref: ProjectRef) async throws {
+        guard let runtime = runtime(id: ref.connectionID) else {
+            throw ATCError.api(
+                code: "connection_not_found",
+                message: "This connection no longer exists.",
+                sessionID: nil
+            )
+        }
+        try await runtime.projects.delete(id: ref.projectID)
+        workspaceStartup.removeProject(
+            connectionID: ref.connectionID,
+            projectID: ref.projectID
+        )
     }
 
     // MARK: - Terminal registry

--- a/macos/ATC/ConnectionRuntime.swift
+++ b/macos/ATC/ConnectionRuntime.swift
@@ -10,10 +10,13 @@ struct SessionRef: Hashable, Sendable {
     let sessionID: String
 }
 
-/// Composite identity for a project (see `SessionRef`).
-struct ProjectRef: Hashable, Sendable {
+/// Composite identity for a project (see `SessionRef`). Identifiable so a
+/// ProjectRef can drive item-based sheet presentation directly.
+struct ProjectRef: Hashable, Sendable, Identifiable {
     let connectionID: UUID
     let projectID: String
+
+    var id: Self { self }
 }
 
 /// Composite identity for a workspace (see `SessionRef`).

--- a/macos/ATC/Features/Dashboard/DashboardView.swift
+++ b/macos/ATC/Features/Dashboard/DashboardView.swift
@@ -6,6 +6,7 @@ import ATCAPI
 /// destination inside the stable window split view.
 struct DashboardView: View {
     @Environment(AppModel.self) private var appModel
+    @Environment(WindowState.self) private var windowState
     /// Opens a Workspace in the shell.
     var onOpenWorkspace: (WorkspaceRef) -> Void
     /// Presents the create-Workspace sheet fixed to a Project.
@@ -151,10 +152,9 @@ struct DashboardView: View {
             )
         ) {
             Button("Delete Project", role: .destructive) {
-                if let card = deletingProject,
-                   let store = appModel.runtime(id: card.ref.connectionID)?.projects {
+                if let card = deletingProject {
                     appModel.run(on: card.ref.connectionID, reporting: $actionError) {
-                        try await store.delete(id: card.project.id)
+                        try await appModel.deleteProject(card.ref)
                     }
                 }
             }
@@ -353,6 +353,9 @@ struct DashboardView: View {
             renamingProject = card
         }
         .disabled(!reachable)
+        Button("Workspace Startup…", systemImage: "rectangle.stack.badge.plus") {
+            windowState.workspaceStartupProject = card.ref
+        }
         Divider()
         Button("Delete Project…", systemImage: "trash", role: .destructive) {
             deletingProject = card
@@ -516,5 +519,6 @@ struct DashboardView: View {
         onWorkspaceDeleted: { _ in }
     )
         .environment(AppModel.preview())
+        .environment(WindowState())
         .preferredColorScheme(.dark)
 }

--- a/macos/ATC/Features/WorkspaceStartup/StartupEntryValidation.swift
+++ b/macos/ATC/Features/WorkspaceStartup/StartupEntryValidation.swift
@@ -1,0 +1,66 @@
+import Foundation
+import ATCAPI
+
+enum StartupEntryAvailability: Equatable {
+    case valid
+    case disabled
+    case missing
+    case unableToValidate
+}
+
+struct ValidatedStartupEntry: Identifiable, Equatable {
+    let entryID: UUID
+    let availability: StartupEntryAvailability
+    let cachedActionName: String?
+
+    var id: UUID { entryID }
+}
+
+struct StartupConfigurationValidation: Equatable {
+    let entries: [ValidatedStartupEntry]
+    let canEdit: Bool
+
+    func entry(id: UUID) -> ValidatedStartupEntry? {
+        entries.first { $0.entryID == id }
+    }
+}
+
+enum StartupEntryValidator {
+    /// Validates strictly against the current cache snapshot. Callers decide
+    /// reachability from the owning runtime; this function never causes I/O.
+    static func validate(
+        configuration: StartupConfiguration,
+        actions: [ATCAction],
+        hasLoadedOnce: Bool,
+        isReachable: Bool
+    ) -> StartupConfigurationValidation {
+        let canEdit = hasLoadedOnce && isReachable
+        let actionsByID = Dictionary(uniqueKeysWithValues: actions.map { ($0.id, $0) })
+        let entries = configuration.entries.map { entry in
+            switch entry.target {
+            case .shell:
+                return ValidatedStartupEntry(
+                    entryID: entry.id,
+                    availability: canEdit ? .valid : .unableToValidate,
+                    cachedActionName: nil
+                )
+            case .action(let id):
+                let action = actionsByID[id]
+                let availability: StartupEntryAvailability
+                if !canEdit {
+                    availability = .unableToValidate
+                } else if let action {
+                    availability = action.enabled ? .valid : .disabled
+                } else {
+                    availability = .missing
+                }
+                return ValidatedStartupEntry(
+                    entryID: entry.id,
+                    availability: availability,
+                    cachedActionName: action?.name
+                )
+            }
+        }
+        return StartupConfigurationValidation(entries: entries, canEdit: canEdit)
+    }
+}

--- a/macos/ATC/Features/WorkspaceStartup/WorkspaceStartupEditor.swift
+++ b/macos/ATC/Features/WorkspaceStartup/WorkspaceStartupEditor.swift
@@ -1,0 +1,385 @@
+import SwiftUI
+import ATCAPI
+
+enum WorkspaceStartupEditorTarget: Hashable, Identifiable {
+    case connection(UUID)
+    case project(ProjectRef)
+
+    var id: Self { self }
+}
+
+enum WorkspaceStartupSummary {
+    static func text(
+        configuration: StartupConfiguration,
+        actions: [ATCAction],
+        hasLoadedOnce: Bool
+    ) -> String {
+        guard !configuration.entries.isEmpty,
+              let defaultID = configuration.defaultEntryID,
+              let defaultEntry = configuration.entries.first(where: { $0.id == defaultID })
+        else { return "None configured" }
+
+        let count = configuration.entries.count
+        let countText = count == 1 ? "1 Session" : "\(count) Sessions"
+        let name = defaultName(
+            for: defaultEntry, actions: actions, hasLoadedOnce: hasLoadedOnce
+        )
+        return "\(countText) · Default: \(name)"
+    }
+
+    private static func defaultName(
+        for entry: StartupEntry,
+        actions: [ATCAction],
+        hasLoadedOnce: Bool
+    ) -> String {
+        switch entry.target {
+        case .shell:
+            return "Shell"
+        case .action(let id):
+            let action = actions.first { $0.id == id }
+            // Mirrors the editor's identity labels: before the registry has
+            // loaded, an unknown Action is unvalidated rather than missing.
+            guard hasLoadedOnce else { return action?.name ?? "Action" }
+            guard let action, action.enabled else { return "Unavailable Action" }
+            return action.name
+        }
+    }
+}
+
+/// Shared sheet shell used by Connection Settings and both Project menus.
+struct WorkspaceStartupEditorSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    let target: WorkspaceStartupEditorTarget
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: Spacing.sm) {
+                Image(systemName: "rectangle.stack.badge.plus")
+                    .foregroundStyle(.secondary)
+                Text("Workspace Startup")
+                    .font(.title2.weight(.semibold))
+                Spacer()
+            }
+            .padding(Spacing.lg)
+
+            Divider()
+            WorkspaceStartupEditor(target: target)
+            Divider()
+
+            HStack {
+                Spacer()
+                Button("Done") { dismiss() }
+                    .keyboardShortcut(.defaultAction)
+            }
+            .padding(Spacing.md)
+        }
+        .frame(width: 580, height: 520)
+    }
+}
+
+/// Reusable editor for either Connection defaults or one Project override.
+/// All mutations write through immediately to the local preference store.
+struct WorkspaceStartupEditor: View {
+    @Environment(AppModel.self) private var appModel
+    let target: WorkspaceStartupEditorTarget
+
+    private var store: WorkspaceStartupStore { appModel.workspaceStartup }
+
+    private var connectionID: UUID {
+        switch target {
+        case .connection(let id): id
+        case .project(let ref): ref.connectionID
+        }
+    }
+
+    private var projectRef: ProjectRef? {
+        guard case .project(let ref) = target else { return nil }
+        return ref
+    }
+
+    private var runtime: ConnectionRuntime? {
+        appModel.runtime(id: connectionID)
+    }
+
+    private var actions: [ATCAction] {
+        runtime?.actions.actions ?? []
+    }
+
+    private var configuration: StartupConfiguration {
+        switch target {
+        case .connection(let connectionID):
+            return store.connectionConfiguration(connectionID: connectionID)
+        case .project(let ref):
+            return store.resolvedConfiguration(
+                connectionID: ref.connectionID,
+                projectID: ref.projectID
+            )
+        }
+    }
+
+    private var projectMode: ProjectStartupMode? {
+        projectRef.map {
+            store.projectMode(connectionID: $0.connectionID, projectID: $0.projectID)
+        }
+    }
+
+    private var isDirectlyEditable: Bool {
+        switch target {
+        case .connection:
+            return true
+        case .project:
+            return projectMode == .custom
+        }
+    }
+
+    private var isReachable: Bool {
+        guard let runtime else { return false }
+        if case .connected = runtime.reachability { return true }
+        return false
+    }
+
+    private var validation: StartupConfigurationValidation {
+        StartupEntryValidator.validate(
+            configuration: configuration,
+            actions: actions,
+            hasLoadedOnce: runtime?.actions.hasLoadedOnce ?? false,
+            isReachable: isReachable
+        )
+    }
+
+    private var canEditEntries: Bool {
+        isDirectlyEditable && validation.canEdit
+    }
+
+    var body: some View {
+        Form {
+            if let ref = projectRef {
+                Section("Project Configuration") {
+                    Picker("Mode", selection: projectModeBinding(for: ref)) {
+                        Text("Use Connection Defaults")
+                            .tag(ProjectStartupMode.useConnectionDefaults)
+                        Text("Custom")
+                            .tag(ProjectStartupMode.custom)
+                    }
+                    .pickerStyle(.segmented)
+
+                    if projectMode == .useConnectionDefaults {
+                        Text("This Project follows the Connection configuration, including future changes.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            Section {
+                if configuration.entries.isEmpty {
+                    ContentUnavailableView {
+                        Label("No Startup Sessions", systemImage: "rectangle.stack")
+                    } description: {
+                        Text("Add Actions or an Interactive Shell to use when a Workspace is created.")
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 150)
+                } else {
+                    ForEach(configuration.entries) { entry in
+                        entryRow(entry)
+                    }
+                }
+            } header: {
+                HStack {
+                    Text(projectMode == .useConnectionDefaults ? "Inherited Sessions" : "Sessions")
+                    Spacer()
+                    addMenu
+                }
+            } footer: {
+                if projectMode == .useConnectionDefaults {
+                    Text("Switch to Custom to edit these sessions.")
+                } else if !validation.canEdit {
+                    Text("The Action registry is unavailable. Saved entries are read-only until this Connection loads successfully; you can still clear the configuration.")
+                } else {
+                    Text("Startup order after the Default Session is not significant.")
+                }
+            }
+
+            if !configuration.entries.isEmpty, isDirectlyEditable {
+                Section {
+                    Button("Clear Configuration", role: .destructive) {
+                        updateConfiguration { $0.removeAll() }
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    private var addMenu: some View {
+        let enabledActions = actions.filter(\.enabled)
+        return Menu {
+            Button("Interactive Shell", systemImage: "terminal") {
+                updateConfiguration { $0.add(target: .shell) }
+            }
+            if !enabledActions.isEmpty {
+                Divider()
+                ForEach(enabledActions) { action in
+                    Button(action.name) {
+                        updateConfiguration { $0.add(target: .action(id: action.id)) }
+                    }
+                }
+            }
+        } label: {
+            Label("Add", systemImage: "plus")
+        }
+        .disabled(!canEditEntries)
+        .help(addHelp)
+    }
+
+    private var addHelp: String {
+        if projectMode == .useConnectionDefaults {
+            return "Switch to Custom to add startup sessions"
+        }
+        return canEditEntries
+            ? "Add a startup session"
+            : "A loaded Action registry is required"
+    }
+
+    @ViewBuilder
+    private func entryRow(_ entry: StartupEntry) -> some View {
+        let validated = validation.entry(id: entry.id)
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            HStack(spacing: Spacing.sm) {
+                Label(
+                    identityName(for: entry, validated: validated),
+                    systemImage: identityImage(for: entry)
+                )
+                .font(.headline)
+
+                if configuration.defaultEntryID == entry.id {
+                    Label("Default", systemImage: "star.fill")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(Color.accentColor)
+                } else {
+                    Button("Make Default", systemImage: "star") {
+                        updateConfiguration { $0.transferDefault(to: entry.id) }
+                    }
+                    .labelStyle(.iconOnly)
+                    .buttonStyle(.borderless)
+                    .disabled(!canEditEntries)
+                    .help("Make Default Session")
+                }
+
+                Spacer()
+
+                Button("Remove", systemImage: "minus.circle", role: .destructive) {
+                    updateConfiguration { $0.remove(id: entry.id) }
+                }
+                .labelStyle(.iconOnly)
+                .buttonStyle(.borderless)
+                .disabled(!canEditEntries)
+            }
+
+            TextField(
+                "Custom Name (optional)",
+                text: Binding(
+                    get: { entry.customName ?? "" },
+                    set: { name in
+                        updateConfiguration { $0.setCustomName(name, for: entry.id) }
+                    }
+                )
+            )
+            .disabled(!canEditEntries)
+
+            if let diagnostic = diagnosticText(for: entry, validated: validated) {
+                Text(diagnostic)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+        }
+        .padding(.vertical, Spacing.xs)
+        .help(helpText(for: entry, validated: validated))
+    }
+
+    private func projectModeBinding(for ref: ProjectRef) -> Binding<ProjectStartupMode> {
+        Binding(
+            get: {
+                store.projectMode(connectionID: ref.connectionID, projectID: ref.projectID)
+            },
+            set: { mode in
+                store.setProjectMode(
+                    mode,
+                    connectionID: ref.connectionID,
+                    projectID: ref.projectID
+                )
+            }
+        )
+    }
+
+    private func updateConfiguration(_ update: (inout StartupConfiguration) -> Void) {
+        switch target {
+        case .connection(let connectionID):
+            store.updateConnectionConfiguration(connectionID: connectionID, update)
+        case .project(let ref):
+            store.updateProjectConfiguration(
+                connectionID: ref.connectionID,
+                projectID: ref.projectID,
+                update
+            )
+        }
+    }
+
+    private func identityName(
+        for entry: StartupEntry,
+        validated: ValidatedStartupEntry?
+    ) -> String {
+        switch entry.target {
+        case .shell:
+            return "Shell"
+        case .action:
+            switch validated?.availability {
+            case .disabled, .missing:
+                return "Unavailable Action"
+            case .valid, .unableToValidate:
+                return validated?.cachedActionName ?? "Action"
+            case nil:
+                return "Action"
+            }
+        }
+    }
+
+    private func identityImage(for entry: StartupEntry) -> String {
+        switch entry.target {
+        case .shell: "terminal"
+        case .action: "play.circle"
+        }
+    }
+
+    private func diagnosticText(
+        for entry: StartupEntry,
+        validated: ValidatedStartupEntry?
+    ) -> String? {
+        guard case .action(let id) = entry.target else { return nil }
+        switch validated?.availability {
+        case .disabled:
+            return "Disabled · \(id)"
+        case .missing:
+            return "Missing · \(id)"
+        case .unableToValidate where validated?.cachedActionName == nil:
+            return "Unable to validate · \(id)"
+        case .valid, .unableToValidate, nil:
+            return nil
+        }
+    }
+
+    private func helpText(
+        for entry: StartupEntry,
+        validated: ValidatedStartupEntry?
+    ) -> String {
+        switch entry.target {
+        case .shell:
+            return validated?.availability == .unableToValidate
+                ? "Unable to validate Interactive Shell while the Connection is unavailable"
+                : "Interactive Shell"
+        case .action(let id):
+            return "Action ID: \(id)"
+        }
+    }
+}

--- a/macos/ATC/Features/WorkspaceStartup/WorkspaceStartupModels.swift
+++ b/macos/ATC/Features/WorkspaceStartup/WorkspaceStartupModels.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+struct StartupEntry: Identifiable, Codable, Equatable {
+    enum Target: Codable, Equatable {
+        case action(id: String)
+        case shell
+    }
+
+    let id: UUID
+    let target: Target
+    var customName: String?
+
+    init(id: UUID = UUID(), target: Target, customName: String? = nil) {
+        self.id = id
+        self.target = target
+        self.customName = Self.normalized(customName)
+    }
+
+    mutating func setCustomName(_ name: String) {
+        customName = Self.normalized(name)
+    }
+
+    /// Interior/trailing spaces are preserved so live text-field bindings can
+    /// type through; only an effectively blank name collapses to nil.
+    private static func normalized(_ name: String?) -> String? {
+        guard let name,
+              !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return nil }
+        return name
+    }
+}
+
+/// Value-semantic startup configuration whose mutations preserve the single
+/// Default Session invariant. Decoding also repairs stale or malformed
+/// default references instead of allowing invalid persisted state into the app.
+struct StartupConfiguration: Codable, Equatable {
+    private(set) var entries: [StartupEntry]
+    private(set) var defaultEntryID: UUID?
+
+    static let empty = StartupConfiguration()
+
+    init(entries: [StartupEntry] = [], defaultEntryID: UUID? = nil) {
+        self.entries = entries
+        self.defaultEntryID = Self.validDefault(in: entries, requested: defaultEntryID)
+    }
+
+    @discardableResult
+    mutating func add(
+        target: StartupEntry.Target,
+        customName: String? = nil,
+        id: UUID = UUID()
+    ) -> UUID {
+        let entry = StartupEntry(id: id, target: target, customName: customName)
+        entries.append(entry)
+        if entries.count == 1 {
+            defaultEntryID = entry.id
+        }
+        return entry.id
+    }
+
+    mutating func remove(id: UUID) {
+        guard let index = entries.firstIndex(where: { $0.id == id }) else { return }
+        let removedDefault = defaultEntryID == id
+        entries.remove(at: index)
+        if entries.isEmpty {
+            defaultEntryID = nil
+        } else if removedDefault {
+            defaultEntryID = entries.first?.id
+        }
+    }
+
+    mutating func transferDefault(to id: UUID) {
+        guard entries.contains(where: { $0.id == id }) else { return }
+        defaultEntryID = id
+    }
+
+    mutating func setCustomName(_ name: String, for id: UUID) {
+        guard let index = entries.firstIndex(where: { $0.id == id }) else { return }
+        entries[index].setCustomName(name)
+    }
+
+    mutating func removeAll() {
+        entries = []
+        defaultEntryID = nil
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case entries
+        case defaultEntryID
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let entries = try container.decode([StartupEntry].self, forKey: .entries)
+        let requestedDefault = try container.decodeIfPresent(UUID.self, forKey: .defaultEntryID)
+        self.init(entries: entries, defaultEntryID: requestedDefault)
+    }
+
+    private static func validDefault(in entries: [StartupEntry], requested: UUID?) -> UUID? {
+        guard !entries.isEmpty else { return nil }
+        if let requested, entries.contains(where: { $0.id == requested }) {
+            return requested
+        }
+        return entries[0].id
+    }
+}
+
+enum ProjectStartupMode: String, Codable, CaseIterable, Equatable {
+    case useConnectionDefaults
+    case custom
+}

--- a/macos/ATC/Features/WorkspaceStartup/WorkspaceStartupStore.swift
+++ b/macos/ATC/Features/WorkspaceStartup/WorkspaceStartupStore.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Observation
+
+struct ProjectStartupKey: Codable, Hashable {
+    let connectionID: UUID
+    let projectID: String
+}
+
+/// Local-only Workspace startup preferences. One versioned JSON value keeps
+/// connection defaults and explicit Project overrides atomic and easy to
+/// discard safely if a future or corrupted payload cannot be decoded.
+@MainActor
+@Observable
+final class WorkspaceStartupStore {
+    private struct PersistedState: Codable {
+        var connectionDefaults: [UUID: StartupConfiguration] = [:]
+        // Key presence alone marks a Project as Custom; an empty value is the
+        // valid explicitly-empty override that suppresses Connection defaults.
+        var projectOverrides: [ProjectStartupKey: StartupConfiguration] = [:]
+    }
+
+    private static let key = "workspaceStartup.v1"
+
+    @ObservationIgnored private let defaults: UserDefaults
+    private var connectionDefaults: [UUID: StartupConfiguration]
+    private var projectOverrides: [ProjectStartupKey: StartupConfiguration]
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        let state = Self.load(from: defaults)
+        connectionDefaults = state.connectionDefaults
+        projectOverrides = state.projectOverrides
+    }
+
+    func connectionConfiguration(connectionID: UUID) -> StartupConfiguration {
+        connectionDefaults[connectionID] ?? .empty
+    }
+
+    func projectMode(connectionID: UUID, projectID: String) -> ProjectStartupMode {
+        projectOverrides[ProjectStartupKey(
+            connectionID: connectionID,
+            projectID: projectID
+        )] == nil ? .useConnectionDefaults : .custom
+    }
+
+    func resolvedConfiguration(
+        connectionID: UUID,
+        projectID: String
+    ) -> StartupConfiguration {
+        let key = ProjectStartupKey(connectionID: connectionID, projectID: projectID)
+        if let configuration = projectOverrides[key] {
+            return configuration
+        }
+        return connectionConfiguration(connectionID: connectionID)
+    }
+
+    func setProjectMode(
+        _ mode: ProjectStartupMode,
+        connectionID: UUID,
+        projectID: String
+    ) {
+        let key = ProjectStartupKey(connectionID: connectionID, projectID: projectID)
+        switch mode {
+        case .useConnectionDefaults:
+            guard projectOverrides.removeValue(forKey: key) != nil else { return }
+        case .custom:
+            guard projectOverrides[key] == nil else { return }
+            projectOverrides[key] = connectionConfiguration(connectionID: connectionID)
+        }
+        persist()
+    }
+
+    func updateConnectionConfiguration(
+        connectionID: UUID,
+        _ update: (inout StartupConfiguration) -> Void
+    ) {
+        var configuration = connectionConfiguration(connectionID: connectionID)
+        update(&configuration)
+        if configuration == .empty {
+            connectionDefaults.removeValue(forKey: connectionID)
+        } else {
+            connectionDefaults[connectionID] = configuration
+        }
+        persist()
+    }
+
+    func updateProjectConfiguration(
+        connectionID: UUID,
+        projectID: String,
+        _ update: (inout StartupConfiguration) -> Void
+    ) {
+        let key = ProjectStartupKey(connectionID: connectionID, projectID: projectID)
+        guard var configuration = projectOverrides[key] else { return }
+        update(&configuration)
+        // Keep the explicit override even when empty: custom empty suppresses
+        // the Connection defaults.
+        projectOverrides[key] = configuration
+        persist()
+    }
+
+    func removeConnection(connectionID: UUID) {
+        let removedDefault = connectionDefaults.removeValue(forKey: connectionID) != nil
+        let previousCount = projectOverrides.count
+        projectOverrides = projectOverrides.filter { $0.key.connectionID != connectionID }
+        guard removedDefault || projectOverrides.count != previousCount else { return }
+        persist()
+    }
+
+    func removeProject(connectionID: UUID, projectID: String) {
+        let key = ProjectStartupKey(connectionID: connectionID, projectID: projectID)
+        guard projectOverrides.removeValue(forKey: key) != nil else { return }
+        persist()
+    }
+
+    private static func load(from defaults: UserDefaults) -> PersistedState {
+        guard let data = defaults.data(forKey: key),
+              let state = try? JSONDecoder().decode(PersistedState.self, from: data)
+        else { return PersistedState() }
+        return state
+    }
+
+    private func persist() {
+        let state = PersistedState(
+            connectionDefaults: connectionDefaults,
+            projectOverrides: projectOverrides
+        )
+        guard let data = try? JSONEncoder().encode(state) else { return }
+        defaults.set(data, forKey: Self.key)
+    }
+}

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -193,10 +193,9 @@ struct ProjectsNavigatorView: View {
             )
         ) {
             Button("Delete Project", role: .destructive) {
-                if let group = deletingProject,
-                   let store = appModel.runtime(id: group.ref.connectionID)?.projects {
+                if let group = deletingProject {
                     appModel.run(on: group.ref.connectionID, reporting: $actionError) {
-                        try await store.delete(id: group.project.id)
+                        try await appModel.deleteProject(group.ref)
                     }
                 }
             }
@@ -284,6 +283,9 @@ struct ProjectsNavigatorView: View {
             renamingProject = group
         }
         .disabled(group.reachability != .connected)
+        Button("Workspace Startup…", systemImage: "rectangle.stack.badge.plus") {
+            windowState.workspaceStartupProject = group.ref
+        }
         Divider()
         Button("Delete Project…", systemImage: "trash", role: .destructive) {
             deletingProject = group

--- a/macos/ATC/PreviewSupport/MockATCClient.swift
+++ b/macos/ATC/PreviewSupport/MockATCClient.swift
@@ -12,7 +12,8 @@ extension AppModel {
         return AppModel(
             connections: store,
             clientFactory: { _ in client },
-            terminalRecoveryMonitor: .disabled()
+            terminalRecoveryMonitor: .disabled(),
+            workspaceStartupDefaults: defaults
         )
     }
 
@@ -37,7 +38,8 @@ extension AppModel {
         return AppModel(
             connections: store,
             clientFactory: { clientsByID[$0.id] ?? MockATCClient() },
-            terminalRecoveryMonitor: .disabled()
+            terminalRecoveryMonitor: .disabled(),
+            workspaceStartupDefaults: defaults
         )
     }
 }

--- a/macos/ATC/RootView.swift
+++ b/macos/ATC/RootView.swift
@@ -73,6 +73,9 @@ struct RootView: View {
                 }
             }
         }
+        .sheet(item: $windowState.workspaceStartupProject) { ref in
+            WorkspaceStartupEditorSheet(target: .project(ref))
+        }
         .onChange(of: appModel.windowNavigationSnapshot(), initial: true) {
             appModel.reconcileTerminalLifecycle()
             windowState.reconcile(in: appModel)

--- a/macos/ATC/Settings/ConnectionsSettingsView.swift
+++ b/macos/ATC/Settings/ConnectionsSettingsView.swift
@@ -132,6 +132,7 @@ private struct ConnectionEditorView: View {
     @State private var confirmRebuild = false
 
     @State private var testState: TestState = .idle
+    @State private var workspaceStartupTarget: WorkspaceStartupEditorTarget?
     /// Bumped on every draft edit and every new test; stale results are dropped.
     @State private var testGeneration = 0
 
@@ -202,6 +203,29 @@ private struct ConnectionEditorView: View {
                         Spacer()
                     }
                 }
+                if let record = currentRecord {
+                    Section {
+                        HStack(spacing: Spacing.md) {
+                            Text(WorkspaceStartupSummary.text(
+                                configuration: appModel.workspaceStartup.connectionConfiguration(
+                                    connectionID: record.id
+                                ),
+                                actions: appModel.runtime(id: record.id)?.actions.actions ?? [],
+                                hasLoadedOnce: appModel.runtime(id: record.id)?.actions.hasLoadedOnce ?? false
+                            ))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            Spacer()
+                            Button("Edit…") {
+                                workspaceStartupTarget = .connection(record.id)
+                            }
+                        }
+                    } header: {
+                        Text("Workspace Startup")
+                    } footer: {
+                        Text("Sessions configured here are inherited by Projects that use Connection defaults.")
+                    }
+                }
             }
             .formStyle(.grouped)
 
@@ -227,6 +251,9 @@ private struct ConnectionEditorView: View {
             Button("Save and Disconnect", role: .destructive) { performSave() }
         } message: {
             Text("Changing the URL or token reconnects this connection, and its open terminal sessions will be disconnected. Sessions keep running on the server.")
+        }
+        .sheet(item: $workspaceStartupTarget) { target in
+            WorkspaceStartupEditorSheet(target: target)
         }
     }
 

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -48,11 +48,13 @@ final class WindowState {
     var isCreateProjectPresented = false
     var createWorkspaceContext: CreateWorkspaceContext?
     var startSessionKind: StartSessionKind?
+    var workspaceStartupProject: ProjectRef?
 
     var isSheetPresented: Bool {
         isCreateProjectPresented
             || createWorkspaceContext != nil
             || startSessionKind != nil
+            || workspaceStartupProject != nil
     }
 
     /// Advances for every explicit request to type in the selected Terminal
@@ -173,6 +175,12 @@ final class WindowState {
     /// Reconciles store-driven removal and delayed restoration. An unloaded
     /// store is unresolved and never clears the current Workspace.
     func reconcile(in appModel: AppModel) {
+        // The startup editor is keyed to its own target Connection, not the
+        // Active Workspace: dismiss it only when that Connection is removed.
+        if let projectRef = workspaceStartupProject,
+           appModel.runtime(id: projectRef.connectionID) == nil {
+            workspaceStartupProject = nil
+        }
         guard let activeWorkspace else { return }
         guard let runtime = appModel.runtime(id: activeWorkspace.connectionID) else {
             selectionMemory.forget(connectionID: activeWorkspace.connectionID)

--- a/macos/ATCTests/ProjectUIHostingSmokeTest.swift
+++ b/macos/ATCTests/ProjectUIHostingSmokeTest.swift
@@ -40,6 +40,7 @@ struct ProjectUIHostingSmokeTest {
             onWorkspaceDeleted: { _ in }
         )
             .environment(appModel)
+            .environment(WindowState.ephemeral())
     }
 
     @Test("dashboard renders one populated connection without crashing")

--- a/macos/ATCTests/WorkspaceStartupTests.swift
+++ b/macos/ATCTests/WorkspaceStartupTests.swift
@@ -1,0 +1,435 @@
+import AppKit
+import SwiftUI
+import Testing
+import ATCAPI
+@testable import ATC
+
+@MainActor
+@Suite("Workspace startup configuration")
+struct WorkspaceStartupTests {
+    private func defaults() -> UserDefaults {
+        let suite = "WorkspaceStartupTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+
+    private func configuredStore() -> (WorkspaceStartupStore, UUID, UUID) {
+        let store = WorkspaceStartupStore(defaults: defaults())
+        return (store, UUID(), UUID())
+    }
+
+    @Test("default invariant survives adds, transfer, and removals")
+    func defaultInvariant() {
+        var configuration = StartupConfiguration()
+        let first = UUID()
+        let second = UUID()
+
+        configuration.add(target: .shell, id: first)
+        #expect(configuration.defaultEntryID == first)
+
+        configuration.add(target: .action(id: "act_codex"), id: second)
+        #expect(configuration.defaultEntryID == first)
+
+        configuration.transferDefault(to: second)
+        #expect(configuration.defaultEntryID == second)
+
+        configuration.remove(id: second)
+        #expect(configuration.defaultEntryID == first)
+
+        configuration.remove(id: first)
+        #expect(configuration == .empty)
+    }
+
+    @Test("duplicate targets retain independent identity and names")
+    func duplicateTargets() {
+        var configuration = StartupConfiguration()
+        let first = configuration.add(target: .action(id: "act_same"))
+        let second = configuration.add(target: .action(id: "act_same"))
+
+        configuration.setCustomName("One", for: first)
+        configuration.setCustomName("Two", for: second)
+
+        #expect(first != second)
+        #expect(configuration.entries.map(\.customName) == ["One", "Two"])
+
+        configuration.remove(id: first)
+        #expect(configuration.entries.count == 1)
+        #expect(configuration.entries[0].id == second)
+        #expect(configuration.entries[0].customName == "Two")
+        #expect(configuration.defaultEntryID == second)
+    }
+
+    @Test("persistence round-trips and garbage fails safe")
+    func persistence() {
+        let defaults = defaults()
+        let connectionID = UUID()
+        let projectID = "prj_one"
+        let store = WorkspaceStartupStore(defaults: defaults)
+        store.updateConnectionConfiguration(connectionID: connectionID) {
+            $0.add(target: .shell)
+            $0.add(target: .action(id: "act_codex"), customName: "Review")
+        }
+        store.setProjectMode(.custom, connectionID: connectionID, projectID: projectID)
+        store.updateProjectConfiguration(connectionID: connectionID, projectID: projectID) {
+            $0.removeAll()
+        }
+
+        let reloaded = WorkspaceStartupStore(defaults: defaults)
+        #expect(reloaded.connectionConfiguration(connectionID: connectionID).entries.count == 2)
+        #expect(reloaded.projectMode(connectionID: connectionID, projectID: projectID) == .custom)
+        #expect(reloaded.resolvedConfiguration(
+            connectionID: connectionID,
+            projectID: projectID
+        ) == .empty)
+
+        defaults.set(Data("not-json".utf8), forKey: "workspaceStartup.v1")
+        let corrupted = WorkspaceStartupStore(defaults: defaults)
+        #expect(corrupted.connectionConfiguration(connectionID: connectionID) == .empty)
+        #expect(corrupted.projectMode(
+            connectionID: connectionID,
+            projectID: projectID
+        ) == .useConnectionDefaults)
+    }
+
+    @Test("Project inheritance is live until Custom copies once")
+    func inheritance() {
+        let (store, connectionID, _) = configuredStore()
+        let projectID = "prj_one"
+
+        store.updateConnectionConfiguration(connectionID: connectionID) {
+            $0.add(target: .shell)
+        }
+        #expect(store.resolvedConfiguration(
+            connectionID: connectionID,
+            projectID: projectID
+        ).entries.count == 1)
+
+        store.updateConnectionConfiguration(connectionID: connectionID) {
+            $0.add(target: .action(id: "act_live"))
+        }
+        #expect(store.resolvedConfiguration(
+            connectionID: connectionID,
+            projectID: projectID
+        ).entries.count == 2)
+
+        store.setProjectMode(.custom, connectionID: connectionID, projectID: projectID)
+        let copied = store.resolvedConfiguration(
+            connectionID: connectionID,
+            projectID: projectID
+        )
+        store.updateConnectionConfiguration(connectionID: connectionID) {
+            $0.add(target: .action(id: "act_later"))
+        }
+        #expect(store.resolvedConfiguration(
+            connectionID: connectionID,
+            projectID: projectID
+        ) == copied)
+    }
+
+    @Test("custom empty suppresses defaults and returning to inheritance discards it")
+    func explicitEmptyOverride() {
+        let (store, connectionID, _) = configuredStore()
+        let projectID = "prj_one"
+        store.updateConnectionConfiguration(connectionID: connectionID) {
+            $0.add(target: .shell)
+        }
+        store.setProjectMode(.custom, connectionID: connectionID, projectID: projectID)
+        store.updateProjectConfiguration(connectionID: connectionID, projectID: projectID) {
+            $0.removeAll()
+        }
+
+        #expect(store.projectMode(connectionID: connectionID, projectID: projectID) == .custom)
+        #expect(store.resolvedConfiguration(
+            connectionID: connectionID,
+            projectID: projectID
+        ) == .empty)
+
+        store.setProjectMode(
+            .useConnectionDefaults,
+            connectionID: connectionID,
+            projectID: projectID
+        )
+        #expect(store.resolvedConfiguration(
+            connectionID: connectionID,
+            projectID: projectID
+        ).entries.count == 1)
+
+        store.setProjectMode(.custom, connectionID: connectionID, projectID: projectID)
+        #expect(store.resolvedConfiguration(
+            connectionID: connectionID,
+            projectID: projectID
+        ).entries.count == 1)
+    }
+
+    @Test("cascade removals are scoped to the target")
+    func cascadeRemovals() {
+        let (store, connectionA, connectionB) = configuredStore()
+        for connectionID in [connectionA, connectionB] {
+            store.updateConnectionConfiguration(connectionID: connectionID) {
+                $0.add(target: .shell)
+            }
+            store.setProjectMode(.custom, connectionID: connectionID, projectID: "keep")
+            store.setProjectMode(.custom, connectionID: connectionID, projectID: "remove")
+        }
+
+        store.removeProject(connectionID: connectionA, projectID: "remove")
+        #expect(store.projectMode(connectionID: connectionA, projectID: "remove")
+            == .useConnectionDefaults)
+        #expect(store.projectMode(connectionID: connectionA, projectID: "keep") == .custom)
+        #expect(store.projectMode(connectionID: connectionB, projectID: "remove") == .custom)
+
+        store.removeConnection(connectionID: connectionA)
+        #expect(store.connectionConfiguration(connectionID: connectionA) == .empty)
+        #expect(store.projectMode(connectionID: connectionA, projectID: "keep")
+            == .useConnectionDefaults)
+        #expect(store.connectionConfiguration(connectionID: connectionB).entries.count == 1)
+        #expect(store.projectMode(connectionID: connectionB, projectID: "keep") == .custom)
+    }
+
+    @Test("AppModel clears an override after successful Project deletion")
+    func appInitiatedProjectDelete() async throws {
+        let defaults = defaults()
+        let connections = ConnectionsStore(
+            defaults: defaults,
+            credentials: InMemoryCredentialStore()
+        )
+        let record = try connections.add(
+            name: "Test",
+            urlString: "http://test.example:7331",
+            token: ""
+        )
+        let model = AppModel(
+            connections: connections,
+            clientFactory: { _ in MockATCClient(mockWorkspaces: []) },
+            terminalRecoveryMonitor: .disabled(),
+            workspaceStartupDefaults: defaults
+        )
+        model.workspaceStartup.setProjectMode(
+            .custom,
+            connectionID: record.id,
+            projectID: "prj_notes"
+        )
+
+        try await model.deleteProject(ProjectRef(
+            connectionID: record.id,
+            projectID: "prj_notes"
+        ))
+
+        #expect(model.workspaceStartup.projectMode(
+            connectionID: record.id,
+            projectID: "prj_notes"
+        ) == .useConnectionDefaults)
+    }
+
+    @Test("failed Project deletion preserves its override")
+    func failedProjectDeletePreservesOverride() async throws {
+        let defaults = defaults()
+        let connections = ConnectionsStore(
+            defaults: defaults,
+            credentials: InMemoryCredentialStore()
+        )
+        let record = try connections.add(
+            name: "Test",
+            urlString: "http://test.example:7331",
+            token: ""
+        )
+        let model = AppModel(
+            connections: connections,
+            clientFactory: { _ in MockATCClient() },
+            terminalRecoveryMonitor: .disabled(),
+            workspaceStartupDefaults: defaults
+        )
+        model.workspaceStartup.setProjectMode(
+            .custom,
+            connectionID: record.id,
+            projectID: "prj_atelier"
+        )
+
+        await #expect(throws: ATCError.self) {
+            try await model.deleteProject(ProjectRef(
+                connectionID: record.id,
+                projectID: "prj_atelier"
+            ))
+        }
+
+        #expect(model.workspaceStartup.projectMode(
+            connectionID: record.id,
+            projectID: "prj_atelier"
+        ) == .custom)
+    }
+
+    @Test("AppModel Connection removal cascades startup preferences")
+    func appModelConnectionCascade() throws {
+        let defaults = defaults()
+        let connections = ConnectionsStore(
+            defaults: defaults,
+            credentials: InMemoryCredentialStore()
+        )
+        let record = try connections.add(
+            name: "Test",
+            urlString: "http://test.example:7331",
+            token: ""
+        )
+        let model = AppModel(
+            connections: connections,
+            clientFactory: { _ in MockATCClient() },
+            terminalRecoveryMonitor: .disabled(),
+            workspaceStartupDefaults: defaults
+        )
+        model.workspaceStartup.updateConnectionConfiguration(connectionID: record.id) {
+            $0.add(target: .shell)
+        }
+        model.workspaceStartup.setProjectMode(
+            .custom,
+            connectionID: record.id,
+            projectID: "prj_one"
+        )
+
+        model.removeConnection(id: record.id)
+
+        #expect(model.workspaceStartup.connectionConfiguration(connectionID: record.id) == .empty)
+        #expect(model.workspaceStartup.projectMode(
+            connectionID: record.id,
+            projectID: "prj_one"
+        ) == .useConnectionDefaults)
+    }
+}
+
+@MainActor
+@Suite("Workspace startup validation")
+struct WorkspaceStartupValidationTests {
+    private let enabled = ATCAction(
+        id: "act_enabled",
+        name: "Enabled",
+        description: nil,
+        enabled: true,
+        command: "enabled",
+        args: [],
+        isAgent: true
+    )
+    private let disabled = ATCAction(
+        id: "act_disabled",
+        name: "Disabled",
+        description: nil,
+        enabled: false,
+        command: "disabled",
+        args: [],
+        isAgent: false
+    )
+
+    private func configuration() -> StartupConfiguration {
+        var configuration = StartupConfiguration()
+        configuration.add(target: .action(id: enabled.id))
+        configuration.add(target: .action(id: disabled.id))
+        configuration.add(target: .action(id: "act_missing"))
+        configuration.add(target: .shell)
+        return configuration
+    }
+
+    @Test("loaded reachable registry distinguishes all entry statuses")
+    func loadedMatrix() {
+        let result = StartupEntryValidator.validate(
+            configuration: configuration(),
+            actions: [enabled, disabled],
+            hasLoadedOnce: true,
+            isReachable: true
+        )
+
+        #expect(result.canEdit)
+        #expect(result.entries.map(\.availability) == [
+            .valid, .disabled, .missing, .valid,
+        ])
+        #expect(result.entries[0].cachedActionName == "Enabled")
+        #expect(result.entries[1].cachedActionName == "Disabled")
+    }
+
+    @Test("unloaded or unreachable registry cannot validate any target")
+    func unableMatrix() {
+        for snapshot in [(false, false), (false, true), (true, false)] {
+            let result = StartupEntryValidator.validate(
+                configuration: configuration(),
+                actions: [enabled, disabled],
+                hasLoadedOnce: snapshot.0,
+                isReachable: snapshot.1
+            )
+            #expect(!result.canEdit)
+            #expect(result.entries.allSatisfy {
+                $0.availability == .unableToValidate
+            })
+        }
+    }
+
+    @Test("summary formats empty, singular, plural, and unavailable defaults")
+    func summaries() {
+        #expect(WorkspaceStartupSummary.text(
+            configuration: .empty,
+            actions: [enabled],
+            hasLoadedOnce: true
+        ) == "None configured")
+
+        var configuration = StartupConfiguration()
+        configuration.add(target: .shell)
+        #expect(WorkspaceStartupSummary.text(
+            configuration: configuration,
+            actions: [enabled],
+            hasLoadedOnce: true
+        ) == "1 Session · Default: Shell")
+
+        let actionID = configuration.add(target: .action(id: enabled.id))
+        configuration.transferDefault(to: actionID)
+        #expect(WorkspaceStartupSummary.text(
+            configuration: configuration,
+            actions: [enabled],
+            hasLoadedOnce: true
+        ) == "2 Sessions · Default: Enabled")
+
+        #expect(WorkspaceStartupSummary.text(
+            configuration: configuration,
+            actions: [],
+            hasLoadedOnce: true
+        ) == "2 Sessions · Default: Unavailable Action")
+
+        // Before the registry has loaded, an unknown Action is unvalidated
+        // rather than missing — mirror the editor instead of alarming.
+        #expect(WorkspaceStartupSummary.text(
+            configuration: configuration,
+            actions: [],
+            hasLoadedOnce: false
+        ) == "2 Sessions · Default: Action")
+    }
+}
+
+@MainActor
+@Suite("Workspace startup editor hosting smoke")
+struct WorkspaceStartupEditorHostingSmokeTests {
+    @Test("Connection and Project editors host without crashing")
+    func hostEditors() async throws {
+        let model = AppModel.preview()
+        await model.refreshAll()
+        let connectionID = try #require(model.runtimes.first?.id)
+        model.workspaceStartup.updateConnectionConfiguration(connectionID: connectionID) {
+            $0.add(target: .shell)
+            $0.add(target: .action(id: "act_fh9g7e6571qo53r0t647ughtfg"))
+        }
+
+        for target in [
+            WorkspaceStartupEditorTarget.connection(connectionID),
+            .project(ProjectRef(connectionID: connectionID, projectID: "prj_atelier")),
+        ] {
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 580, height: 520),
+                styleMask: [.titled],
+                backing: .buffered,
+                defer: false
+            )
+            window.contentView = NSHostingView(
+                rootView: WorkspaceStartupEditorSheet(target: target)
+                    .environment(model)
+            )
+            window.orderFront(nil)
+            pump(seconds: 0.25)
+            window.orderOut(nil)
+        }
+    }
+}

--- a/macos/CONTEXT.md
+++ b/macos/CONTEXT.md
@@ -21,6 +21,14 @@ _Avoid_: Local project, app project
 A Server-owned task context within one Project. In the initial version, every Workspace uses its Project's default folder, owns its Sessions, and persists after they end. Its name is user-owned, renameable, and need not be unique. Deleting a Workspace never changes its working directory or other filesystem state, but stops and deletes all of its associated Sessions only after every stop succeeds.
 _Avoid_: Checkout, worktree
 
+**Workspace Startup Configuration**:
+The local macOS preference that lists Action and Interactive Shell entries for Workspace startup. Each Connection has defaults; a Project either uses those defaults with live inheritance or has a Custom configuration copied once and then independent. An explicitly empty Custom configuration suppresses the Connection defaults.
+_Avoid_: Workspace template, server startup configuration
+
+**Default Session**:
+The one entry designated as the Default in every nonempty Workspace Startup Configuration. The first entry added becomes Default, the designation can be transferred, and removing it promotes the earliest remaining entry.
+_Avoid_: Primary Session, first Session
+
 **Session**:
 A Server-owned terminal process created on a particular atc server. A Session belongs to its Workspace, except for legacy Project-scoped Sessions. Its lifecycle is Live or Ended; Ended is a retained read-only tombstone shown only after the server confirms the backing zmx session is absent. Transport and attach failures remain retryable and do not end it.
 _Avoid_: Terminal Session, shell


### PR DESCRIPTION
## Summary

Implements [ATC-49](https://linear.app/elevenideas/issue/ATC-49/add-workspace-startup-configuration-and-editor): users can define local Connection startup defaults and independent Project overrides through one reusable editor. Nothing launches yet — execution during Workspace creation is ATC-52.

**Stacked on #118 (ATC-51)** — merge order: #117 → #118 → this.

### Model and store
- `StartupConfiguration`: entries (stable Action ID or Interactive Shell, optional custom name, local UUID identity so duplicates work) with the single-Default-Session invariant (first add becomes Default, explicit transfer, earliest-remaining promotion, valid empty state). Decode repairs malformed persisted defaults.
- `WorkspaceStartupStore`: one JSON value under UserDefaults `workspaceStartup.v1` (the `WorkspaceSelectionMemory` pattern). Connection defaults keyed by Connection UUID; Project overrides keyed by (Connection UUID, stable Project ID) — key presence alone marks Custom, so an explicitly empty Custom override validly suppresses Connection defaults. Live inheritance for Use Connection Defaults; switching to Custom copies the currently resolved defaults once.
- Cascades: `AppModel.removeConnection` clears defaults + that Connection's overrides; a new centralized `AppModel.deleteProject` removes the local override only after the server deletion succeeds. Overrides are never swept during refresh, so transient load failures can't wipe configuration.

### Validation and editor
- Pure validation against the cached Actions registry: enabled / disabled / missing / unable-to-validate (registry unloaded or unreachable — including Shell). Unavailable entries are preserved, rendered "Unavailable Action", and expose their stable ID for diagnosis. Opening the editor never triggers an Actions refresh.
- One reusable editor sheet: add menu (enabled Actions + Interactive Shell, duplicates allowed), per-entry custom name, Default transfer, remove, no reordering. Offline: read-only except Clear Configuration. Entry points: a Workspace Startup section in Connection Settings, and Workspace Startup… in the Project context menus (Projects Navigator + Dashboard) with the mode picker.

### Docs
- `macos/CONTEXT.md`: Workspace Startup Configuration and Default Session vocabulary. New `.memory/adr/0003`: startup preferences are local app state, not server data or macos.toml.

### Tests
- Invariants, persistence round-trip + garbage-fails-safe, live inheritance vs copy-once vs explicit-empty, cascades (connection removal, successful vs failed project deletion), validation matrix, summary formatting, and editor hosting smoke tests. Full `mise run macos:test` green.

Part of the ATC-48 series.