### PR TITLE
ATC-117: Scaffold the Effect App Server package, serve skeleton, and CI

### DIFF
--- a/.github/workflows/app-server-ci.yml
+++ b/.github/workflows/app-server-ci.yml
@@ -1,0 +1,44 @@
+name: App Server CI
+
+on:
+  pull_request:
+    paths:
+      - "app-server/**"
+      - "mise.toml"
+      - ".github/workflows/app-server-ci.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "app-server/**"
+      - "mise.toml"
+      - ".github/workflows/app-server-ci.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: app-server-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: app-server
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: jdx/mise-action@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          working_directory: app-server
+
+      # Same gates as local `mise run check`: frozen-lockfile install,
+      # Prettier format check, strict tsc, and the vitest suite (which
+      # includes the black-box serve/shutdown test over loopback TCP).
+      - name: Check
+        run: mise run check

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ coverage/
 # Logs
 *.log
 
+# Read-only reference checkouts (mise run refs)
+/repos/
+
 # Provider POC artifacts
 experiments/provider-identity-resume/.generated/
 experiments/provider-identity-resume/runs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 # macOS
 .DS_Store
 
+# Editors
+.idea/
+*.swp
+*.swo
+
 # Xcode
 xcuserdata/
 DerivedData/
@@ -9,7 +14,23 @@ DerivedData/
 .build/
 .swiftpm/
 
+# Environment and local configuration
+.env
+.env.*
+!.env.example
+!.env.*.example
+
+# JavaScript / TypeScript / Bun
+node_modules/
+dist/
+coverage/
+.cache/
+.bun/
+*.tsbuildinfo
+
+# Logs
+*.log
+
 # Provider POC artifacts
-experiments/provider-identity-resume/node_modules/
 experiments/provider-identity-resume/.generated/
 experiments/provider-identity-resume/runs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,8 @@ deliberately). Write new code the same way:
 
 - Services are `Context.Service` classes with `Layer` implementations
   (`Layer.succeed` / `Layer.effect`). One service per module; export the class
-  and its `layer`.
+  and its `layer`. `HttpApiBuilder.group` handler layers are the exception:
+  name them `<Group>Handlers`.
 - Errors are Schema-based tagged error classes (`Schema.TaggedErrorClass`).
   API-visible errors carry an `httpApiStatus` annotation so HTTP status
   mapping derives from the contract. No plain `throw`/`Error` for domain

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,38 @@ OpenCode (https://github.com/sst/opencode) as Effect architecture references.
   training data — both skew heavily toward Effect v3.
 - To update a checkout, delete its directory and re-run `mise run refs`.
 
+## Effect Conventions (App Server)
+
+All TypeScript App Server code (`app-server/`) is written on Effect
+(`effect@4.0.0-beta.x` line + `@effect/platform-bun`, exact-pinned and upgraded
+deliberately). Write new code the same way:
+
+- Services are `Context.Service` classes with `Layer` implementations
+  (`Layer.succeed` / `Layer.effect`). One service per module; export the class
+  and its `layer`.
+- Errors are Schema-based tagged error classes (`Schema.TaggedErrorClass`).
+  API-visible errors carry an `httpApiStatus` annotation so HTTP status
+  mapping derives from the contract. No plain `throw`/`Error` for domain
+  failures.
+- HTTP is schema-first: endpoints are declared in the `HttpApi` contract
+  (`src/api.ts`) with Schema-typed responses, implemented with
+  `HttpApiBuilder.group`. The server, OpenAPI document, and typed clients all
+  derive from the contract.
+- All validation and domain types are Effect Schema. No zod or hand-rolled
+  parsing.
+- Exactly one runtime entrypoint: `BunRuntime.runMain` in `src/main.ts`. No
+  `runPromise`/manual runtimes anywhere else — tests use `@effect/vitest`
+  (`it.effect`), which manages the runtime for you.
+- Lifecycle is structured concurrency: resources live in Layers/Scopes so
+  SIGINT/SIGTERM interruption releases them. No hand-rolled signal listeners
+  or drain loops.
+- Tests substitute test Layers for production Layers; prefer in-process tests
+  (e.g. `HttpApiTest`) and reserve real listeners for lifecycle/black-box
+  coverage.
+- For Effect v4 APIs and idioms, read the pinned source under `repos/`
+  (`mise run refs`) and follow T3Code/OpenCode patterns; web search and
+  training data skew to Effect v3.
+
 ## Code Style
 
 - Always strive for simplicity. This is not a complex enterprise app.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,18 @@ Codex Desktop App (https://chatgpt.com/codex): Greate user experience
 AGTerm (https://github.com/umputun/agterm): LibGhostty app with a lot of similar features.
 CMUX (https://github.com/manaflow-ai/cmux): Agentic coding focused terminal based on libghostty.
 
+## Reference Source Checkouts
+
+`mise run refs` shallow-clones read-only reference source into `repos/` (gitignored):
+the Effect monorepo pinned to the app-server's Effect version, plus T3Code and
+OpenCode (https://github.com/sst/opencode) as Effect architecture references.
+
+- Treat everything under `repos/` as read-only reference material. Never import
+  from it, edit it, or copy files out of it wholesale.
+- For Effect v4 APIs and idioms, prefer reading this source over web search or
+  training data — both skew heavily toward Effect v3.
+- To update a checkout, delete its directory and re-run `mise run refs`.
+
 ## Code Style
 
 - Always strive for simplicity. This is not a complex enterprise app.

--- a/app-server/.gitignore
+++ b/app-server/.gitignore
@@ -1,1 +1,0 @@
-node_modules/

--- a/app-server/.gitignore
+++ b/app-server/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/app-server/.prettierignore
+++ b/app-server/.prettierignore
@@ -1,0 +1,1 @@
+bun.lock

--- a/app-server/README.md
+++ b/app-server/README.md
@@ -1,9 +1,7 @@
 # ATC App Server
 
 The TypeScript implementation of the ATC server and `atc` CLI, built on
-[Effect](https://effect.website) and [Bun](https://bun.sh). It lives alongside
-the existing Go server in [`../server/`](../server/) until cutover; the Go
-server remains the installed product today.
+[Effect](https://effect.website) and [Bun](https://bun.sh).
 
 Bun is pinned in [`mise.toml`](mise.toml) and installed automatically by
 [mise](https://mise.jdx.dev). All workflows are mise tasks:
@@ -18,17 +16,15 @@ mise run typecheck  # strict TypeScript type check
 mise run check      # everything CI runs: fmt:check + typecheck + test
 ```
 
-The dev port 7332 is a temporary development default (the Go server uses
-7331); production listener behavior is settled in later work.
+The server listens on port 7332 by default; pass `--port` to override.
 
 ## Structure
 
 One Bun package, one `package.json`, one committed `bun.lock`. Runtime
 dependencies are pinned exactly and kept minimal: `effect` (the application
 spine — HTTP, CLI, Schema, concurrency) and `@effect/platform-bun` (the Bun
-adapter). Effect is on the `4.0.0-beta.x` line, upgraded deliberately, never
-floated. `mise run refs` (repo root) checks out the matching Effect source for
-API reference.
+adapter), upgraded deliberately, never floated. `mise run refs` (repo root)
+checks out the matching Effect source for API reference.
 
 | Path               | Responsibility                                                    |
 | ------------------ | ----------------------------------------------------------------- |

--- a/app-server/README.md
+++ b/app-server/README.md
@@ -1,0 +1,50 @@
+# ATC App Server
+
+The TypeScript implementation of the ATC server and `atc` CLI, built on
+[Effect](https://effect.website) and [Bun](https://bun.sh). It lives alongside
+the existing Go server in [`../server/`](../server/) until cutover; the Go
+server remains the installed product today.
+
+Bun is pinned in [`mise.toml`](mise.toml) and installed automatically by
+[mise](https://mise.jdx.dev). All workflows are mise tasks:
+
+```sh
+mise run install    # install dependencies from the committed bun.lock
+mise run dev        # run `atc serve` in the foreground (http://127.0.0.1:7332)
+mise run test       # run the vitest suite on the Bun runtime
+mise run fmt        # format with Prettier
+mise run fmt:check  # fail if formatting is needed
+mise run typecheck  # strict TypeScript type check
+mise run check      # everything CI runs: fmt:check + typecheck + test
+```
+
+The dev port 7332 is a temporary development default (the Go server uses
+7331); production listener behavior is settled in later work.
+
+## Structure
+
+One Bun package, one `package.json`, one committed `bun.lock`. Runtime
+dependencies are pinned exactly and kept minimal: `effect` (the application
+spine — HTTP, CLI, Schema, concurrency) and `@effect/platform-bun` (the Bun
+adapter). Effect is on the `4.0.0-beta.x` line, upgraded deliberately, never
+floated. `mise run refs` (repo root) checks out the matching Effect source for
+API reference.
+
+| Path               | Responsibility                                                    |
+| ------------------ | ----------------------------------------------------------------- |
+| `src/main.ts`      | Entrypoint for the `atc` executable; the only `runMain`           |
+| `src/cli.ts`       | CLI commands and flags (Effect CLI); friendly startup failures    |
+| `src/api.ts`       | The `/api/v1` HttpApi contract: endpoints and response schemas    |
+| `src/handlers.ts`  | Contract implementation (handler Layer, no listener)              |
+| `src/server.ts`    | Server assembly: routes + loopback Bun listener Layer             |
+| `src/buildInfo.ts` | Build metadata service (version, commit, builtAt)                 |
+| `test/`            | `@effect/vitest` tests, including a black-box serve/shutdown test |
+
+The contract module is structured so the server implementation, an OpenAPI
+document, and generated typed clients all derive from the same `HttpApi`
+definition; OpenAPI serving and clients are follow-up work.
+
+Public HTTP routes are versioned under `/api/v1`:
+
+- `GET /api/v1/health` → `{ "status": "ok" }`
+- `GET /api/v1/version` → application version, `apiVersion`, and build metadata

--- a/app-server/bun.lock
+++ b/app-server/bun.lock
@@ -1,0 +1,271 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "atc-app-server",
+      "dependencies": {
+        "@effect/platform-bun": "4.0.0-beta.102",
+        "effect": "4.0.0-beta.102",
+      },
+      "devDependencies": {
+        "@effect/vitest": "4.0.0-beta.102",
+        "@types/bun": "1.3.14",
+        "prettier": "3.9.6",
+        "typescript": "7.0.2",
+        "vitest": "4.1.10",
+      },
+    },
+  },
+  "packages": {
+    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.102", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.102" }, "peerDependencies": { "effect": "^4.0.0-beta.102" } }, "sha512-hTIb0jjTfXhNgnDq2OX5wrigc0OSvTT0VWWb1PLpMM395RJPu8rCIbTlGhy0NS7kZOd8FfgNi9e0sDhgyu+5Ag=="],
+
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.102", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.102" } }, "sha512-gVd793I72MrkX4dXo7eYtRKfNj0RW4eMRfVEKEJI16h2+mBDCzQ+gqMrog2hSTHQnaIbvbYShNQ4TVGuRCYZeQ=="],
+
+    "@effect/vitest": ["@effect/vitest@4.0.0-beta.102", "", { "peerDependencies": { "effect": "^4.0.0-beta.102", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-4dipFAYG6imOzrY3zy3BgzCJkbb9xESyzUef0WSx8bsK0/SpITqbJpdwKeOyDWLZ+rimjua8IbTFMAde865pIQ=="],
+
+    "@emnapi/core": ["@emnapi/core@2.0.0-alpha.3", "", { "dependencies": { "@emnapi/wasi-threads": "2.0.1", "tslib": "^2.4.0" } }, "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@2.0.0-alpha.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@2.0.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4", "", { "os": "linux", "cpu": "arm" }, "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
+
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.2", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3", "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3" } }, "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.142.0", "", {}, "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.1", "", { "os": "android", "cpu": "arm64" }, "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.2.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.2.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.2.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.2.1", "", { "os": "linux", "cpu": "arm" }, "sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.2.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.2.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.2.1", "", { "os": "none", "cpu": "arm64" }, "sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.2.1", "", { "dependencies": { "@emnapi/core": "2.0.0-alpha.3", "@emnapi/runtime": "2.0.0-alpha.3", "@napi-rs/wasm-runtime": "^1.2.0" } }, "sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.2.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.2.1", "", { "os": "win32", "cpu": "x64" }, "sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.10", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.10", "", { "dependencies": { "@vitest/spy": "4.1.10", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.10", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.10", "", { "dependencies": { "@vitest/utils": "4.1.10", "pathe": "^2.0.3" } }, "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "@vitest/utils": "4.1.10", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.10", "", {}, "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "effect": ["effect@4.0.0-beta.102", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-z8Y+Q76Hh/kjLFZrXu8tGn6e+tDsg45R+UHhxd190pXxD53OGwf/G/zDxXTkse4HJ5mobNZfitLfUCp4fMvu6w=="],
+
+    "es-module-lexer": ["es-module-lexer@2.3.1", "", {}, "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
+
+    "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
+
+    "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
+
+    "lightningcss": ["lightningcss@1.33.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.33.0", "lightningcss-darwin-arm64": "1.33.0", "lightningcss-darwin-x64": "1.33.0", "lightningcss-freebsd-x64": "1.33.0", "lightningcss-linux-arm-gnueabihf": "1.33.0", "lightningcss-linux-arm64-gnu": "1.33.0", "lightningcss-linux-arm64-musl": "1.33.0", "lightningcss-linux-x64-gnu": "1.33.0", "lightningcss-linux-x64-musl": "1.33.0", "lightningcss-win32-arm64-msvc": "1.33.0", "lightningcss-win32-x64-msvc": "1.33.0" } }, "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.33.0", "", { "os": "android", "cpu": "arm64" }, "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.33.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.33.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.33.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.33.0", "", { "os": "linux", "cpu": "arm" }, "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.33.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.33.0", "", { "os": "win32", "cpu": "x64" }, "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "msgpackr": ["msgpackr@2.0.5", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA=="],
+
+    "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
+
+    "multipasta": ["multipasta@0.2.8", "", {}, "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q=="],
+
+    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
+
+    "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "postcss": ["postcss@8.5.25", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw=="],
+
+    "prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
+
+    "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
+
+    "rolldown": ["rolldown@1.2.1", "", { "dependencies": { "@oxc-project/types": "=0.142.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.2.1", "@rolldown/binding-darwin-arm64": "1.2.1", "@rolldown/binding-darwin-x64": "1.2.1", "@rolldown/binding-freebsd-x64": "1.2.1", "@rolldown/binding-linux-arm-gnueabihf": "1.2.1", "@rolldown/binding-linux-arm64-gnu": "1.2.1", "@rolldown/binding-linux-arm64-musl": "1.2.1", "@rolldown/binding-linux-ppc64-gnu": "1.2.1", "@rolldown/binding-linux-s390x-gnu": "1.2.1", "@rolldown/binding-linux-x64-gnu": "1.2.1", "@rolldown/binding-linux-x64-musl": "1.2.1", "@rolldown/binding-openharmony-arm64": "1.2.1", "@rolldown/binding-wasm32-wasi": "1.2.1", "@rolldown/binding-win32-arm64-msvc": "1.2.1", "@rolldown/binding-win32-x64-msvc": "1.2.1" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.1", "", {}, "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw=="],
+
+    "toml": ["toml@4.3.0", "", {}, "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
+
+    "vite": ["vite@8.2.0", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.23", "rolldown": "~1.2.0", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ=="],
+
+    "vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+  }
+}

--- a/app-server/mise.toml
+++ b/app-server/mise.toml
@@ -1,0 +1,44 @@
+[tools]
+bun = "1.3.14"
+
+# --- Primary entrypoints ---
+
+[tasks.dev]
+description = "Run the App Server in the foreground (temporary dev default: http://127.0.0.1:7332)"
+depends = ["install"]
+run = "bun run src/main.ts serve"
+
+[tasks.check]
+description = "All App Server gates: format check, strict type check, tests"
+depends = ["fmt:check", "typecheck", "test"]
+
+# --- Building blocks ---
+
+# fmt:check/typecheck/test share install as a dependency instead of each
+# installing themselves: mise runs tasks in parallel, and concurrent installs
+# into the same node_modules race. A shared dependency runs exactly once.
+[tasks.install]
+description = "Install dependencies from the committed lockfile"
+run = "bun install --frozen-lockfile"
+
+[tasks.fmt]
+description = "Format TypeScript, JSON, and Markdown with Prettier"
+depends = ["install"]
+run = "bun run prettier --write ."
+
+[tasks."fmt:check"]
+description = "Fail if any file is not Prettier-clean"
+depends = ["install"]
+run = "bun run prettier --check ."
+
+[tasks.typecheck]
+description = "Strict TypeScript type check (no emit)"
+depends = ["install"]
+run = "bun run tsc --noEmit"
+
+# --bun forces the Bun runtime (vitest's shebang would otherwise pick node),
+# so tests exercise the same runtime the server ships on.
+[tasks.test]
+description = "Run the vitest suite on the Bun runtime"
+depends = ["install"]
+run = "bun --bun vitest run"

--- a/app-server/mise.toml
+++ b/app-server/mise.toml
@@ -4,7 +4,7 @@ bun = "1.3.14"
 # --- Primary entrypoints ---
 
 [tasks.dev]
-description = "Run the App Server in the foreground (temporary dev default: http://127.0.0.1:7332)"
+description = "Run the App Server in the foreground (http://127.0.0.1:7332)"
 depends = ["install"]
 run = "bun run src/main.ts serve"
 

--- a/app-server/package.json
+++ b/app-server/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "atc-app-server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "ATC App Server — the TypeScript server and atc CLI, built on Effect",
+  "prettier": {
+    "semi": false,
+    "printWidth": 100
+  },
+  "dependencies": {
+    "@effect/platform-bun": "4.0.0-beta.102",
+    "effect": "4.0.0-beta.102"
+  },
+  "devDependencies": {
+    "@effect/vitest": "4.0.0-beta.102",
+    "@types/bun": "1.3.14",
+    "prettier": "3.9.6",
+    "typescript": "7.0.2",
+    "vitest": "4.1.10"
+  }
+}

--- a/app-server/src/api.ts
+++ b/app-server/src/api.ts
@@ -1,6 +1,5 @@
 import { Schema } from "effect"
 import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
-import { buildInfo } from "./buildInfo.ts"
 
 // The public HTTP contract. The server implementation (handlers.ts), the
 // OpenAPI document, and future typed clients all derive from this module.
@@ -25,8 +24,8 @@ export class V1 extends HttpApiGroup.make("v1")
   // before this line so they stay under /api/v1.
   .prefix("/api/v1") {}
 
+// The OpenAPI version is the contract version, not the build version, so this
+// module stays client-safe with no dependency on server internals.
 export class Api extends HttpApi.make("atc")
   .add(V1)
-  .annotateMerge(
-    OpenApi.annotations({ title: "ATC App Server API", version: buildInfo.version }),
-  ) {}
+  .annotateMerge(OpenApi.annotations({ title: "ATC App Server API", version: "v1" })) {}

--- a/app-server/src/api.ts
+++ b/app-server/src/api.ts
@@ -1,5 +1,6 @@
 import { Schema } from "effect"
 import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+import { buildInfo } from "./buildInfo.ts"
 
 // The public HTTP contract. The server implementation (handlers.ts), the
 // OpenAPI document, and future typed clients all derive from this module.
@@ -20,8 +21,12 @@ export class V1 extends HttpApiGroup.make("v1")
     HttpApiEndpoint.get("health", "/health", { success: HealthResponse }),
     HttpApiEndpoint.get("version", "/version", { success: VersionResponse }),
   )
+  // .prefix only applies to endpoints added above it — add new endpoints
+  // before this line so they stay under /api/v1.
   .prefix("/api/v1") {}
 
 export class Api extends HttpApi.make("atc")
   .add(V1)
-  .annotateMerge(OpenApi.annotations({ title: "ATC App Server API" })) {}
+  .annotateMerge(
+    OpenApi.annotations({ title: "ATC App Server API", version: buildInfo.version }),
+  ) {}

--- a/app-server/src/api.ts
+++ b/app-server/src/api.ts
@@ -1,0 +1,27 @@
+import { Schema } from "effect"
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+
+// The public HTTP contract. The server implementation (handlers.ts), the
+// OpenAPI document, and future typed clients all derive from this module.
+
+export const HealthResponse = Schema.Struct({
+  status: Schema.Literal("ok"),
+})
+
+export const VersionResponse = Schema.Struct({
+  version: Schema.String,
+  apiVersion: Schema.Literal("v1"),
+  commit: Schema.String,
+  builtAt: Schema.String,
+})
+
+export class V1 extends HttpApiGroup.make("v1")
+  .add(
+    HttpApiEndpoint.get("health", "/health", { success: HealthResponse }),
+    HttpApiEndpoint.get("version", "/version", { success: VersionResponse }),
+  )
+  .prefix("/api/v1") {}
+
+export class Api extends HttpApi.make("atc")
+  .add(V1)
+  .annotateMerge(OpenApi.annotations({ title: "ATC App Server API" })) {}

--- a/app-server/src/buildInfo.ts
+++ b/app-server/src/buildInfo.ts
@@ -1,0 +1,29 @@
+import { Context, Layer } from "effect"
+import packageJson from "../package.json"
+
+// Injected by the standalone-executable build (`bun build --define`, later
+// work). When running from source they are undefined and fall back to dev
+// placeholders.
+declare const ATC_BUILD_COMMIT: string | undefined
+declare const ATC_BUILD_TIME: string | undefined
+
+/**
+ * Build metadata for the running executable. Handlers and the CLI read this
+ * service instead of probing the environment themselves.
+ */
+export class BuildInfo extends Context.Service<
+  BuildInfo,
+  {
+    readonly version: string
+    readonly commit: string
+    readonly builtAt: string
+  }
+>()("app-server/BuildInfo") {}
+
+export const buildInfo: BuildInfo["Service"] = {
+  version: packageJson.version,
+  commit: typeof ATC_BUILD_COMMIT === "string" ? ATC_BUILD_COMMIT : "dev",
+  builtAt: typeof ATC_BUILD_TIME === "string" ? ATC_BUILD_TIME : "dev",
+}
+
+export const layer = Layer.succeed(BuildInfo)(buildInfo)

