### PR TITLE
ATC-86: Generate deterministic OpenAPI for the App Server skeleton

### DIFF
--- a/.github/workflows/app-server-ci.yml
+++ b/.github/workflows/app-server-ci.yml
@@ -38,8 +38,9 @@ jobs:
           working_directory: app-server
 
       # Same gates as local `mise run check`: frozen-lockfile install,
-      # Prettier format check, strict tsc, and the vitest suite (which
-      # includes the black-box serve/shutdown test over loopback TCP).
+      # Prettier format check, strict tsc, the vitest suite (which includes
+      # the black-box serve/shutdown test over loopback TCP), and OpenAPI
+      # drift detection (openapi.json must match the contract).
       - name: Check
         run: mise run check
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,35 @@ deliberately). Write new code the same way:
   (`mise run refs`) and follow T3Code/OpenCode patterns; web search and
   training data skew to Effect v3.
 
+## OpenAPI Contract (App Server)
+
+The `HttpApi` contract module (`app-server/src/api.ts`) is the single source of
+truth for the public API. The checked-in OpenAPI document
+(`app-server/openapi.json`) is generated from it — never edit the document by
+hand, and never maintain a parallel route-description layer.
+
+- Regenerate with `mise run -C app-server openapi` (or `mise run
+  app-server:openapi` at the root) after any contract change and commit the
+  result. Generation is pure (`OpenApi.fromApi`, no server) and byte-identical
+  for unchanged source; `mise run -C app-server openapi:check` (part of
+  `check` and CI) fails on drift.
+- Every endpoint pins a stable operation id with
+  `.annotate(OpenApi.Identifier, "...")`: camelCase verb+resource (e.g.
+  `getHealth`), unique across the whole API. Generated clients key off these
+  ids — renaming one is a breaking change.
+- Every request/response schema carries an `identifier` annotation (PascalCase
+  type name, e.g. `HealthResponse`) so it becomes a named component schema,
+  plus a short `description`. Endpoints carry an `OpenApi.Description`.
+- JSON fields are camelCase. Fields the server always returns are
+  non-optional in the schema and appear in `required`; health/version have no
+  optional fields yet, so no optionality convention exists beyond that.
+- The document version is the contract version (`v1`), never the compile-time
+  build metadata (`commit`/`builtAt`), which would break deterministic
+  generation.
+- `openapi.json` is generated output: `src/openapi.ts` is its single
+  formatting authority, and it sits in `.prettierignore` so `fmt` never
+  rewrites it.
+
 ## Compiled Executable and Subprocesses (App Server)
 
 - `mise run -C app-server build` compiles the standalone `atc` executable for

--- a/app-server/.prettierignore
+++ b/app-server/.prettierignore
@@ -1,1 +1,2 @@
 bun.lock
+openapi.json

--- a/app-server/README.md
+++ b/app-server/README.md
@@ -13,7 +13,9 @@ mise run test          # run the vitest suite on the Bun runtime
 mise run fmt           # format with Prettier
 mise run fmt:check     # fail if formatting is needed
 mise run typecheck     # strict TypeScript type check
-mise run check         # standing CI gates: fmt:check + typecheck + test
+mise run openapi       # regenerate the checked-in OpenAPI artifact (openapi.json)
+mise run openapi:check # fail if openapi.json is stale relative to the contract
+mise run check         # standing CI gates: fmt:check + typecheck + test + openapi:check
 mise run build         # compile the standalone atc executable (dist/atc-<os>-<arch>)
 mise run build:all     # cross-compile all four release targets
 mise run test:compiled # black-box tests of the compiled artifact (builds first)
@@ -33,22 +35,27 @@ the user's installed `codex` and `claude` are resolved from an env override
 or PATH. `mise run refs` (repo root) checks out the matching Effect source
 for API reference.
 
