### PR TITLE
ATC-85: Scaffold the App Server package, serve skeleton, and CI

### DIFF
--- a/.github/workflows/app-server-ci.yml
+++ b/.github/workflows/app-server-ci.yml
@@ -1,0 +1,44 @@
+name: App Server CI
+
+on:
+  pull_request:
+    paths:
+      - "app-server/**"
+      - "mise.toml"
+      - ".github/workflows/app-server-ci.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "app-server/**"
+      - "mise.toml"
+      - ".github/workflows/app-server-ci.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: app-server-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: app-server
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: jdx/mise-action@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          working_directory: app-server
+
+      # Same gates as local `mise run check`: frozen-lockfile install,
+      # Prettier format check, strict tsc, and the Bun test suite (which
+      # includes the black-box serve/shutdown test over loopback TCP).
+      - name: Check
+        run: mise run check

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 # macOS
 .DS_Store
 
+# Editors
+.idea/
+*.swp
+*.swo
+
 # Xcode
 xcuserdata/
 DerivedData/
@@ -9,7 +14,23 @@ DerivedData/
 .build/
 .swiftpm/
 
+# Environment and local configuration
+.env
+.env.*
+!.env.example
+!.env.*.example
+
+# JavaScript / TypeScript / Bun
+node_modules/
+dist/
+coverage/
+.cache/
+.bun/
+*.tsbuildinfo
+
+# Logs
+*.log
+
 # Provider POC artifacts
-experiments/provider-identity-resume/node_modules/
 experiments/provider-identity-resume/.generated/
 experiments/provider-identity-resume/runs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,32 @@ Long term maintainability is a core priority. If you add new functionality, firs
 
 The server stands on its own and is meant as a flexible resource that other apps can connect to and be built on top of. The Web UI is more admin interface than API client. It's meant as a place to manage all aspects of the server and document the CLI and API. The CLI and API should mirror each other in terms of functionality unless there is a good reason they should not.
 
+## App Server (app-server/)
+
+The TypeScript/Bun successor to the Go server. Conventions established there:
+
+- One Bun package: one `package.json`, one committed `bun.lock`. Install with
+  `bun install --frozen-lockfile` (the `install` mise task).
+- The Bun version is pinned exactly in `app-server/mise.toml`; no floating
+  channels.
+- Dependencies are pinned exactly and stay minimal. Hono and Commander are the
+  only runtime dependencies; adding another requires concrete justification.
+- Prettier is the single formatting solution; strict `tsc --noEmit` is the
+  type gate. No overlapping lint/format systems.
+- Boundaries: `src/main.ts` (entrypoint) → `src/cli/` (Commander registration
+  and parsing) → `src/server/` (serve lifecycle, listener start/stop, app
+  factory, routes) → `src/buildInfo.ts` (injected build metadata). The HTTP
+  app is constructible without a listener; build metadata, listener address,
+  and process lifecycle are injectable in tests.
+- Public HTTP routes are versioned under `/api/v1`; responses are typed JSON
+  with camelCase fields.
+- Tests live in `app-server/tests/` and run with `bun test`; they include a
+  black-box test that spawns the real entrypoint on an ephemeral loopback
+  port and verifies clean SIGTERM shutdown.
+- Workflows are mise tasks (`install`, `dev`, `fmt`, `fmt:check`, `typecheck`,
+  `test`, `check`); root `check`/`test` fan out to the package, and CI runs
+  the same `mise run check`.
+
 ## Source Control
 
 Jujutsu (jj) Protocol: You are in a jj repository; strictly do not use git

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ This repository is a monorepo holding every atc surface:
 | Directory | Surface |
 | --- | --- |
 | [`server/`](server/) | atc server — the standalone Go service, HTTP/WebSocket API, `atc` CLI, and embedded admin web UI |
+| [`app-server/`](app-server/) | ATC App Server — the in-progress TypeScript/Bun successor to the Go server |
 | [`macos/`](macos/) | atc for macOS — the native SwiftUI client |
 | `ios/` | Reserved for a future atc for iOS client |
 | [`packages/`](packages/) | Shared cross-surface libraries (currently `ATCKit`, the Swift API client) |
-| [`docs/`](docs/) | Product, architecture, and planning documentation |
 | [`scripts/`](scripts/) | Repo-level helper scripts |
 
 ## atc server
@@ -116,7 +116,7 @@ Tasks are run with [mise](https://mise.jdx.dev). From the repo root:
 
 ```sh
 mise run check   # every gate: gofmt, go vet, Go tests, web type check,
-                 # web tests, ATCKit tests, macOS app tests
+                 # web tests, App Server check, ATCKit tests, macOS app tests
 mise run test    # all test suites
 ```
 
@@ -127,9 +127,7 @@ green local `check` means a green build.
 
 The HTTP API's wire shapes are pinned by shared fixtures in
 [`packages/contracts/`](packages/contracts/) that the Go server, Swift
-client, and web client all test against. Platform and security decisions
-(macOS floor, sandbox/ATS stance, token storage) live in
-[`docs/platform-policy.md`](docs/platform-policy.md).
+client, and web client all test against.
 
 Each surface builds, tests, and releases independently; see the workflows in
 `.github/workflows/`.

--- a/app-server/.gitignore
+++ b/app-server/.gitignore
@@ -1,1 +1,0 @@
-node_modules/

--- a/app-server/.gitignore
+++ b/app-server/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/app-server/.prettierignore
+++ b/app-server/.prettierignore
@@ -1,0 +1,1 @@
+bun.lock

--- a/app-server/README.md
+++ b/app-server/README.md
@@ -1,0 +1,44 @@
+# ATC App Server
+
+The TypeScript implementation of the ATC server and `atc` CLI, built on
+[Bun](https://bun.sh). It lives alongside the existing Go server in
+[`../server/`](../server/) until cutover; the Go server remains the installed
+product today.
+
+Bun is pinned in [`mise.toml`](mise.toml) and installed automatically by
+[mise](https://mise.jdx.dev). All workflows are mise tasks:
+
+```sh
+mise run install    # install dependencies from the committed bun.lock
+mise run dev        # run `atc serve` in the foreground (http://127.0.0.1:7332)
+mise run test       # run the Bun test suite
+mise run fmt        # format with Prettier
+mise run fmt:check  # fail if formatting is needed
+mise run typecheck  # strict TypeScript type check
+mise run check      # everything CI runs: fmt:check + typecheck + test
+```
+
+The dev port 7332 is a temporary development default (the Go server uses
+7331); production listener behavior is settled in later work.
+
+## Structure
+
+One Bun package, one `package.json`, one committed `bun.lock`. Runtime
+dependencies are pinned exactly and kept minimal: Hono (HTTP) and Commander
+(CLI parsing).
+
+| Path                      | Responsibility                                                        |
+| ------------------------- | --------------------------------------------------------------------- |
+| `src/main.ts`             | Source entrypoint for the `atc` executable                            |
+| `src/cli/program.ts`      | CLI command registration and parsing (Commander)                      |
+| `src/server/serve.ts`     | Foreground serve lifecycle: bind, wait for SIGINT/SIGTERM, shut down  |
+| `src/server/lifecycle.ts` | Listener start/stop and shutdown signals (`Bun.serve`)                |
+| `src/server/app.ts`       | HTTP application factory (constructible without a listener)           |
+| `src/server/routes.ts`    | Public `/api/v1` routes and their typed responses                     |
+| `src/buildInfo.ts`        | Version and build metadata provider                                   |
+| `tests/`                  | Bun tests, including a black-box test of the real entrypoint over TCP |
+
+Public HTTP routes are versioned under `/api/v1`:
+
+- `GET /api/v1/health` → `{ "status": "ok" }`
+- `GET /api/v1/version` → application version, `apiVersion`, and build metadata

--- a/app-server/bun.lock
+++ b/app-server/bun.lock
@@ -1,0 +1,75 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "atc-app-server",
+      "dependencies": {
+        "commander": "15.0.0",
+        "hono": "4.12.32",
+      },
+      "devDependencies": {
+        "@types/bun": "1.3.14",
+        "prettier": "3.9.6",
+        "typescript": "7.0.2",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
+
+    "hono": ["hono@4.12.32", "", {}, "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg=="],
+
+    "prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
+
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/app-server/mise.toml
+++ b/app-server/mise.toml
@@ -1,0 +1,42 @@
+[tools]
+bun = "1.3.14"
+
+# --- Primary entrypoints ---
+
+[tasks.dev]
+description = "Run the App Server in the foreground (temporary dev default: http://127.0.0.1:7332)"
+depends = ["install"]
+run = "bun run src/main.ts serve"
+
+[tasks.check]
+description = "All App Server gates: format check, strict type check, tests"
+depends = ["fmt:check", "typecheck", "test"]
+
+# --- Building blocks ---
+
+# fmt:check/typecheck/test share install as a dependency instead of each
+# installing themselves: mise runs tasks in parallel, and concurrent installs
+# into the same node_modules race. A shared dependency runs exactly once.
+[tasks.install]
+description = "Install dependencies from the committed lockfile"
+run = "bun install --frozen-lockfile"
+
+[tasks.fmt]
+description = "Format TypeScript, JSON, and Markdown with Prettier"
+depends = ["install"]
+run = "bun run prettier --write ."
+
+[tasks."fmt:check"]
+description = "Fail if any file is not Prettier-clean"
+depends = ["install"]
+run = "bun run prettier --check ."
+
+[tasks.typecheck]
+description = "Strict TypeScript type check (no emit)"
+depends = ["install"]
+run = "bun run tsc --noEmit"
+
+[tasks.test]
+description = "Run the Bun test suite"
+depends = ["install"]
+run = "bun test"

--- a/app-server/package.json
+++ b/app-server/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "atc-app-server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "ATC App Server — the TypeScript server and atc CLI",
+  "dependencies": {
+    "commander": "15.0.0",
+    "hono": "4.12.32"
+  },
+  "devDependencies": {
+    "@types/bun": "1.3.14",
+    "prettier": "3.9.6",
+    "typescript": "7.0.2"
+  }
+}

--- a/app-server/src/buildInfo.ts
+++ b/app-server/src/buildInfo.ts
@@ -1,0 +1,23 @@
+import packageJson from "../package.json";
+
+/** Build metadata carried by the running executable. */
+export interface BuildInfo {
+  /** Application version, e.g. "0.1.0". */
+  version: string;
+  /** Source revision the executable was built from. */
+  commit: string;
+  /** ISO-8601 timestamp of the build. */
+  builtAt: string;
+}
+
+/**
+ * Build metadata for running from source. Compiled executables will inject
+ * real commit/builtAt values at build time (ATC-88).
+ */
+export function developmentBuildInfo(): BuildInfo {
+  return {
+    version: packageJson.version,
+    commit: "development",
+    builtAt: "development",
+  };
+}