--- a/app-server/src/buildInfo.ts
+++ b/app-server/src/buildInfo.ts
@@ -1,12 +1,6 @@
 import { Context, Layer } from "effect"
 import packageJson from "../package.json"
 
-// Injected by the standalone-executable build (`bun build --define`, later
-// work). When running from source they are undefined and fall back to dev
-// placeholders.
-declare const ATC_BUILD_COMMIT: string | undefined
-declare const ATC_BUILD_TIME: string | undefined
-
 /**
  * Build metadata for the running executable. Handlers and the CLI read this
  * service instead of probing the environment themselves.
@@ -22,8 +16,10 @@ export class BuildInfo extends Context.Service<
 
 export const buildInfo: BuildInfo["Service"] = {
   version: packageJson.version,
-  commit: typeof ATC_BUILD_COMMIT === "string" ? ATC_BUILD_COMMIT : "dev",
-  builtAt: typeof ATC_BUILD_TIME === "string" ? ATC_BUILD_TIME : "dev",
+  // Real values arrive with the standalone-executable build, which will
+  // inject them at compile time; running from source uses placeholders.
+  commit: "dev",
+  builtAt: "dev",
 }
 
 export const layer = Layer.succeed(BuildInfo)(buildInfo)

--- a/app-server/src/cli.ts
+++ b/app-server/src/cli.ts
@@ -11,7 +11,7 @@ export const port = Flag.integer("port").pipe(
     (value) => value >= 1 && value <= 65535,
     () => "port must be between 1 and 65535",
   ),
-  Flag.withDescription("TCP port to listen on (loopback only)"),
+  Flag.withDescription(`TCP port to listen on (loopback only, default ${DEFAULT_PORT})`),
 )
 
 /** Startup failure already shown to the user; the marker stops runMain from logging it again. */
