### PR TITLE
ATC-88: Prove standalone compilation and provider spawning

### DIFF
--- a/.github/workflows/app-server-ci.yml
+++ b/.github/workflows/app-server-ci.yml
@@ -42,3 +42,47 @@ jobs:
       # includes the black-box serve/shutdown test over loopback TCP).
       - name: Check
         run: mise run check
+
+  # Proves all four release targets compile. Cross-compilation alone says
+  # nothing about runtime behavior — that is what native-validate is for.
+  cross-compile:
+    name: cross-compile (build only, no runtime validation)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: jdx/mise-action@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          working_directory: app-server
+
+      - name: Build all targets
+        run: mise run build:all
+
+      - name: Verify deterministic artifact names
+        run: |
+          for target in darwin-arm64 darwin-x64 linux-arm64 linux-x64; do
+            test -x "dist/atc-$target" || { echo "missing dist/atc-$target"; exit 1; }
+          done
+
+  # Native runtime validation of the compiled artifact: macOS arm64 and
+  # Linux x64 on hosted runners. The other two targets are cross-compile-only
+  # until the release/packaging milestone adds native coverage.
+  native-validate:
+    name: native compiled validation (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [macos-14, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: jdx/mise-action@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          working_directory: app-server
+
+      - name: Compiled artifact black-box tests
+        run: mise run test:compiled

--- a/.github/workflows/app-server-ci.yml
+++ b/.github/workflows/app-server-ci.yml
@@ -61,6 +61,7 @@ jobs:
         run: mise run build:all
 
       - name: Verify deterministic artifact names
+        # Keep this target list in sync with TARGETS in app-server/scripts/build.ts.
         run: |
           for target in darwin-arm64 darwin-x64 linux-arm64 linux-x64; do
             test -x "dist/atc-$target" || { echo "missing dist/atc-$target"; exit 1; }
@@ -83,6 +84,11 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           working_directory: app-server
+
+      # The fast suite exercises the OS-sensitive subprocess seam (process
+      # groups, signal escalation), so run it natively on both platforms too.
+      - name: Fast suite
+        run: mise run test
 
       - name: Compiled artifact black-box tests
         run: mise run test:compiled

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,33 @@ deliberately). Write new code the same way:
   (`mise run refs`) and follow T3Code/OpenCode patterns; web search and
   training data skew to Effect v3.
 
+## Compiled Executable and Subprocesses (App Server)
+
+- `mise run -C app-server build` compiles the standalone `atc` executable for
+  the host into `app-server/dist/atc-<os>-<arch>`; `build:all` cross-compiles
+  all four release targets (darwin/linux × arm64/x64). Artifact names are
+  deterministic — CI and release tooling rely on them.
+- Build metadata (commit, build time) is injected at compile time by
+  `scripts/build.ts` via `--define`; running from source reports `dev`.
+- Compiled behavior must never depend on the working directory. `.env`/bunfig
+  autoloading is disabled at compile; assets that ship with the executable
+  (e.g. the packaged Claude Code binary staged at `dist/claude`) resolve
+  relative to `process.execPath`.
+- All child processes go through the `Subprocess` service
+  (`src/subprocess.ts`): scoped acquisition (scope close terminates the child,
+  SIGTERM escalating to SIGKILL), bounded stderr diagnostics, explicit
+  environment. No ad-hoc `Bun.spawn` in server code.
+- Provider executables resolve explicitly, never implicitly: env override
+  first (`ATC_CODEX_EXECUTABLE` / `ATC_CLAUDE_CODE_EXECUTABLE`), then a known
+  location (PATH for codex; the executable-adjacent staged binary, then the
+  platform package in `node_modules`, for Claude Code).
+- Cross-compilation success is not runtime validation. CI runs the compiled
+  black-box suite natively on macOS arm64 and Linux x64 only; darwin-x64 and
+  linux-arm64 stay cross-compile-only until the release milestone.
+- After upgrading Bun, Effect, or the Claude Agent SDK, rerun
+  `mise run -C app-server test:compiled` and the opt-in live
+  `mise run -C app-server test:smoke` suite.
+
 ## Code Style
 
 - Always strive for simplicity. This is not a complex enterprise app.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,8 +90,8 @@ deliberately). Write new code the same way:
   `scripts/build.ts` via `--define`; running from source reports `dev`.
 - Compiled behavior must never depend on the working directory. `.env`/bunfig
   autoloading is disabled at compile; assets that ship with the executable
-  (e.g. the packaged Claude Code binary staged at `dist/claude`) resolve
-  relative to `process.execPath`.
+  (e.g. the packaged Claude Code binary staged at `dist/claude-<os>-<arch>`)
+  resolve relative to `process.execPath` under target-scoped names.
 - All child processes go through the `Subprocess` service
   (`src/subprocess.ts`): scoped acquisition (scope close terminates the child,
   SIGTERM escalating to SIGKILL), bounded stderr diagnostics, explicit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,17 +89,18 @@ deliberately). Write new code the same way:
 - Build metadata (commit, build time) is injected at compile time by
   `scripts/build.ts` via `--define`; running from source reports `dev`.
 - Compiled behavior must never depend on the working directory. `.env`/bunfig
-  autoloading is disabled at compile; assets that ship with the executable
-  (e.g. the packaged Claude Code binary staged at `dist/claude-<os>-<arch>`)
-  resolve relative to `process.execPath` under target-scoped names.
+  autoloading is disabled at compile; any asset that ships with the
+  executable must resolve relative to `process.execPath`, never the cwd.
 - All child processes go through the `Subprocess` service
   (`src/subprocess.ts`): scoped acquisition (scope close terminates the child,
   SIGTERM escalating to SIGKILL), bounded stderr diagnostics, explicit
   environment. No ad-hoc `Bun.spawn` in server code.
-- Provider executables resolve explicitly, never implicitly: env override
-  first (`ATC_CODEX_EXECUTABLE` / `ATC_CLAUDE_CODE_EXECUTABLE`), then a known
-  location (PATH for codex; the executable-adjacent staged binary, then the
-  platform package in `node_modules`, for Claude Code).
+- atc ships no provider binaries: the user installs and authenticates the
+  Codex CLI and Claude Code themselves. Provider executables resolve
+  explicitly, never implicitly: env override first (`ATC_CODEX_EXECUTABLE` /
+  `ATC_CLAUDE_CODE_EXECUTABLE`), then the user's install on PATH. The Claude
+  Agent SDK is always given an explicit `pathToClaudeCodeExecutable`; its
+  packaged platform binaries are never relied on.
 - Cross-compilation success is not runtime validation. CI runs the compiled
   black-box suite natively on macOS arm64 and Linux x64 only; darwin-x64 and
   linux-arm64 stay cross-compile-only until the release milestone.

--- a/app-server/README.md
+++ b/app-server/README.md
@@ -27,10 +27,11 @@ The server listens on port 7332 by default; pass `--port` to override.
 One Bun package, one `package.json`, one committed `bun.lock`. Runtime
 dependencies are pinned exactly and kept minimal: `effect` (the application
 spine — HTTP, CLI, Schema, concurrency), `@effect/platform-bun` (the Bun
-adapter), and `@anthropic-ai/claude-agent-sdk` (the Claude provider seam,
-including its packaged platform-specific Claude Code executable), upgraded
-deliberately, never floated. `mise run refs` (repo root) checks out the
-matching Effect source for API reference.
+adapter), and `@anthropic-ai/claude-agent-sdk` (the Claude provider seam),
+upgraded deliberately, never floated. Provider executables are not shipped:
+the user's installed `codex` and `claude` are resolved from an env override
+or PATH. `mise run refs` (repo root) checks out the matching Effect source
+for API reference.
 
 | Path                | Responsibility                                                      |
 | ------------------- | ------------------------------------------------------------------- |

--- a/app-server/README.md
+++ b/app-server/README.md
@@ -7,13 +7,17 @@ Bun is pinned in [`mise.toml`](mise.toml) and installed automatically by
 [mise](https://mise.jdx.dev). All workflows are mise tasks:
 
 ```sh
-mise run install    # install dependencies from the committed bun.lock
-mise run dev        # run `atc serve` in the foreground (http://127.0.0.1:7332)
-mise run test       # run the vitest suite on the Bun runtime
-mise run fmt        # format with Prettier
-mise run fmt:check  # fail if formatting is needed
-mise run typecheck  # strict TypeScript type check
-mise run check      # everything CI runs: fmt:check + typecheck + test
+mise run install       # install dependencies from the committed bun.lock
+mise run dev           # run `atc serve` in the foreground (http://127.0.0.1:7332)
+mise run test          # run the vitest suite on the Bun runtime
+mise run fmt           # format with Prettier
+mise run fmt:check     # fail if formatting is needed
+mise run typecheck     # strict TypeScript type check
+mise run check         # standing CI gates: fmt:check + typecheck + test
+mise run build         # compile the standalone atc executable (dist/atc-<os>-<arch>)
+mise run build:all     # cross-compile all four release targets
+mise run test:compiled # black-box tests of the compiled artifact (builds first)
+mise run test:smoke    # opt-in live provider smoke tests (Codex + Claude credentials)
 ```
 
 The server listens on port 7332 by default; pass `--port` to override.
@@ -22,19 +26,24 @@ The server listens on port 7332 by default; pass `--port` to override.
 
 One Bun package, one `package.json`, one committed `bun.lock`. Runtime
 dependencies are pinned exactly and kept minimal: `effect` (the application
-spine — HTTP, CLI, Schema, concurrency) and `@effect/platform-bun` (the Bun
-adapter), upgraded deliberately, never floated. `mise run refs` (repo root)
-checks out the matching Effect source for API reference.
+spine — HTTP, CLI, Schema, concurrency), `@effect/platform-bun` (the Bun
+adapter), and `@anthropic-ai/claude-agent-sdk` (the Claude provider seam,
+including its packaged platform-specific Claude Code executable), upgraded
+deliberately, never floated. `mise run refs` (repo root) checks out the
+matching Effect source for API reference.
 
-| Path               | Responsibility                                                    |
-| ------------------ | ----------------------------------------------------------------- |
-| `src/main.ts`      | Entrypoint for the `atc` executable; the only `runMain`           |
-| `src/cli.ts`       | CLI commands and flags (Effect CLI); friendly startup failures    |
-| `src/api.ts`       | The `/api/v1` HttpApi contract: endpoints and response schemas    |
-| `src/handlers.ts`  | Contract implementation (handler Layer, no listener)              |
-| `src/server.ts`    | Server assembly: routes + loopback Bun listener Layer             |
-| `src/buildInfo.ts` | Build metadata service (version, commit, builtAt)                 |
-| `test/`            | `@effect/vitest` tests, including a black-box serve/shutdown test |
+| Path                | Responsibility                                                      |
+| ------------------- | ------------------------------------------------------------------- |
+| `src/main.ts`       | Entrypoint for the `atc` executable; the only `runMain`             |
+| `src/cli.ts`        | CLI commands and flags (Effect CLI); friendly startup failures      |
+| `src/api.ts`        | The `/api/v1` HttpApi contract: endpoints and response schemas      |
+| `src/handlers.ts`   | Contract implementation (handler Layer, no listener)                |
+| `src/server.ts`     | Server assembly: routes + loopback Bun listener Layer               |
+| `src/buildInfo.ts`  | Build metadata service (version, commit, builtAt)                   |
+| `src/subprocess.ts` | Subprocess service: scoped child processes, bounded diagnostics     |
+| `src/smoke.ts`      | Hidden, unstable `atc smoke` provider round trips (ATC-88)          |
+| `scripts/build.ts`  | Standalone-executable compile (Bun `--compile`, metadata injection) |
+| `test/`             | `@effect/vitest` tests, including black-box and opt-in live suites  |
 
 The contract module is structured so the server implementation, an OpenAPI
 document, and generated typed clients all derive from the same `HttpApi`

--- a/app-server/bun.lock
+++ b/app-server/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "atc-app-server",
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "0.3.220",
         "@effect/platform-bun": "4.0.0-beta.102",
         "effect": "4.0.0-beta.102",
       },