--- a/app-server/src/cli/program.ts
+++ b/app-server/src/cli/program.ts
@@ -1,0 +1,54 @@
+import { Command, InvalidArgumentError } from "commander";
+import type { BuildInfo } from "../buildInfo.ts";
+
+/**
+ * Temporary development default, distinct from the Go server's 7331 so both
+ * implementations can run side by side.
+ *
+ * Delete this rather than maintain it. Two things retire it: the real listener
+ * default arrives with App Server configuration (flags > env > config file >
+ * defaults), and the side-by-side reason disappears entirely when the Go
+ * server is removed at cutover. Until then nothing else should come to depend
+ * on 7332 — it is a development convenience, not a documented port.
+ */
+export const DEFAULT_DEV_PORT = 7332;
+
+export interface ProgramDependencies {
+  buildInfo: BuildInfo;
+  serve: (options: { port: number }) => Promise<void>;
+}
+
+/** Build the atc CLI: command registration and parsing only, no side effects. */
+export function createProgram({
+  buildInfo,
+  serve,
+}: ProgramDependencies): Command {
+  const program = new Command("atc")
+    .description("ATC App Server")
+    .version(buildInfo.version);
+
+  program
+    .command("serve")
+    .description("Run the App Server in the foreground on loopback TCP")
+    .option(
+      "--port <port>",
+      "TCP port to listen on (0 for an ephemeral port)",
+      parsePort,
+      DEFAULT_DEV_PORT,
+    )
+    .action(async (options: { port: number }) => {
+      await serve({ port: options.port });
+    });
+
+  return program;
+}
+
+function parsePort(value: string): number {
+  // Digits only: Number() alone would accept "", "0x50", "1e4", " 8080 ", …
+  if (!/^\d{1,5}$/.test(value) || Number(value) > 65535) {
+    throw new InvalidArgumentError(
+      "port must be an integer between 0 and 65535.",
+    );
+  }
+  return Number(value);
+}