@@ -21,22 +21,21 @@ class ServeStartupError extends Schema.TaggedErrorClass<ServeStartupError>()("Se
   override readonly [Runtime.errorReported] = false
 }
 
-// Defects are only caught while the server layer is being built, so a bind
-// failure becomes one friendly line while genuine runtime bugs still get the
-// default loud reporting.
+// System errors carry a syscall code (EADDRINUSE, EACCES, ...). Those are
+// environment problems and become one friendly line; anything else is a bug
+// and re-dies so it keeps the default loud report.
+const isSystemError = (defect: unknown): defect is Error & { code: string } =>
+  defect instanceof Error && typeof (defect as { code?: unknown }).code === "string"
+
 const serve = Command.make("serve", { port }, ({ port }) =>
-  Effect.scoped(
-    Effect.gen(function* () {
-      yield* Layer.build(Server.layer({ port })).pipe(
-        Effect.catchDefect((defect) => {
-          const message = defect instanceof Error ? defect.message : String(defect)
-          return Console.error(`atc serve: ${message}`).pipe(
-            Effect.andThen(Effect.fail(new ServeStartupError({ message }))),
+  Layer.launch(Server.layer({ port })).pipe(
+    Effect.catchDefect((defect) =>
+      isSystemError(defect)
+        ? Console.error(`atc serve: ${defect.message}`).pipe(
+            Effect.andThen(Effect.fail(new ServeStartupError({ message: defect.message }))),
           )
-        }),
-      )
-      yield* Effect.never
-    }),
+        : Effect.die(defect),
+    ),
   ),
 ).pipe(Command.withDescription("Run the App Server in the foreground until interrupted"))
 

--- a/app-server/src/cli.ts
+++ b/app-server/src/cli.ts
@@ -5,12 +5,12 @@ import * as Server from "./server.ts"
 // Temporary dev default so the Go server on 7331 can run alongside.
 export const DEFAULT_PORT = 7332
 
+/** The one reusable port contract for CLI (and later config/API) inputs. */
+export const Port = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 65535 }))
+
 export const port = Flag.integer("port").pipe(
   Flag.withDefault(DEFAULT_PORT),
-  Flag.filter(
-    (value) => value >= 1 && value <= 65535,
-    () => "port must be between 1 and 65535",
-  ),
+  Flag.withSchema(Port),
   Flag.withDescription(`TCP port to listen on (loopback only, default ${DEFAULT_PORT})`),
 )
 

