### PR TITLE
Refactor prep: drop stale docs/ references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ This repository is a monorepo holding every atc surface:
 | [`macos/`](macos/) | atc for macOS — the native SwiftUI client |
 | `ios/` | Reserved for a future atc for iOS client |
 | [`packages/`](packages/) | Shared cross-surface libraries (currently `ATCKit`, the Swift API client) |
-| [`docs/`](docs/) | Product, architecture, and planning documentation |
 | [`scripts/`](scripts/) | Repo-level helper scripts |
 
 ## atc server
@@ -127,9 +126,7 @@ green local `check` means a green build.
 
 The HTTP API's wire shapes are pinned by shared fixtures in
 [`packages/contracts/`](packages/contracts/) that the Go server, Swift
-client, and web client all test against. Platform and security decisions
-(macOS floor, sandbox/ATS stance, token storage) live in
-[`docs/platform-policy.md`](docs/platform-policy.md).
+client, and web client all test against.
 
 Each surface builds, tests, and releases independently; see the workflows in
 `.github/workflows/`.


### PR DESCRIPTION
Split out of #121 per review: this README housekeeping change removes stale `docs/` references. It is not an App Server convention established by ATC-85, so it gets its own reviewable change.

https://claude.ai/code/session_01Hc5f2vXdqm3Un6J4GfJ4qp