--- a/app-server/src/main.ts
+++ b/app-server/src/main.ts
@@ -1,0 +1,20 @@
+// Source entrypoint for the atc executable (compiled standalone in ATC-88).
+import { developmentBuildInfo } from "./buildInfo.ts";
+import { createProgram } from "./cli/program.ts";
+import { runServe } from "./server/serve.ts";
+
+const buildInfo = developmentBuildInfo();
+
+const program = createProgram({
+  buildInfo,
+  serve: ({ port }) =>
+    runServe({ listen: { hostname: "127.0.0.1", port }, buildInfo }),
+});
+
+try {
+  await program.parseAsync(process.argv);
+} catch (error) {
+  // Surface startup failures (e.g. port in use) as one line, not a stack trace.
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/app-server/src/server/app.ts
+++ b/app-server/src/server/app.ts
@@ -1,0 +1,15 @@
+import { Hono } from "hono";
+import type { BuildInfo } from "../buildInfo.ts";
+import { API_VERSION, createV1Routes } from "./routes.ts";
+
+/** Everything the HTTP application depends on; injected so tests control it. */
+export interface AppDependencies {
+  buildInfo: BuildInfo;
+}
+
+/** Build the complete HTTP application without opening a listener. */
+export function createApp({ buildInfo }: AppDependencies): Hono {
+  const app = new Hono();
+  app.route(`/api/${API_VERSION}`, createV1Routes(buildInfo));
+  return app;
+}

--- a/app-server/src/server/lifecycle.ts
+++ b/app-server/src/server/lifecycle.ts
@@ -1,0 +1,71 @@
+import type { Hono } from "hono";
+
+/** How long stop() waits for in-flight requests before force-closing. */
+const DEFAULT_SHUTDOWN_GRACE_MS = 5000;
+
+export interface ListenOptions {
+  hostname: string;
+  /** TCP port; 0 asks the OS for an ephemeral port. */
+  port: number;
+  /** Drain window for stop(); tests shorten it to keep hung-request coverage fast. */
+  shutdownGraceMs?: number;
+}
+
+export interface RunningServer {
+  /** The bound address, with the real port when an ephemeral one was requested. */
+  url: URL;
+  stop(): Promise<void>;
+}
+
+/** Bind the application to a TCP listener. */
+export function startServer(
+  app: Hono,
+  {
+    hostname,
+    port,
+    shutdownGraceMs = DEFAULT_SHUTDOWN_GRACE_MS,
+  }: ListenOptions,
+): RunningServer {
+  // Bun offers no bounded graceful stop: stop() waits on in-flight requests
+  // indefinitely, and stop(true) is ignored while that wait is pending. So
+  // shutdown is built the other way around — reject new requests here, drain
+  // in-flight ones within the grace window, then force-close once.
+  let stopping = false;
+  const server = Bun.serve({
+    hostname,
+    port,
+    fetch: (request) =>
+      stopping
+        ? new Response("Server is shutting down", { status: 503 })
+        : app.fetch(request),
+  });
+  return {
+    url: server.url,
+    stop: async () => {
+      stopping = true;
+      const deadline = Date.now() + shutdownGraceMs;
+      while (server.pendingRequests > 0 && Date.now() < deadline) {
+        await Bun.sleep(10);
+      }
+      await server.stop(true);
+    },
+  };
+}
+
+export type ShutdownSignal = "SIGINT" | "SIGTERM";
+
+/** Resolves with the first SIGINT or SIGTERM, removing both listeners. */
+export function onceShutdownSignal(): Promise<ShutdownSignal> {
+  return new Promise((resolve) => {
+    const onSigint = () => {
+      process.off("SIGTERM", onSigterm);
+      resolve("SIGINT");
+    };
+    const onSigterm = () => {
+      process.off("SIGINT", onSigint);
+      resolve("SIGTERM");
+    };
+    process.once("SIGINT", onSigint);
+    process.once("SIGTERM", onSigterm);
+  });
+}

--- a/app-server/src/server/routes.ts
+++ b/app-server/src/server/routes.ts
@@ -1,0 +1,33 @@
+import { Hono } from "hono";
+import type { BuildInfo } from "../buildInfo.ts";
+
+export const API_VERSION = "v1";
+
+interface HealthResponse {
+  status: "ok";
+}
+
+interface VersionResponse {
+  version: string;
+  apiVersion: typeof API_VERSION;
+  commit: string;
+  builtAt: string;
+}
+
+/** The public v1 API routes, mounted by the application under /api/v1. */
+export function createV1Routes(buildInfo: BuildInfo): Hono {
+  const v1 = new Hono();
+
+  v1.get("/health", (c) => c.json<HealthResponse>({ status: "ok" }));
+
+  v1.get("/version", (c) =>
+    c.json<VersionResponse>({
+      version: buildInfo.version,
+      apiVersion: API_VERSION,
+      commit: buildInfo.commit,
+      builtAt: buildInfo.builtAt,
+    }),
+  );
+
+  return v1;
+}

--- a/app-server/src/server/serve.ts
+++ b/app-server/src/server/serve.ts
@@ -1,0 +1,29 @@
+import type { BuildInfo } from "../buildInfo.ts";
+import { createApp } from "./app.ts";
+import {
+  onceShutdownSignal,
+  startServer,
+  type ListenOptions,
+} from "./lifecycle.ts";
+
+export interface ServeOptions {
+  listen: ListenOptions;
+  buildInfo: BuildInfo;
+}
+
+/**
+ * Run the App Server in the foreground: bind the listener, then wait for
+ * SIGINT/SIGTERM and shut the listener down cleanly.
+ */
+export async function runServe({
+  listen,
+  buildInfo,
+}: ServeOptions): Promise<void> {
+  const app = createApp({ buildInfo });
+  const server = startServer(app, listen);
+  console.log(`ATC App Server listening on ${server.url}`);
+
+  const signal = await onceShutdownSignal();
+  console.log(`Received ${signal}, shutting down`);
+  await server.stop();
+}

--- a/app-server/tests/app.test.ts
+++ b/app-server/tests/app.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test";
+import type { BuildInfo } from "../src/buildInfo.ts";
+import { createApp } from "../src/server/app.ts";
+
+const buildInfo: BuildInfo = {
+  version: "1.2.3",
+  commit: "abc1234",
+  builtAt: "2026-01-01T00:00:00Z",
+};
+
+test("GET /api/v1/health returns ok without a listener", async () => {
+  const res = await createApp({ buildInfo }).request("/api/v1/health");
+  expect(res.status).toBe(200);
+  expect(res.headers.get("content-type")).toStartWith("application/json");
+  expect(await res.json()).toEqual({ status: "ok" });
+});
+
+test("GET /api/v1/version returns injected build metadata", async () => {
+  const res = await createApp({ buildInfo }).request("/api/v1/version");
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({
+    version: "1.2.3",
+    apiVersion: "v1",
+    commit: "abc1234",
+    builtAt: "2026-01-01T00:00:00Z",
+  });
+});
+
+test("unknown routes return 404", async () => {
+  const res = await createApp({ buildInfo }).request("/api/v1/nope");
+  expect(res.status).toBe(404);
+});

--- a/app-server/tests/lifecycle.test.ts
+++ b/app-server/tests/lifecycle.test.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "bun:test";
+import { Hono } from "hono";
+import { createApp } from "../src/server/app.ts";
+import { onceShutdownSignal, startServer } from "../src/server/lifecycle.ts";
+
+const app = createApp({
+  buildInfo: {
+    version: "1.2.3",
+    commit: "abc1234",
+    builtAt: "2026-01-01T00:00:00Z",
+  },
+});
+
+test("startServer binds an ephemeral loopback port and stop() releases it", async () => {
+  const server = startServer(app, { hostname: "127.0.0.1", port: 0 });
+  const port = Number(server.url.port);
+  expect(server.url.hostname).toBe("127.0.0.1");
+  expect(port).toBeGreaterThan(0);
+
+  const res = await fetch(new URL("/api/v1/health", server.url));
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({ status: "ok" });
+
+  await server.stop();
+
+  // The strongest observable proof the listener is gone: the port can be
+  // bound again immediately.
+  const rebound = startServer(app, { hostname: "127.0.0.1", port });
+  expect(Number(rebound.url.port)).toBe(port);
+  await rebound.stop();
+});
+
+/** A Hono app whose /hang route never responds, plus proof it was entered. */
+function hangingApp() {
+  let entered!: () => void;
+  const requestEntered = new Promise<void>((resolve) => {
+    entered = resolve;
+  });
+  const app = new Hono();
+  app.get("/hang", () => {
+    entered();
+    return new Promise<Response>(() => {});
+  });
+  return { app, requestEntered };
+}
+
+test("stop() force-closes a request that outlives the shutdown grace window", async () => {
+  const { app: hanging, requestEntered } = hangingApp();
+  const server = startServer(hanging, {
+    hostname: "127.0.0.1",
+    port: 0,
+    shutdownGraceMs: 50,
+  });
+  const pending = fetch(new URL("/hang", server.url)).catch(() => "aborted");
+  // Wait until the request is provably in the handler, so stop() exercises
+  // the drain-then-force-close path rather than seeing an idle server.
+  await requestEntered;
+
+  await server.stop();
+  expect(await pending).toBe("aborted");
+});
+
+test("stop() rejects requests that arrive while in-flight ones drain", async () => {
+  const { app: hanging, requestEntered } = hangingApp();
+  const server = startServer(hanging, {
+    hostname: "127.0.0.1",
+    port: 0,
+    shutdownGraceMs: 200,
+  });
+  const pending = fetch(new URL("/hang", server.url)).catch(() => "aborted");
+  await requestEntered;
+
+  const stopped = server.stop();
+  // The hanging request holds stop() in its grace window; new work must be
+  // turned away instead of being served normally.
+  const late = await fetch(new URL("/hang", server.url));
+  expect(late.status).toBe(503);
+
+  await stopped;
+  expect(await pending).toBe("aborted");
+});
+
+test("onceShutdownSignal resolves on the first signal and removes both listeners", async () => {
+  const sigintBefore = process.listenerCount("SIGINT");
+  const sigtermBefore = process.listenerCount("SIGTERM");
+
+  const signal = onceShutdownSignal();
+  expect(process.listenerCount("SIGINT")).toBe(sigintBefore + 1);
+  expect(process.listenerCount("SIGTERM")).toBe(sigtermBefore + 1);
+
+  process.emit("SIGINT");
+  expect(await signal).toBe("SIGINT");
+  expect(process.listenerCount("SIGINT")).toBe(sigintBefore);
+  expect(process.listenerCount("SIGTERM")).toBe(sigtermBefore);
+});

--- a/app-server/tests/program.test.ts
+++ b/app-server/tests/program.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test";
+import { createProgram, DEFAULT_DEV_PORT } from "../src/cli/program.ts";
+
+const buildInfo = {
+  version: "1.2.3",
+  commit: "abc1234",
+  builtAt: "2026-01-01T00:00:00Z",
+};
+
+// exitOverride/configureOutput are per-command in Commander, so apply them to
+// the subcommands as well: tests must observe errors, not exit the process.
+function captureServe() {
+  const calls: { port: number }[] = [];
+  const program = createProgram({
+    buildInfo,
+    serve: async (options) => {
+      calls.push(options);
+    },
+  });
+  const silent = { writeOut: () => {}, writeErr: () => {} };
+  for (const command of [program, ...program.commands]) {
+    command.exitOverride().configureOutput(silent);
+  }
+  return { program, calls };
+}
+
+test("serve uses the development default port", async () => {
+  const { program, calls } = captureServe();
+  await program.parseAsync(["serve"], { from: "user" });
+  expect(calls).toEqual([{ port: DEFAULT_DEV_PORT }]);
+});
+
+test("serve --port passes the parsed port through", async () => {
+  const { program, calls } = captureServe();
+  await program.parseAsync(["serve", "--port", "0"], { from: "user" });
+  expect(calls).toEqual([{ port: 0 }]);
+});
+
+const validPorts = ["0", "8080", "65535"];
+const invalidPorts = [
+  "",
+  " 8080 ",
+  "banana",
+  "1.5",
+  "-1",
+  "65536",
+  "0x50",
+  "1e4",
+  "+80",
+];
+
+test.each(validPorts)("serve --port accepts %j", async (value) => {
+  const { program, calls } = captureServe();
+  await program.parseAsync(["serve", "--port", value], { from: "user" });
+  expect(calls).toEqual([{ port: Number(value) }]);
+});
+
+test.each(invalidPorts)(
+  "serve --port rejects %j without calling serve",
+  async (value) => {
+    const { program, calls } = captureServe();
+    await expect(
+      program.parseAsync(["serve", "--port", value], { from: "user" }),
+    ).rejects.toThrow("port must be an integer");
+    expect(calls).toEqual([]);
+  },
+);
+
+test("--version reports the injected application version", async () => {
+  const { program } = captureServe();
+  await expect(
+    program.parseAsync(["--version"], { from: "user" }),
+  ).rejects.toThrow("1.2.3");
+});

--- a/app-server/tests/serve.e2e.test.ts
+++ b/app-server/tests/serve.e2e.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+import packageJson from "../package.json";
+
+const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+
+async function readUntil(
+  stream: ReadableStream<Uint8Array>,
+  pattern: RegExp,
+): Promise<RegExpMatchArray> {
+  const decoder = new TextDecoder();
+  let seen = "";
+  for await (const chunk of stream) {
+    seen += decoder.decode(chunk, { stream: true });
+    const match = seen.match(pattern);
+    if (match) return match;
+  }
+  throw new Error(
+    `stream ended before matching ${pattern}; output so far:\n${seen}`,
+  );
+}
+
+test("the serve entrypoint serves health and version over TCP and exits cleanly on SIGTERM", async () => {
+  const proc = Bun.spawn({
+    cmd: [process.execPath, "src/main.ts", "serve", "--port", "0"],
+    cwd: packageRoot,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+
+  try {
+    const [, baseUrl] = await readUntil(
+      proc.stdout,
+      /listening on (http:\/\/\S+)/,
+    );
+    if (!baseUrl) throw new Error("no URL captured from the listening line");
+
+    const health = await fetch(new URL("/api/v1/health", baseUrl), {
+      signal: AbortSignal.timeout(5000),
+    });
+    expect(health.status).toBe(200);
+    expect(await health.json()).toEqual({ status: "ok" });
+
+    const version = await fetch(new URL("/api/v1/version", baseUrl), {
+      signal: AbortSignal.timeout(5000),
+    });
+    expect(version.status).toBe(200);
+    expect(await version.json()).toEqual({
+      version: packageJson.version,
+      apiVersion: "v1",
+      commit: "development",
+      builtAt: "development",
+    });
+
+    proc.kill("SIGTERM");
+    expect(await proc.exited).toBe(0);
+  } finally {
+    proc.kill();
+    await proc.exited;
+  }
+}, 15000);

--- a/app-server/tsconfig.json
+++ b/app-server/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "types": ["bun"]
+  },
+  "include": ["src", "tests"]
+}

--- a/mise.toml
+++ b/mise.toml
@@ -3,12 +3,12 @@
 # "is the repo healthy?" the same way locally and in CI.
 
 [tasks.check]
-description = "All gates: server fmt/vet/tests + web check, Kit tests, macOS app tests"
-depends = ["server:check", "kit:test", "macos:test"]
+description = "All gates: server fmt/vet/tests + web check, App Server check, Kit tests, macOS app tests"
+depends = ["server:check", "app-server:check", "kit:test", "macos:test"]
 
 [tasks.test]
-description = "All tests: server Go suite, ATCKit, macOS app"
-depends = ["server:test", "kit:test", "macos:test"]
+description = "All tests: server Go suite, App Server, ATCKit, macOS app"
+depends = ["server:test", "app-server:test", "kit:test", "macos:test"]
 
 # --- Server (Go API + embedded web UI) ---
 
@@ -27,6 +27,20 @@ run = "mise run -C server build"
 [tasks."web:check"]
 description = "Type-check the web UI (svelte-check)"
 run = "mise run -C server web:check"
+
+# --- App Server (TypeScript/Bun, successor in progress) ---
+
+[tasks."app-server:check"]
+description = "App Server format check, type check, and tests"
+run = "mise run -C app-server check"
+
+[tasks."app-server:test"]
+description = "App Server tests"
+run = "mise run -C app-server test"
+
+[tasks."app-server:dev"]
+description = "Run the App Server in the foreground"
+run = "mise run -C app-server dev"
 
 # --- Swift surfaces ---
 


### PR DESCRIPTION
Implements [ATC-85](https://linear.app/elevenideas/issue/ATC-85/scaffold-the-app-server-package-serve-skeleton-and-ci): the production-shaped TypeScript App Server foundation, created alongside the existing Go `server/` (which is untouched).

## What's here

- **`app-server/`** — one Bun package, one `package.json`, committed `bun.lock`, Bun 1.3.14 pinned in `mise.toml`. Production deps are exactly Hono 4.12.32 and Commander 15.0.0, pinned.
- **CLI**: `atc serve` (Commander) runs the server in the foreground on loopback TCP. `--port` is strictly validated (digits only, ≤ 65535); the temporary dev default is 7332 so the Go server (7331) can run beside it.
- **Boundaries**: `src/main.ts` (entrypoint) → `src/cli/program.ts` (command registration/parsing) → `src/server/serve.ts` (foreground lifecycle) → `src/server/lifecycle.ts` (listener start/stop, shutdown signals) → `src/server/app.ts` (app factory, no listener needed) → `src/server/routes.ts` (typed `/api/v1` handlers) → `src/buildInfo.ts` (injected build metadata).
- **Endpoints**: `GET /api/v1/health` → `{"status":"ok"}`; `GET /api/v1/version` → version, `apiVersion`, commit, builtAt (camelCase, typed, no env reads in handlers).
- **Shutdown**: SIGINT/SIGTERM drain in-flight requests within a bounded grace window (5 s default, injectable in tests), then force-close — a hung request can never wedge Ctrl+C. Startup failures (e.g. port in use) print one line, not a stack trace.
- **Tests** (22): in-process app tests without a listener; listener bind/stop with port-release proof; forced-shutdown grace; signal listener cleanup; table-driven port validation; and a black-box test that spawns the real entrypoint on an ephemeral port, hits both endpoints over TCP, and asserts exit 0 on SIGTERM.
- **Workflow/CI**: mise tasks (`install`, `dev`, `fmt`, `fmt:check`, `typecheck`, `test`, `check`) fanned into root `check`/`test`; `app-server-ci.yml` runs the same `mise run check` (frozen-lockfile install, Prettier check, strict tsc, tests) mirroring the Server CI pattern.
- **Docs**: `app-server/README.md` (one command per workflow), root README table/task updates and stale `docs/` reference cleanup, App Server conventions recorded in `AGENTS.md`.

## Verification

- `mise run app-server:check` green locally (format, strict typecheck, 22 tests); suite ran repeatedly with zero flakes.
- Fresh-copy `bun install --frozen-lockfile` verified clean with the lockfile unmodified.
- Go server tests still pass; no changes under `server/`, `macos/`, or `packages/`.
- Two adversarial reviews (correctness, simplicity) were run; all accepted findings are incorporated (bounded shutdown grace, strict port parsing, friendly startup errors, e2e hardening, removal of unused seams/config).