--- a/app-server/src/cli.ts
+++ b/app-server/src/cli.ts
@@ -1,0 +1,46 @@
+import { Console, Effect, Layer, Runtime, Schema } from "effect"
+import { Command, Flag } from "effect/unstable/cli"
+import * as Server from "./server.ts"
+
+// Temporary dev default so the Go server on 7331 can run alongside.
+export const DEFAULT_PORT = 7332
+
+export const port = Flag.integer("port").pipe(
+  Flag.withDefault(DEFAULT_PORT),
+  Flag.filter(
+    (value) => value >= 1 && value <= 65535,
+    () => "port must be between 1 and 65535",
+  ),
+  Flag.withDescription("TCP port to listen on (loopback only)"),
+)
+
+/** Startup failure already shown to the user; the marker stops runMain from logging it again. */
+class ServeStartupError extends Schema.TaggedErrorClass<ServeStartupError>()("ServeStartupError", {
+  message: Schema.String,
+}) {
+  override readonly [Runtime.errorReported] = false
+}
+
+// Defects are only caught while the server layer is being built, so a bind
+// failure becomes one friendly line while genuine runtime bugs still get the
+// default loud reporting.
+const serve = Command.make("serve", { port }, ({ port }) =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      yield* Layer.build(Server.layer({ port })).pipe(
+        Effect.catchDefect((defect) => {
+          const message = defect instanceof Error ? defect.message : String(defect)
+          return Console.error(`atc serve: ${message}`).pipe(
+            Effect.andThen(Effect.fail(new ServeStartupError({ message }))),
+          )
+        }),
+      )
+      yield* Effect.never
+    }),
+  ),
+).pipe(Command.withDescription("Run the App Server in the foreground until interrupted"))
+
+export const atc = Command.make("atc").pipe(
+  Command.withDescription("ATC App Server"),
+  Command.withSubcommands([serve]),
+)

--- a/app-server/src/cli.ts
+++ b/app-server/src/cli.ts
@@ -2,7 +2,6 @@ import { Console, Effect, Layer, Runtime, Schema } from "effect"
 import { Command, Flag } from "effect/unstable/cli"
 import * as Server from "./server.ts"
 
-// Temporary dev default so the Go server on 7331 can run alongside.
 export const DEFAULT_PORT = 7332
 
 /** The one reusable port contract for CLI (and later config/API) inputs. */