-| Path                | Responsibility                                                      |
-| ------------------- | ------------------------------------------------------------------- |
-| `src/main.ts`       | Entrypoint for the `atc` executable; the only `runMain`             |
-| `src/cli.ts`        | CLI commands and flags (Effect CLI); friendly startup failures      |
-| `src/api.ts`        | The `/api/v1` HttpApi contract: endpoints and response schemas      |
-| `src/handlers.ts`   | Contract implementation (handler Layer, no listener)                |
-| `src/server.ts`     | Server assembly: routes + loopback Bun listener Layer               |
-| `src/buildInfo.ts`  | Build metadata service (version, commit, builtAt)                   |
-| `src/subprocess.ts` | Subprocess service: scoped child processes, bounded diagnostics     |
-| `src/smoke.ts`      | Hidden, unstable `atc smoke` provider round trips (ATC-88)          |
-| `scripts/build.ts`  | Standalone-executable compile (Bun `--compile`, metadata injection) |
-| `test/`             | `@effect/vitest` tests, including black-box and opt-in live suites  |
+| Path                 | Responsibility                                                      |
+| -------------------- | ------------------------------------------------------------------- |
+| `src/main.ts`        | Entrypoint for the `atc` executable; the only `runMain`             |
+| `src/cli.ts`         | CLI commands and flags (Effect CLI); friendly startup failures      |
+| `src/api.ts`         | The `/api/v1` HttpApi contract: endpoints and response schemas      |
+| `src/openapi.ts`     | The OpenAPI document derived from the contract (pure, no server)    |
+| `src/handlers.ts`    | Contract implementation (handler Layer, no listener)                |
+| `src/server.ts`      | Server assembly: routes + loopback Bun listener Layer               |
+| `src/buildInfo.ts`   | Build metadata service (version, commit, builtAt)                   |
+| `src/subprocess.ts`  | Subprocess service: scoped child processes, bounded diagnostics     |
+| `src/smoke.ts`       | Hidden, unstable `atc smoke` provider round trips (ATC-88)          |
+| `scripts/build.ts`   | Standalone-executable compile (Bun `--compile`, metadata injection) |
+| `scripts/openapi.ts` | Writes/checks the checked-in `openapi.json` artifact                |
+| `openapi.json`       | Generated OpenAPI 3.1 document — regenerate, never edit             |
+| `test/`              | `@effect/vitest` tests, including black-box and opt-in live suites  |
 
-The contract module is structured so the server implementation, an OpenAPI
-document, and generated typed clients all derive from the same `HttpApi`
-definition; OpenAPI serving and clients are follow-up work.
+The contract module is structured so the server implementation, the checked-in
+OpenAPI document (`openapi.json`), and generated typed clients all derive from
+the same `HttpApi` definition. See "OpenAPI Contract" in the repository
+`AGENTS.md` for the contract-authoring conventions; OpenAPI serving over HTTP
+and generated clients are follow-up work.
 
 Public HTTP routes are versioned under `/api/v1`:
 

--- a/app-server/mise.toml
+++ b/app-server/mise.toml
@@ -9,8 +9,8 @@ depends = ["install"]
 run = "bun run src/main.ts serve"
 
 [tasks.check]
-description = "All App Server gates: format check, strict type check, tests"
-depends = ["fmt:check", "typecheck", "test"]
+description = "All App Server gates: format check, strict type check, tests, OpenAPI drift"
+depends = ["fmt:check", "typecheck", "test", "openapi:check"]
 
 [tasks.build]
 description = "Compile the standalone atc executable for this machine into dist/"
@@ -30,6 +30,16 @@ run = "bun run scripts/build.ts --all"
 [tasks.install]
 description = "Install dependencies from the committed lockfile"
 run = "bun install --frozen-lockfile"
+
+[tasks.openapi]
+description = "Regenerate the checked-in OpenAPI artifact (openapi.json) from the contract"
+depends = ["install"]
+run = "bun run scripts/openapi.ts"
+
+[tasks."openapi:check"]
+description = "Fail if openapi.json is stale relative to the contract"
+depends = ["install"]
+run = "bun run scripts/openapi.ts --check"
 
 [tasks.fmt]
 description = "Format TypeScript, JSON, and Markdown with Prettier"

--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -1,0 +1,124 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "ATC App Server API",
+    "version": "v1"
+  },
+  "paths": {
+    "/api/v1/health": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "getHealth",
+        "parameters": [],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Result of the liveness probe.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Liveness probe: confirms the server is accepting requests."
+      }
+    },
+    "/api/v1/version": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "getVersion",
+        "parameters": [],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Build and contract version information for the running server.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VersionResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Report the server's build metadata and API version."
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HealthResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "ok"
+            ]
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "additionalProperties": false,
+        "description": "Result of the liveness probe."
+      },
+      "VersionResponse": {
+        "type": "object",
+        "properties": {
+          "version": {
+            "type": "string",
+            "description": "App Server release version."
+          },
+          "apiVersion": {
+            "type": "string",
+            "enum": [
+              "v1"
+            ]
+          },
+          "commit": {
+            "type": "string",
+            "description": "Commit the executable was built from (\"dev\" when running from source)."
+          },
+          "builtAt": {
+            "type": "string",
+            "description": "Build timestamp of the executable (\"dev\" when running from source)."
+          }
+        },
+        "required": [
+          "version",
+          "apiVersion",
+          "commit",
+          "builtAt"
+        ],
+        "additionalProperties": false,
+        "description": "Build and contract version information for the running server."
+      }
+    },
+    "securitySchemes": {}
+  },
+  "security": [],
+  "tags": [
+    {
+      "name": "v1"
+    }
+  ],
+  "servers": [
+    {
+      "url": "http://127.0.0.1:{port}",
+      "description": "Local App Server",
+      "variables": {
+        "port": {
+          "default": "7332"
+        }
+      }
+    }
+  ]
+}