@@ -18,6 +19,28 @@
     },
   },
   "packages": {
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.220", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.220", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.220", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.220", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.220", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.220", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.220", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.220", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.220" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-glc7SdwPkOkLw8oxwLo9PKTdLJGqW/PIR4urWXFoRtX9YllwozsEVc5Tc1+EvLSkfrsxPJqQWqOgpjUOQXf1oA=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.220", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7VxlbEosK7DODiOnsjoVd0DSJzbnaPrM2jelMHI0y8zx1UnLS3WC6EFUXbvy74F2sXqEznh2tzn7EKWInaRN6Q=="],
+
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.220", "", { "os": "darwin", "cpu": "x64" }, "sha512-X9RwDsSmbF6ultKZroaip+DL8WRgC64gHbrAwrRlAFSPNZV7zmJyP2ur8rW7KrxqmtuehdMMkw8+SAC/6hD2PA=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.220", "", { "os": "linux", "cpu": "arm64" }, "sha512-WkROPwWskqhKR9XgnmseHQ6rLi9zM9qt57IWoToIjL/eXOqDWipp7JXZ1L5ud+LrA42dunHPZfBwD/vXZ+A7LA=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.220", "", { "os": "linux", "cpu": "arm64" }, "sha512-OHoZOZ8Cf2TBr6oXIXPwyvUxj9jrq2w8E4poA8dMpacXszcPSPiCQCMuuOh4aWJzfeJE1+TtWxhKMVb2csXyZQ=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.220", "", { "os": "linux", "cpu": "x64" }, "sha512-tkTJFnpR9VifvWX2fmkCAPkT6+8Wk/gVu8B5jsVekKZPiZoWRHmMXO30BnZn+f0TZhgYP+82PSX3S8crH1kn+w=="],
+
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.220", "", { "os": "linux", "cpu": "x64" }, "sha512-K+FWj+LcGhC1Z7wqeWoLxm1iemcba5xKpLLFVwYm4V6HyMx3ruYd/2r2TiQtjT+JWeNFWIys0ScHiItR6vWAiA=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.220", "", { "os": "win32", "cpu": "arm64" }, "sha512-rIwgq0UwQExWl6KrHUyC4w5KwpL9l6nd95aUTx6RitexaAuEw//xtfTVLnuE4hDDQZFkzEwpdKc3nxDWoGcUbA=="],
+
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.220", "", { "os": "win32", "cpu": "x64" }, "sha512-MuOuXhbr66HlGaWXD2f3w0k2PsvmnbkwcUZ0dAe2poFLdl72GC2dapwwOBefxm9QmoNqk9+jmv/dSKGOVWyvLw=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.115.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
     "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.102", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.102" }, "peerDependencies": { "effect": "^4.0.0-beta.102" } }, "sha512-hTIb0jjTfXhNgnDq2OX5wrigc0OSvTT0VWWb1PLpMM395RJPu8rCIbTlGhy0NS7kZOd8FfgNi9e0sDhgyu+5Ag=="],
 
     "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.102", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.102" } }, "sha512-gVd793I72MrkX4dXo7eYtRKfNj0RW4eMRfVEKEJI16h2+mBDCzQ+gqMrog2hSTHQnaIbvbYShNQ4TVGuRCYZeQ=="],
@@ -30,7 +53,11 @@
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@2.0.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ=="],
 
+    "@hono/node-server": ["@hono/node-server@2.0.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg=="],
+
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
 
@@ -79,6 +106,8 @@
     "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.2.1", "", { "os": "win32", "cpu": "x64" }, "sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
+    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -150,33 +179,135 @@
 
     "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "effect": ["effect@4.0.0-beta.102", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-z8Y+Q76Hh/kjLFZrXu8tGn6e+tDsg45R+UHhxd190pXxD53OGwf/G/zDxXTkse4HJ5mobNZfitLfUCp4fMvu6w=="],
 
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
     "es-module-lexer": ["es-module-lexer@2.3.1", "", {}, "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
     "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.6.1", "", { "dependencies": { "debug": "^4.4.3", "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA=="],
 
     "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
+
+    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
 
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "hono": ["hono@4.12.33", "", {}, "sha512-+SwvkaiJtxsiPjhy9LivY/1m7UsNqCJetM1BrZl9A5DkQhlbHQDU730mMiDPWjnoCYOM8Chf3WrCJw27kNTPFQ=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
     "ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
+
+    "ip-address": ["ip-address@10.4.0", "", {}, "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.7", "", {}, "sha512-hq1OB1bALKfydZNoViyg6hPVGV4i93ny9Op+n4zP5RSf7SCZEXa/TsG2O3IEr7+WlHRTPnpqDmHfMH6qXAD60w=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
 
@@ -206,6 +337,18 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.1", "", {}, "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
     "msgpackr": ["msgpackr@2.0.5", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA=="],
 
     "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
@@ -214,9 +357,25 @@
 
     "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
     "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -224,19 +383,57 @@
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
     "postcss": ["postcss@8.5.25", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw=="],
 
     "prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
     "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
+    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+
+    "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "rolldown": ["rolldown@1.2.1", "", { "dependencies": { "@oxc-project/types": "=0.142.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.2.1", "@rolldown/binding-darwin-arm64": "1.2.1", "@rolldown/binding-darwin-x64": "1.2.1", "@rolldown/binding-freebsd-x64": "1.2.1", "@rolldown/binding-linux-arm-gnueabihf": "1.2.1", "@rolldown/binding-linux-arm64-gnu": "1.2.1", "@rolldown/binding-linux-arm64-musl": "1.2.1", "@rolldown/binding-linux-ppc64-gnu": "1.2.1", "@rolldown/binding-linux-s390x-gnu": "1.2.1", "@rolldown/binding-linux-x64-gnu": "1.2.1", "@rolldown/binding-linux-x64-musl": "1.2.1", "@rolldown/binding-openharmony-arm64": "1.2.1", "@rolldown/binding-wasm32-wasi": "1.2.1", "@rolldown/binding-win32-arm64-msvc": "1.2.1", "@rolldown/binding-win32-x64-msvc": "1.2.1" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
 
@@ -248,24 +445,46 @@
 
     "tinyrainbow": ["tinyrainbow@3.1.1", "", {}, "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "toml": ["toml@4.3.0", "", {}, "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A=="],
 
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vite": ["vite@8.2.0", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.23", "rolldown": "~1.2.0", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ=="],
 
     "vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
 
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
   }
 }

--- a/app-server/mise.toml
+++ b/app-server/mise.toml
@@ -12,6 +12,16 @@ run = "bun run src/main.ts serve"
 description = "All App Server gates: format check, strict type check, tests"
 depends = ["fmt:check", "typecheck", "test"]
 
+[tasks.build]
+description = "Compile the standalone atc executable for this machine into dist/"
+depends = ["install"]
+run = "bun run scripts/build.ts"
+
+[tasks."build:all"]
+description = "Cross-compile standalone atc executables for every release target into dist/"
+depends = ["install"]
+run = "bun run scripts/build.ts --all"
+
 # --- Building blocks ---
 
 # fmt:check/typecheck/test share install as a dependency instead of each

--- a/app-server/mise.toml
+++ b/app-server/mise.toml
@@ -52,3 +52,13 @@ run = "bun run tsc --noEmit"
 description = "Run the vitest suite on the Bun runtime"
 depends = ["install"]
 run = "bun --bun vitest run"
+
+[tasks."test:compiled"]
+description = "Black-box tests of the compiled artifact (builds the host target first)"
+depends = ["build"]
+run = "ATC_COMPILED_TEST=1 bun --bun vitest run test/compiled.blackbox.test.ts"
+
+[tasks."test:smoke"]
+description = "Opt-in live provider smoke tests (requires Codex CLI and Claude Code credentials)"
+depends = ["build"]
+run = "ATC_SMOKE=1 bun --bun vitest run test/provider.smoke.test.ts"

--- a/app-server/package.json
+++ b/app-server/package.json
@@ -9,6 +9,7 @@
     "printWidth": 100
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "0.3.220",
     "@effect/platform-bun": "4.0.0-beta.102",
     "effect": "4.0.0-beta.102"
   },

--- a/app-server/scripts/build.ts
+++ b/app-server/scripts/build.ts
@@ -1,0 +1,75 @@
+// Compiles src/main.ts into standalone `atc` executables with Bun.
+//
+// Usage: bun run scripts/build.ts [--all]
+//   default  compile for the host platform only
+//   --all    cross-compile every release target
+//
+// Output names are deterministic (dist/atc-<os>-<arch>) so CI and release
+// tooling can consume them without discovery logic.
+
+import { existsSync } from "node:fs"
+import { copyFile, mkdir } from "node:fs/promises"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+export const TARGETS = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"] as const
+type Target = (typeof TARGETS)[number]
+
+const appServerRoot = fileURLToPath(new URL("..", import.meta.url))
+
+const hostTarget = (): Target => {
+  const target = `${process.platform}-${process.arch}`
+  if (!(TARGETS as readonly string[]).includes(target)) {
+    throw new Error(`unsupported host platform ${target}; expected one of: ${TARGETS.join(", ")}`)
+  }
+  return target as Target
+}
+
+const run = (cmd: ReadonlyArray<string>): string => {
+  const result = Bun.spawnSync([...cmd], { cwd: appServerRoot, stdout: "pipe", stderr: "inherit" })
+  if (result.exitCode !== 0) {
+    throw new Error(`${cmd.join(" ")} failed with exit code ${result.exitCode}`)
+  }
+  return result.stdout.toString().trim()
+}
+
+const commit = run(["git", "rev-parse", "HEAD"])
+const builtAt = new Date().toISOString()
+const targets: ReadonlyArray<Target> = process.argv.includes("--all") ? TARGETS : [hostTarget()]
+
+for (const target of targets) {
+  const outfile = `dist/atc-${target}`
+  run([
+    process.execPath,
+    "build",
+    "--compile",
+    `--target=bun-${target}`,
+    // A stray .env or bunfig.toml in whatever directory the executable starts
+    // from must not change server behavior.
+    "--no-compile-autoload-dotenv",
+    "--no-compile-autoload-bunfig",
+    // The define value is a JS expression, so a string needs its quotes.
+    `--define=ATC_BUILD_COMMIT=${JSON.stringify(commit)}`,
+    `--define=ATC_BUILD_BUILT_AT=${JSON.stringify(builtAt)}`,
+    `--outfile=${outfile}`,
+    "src/main.ts",
+  ])
+  console.log(`built ${outfile} (commit ${commit.slice(0, 12)}, ${builtAt})`)
+}
+
+// Stage the Claude Agent SDK's packaged platform-specific Claude Code binary
+// next to the compiled executable. The smoke command resolves it relative to
+// the executable's own location (never the working directory). Bun only
+// installs the host's platform package, so cross-compiled targets ship
+// without it until the release milestone settles per-target acquisition.
+const claudeSource = join(
+  appServerRoot,
+  "node_modules",
+  `@anthropic-ai/claude-agent-sdk-${hostTarget()}`,
+  "claude",
+)
+if (targets.includes(hostTarget()) && existsSync(claudeSource)) {
+  await mkdir(join(appServerRoot, "dist"), { recursive: true })
+  await copyFile(claudeSource, join(appServerRoot, "dist", "claude"))
+  console.log("staged dist/claude (packaged Claude Code executable for the host platform)")
+}

--- a/app-server/scripts/build.ts
+++ b/app-server/scripts/build.ts
@@ -12,18 +12,16 @@ import { copyFile, mkdir } from "node:fs/promises"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
 
-export const TARGETS = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"] as const
+// Keep in sync with the artifact checks in .github/workflows/app-server-ci.yml.
+const TARGETS = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"] as const
 type Target = (typeof TARGETS)[number]
 
 const appServerRoot = fileURLToPath(new URL("..", import.meta.url))
 
-const hostTarget = (): Target => {
-  const target = `${process.platform}-${process.arch}`
-  if (!(TARGETS as readonly string[]).includes(target)) {
-    throw new Error(`unsupported host platform ${target}; expected one of: ${TARGETS.join(", ")}`)
-  }
-  return target as Target
-}
+const host = `${process.platform}-${process.arch}`
+const hostTarget: Target | null = (TARGETS as readonly string[]).includes(host)
+  ? (host as Target)
+  : null
 
 const run = (cmd: ReadonlyArray<string>): string => {
   const result = Bun.spawnSync([...cmd], { cwd: appServerRoot, stdout: "pipe", stderr: "inherit" })
@@ -33,9 +31,20 @@ const run = (cmd: ReadonlyArray<string>): string => {
   return result.stdout.toString().trim()
 }
 
-const commit = run(["git", "rev-parse", "HEAD"])
+// The stamped commit is git HEAD (the working-copy parent in a colocated jj
+// repo), so mark builds whose tree differs from it.
+const dirty = run(["git", "status", "--porcelain"]) === "" ? "" : "-dirty"
+const commit = run(["git", "rev-parse", "HEAD"]) + dirty
 const builtAt = new Date().toISOString()
-const targets: ReadonlyArray<Target> = process.argv.includes("--all") ? TARGETS : [hostTarget()]
+
+const targets: ReadonlyArray<Target> = process.argv.includes("--all")
+  ? TARGETS
+  : hostTarget !== null
+    ? [hostTarget]
+    : []
+if (targets.length === 0) {
+  throw new Error(`unsupported host platform ${host}; expected one of: ${TARGETS.join(", ")}`)
+}
 
 for (const target of targets) {
   const outfile = `dist/atc-${target}`
@@ -54,22 +63,25 @@ for (const target of targets) {
     `--outfile=${outfile}`,
     "src/main.ts",
   ])
-  console.log(`built ${outfile} (commit ${commit.slice(0, 12)}, ${builtAt})`)
+  console.log(`built ${outfile} (commit ${commit.slice(0, 12)}${dirty}, ${builtAt})`)
 }
 
 // Stage the Claude Agent SDK's packaged platform-specific Claude Code binary
-// next to the compiled executable. The smoke command resolves it relative to
-// the executable's own location (never the working directory). Bun only
-// installs the host's platform package, so cross-compiled targets ship
-// without it until the release milestone settles per-target acquisition.
-const claudeSource = join(
-  appServerRoot,
-  "node_modules",
-  `@anthropic-ai/claude-agent-sdk-${hostTarget()}`,
-  "claude",
-)
-if (targets.includes(hostTarget()) && existsSync(claudeSource)) {
-  await mkdir(join(appServerRoot, "dist"), { recursive: true })
-  await copyFile(claudeSource, join(appServerRoot, "dist", "claude"))
-  console.log("staged dist/claude (packaged Claude Code executable for the host platform)")
+// next to the compiled executable, under a target-scoped name so an artifact
+// can never pair with a wrong-platform binary. Bun only installs the host's
+// platform package, so cross-compiled targets ship without one until the
+// release milestone settles per-target acquisition.
+if (hostTarget !== null && targets.includes(hostTarget)) {
+  const claudeSource = join(
+    appServerRoot,
+    "node_modules",
+    `@anthropic-ai/claude-agent-sdk-${hostTarget}`,
+    "claude",
+  )
+  if (existsSync(claudeSource)) {
+    const staged = `dist/claude-${hostTarget}`
+    await mkdir(join(appServerRoot, "dist"), { recursive: true })
+    await copyFile(claudeSource, join(appServerRoot, staged))
+    console.log(`staged ${staged} (packaged Claude Code executable)`)
+  }
 }

--- a/app-server/scripts/build.ts
+++ b/app-server/scripts/build.ts
@@ -7,9 +7,6 @@
 // Output names are deterministic (dist/atc-<os>-<arch>) so CI and release
 // tooling can consume them without discovery logic.
 
-import { existsSync } from "node:fs"
-import { copyFile, mkdir } from "node:fs/promises"
-import { join } from "node:path"
 import { fileURLToPath } from "node:url"
 
 // Keep in sync with the artifact checks in .github/workflows/app-server-ci.yml.
@@ -64,24 +61,4 @@ for (const target of targets) {
     "src/main.ts",
   ])
   console.log(`built ${outfile} (commit ${commit.slice(0, 12)}${dirty}, ${builtAt})`)
-}
-
-// Stage the Claude Agent SDK's packaged platform-specific Claude Code binary
-// next to the compiled executable, under a target-scoped name so an artifact
-// can never pair with a wrong-platform binary. Bun only installs the host's
-// platform package, so cross-compiled targets ship without one until the
-// release milestone settles per-target acquisition.
-if (hostTarget !== null && targets.includes(hostTarget)) {
-  const claudeSource = join(
-    appServerRoot,
-    "node_modules",
-    `@anthropic-ai/claude-agent-sdk-${hostTarget}`,
-    "claude",
-  )
-  if (existsSync(claudeSource)) {
-    const staged = `dist/claude-${hostTarget}`
-    await mkdir(join(appServerRoot, "dist"), { recursive: true })
-    await copyFile(claudeSource, join(appServerRoot, staged))
-    console.log(`staged ${staged} (packaged Claude Code executable)`)
-  }
 }

--- a/app-server/src/buildInfo.ts
+++ b/app-server/src/buildInfo.ts
@@ -1,6 +1,11 @@
 import { Context, Layer } from "effect"
 import packageJson from "../package.json"
 
+// Compile-time constants injected by scripts/build.ts via `bun build --define`.
+// Running from source leaves them undefined, so dev placeholders apply.
+declare const ATC_BUILD_COMMIT: string | undefined
+declare const ATC_BUILD_BUILT_AT: string | undefined
+
 /**
  * Build metadata for the running executable. Handlers and the CLI read this
  * service instead of probing the environment themselves.
@@ -16,10 +21,8 @@ export class BuildInfo extends Context.Service<
 
 export const buildInfo: BuildInfo["Service"] = {
   version: packageJson.version,
-  // Real values arrive with the standalone-executable build, which will
-  // inject them at compile time; running from source uses placeholders.
-  commit: "dev",
-  builtAt: "dev",
+  commit: typeof ATC_BUILD_COMMIT === "string" ? ATC_BUILD_COMMIT : "dev",
+  builtAt: typeof ATC_BUILD_BUILT_AT === "string" ? ATC_BUILD_BUILT_AT : "dev",
 }
 
 export const layer = Layer.succeed(BuildInfo)(buildInfo)

--- a/app-server/src/cli.ts
+++ b/app-server/src/cli.ts
@@ -1,6 +1,7 @@
 import { Console, Effect, Layer, Runtime, Schema } from "effect"
 import { Command, Flag } from "effect/unstable/cli"
 import * as Server from "./server.ts"
+import { smoke } from "./smoke.ts"
 
 export const DEFAULT_PORT = 7332
 
@@ -40,5 +41,5 @@ const serve = Command.make("serve", { port }, ({ port }) =>
 
 export const atc = Command.make("atc").pipe(
   Command.withDescription("ATC App Server"),
-  Command.withSubcommands([serve]),
+  Command.withSubcommands([serve, smoke]),
 )

--- a/app-server/src/main.ts
+++ b/app-server/src/main.ts
@@ -3,10 +3,20 @@ import { Effect, Layer } from "effect"
 import { Command } from "effect/unstable/cli"
 import * as BuildInfo from "./buildInfo.ts"
 import { atc } from "./cli.ts"
+import * as Subprocess from "./subprocess.ts"
 
 // The only runMain in the application. Everything else is Layers and Effects,
 // so even the CLI version resolves through the injected BuildInfo service.
 Effect.gen(function* () {
   const build = yield* BuildInfo.BuildInfo
   yield* Command.run(atc, { version: build.version })
-}).pipe(Effect.provide(Layer.mergeAll(BuildInfo.layer, BunServices.layer)), BunRuntime.runMain)
+}).pipe(
+  Effect.provide(
+    Layer.mergeAll(
+      BuildInfo.layer,
+      BunServices.layer,
+      Subprocess.layer.pipe(Layer.provide(BunServices.layer)),
+    ),
+  ),
+  BunRuntime.runMain,
+)

--- a/app-server/src/smoke.ts
+++ b/app-server/src/smoke.ts
@@ -282,8 +282,7 @@ export const claudeSmoke = (claudeExecutable: string) =>
       yield* Effect.addFinalizer(() => Effect.sync(() => abortController.abort()))
       const summary = yield* Effect.tryPromise({
         try: () => claudeRoundTrip(claudeExecutable, cwd, abortController),
-        catch: (error) =>
-          new SmokeError({ provider: "claude", message: describeError(error) }),
+        catch: (error) => new SmokeError({ provider: "claude", message: describeError(error) }),
       }).pipe(
         Effect.timeoutOrElse({
           duration: "180 seconds",

--- a/app-server/src/smoke.ts
+++ b/app-server/src/smoke.ts
@@ -1,11 +1,9 @@
 import { query, type SDKMessage } from "@anthropic-ai/claude-agent-sdk"
 import { Console, Deferred, Duration, Effect, Runtime, Schema, Stream } from "effect"
 import { Command } from "effect/unstable/cli"
-import { existsSync } from "node:fs"
 import { mkdtemp, rm } from "node:fs/promises"
-import { createRequire } from "node:module"
 import { tmpdir } from "node:os"
-import { dirname, join } from "node:path"
+import { join } from "node:path"
 import * as BuildInfo from "./buildInfo.ts"
 import * as Subprocess from "./subprocess.ts"
 
@@ -42,31 +40,22 @@ export const resolveCodexExecutable = Effect.suspend(() => {
 })
 
 /**
- * Claude Code: explicit env override, then the packaged platform binary staged
- * next to this executable (compiled distribution; target-scoped name so a
- * wrong-platform binary can never pair), then the platform package in
- * node_modules (running from source). Never the working directory.
+ * Claude Code: explicit env override, then the user's installed `claude` on
+ * PATH — the same bring-your-own-CLI rule as codex. atc does not ship a
+ * Claude Code binary; the user's install also carries the credentials the
+ * SDK needs.
  */
 export const resolveClaudeCodeExecutable = Effect.suspend(() => {
   const override = process.env["ATC_CLAUDE_CODE_EXECUTABLE"]
   if (override !== undefined && override !== "") return Effect.succeed(override)
-  const platformTarget = `${process.platform}-${process.arch}`
-  const adjacent = join(dirname(process.execPath), `claude-${platformTarget}`)
-  if (existsSync(adjacent)) return Effect.succeed(adjacent)
-  const platformPackage = `@anthropic-ai/claude-agent-sdk-${platformTarget}`
-  try {
-    const resolved = createRequire(import.meta.url).resolve(`${platformPackage}/claude`)
-    if (existsSync(resolved)) return Effect.succeed(resolved)
-  } catch {
-    // No node_modules in a compiled executable; fall through to the error.
-  }
+  const found = Bun.which("claude")
+  if (found !== null) return Effect.succeed(found)
   return Effect.fail(
     new SmokeError({
       provider: "claude",
       message:
-        "Claude Code executable not found; tried $ATC_CLAUDE_CODE_EXECUTABLE, " +
-        `${adjacent}, and ${platformPackage} in node_modules. ` +
-        "Run `mise run build` to stage it, or set ATC_CLAUDE_CODE_EXECUTABLE.",
+        "claude not found on PATH; install and authenticate Claude Code " +
+        "or set ATC_CLAUDE_CODE_EXECUTABLE",
     }),
   )
 })

--- a/app-server/src/smoke.ts
+++ b/app-server/src/smoke.ts
@@ -1,5 +1,5 @@
 import { query, type SDKMessage } from "@anthropic-ai/claude-agent-sdk"
-import { Console, Duration, Effect, Option, Runtime, Schema, Stream } from "effect"
+import { Console, Deferred, Duration, Effect, Runtime, Schema, Stream } from "effect"
 import { Command } from "effect/unstable/cli"
 import { existsSync } from "node:fs"
 import { mkdtemp, rm } from "node:fs/promises"
@@ -43,15 +43,17 @@ export const resolveCodexExecutable = Effect.suspend(() => {
 
 /**
  * Claude Code: explicit env override, then the packaged platform binary staged
- * next to this executable (compiled distribution), then the platform package
- * in node_modules (running from source). Never the working directory.
+ * next to this executable (compiled distribution; target-scoped name so a
+ * wrong-platform binary can never pair), then the platform package in
+ * node_modules (running from source). Never the working directory.
  */
 export const resolveClaudeCodeExecutable = Effect.suspend(() => {
   const override = process.env["ATC_CLAUDE_CODE_EXECUTABLE"]
   if (override !== undefined && override !== "") return Effect.succeed(override)
-  const adjacent = join(dirname(process.execPath), "claude")
+  const platformTarget = `${process.platform}-${process.arch}`
+  const adjacent = join(dirname(process.execPath), `claude-${platformTarget}`)
   if (existsSync(adjacent)) return Effect.succeed(adjacent)
-  const platformPackage = `@anthropic-ai/claude-agent-sdk-${process.platform}-${process.arch}`
+  const platformPackage = `@anthropic-ai/claude-agent-sdk-${platformTarget}`
   try {
     const resolved = createRequire(import.meta.url).resolve(`${platformPackage}/claude`)
     if (existsSync(resolved)) return Effect.succeed(resolved)
@@ -71,21 +73,13 @@ export const resolveClaudeCodeExecutable = Effect.suspend(() => {
 
 // --- Shared termination checks ----------------------------------------------
 
-const isAlive = (pid: number): boolean => {
-  try {
-    process.kill(pid, 0)
-    return true
-  } catch {
-    return false
-  }
-}
-
+// Scope close already awaits child termination (SIGTERM + SIGKILL
+// escalation), so this is not cleanup: it is the explicit no-orphan proof the
+// smoke checks exist to provide.
 const verifyProcessGone = (provider: "codex" | "claude", pid: number) =>
   Effect.gen(function* () {
-    for (let attempt = 0; attempt < 40 && isAlive(pid); attempt++) {
-      yield* Effect.sleep("50 millis")
-    }
-    if (isAlive(pid)) {
+    const exited = yield* Subprocess.waitForProcessExit(pid)
+    if (!exited) {
       return yield* Effect.fail(
         new SmokeError({ provider, message: `child process ${pid} is still alive after cleanup` }),
       )
@@ -110,7 +104,13 @@ const verifyNoChildOrphans = (provider: "codex" | "claude") =>
           yield* pgrep.exitCode // 0 = matches, 1 = none; either is a clean run
           return lines.filter((line) => line.trim() !== "")
         }),
-      ).pipe(Effect.mapError((e) => new SmokeError({ provider, message: e.message })))
+      ).pipe(
+        Effect.mapError(
+          // A broken check is not a provider failure; say which one it is.
+          (error) =>
+            new SmokeError({ provider, message: `orphan check could not run: ${error.message}` }),
+        ),
+      )
       if (survivors.length === 0) return
       if (attempt >= 20) {
         return yield* Effect.fail(
@@ -126,27 +126,46 @@ const verifyNoChildOrphans = (provider: "codex" | "claude") =>
 
 // --- Codex: one JSON-RPC initialize round trip over stdio --------------------
 
-interface JsonRpcMessage {
-  readonly id?: unknown
-  readonly result?: unknown
-  readonly error?: { readonly code?: unknown; readonly message?: unknown }
+/** The one message shape this smoke check inspects; `error: null` counts as absent. */
+const InitializeResponse = Schema.Struct({
+  error: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        code: Schema.optional(Schema.Number),
+        message: Schema.optional(Schema.String),
+      }),
+    ),
+  ),
+})
+
+const INITIALIZE_REQUEST_ID = 1
+
+/** Loose parse: provider stdout noise (banners, warnings) is tolerated. */
+const parseResponseLine = (line: string): unknown | undefined => {
+  try {
+    const parsed: unknown = JSON.parse(line)
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      (parsed as { id?: unknown }).id === INITIALIZE_REQUEST_ID
+    ) {
+      return parsed
+    }
+  } catch {
+    // Not protocol JSON; skip.
+  }
+  return undefined
 }
 
-const parseJsonRpcLine = (line: string) =>
-  Effect.try({
-    try: () => JSON.parse(line) as JsonRpcMessage,
-    catch: () =>
-      new SmokeError({
-        provider: "codex",
-        message: `invalid JSON on codex app-server stdout: ${line.slice(0, 200)}`,
-      }),
-  })
+const stderrSuffix = (tail: ReadonlyArray<string>): string =>
+  tail.length === 0 ? "" : `\nprovider stderr:\n${tail.join("\n")}`
 
 const failWithStderr = (child: Subprocess.Child, message: string) =>
   Effect.gen(function* () {
     const tail = yield* child.stderrTail
-    const diagnostics = tail.length === 0 ? "" : `\nprovider stderr:\n${tail.join("\n")}`
-    return yield* Effect.fail(new SmokeError({ provider: "codex", message: message + diagnostics }))
+    return yield* Effect.fail(
+      new SmokeError({ provider: "codex", message: message + stderrSuffix(tail) }),
+    )
   })
 
 /**
@@ -162,15 +181,41 @@ export const codexSmoke = (
     const initializeTimeout = options?.initializeTimeout ?? "15 seconds"
     const build = yield* BuildInfo.BuildInfo
     const subprocess = yield* Subprocess.Subprocess
-    let pid = 0
+    let pid: number | null = null
     yield* Effect.scoped(
       Effect.gen(function* () {
         const child = yield* subprocess.spawn(spec)
         pid = child.pid
         yield* Console.log(`launched ${spec.executable} (pid ${pid})`)
+
+        // Consume stdout exactly once for the child's whole lifetime, so the
+        // pipe can never fill: the initialize response resolves the deferred
+        // and everything else keeps draining.
+        const responseSlot = yield* Deferred.make<unknown, SmokeError>()
+        yield* Effect.gen(function* () {
+          yield* child.stdoutLines.pipe(
+            Stream.runForEach((line) => {
+              const response = parseResponseLine(line)
+              return response === undefined
+                ? Effect.void
+                : Effect.asVoid(Deferred.succeed(responseSlot, response))
+            }),
+            Effect.ignore,
+          )
+          // Stream end without a response = child closed stdout early.
+          const tail = yield* child.stderrTail
+          yield* Deferred.fail(
+            responseSlot,
+            new SmokeError({
+              provider: "codex",
+              message: "codex app-server closed stdout before responding" + stderrSuffix(tail),
+            }),
+          )
+        }).pipe(Effect.forkScoped)
+
         yield* child.writeLine(
           JSON.stringify({
-            id: 1,
+            id: INITIALIZE_REQUEST_ID,
             method: "initialize",
             params: {
               clientInfo: { name: "atc", title: "ATC App Server", version: build.version },
@@ -178,10 +223,7 @@ export const codexSmoke = (
             },
           }),
         )
-        const response = yield* child.stdoutLines.pipe(
-          Stream.mapEffect(parseJsonRpcLine),
-          Stream.filter((message) => message.id === 1),
-          Stream.runHead,
+        const raw = yield* Deferred.await(responseSlot).pipe(
           Effect.timeoutOrElse({
             duration: initializeTimeout,
             orElse: () =>
@@ -191,13 +233,19 @@ export const codexSmoke = (
               ),
           }),
         )
-        if (Option.isNone(response)) {
-          return yield* failWithStderr(child, "codex app-server closed stdout before responding")
-        }
-        if (response.value.error !== undefined) {
+        const response = yield* Schema.decodeUnknownEffect(InitializeResponse)(raw).pipe(
+          Effect.mapError(
+            (error) =>
+              new SmokeError({
+                provider: "codex",
+                message: `unexpected initialize response shape: ${error.message}`,
+              }),
+          ),
+        )
+        if (response.error !== undefined && response.error !== null) {
           return yield* failWithStderr(
             child,
-            `initialize failed: ${JSON.stringify(response.value.error)}`,
+            `initialize failed: ${JSON.stringify(response.error)}`,
           )
         }
         yield* Console.log("initialize round trip OK")
@@ -212,7 +260,7 @@ export const codexSmoke = (
           : Console.log(`codex app-server exited with code ${exitCode}`)
       }),
     )
-    yield* verifyProcessGone("codex", pid)
+    if (pid !== null) yield* verifyProcessGone("codex", pid)
     yield* Console.log("PASS: codex app-server round trip complete; child terminated")
   })
 
@@ -268,7 +316,8 @@ const claudeRoundTrip = async (
 /**
  * One bounded round trip through the Claude Agent SDK using an explicitly
  * resolved packaged Claude Code executable, from a working directory outside
- * any repository.
+ * any repository. The no-orphan check runs on success *and* failure — the
+ * failure path is exactly where orphans are likely.
  */
 export const claudeSmoke = (claudeExecutable: string) =>
   Effect.scoped(
@@ -280,25 +329,46 @@ export const claudeSmoke = (claudeExecutable: string) =>
       )
       const abortController = new AbortController()
       yield* Effect.addFinalizer(() => Effect.sync(() => abortController.abort()))
-      const summary = yield* Effect.tryPromise({
-        try: () => claudeRoundTrip(claudeExecutable, cwd, abortController),
-        catch: (error) => new SmokeError({ provider: "claude", message: describeError(error) }),
-      }).pipe(
-        Effect.timeoutOrElse({
-          duration: "180 seconds",
-          orElse: () =>
-            Effect.fail(
-              new SmokeError({
+      const attempt = yield* Effect.result(
+        Effect.tryPromise({
+          // Wire Effect interruption straight through to the SDK.
+          try: (signal) => {
+            signal.addEventListener("abort", () => abortController.abort())
+            return claudeRoundTrip(claudeExecutable, cwd, abortController)
+          },
+          catch: (error) => new SmokeError({ provider: "claude", message: describeError(error) }),
+        }).pipe(
+          Effect.timeoutOrElse({
+            duration: "180 seconds",
+            orElse: () =>
+              Effect.fail(
+                new SmokeError({
+                  provider: "claude",
+                  message: "timed out after 180s waiting for the Claude round trip",
+                }),
+              ),
+          }),
+        ),
+      )
+      // Whatever happened, the SDK's child must be gone before we finish
+      // (and before the temp cwd is removed underneath it). Keep the original
+      // failure primary so an orphan report never masks the root cause.
+      abortController.abort()
+      const orphanCheck = yield* Effect.result(verifyNoChildOrphans("claude"))
+      if (attempt._tag === "Failure") {
+        return yield* Effect.fail(
+          orphanCheck._tag === "Failure"
+            ? new SmokeError({
                 provider: "claude",
-                message: "timed out after 180s waiting for the Claude round trip",
-              }),
-            ),
-        }),
-      )
+                message: `${attempt.failure.message}\nadditionally: ${orphanCheck.failure.message}`,
+              })
+            : attempt.failure,
+        )
+      }
+      if (orphanCheck._tag === "Failure") return yield* Effect.fail(orphanCheck.failure)
       yield* Console.log(
-        `claude session ${summary.sessionId} answered: ${JSON.stringify(summary.text)}`,
+        `claude session ${attempt.success.sessionId} answered: ${JSON.stringify(attempt.success.text)}`,
       )
-      yield* verifyNoChildOrphans("claude")
       yield* Console.log("PASS: Claude Agent SDK round trip complete; no orphaned children")
     }),
   )
@@ -306,7 +376,9 @@ export const claudeSmoke = (claudeExecutable: string) =>
 // --- CLI wiring ---------------------------------------------------------------
 
 /** Print the failure as actionable diagnostics, then fail quietly. */
-const reported = <A, R>(effect: Effect.Effect<A, SmokeError | Subprocess.SubprocessError, R>) =>
+const reportFailures = <A, R>(
+  effect: Effect.Effect<A, SmokeError | Subprocess.SubprocessError, R>,
+) =>
   effect.pipe(
     Effect.catchTag(["SmokeError", "SubprocessError"], (error) =>
       Console.error(
@@ -318,7 +390,7 @@ const reported = <A, R>(effect: Effect.Effect<A, SmokeError | Subprocess.Subproc
   )
 
 const codexCommand = Command.make("codex", {}, () =>
-  reported(
+  reportFailures(
     Effect.gen(function* () {
       const executable = yield* resolveCodexExecutable
       yield* codexSmoke({
@@ -333,7 +405,7 @@ const codexCommand = Command.make("codex", {}, () =>
 ).pipe(Command.withDescription("[unstable] Codex app-server launch and initialize round trip"))
 
 const claudeCommand = Command.make("claude", {}, () =>
-  reported(
+  reportFailures(
     Effect.gen(function* () {
       const executable = yield* resolveClaudeCodeExecutable
       yield* claudeSmoke(executable)

--- a/app-server/src/smoke.ts
+++ b/app-server/src/smoke.ts
@@ -62,6 +62,9 @@ export const resolveClaudeCodeExecutable = Effect.suspend(() => {
 
 // --- Shared termination checks ----------------------------------------------
 
+const stderrSuffix = (tail: ReadonlyArray<string>): string =>
+  tail.length === 0 ? "" : `\nprovider stderr:\n${tail.join("\n")}`
+
 // Scope close already awaits child termination (SIGTERM + SIGKILL
 // escalation), so this is not cleanup: it is the explicit no-orphan proof the
 // smoke checks exist to provide.
@@ -79,7 +82,9 @@ const verifyProcessGone = (provider: "codex" | "claude", pid: number) =>
 const verifyNoChildOrphans = (provider: "codex" | "claude") =>
   Effect.gen(function* () {
     const subprocess = yield* Subprocess.Subprocess
-    // The SDK reaps its child asynchronously, so allow a short settle window.
+    // The settle window must outlast the Agent SDK's full termination
+    // escalation — abort closes stdin, SIGTERM follows after 2s, SIGKILL
+    // after 5 more — because its timers are unref'ed and die with us.
     for (let attempt = 0; ; attempt++) {
       const survivors = yield* Effect.scoped(
         Effect.gen(function* () {
@@ -90,18 +95,29 @@ const verifyNoChildOrphans = (provider: "codex" | "claude") =>
             extendEnv: true,
           })
           const lines = yield* Stream.runCollect(pgrep.stdoutLines)
-          yield* pgrep.exitCode // 0 = matches, 1 = none; either is a clean run
+          // 0 = matches, 1 = none; anything else means the check itself broke.
+          const exitCode = yield* pgrep.exitCode
+          if (exitCode > 1) {
+            const tail = yield* pgrep.stderrTail
+            return yield* Effect.fail(
+              new SmokeError({
+                provider,
+                message: `orphan check could not run: pgrep exited with ${exitCode}${stderrSuffix(tail)}`,
+              }),
+            )
+          }
           return lines.filter((line) => line.trim() !== "")
         }),
       ).pipe(
-        Effect.mapError(
+        Effect.catchTag("SubprocessError", (error) =>
           // A broken check is not a provider failure; say which one it is.
-          (error) =>
+          Effect.fail(
             new SmokeError({ provider, message: `orphan check could not run: ${error.message}` }),
+          ),
         ),
       )
       if (survivors.length === 0) return
-      if (attempt >= 20) {
+      if (attempt >= 100) {
         return yield* Effect.fail(
           new SmokeError({
             provider,
@@ -115,8 +131,12 @@ const verifyNoChildOrphans = (provider: "codex" | "claude") =>
 
 // --- Codex: one JSON-RPC initialize round trip over stdio --------------------
 
-/** The one message shape this smoke check inspects; `error: null` counts as absent. */
+/**
+ * The one message shape this smoke check inspects. A real round trip must
+ * carry a `result` object or an `error` object; `null` counts as absent.
+ */
 const InitializeResponse = Schema.Struct({
+  result: Schema.optional(Schema.NullOr(Schema.Record(Schema.String, Schema.Unknown))),
   error: Schema.optional(
     Schema.NullOr(
       Schema.Struct({
@@ -145,9 +165,6 @@ const parseResponseLine = (line: string): unknown | undefined => {
   }
   return undefined
 }
-
-const stderrSuffix = (tail: ReadonlyArray<string>): string =>
-  tail.length === 0 ? "" : `\nprovider stderr:\n${tail.join("\n")}`
 
 const failWithStderr = (child: Subprocess.Child, message: string) =>
   Effect.gen(function* () {
@@ -237,6 +254,12 @@ export const codexSmoke = (
             `initialize failed: ${JSON.stringify(response.error)}`,
           )
         }
+        if (response.result === undefined || response.result === null) {
+          return yield* failWithStderr(
+            child,
+            "initialize response carried neither result nor error",
+          )
+        }
         yield* Console.log("initialize round trip OK")
         yield* child.writeLine(JSON.stringify({ method: "initialized", params: {} }))
         yield* child.endInput
@@ -244,9 +267,17 @@ export const codexSmoke = (
           Effect.timeoutOrElse({ duration: "5 seconds", orElse: () => Effect.succeed(null) }),
           Effect.orElseSucceed(() => null),
         )
+        // A clean shutdown means exit 0; the null branch is the deliberate
+        // forced-cleanup path (EOF ignored, scope close terminates).
+        if (exitCode !== null && exitCode !== 0) {
+          return yield* failWithStderr(
+            child,
+            `codex app-server exited with code ${exitCode} after the round trip`,
+          )
+        }
         yield* exitCode === null
           ? Console.log("codex app-server did not exit on stdin EOF; terminating it")
-          : Console.log(`codex app-server exited with code ${exitCode}`)
+          : Console.log("codex app-server exited cleanly on stdin EOF")
       }),
     )
     if (pid !== null) yield* verifyProcessGone("codex", pid)

--- a/app-server/src/smoke.ts
+++ b/app-server/src/smoke.ts
@@ -1,0 +1,352 @@
+import { query, type SDKMessage } from "@anthropic-ai/claude-agent-sdk"
+import { Console, Duration, Effect, Option, Runtime, Schema, Stream } from "effect"
+import { Command } from "effect/unstable/cli"
+import { existsSync } from "node:fs"
+import { mkdtemp, rm } from "node:fs/promises"
+import { createRequire } from "node:module"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import * as BuildInfo from "./buildInfo.ts"
+import * as Subprocess from "./subprocess.ts"
+
+// Unstable provider smoke checks (ATC-88). `atc smoke ...` proves that the
+// compiled executable can launch each provider technology and complete one
+// bounded structured round trip. The command is hidden, is not a stable
+// interface, and will be replaced by the production provider integration.
+// Provider SDK and protocol types stay private to this module.
+
+export class SmokeError extends Schema.TaggedErrorClass<SmokeError>()("SmokeError", {
+  provider: Schema.Literals(["codex", "claude"]),
+  message: Schema.String,
+}) {}
+
+/** Failure already printed as diagnostics; stops runMain's loud re-report. */
+class SmokeReported extends Schema.TaggedErrorClass<SmokeReported>()("SmokeReported", {}) {
+  override readonly [Runtime.errorReported] = false
+}
+
+// --- Executable resolution ---------------------------------------------------
+
+/** Codex: explicit env override, then PATH. */
+export const resolveCodexExecutable = Effect.suspend(() => {
+  const override = process.env["ATC_CODEX_EXECUTABLE"]
+  if (override !== undefined && override !== "") return Effect.succeed(override)
+  const found = Bun.which("codex")
+  if (found !== null) return Effect.succeed(found)
+  return Effect.fail(
+    new SmokeError({
+      provider: "codex",
+      message: "codex not found on PATH; install the Codex CLI or set ATC_CODEX_EXECUTABLE",
+    }),
+  )
+})
+
+/**
+ * Claude Code: explicit env override, then the packaged platform binary staged
+ * next to this executable (compiled distribution), then the platform package
+ * in node_modules (running from source). Never the working directory.
+ */
+export const resolveClaudeCodeExecutable = Effect.suspend(() => {
+  const override = process.env["ATC_CLAUDE_CODE_EXECUTABLE"]
+  if (override !== undefined && override !== "") return Effect.succeed(override)
+  const adjacent = join(dirname(process.execPath), "claude")
+  if (existsSync(adjacent)) return Effect.succeed(adjacent)
+  const platformPackage = `@anthropic-ai/claude-agent-sdk-${process.platform}-${process.arch}`
+  try {
+    const resolved = createRequire(import.meta.url).resolve(`${platformPackage}/claude`)
+    if (existsSync(resolved)) return Effect.succeed(resolved)
+  } catch {
+    // No node_modules in a compiled executable; fall through to the error.
+  }
+  return Effect.fail(
+    new SmokeError({
+      provider: "claude",
+      message:
+        "Claude Code executable not found; tried $ATC_CLAUDE_CODE_EXECUTABLE, " +
+        `${adjacent}, and ${platformPackage} in node_modules. ` +
+        "Run `mise run build` to stage it, or set ATC_CLAUDE_CODE_EXECUTABLE.",
+    }),
+  )
+})
+
+// --- Shared termination checks ----------------------------------------------
+
+const isAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const verifyProcessGone = (provider: "codex" | "claude", pid: number) =>
+  Effect.gen(function* () {
+    for (let attempt = 0; attempt < 40 && isAlive(pid); attempt++) {
+      yield* Effect.sleep("50 millis")
+    }
+    if (isAlive(pid)) {
+      return yield* Effect.fail(
+        new SmokeError({ provider, message: `child process ${pid} is still alive after cleanup` }),
+      )
+    }
+  })
+
+/** No direct child of this process may outlive a smoke check. */
+const verifyNoChildOrphans = (provider: "codex" | "claude") =>
+  Effect.gen(function* () {
+    const subprocess = yield* Subprocess.Subprocess
+    // The SDK reaps its child asynchronously, so allow a short settle window.
+    for (let attempt = 0; ; attempt++) {
+      const survivors = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const pgrep = yield* subprocess.spawn({
+            executable: "pgrep",
+            args: ["-l", "-P", String(process.pid)],
+            env: {},
+            extendEnv: true,
+          })
+          const lines = yield* Stream.runCollect(pgrep.stdoutLines)
+          yield* pgrep.exitCode // 0 = matches, 1 = none; either is a clean run
+          return lines.filter((line) => line.trim() !== "")
+        }),
+      ).pipe(Effect.mapError((e) => new SmokeError({ provider, message: e.message })))
+      if (survivors.length === 0) return
+      if (attempt >= 20) {
+        return yield* Effect.fail(
+          new SmokeError({
+            provider,
+            message: `orphaned child processes remain: ${survivors.join("; ")}`,
+          }),
+        )
+      }
+      yield* Effect.sleep("100 millis")
+    }
+  })
+
+// --- Codex: one JSON-RPC initialize round trip over stdio --------------------
+
+interface JsonRpcMessage {
+  readonly id?: unknown
+  readonly result?: unknown
+  readonly error?: { readonly code?: unknown; readonly message?: unknown }
+}
+
+const parseJsonRpcLine = (line: string) =>
+  Effect.try({
+    try: () => JSON.parse(line) as JsonRpcMessage,
+    catch: () =>
+      new SmokeError({
+        provider: "codex",
+        message: `invalid JSON on codex app-server stdout: ${line.slice(0, 200)}`,
+      }),
+  })
+
+const failWithStderr = (child: Subprocess.Child, message: string) =>
+  Effect.gen(function* () {
+    const tail = yield* child.stderrTail
+    const diagnostics = tail.length === 0 ? "" : `\nprovider stderr:\n${tail.join("\n")}`
+    return yield* Effect.fail(new SmokeError({ provider: "codex", message: message + diagnostics }))
+  })
+
+/**
+ * Launch a codex app-server over stdio, complete `initialize`/`initialized`,
+ * and shut the child down. The spawn spec and timeout are parameters so tests
+ * can substitute a fixture app-server for the real executable.
+ */
+export const codexSmoke = (
+  spec: Subprocess.SpawnSpec,
+  options?: { readonly initializeTimeout?: Duration.Input },
+) =>
+  Effect.gen(function* () {
+    const initializeTimeout = options?.initializeTimeout ?? "15 seconds"
+    const build = yield* BuildInfo.BuildInfo
+    const subprocess = yield* Subprocess.Subprocess
+    let pid = 0
+    yield* Effect.scoped(
+      Effect.gen(function* () {
+        const child = yield* subprocess.spawn(spec)
+        pid = child.pid
+        yield* Console.log(`launched ${spec.executable} (pid ${pid})`)
+        yield* child.writeLine(
+          JSON.stringify({
+            id: 1,
+            method: "initialize",
+            params: {
+              clientInfo: { name: "atc", title: "ATC App Server", version: build.version },
+              capabilities: null,
+            },
+          }),
+        )
+        const response = yield* child.stdoutLines.pipe(
+          Stream.mapEffect(parseJsonRpcLine),
+          Stream.filter((message) => message.id === 1),
+          Stream.runHead,
+          Effect.timeoutOrElse({
+            duration: initializeTimeout,
+            orElse: () =>
+              failWithStderr(
+                child,
+                `timed out after ${Duration.format(Duration.fromInputUnsafe(initializeTimeout))} waiting for the initialize response`,
+              ),
+          }),
+        )
+        if (Option.isNone(response)) {
+          return yield* failWithStderr(child, "codex app-server closed stdout before responding")
+        }
+        if (response.value.error !== undefined) {
+          return yield* failWithStderr(
+            child,
+            `initialize failed: ${JSON.stringify(response.value.error)}`,
+          )
+        }
+        yield* Console.log("initialize round trip OK")
+        yield* child.writeLine(JSON.stringify({ method: "initialized", params: {} }))
+        yield* child.endInput
+        const exitCode = yield* child.exitCode.pipe(
+          Effect.timeoutOrElse({ duration: "5 seconds", orElse: () => Effect.succeed(null) }),
+          Effect.orElseSucceed(() => null),
+        )
+        yield* exitCode === null
+          ? Console.log("codex app-server did not exit on stdin EOF; terminating it")
+          : Console.log(`codex app-server exited with code ${exitCode}`)
+      }),
+    )
+    yield* verifyProcessGone("codex", pid)
+    yield* Console.log("PASS: codex app-server round trip complete; child terminated")
+  })
+
+// --- Claude: one Agent SDK round trip ----------------------------------------
+
+const describeError = (error: unknown): string =>
+  error instanceof Error ? (error.stack ?? error.message) : String(error)
+
+const claudeRoundTrip = async (
+  pathToClaudeCodeExecutable: string,
+  cwd: string,
+  abortController: AbortController,
+): Promise<{ readonly sessionId: string; readonly text: string }> => {
+  // Controlled but complete environment: the child needs HOME and any
+  // credential configuration the user has; nothing is added or dropped.
+  const env: Record<string, string> = {}
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) env[key] = value
+  }
+  const stream = query({
+    prompt: "Reply with exactly: ATC-SMOKE-OK",
+    options: {
+      abortController,
+      cwd,
+      env,
+      pathToClaudeCodeExecutable,
+      allowedTools: [],
+      tools: [],
+      settingSources: [],
+      permissionMode: "dontAsk",
+      maxTurns: 1,
+      persistSession: false,
+    },
+  })
+  let sessionId: string | undefined
+  let resultText: string | undefined
+  for await (const message of stream as AsyncIterable<SDKMessage>) {
+    if (message.type === "system" && message.subtype === "init") {
+      sessionId = message.session_id
+    } else if (message.type === "result") {
+      if (message.subtype !== "success") {
+        throw new Error(`claude result was ${message.subtype}`)
+      }
+      resultText = message.result
+    }
+  }
+  if (sessionId === undefined || resultText === undefined) {
+    throw new Error("claude stream ended without a system/init and a successful result")
+  }
+  return { sessionId, text: resultText }
+}
+
+/**
+ * One bounded round trip through the Claude Agent SDK using an explicitly
+ * resolved packaged Claude Code executable, from a working directory outside
+ * any repository.
+ */
+export const claudeSmoke = (claudeExecutable: string) =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      yield* Console.log(`claude code executable: ${claudeExecutable}`)
+      const cwd = yield* Effect.acquireRelease(
+        Effect.promise(() => mkdtemp(join(tmpdir(), "atc-smoke-"))),
+        (dir) => Effect.promise(() => rm(dir, { recursive: true, force: true })),
+      )
+      const abortController = new AbortController()
+      yield* Effect.addFinalizer(() => Effect.sync(() => abortController.abort()))
+      const summary = yield* Effect.tryPromise({
+        try: () => claudeRoundTrip(claudeExecutable, cwd, abortController),
+        catch: (error) =>
+          new SmokeError({ provider: "claude", message: describeError(error) }),
+      }).pipe(
+        Effect.timeoutOrElse({
+          duration: "180 seconds",
+          orElse: () =>
+            Effect.fail(
+              new SmokeError({
+                provider: "claude",
+                message: "timed out after 180s waiting for the Claude round trip",
+              }),
+            ),
+        }),
+      )
+      yield* Console.log(
+        `claude session ${summary.sessionId} answered: ${JSON.stringify(summary.text)}`,
+      )
+      yield* verifyNoChildOrphans("claude")
+      yield* Console.log("PASS: Claude Agent SDK round trip complete; no orphaned children")
+    }),
+  )
+
+// --- CLI wiring ---------------------------------------------------------------
+
+/** Print the failure as actionable diagnostics, then fail quietly. */
+const reported = <A, R>(effect: Effect.Effect<A, SmokeError | Subprocess.SubprocessError, R>) =>
+  effect.pipe(
+    Effect.catchTag(["SmokeError", "SubprocessError"], (error) =>
+      Console.error(
+        error._tag === "SmokeError"
+          ? `atc smoke ${error.provider}: ${error.message}`
+          : `atc smoke: ${error.executable} ${error.operation} failed: ${error.message}`,
+      ).pipe(Effect.andThen(Effect.fail(new SmokeReported()))),
+    ),
+  )
+
+const codexCommand = Command.make("codex", {}, () =>
+  reported(
+    Effect.gen(function* () {
+      const executable = yield* resolveCodexExecutable
+      yield* codexSmoke({
+        executable,
+        args: ["app-server", "--stdio"],
+        env: {},
+        extendEnv: true,
+        forceKillAfter: "2 seconds",
+      })
+    }),
+  ),
+).pipe(Command.withDescription("[unstable] Codex app-server launch and initialize round trip"))
+
+const claudeCommand = Command.make("claude", {}, () =>
+  reported(
+    Effect.gen(function* () {
+      const executable = yield* resolveClaudeCodeExecutable
+      yield* claudeSmoke(executable)
+    }),
+  ),
+).pipe(
+  Command.withDescription("[unstable] Claude Agent SDK round trip via the packaged executable"),
+)
+
+/** Hidden and unstable: a de-risking entrypoint, not part of the CLI surface. */
+export const smoke = Command.make("smoke").pipe(
+  Command.withDescription("[unstable] Provider smoke checks for the compiled executable (ATC-88)"),
+  Command.withSubcommands([codexCommand, claudeCommand]),
+  Command.withHidden,
+)

--- a/app-server/src/subprocess.ts
+++ b/app-server/src/subprocess.ts
@@ -34,13 +34,16 @@ export interface SpawnSpec {
 
 export interface Child {
   readonly pid: number
-  /** stdout as a line stream. Consume it while the child runs. */
+  /**
+   * stdout as a line stream. Single-consumer: run it exactly once, and
+   * consume it while the child runs so the pipe never fills.
+   */
   readonly stdoutLines: Stream.Stream<string, SubprocessError>
   /** Snapshot of the most recent stderr lines, for failure diagnostics. */
   readonly stderrTail: Effect.Effect<ReadonlyArray<string>>
-  /** Write one line to the child's stdin. */
-  readonly writeLine: (line: string) => Effect.Effect<void>
-  /** Close the child's stdin (EOF). */
+  /** Write one line to the child's stdin; fails once stdin is closed. */
+  readonly writeLine: (line: string) => Effect.Effect<void, SubprocessError>
+  /** Close the child's stdin (EOF). Idempotent. */
   readonly endInput: Effect.Effect<void>
   /** Await exit. Fails if the child was terminated by a signal. */
   readonly exitCode: Effect.Effect<number, SubprocessError>
@@ -52,6 +55,33 @@ export class Subprocess extends Context.Service<
     readonly spawn: (spec: SpawnSpec) => Effect.Effect<Child, SubprocessError, Scope.Scope>
   }
 >()("app-server/Subprocess") {}
+
+/** True while `pid` refers to a live (or not yet reaped) process. */
+export const isProcessAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Poll until `pid` is gone; resolves to whether it exited within the window.
+ * Scope close already awaits child termination, so callers use this as an
+ * explicit post-condition check, not as cleanup.
+ */
+export const waitForProcessExit = (
+  pid: number,
+  options?: { readonly attempts?: number; readonly interval?: Duration.Input },
+): Effect.Effect<boolean> =>
+  Effect.gen(function* () {
+    const attempts = options?.attempts ?? 40
+    for (let attempt = 0; attempt < attempts && isProcessAlive(pid); attempt++) {
+      yield* Effect.sleep(options?.interval ?? "50 millis")
+    }
+    return !isProcessAlive(pid)
+  })
 
 const truncate = (line: string): string =>
   line.length > MAX_CAPTURED_LINE_LENGTH ? `${line.slice(0, MAX_CAPTURED_LINE_LENGTH)}…` : line
@@ -80,8 +110,15 @@ const spawn = Effect.fnUntraced(function* (
     )
     .pipe(Effect.mapError(mapPlatformError(spec.executable, "spawn")))
 
-  // Drain stderr concurrently into a bounded tail so a chatty child can
-  // neither fill the pipe (deadlock) nor grow diagnostics without limit.
+  // End stdin once the child exits so later writes fail loudly instead of
+  // vanishing into a dead pipe. (A write in the instant between exit and its
+  // observation can still be lost — inherent to pipes.)
+  yield* handle.exitCode.pipe(Effect.ignore, Effect.andThen(Queue.end(stdin)), Effect.forkScoped)
+
+  // Drain stderr concurrently into a bounded tail so a chatty child cannot
+  // fill the pipe (deadlock) or grow diagnostics without limit. Note the
+  // bound is per line after splitting: output with no newlines at all still
+  // accumulates in splitLines before truncation applies.
   const stderrTail: Array<string> = []
   yield* handle.stderr.pipe(
     Stream.decodeText,
@@ -104,7 +141,20 @@ const spawn = Effect.fnUntraced(function* (
       Stream.mapError(mapPlatformError(spec.executable, "stdout")),
     ),
     stderrTail: Effect.sync(() => [...stderrTail]),
-    writeLine: (line) => Effect.asVoid(Queue.offer(stdin, encoder.encode(`${line}\n`))),
+    writeLine: (line) =>
+      Queue.offer(stdin, encoder.encode(`${line}\n`)).pipe(
+        Effect.flatMap((accepted) =>
+          accepted
+            ? Effect.void
+            : Effect.fail(
+                new SubprocessError({
+                  executable: spec.executable,
+                  operation: "stdin",
+                  message: "stdin is closed (input ended or child exited)",
+                }),
+              ),
+        ),
+      ),
     endInput: Effect.asVoid(Queue.end(stdin)),
     exitCode: handle.exitCode.pipe(
       Effect.map((code) => code as number),

--- a/app-server/src/subprocess.ts
+++ b/app-server/src/subprocess.ts
@@ -116,22 +116,36 @@ const spawn = Effect.fnUntraced(function* (
   yield* handle.exitCode.pipe(Effect.ignore, Effect.andThen(Queue.end(stdin)), Effect.forkScoped)
 
   // Drain stderr concurrently into a bounded tail so a chatty child cannot
-  // fill the pipe (deadlock) or grow diagnostics without limit. Note the
-  // bound is per line after splitting: output with no newlines at all still
-  // accumulates in splitLines before truncation applies.
+  // fill the pipe (deadlock) or grow diagnostics without limit. Lines are
+  // split by hand rather than with Stream.splitLines so the pending fragment
+  // stays capped even when the child never writes a newline.
   const stderrTail: Array<string> = []
-  yield* handle.stderr.pipe(
-    Stream.decodeText,
-    Stream.splitLines,
-    Stream.runForEach((line) =>
-      Effect.sync(() => {
-        stderrTail.push(truncate(line))
-        if (stderrTail.length > STDERR_TAIL_LINES) stderrTail.shift()
-      }),
-    ),
-    Effect.ignore,
-    Effect.forkScoped,
-  )
+  const pushLine = (line: string): void => {
+    stderrTail.push(truncate(line))
+    if (stderrTail.length > STDERR_TAIL_LINES) stderrTail.shift()
+  }
+  let pendingLine = ""
+  yield* Effect.gen(function* () {
+    yield* handle.stderr.pipe(
+      Stream.decodeText,
+      Stream.runForEach((chunk) =>
+        Effect.sync(() => {
+          pendingLine += chunk
+          let newline
+          while ((newline = pendingLine.indexOf("\n")) !== -1) {
+            pushLine(pendingLine.slice(0, newline).replace(/\r$/, ""))
+            pendingLine = pendingLine.slice(newline + 1)
+          }
+          // Cap the unterminated fragment; overflow is dropped, and truncate
+          // marks the eventual line as cut.
+          if (pendingLine.length > MAX_CAPTURED_LINE_LENGTH) {
+            pendingLine = pendingLine.slice(0, MAX_CAPTURED_LINE_LENGTH + 1)
+          }
+        }),
+      ),
+    )
+    if (pendingLine !== "") pushLine(pendingLine)
+  }).pipe(Effect.ignore, Effect.forkScoped)
 
   const child: Child = {
     pid: handle.pid,

--- a/app-server/src/subprocess.ts
+++ b/app-server/src/subprocess.ts
@@ -13,14 +13,11 @@ const STDERR_TAIL_LINES = 100
 /** Individual captured lines are truncated to keep diagnostics bounded. */
 const MAX_CAPTURED_LINE_LENGTH = 2_000
 
-export class SubprocessError extends Schema.TaggedErrorClass<SubprocessError>()(
-  "SubprocessError",
-  {
-    executable: Schema.String,
-    operation: Schema.Literals(["spawn", "stdin", "stdout", "exit"]),
-    message: Schema.String,
-  },
-) {}
+export class SubprocessError extends Schema.TaggedErrorClass<SubprocessError>()("SubprocessError", {
+  executable: Schema.String,
+  operation: Schema.Literals(["spawn", "stdin", "stdout", "exit"]),
+  message: Schema.String,
+}) {}
 
 export interface SpawnSpec {
   /** Absolute path or executable name; resolution happens before spawning. */

--- a/app-server/src/subprocess.ts
+++ b/app-server/src/subprocess.ts
@@ -1,0 +1,125 @@
+import { Cause, Context, Duration, Effect, Layer, Queue, Schema, Scope, Stream } from "effect"
+import type { PlatformError } from "effect/PlatformError"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+
+// The generic subprocess seam: how the App Server launches and supervises
+// child processes. Children are acquired in Scopes, so closing the scope —
+// on success, failure, timeout, or interruption — terminates the child
+// (SIGTERM, escalating to SIGKILL after `forceKillAfter`). Callers compose
+// timeouts with Effect.timeout; the scope guarantees cleanup.
+
+/** How much recent stderr to keep for diagnostics. */
+const STDERR_TAIL_LINES = 100
+/** Individual captured lines are truncated to keep diagnostics bounded. */
+const MAX_CAPTURED_LINE_LENGTH = 2_000
+
+export class SubprocessError extends Schema.TaggedErrorClass<SubprocessError>()(
+  "SubprocessError",
+  {
+    executable: Schema.String,
+    operation: Schema.Literals(["spawn", "stdin", "stdout", "exit"]),
+    message: Schema.String,
+  },
+) {}
+
+export interface SpawnSpec {
+  /** Absolute path or executable name; resolution happens before spawning. */
+  readonly executable: string
+  readonly args?: ReadonlyArray<string>
+  /** Explicit environment for the child. Nothing is inherited implicitly. */
+  readonly env?: Record<string, string>
+  /** Merge `env` on top of the parent environment instead of replacing it. */
+  readonly extendEnv?: boolean
+  readonly cwd?: string
+  /** Grace period before SIGKILL when the child ignores SIGTERM at cleanup. */
+  readonly forceKillAfter?: Duration.Input
+}
+
+export interface Child {
+  readonly pid: number
+  /** stdout as a line stream. Consume it while the child runs. */
+  readonly stdoutLines: Stream.Stream<string, SubprocessError>
+  /** Snapshot of the most recent stderr lines, for failure diagnostics. */
+  readonly stderrTail: Effect.Effect<ReadonlyArray<string>>
+  /** Write one line to the child's stdin. */
+  readonly writeLine: (line: string) => Effect.Effect<void>
+  /** Close the child's stdin (EOF). */
+  readonly endInput: Effect.Effect<void>
+  /** Await exit. Fails if the child was terminated by a signal. */
+  readonly exitCode: Effect.Effect<number, SubprocessError>
+}
+
+export class Subprocess extends Context.Service<
+  Subprocess,
+  {
+    readonly spawn: (spec: SpawnSpec) => Effect.Effect<Child, SubprocessError, Scope.Scope>
+  }
+>()("app-server/Subprocess") {}
+
+const truncate = (line: string): string =>
+  line.length > MAX_CAPTURED_LINE_LENGTH ? `${line.slice(0, MAX_CAPTURED_LINE_LENGTH)}…` : line
+
+const mapPlatformError =
+  (executable: string, operation: SubprocessError["operation"]) =>
+  (error: PlatformError): SubprocessError =>
+    new SubprocessError({ executable, operation, message: error.message })
+
+const spawn = Effect.fnUntraced(function* (
+  spawner: ChildProcessSpawner.ChildProcessSpawner["Service"],
+  spec: SpawnSpec,
+) {
+  const encoder = new TextEncoder()
+  const stdin = yield* Queue.make<Uint8Array, Cause.Done>()
+  const handle = yield* spawner
+    .spawn(
+      ChildProcess.make(spec.executable, [...(spec.args ?? [])], {
+        ...(spec.cwd !== undefined ? { cwd: spec.cwd } : {}),
+        env: spec.env ?? {},
+        extendEnv: spec.extendEnv ?? false,
+        stdin: { stream: Stream.fromQueue(stdin) },
+        killSignal: "SIGTERM",
+        forceKillAfter: spec.forceKillAfter ?? "2 seconds",
+      }),
+    )
+    .pipe(Effect.mapError(mapPlatformError(spec.executable, "spawn")))
+
+  // Drain stderr concurrently into a bounded tail so a chatty child can
+  // neither fill the pipe (deadlock) nor grow diagnostics without limit.
+  const stderrTail: Array<string> = []
+  yield* handle.stderr.pipe(
+    Stream.decodeText,
+    Stream.splitLines,
+    Stream.runForEach((line) =>
+      Effect.sync(() => {
+        stderrTail.push(truncate(line))
+        if (stderrTail.length > STDERR_TAIL_LINES) stderrTail.shift()
+      }),
+    ),
+    Effect.ignore,
+    Effect.forkScoped,
+  )
+
+  const child: Child = {
+    pid: handle.pid,
+    stdoutLines: handle.stdout.pipe(
+      Stream.decodeText,
+      Stream.splitLines,
+      Stream.mapError(mapPlatformError(spec.executable, "stdout")),
+    ),
+    stderrTail: Effect.sync(() => [...stderrTail]),
+    writeLine: (line) => Effect.asVoid(Queue.offer(stdin, encoder.encode(`${line}\n`))),
+    endInput: Effect.asVoid(Queue.end(stdin)),
+    exitCode: handle.exitCode.pipe(
+      Effect.map((code) => code as number),
+      Effect.mapError(mapPlatformError(spec.executable, "exit")),
+    ),
+  }
+  return child
+})
+
+export const layer = Layer.effect(Subprocess)(
+  Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+    return { spawn: (spec) => spawn(spawner, spec) }
+  }),
+)

--- a/app-server/test/blackbox.ts
+++ b/app-server/test/blackbox.ts
@@ -1,0 +1,46 @@
+import { fileURLToPath } from "node:url"
+
+// Shared helpers for black-box tests that spawn a real `atc serve` process —
+// from source (serve.blackbox.test.ts) or from the compiled artifact
+// (compiled.blackbox.test.ts) — and talk to it over loopback TCP.
+
+export const appServerRoot = fileURLToPath(new URL("..", import.meta.url))
+
+/** Deterministic host-target artifact path produced by `mise run build`. */
+export const compiledBinaryPath =
+  process.env["ATC_COMPILED_BIN"] ?? `${appServerRoot}dist/atc-${process.platform}-${process.arch}`
+
+/** Spawn `<command> serve --port <port>`; `command` is the program plus any leading args. */
+export const spawnServe = (
+  command: ReadonlyArray<string>,
+  port: number,
+  cwd: string = appServerRoot,
+) =>
+  Bun.spawn([...command, "serve", "--port", String(port)], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+
+// Bind-then-release to pick a port for the child. Racy in principle (another
+// process could grab it in between), but --port 0 is deliberately rejected by
+// validation, so this is the practical option; stderr is surfaced on failure.
+export const freePort = async (): Promise<number> => {
+  const probe = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response("") })
+  const port = probe.port!
+  await probe.stop(true)
+  return port
+}
+
+export const waitForHealth = async (base: string, proc: Bun.Subprocess): Promise<Response> => {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      return await fetch(`${base}/api/v1/health`)
+    } catch {
+      await Bun.sleep(50)
+    }
+  }
+  proc.kill()
+  const stderr = await new Response(proc.stderr as ReadableStream).text()
+  throw new Error(`server at ${base} never became healthy; stderr:\n${stderr}`)
+}

--- a/app-server/test/codexSmoke.test.ts
+++ b/app-server/test/codexSmoke.test.ts
@@ -29,6 +29,28 @@ describe("codexSmoke against a fixture app-server", () => {
     codexSmoke(fixtureSpec()).pipe(Effect.provide(TestLayer)),
   )
 
+  it.live("fails when the response carries neither result nor error", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.result(codexSmoke(fixtureSpec("empty")))
+      assert.strictEqual(result._tag, "Failure")
+      if (result._tag === "Failure") {
+        assert.instanceOf(result.failure, SmokeError)
+        assert.match(result.failure.message, /neither result nor error/)
+      }
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.live("fails when the server exits non-zero after the round trip", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.result(codexSmoke(fixtureSpec("exit-nonzero")))
+      assert.strictEqual(result._tag, "Failure")
+      if (result._tag === "Failure") {
+        assert.instanceOf(result.failure, SmokeError)
+        assert.match(result.failure.message, /exited with code 3/)
+      }
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
   it.live("fails with diagnostics when initialize is rejected", () =>
     Effect.gen(function* () {
       const result = yield* Effect.result(codexSmoke(fixtureSpec("error")))

--- a/app-server/test/codexSmoke.test.ts
+++ b/app-server/test/codexSmoke.test.ts
@@ -1,0 +1,66 @@
+import { assert, describe, it } from "@effect/vitest"
+import { BunServices } from "@effect/platform-bun"
+import { Effect, Layer } from "effect"
+import { fileURLToPath } from "node:url"
+import { codexSmoke, SmokeError } from "../src/smoke.ts"
+import * as Subprocess from "../src/subprocess.ts"
+import { TestBuildInfoLayer } from "./testBuildInfo.ts"
+
+// The codex round-trip logic against a fixture app-server: no Codex install,
+// no credentials, deterministic. The live provider is exercised by the opt-in
+// provider.smoke tests.
+
+const appServerRoot = fileURLToPath(new URL("..", import.meta.url))
+
+const TestLayer = Layer.mergeAll(
+  Subprocess.layer.pipe(Layer.provideMerge(BunServices.layer)),
+  TestBuildInfoLayer,
+)
+
+const fixtureSpec = (...args: ReadonlyArray<string>): Subprocess.SpawnSpec => ({
+  executable: process.execPath,
+  args: ["test/fixtures/fake-codex-app-server.ts", ...args],
+  cwd: appServerRoot,
+  env: {},
+})
+
+describe("codexSmoke against a fixture app-server", () => {
+  it.live("completes the initialize round trip and terminates the child", () =>
+    codexSmoke(fixtureSpec()).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.live("fails with diagnostics when initialize is rejected", () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.result(codexSmoke(fixtureSpec("error")))
+      assert.strictEqual(result._tag, "Failure")
+      if (result._tag === "Failure") {
+        assert.instanceOf(result.failure, SmokeError)
+        assert.match(result.failure.message, /initialize failed/)
+        assert.match(result.failure.message, /fixture rejects initialize/)
+      }
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.live("times out with stderr diagnostics when the server never responds", () =>
+    Effect.gen(function* () {
+      // sleep-forever stays silent, so waiting for the response must time out.
+      const result = yield* Effect.result(
+        codexSmoke(
+          {
+            executable: process.execPath,
+            args: ["test/fixtures/sleep-forever.ts"],
+            cwd: appServerRoot,
+            env: {},
+            forceKillAfter: "200 millis",
+          },
+          { initializeTimeout: "300 millis" },
+        ),
+      )
+      assert.strictEqual(result._tag, "Failure")
+      if (result._tag === "Failure") {
+        assert.instanceOf(result.failure, SmokeError)
+        assert.match(result.failure.message, /timed out/)
+      }
+    }).pipe(Effect.provide(TestLayer)),
+  )
+})

--- a/app-server/test/compiled.blackbox.test.ts
+++ b/app-server/test/compiled.blackbox.test.ts
@@ -1,0 +1,56 @@
+import { existsSync } from "node:fs"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, test } from "vitest"
+import { compiledBinaryPath, freePort, spawnServe, waitForHealth } from "./blackbox.ts"
+
+// Black-box validation of the compiled artifact: the standalone executable
+// must serve health/version with real injected build metadata and shut down
+// cleanly, all from a working directory outside the repository.
+//
+// Opt-in (mise run test:compiled) so the default fast suite never depends on
+// a build; CI runs it natively on macOS arm64 and Linux x64.
+
+const enabled =
+  process.env["ATC_COMPILED_TEST"] === "1" || process.env["ATC_COMPILED_BIN"] !== undefined
+
+describe.skipIf(!enabled)("compiled atc artifact (opt-in: mise run test:compiled)", () => {
+  test("serves health/version with injected build metadata from outside the repository and exits cleanly on SIGTERM", async () => {
+    expect(
+      existsSync(compiledBinaryPath),
+      `missing compiled artifact at ${compiledBinaryPath}; run \`mise run build\``,
+    ).toBe(true)
+
+    // A scratch cwd outside the repository: compiled behavior must not
+    // depend on the repository working directory.
+    const outsideCwd = mkdtempSync(join(tmpdir(), "atc-compiled-"))
+    const port = await freePort()
+    const base = `http://127.0.0.1:${port}`
+    const proc = spawnServe([compiledBinaryPath], port, outsideCwd)
+    try {
+      const health = await waitForHealth(base, proc)
+      expect(health.status).toBe(200)
+      expect(await health.json()).toEqual({ status: "ok" })
+
+      const version = await fetch(`${base}/api/v1/version`)
+      expect(version.status).toBe(200)
+      const body = (await version.json()) as {
+        version: string
+        apiVersion: string
+        commit: string
+        builtAt: string
+      }
+      expect(body.apiVersion).toBe("v1")
+      // Compiled builds must carry real injected metadata, not dev fallbacks.
+      expect(body.commit).toMatch(/^[0-9a-f]{40}$/)
+      expect(Number.isNaN(Date.parse(body.builtAt))).toBe(false)
+
+      proc.kill("SIGTERM")
+      expect(await proc.exited).toBe(130)
+    } finally {
+      proc.kill()
+      rmSync(outsideCwd, { recursive: true, force: true })
+    }
+  }, 30_000)
+})

--- a/app-server/test/compiled.blackbox.test.ts
+++ b/app-server/test/compiled.blackbox.test.ts
@@ -43,7 +43,8 @@ describe.skipIf(!enabled)("compiled atc artifact (opt-in: mise run test:compiled
       }
       expect(body.apiVersion).toBe("v1")
       // Compiled builds must carry real injected metadata, not dev fallbacks.
-      expect(body.commit).toMatch(/^[0-9a-f]{40}$/)
+      // Local builds from an edited tree carry a -dirty marker; CI is exact.
+      expect(body.commit).toMatch(/^[0-9a-f]{40}(-dirty)?$/)
       expect(Number.isNaN(Date.parse(body.builtAt))).toBe(false)
 
       proc.kill("SIGTERM")

--- a/app-server/test/fixtures/echo-lines.ts
+++ b/app-server/test/fixtures/echo-lines.ts
@@ -1,0 +1,5 @@
+// Fixture child: three stdout lines, one stderr line, clean exit.
+console.log("one")
+console.log("two")
+console.error("noise")
+console.log("three")

--- a/app-server/test/fixtures/exit-code.ts
+++ b/app-server/test/fixtures/exit-code.ts
@@ -1,0 +1,2 @@
+// Fixture child: exits with a distinctive non-zero code.
+process.exit(7)

--- a/app-server/test/fixtures/fake-codex-app-server.ts
+++ b/app-server/test/fixtures/fake-codex-app-server.ts
@@ -1,0 +1,20 @@
+// Fixture stand-in for `codex app-server --stdio`: answers initialize over
+// newline-delimited JSON-RPC and exits cleanly on stdin EOF. Pass "error" as
+// argv[2] to answer initialize with a JSON-RPC error instead.
+import { createInterface } from "node:readline"
+
+const mode = process.argv[2] ?? "ok"
+const lines = createInterface({ input: process.stdin })
+lines.on("line", (line) => {
+  const message = JSON.parse(line) as { id?: number; method?: string }
+  if (message.method === "initialize" && message.id !== undefined) {
+    console.log(
+      JSON.stringify(
+        mode === "error"
+          ? { id: message.id, error: { code: -32600, message: "fixture rejects initialize" } }
+          : { id: message.id, result: { userAgent: "fake-codex-app-server" } },
+      ),
+    )
+  }
+})
+lines.on("close", () => process.exit(0))

--- a/app-server/test/fixtures/fake-codex-app-server.ts
+++ b/app-server/test/fixtures/fake-codex-app-server.ts
@@ -1,6 +1,7 @@
 // Fixture stand-in for `codex app-server --stdio`: answers initialize over
-// newline-delimited JSON-RPC and exits cleanly on stdin EOF. Pass "error" as
-// argv[2] to answer initialize with a JSON-RPC error instead.
+// newline-delimited JSON-RPC and exits cleanly on stdin EOF. argv[2] selects
+// a failure mode: "error" answers with a JSON-RPC error, "empty" answers
+// with neither result nor error, "exit-nonzero" answers ok but exits 3.
 import { createInterface } from "node:readline"
 
 const mode = process.argv[2] ?? "ok"
@@ -12,9 +13,11 @@ lines.on("line", (line) => {
       JSON.stringify(
         mode === "error"
           ? { id: message.id, error: { code: -32600, message: "fixture rejects initialize" } }
-          : { id: message.id, result: { userAgent: "fake-codex-app-server" } },
+          : mode === "empty"
+            ? { id: message.id }
+            : { id: message.id, result: { userAgent: "fake-codex-app-server" } },
       ),
     )
   }
 })
-lines.on("close", () => process.exit(0))
+lines.on("close", () => process.exit(mode === "exit-nonzero" ? 3 : 0))

--- a/app-server/test/fixtures/line-echo.ts
+++ b/app-server/test/fixtures/line-echo.ts
@@ -1,0 +1,6 @@
+// Fixture child: echoes each stdin line back on stdout, exits cleanly at EOF.
+import { createInterface } from "node:readline"
+
+const lines = createInterface({ input: process.stdin })
+lines.on("line", (line) => console.log(`echo:${line}`))
+lines.on("close", () => process.exit(0))

--- a/app-server/test/fixtures/sleep-forever.ts
+++ b/app-server/test/fixtures/sleep-forever.ts
@@ -1,0 +1,2 @@
+// Fixture child: stays alive until terminated.
+setInterval(() => {}, 1_000)

--- a/app-server/test/fixtures/stderr-flood.ts
+++ b/app-server/test/fixtures/stderr-flood.ts
@@ -1,0 +1,4 @@
+// Fixture child: floods stderr to exercise the bounded diagnostics tail;
+// the final line is oversized to exercise per-line truncation.
+for (let i = 1; i <= 499; i++) console.error(`line ${i}`)
+console.error(`end ${"x".repeat(2500)}`)

--- a/app-server/test/fixtures/stderr-no-newline.ts
+++ b/app-server/test/fixtures/stderr-no-newline.ts
@@ -1,0 +1,3 @@
+// Fixture child: floods stderr with a single 2 MB write containing no
+// newline, to prove the diagnostics tail stays bounded regardless.
+process.stderr.write(`start ${"x".repeat(2_000_000)}`)

--- a/app-server/test/fixtures/stubborn.ts
+++ b/app-server/test/fixtures/stubborn.ts
@@ -1,0 +1,4 @@
+// Fixture child: ignores SIGTERM so cleanup must escalate to SIGKILL.
+process.on("SIGTERM", () => {})
+setInterval(() => {}, 1_000)
+console.log("armed")

--- a/app-server/test/provider.smoke.test.ts
+++ b/app-server/test/provider.smoke.test.ts
@@ -1,6 +1,5 @@
 import { existsSync } from "node:fs"
 import { tmpdir } from "node:os"
-import { dirname, join } from "node:path"
 import { describe, expect, test } from "vitest"
 import { compiledBinaryPath } from "./blackbox.ts"
 
@@ -48,11 +47,11 @@ describe.skipIf(!enabled)("live provider smoke (opt-in: mise run test:smoke)", (
   }, 120_000)
 
   test("Claude Agent SDK round trip", async () => {
-    const staged = join(dirname(compiledBinaryPath), `claude-${process.platform}-${process.arch}`)
-    const resolvable = process.env["ATC_CLAUDE_CODE_EXECUTABLE"] !== undefined || existsSync(staged)
+    const resolvable =
+      process.env["ATC_CLAUDE_CODE_EXECUTABLE"] !== undefined || Bun.which("claude") !== null
     expect(
       resolvable,
-      `packaged Claude Code executable not staged at ${staged}; run \`mise run build\` or set ATC_CLAUDE_CODE_EXECUTABLE`,
+      "claude not found; install and authenticate Claude Code or set ATC_CLAUDE_CODE_EXECUTABLE",
     ).toBe(true)
     await runSmoke("claude")
   }, 300_000)

--- a/app-server/test/provider.smoke.test.ts
+++ b/app-server/test/provider.smoke.test.ts
@@ -1,0 +1,55 @@
+import { existsSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { describe, expect, test } from "vitest"
+import { compiledBinaryPath } from "./blackbox.ts"
+
+// Live provider smoke tests: run the hidden `smoke` command of the compiled
+// executable against the real providers. Opt-in (mise run test:smoke) because
+// they need an installed, authenticated Codex CLI and Claude Code credentials.
+// Prerequisites are checked here so failures are actionable, and each smoke
+// runs from a working directory outside the repository.
+
+const enabled = process.env["ATC_SMOKE"] === "1"
+
+const runSmoke = async (provider: "codex" | "claude") => {
+  const proc = Bun.spawn([compiledBinaryPath, "smoke", provider], {
+    cwd: tmpdir(),
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const exitCode = await proc.exited
+  const stdout = await new Response(proc.stdout as ReadableStream).text()
+  const stderr = await new Response(proc.stderr as ReadableStream).text()
+  expect(exitCode, `atc smoke ${provider} failed\nstdout:\n${stdout}\nstderr:\n${stderr}`).toBe(0)
+  expect(stdout).toContain("PASS")
+}
+
+describe.skipIf(!enabled)("live provider smoke (opt-in: mise run test:smoke)", () => {
+  test("compiled artifact exists", () => {
+    expect(
+      existsSync(compiledBinaryPath),
+      `missing compiled artifact at ${compiledBinaryPath}; run \`mise run build\``,
+    ).toBe(true)
+  })
+
+  test("codex app-server round trip", async () => {
+    const resolvable =
+      process.env["ATC_CODEX_EXECUTABLE"] !== undefined || Bun.which("codex") !== null
+    expect(
+      resolvable,
+      "codex CLI not found; install and authenticate Codex or set ATC_CODEX_EXECUTABLE",
+    ).toBe(true)
+    await runSmoke("codex")
+  }, 120_000)
+
+  test("Claude Agent SDK round trip", async () => {
+    const staged = join(dirname(compiledBinaryPath), "claude")
+    const resolvable = process.env["ATC_CLAUDE_CODE_EXECUTABLE"] !== undefined || existsSync(staged)
+    expect(
+      resolvable,
+      `packaged Claude Code executable not staged at ${staged}; run \`mise run build\` or set ATC_CLAUDE_CODE_EXECUTABLE`,
+    ).toBe(true)
+    await runSmoke("claude")
+  }, 300_000)
+})

--- a/app-server/test/provider.smoke.test.ts
+++ b/app-server/test/provider.smoke.test.ts
@@ -18,9 +18,13 @@ const runSmoke = async (provider: "codex" | "claude") => {
     stdout: "pipe",
     stderr: "pipe",
   })
-  const exitCode = await proc.exited
-  const stdout = await new Response(proc.stdout as ReadableStream).text()
-  const stderr = await new Response(proc.stderr as ReadableStream).text()
+  // Drain the pipes while awaiting exit so verbose output can never block
+  // the child on a full pipe.
+  const [exitCode, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout as ReadableStream).text(),
+    new Response(proc.stderr as ReadableStream).text(),
+  ])
   expect(exitCode, `atc smoke ${provider} failed\nstdout:\n${stdout}\nstderr:\n${stderr}`).toBe(0)
   expect(stdout).toContain("PASS")
 }
@@ -44,7 +48,7 @@ describe.skipIf(!enabled)("live provider smoke (opt-in: mise run test:smoke)", (
   }, 120_000)
 
   test("Claude Agent SDK round trip", async () => {
-    const staged = join(dirname(compiledBinaryPath), "claude")
+    const staged = join(dirname(compiledBinaryPath), `claude-${process.platform}-${process.arch}`)
     const resolvable = process.env["ATC_CLAUDE_CODE_EXECUTABLE"] !== undefined || existsSync(staged)
     expect(
       resolvable,

--- a/app-server/test/serve.blackbox.test.ts
+++ b/app-server/test/serve.blackbox.test.ts
@@ -1,44 +1,15 @@
-import { fileURLToPath } from "node:url"
 import { describe, expect, test } from "vitest"
+import { appServerRoot, freePort, spawnServe, waitForHealth } from "./blackbox.ts"
 
 // Black-box tests of the real entrypoint: spawn `bun src/main.ts serve` on a
 // loopback port, exercise both endpoints over TCP, and verify clean shutdown
 // on SIGTERM and SIGINT (exit 130 = interrupted by signal), including with an
 // open half-sent request at signal time.
 
-const appServerRoot = fileURLToPath(new URL("..", import.meta.url))
-
 // Tests run under `bun --bun vitest`, so execPath is the pinned bun binary —
 // no PATH lookup for the child.
-const spawnServe = (port: number) =>
-  Bun.spawn([process.execPath, "src/main.ts", "serve", "--port", String(port)], {
-    cwd: appServerRoot,
-    stdout: "pipe",
-    stderr: "pipe",
-  })
-
-// Bind-then-release to pick a port for the child. Racy in principle (another
-// process could grab it in between), but --port 0 is deliberately rejected by
-// validation, so this is the practical option; stderr is surfaced on failure.
-const freePort = async (): Promise<number> => {
-  const probe = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response("") })
-  const port = probe.port!
-  await probe.stop(true)
-  return port
-}
-
-const waitForHealth = async (base: string, proc: Bun.Subprocess): Promise<Response> => {
-  for (let attempt = 0; attempt < 100; attempt++) {
-    try {
-      return await fetch(`${base}/api/v1/health`)
-    } catch {
-      await Bun.sleep(50)
-    }
-  }
-  proc.kill()
-  const stderr = await new Response(proc.stderr as ReadableStream).text()
-  throw new Error(`server at ${base} never became healthy; stderr:\n${stderr}`)
-}
+const spawnFromSource = (port: number) =>
+  spawnServe([process.execPath, "src/main.ts"], port, appServerRoot)
 
 describe("atc serve (black box)", () => {
   test.each(["SIGTERM", "SIGINT"] as const)(
@@ -46,7 +17,7 @@ describe("atc serve (black box)", () => {
     async (signal) => {
       const port = await freePort()
       const base = `http://127.0.0.1:${port}`
-      const proc = spawnServe(port)
+      const proc = spawnFromSource(port)
       try {
         const health = await waitForHealth(base, proc)
         expect(health.status).toBe(200)
@@ -85,7 +56,7 @@ describe("atc serve (black box)", () => {
 
   test("fails with one friendly stderr line when the port is taken", async () => {
     const occupant = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response("") })
-    const proc = spawnServe(occupant.port!)
+    const proc = spawnFromSource(occupant.port!)
     try {
       expect(await proc.exited).toBe(1)
       const stderr = await new Response(proc.stderr as ReadableStream).text()

--- a/app-server/test/subprocess.test.ts
+++ b/app-server/test/subprocess.test.ts
@@ -1,0 +1,165 @@
+import { assert, describe, it } from "@effect/vitest"
+import { BunServices } from "@effect/platform-bun"
+import { Deferred, Effect, Exit, Fiber, Layer, Option, Scope, Stream } from "effect"
+import { fileURLToPath } from "node:url"
+import * as Subprocess from "../src/subprocess.ts"
+
+// Deterministic seam tests against fixture children. Tests run under
+// `bun --bun vitest`, so process.execPath is the pinned bun binary. All tests
+// are it.live: they do real process I/O and need the real clock for kill
+// escalation and timeouts.
+
+const appServerRoot = fileURLToPath(new URL("..", import.meta.url))
+
+const TestLayer = Subprocess.layer.pipe(Layer.provideMerge(BunServices.layer))
+
+const fixture = (name: string): Subprocess.SpawnSpec => ({
+  executable: process.execPath,
+  args: [`test/fixtures/${name}.ts`],
+  cwd: appServerRoot,
+  // PATH is deliberately omitted: fixtures resolve via the absolute bun path.
+  env: {},
+})
+
+const isAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// The release finalizer awaits exit, but give the OS a moment to reap.
+const expectDead = (pid: number) =>
+  Effect.gen(function* () {
+    for (let attempt = 0; attempt < 20 && isAlive(pid); attempt++) {
+      yield* Effect.sleep("50 millis")
+    }
+    assert.strictEqual(isAlive(pid), false)
+  })
+
+describe("Subprocess", () => {
+  it.live("captures stdout lines and observes a clean exit", () =>
+    Effect.gen(function* () {
+      const subprocess = yield* Subprocess.Subprocess
+      const child = yield* subprocess.spawn(fixture("echo-lines"))
+      const lines = yield* Stream.runCollect(child.stdoutLines)
+      assert.deepStrictEqual(lines, ["one", "two", "three"])
+      assert.strictEqual(yield* child.exitCode, 0)
+    }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+  )
+
+  it.live("reports a non-zero exit code", () =>
+    Effect.gen(function* () {
+      const subprocess = yield* Subprocess.Subprocess
+      const child = yield* subprocess.spawn(fixture("exit-code"))
+      assert.strictEqual(yield* child.exitCode, 7)
+    }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+  )
+
+  it.live("round-trips lines over stdin and stdout, then exits on EOF", () =>
+    Effect.gen(function* () {
+      const subprocess = yield* Subprocess.Subprocess
+      const child = yield* subprocess.spawn(fixture("line-echo"))
+      yield* child.writeLine("ping")
+      const first = yield* Stream.runHead(child.stdoutLines)
+      assert.deepStrictEqual(first, Option.some("echo:ping"))
+      yield* child.endInput
+      assert.strictEqual(yield* child.exitCode, 0)
+    }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+  )
+
+  it.live("keeps a bounded, truncated stderr tail", () =>
+    Effect.gen(function* () {
+      const subprocess = yield* Subprocess.Subprocess
+      const child = yield* subprocess.spawn(fixture("stderr-flood"))
+      assert.strictEqual(yield* child.exitCode, 0)
+      const tail = yield* child.stderrTail
+      assert.strictEqual(tail.length, 100)
+      assert.strictEqual(tail[0], "line 401")
+      const last = tail[99]!
+      assert.strictEqual(last.startsWith("end "), true)
+      assert.strictEqual(last.length, 2_001)
+      assert.strictEqual(last.endsWith("…"), true)
+    }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+  )
+
+  it.live("fails to spawn a missing executable with a tagged error", () =>
+    Effect.gen(function* () {
+      const subprocess = yield* Subprocess.Subprocess
+      const result = yield* Effect.result(
+        subprocess.spawn({ executable: "/nonexistent/definitely-not-here", env: {} }),
+      )
+      assert.strictEqual(result._tag, "Failure")
+      if (result._tag === "Failure") {
+        assert.strictEqual(result.failure._tag, "SubprocessError")
+        assert.strictEqual(result.failure.operation, "spawn")
+      }
+    }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+  )
+
+  it.live("terminates the child when the scope closes", () =>
+    Effect.gen(function* () {
+      const scope = yield* Scope.make()
+      const child = yield* Effect.gen(function* () {
+        const subprocess = yield* Subprocess.Subprocess
+        return yield* subprocess.spawn(fixture("sleep-forever"))
+      }).pipe(Scope.provide(scope))
+      assert.strictEqual(isAlive(child.pid), true)
+      yield* Scope.close(scope, Exit.void)
+      yield* expectDead(child.pid)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.live("escalates to SIGKILL when the child ignores SIGTERM", () =>
+    Effect.gen(function* () {
+      const scope = yield* Scope.make()
+      const child = yield* Effect.gen(function* () {
+        const subprocess = yield* Subprocess.Subprocess
+        return yield* subprocess.spawn({
+          ...fixture("stubborn"),
+          forceKillAfter: "200 millis",
+        })
+      }).pipe(Scope.provide(scope))
+      // Wait until the SIGTERM handler is installed before terminating.
+      assert.deepStrictEqual(yield* Stream.runHead(child.stdoutLines), Option.some("armed"))
+      yield* Scope.close(scope, Exit.void)
+      yield* expectDead(child.pid)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.live("kills the child when an operation times out", () =>
+    Effect.gen(function* () {
+      let pid = 0
+      const result = yield* Effect.result(
+        Effect.gen(function* () {
+          const subprocess = yield* Subprocess.Subprocess
+          const child = yield* subprocess.spawn(fixture("sleep-forever"))
+          pid = child.pid
+          // The child never writes, so waiting for output must time out.
+          return yield* Stream.runHead(child.stdoutLines).pipe(Effect.timeout("250 millis"))
+        }).pipe(Effect.scoped),
+      )
+      assert.strictEqual(result._tag, "Failure")
+      yield* expectDead(pid)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.live("kills the child when the caller is interrupted", () =>
+    Effect.gen(function* () {
+      let pid = 0
+      const started = yield* Deferred.make<void>()
+      const fiber = yield* Effect.gen(function* () {
+        const subprocess = yield* Subprocess.Subprocess
+        const child = yield* subprocess.spawn(fixture("sleep-forever"))
+        pid = child.pid
+        yield* Deferred.succeed(started, void 0)
+        yield* Effect.never
+      }).pipe(Effect.scoped, Effect.forkChild)
+      yield* Deferred.await(started)
+      yield* Fiber.interrupt(fiber)
+      yield* expectDead(pid)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+})

--- a/app-server/test/subprocess.test.ts
+++ b/app-server/test/subprocess.test.ts
@@ -92,6 +92,20 @@ describe("Subprocess", () => {
     }).pipe(Effect.scoped, Effect.provide(TestLayer)),
   )
 
+  it.live("keeps the tail bounded when stderr never contains a newline", () =>
+    Effect.gen(function* () {
+      const subprocess = yield* Subprocess.Subprocess
+      const child = yield* subprocess.spawn(fixture("stderr-no-newline"))
+      assert.strictEqual(yield* child.exitCode, 0)
+      const tail = yield* child.stderrTail
+      assert.strictEqual(tail.length, 1)
+      const only = tail[0]!
+      assert.strictEqual(only.startsWith("start "), true)
+      assert.strictEqual(only.length, 2_001)
+      assert.strictEqual(only.endsWith("…"), true)
+    }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+  )
+
   it.live("fails to spawn a missing executable with a tagged error", () =>
     Effect.gen(function* () {
       const subprocess = yield* Subprocess.Subprocess

--- a/app-server/test/subprocess.test.ts
+++ b/app-server/test/subprocess.test.ts
@@ -21,22 +21,10 @@ const fixture = (name: string): Subprocess.SpawnSpec => ({
   env: {},
 })
 
-const isAlive = (pid: number): boolean => {
-  try {
-    process.kill(pid, 0)
-    return true
-  } catch {
-    return false
-  }
-}
-
 // The release finalizer awaits exit, but give the OS a moment to reap.
 const expectDead = (pid: number) =>
   Effect.gen(function* () {
-    for (let attempt = 0; attempt < 20 && isAlive(pid); attempt++) {
-      yield* Effect.sleep("50 millis")
-    }
-    assert.strictEqual(isAlive(pid), false)
+    assert.strictEqual(yield* Subprocess.waitForProcessExit(pid), true)
   })
 
 describe("Subprocess", () => {
@@ -67,6 +55,25 @@ describe("Subprocess", () => {
       assert.deepStrictEqual(first, Option.some("echo:ping"))
       yield* child.endInput
       assert.strictEqual(yield* child.exitCode, 0)
+    }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+  )
+
+  it.live("fails writes once the child has exited instead of dropping them", () =>
+    Effect.gen(function* () {
+      const subprocess = yield* Subprocess.Subprocess
+      const child = yield* subprocess.spawn(fixture("exit-code"))
+      assert.strictEqual(yield* child.exitCode, 7)
+      // stdin closes when exit is observed by a background fiber; poll until
+      // the write is rejected rather than silently dropped.
+      for (let attempt = 0; ; attempt++) {
+        const result = yield* Effect.result(child.writeLine("after-death"))
+        if (result._tag === "Failure") {
+          assert.strictEqual(result.failure.operation, "stdin")
+          break
+        }
+        assert.isBelow(attempt, 50, "writeLine kept succeeding after child exit")
+        yield* Effect.sleep("20 millis")
+      }
     }).pipe(Effect.scoped, Effect.provide(TestLayer)),
   )
 
@@ -106,7 +113,7 @@ describe("Subprocess", () => {
         const subprocess = yield* Subprocess.Subprocess
         return yield* subprocess.spawn(fixture("sleep-forever"))
       }).pipe(Scope.provide(scope))
-      assert.strictEqual(isAlive(child.pid), true)
+      assert.strictEqual(Subprocess.isProcessAlive(child.pid), true)
       yield* Scope.close(scope, Exit.void)
       yield* expectDead(child.pid)
     }).pipe(Effect.provide(TestLayer)),

--- a/app-server/tsconfig.json
+++ b/app-server/tsconfig.json
@@ -19,5 +19,5 @@
     "skipLibCheck": true,
     "types": ["bun"]
   },
-  "include": ["src", "test", "vitest.config.ts"]
+  "include": ["src", "test", "scripts", "vitest.config.ts"]
 }

--- a/mise.toml
+++ b/mise.toml
@@ -38,6 +38,14 @@ run = "mise run -C app-server check"
 description = "App Server test suite"
 run = "mise run -C app-server test"
 
+[tasks."app-server:build"]
+description = "Compile the standalone App Server atc executable for this machine"
+run = "mise run -C app-server build"
+
+[tasks."app-server:build:all"]
+description = "Cross-compile standalone App Server atc executables for every release target"
+run = "mise run -C app-server 'build:all'"
+
 # --- Swift surfaces ---
 
 [tasks."kit:test"]


### PR DESCRIPTION
Implements [ATC-88](https://linear.app/elevenideas/issue/ATC-88/prove-standalone-compilation-and-provider-spawning): proves the production-shaped `atc` executable compiles with Bun and can launch both provider technologies, before the App Server grows around assumptions that don't hold in a compiled executable.

## What's here

**Standalone executable**
- `mise run build` / `mise run build:all` (fanned into root tasks) compile `src/main.ts` into deterministic `dist/atc-<os>-<arch>` artifacts for darwin/linux × arm64/x64.
- Build metadata is injected at compile time via `--define` (commit + `-dirty` marker, build timestamp); source runs report `dev`. `.env`/bunfig autoloading is disabled so compiled behavior never depends on the working directory.

**Generic subprocess seam** (`src/subprocess.ts`)
- `Subprocess` service on Effect's `ChildProcess`/`ChildProcessSpawner`: scoped acquisition (scope close terminates the child, SIGTERM → SIGKILL escalation), explicit env, line-oriented stdin/stdout, bounded stderr diagnostics, stdin writes that fail loudly once the child is gone.

**Provider smoke checks** (`src/smoke.ts`, hidden `atc smoke codex|claude`)
- Both providers follow one bring-your-own-CLI rule: atc ships no provider binaries. Resolution is explicit — env override (`ATC_CODEX_EXECUTABLE` / `ATC_CLAUDE_CODE_EXECUTABLE`) → the user's install on PATH.
- Codex: one JSON-RPC `initialize`/`initialized` round trip over stdio, clean shutdown, explicit no-orphan verification.
- Claude: Agent SDK round trip with `pathToClaudeCodeExecutable` always set explicitly (the SDK's node_modules-based default resolution is dead inside a compiled binary); runs from a temp cwd outside any repo; orphan check runs on success *and* failure.
- The command is `Command.withHidden`, marked unstable, and will be replaced by the production provider integration.

**Tests & CI**
- Fixture-based seam tests (launch, capture, timeout, cancellation, exit, cleanup, SIGKILL escalation, stdin-after-exit) and a fake codex app-server round-trip test run in the default fast suite — no provider accounts needed.
- Opt-in `mise run test:compiled` (compiled artifact black-box: health/version with real metadata from outside the repo, clean SIGTERM) and `mise run test:smoke` (live providers, prerequisite checks).
- CI: cross-compile job (build-only, labeled as such) + native compiled validation on macOS arm64 and Linux x64, which also run the OS-sensitive fast suite natively.
- AGENTS.md records the compiled-asset/executable-discovery/subprocess conventions and the Bun/Effect upgrade re-validation requirement.

## Key decisions

- **Claude Code is the user's install, not shipped by atc.** The SDK's packaged platform binary is ~245 MB per target and resolves via node_modules — a dead path inside a compiled executable. An earlier revision of this PR staged that binary next to the artifact; after comparing with T3Code's approach we settled on relying on the user's installed `claude` instead: the user must have an authenticated Claude Code install anyway (the binary is useless without its credentials), it makes both providers symmetric, and it keeps artifacts at ~65–100 MB with no per-target binary acquisition at release time. This deliberately supersedes the issue's original "packaged platform-specific executable" direction. Version-compatibility advisories (user's CLI vs pinned SDK) are follow-up work for the production adapter.
- **Codex round trip = `initialize`.** A real structured request/response over the app-server protocol that needs no thread state and leaves nothing behind in `~/.codex`.
- **Live smokes verified locally**: both `atc smoke codex` and `atc smoke claude` pass from the compiled binary running outside the repository (codex-cli 0.146.0, Agent SDK 0.3.220 driving the user's installed Claude Code 2.1.220).

Two adversarial reviews (correctness, simplicity) ran before this PR; all major findings were applied (stdin write contract, always-on orphan check, dirty marker, JSON tolerance on provider stdout, native fast suite in CI).

https://claude.ai/code/session_01GwZRRGJnPmgbTnSNwuBT3j