--- a/app-server/src/handlers.ts
+++ b/app-server/src/handlers.ts
@@ -1,0 +1,23 @@
+import { Effect } from "effect"
+import { HttpApiBuilder } from "effect/unstable/httpapi"
+import { Api } from "./api.ts"
+import { BuildInfo } from "./buildInfo.ts"
+
+/** Implements the /api/v1 contract. App construction only — no listener. */
+export const V1Handlers = HttpApiBuilder.group(
+  Api,
+  "v1",
+  Effect.fnUntraced(function* (handlers) {
+    const build = yield* BuildInfo
+    return handlers
+      .handle("health", () => Effect.succeed({ status: "ok" } as const))
+      .handle("version", () =>
+        Effect.succeed({
+          version: build.version,
+          apiVersion: "v1",
+          commit: build.commit,
+          builtAt: build.builtAt,
+        } as const),
+      )
+  }),
+)

--- a/app-server/src/main.ts
+++ b/app-server/src/main.ts
@@ -4,10 +4,9 @@ import { Command } from "effect/unstable/cli"
 import * as BuildInfo from "./buildInfo.ts"
 import { atc } from "./cli.ts"
 
-// The only runMain in the application. Everything else is Layers and Effects.
-// Command.run needs a plain string before any Layer exists, so it reads the
-// buildInfo constant directly; everything downstream uses the injected service.
-Command.run(atc, { version: BuildInfo.buildInfo.version }).pipe(
-  Effect.provide(Layer.mergeAll(BuildInfo.layer, BunServices.layer)),
-  BunRuntime.runMain,
-)
+// The only runMain in the application. Everything else is Layers and Effects,
+// so even the CLI version resolves through the injected BuildInfo service.
+Effect.gen(function* () {
+  const build = yield* BuildInfo.BuildInfo
+  yield* Command.run(atc, { version: build.version })
+}).pipe(Effect.provide(Layer.mergeAll(BuildInfo.layer, BunServices.layer)), BunRuntime.runMain)

--- a/app-server/src/main.ts
+++ b/app-server/src/main.ts
@@ -5,6 +5,8 @@ import * as BuildInfo from "./buildInfo.ts"
 import { atc } from "./cli.ts"
 
 // The only runMain in the application. Everything else is Layers and Effects.