--- a/app-server/scripts/openapi.ts
+++ b/app-server/scripts/openapi.ts
@@ -1,0 +1,41 @@
+import { fileURLToPath } from "node:url"
+import { openApiJson } from "../src/openapi.ts"
+
+// Maintains the checked-in OpenAPI artifact (app-server/openapi.json).
+//
+//   bun run scripts/openapi.ts           regenerate the artifact (--write)
+//   bun run scripts/openapi.ts --check   fail (exit 1) if the artifact is stale
+//   bun run scripts/openapi.ts --print   write the document to stdout (used by tests)
+//
+// Exposed as `mise run openapi` / `mise run openapi:check`.
+
+const artifactPath = fileURLToPath(new URL("../openapi.json", import.meta.url))
+const mode = Bun.argv[2] ?? "--write"
+
+switch (mode) {
+  case "--write": {
+    await Bun.write(artifactPath, openApiJson)
+    console.error(`wrote ${artifactPath}`)
+    break
+  }
+  case "--check": {
+    const checkedIn = await Bun.file(artifactPath)
+      .text()
+      .catch(() => "")
+    if (checkedIn !== openApiJson) {
+      console.error(
+        "openapi.json is stale — run `mise run openapi`, review the diff, and commit the result",
+      )
+      process.exit(1)
+    }
+    break
+  }
+  case "--print": {
+    process.stdout.write(openApiJson)
+    break
+  }
+  default: {
+    console.error(`unknown mode ${mode}; expected --write (default), --check, or --print`)
+    process.exit(2)
+  }
+}

--- a/app-server/src/api.ts
+++ b/app-server/src/api.ts
@@ -2,23 +2,42 @@ import { Schema } from "effect"
 import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
 
 // The public HTTP contract. The server implementation (handlers.ts), the
-// OpenAPI document, and future typed clients all derive from this module.
+// checked-in OpenAPI document (openapi.ts), and typed clients all derive from
+// this module. Authoring conventions (pinned operation ids, schema
+// identifiers, descriptions) live in AGENTS.md "OpenAPI Contract".
+
+/** Default TCP port of a locally running App Server. */
+export const DEFAULT_PORT = 7332
 
 export const HealthResponse = Schema.Struct({
   status: Schema.Literal("ok"),
+}).annotate({
+  identifier: "HealthResponse",
+  description: "Result of the liveness probe.",
 })
 
 export const VersionResponse = Schema.Struct({
-  version: Schema.String,
+  version: Schema.String.annotate({ description: "App Server release version." }),
   apiVersion: Schema.Literal("v1"),
-  commit: Schema.String,
-  builtAt: Schema.String,
+  commit: Schema.String.annotate({
+    description: 'Commit the executable was built from ("dev" when running from source).',
+  }),
+  builtAt: Schema.String.annotate({
+    description: 'Build timestamp of the executable ("dev" when running from source).',
+  }),
+}).annotate({
+  identifier: "VersionResponse",
+  description: "Build and contract version information for the running server.",
 })
 
 export class V1 extends HttpApiGroup.make("v1")
   .add(
-    HttpApiEndpoint.get("health", "/health", { success: HealthResponse }),
-    HttpApiEndpoint.get("version", "/version", { success: VersionResponse }),
+    HttpApiEndpoint.get("health", "/health", { success: HealthResponse })
+      .annotate(OpenApi.Identifier, "getHealth")
+      .annotate(OpenApi.Description, "Liveness probe: confirms the server is accepting requests."),
+    HttpApiEndpoint.get("version", "/version", { success: VersionResponse })
+      .annotate(OpenApi.Identifier, "getVersion")
+      .annotate(OpenApi.Description, "Report the server's build metadata and API version."),
   )
   // .prefix only applies to endpoints added above it — add new endpoints
   // before this line so they stay under /api/v1.
