### PR TITLE
macOS: launch configured Sessions when creating a Workspace (ATC-52)

### DIFF
--- a/macos/ATC/Features/WorkspaceStartup/StartupEntryValidation.swift
+++ b/macos/ATC/Features/WorkspaceStartup/StartupEntryValidation.swift
@@ -1,14 +1,14 @@
 import Foundation
 import ATCAPI
 
-enum StartupEntryAvailability: Equatable {
+enum StartupEntryAvailability: Equatable, Sendable {
     case valid
     case disabled
     case missing
     case unableToValidate
 }
 
-struct ValidatedStartupEntry: Identifiable, Equatable {
+struct ValidatedStartupEntry: Identifiable, Equatable, Sendable {
     let entryID: UUID
     let availability: StartupEntryAvailability
     let cachedActionName: String?
@@ -16,7 +16,7 @@ struct ValidatedStartupEntry: Identifiable, Equatable {
     var id: UUID { entryID }
 }
 
-struct StartupConfigurationValidation: Equatable {
+struct StartupConfigurationValidation: Equatable, Sendable {
     let entries: [ValidatedStartupEntry]
     let canEdit: Bool
 

--- a/macos/ATC/Features/WorkspaceStartup/WorkspaceStartupCoordinator.swift
+++ b/macos/ATC/Features/WorkspaceStartup/WorkspaceStartupCoordinator.swift
@@ -1,0 +1,369 @@
+import Foundation
+import Observation
+import ATCAPI
+
+enum WorkspaceStartupCreationCue: Equatable {
+    case none
+    case configured
+    case defaultUnavailable
+
+    static func resolve(
+        configuration: StartupConfiguration,
+        validation: StartupConfigurationValidation
+    ) -> Self {
+        guard !configuration.entries.isEmpty,
+              let defaultID = configuration.defaultEntryID
+        else { return .none }
+
+        switch validation.entry(id: defaultID)?.availability {
+        case .disabled, .missing:
+            return .defaultUnavailable
+        case .valid, .unableToValidate, nil:
+            return .configured
+        }
+    }
+}
+
+struct StartupNotice: Identifiable, Equatable {
+    let id: UUID
+    let workspaceName: String
+    let messages: [String]
+
+    init(id: UUID = UUID(), workspaceName: String, messages: [String]) {
+        self.id = id
+        self.workspaceName = workspaceName
+        self.messages = messages
+    }
+}
+
+struct WorkspaceStartupLaunch: Equatable, Sendable {
+    let entryID: UUID
+    let target: StartupEntry.Target
+    let customName: String?
+    let identity: String
+    let availability: StartupEntryAvailability
+
+    var displayName: String {
+        guard let customName else { return identity }
+        return "\(identity) · \(customName)"
+    }
+
+    func request(workspaceID: String) -> StartSessionRequest {
+        let actionID: String?
+        switch target {
+        case .action(let id): actionID = id
+        case .shell: actionID = nil
+        }
+        return StartSessionRequest(
+            workspaceId: workspaceID,
+            actionId: actionID,
+            name: customName
+        )
+    }
+}
+
+struct WorkspaceStartupLaunchPlan: Equatable, Sendable {
+    let defaultLaunch: WorkspaceStartupLaunch
+    let backgroundLaunches: [WorkspaceStartupLaunch]
+
+    init?(
+        configuration: StartupConfiguration,
+        validation: StartupConfigurationValidation
+    ) {
+        guard let defaultID = configuration.defaultEntryID,
+              let defaultEntry = configuration.entries.first(where: {
+                  $0.id == defaultID
+              })
+        else { return nil }
+
+        func launch(for entry: StartupEntry) -> WorkspaceStartupLaunch {
+            let validated = validation.entry(id: entry.id)
+            let identity: String
+            switch entry.target {
+            case .shell:
+                identity = "Shell"
+            case .action:
+                identity = validated?.cachedActionName ?? "Action"
+            }
+            return WorkspaceStartupLaunch(
+                entryID: entry.id,
+                target: entry.target,
+                customName: entry.customName,
+                identity: identity,
+                availability: validated?.availability ?? .unableToValidate
+            )
+        }
+
+        defaultLaunch = launch(for: defaultEntry)
+        backgroundLaunches = configuration.entries
+            .filter { $0.id != defaultID }
+            .map(launch)
+    }
+}
+
+@MainActor
+@Observable
+final class WorkspaceStartupCoordinator {
+    enum State: Equatable {
+        case idle
+        case creatingWorkspace
+        case launchingDefault(identity: String)
+        case succeeded
+        case failedCreation(message: String)
+        // Definitive server-reported failure; transport-level uncertainty is
+        // the separate `ambiguous` case.
+        case failedDefault(message: String)
+        case ambiguous(message: String)
+    }
+
+    struct Operations {
+        var createWorkspace: (_ projectID: String, _ name: String) async throws -> Workspace
+        var startSession: (_ request: StartSessionRequest) async throws -> Session
+        var refreshSessions: () async -> Void
+    }
+
+    enum BackgroundIssue: Equatable {
+        case skipped(identity: String)
+        case failed(identity: String, reason: String)
+
+        var message: String {
+            switch self {
+            case .skipped(let identity):
+                return "\(identity) skipped: unavailable"
+            case .failed(let identity, let reason):
+                return "\(identity) failed: \(reason)"
+            }
+        }
+    }
+
+    private(set) var state: State = .idle
+    private(set) var workspaceRef: WorkspaceRef?
+
+    let connectionID: UUID
+    let plan: WorkspaceStartupLaunchPlan
+
+    @ObservationIgnored private let operations: Operations
+    @ObservationIgnored private let onActivate: (WorkspaceRef, SessionRef?) -> Void
+    @ObservationIgnored private let onNotice: (StartupNotice) -> Void
+    @ObservationIgnored private var workspaceName = ""
+    /// The one background-launch task; also the "all launches settled" signal.
+    @ObservationIgnored private(set) var backgroundTask: Task<Void, Never>?
+
+    init(
+        connectionID: UUID,
+        plan: WorkspaceStartupLaunchPlan,
+        operations: Operations,
+        onActivate: @escaping (WorkspaceRef, SessionRef?) -> Void,
+        onNotice: @escaping (StartupNotice) -> Void
+    ) {
+        self.connectionID = connectionID
+        self.plan = plan
+        self.operations = operations
+        self.onActivate = onActivate
+        self.onNotice = onNotice
+    }
+
+    var isInProgress: Bool {
+        switch state {
+        case .creatingWorkspace, .launchingDefault:
+            return true
+        case .idle, .succeeded, .failedCreation, .failedDefault, .ambiguous:
+            return false
+        }
+    }
+
+    var isDismissDisabled: Bool { isInProgress }
+
+    var progressLabel: String? {
+        switch state {
+        case .creatingWorkspace:
+            return "Creating Workspace…"
+        case .launchingDefault(let identity):
+            return "Starting \(identity)…"
+        case .idle, .succeeded, .failedCreation, .failedDefault, .ambiguous:
+            return nil
+        }
+    }
+
+    var errorMessage: String? {
+        switch state {
+        case .failedCreation(let message):
+            return message
+        case .failedDefault(let message):
+            return message
+        case .ambiguous(let message):
+            return "Default Session startup status could not be confirmed. \(message)"
+        case .idle, .creatingWorkspace, .launchingDefault, .succeeded:
+            return nil
+        }
+    }
+
+    func start(projectID: String, name: String) async {
+        guard workspaceRef == nil, !isInProgress else { return }
+        workspaceName = name
+        state = .creatingWorkspace
+        do {
+            let workspace = try await operations.createWorkspace(projectID, name)
+            workspaceRef = WorkspaceRef(
+                connectionID: connectionID,
+                workspaceID: workspace.id
+            )
+            await launchDefault()
+        } catch {
+            state = .failedCreation(message: error.localizedDescription)
+        }
+    }
+
+    /// Title of the sheet's primary action once a result state is reached;
+    /// nil while the initial Create Workspace submit still belongs to the
+    /// sheet itself.
+    var primaryActionTitle: String? {
+        switch state {
+        case .failedDefault:
+            return "Retry"
+        case .ambiguous:
+            return "Open Workspace"
+        case .idle, .creatingWorkspace, .launchingDefault, .succeeded,
+             .failedCreation:
+            return nil
+        }
+    }
+
+    var secondaryActionTitle: String? {
+        guard case .failedDefault = state else { return nil }
+        return "Open Workspace Anyway"
+    }
+
+    func performPrimaryAction() async {
+        switch state {
+        case .failedDefault:
+            await launchDefault()
+        case .ambiguous:
+            activateWithoutSelectionAndLaunchBackground()
+        case .idle, .creatingWorkspace, .launchingDefault, .succeeded,
+             .failedCreation:
+            break
+        }
+    }
+
+    func performSecondaryAction() {
+        guard case .failedDefault = state else { return }
+        activateWithoutSelectionAndLaunchBackground()
+    }
+
+    static func isDefinitiveDefaultFailure(_ error: any Error) -> Bool {
+        guard let error = error as? ATCError else { return false }
+        if case .api = error { return true }
+        return false
+    }
+
+    static func backgroundFailureReason(_ error: any Error) -> String {
+        if let error = error as? ATCError, let code = error.apiCode {
+            return code
+        }
+        return error.localizedDescription
+    }
+
+    static func notice(
+        workspaceName: String,
+        issues: [BackgroundIssue]
+    ) -> StartupNotice? {
+        guard !issues.isEmpty else { return nil }
+        var orderedMessages: [String] = []
+        var counts: [String: Int] = [:]
+        for issue in issues {
+            let message = issue.message
+            if counts[message] == nil {
+                orderedMessages.append(message)
+            }
+            counts[message, default: 0] += 1
+        }
+        let messages = orderedMessages.map { message in
+            let count = counts[message, default: 1]
+            return count == 1 ? message : "\(count) × \(message)"
+        }
+        return StartupNotice(workspaceName: workspaceName, messages: messages)
+    }
+
+    private func launchDefault() async {
+        guard let workspaceRef else { return }
+        state = .launchingDefault(identity: plan.defaultLaunch.displayName)
+        do {
+            let session = try await operations.startSession(
+                plan.defaultLaunch.request(workspaceID: workspaceRef.workspaceID)
+            )
+            state = .succeeded
+            onActivate(
+                workspaceRef,
+                SessionRef(connectionID: connectionID, sessionID: session.id)
+            )
+            startBackgroundLaunches()
+        } catch {
+            let message = error.localizedDescription
+            if Self.isDefinitiveDefaultFailure(error) {
+                state = .failedDefault(message: message)
+            } else {
+                state = .ambiguous(message: message)
+                await operations.refreshSessions()
+            }
+        }
+    }
+
+    private func activateWithoutSelectionAndLaunchBackground() {
+        guard let workspaceRef else { return }
+        state = .succeeded
+        onActivate(workspaceRef, nil)
+        startBackgroundLaunches()
+    }
+
+    private func startBackgroundLaunches() {
+        guard backgroundTask == nil, let workspaceRef else { return }
+        let launches = plan.backgroundLaunches
+        let workspaceName = workspaceName
+        backgroundTask = Task { [self] in
+            let issues = await launchBackground(
+                launches,
+                workspaceID: workspaceRef.workspaceID
+            )
+            if let notice = Self.notice(workspaceName: workspaceName, issues: issues) {
+                onNotice(notice)
+            }
+        }
+    }
+
+    private func launchBackground(
+        _ launches: [WorkspaceStartupLaunch],
+        workspaceID: String
+    ) async -> [BackgroundIssue] {
+        // Slot per launch so concurrent completions keep configuration order.
+        var issues: [BackgroundIssue?] = Array(repeating: nil, count: launches.count)
+        var tasks: [(Int, Task<BackgroundIssue?, Never>)] = []
+
+        for (index, launch) in launches.enumerated() {
+            switch launch.availability {
+            case .disabled, .missing:
+                issues[index] = .skipped(identity: launch.displayName)
+            case .valid, .unableToValidate:
+                let startSession = operations.startSession
+                tasks.append((index, Task { @MainActor in
+                    do {
+                        _ = try await startSession(
+                            launch.request(workspaceID: workspaceID)
+                        )
+                        return nil
+                    } catch {
+                        return .failed(
+                            identity: launch.displayName,
+                            reason: Self.backgroundFailureReason(error)
+                        )
+                    }
+                }))
+            }
+        }
+
+        for (index, task) in tasks {
+            issues[index] = await task.value
+        }
+        return issues.compactMap(\.self)
+    }
+}

--- a/macos/ATC/Features/WorkspaceStartup/WorkspaceStartupModels.swift
+++ b/macos/ATC/Features/WorkspaceStartup/WorkspaceStartupModels.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-struct StartupEntry: Identifiable, Codable, Equatable {
-    enum Target: Codable, Equatable {
+struct StartupEntry: Identifiable, Codable, Equatable, Sendable {
+    enum Target: Codable, Equatable, Sendable {
         case action(id: String)
         case shell
     }
@@ -33,7 +33,7 @@ struct StartupEntry: Identifiable, Codable, Equatable {
 /// Value-semantic startup configuration whose mutations preserve the single
 /// Default Session invariant. Decoding also repairs stale or malformed
 /// default references instead of allowing invalid persisted state into the app.
-struct StartupConfiguration: Codable, Equatable {
+struct StartupConfiguration: Codable, Equatable, Sendable {
     private(set) var entries: [StartupEntry]
     private(set) var defaultEntryID: UUID?
 
@@ -105,7 +105,7 @@ struct StartupConfiguration: Codable, Equatable {
     }
 }
 
-enum ProjectStartupMode: String, Codable, CaseIterable, Equatable {
+enum ProjectStartupMode: String, Codable, CaseIterable, Equatable, Sendable {
     case useConnectionDefaults
     case custom
 }

--- a/macos/ATC/Features/Workspaces/CreateWorkspaceSheet.swift
+++ b/macos/ATC/Features/Workspaces/CreateWorkspaceSheet.swift
@@ -8,13 +8,17 @@ struct CreateWorkspaceSheet: View {
     @Environment(AppModel.self) private var appModel
     @Environment(\.dismiss) private var dismiss
     let context: CreateWorkspaceContext
-    /// Called with the new Workspace's ref so the window activates it.
-    var onCreated: (WorkspaceRef) -> Void = { _ in }
+    /// Called after dismissal so the window activates the Workspace and,
+    /// for configured startup, selects the real Default Session.
+    var onCreated: (WorkspaceRef, SessionRef?) -> Void = { _, _ in }
+    var onNotice: (StartupNotice) -> Void = { _ in }
+    var onEditStartupSettings: (ProjectRef) -> Void = { _ in }
 
     @State private var selectedProject: ProjectRef?
     @State private var name = ""
     @State private var isSubmitting = false
     @State private var submitError: String?
+    @State private var coordinator: WorkspaceStartupCoordinator?
 
     /// Dashboard invocations fix the Project; the in-shell and File-menu
     /// forms keep the picker enabled.
@@ -42,11 +46,15 @@ struct CreateWorkspaceSheet: View {
         SheetScaffold(
             title: "New Workspace",
             systemImage: "square.on.square",
-            primaryLabel: "Create Workspace",
-            isBusy: isSubmitting,
+            primaryLabel: primaryLabel,
+            isBusy: isBusy,
             canSubmit: canSubmit,
+            cancelDisabled: isDismissDisabled,
+            primaryIndicator: primaryIndicator,
+            secondaryLabel: secondaryLabel,
+            onSecondary: secondaryAction,
             onCancel: { dismiss() },
-            onSubmit: { Task { await submit() } }
+            onSubmit: { handlePrimaryAction() }
         ) {
             Section {
                 if isProjectFixed {
@@ -72,8 +80,37 @@ struct CreateWorkspaceSheet: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+            .disabled(inputsDisabled)
 
-            if let message = submitError ?? availabilityError {
+            if cue == .defaultUnavailable {
+                Section {
+                    Label(
+                        "Configured Default Session is unavailable.",
+                        systemImage: "exclamationmark.triangle.fill"
+                    )
+                    .foregroundStyle(.orange)
+                    .font(.callout)
+                    Button("Edit Startup Settings") {
+                        // The handler dismisses this sheet by clearing its
+                        // presentation state, then presents the editor.
+                        guard let selectedProject else { return }
+                        onEditStartupSettings(selectedProject)
+                    }
+                }
+            }
+
+            if let progressLabel = coordinator?.progressLabel {
+                Section {
+                    Label {
+                        Text(progressLabel)
+                    } icon: {
+                        ProgressView().controlSize(.small)
+                    }
+                    .font(.callout)
+                }
+            }
+
+            if let message = submitError ?? coordinator?.errorMessage ?? availabilityError {
                 Section {
                     Label(message, systemImage: "exclamationmark.triangle")
                         .foregroundStyle(.red)
@@ -81,7 +118,8 @@ struct CreateWorkspaceSheet: View {
                 }
             }
         }
-        .frame(width: 460, height: 280)
+        .frame(width: 460, height: resolvedConfiguration.entries.isEmpty ? 280 : 340)
+        .interactiveDismissDisabled(isDismissDisabled)
         .onAppear {
             switch context.mode {
             case .fixed(let ref), .preselected(let ref):
@@ -99,8 +137,92 @@ struct CreateWorkspaceSheet: View {
         return project.name
     }
 
+    private var resolvedConfiguration: StartupConfiguration {
+        guard let selectedProject else { return .empty }
+        return appModel.workspaceStartup.resolvedConfiguration(
+            connectionID: selectedProject.connectionID,
+            projectID: selectedProject.projectID
+        )
+    }
+
+    private var validation: StartupConfigurationValidation {
+        guard let selectedProject,
+              let runtime = appModel.runtime(id: selectedProject.connectionID)
+        else {
+            return StartupConfigurationValidation(entries: [], canEdit: false)
+        }
+        let isReachable: Bool
+        if case .connected = runtime.reachability {
+            isReachable = true
+        } else {
+            isReachable = false
+        }
+        return StartupEntryValidator.validate(
+            configuration: resolvedConfiguration,
+            actions: runtime.actions.actions,
+            hasLoadedOnce: runtime.actions.hasLoadedOnce,
+            isReachable: isReachable
+        )
+    }
+
+    private var cue: WorkspaceStartupCreationCue {
+        WorkspaceStartupCreationCue.resolve(
+            configuration: resolvedConfiguration,
+            validation: validation
+        )
+    }
+
+    private var primaryIndicator: SheetPrimaryIndicator? {
+        guard coordinator == nil, !isSubmitting else { return nil }
+        switch cue {
+        case .none:
+            return nil
+        case .configured:
+            return SheetPrimaryIndicator(
+                systemImage: "bolt.fill",
+                color: .accentColor,
+                accessibilityLabel: "Starts configured Sessions"
+            )
+        case .defaultUnavailable:
+            return SheetPrimaryIndicator(
+                systemImage: "exclamationmark.triangle.fill",
+                color: .orange,
+                accessibilityLabel: "Configured Default Session is unavailable."
+            )
+        }
+    }
+
+    private var primaryLabel: String {
+        coordinator?.primaryActionTitle ?? "Create Workspace"
+    }
+
+    private var secondaryLabel: String? {
+        coordinator?.secondaryActionTitle
+    }
+
+    private var secondaryAction: (() -> Void)? {
+        guard secondaryLabel != nil else { return nil }
+        return { coordinator?.performSecondaryAction() }
+    }
+
+    private var isBusy: Bool {
+        isSubmitting || coordinator?.isInProgress == true
+    }
+
+    private var isDismissDisabled: Bool {
+        coordinator?.isDismissDisabled == true
+    }
+
+    private var inputsDisabled: Bool {
+        coordinator != nil
+    }
+
     private var canSubmit: Bool {
-        !isSubmitting
+        if case .failedDefault = coordinator?.state { return true }
+        if case .ambiguous = coordinator?.state { return true }
+        return !isBusy
+            && coordinator?.workspaceRef == nil
+            && cue != .defaultUnavailable
             && (selectedProject.map { appModel.canCreateWorkspace(in: $0) } ?? false)
             && !name.trimmingCharacters(in: .whitespaces).isEmpty
     }
@@ -113,6 +235,16 @@ struct CreateWorkspaceSheet: View {
         return nil
     }
 
+    private func handlePrimaryAction() {
+        if let coordinator, coordinator.primaryActionTitle != nil {
+            Task { await coordinator.performPrimaryAction() }
+            return
+        }
+        // A failed creation left nothing durable; a fresh submit starts over.
+        coordinator = nil
+        Task { await submit() }
+    }
+
     private func submit() async {
         guard let ref = selectedProject,
               appModel.canCreateWorkspace(in: ref),
@@ -120,16 +252,58 @@ struct CreateWorkspaceSheet: View {
             submitError = "This project's connection is unavailable."
             return
         }
+
+        let trimmedName = name.trimmingCharacters(in: .whitespaces)
+        let configuration = resolvedConfiguration
+        if !configuration.entries.isEmpty {
+            guard cue != .defaultUnavailable,
+                  let plan = WorkspaceStartupLaunchPlan(
+                    configuration: configuration,
+                    validation: validation
+                  )
+            else { return }
+            submitError = nil
+            let newCoordinator = WorkspaceStartupCoordinator(
+                connectionID: ref.connectionID,
+                plan: plan,
+                operations: .init(
+                    createWorkspace: { projectID, name in
+                        try await runtime.workspaces.create(
+                            projectID: projectID,
+                            name: name
+                        )
+                    },
+                    startSession: { request in
+                        try await runtime.sessions.start(request)
+                    },
+                    refreshSessions: {
+                        await runtime.sessions.refresh()
+                    }
+                ),
+                onActivate: { workspaceRef, sessionRef in
+                    dismiss()
+                    onCreated(workspaceRef, sessionRef)
+                },
+                onNotice: onNotice
+            )
+            coordinator = newCoordinator
+            await newCoordinator.start(projectID: ref.projectID, name: trimmedName)
+            return
+        }
+
         isSubmitting = true
         defer { isSubmitting = false }
         do {
             let workspace = try await runtime.workspaces.create(
                 projectID: ref.projectID,
-                name: name.trimmingCharacters(in: .whitespaces)
+                name: trimmedName
             )
             submitError = nil
             dismiss()
-            onCreated(WorkspaceRef(connectionID: ref.connectionID, workspaceID: workspace.id))
+            onCreated(
+                WorkspaceRef(connectionID: ref.connectionID, workspaceID: workspace.id),
+                nil
+            )
         } catch {
             submitError = error.localizedDescription
         }

--- a/macos/ATC/RootView.swift
+++ b/macos/ATC/RootView.swift
@@ -59,10 +59,24 @@ struct RootView: View {
         .sheet(isPresented: $windowState.isCreateProjectPresented) {
             CreateProjectSheet()
         }
-        .sheet(item: $windowState.createWorkspaceContext) { context in
-            CreateWorkspaceSheet(context: context) { ref in
-                _ = windowState.activateWorkspace(ref, in: appModel)
-            }
+        .sheet(item: $windowState.createWorkspaceContext, onDismiss: {
+            windowState.presentPendingWorkspaceStartupEditor()
+        }) { context in
+            CreateWorkspaceSheet(
+                context: context,
+                onCreated: { workspaceRef, sessionRef in
+                    guard windowState.activateWorkspace(workspaceRef, in: appModel) else {
+                        return
+                    }
+                    if let sessionRef {
+                        _ = windowState.selectSession(sessionRef, in: appModel)
+                    }
+                },
+                onNotice: { windowState.startupNotice = $0 },
+                onEditStartupSettings: {
+                    windowState.editWorkspaceStartupAfterCreateSheetDismisses($0)
+                }
+            )
         }
         .sheet(item: $windowState.startSessionKind, onDismiss: {
             windowState.requestTerminalFocus()
@@ -80,6 +94,16 @@ struct RootView: View {
             appModel.reconcileTerminalLifecycle()
             windowState.reconcile(in: appModel)
         }
+        .overlay(alignment: .top) {
+            if let notice = windowState.startupNotice {
+                StartupNoticeBanner(notice: notice) {
+                    windowState.startupNotice = nil
+                }
+                .padding(Spacing.md)
+                .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+        .animation(.snappy, value: windowState.startupNotice?.id)
     }
 
     private var mainContent: some View {
@@ -134,6 +158,40 @@ struct RootView: View {
             newTerminal: { windowState.startSessionKind = .terminal },
             creationEnabled: windowState.canStartSession(in: appModel)
         )
+    }
+}
+
+private struct StartupNoticeBanner: View {
+    let notice: StartupNotice
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: Spacing.md) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            VStack(alignment: .leading, spacing: Spacing.xs) {
+                Text("Workspace Startup — \(notice.workspaceName)")
+                    .font(.callout.weight(.semibold))
+                ForEach(notice.messages, id: \.self) {
+                    Text($0)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer(minLength: Spacing.md)
+            Button("Dismiss", systemImage: "xmark", action: onDismiss)
+                .labelStyle(.iconOnly)
+                .buttonStyle(.borderless)
+        }
+        .padding(Spacing.md)
+        .frame(maxWidth: 560)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .overlay {
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color(nsColor: .separatorColor).opacity(0.5))
+        }
+        .shadow(radius: 8, y: 3)
+        .accessibilityElement(children: .contain)
     }
 }
 

--- a/macos/ATC/Shared/SheetScaffold.swift
+++ b/macos/ATC/Shared/SheetScaffold.swift
@@ -1,5 +1,11 @@
 import SwiftUI
 
+struct SheetPrimaryIndicator {
+    let systemImage: String
+    let color: Color
+    let accessibilityLabel: String
+}
+
 /// Standard chrome for form sheets: a Label title header, grouped Form
 /// content, and a trailing button row in the HIG arrangement — Cancel
 /// adjacent-left of the primary action, both trailing.
@@ -10,6 +16,10 @@ struct SheetScaffold<Content: View>: View {
     let primaryLabel: String
     var isBusy = false
     var canSubmit = true
+    var cancelDisabled = false
+    var primaryIndicator: SheetPrimaryIndicator?
+    var secondaryLabel: String?
+    var onSecondary: (() -> Void)?
     var onCancel: () -> Void
     var onSubmit: () -> Void
     @ViewBuilder var content: () -> Content
@@ -28,6 +38,16 @@ struct SheetScaffold<Content: View>: View {
                 Spacer()
                 Button("Cancel", role: .cancel, action: onCancel)
                     .keyboardShortcut(.cancelAction)
+                    .disabled(cancelDisabled)
+                if let secondaryLabel, let onSecondary {
+                    Button(secondaryLabel, action: onSecondary)
+                }
+                if let primaryIndicator {
+                    Image(systemName: primaryIndicator.systemImage)
+                        .foregroundStyle(primaryIndicator.color)
+                        .help(primaryIndicator.accessibilityLabel)
+                        .accessibilityLabel(primaryIndicator.accessibilityLabel)
+                }
                 Button(action: onSubmit) {
                     if isBusy {
                         ProgressView().controlSize(.small)

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -49,12 +49,18 @@ final class WindowState {
     var createWorkspaceContext: CreateWorkspaceContext?
     var startSessionKind: StartSessionKind?
     var workspaceStartupProject: ProjectRef?
+    var startupNotice: StartupNotice?
+
+    /// Defers the startup editor until the creation sheet has fully
+    /// dismissed; AppKit cannot present the two sibling sheets together.
+    private(set) var pendingWorkspaceStartupProject: ProjectRef?
 
     var isSheetPresented: Bool {
         isCreateProjectPresented
             || createWorkspaceContext != nil
             || startSessionKind != nil
             || workspaceStartupProject != nil
+            || pendingWorkspaceStartupProject != nil
     }
 
     /// Advances for every explicit request to type in the selected Terminal
@@ -181,6 +187,10 @@ final class WindowState {
            appModel.runtime(id: projectRef.connectionID) == nil {
             workspaceStartupProject = nil
         }
+        if let pending = pendingWorkspaceStartupProject,
+           appModel.runtime(id: pending.connectionID) == nil {
+            pendingWorkspaceStartupProject = nil
+        }
         guard let activeWorkspace else { return }
         guard let runtime = appModel.runtime(id: activeWorkspace.connectionID) else {
             selectionMemory.forget(connectionID: activeWorkspace.connectionID)
@@ -270,6 +280,17 @@ final class WindowState {
         } else {
             createWorkspaceContext = CreateWorkspaceContext(mode: .free)
         }
+    }
+
+    func editWorkspaceStartupAfterCreateSheetDismisses(_ ref: ProjectRef) {
+        pendingWorkspaceStartupProject = ref
+        createWorkspaceContext = nil
+    }
+
+    func presentPendingWorkspaceStartupEditor() {
+        guard let ref = pendingWorkspaceStartupProject else { return }
+        pendingWorkspaceStartupProject = nil
+        workspaceStartupProject = ref
     }
 
     private func validRememberedSelection(

--- a/macos/ATCTests/ScriptableClient.swift
+++ b/macos/ATCTests/ScriptableClient.swift
@@ -9,6 +9,7 @@ nonisolated final class ScriptableClient: ATCClient, @unchecked Sendable {
     private let lock = NSLock()
     private var _shouldFail = false
     private var _delay: Duration?
+    private var _startSessionRequests: [StartSessionRequest] = []
 
     var shouldFail: Bool {
         get { lock.withLock { _shouldFail } }
@@ -18,6 +19,10 @@ nonisolated final class ScriptableClient: ATCClient, @unchecked Sendable {
     var delay: Duration? {
         get { lock.withLock { _delay } }
         set { lock.withLock { _delay = newValue } }
+    }
+
+    var startSessionRequests: [StartSessionRequest] {
+        lock.withLock { _startSessionRequests }
     }
 
     private func gate() async throws {
@@ -39,6 +44,7 @@ nonisolated final class ScriptableClient: ATCClient, @unchecked Sendable {
         try await gate(); return try await inner.session(id: id)
     }
     func startSession(_ request: StartSessionRequest) async throws -> Session {
+        lock.withLock { _startSessionRequests.append(request) }
         try await gate(); return try await inner.startSession(request)
     }
     func renameSession(id: String, name: String?) async throws -> Session {

--- a/macos/ATCTests/WorkspaceStartupCoordinatorTests.swift
+++ b/macos/ATCTests/WorkspaceStartupCoordinatorTests.swift
@@ -1,0 +1,452 @@
+import Foundation
+import Testing
+import ATCAPI
+@testable import ATC
+
+@MainActor
+private final class WorkspaceStartupRecorder {
+    enum StartResult {
+        case success
+        case definitiveFailure
+        case ambiguousFailure
+    }
+
+    var events: [String] = []
+    var requests: [StartSessionRequest] = []
+    var results: [String: [StartResult]] = [:]
+    var heldNames: Set<String> = []
+    var refreshCount = 0
+    var holdCreate = false
+
+    private var createContinuation: CheckedContinuation<Void, Never>?
+    private var startContinuations: [CheckedContinuation<Void, Never>] = []
+
+    func create(projectID: String, name: String) async throws -> Workspace {
+        events.append("create")
+        if holdCreate {
+            await withCheckedContinuation { createContinuation = $0 }
+        }
+        return Workspace(
+            id: "wsp_created",
+            projectId: projectID,
+            name: name,
+            createdAt: .now,
+            updatedAt: .now
+        )
+    }
+
+    func start(_ request: StartSessionRequest) async throws -> Session {
+        requests.append(request)
+        let key = request.name ?? request.actionId ?? "Shell"
+        events.append("start:\(key)")
+        if heldNames.contains(key) {
+            await withCheckedContinuation { startContinuations.append($0) }
+        }
+
+        let result: StartResult
+        if var queued = results[key], !queued.isEmpty {
+            result = queued.removeFirst()
+            results[key] = queued
+        } else {
+            result = .success
+        }
+        switch result {
+        case .success:
+            return Session(
+                id: "ses_\(requests.count)",
+                name: request.name,
+                actionId: request.actionId,
+                actionName: request.actionId,
+                isAgent: request.actionId != nil,
+                workingDir: "/tmp",
+                status: .live,
+                createdAt: .now,
+                updatedAt: .now,
+                workspace: SessionWorkspace(id: request.workspaceId, name: "Created")
+            )
+        case .definitiveFailure:
+            throw ATCError.api(
+                code: "launch_failed",
+                message: "launch failed",
+                sessionID: nil
+            )
+        case .ambiguousFailure:
+            throw URLError(.timedOut)
+        }
+    }
+
+    func refresh() async {
+        refreshCount += 1
+        events.append("refresh")
+    }
+
+    func releaseCreate() {
+        holdCreate = false
+        createContinuation?.resume()
+        createContinuation = nil
+    }
+
+    func releaseStarts() {
+        heldNames = []
+        let continuations = startContinuations
+        startContinuations = []
+        continuations.forEach { $0.resume() }
+    }
+}
+
+/// Yields the cooperative MainActor executor until `condition` holds.
+/// Deterministic replacement for run-loop pumping here: nested
+/// `RunLoop.run` can starve queued MainActor tasks, while yielding always
+/// drains them.
+@MainActor
+private func settle(until condition: () -> Bool) async {
+    var iterations = 0
+    while !condition(), iterations < 10_000 {
+        iterations += 1
+        await Task.yield()
+    }
+}
+
+@MainActor
+@Suite("Workspace startup coordinator")
+struct WorkspaceStartupCoordinatorTests {
+    private let connectionID = UUID()
+
+    private func action(_ id: String, name: String, enabled: Bool = true) -> ATCAction {
+        ATCAction(
+            id: id,
+            name: name,
+            description: nil,
+            enabled: enabled,
+            command: id,
+            args: [],
+            isAgent: true
+        )
+    }
+
+    private func plan(
+        configuration: StartupConfiguration,
+        actions: [ATCAction] = []
+    ) throws -> WorkspaceStartupLaunchPlan {
+        let validation = StartupEntryValidator.validate(
+            configuration: configuration,
+            actions: actions,
+            hasLoadedOnce: true,
+            isReachable: true
+        )
+        return try #require(WorkspaceStartupLaunchPlan(
+            configuration: configuration,
+            validation: validation
+        ))
+    }
+
+    private func coordinator(
+        recorder: WorkspaceStartupRecorder,
+        plan: WorkspaceStartupLaunchPlan,
+        activations: @escaping (WorkspaceRef, SessionRef?) -> Void = { _, _ in },
+        notices: @escaping (StartupNotice) -> Void = { _ in }
+    ) -> WorkspaceStartupCoordinator {
+        WorkspaceStartupCoordinator(
+            connectionID: connectionID,
+            plan: plan,
+            operations: .init(
+                createWorkspace: recorder.create,
+                startSession: recorder.start,
+                refreshSessions: recorder.refresh
+            ),
+            onActivate: activations,
+            onNotice: notices
+        )
+    }
+
+    @Test("default launches first, activation selects it, then companions launch concurrently")
+    func happyPath() async throws {
+        var configuration = StartupConfiguration()
+        configuration.add(target: .shell, customName: "Default")
+        configuration.add(target: .action(id: "act_one"), customName: "One")
+        configuration.add(target: .action(id: "act_two"), customName: "Two")
+        let recorder = WorkspaceStartupRecorder()
+        recorder.heldNames = ["One", "Two"]
+        var selected: SessionRef?
+        let coordinator = coordinator(
+            recorder: recorder,
+            plan: try plan(
+                configuration: configuration,
+                actions: [action("act_one", name: "One"), action("act_two", name: "Two")]
+            ),
+            activations: { _, session in
+                recorder.events.append("activate")
+                selected = session
+            }
+        )
+
+        await coordinator.start(projectID: "prj_one", name: "Created")
+        await settle(until: { recorder.requests.count == 3 })
+
+        #expect(coordinator.state == .succeeded)
+        #expect(selected?.sessionID == "ses_1")
+        #expect(recorder.events == [
+            "create", "start:Default", "activate", "start:One", "start:Two",
+        ])
+        // Both companion calls entered before either was allowed to finish.
+        #expect(recorder.requests.map(\.name) == ["Default", "One", "Two"])
+        recorder.releaseStarts()
+    }
+
+    @Test("definitive failure retries only the default and is repeatable")
+    func definitiveRetry() async throws {
+        var configuration = StartupConfiguration()
+        configuration.add(target: .shell, customName: "Default")
+        configuration.add(target: .shell, customName: "Companion")
+        let recorder = WorkspaceStartupRecorder()
+        recorder.results["Default"] = [
+            .definitiveFailure, .definitiveFailure, .success,
+        ]
+        var activation: (WorkspaceRef, SessionRef?)?
+        let coordinator = coordinator(
+            recorder: recorder,
+            plan: try plan(configuration: configuration),
+            activations: { activation = ($0, $1) }
+        )
+
+        await coordinator.start(projectID: "prj_one", name: "Created")
+        #expect(coordinator.state == .failedDefault(message: "launch failed"))
+        #expect(coordinator.primaryActionTitle == "Retry")
+        #expect(recorder.requests.map(\.name) == ["Default"])
+
+        await coordinator.performPrimaryAction()
+        #expect(coordinator.state == .failedDefault(message: "launch failed"))
+        #expect(recorder.requests.map(\.name) == ["Default", "Default"])
+
+        await coordinator.performPrimaryAction()
+        #expect(coordinator.state == .succeeded)
+        #expect(activation?.1 != nil)
+        await settle(until: { recorder.requests.count == 4 })
+        #expect(recorder.requests.map(\.name) == [
+            "Default", "Default", "Default", "Companion",
+        ])
+    }
+
+    @Test("Open Workspace Anyway activates without selection and starts companions")
+    func openAnyway() async throws {
+        var configuration = StartupConfiguration()
+        configuration.add(target: .shell, customName: "Default")
+        configuration.add(target: .shell, customName: "Companion")
+        let recorder = WorkspaceStartupRecorder()
+        recorder.results["Default"] = [.definitiveFailure]
+        var activation: (WorkspaceRef, SessionRef?)?
+        let coordinator = coordinator(
+            recorder: recorder,
+            plan: try plan(configuration: configuration),
+            activations: { activation = ($0, $1) }
+        )
+
+        await coordinator.start(projectID: "prj_one", name: "Created")
+        #expect(coordinator.secondaryActionTitle == "Open Workspace Anyway")
+        coordinator.performSecondaryAction()
+        await settle(until: { recorder.requests.count == 2 })
+
+        #expect(activation?.0.workspaceID == "wsp_created")
+        #expect(activation?.1 == nil)
+        #expect(recorder.requests.map(\.name) == ["Default", "Companion"])
+    }
+
+    @Test("transport ambiguity refreshes, never retries, and opens without selection")
+    func ambiguous() async throws {
+        var configuration = StartupConfiguration()
+        configuration.add(target: .shell, customName: "Default")
+        configuration.add(target: .shell, customName: "Companion")
+        let recorder = WorkspaceStartupRecorder()
+        recorder.results["Default"] = [.ambiguousFailure]
+        var activation: (WorkspaceRef, SessionRef?)?
+        let coordinator = coordinator(
+            recorder: recorder,
+            plan: try plan(configuration: configuration),
+            activations: { activation = ($0, $1) }
+        )
+
+        await coordinator.start(projectID: "prj_one", name: "Created")
+        #expect(recorder.refreshCount == 1)
+        #expect(recorder.requests.map(\.name) == ["Default"])
+        if case .ambiguous = coordinator.state {
+            // Expected.
+        } else {
+            Issue.record("Expected ambiguous state")
+        }
+
+        // Ambiguity offers no Retry and no Open Workspace Anyway.
+        #expect(coordinator.secondaryActionTitle == nil)
+        coordinator.performSecondaryAction()
+        #expect(recorder.requests.map(\.name) == ["Default"])
+        #expect(activation == nil)
+
+        #expect(coordinator.primaryActionTitle == "Open Workspace")
+        await coordinator.performPrimaryAction()
+        await settle(until: { recorder.requests.count == 2 })
+        #expect(activation?.1 == nil)
+        #expect(recorder.requests.map(\.name) == ["Default", "Companion"])
+    }
+
+    @Test("background failures aggregate, unavailable entries skip, and successes remain")
+    func backgroundAggregation() async throws {
+        var configuration = StartupConfiguration()
+        configuration.add(target: .shell, customName: "Default")
+        configuration.add(target: .action(id: "act_editor"))
+        configuration.add(target: .action(id: "act_editor"))
+        configuration.add(target: .action(id: "act_missing"))
+        configuration.add(target: .action(id: "act_success"), customName: "Healthy")
+        let recorder = WorkspaceStartupRecorder()
+        recorder.results["act_editor"] = [.definitiveFailure, .definitiveFailure]
+        var notices: [StartupNotice] = []
+        let coordinator = coordinator(
+            recorder: recorder,
+            plan: try plan(
+                configuration: configuration,
+                actions: [
+                    action("act_editor", name: "Editor"),
+                    action("act_success", name: "Success"),
+                ]
+            ),
+            notices: { notices.append($0) }
+        )
+
+        await coordinator.start(projectID: "prj_one", name: "Created")
+        await settle(until: { notices.count == 1 })
+
+        #expect(recorder.requests.count == 4)
+        #expect(!recorder.requests.contains { $0.actionId == "act_missing" })
+        #expect(recorder.requests.contains { $0.name == "Healthy" })
+        #expect(notices.count == 1)
+        #expect(notices.first?.workspaceName == "Created")
+        #expect(notices.first?.messages == [
+            "2 × Editor failed: launch_failed",
+            "Action skipped: unavailable",
+        ])
+    }
+
+    @Test("all successful background launches produce no notice")
+    func noNotice() async throws {
+        var configuration = StartupConfiguration()
+        configuration.add(target: .shell, customName: "Default")
+        configuration.add(target: .shell, customName: "Companion")
+        let recorder = WorkspaceStartupRecorder()
+        var notices: [StartupNotice] = []
+        let coordinator = coordinator(
+            recorder: recorder,
+            plan: try plan(configuration: configuration),
+            notices: { notices.append($0) }
+        )
+
+        await coordinator.start(projectID: "prj_one", name: "Created")
+        await coordinator.backgroundTask?.value
+        #expect(recorder.requests.count == 2)
+        #expect(notices.isEmpty)
+    }
+
+    @Test("sheet dismissal is blocked during progress and restored after failure")
+    func dismissalPresentation() async throws {
+        var configuration = StartupConfiguration()
+        configuration.add(target: .shell, customName: "Default")
+        let recorder = WorkspaceStartupRecorder()
+        recorder.holdCreate = true
+        recorder.results["Default"] = [.definitiveFailure]
+        let coordinator = coordinator(
+            recorder: recorder,
+            plan: try plan(configuration: configuration)
+        )
+
+        let start = Task {
+            await coordinator.start(projectID: "prj_one", name: "Created")
+        }
+        await Task.yield()
+        #expect(coordinator.state == .creatingWorkspace)
+        #expect(coordinator.isDismissDisabled)
+
+        recorder.releaseCreate()
+        await start.value
+        #expect(!coordinator.isDismissDisabled)
+        #expect(coordinator.state == .failedDefault(message: "launch failed"))
+    }
+}
+
+@MainActor
+@Suite("Workspace startup creation cue")
+struct WorkspaceStartupCreationCueTests {
+    private func cue(
+        _ configuration: StartupConfiguration,
+        availability: StartupEntryAvailability?
+    ) -> WorkspaceStartupCreationCue {
+        let entries = configuration.entries.map {
+            ValidatedStartupEntry(
+                entryID: $0.id,
+                availability: availability ?? .unableToValidate,
+                cachedActionName: nil
+            )
+        }
+        return WorkspaceStartupCreationCue.resolve(
+            configuration: configuration,
+            validation: StartupConfigurationValidation(entries: entries, canEdit: true)
+        )
+    }
+
+    @Test("empty, valid, unavailable, and unvalidated configurations choose the right cue")
+    func cueMatrix() {
+        #expect(cue(.empty, availability: nil) == .none)
+
+        var configuration = StartupConfiguration()
+        configuration.add(target: .action(id: "act_default"))
+        #expect(cue(configuration, availability: .valid) == .configured)
+        #expect(cue(configuration, availability: .missing) == .defaultUnavailable)
+        #expect(cue(configuration, availability: .disabled) == .defaultUnavailable)
+        #expect(cue(configuration, availability: .unableToValidate) == .configured)
+
+        configuration.add(target: .action(id: "act_background"))
+        let mixedValidation = StartupConfigurationValidation(
+            entries: [
+                ValidatedStartupEntry(
+                    entryID: configuration.entries[0].id,
+                    availability: .valid,
+                    cachedActionName: "Default"
+                ),
+                ValidatedStartupEntry(
+                    entryID: configuration.entries[1].id,
+                    availability: .missing,
+                    cachedActionName: nil
+                ),
+            ],
+            canEdit: true
+        )
+        #expect(WorkspaceStartupCreationCue.resolve(
+            configuration: configuration,
+            validation: mixedValidation
+        ) == .configured)
+    }
+
+    @Test("an empty configuration has no launch plan")
+    func emptyPlan() {
+        #expect(WorkspaceStartupLaunchPlan(
+            configuration: .empty,
+            validation: StartupConfigurationValidation(entries: [], canEdit: false)
+        ) == nil)
+    }
+
+    @Test("activating an existing Workspace never reruns startup")
+    func reopeningDoesNotLaunch() async throws {
+        let client = ScriptableClient()
+        let appModel = AppModel.preview(client: client)
+        await appModel.refreshAll()
+        let runtime = try #require(appModel.runtimes.first)
+        appModel.workspaceStartup.updateConnectionConfiguration(connectionID: runtime.id) {
+            $0.add(target: .shell)
+        }
+        let state = WindowState.ephemeral()
+
+        #expect(state.activateWorkspace(
+            WorkspaceRef(connectionID: runtime.id, workspaceID: "wsp_parser"),
+            in: appModel
+        ))
+        pump(seconds: 0.05)
+
+        #expect(client.startSessionRequests.isEmpty)
+    }
+}

--- a/macos/CONTEXT.md
+++ b/macos/CONTEXT.md
@@ -22,11 +22,11 @@ A Server-owned task context within one Project. In the initial version, every Wo
 _Avoid_: Checkout, worktree
 
 **Workspace Startup Configuration**:
-The local macOS preference that lists Action and Interactive Shell entries for Workspace startup. Each Connection has defaults; a Project either uses those defaults with live inheritance or has a Custom configuration copied once and then independent. An explicitly empty Custom configuration suppresses the Connection defaults.
+The local macOS preference that lists Action and Interactive Shell entries launched when a Workspace is created. Each Connection has defaults; a Project either uses those defaults with live inheritance or has a Custom configuration copied once and then independent. An explicitly empty Custom configuration suppresses the Connection defaults.
 _Avoid_: Workspace template, server startup configuration
 
 **Default Session**:
-The one entry designated as the Default in every nonempty Workspace Startup Configuration. The first entry added becomes Default, the designation can be transferred, and removing it promotes the earliest remaining entry.
+The one entry designated as the Default in every nonempty Workspace Startup Configuration. It launches first during Workspace creation, and the new Workspace opens with that Session selected after it starts. The first entry added becomes Default, the designation can be transferred, and removing it promotes the earliest remaining entry.
 _Avoid_: Primary Session, first Session
 
 **Session**:


### PR DESCRIPTION
## Summary

Implements [ATC-52](https://linear.app/elevenideas/issue/ATC-52/launch-configured-sessions-when-creating-a-workspace): creating a Workspace now honors the Project's resolved startup configuration, dropping the user into the Default Session as soon as it is real.

**Stacked on #119 (ATC-49)** — merge order: #117 → #118 → #119 → this.

### Creation sheet
- Empty resolved configuration: today's flow is byte-for-byte unchanged.
- Nonempty valid: subtle accent bolt beside Create Workspace ("Starts configured Sessions"). A Default Session known missing/disabled per a loaded registry blocks creation with a warning, inline message, and an Edit Startup Settings route that opens the startup editor after the sheet dismisses; unvalidated configurations never block (server response stays authoritative).
- During confirmed progress the sheet is non-dismissible (Cancel disabled + `interactiveDismissDisabled`) with stage labels; Open Workspace Anyway is never offered while a launch is merely in progress.

### Coordinator
- New testable `WorkspaceStartupCoordinator` state machine (idle → creatingWorkspace → launchingDefault → succeeded / failedCreation / failedDefault / ambiguous) with injected operations; it vends the sheet's primary/secondary action titles so state interpretation lives in one place.
- Success: dismiss → activate Workspace → select the real Default Session → launch remaining entries concurrently in the background.
- Definitive failure (`ATCError.api`): durable Workspace kept; Retry (default only, repeatable) and Open Workspace Anyway (activate with no selection, then background launches). Ambiguous transport failure: sessions refreshed, only Open Workspace, never auto-retried.
- Background: known-unavailable entries skipped; failures independent; at most one dismissible in-memory window-level notice naming the Workspace and aggregating identical failures ("2 × Editor failed: launch_failed"). Nothing persists or resumes; reopening a Workspace never reruns startup.

### Docs
- `macos/CONTEXT.md`: Workspace Startup Configuration / Default Session entries updated for execution semantics.

### Tests
- Coordinator happy-path ordering and concurrency (continuation-held fakes prove the default launches first and companions run concurrently), repeatable retry, Open Workspace Anyway, ambiguous refresh/no-auto-retry, aggregation and skip behavior, no-notice success, creation-cue matrix, dismissal gating, empty plan, and reopen-never-relaunches. Full `mise run macos:test` green.

Completes the ATC-48 implementation series.