+// Command.run needs a plain string before any Layer exists, so it reads the
+// buildInfo constant directly; everything downstream uses the injected service.
 Command.run(atc, { version: BuildInfo.buildInfo.version }).pipe(
   Effect.provide(Layer.mergeAll(BuildInfo.layer, BunServices.layer)),
   BunRuntime.runMain,

--- a/app-server/src/main.ts
+++ b/app-server/src/main.ts
@@ -1,0 +1,11 @@
+import { BunRuntime, BunServices } from "@effect/platform-bun"
+import { Effect, Layer } from "effect"
+import { Command } from "effect/unstable/cli"
+import * as BuildInfo from "./buildInfo.ts"
+import { atc } from "./cli.ts"
+
+// The only runMain in the application. Everything else is Layers and Effects.
+Command.run(atc, { version: BuildInfo.buildInfo.version }).pipe(
+  Effect.provide(Layer.mergeAll(BuildInfo.layer, BunServices.layer)),
+  BunRuntime.runMain,
+)

--- a/app-server/src/server.ts
+++ b/app-server/src/server.ts
@@ -1,0 +1,19 @@
+import { BunHttpServer } from "@effect/platform-bun"
+import { Layer } from "effect"
+import { HttpRouter } from "effect/unstable/http"
+import { HttpApiBuilder } from "effect/unstable/httpapi"
+import { Api } from "./api.ts"
+import { V1Handlers } from "./handlers.ts"
+
+/** All HTTP routes, independent of any listener. Requires BuildInfo. */
+export const routes = HttpApiBuilder.layer(Api).pipe(Layer.provide(V1Handlers))
+
+/**
+ * The full server: routes on a loopback TCP listener. The layer's scope owns
+ * the listener, so closing the scope (e.g. on SIGINT/SIGTERM interruption)
+ * stops the server and releases the port.
+ */
+export const layer = (options: { readonly port: number }) =>
+  HttpRouter.serve(routes).pipe(
+    Layer.provideMerge(BunHttpServer.layer({ port: options.port, hostname: "127.0.0.1" })),
+  )

--- a/app-server/test/api.test.ts
+++ b/app-server/test/api.test.ts
@@ -1,0 +1,37 @@
+import { assert, describe, it } from "@effect/vitest"
+import { BunHttpServer } from "@effect/platform-bun"
+import { Effect, Layer } from "effect"
+import { HttpApiTest } from "effect/unstable/httpapi"
+import { Api } from "../src/api.ts"
+import { V1Handlers } from "../src/handlers.ts"
+import { TestBuildInfoLayer, testBuildInfo } from "./testBuildInfo.ts"
+
+// In-process contract tests: the same encode/route/decode pipeline as the real
+// server, but no listener.
+const TestLayer = Layer.mergeAll(
+  V1Handlers.pipe(Layer.provide(TestBuildInfoLayer)),
+  BunHttpServer.layerHttpServices,
+)
+
+describe("/api/v1", () => {
+  it.effect("health returns ok", () =>
+    Effect.gen(function* () {
+      const client = yield* HttpApiTest.groups(Api, ["v1"])
+      const health = yield* client.v1.health()
+      assert.deepStrictEqual(health, { status: "ok" })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("version reports injected build metadata", () =>
+    Effect.gen(function* () {
+      const client = yield* HttpApiTest.groups(Api, ["v1"])
+      const version = yield* client.v1.version()
+      assert.deepStrictEqual(version, {
+        version: testBuildInfo.version,
+        apiVersion: "v1",
+        commit: testBuildInfo.commit,
+        builtAt: testBuildInfo.builtAt,
+      })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+})

--- a/app-server/test/cli.test.ts
+++ b/app-server/test/cli.test.ts
@@ -1,0 +1,51 @@
+import { assert, describe, it } from "@effect/vitest"
+import { BunServices } from "@effect/platform-bun"
+import { Effect } from "effect"
+import { CliError, Command } from "effect/unstable/cli"
+import { DEFAULT_PORT, port } from "../src/cli.ts"
+
+// Parse the real --port flag against a probe command so validation is tested
+// without starting a server.
+const parsePort = (args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    let parsed: number | undefined
+    const probe = Command.make("probe", { port }, ({ port }) =>
+      Effect.sync(() => {
+        parsed = port
+      }),
+    )
+    const result = yield* Effect.result(Command.runWith(probe, { version: "0.0.0" })(args))
+    return { parsed, result }
+  }).pipe(Effect.provide(BunServices.layer))
+
+describe("serve --port validation", () => {
+  it.effect("defaults to the dev port", () =>
+    Effect.gen(function* () {
+      const { parsed } = yield* parsePort([])
+      assert.strictEqual(parsed, DEFAULT_PORT)
+    }),
+  )
+
+  it.effect("accepts a valid port", () =>
+    Effect.gen(function* () {
+      const { parsed } = yield* parsePort(["--port", "8080"])
+      assert.strictEqual(parsed, 8080)
+    }),
+  )
+
+  it.effect.each([
+    ["not a number", "abc"],
+    ["zero", "0"],
+    ["negative", "-1"],
+    ["above 65535", "70000"],
+  ] as const)("rejects %s with a CLI error", ([, value]) =>
+    Effect.gen(function* () {
+      const { parsed, result } = yield* parsePort(["--port", value])
+      assert.strictEqual(parsed, undefined)
+      assert.strictEqual(result._tag, "Failure")
+      if (result._tag === "Failure") {
+        assert.strictEqual(CliError.isCliError(result.failure), true)
+      }
+    }),
+  )
+})

--- a/app-server/test/cli.test.ts
+++ b/app-server/test/cli.test.ts
@@ -33,18 +33,26 @@ describe("serve --port validation", () => {
     }),
   )
 
+  // --port=value keeps negative values from being tokenized as flags, so
+  // every case exercises the integer parse or the range filter itself.
   it.effect.each([
-    ["not a number", "abc"],
-    ["zero", "0"],
-    ["negative", "-1"],
-    ["above 65535", "70000"],
-  ] as const)("rejects %s with a CLI error", ([, value]) =>
+    ["not a number", "--port=abc"],
+    ["zero", "--port=0"],
+    ["negative", "--port=-1"],
+    ["above 65535", "--port=70000"],
+  ] as const)("rejects %s as an invalid value", ([, flag]) =>
     Effect.gen(function* () {
-      const { parsed, result } = yield* parsePort(["--port", value])
+      const { parsed, result } = yield* parsePort([flag])
       assert.strictEqual(parsed, undefined)
       assert.strictEqual(result._tag, "Failure")
       if (result._tag === "Failure") {
+        // Parse failures surface as ShowHelp wrapping the real error; a bare
+        // --help would be ShowHelp with no errors, so assert the wrapped tag.
         assert.strictEqual(CliError.isCliError(result.failure), true)
+        assert.strictEqual(result.failure._tag, "ShowHelp")
+        if (result.failure._tag === "ShowHelp") {
+          assert.strictEqual(result.failure.errors[0]?._tag, "InvalidValue")
+        }
       }
     }),
   )

--- a/app-server/test/serve.blackbox.test.ts
+++ b/app-server/test/serve.blackbox.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "vitest"
+
+// Black-box test of the real entrypoint: spawn `bun src/main.ts serve` on an
+// ephemeral loopback port, exercise both endpoints over TCP, and verify clean
+// shutdown on SIGTERM (130 = interrupted by signal), including with a request
+// in flight.
+
+const appServerRoot = new URL("..", import.meta.url).pathname
+
+const freePort = async (): Promise<number> => {
+  const probe = Bun.serve({ port: 0, fetch: () => new Response("") })
+  const port = probe.port!
+  await probe.stop(true)
+  return port
+}
+
+const waitForHealth = async (base: string): Promise<Response> => {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      return await fetch(`${base}/api/v1/health`)
+    } catch {
+      await Bun.sleep(50)
+    }
+  }
+  throw new Error(`server at ${base} never became healthy`)
+}
+
+describe("atc serve (black box)", () => {
+  test("serves both endpoints and shuts down cleanly on SIGTERM", async () => {
+    const port = await freePort()
+    const base = `http://127.0.0.1:${port}`
+    const proc = Bun.spawn(["bun", "src/main.ts", "serve", "--port", String(port)], {
+      cwd: appServerRoot,
+      stdout: "ignore",
+      stderr: "pipe",
+    })
+    try {
+      const health = await waitForHealth(base)
+      expect(health.status).toBe(200)
+      expect(await health.json()).toEqual({ status: "ok" })
+
+      const version = await fetch(`${base}/api/v1/version`)
+      expect(version.status).toBe(200)
+      expect(await version.json()).toEqual({
+        version: expect.any(String),
+        apiVersion: "v1",
+        commit: expect.any(String),
+        builtAt: expect.any(String),
+      })
+
+      // Shut down with a request in flight: the fetch may complete or be
+      // dropped mid-connection, but the process itself must exit cleanly.
+      const inFlight = fetch(`${base}/api/v1/health`).then(
+        () => "completed",
+        () => "dropped",
+      )
+      proc.kill("SIGTERM")
+      expect(await proc.exited).toBe(130)
+      expect(["completed", "dropped"]).toContain(await inFlight)
+
+      // The port is released once the process is gone.
+      await expect(fetch(`${base}/api/v1/health`)).rejects.toThrow()
+    } finally {
+      proc.kill()
+    }
+  }, 30_000)
+
+  test("fails with one friendly line when the port is taken", async () => {
+    const occupant = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response("") })
+    try {
+      const proc = Bun.spawn(["bun", "src/main.ts", "serve", "--port", String(occupant.port)], {
+        cwd: appServerRoot,
+        stdout: "ignore",
+        stderr: "pipe",
+      })
+      expect(await proc.exited).toBe(1)
+      const stderr = await new Response(proc.stderr).text()
+      expect(stderr).toMatch(/^atc serve: /)
+      expect(stderr.trim().split("\n")).toHaveLength(1)
+    } finally {
+      await occupant.stop(true)
+    }
+  }, 30_000)
+})

--- a/app-server/test/serve.blackbox.test.ts
+++ b/app-server/test/serve.blackbox.test.ts
@@ -1,20 +1,33 @@
+import { fileURLToPath } from "node:url"
 import { describe, expect, test } from "vitest"
 
-// Black-box test of the real entrypoint: spawn `bun src/main.ts serve` on an
-// ephemeral loopback port, exercise both endpoints over TCP, and verify clean
-// shutdown on SIGTERM (130 = interrupted by signal), including with a request
-// in flight.
+// Black-box tests of the real entrypoint: spawn `bun src/main.ts serve` on a
+// loopback port, exercise both endpoints over TCP, and verify clean shutdown
+// on SIGTERM and SIGINT (exit 130 = interrupted by signal), including with an
+// open half-sent request at signal time.
 
-const appServerRoot = new URL("..", import.meta.url).pathname
+const appServerRoot = fileURLToPath(new URL("..", import.meta.url))
 
+// Tests run under `bun --bun vitest`, so execPath is the pinned bun binary —
+// no PATH lookup for the child.
+const spawnServe = (port: number) =>
+  Bun.spawn([process.execPath, "src/main.ts", "serve", "--port", String(port)], {
+    cwd: appServerRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+
+// Bind-then-release to pick a port for the child. Racy in principle (another
+// process could grab it in between), but --port 0 is deliberately rejected by
+// validation, so this is the practical option; stderr is surfaced on failure.
 const freePort = async (): Promise<number> => {
-  const probe = Bun.serve({ port: 0, fetch: () => new Response("") })
+  const probe = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response("") })
   const port = probe.port!
   await probe.stop(true)
   return port
 }
 