@@ -28,4 +47,16 @@ export class V1 extends HttpApiGroup.make("v1")
 // module stays client-safe with no dependency on server internals.
 export class Api extends HttpApi.make("atc")
   .add(V1)
-  .annotateMerge(OpenApi.annotations({ title: "ATC App Server API", version: "v1" })) {}
+  .annotateMerge(
+    OpenApi.annotations({
+      title: "ATC App Server API",
+      version: "v1",
+      servers: [
+        {
+          url: "http://127.0.0.1:{port}",
+          description: "Local App Server",
+          variables: { port: { default: `${DEFAULT_PORT}` } },
+        },
+      ],
+    }),
+  ) {}

--- a/app-server/src/cli.ts
+++ b/app-server/src/cli.ts
@@ -1,9 +1,8 @@
 import { Console, Effect, Layer, Runtime, Schema } from "effect"
 import { Command, Flag } from "effect/unstable/cli"
+import { DEFAULT_PORT } from "./api.ts"
 import * as Server from "./server.ts"
 import { smoke } from "./smoke.ts"
-
-export const DEFAULT_PORT = 7332
 
 /** The one reusable port contract for CLI (and later config/API) inputs. */
 export const Port = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 65535 }))

--- a/app-server/src/openapi.ts
+++ b/app-server/src/openapi.ts
@@ -1,0 +1,16 @@
+import { OpenApi } from "effect/unstable/httpapi"
+import { Api } from "./api.ts"
+
+// The OpenAPI document derived from the contract. This module is pure — no
+// server, no side effects — so generation works anywhere the contract compiles.
+
+export const openApiDocument = OpenApi.fromApi(Api)
+
+/**
+ * The canonical serialized form of the document: 2-space indentation and a
+ * trailing newline. `JSON.stringify` preserves the deterministic insertion
+ * order `OpenApi.fromApi` produces, so identical source yields byte-identical
+ * output. The artifact is generated output, so it sits in `.prettierignore` —
+ * this serialization is the single formatting authority.
+ */
+export const openApiJson = JSON.stringify(openApiDocument, null, 2) + "\n"

--- a/app-server/test/cli.test.ts
+++ b/app-server/test/cli.test.ts
@@ -2,7 +2,8 @@ import { assert, describe, it } from "@effect/vitest"
 import { BunServices } from "@effect/platform-bun"
 import { Effect } from "effect"
 import { CliError, Command } from "effect/unstable/cli"
-import { DEFAULT_PORT, port } from "../src/cli.ts"
+import { DEFAULT_PORT } from "../src/api.ts"
+import { port } from "../src/cli.ts"
 
 // Parse the real --port flag against a probe command so validation is tested
 // without starting a server.