-const waitForHealth = async (base: string): Promise<Response> => {
+const waitForHealth = async (base: string, proc: Bun.Subprocess): Promise<Response> => {
   for (let attempt = 0; attempt < 100; attempt++) {
     try {
       return await fetch(`${base}/api/v1/health`)
@@ -22,62 +35,65 @@ const waitForHealth = async (base: string): Promise<Response> => {
       await Bun.sleep(50)
     }
   }
-  throw new Error(`server at ${base} never became healthy`)
+  proc.kill()
+  const stderr = await new Response(proc.stderr as ReadableStream).text()
+  throw new Error(`server at ${base} never became healthy; stderr:\n${stderr}`)
 }
 
 describe("atc serve (black box)", () => {
-  test("serves both endpoints and shuts down cleanly on SIGTERM", async () => {
-    const port = await freePort()
-    const base = `http://127.0.0.1:${port}`
-    const proc = Bun.spawn(["bun", "src/main.ts", "serve", "--port", String(port)], {
-      cwd: appServerRoot,
-      stdout: "ignore",
-      stderr: "pipe",
-    })
-    try {
-      const health = await waitForHealth(base)
-      expect(health.status).toBe(200)
-      expect(await health.json()).toEqual({ status: "ok" })
+  test.each(["SIGTERM", "SIGINT"] as const)(
+    "serves both endpoints and shuts down cleanly on %s",
+    async (signal) => {
+      const port = await freePort()
+      const base = `http://127.0.0.1:${port}`
+      const proc = spawnServe(port)
+      try {
+        const health = await waitForHealth(base, proc)
+        expect(health.status).toBe(200)
+        expect(await health.json()).toEqual({ status: "ok" })
 
-      const version = await fetch(`${base}/api/v1/version`)
-      expect(version.status).toBe(200)
-      expect(await version.json()).toEqual({
-        version: expect.any(String),
-        apiVersion: "v1",
-        commit: expect.any(String),
-        builtAt: expect.any(String),
-      })
+        const version = await fetch(`${base}/api/v1/version`)
+        expect(version.status).toBe(200)
+        expect(await version.json()).toEqual({
+          version: expect.any(String),
+          apiVersion: "v1",
+          commit: expect.any(String),
+          builtAt: expect.any(String),
+        })
 
-      // Shut down with a request in flight: the fetch may complete or be
-      // dropped mid-connection, but the process itself must exit cleanly.
-      const inFlight = fetch(`${base}/api/v1/health`).then(
-        () => "completed",
-        () => "dropped",
-      )
-      proc.kill("SIGTERM")
-      expect(await proc.exited).toBe(130)
-      expect(["completed", "dropped"]).toContain(await inFlight)
+        // Leave a half-sent request open across the signal: shutdown must not
+        // hang on the open connection.
+        const halfOpen = await Bun.connect({
+          hostname: "127.0.0.1",
+          port,
+          socket: { data: () => {}, close: () => {}, error: () => {} },
+        })
+        halfOpen.write("GET /api/v1/health HTTP/1.1\r\nHost: atc\r\n")
 
-      // The port is released once the process is gone.
-      await expect(fetch(`${base}/api/v1/health`)).rejects.toThrow()
-    } finally {
-      proc.kill()
-    }
-  }, 30_000)
+        proc.kill(signal)
+        expect(await proc.exited).toBe(130)
+        halfOpen.end()
 
-  test("fails with one friendly line when the port is taken", async () => {
+        // The port is released once the process is gone.
+        await expect(fetch(`${base}/api/v1/health`)).rejects.toThrow()
+      } finally {
+        proc.kill()
+      }
+    },
+    30_000,
+  )
+
+  test("fails with one friendly stderr line when the port is taken", async () => {
     const occupant = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response("") })
+    const proc = spawnServe(occupant.port!)
     try {
-      const proc = Bun.spawn(["bun", "src/main.ts", "serve", "--port", String(occupant.port)], {
-        cwd: appServerRoot,
-        stdout: "ignore",
-        stderr: "pipe",
-      })
       expect(await proc.exited).toBe(1)
-      const stderr = await new Response(proc.stderr).text()
+      const stderr = await new Response(proc.stderr as ReadableStream).text()
       expect(stderr).toMatch(/^atc serve: /)
       expect(stderr.trim().split("\n")).toHaveLength(1)
+      expect(await new Response(proc.stdout as ReadableStream).text()).toBe("")
     } finally {
+      proc.kill()
       await occupant.stop(true)
     }
   }, 30_000)

--- a/app-server/test/server.test.ts
+++ b/app-server/test/server.test.ts
@@ -5,9 +5,14 @@ import * as Server from "../src/server.ts"
 import { TestBuildInfoLayer } from "./testBuildInfo.ts"
 
 describe("server layer", () => {
-  it.effect("binds loopback, serves the API, and releases the port when closed", () =>
+  // it.live: this test does real socket I/O, and the platform's shutdown
+  // timeout must run on the real clock, not it.effect's TestClock.
+  it.live("binds loopback, serves the API, and releases the port when closed", () =>
     Effect.gen(function* () {
+      // A manual scope so the server can be closed mid-test; the finalizer
+      // guarantees the listener dies even when an assertion fails first.
       const scope = yield* Scope.make()
+      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
       const context = yield* Layer.build(
         Server.layer({ port: 0 }).pipe(Layer.provide(TestBuildInfoLayer)),
       ).pipe(Effect.provideService(Scope.Scope, scope))

--- a/app-server/test/server.test.ts
+++ b/app-server/test/server.test.ts
@@ -1,0 +1,40 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Context, Effect, Exit, Layer, Scope } from "effect"
+import { HttpServer } from "effect/unstable/http"
+import * as Server from "../src/server.ts"
+import { TestBuildInfoLayer } from "./testBuildInfo.ts"
+
+describe("server layer", () => {
+  it.effect("binds loopback, serves the API, and releases the port when closed", () =>
+    Effect.gen(function* () {
+      const scope = yield* Scope.make()
+      const context = yield* Layer.build(
+        Server.layer({ port: 0 }).pipe(Layer.provide(TestBuildInfoLayer)),
+      ).pipe(Effect.provideService(Scope.Scope, scope))
+
+      const address = Context.get(context, HttpServer.HttpServer).address
+      assert.strictEqual(address._tag, "TcpAddress")
+      if (address._tag !== "TcpAddress") return
+      assert.strictEqual(address.hostname, "127.0.0.1")
+
+      // Connection: close keeps fetch from pooling an idle socket, so the
+      // release check below is forced onto a fresh connection.
+      const base = `http://127.0.0.1:${address.port}`
+      const health = yield* Effect.promise(() =>
+        fetch(`${base}/api/v1/health`, { headers: { connection: "close" } }),
+      )
+      assert.strictEqual(health.status, 200)
+      assert.deepStrictEqual(yield* Effect.promise(() => health.json()), { status: "ok" })
+
+      yield* Scope.close(scope, Exit.void)
+
+      const released = yield* Effect.promise(() =>
+        fetch(`${base}/api/v1/health`).then(
+          () => false,
+          () => true,
+        ),
+      )
+      assert.strictEqual(released, true)
+    }),
+  )
+})

--- a/app-server/test/testBuildInfo.ts
+++ b/app-server/test/testBuildInfo.ts
@@ -1,0 +1,10 @@
+import { Layer } from "effect"
+import { BuildInfo } from "../src/buildInfo.ts"
+
+export const testBuildInfo = {
+  version: "1.2.3-test",
+  commit: "abc1234",
+  builtAt: "2026-07-31T00:00:00Z",
+} as const
+
+export const TestBuildInfoLayer = Layer.succeed(BuildInfo)(testBuildInfo)

--- a/app-server/tsconfig.json
+++ b/app-server/tsconfig.json
@@ -10,6 +10,8 @@
     "noEmit": true,
     "strict": true,
     "noUncheckedIndexedAccess": true,
+    "noImplicitReturns": true,
+    "exactOptionalPropertyTypes": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitOverride": true,

--- a/app-server/tsconfig.json
+++ b/app-server/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "types": ["bun"]
+  },
+  "include": ["src", "test", "vitest.config.ts"]
+}

--- a/app-server/vitest.config.ts
+++ b/app-server/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+  },
+})

--- a/mise.toml
+++ b/mise.toml
@@ -3,12 +3,12 @@
 # "is the repo healthy?" the same way locally and in CI.
 
 [tasks.check]
-description = "All gates: server fmt/vet/tests + web check, Kit tests, macOS app tests"
-depends = ["server:check", "kit:test", "macos:test"]
+description = "All gates: server fmt/vet/tests + web check, App Server check, Kit tests, macOS app tests"
+depends = ["server:check", "app-server:check", "kit:test", "macos:test"]
 
 [tasks.test]
-description = "All tests: server Go suite, ATCKit, macOS app"
-depends = ["server:test", "kit:test", "macos:test"]
+description = "All tests: server Go suite, App Server, ATCKit, macOS app"
+depends = ["server:test", "app-server:test", "kit:test", "macos:test"]
 
 # --- Server (Go API + embedded web UI) ---
 
@@ -27,6 +27,16 @@ run = "mise run -C server build"
 [tasks."web:check"]
 description = "Type-check the web UI (svelte-check)"
 run = "mise run -C server web:check"
+
+# --- App Server (TypeScript/Effect on Bun) ---
+
+[tasks."app-server:check"]
+description = "App Server format check, strict type check, tests"
+run = "mise run -C app-server check"
+
+[tasks."app-server:test"]
+description = "App Server test suite"
+run = "mise run -C app-server test"
 
 # --- Swift surfaces ---
 

--- a/mise.toml
+++ b/mise.toml
@@ -45,6 +45,24 @@ xcodebuild test \
   CODE_SIGNING_ALLOWED=NO
 """
 
+[tasks.refs]
+description = "Fetch read-only reference source into repos/ (gitignored); delete a checkout and re-run to update"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+clone() {
+  if [ -d "repos/$1" ]; then
+    echo "repos/$1 already present; delete it and re-run to update"
+  else
+    git clone --depth 1 "${@:2}" "repos/$1"
+  fi
+}
+# Keep the Effect tag in sync with the version pinned in app-server.
+clone effect --branch 'effect@4.0.0-beta.102' https://github.com/Effect-TS/effect.git
+clone t3code https://github.com/pingdotgg/t3code.git
+clone opencode https://github.com/sst/opencode.git
+"""
+
 [tasks."macos:release-dev"]
 description = "Build and publish a notarized dev DMG to GitHub Releases"
 run = "ATC_NOTARY_PROFILE=ateliercode-notary scripts/release-dev.sh --upload"


### PR DESCRIPTION
Implements [ATC-117](https://linear.app/elevenideas/issue/ATC-117/scaffold-the-effect-app-server-package-serve-skeleton-and-ci): the production-shaped TypeScript App Server foundation, built on **Effect** as the application spine. Replaces #121 (Hono + Commander scaffold), which will be abandoned.

## What's here

- **`app-server/`** — one Bun + strict TypeScript package. Production deps are exactly two, exact-pinned: `effect@4.0.0-beta.102` and `@effect/platform-bun@4.0.0-beta.102` (the same line T3Code and OpenCode build on). Committed `bun.lock`; Bun 1.3.14 pinned in `app-server/mise.toml`.
- **Contract** (`src/api.ts`) — the `/api/v1` group (`health`, `version`) as a schema-first `HttpApi` module with Schema-typed camelCase responses. The server implementation, OpenAPI document, and future typed clients all derive from this one definition (OpenAPI serving itself is follow-up work).
- **CLI + lifecycle** — `atc serve` via Effect CLI: foreground loopback listener, `--port` validated 1–65535 (temporary dev default 7332 so the Go server on 7331 runs alongside). Graceful SIGINT/SIGTERM shutdown flows through `BunRuntime.runMain` interruption and scoped finalizers — no hand-rolled signal listeners. Startup failures with a syscall code (e.g. `EADDRINUSE`) surface as one friendly stderr line and exit 1; anything else re-dies so real bugs keep the loud report.
- **Build metadata** (`src/buildInfo.ts`) — `BuildInfo` as an injected `Context.Service` (version from package.json; commit/builtAt are dev placeholders until the standalone-executable build injects real values).
- **Tests** (`@effect/vitest`, run on the Bun runtime via `bun --bun vitest`) — in-process contract tests through `HttpApiTest` with a substituted BuildInfo layer (no listener); real-listener bind/serve/port-release; `--port` validation down to the wrapped `InvalidValue`; and black-box tests that spawn the real entrypoint, hit both endpoints over TCP, hold a half-sent request open across the signal, and assert clean exit 130 on both SIGTERM and SIGINT plus the one-line startup failure.
- **Workflow/CI** — app-server mise tasks (`install`/`dev`/`fmt`/`fmt:check`/`typecheck`/`test`/`check`) fanned into root `check`/`test`; App Server CI workflow runs the same `mise run check` (frozen-lockfile install, Prettier check, strict tsc, vitest).
- **Conventions** — Effect conventions section added to `AGENTS.md` (Context.Service + Layer shape, tagged errors only, one `runMain`, `it.effect`, Schema for validation, exact pins, reference checkouts).

## Key decisions

- **Effect v4 API reality check**: on the 4.0.0-beta line everything lives in the single `effect` package (`effect/unstable/httpapi`, `effect/unstable/cli` where v3's `Options` is now `Flag`); serving is `HttpRouter.serve(HttpApiBuilder.layer(Api))` + `BunHttpServer.layer` (v3's `HttpApiBuilder.serve` no longer exists). Verified against the pinned checkout (`mise run refs`), T3Code, and OpenCode rather than training data.
- **Tests run on Bun**: `bun --bun vitest` forces the Bun runtime (vitest's shebang would pick Node), so tests exercise the same runtime the server ships on — verified `BunHttpServer` works in-process under it.
- **Friendly startup errors**: bind failures are defects (Bun.serve throws), caught only when they carry a syscall `code`, printed as one line, and marked `[Runtime.errorReported] = false` so `runMain` doesn't re-dump the cause. Non-system defects re-die.
- **Adversarially reviewed**: two independent review agents (correctness, simplicity) ran against the scaffold; accepted findings are in the second commit (`Layer.launch` over hand-rolled scope/build/never, narrowed defect catch, real in-flight/SIGINT black-box coverage, `it.live` for socket tests, dropped premature build-define machinery, deleted redundant `.gitignore`).

The two small prep commits (TypeScript `.gitignore` defaults, `mise run refs` for read-only reference checkouts) ride along at the base of the branch.

## Verification

- `mise run check` (app-server): Prettier check, strict tsc, 12 tests — green; suite stress-run 5× with no flakes.
- `mise run server:check`: Go server unaffected — green.
- Manual: `atc serve` on 7399, both endpoints, Ctrl+C/SIGTERM clean shutdown with port release; port-in-use prints exactly one line.

https://claude.ai/code/session_01Hc5f2vXdqm3Un6J4GfJ4qp