--- a/app-server/test/openapi.test.ts
+++ b/app-server/test/openapi.test.ts
@@ -1,0 +1,165 @@
+import { assert, describe, it } from "@effect/vitest"
+import { BunHttpServer } from "@effect/platform-bun"
+import { Context, Effect, Layer } from "effect"
+import { HttpClient, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { HttpApi, OpenApi } from "effect/unstable/httpapi"
+import { Api, DEFAULT_PORT } from "../src/api.ts"
+import { openApiDocument, openApiJson } from "../src/openapi.ts"
+import * as Server from "../src/server.ts"
+import { appServerRoot } from "./blackbox.ts"
+import { TestBuildInfoLayer, testBuildInfo } from "./testBuildInfo.ts"
+
+// Contract-generation tests: the document must be deterministic, match the
+// checked-in artifact, cover every contract operation, and agree with what
+// the runtime routes actually return. Runtime behavior itself is covered
+// separately in api.test.ts, so failures here point at the document, not the
+// handlers.
+
+const operation = (path: string) =>
+  (openApiDocument.paths[path]?.get ?? assert.fail(`no GET operation documented for ${path}`)) as {
+    readonly operationId: string
+    readonly responses: Record<string, { content: Record<string, { schema: { $ref?: string } }> }>
+  }
+
+const componentSchema = (name: string) =>
+  ((openApiDocument.components.schemas as Record<string, unknown>)[name] ??
+    assert.fail(`no component schema named ${name}`)) as {
+    readonly properties: Record<string, unknown>
+    readonly required: ReadonlyArray<string>
+  }
+
+describe("openapi document", () => {
+  it("pins the document version to the contract version, never build metadata", () => {
+    assert.strictEqual(openApiDocument.info.title, "ATC App Server API")
+    assert.strictEqual(openApiDocument.info.version, "v1")
+  })
+
+  it("documents the templated default loopback server", () => {
+    // Generated clients build their default base URL from this entry
+    // (e.g. Swift's Servers.Server1), so it is contract, not decoration.
+    assert.deepStrictEqual(openApiDocument.servers, [
+      {
+        url: "http://127.0.0.1:{port}",
+        description: "Local App Server",
+        variables: { port: { default: `${DEFAULT_PORT}` } },
+      },
+    ])
+  })
+
+  it("matches the checked-in artifact, byte-identical across fresh processes", async () => {
+    // Fresh processes defeat fromApi's in-memory cache, so this proves real
+    // determinism, not just reference equality.
+    const generate = () => {
+      const proc = Bun.spawnSync([process.execPath, "run", "scripts/openapi.ts", "--print"], {
+        cwd: appServerRoot,
+      })
+      assert.strictEqual(proc.exitCode, 0, proc.stderr.toString())
+      return proc.stdout.toString()
+    }
+    const first = generate()
+    assert.strictEqual(first, generate())
+    assert.strictEqual(first, openApiJson)
+    assert.strictEqual(
+      await Bun.file(`${appServerRoot}openapi.json`).text(),
+      openApiJson,
+      "openapi.json is stale — run `mise run openapi` and commit the result",
+    )
+  })
+
+  it("documents every contract operation exactly once, with pinned camelCase ids", () => {
+    const expected: Array<{ path: string; method: string }> = []
+    HttpApi.reflect(Api, {
+      onGroup() {},
+      onEndpoint({ endpoint, mergedAnnotations }) {
+        // OpenApi.Exclude drops an endpoint from the document by design.
+        if (Context.get(mergedAnnotations, OpenApi.Exclude)) return
+        expected.push({
+          path: endpoint.path.replace(/:(\w+)\??/g, "{$1}"),
+          method: endpoint.method.toLowerCase(),
+        })
+      },
+    })
+
+    const documented = Object.entries(openApiDocument.paths).flatMap(([path, operations]) =>
+      Object.keys(operations).map((method) => ({ path, method })),
+    )
+    assert.sameDeepMembers(documented, expected)
+
+    const operationIds = Object.keys(openApiDocument.paths).map((path) => {
+      const id = operation(path).operationId
+      // Derived ids look like "v1.health" — a forgotten OpenApi.Identifier
+      // annotation would ship a bad id whose later fix breaks clients (see
+      // AGENTS.md "OpenAPI Contract").
+      assert.match(id, /^[a-z][A-Za-z0-9]*$/, `operation id for ${path} must be pinned camelCase`)
+      return id
+    })
+    assert.strictEqual(new Set(operationIds).size, expected.length)
+  })
+})
+
+// A raw in-process HTTP client over the real routes layer — the same pattern
+// HttpApiTest uses internally, but returning undecoded responses so assertions
+// see the raw wire payload instead of contract-decoded values.
+const rawClient = Effect.gen(function* () {
+  const handler = yield* HttpRouter.toHttpEffect(
+    Server.routes.pipe(Layer.provide(TestBuildInfoLayer)),
+  )
+  return HttpClient.make(
+    Effect.fnUntraced(function* (request) {
+      const serverRequest = HttpServerRequest.fromClientRequest(request)
+      const response = yield* handler.pipe(
+        Effect.provideService(HttpServerRequest.HttpServerRequest, serverRequest),
+        Effect.orDie,
+      )
+      return HttpServerResponse.toClientResponse(response)
+    }, Effect.scoped),
+  )
+})
+
+// Concrete per-endpoint assertions: each case ties the documented response
+// schema to the actual wire payload. The path-coverage assertion in the first
+// test above ("documents every contract operation") plus the fixed path list
+// here force a new case whenever the contract grows.
+describe("openapi document vs runtime", () => {
+  it("these tests cover every documented path", () => {
+    assert.sameMembers(Object.keys(openApiDocument.paths), ["/api/v1/health", "/api/v1/version"])
+  })
+
+  it.effect("GET /api/v1/health returns the documented payload", () =>
+    Effect.gen(function* () {
+      const response = yield* (yield* rawClient).get("http://in-process/api/v1/health")
+      assert.strictEqual(response.status, 200)
+      assert.deepStrictEqual(yield* response.json, { status: "ok" })
+
+      const ref = operation("/api/v1/health").responses["200"]!.content["application/json"]!.schema
+      assert.deepStrictEqual(ref, { $ref: "#/components/schemas/HealthResponse" })
+      const schema = componentSchema("HealthResponse")
+      assert.sameMembers(Object.keys(schema.properties), ["status"])
+      assert.sameMembers([...schema.required], ["status"])
+    }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
+  )
+
+  it.effect("GET /api/v1/version returns the documented payload", () =>
+    Effect.gen(function* () {
+      const response = yield* (yield* rawClient).get("http://in-process/api/v1/version")
+      assert.strictEqual(response.status, 200)
+      assert.deepStrictEqual(yield* response.json, {
+        version: testBuildInfo.version,
+        apiVersion: "v1",
+        commit: testBuildInfo.commit,
+        builtAt: testBuildInfo.builtAt,
+      })
+
+      const ref = operation("/api/v1/version").responses["200"]!.content["application/json"]!.schema
+      assert.deepStrictEqual(ref, { $ref: "#/components/schemas/VersionResponse" })
+      const schema = componentSchema("VersionResponse")
+      assert.sameMembers(Object.keys(schema.properties), [
+        "version",
+        "apiVersion",
+        "commit",
+        "builtAt",
+      ])
+      assert.sameMembers([...schema.required], ["version", "apiVersion", "commit", "builtAt"])
+    }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
+  )
+})

--- a/mise.toml
+++ b/mise.toml
@@ -31,12 +31,16 @@ run = "mise run -C server web:check"
 # --- App Server (TypeScript/Effect on Bun) ---
 
 [tasks."app-server:check"]
-description = "App Server format check, strict type check, tests"
+description = "App Server format check, strict type check, tests, OpenAPI drift"
 run = "mise run -C app-server check"
 
 [tasks."app-server:test"]
 description = "App Server test suite"
 run = "mise run -C app-server test"
+
+[tasks."app-server:openapi"]
+description = "Regenerate the checked-in App Server OpenAPI artifact from the contract"
+run = "mise run -C app-server openapi"
 
 [tasks."app-server:build"]
 description = "Compile the standalone App Server atc executable for this machine"


### PR DESCRIPTION
Implements [ATC-86](https://linear.app/elevenideas/issue/ATC-86/generate-deterministic-openapi-for-the-app-server-skeleton): the existing Effect `HttpApi` contract now produces the first generated, deterministic OpenAPI document.

## What's here

- **Contract annotations** (`src/api.ts`): pinned stable operation ids (`getHealth`, `getVersion`) via `OpenApi.Identifier`, named component schemas (`HealthResponse`, `VersionResponse`) via schema `identifier` annotations, endpoint/schema/property descriptions, and a templated loopback server entry (`http://127.0.0.1:{port}`, default `7332`). Runtime behavior is unchanged. `DEFAULT_PORT` moved to the contract module (single owner for the default port).
- **Generation** (`src/openapi.ts` + `scripts/openapi.ts`): `OpenApi.fromApi` derives the document purely — no server started. `mise run openapi` regenerates the checked-in `app-server/openapi.json`; `mise run openapi:check` fails on drift and is part of `mise run check`, which CI already runs. The artifact sits in `.prettierignore`; the script's serialization is its single formatting authority.
- **Tests** (`test/openapi.test.ts`): byte-identical generation across fresh processes (defeating `fromApi`'s in-memory cache) matching the checked-in artifact; operation coverage against `HttpApi.reflect` (honoring `OpenApi.Exclude`) with camelCase pinned-id enforcement; and document-vs-runtime agreement through an in-process raw HTTP client so assertions see undecoded wire payloads.
- **Conventions** recorded in `AGENTS.md` ("OpenAPI Contract"): annotation pattern, operation-id and component naming, camelCase fields, required-field representation, regeneration command, artifact ownership.

## Validation

- Checked-in document validated once against Apple Swift OpenAPI Generator 1.13.0 as a throwaway local check per the issue — parses clean, generates `getHealth`/`getVersion` methods and named `HealthResponse`/`VersionResponse` types. Nothing checked in; ATC-87 wires the real Swift target.
- `mise run check` (fmt, tsc, vitest, drift) and `mise run test:compiled` pass; compiled black-box health/version behavior unchanged.

Follow-up: ATC-87 (stacked) consumes this artifact for the Swift client and adds the contract-derived TypeScript client, CLI commands, and API-to-CLI parity.

https://claude.ai/code/session_01GwZRRGJnPmgbTnSNwuBT3j