### PR TITLE
ATC-121: Core persistence, configuration, diagnostics, and local trust

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,10 +125,14 @@ Both public clients derive from the same contract:
   unchanged and coexists until the app migrates.
 
 CLI commands backed by API operations use the contract-derived TypeScript
-client (`atc health`, `atc version`): JSON payload on stdout and exit 0 on
-success; diagnostics on stderr with exit 1 on invalid usage or request
-failure. `--url` is explicit for now; keep base-URL resolution isolated in
-`cli.ts` so later configuration work can make it optional.
+client (`atc health`, `atc version`, `atc project …`, `atc fs check`): JSON
+payload on stdout and exit 0 on success; diagnostics on stderr with exit 1 on
+invalid usage, configuration, or request failure. API-backed commands take
+zero connection flags: the base URL derives from the settled configuration
+(`http://127.0.0.1:<port>`), resolved in the single seam in `cli.ts` — remote
+endpoint addressing (endpoint + token) lands there with the auth work. The
+CLI may resolve relative directory arguments client-side before calling the
+API (which takes server-host absolute paths only).
 
 The CLI command surface is curated, not a 1:1 mirror of the API: commands
 exist to give agents and scripts good access to the app's functionality, and
@@ -140,6 +144,56 @@ client — never re-implement server logic in the CLI. Process commands
 After any contract change: `mise run app-server:openapi` to regenerate the
 artifact, then `mise run contract:check` (OpenAPI drift + TS client tests +
 Swift client build/tests) to verify the whole pipeline.
+
+## Configuration and Data Locations (App Server)
+
+One precedence rule: **command flags > environment > config file > defaults**,
+implemented in `src/config.ts` (the `AppConfig` service). Everything that
+needs a setting or a path consumes `AppConfig` — never `process.env` or
+re-derived locations. Invalid configuration fails fast with one stderr line
+naming the offending source; never a partial boot.
+
+- Paths: one XDG rule on every platform (macOS included), honoring `XDG_*`
+  overrides. Config `~/.config/atc/config.toml`; data (SQLite `atc.db`)
+  `~/.local/share/atc/`; state (log file `atc.log`) `~/.local/state/atc/`.
+- Environment variables are flat `ATC_<KEY>` (`ATC_PORT`, `ATC_LOG_LEVEL`,
+  `ATC_DATA_DIR`, `ATC_CONFIG`). No sectioned naming.
+- The config file is TOML with camelCase keys (`port`, `logLevel`,
+  `dataDir`); unknown keys are rejected. The TOML format never leaks past
+  `config.ts`.
+- Compiled behavior never depends on the working directory; tests isolate
+  themselves by pointing `XDG_*`/`ATC_*` at temp dirs (`test/blackbox.ts`
+  `isolatedEnv`).
+
+## Persistence (App Server)
+
+SQLite via Effect's SQL tooling (`effect/unstable/sql` +
+`@effect/sql-sqlite-bun`, exact-pinned) — not Drizzle, not flat files. The
+stack stays behind the persistence boundary:
+
+- `src/persistence.ts` provides the migrated `SqlClient` at the configured
+  location with documented pragmas (WAL on by default, `busy_timeout = 5000`,
+  `foreign_keys = ON`). `sql.withTransaction` is the transaction boundary.
+- Migrations are an in-code, append-only record in `src/migrations.ts`
+  (`Migrator.fromRecord`, keys `"0001_init"`, compiled into the binary —
+  never a filesystem dependency). Applied transactionally at startup with
+  library bookkeeping (`effect_sql_migrations`); a failed migration rolls
+  back and halts boot naming the migration. Never edit or remove a shipped
+  entry — append. `test/persistence.test.ts` pins loader count to record
+  size because malformed keys are silently dropped.
+- Repositories (e.g. `src/projectRepository.ts`) are the only modules that
+  speak SQL; row types never leak into contract schemas, handlers, or
+  clients. Database failures are defects (500s), not domain errors.
+- Tests get isolated databases via `Persistence.layerFile` (`:memory:` or a
+  temp file); see `test/testLayers.ts`.
+
+## Local Trust (App Server)
+
+The settled trust architecture: one HTTP-over-TCP transport, loopback-only
+bind, with `Host`/`Origin` validation on every request (`src/localTrust.ts`)
+blocking DNS-rebinding/CSRF. Remote access later adds bearer tokens over the
+same listener, purely additively; non-loopback binding stays refused until
+then.
 
 ## Compiled Executable and Subprocesses (App Server)
 

--- a/app-server/README.md
+++ b/app-server/README.md
@@ -22,26 +22,55 @@ mise run test:compiled # black-box tests of the compiled artifact (builds first)
 mise run test:smoke    # opt-in live provider smoke tests (Codex + Claude credentials)
 ```
 
-The server listens on port 7332 by default; pass `--port` to override.
+## Configuration and data locations
+
+One precedence rule everywhere: **command flags > environment > config file >
+defaults**. Invalid or malformed configuration fails fast with one stderr line
+naming the offending source — never a partial boot.
+
+Paths follow one XDG rule on every platform (macOS included), honoring `XDG_*`
+overrides:
+
+| Location    | Default                     | Holds                      |
+| ----------- | --------------------------- | -------------------------- |
+| Config file | `~/.config/atc/config.toml` | Settings (TOML, camelCase) |
+| Data dir    | `~/.local/share/atc/`       | SQLite database (`atc.db`) |
+| State dir   | `~/.local/state/atc/`       | JSON log file (`atc.log`)  |
+
+Environment variables are flat `ATC_<KEY>`: `ATC_PORT`, `ATC_LOG_LEVEL`,
+`ATC_DATA_DIR`, and `ATC_CONFIG` (path to an alternate config file). The
+config file may set `port`, `logLevel` (case-insensitive), and `dataDir`;
+unknown keys are rejected. `atc serve --port` overrides the configured port
+for that server only.
 
 ## CLI
 
-`atc serve` runs the server. API-backed commands use the contract-derived
-client and an explicit `--url` (connection profiles are later work):
+`atc serve` runs the server (it creates and migrates the database on boot).
+API-backed commands take zero connection flags — they derive
+`http://127.0.0.1:<port>` from the same settled configuration the server
+reads, so port changes just work:
 
 ```sh
-atc health --url http://127.0.0.1:7332    # prints the JSON payload, e.g. { "status": "ok" }
-atc version --url http://127.0.0.1:7332   # prints build metadata + apiVersion as JSON
+atc health                                    # { "status": "ok" }
+atc version                                   # build metadata + apiVersion
+atc project create --name Demo --directory .  # directory must exist; stored canonicalized
+atc project list
+atc project get <project-id>
+atc project update <project-id> --name Renamed
+atc project delete <project-id> --yes         # record only; never touches the filesystem
+atc fs check <path>                           # tagged directory health, never persisted
 ```
 
-`atc --version` reports this executable's own version; `atc version --url …`
-reports the version of a running server.
+`atc --version` reports this executable's own version; `atc version` reports
+the version of a running server. Relative directory arguments resolve against
+the caller's working directory before the API (which takes absolute paths
+only) sees them.
 
 Success prints the JSON payload on stdout and exits `0`. Failures exit `1`:
-request failures print one `atc <command>: …` diagnostic line on stderr;
-invalid usage prints an `ERROR` block on stderr (help goes to stdout). The
-command surface is curated for agent and script access to the app's
-functionality — it does not mirror the API operation-for-operation, but
+config/request failures print one `atc <command>: …` diagnostic line on
+stderr; invalid usage prints an `ERROR` block on stderr (help goes to
+stdout). The command surface is curated for agent and script access to the
+app's functionality — it does not mirror the API operation-for-operation, but
 API-backed commands always go through the contract-derived client.
 
 ## Structure
@@ -55,22 +84,29 @@ the user's installed `codex` and `claude` are resolved from an env override
 or PATH. `mise run refs` (repo root) checks out the matching Effect source
 for API reference.
 
-| Path                 | Responsibility                                                                                                        |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `src/main.ts`        | Entrypoint for the `atc` executable; the only `runMain`                                                               |
-| `src/cli.ts`         | CLI commands and flags (Effect CLI); friendly startup failures                                                        |
-| `src/api.ts`         | The `/api/v1` HttpApi contract: endpoints and response schemas                                                        |
-| `src/openapi.ts`     | The OpenAPI document derived from the contract (pure, no server)                                                      |
-| `src/client.ts`      | Contract-derived typed client (`HttpApiClient`, no server imports)                                                    |
-| `src/handlers.ts`    | Contract implementation (handler Layer, no listener)                                                                  |
-| `src/server.ts`      | Server assembly: routes + loopback Bun listener Layer                                                                 |
-| `src/buildInfo.ts`   | Build metadata service (version, commit, builtAt)                                                                     |
-| `src/subprocess.ts`  | Subprocess service: scoped child processes, bounded diagnostics                                                       |
-| `src/smoke.ts`       | Hidden, unstable `atc smoke` provider round trips (ATC-88)                                                            |
-| `scripts/build.ts`   | Standalone-executable compile (Bun `--compile`, metadata injection)                                                   |
-| `scripts/openapi.ts` | Writes/checks the checked-in `openapi.json` artifact                                                                  |
-| `openapi.json`       | Generated OpenAPI 3.1 document — regenerate, never edit; symlinked into `packages/ATCKit` for Swift client generation |
-| `test/`              | `@effect/vitest` tests, including black-box and opt-in live suites                                                    |
+| Path                       | Responsibility                                                                                                        |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `src/main.ts`              | Entrypoint for the `atc` executable; the only `runMain`                                                               |
+| `src/cli.ts`               | CLI commands and flags (Effect CLI); base-URL resolution seam; friendly startup failures                              |
+| `src/config.ts`            | `AppConfig` service: settled paths + settings, precedence pipeline, TOML parsing                                      |
+| `src/api.ts`               | The `/api/v1` HttpApi contract: endpoints, schemas, and tagged error classes                                          |
+| `src/openapi.ts`           | The OpenAPI document derived from the contract (pure, no server)                                                      |
+| `src/client.ts`            | Contract-derived typed client (`HttpApiClient`, no server imports)                                                    |
+| `src/handlers.ts`          | Contract implementation (handler Layer, no listener)                                                                  |
+| `src/server.ts`            | Server assembly: guarded routes + tracer + loopback Bun listener Layer                                                |
+| `src/localTrust.ts`        | Listener hardening: loopback `Host`/`Origin` validation, log correlation                                              |
+| `src/persistence.ts`       | SQLite `SqlClient` layer: settled location, documented pragmas, startup migrations                                    |
+| `src/migrations.ts`        | The checked-in, append-only migration record (compiled into the binary)                                               |
+| `src/projectRepository.ts` | Projects repository: the only SQL for projects; row types stay here                                                   |
+| `src/directories.ts`       | Demand-driven directory validation/health with a bounded timeout                                                      |
+| `src/logging.ts`           | Server logging: JSON file in the state dir, pretty stderr in dev, level from config                                   |
+| `src/buildInfo.ts`         | Build metadata service (version, commit, builtAt)                                                                     |
+| `src/subprocess.ts`        | Subprocess service: scoped child processes, bounded diagnostics                                                       |
+| `src/smoke.ts`             | Hidden, unstable `atc smoke` provider round trips (ATC-88)                                                            |
+| `scripts/build.ts`         | Standalone-executable compile (Bun `--compile`, metadata injection)                                                   |
+| `scripts/openapi.ts`       | Writes/checks the checked-in `openapi.json` artifact                                                                  |
+| `openapi.json`             | Generated OpenAPI 3.1 document — regenerate, never edit; symlinked into `packages/ATCKit` for Swift client generation |
+| `test/`                    | `@effect/vitest` tests, including black-box and opt-in live suites                                                    |
 
 The contract module is structured so the server implementation, the checked-in
 OpenAPI document (`openapi.json`), the contract-derived TypeScript client
@@ -83,3 +119,9 @@ Public HTTP routes are versioned under `/api/v1`:
 
 - `GET /api/v1/health` → `{ "status": "ok" }`
 - `GET /api/v1/version` → application version, `apiVersion`, and build metadata
+- `GET/POST /api/v1/projects`, `GET/PATCH/DELETE /api/v1/projects/{projectId}` → Projects CRUD
+- `GET /api/v1/fs/check?path=…` → demand-driven directory health (tagged states, bounded timeout)
+
+The loopback listener validates `Host`/`Origin` on every request (403
+otherwise) — the local half of the settled trust architecture; bearer-token
+remote access is a later, purely additive layer.

--- a/app-server/bun.lock
+++ b/app-server/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.220",
         "@effect/platform-bun": "4.0.0-beta.102",
+        "@effect/sql-sqlite-bun": "4.0.0-beta.102",
         "effect": "4.0.0-beta.102",
       },
       "devDependencies": {
@@ -44,6 +45,8 @@
     "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.102", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.102" }, "peerDependencies": { "effect": "^4.0.0-beta.102" } }, "sha512-hTIb0jjTfXhNgnDq2OX5wrigc0OSvTT0VWWb1PLpMM395RJPu8rCIbTlGhy0NS7kZOd8FfgNi9e0sDhgyu+5Ag=="],
 
     "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.102", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.102" } }, "sha512-gVd793I72MrkX4dXo7eYtRKfNj0RW4eMRfVEKEJI16h2+mBDCzQ+gqMrog2hSTHQnaIbvbYShNQ4TVGuRCYZeQ=="],
+
+    "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@4.0.0-beta.102", "", { "peerDependencies": { "effect": "^4.0.0-beta.102" } }, "sha512-pBO6FBJ+a21j2qHmzJDK1DeJsxm7HpUQBgucw6prHQXLMUBkhOsfZofhw1FKEdGRDEhO0sGTjffa2KP7iOuDIg=="],
 
     "@effect/vitest": ["@effect/vitest@4.0.0-beta.102", "", { "peerDependencies": { "effect": "^4.0.0-beta.102", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-4dipFAYG6imOzrY3zy3BgzCJkbb9xESyzUef0WSx8bsK0/SpITqbJpdwKeOyDWLZ+rimjua8IbTFMAde865pIQ=="],
 

--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -276,12 +276,8 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^\\/",
-                  "description": "a server-host absolute path (starting with /)"
-                }
-              ]
+              "pattern": "^\\/",
+              "description": "a server-host absolute path (starting with /)"
             },
             "required": true
           }
@@ -361,12 +357,8 @@
           },
           "name": {
             "type": "string",
-            "allOf": [
-              {
-                "minLength": 1,
-                "description": "Human-readable project name."
-              }
-            ]
+            "minLength": 1,
+            "description": "Human-readable project name."
           },
           "defaultWorkingDirectory": {
             "type": "string",
@@ -403,21 +395,13 @@
         "properties": {
           "name": {
             "type": "string",
-            "allOf": [
-              {
-                "minLength": 1,
-                "description": "Human-readable project name."
-              }
-            ]
+            "minLength": 1,
+            "description": "Human-readable project name."
           },
           "defaultWorkingDirectory": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^\\/",
-                "description": "Existing directory; stored canonicalized (symlinks resolved)."
-              }
-            ]
+            "pattern": "^\\/",
+            "description": "Existing directory; stored canonicalized (symlinks resolved)."
           }
         },
         "required": [
@@ -498,21 +482,13 @@
         "properties": {
           "name": {
             "type": "string",
-            "allOf": [
-              {
-                "minLength": 1,
-                "description": "Human-readable project name."
-              }
-            ]
+            "minLength": 1,
+            "description": "Human-readable project name."
           },
           "defaultWorkingDirectory": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^\\/",
-                "description": "Existing directory; stored canonicalized (symlinks resolved)."
-              }
-            ]
+            "pattern": "^\\/",
+            "description": "Existing directory; stored canonicalized (symlinks resolved)."
           }
         },
         "additionalProperties": false,

--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -50,6 +50,257 @@
         },
         "description": "Report the server's build metadata and API version."
       }
+    },
+    "/api/v1/projects": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "listProjects",
+        "parameters": [],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "All projects, newest first.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectList"
+                }
+              }
+            }
+          }
+        },
+        "description": "List all projects."
+      },
+      "post": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "createProject",
+        "parameters": [],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "A Project: the user-facing container organizing a body of work.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Project"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The directory does not exist, is not a directory, or cannot be read/traversed. | The directory check did not complete within its bounded timeout. Retryable — a timeout is not proof the path is missing.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/DirectoryUnavailableJsonEncoding"
+                    },
+                    {
+                      "$ref": "#/components/schemas/DirectoryCheckTimedOutJsonEncoding"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Create a project. The default working directory must be an existing, readable directory; it is stored canonicalized and never created by ATC.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateProjectRequest"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v1/projects/{projectId}": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "getProject",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "A Project: the user-facing container organizing a body of work.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Project"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No project exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectNotFoundJsonEncoding"
+                }
+              }
+            }
+          }
+        },
+        "description": "Fetch one project by id."
+      },
+      "patch": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "updateProject",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "A Project: the user-facing container organizing a body of work.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Project"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No project exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectNotFoundJsonEncoding"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The directory does not exist, is not a directory, or cannot be read/traversed. | The directory check did not complete within its bounded timeout. Retryable — a timeout is not proof the path is missing.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/DirectoryUnavailableJsonEncoding"
+                    },
+                    {
+                      "$ref": "#/components/schemas/DirectoryCheckTimedOutJsonEncoding"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Update a project's name and/or default working directory. Directory changes affect future Threads and Terminals only.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProjectRequest"
+              }
+            }
+          },
+          "required": true
+        }
+      },
+      "delete": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "deleteProject",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "204": {
+            "description": "<No Content>"
+          },
+          "404": {
+            "description": "No project exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectNotFoundJsonEncoding"
+                }
+              }
+            }
+          }
+        },
+        "description": "Delete the project record. Never touches the filesystem or any directory."
+      }
+    },
+    "/api/v1/fs/check": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "checkDirectory",
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "allOf": [
+                {
+                  "pattern": "^\\/",
+                  "description": "a server-host absolute path (starting with /)"
+                }
+              ]
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Result of a directory health check. Never persisted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FsCheckResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Demand-driven directory health check with a bounded timeout. Takes a server-host absolute path; the result is never persisted."
+      }
     }
   },
   "components": {
@@ -100,6 +351,232 @@
         ],
         "additionalProperties": false,
         "description": "Build and contract version information for the running server."
+      },
+      "Project": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "UUIDv7 project id."
+          },
+          "name": {
+            "type": "string",
+            "allOf": [
+              {
+                "minLength": 1,
+                "description": "Human-readable project name."
+              }
+            ]
+          },
+          "defaultWorkingDirectory": {
+            "type": "string",
+            "description": "Canonical (symlink-resolved) absolute path new Threads and Terminals default to."
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation time (ISO 8601 UTC)."
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Last update time (ISO 8601 UTC)."
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "defaultWorkingDirectory",
+          "createdAt",
+          "updatedAt"
+        ],
+        "additionalProperties": false,
+        "description": "A Project: the user-facing container organizing a body of work."
+      },
+      "ProjectList": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Project"
+        },
+        "description": "All projects, newest first."
+      },
+      "CreateProjectRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "allOf": [
+              {
+                "minLength": 1,
+                "description": "Human-readable project name."
+              }
+            ]
+          },
+          "defaultWorkingDirectory": {
+            "type": "string",
+            "allOf": [
+              {
+                "pattern": "^\\/",
+                "description": "Existing directory; stored canonicalized (symlinks resolved)."
+              }
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "defaultWorkingDirectory"
+        ],
+        "additionalProperties": false,
+        "description": "Payload for creating a project."
+      },
+      "DirectoryUnavailableJsonEncoding": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": [
+              "DirectoryUnavailable"
+            ]
+          },
+          "path": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "missing",
+              "inaccessible",
+              "not_directory"
+            ]
+          }
+        },
+        "required": [
+          "_tag",
+          "path",
+          "state"
+        ],
+        "additionalProperties": false
+      },
+      "DirectoryCheckTimedOutJsonEncoding": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": [
+              "DirectoryCheckTimedOut"
+            ]
+          },
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "_tag",
+          "path"
+        ],
+        "additionalProperties": false
+      },
+      "ProjectNotFoundJsonEncoding": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": [
+              "ProjectNotFound"
+            ]
+          },
+          "projectId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "_tag",
+          "projectId"
+        ],
+        "additionalProperties": false
+      },
+      "UpdateProjectRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "allOf": [
+                  {
+                    "minLength": 1,
+                    "description": "Human-readable project name."
+                  }
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "defaultWorkingDirectory": {
+            "anyOf": [
+              {
+                "type": "string",
+                "allOf": [
+                  {
+                    "pattern": "^\\/",
+                    "description": "Existing directory; stored canonicalized (symlinks resolved)."
+                  }
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "description": "Partial update; affects future Threads and Terminals only."
+      },
+      "DirectoryState": {
+        "type": "string",
+        "enum": [
+          "available",
+          "missing",
+          "inaccessible",
+          "not_directory",
+          "unknown"
+        ],
+        "description": "Tagged result of a demand-driven directory health check."
+      },
+      "FsCheckResponse": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "The checked path (canonicalized when the directory is available)."
+          },
+          "state": {
+            "$ref": "#/components/schemas/DirectoryState"
+          },
+          "checkedAt": {
+            "type": "string",
+            "description": "Check time (ISO 8601 UTC)."
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Why the state is not conclusive (e.g. \"timeout\" for unknown)."
+          }
+        },
+        "required": [
+          "path",
+          "state",
+          "checkedAt",
+          "reason"
+        ],
+        "additionalProperties": false,
+        "description": "Result of a directory health check. Never persisted."
       }
     },
     "securitySchemes": {}

--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -497,34 +497,20 @@
         "type": "object",
         "properties": {
           "name": {
-            "anyOf": [
+            "type": "string",
+            "allOf": [
               {
-                "type": "string",
-                "allOf": [
-                  {
-                    "minLength": 1,
-                    "description": "Human-readable project name."
-                  }
-                ]
-              },
-              {
-                "type": "null"
+                "minLength": 1,
+                "description": "Human-readable project name."
               }
             ]
           },
           "defaultWorkingDirectory": {
-            "anyOf": [
+            "type": "string",
+            "allOf": [
               {
-                "type": "string",
-                "allOf": [
-                  {
-                    "pattern": "^\\/",
-                    "description": "Existing directory; stored canonicalized (symlinks resolved)."
-                  }
-                ]
-              },
-              {
-                "type": "null"
+                "pattern": "^\\/",
+                "description": "Existing directory; stored canonicalized (symlinks resolved)."
               }
             ]
           }
@@ -558,22 +544,14 @@
             "description": "Check time (ISO 8601 UTC)."
           },
           "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Why the state is not conclusive (e.g. \"timeout\" for unknown)."
+            "type": "string",
+            "description": "Why the state is not conclusive (e.g. \"timeout\" for unknown); absent otherwise."
           }
         },
         "required": [
           "path",
           "state",
-          "checkedAt",
-          "reason"
+          "checkedAt"
         ],
         "additionalProperties": false,
         "description": "Result of a directory health check. Never persisted."

--- a/app-server/package.json
+++ b/app-server/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.220",
     "@effect/platform-bun": "4.0.0-beta.102",
+    "@effect/sql-sqlite-bun": "4.0.0-beta.102",
     "effect": "4.0.0-beta.102"
   },
   "devDependencies": {

--- a/app-server/src/api.ts
+++ b/app-server/src/api.ts
@@ -67,9 +67,12 @@ export const CreateProjectRequest = Schema.Struct({
   description: "Payload for creating a project.",
 })
 
+// optionalKey (absent key), not optional (key-or-undefined): the undefined
+// union renders as an anyOf-with-null the pinned Swift generator drops,
+// which would strip these fields from the generated client entirely.
 export const UpdateProjectRequest = Schema.Struct({
-  name: Schema.optional(ProjectName),
-  defaultWorkingDirectory: Schema.optional(
+  name: Schema.optionalKey(ProjectName),
+  defaultWorkingDirectory: Schema.optionalKey(
     AbsolutePath.annotate({
       description: "Existing directory; stored canonicalized (symlinks resolved).",
     }),
@@ -96,9 +99,13 @@ export const FsCheckResponse = Schema.Struct({
   }),
   state: DirectoryState,
   checkedAt: Schema.String.annotate({ description: "Check time (ISO 8601 UTC)." }),
-  reason: Schema.NullOr(Schema.String).annotate({
-    description: 'Why the state is not conclusive (e.g. "timeout" for unknown).',
-  }),
+  // Absent when the state is conclusive (not null — see UpdateProjectRequest).
+  reason: Schema.optionalKey(
+    Schema.String.annotate({
+      description:
+        'Why the state is not conclusive (e.g. "timeout" for unknown); absent otherwise.',
+    }),
+  ),
 }).annotate({
   identifier: "FsCheckResponse",
   description: "Result of a directory health check. Never persisted.",

--- a/app-server/src/api.ts
+++ b/app-server/src/api.ts
@@ -104,6 +104,10 @@ export const FsCheckResponse = Schema.Struct({
   description: "Result of a directory health check. Never persisted.",
 })
 
+// The error classes carry human `message`s so every consumer (the CLI above
+// all) can print a real diagnostic — a TaggedErrorClass message is otherwise
+// empty.
+
 /** Unknown project id. */
 export class ProjectNotFound extends Schema.TaggedErrorClass<ProjectNotFound>()(
   "ProjectNotFound",
@@ -113,7 +117,11 @@ export class ProjectNotFound extends Schema.TaggedErrorClass<ProjectNotFound>()(
     description: "No project exists with the given id.",
     httpApiStatus: 404,
   },
-) {}
+) {
+  override get message(): string {
+    return `no project with id ${this.projectId}`
+  }
+}
 
 /** The directory failed validation; `state` carries the tagged failure. */
 export class DirectoryUnavailable extends Schema.TaggedErrorClass<DirectoryUnavailable>()(
@@ -127,7 +135,18 @@ export class DirectoryUnavailable extends Schema.TaggedErrorClass<DirectoryUnava
     description: "The directory does not exist, is not a directory, or cannot be read/traversed.",
     httpApiStatus: 422,
   },
-) {}
+) {
+  override get message(): string {
+    switch (this.state) {
+      case "missing":
+        return `directory ${this.path} does not exist`
+      case "inaccessible":
+        return `directory ${this.path} cannot be read or traversed`
+      case "not_directory":
+        return `${this.path} is not a directory`
+    }
+  }
+}
 
 /** The bounded directory check did not complete; retryable, fail-closed. */
 export class DirectoryCheckTimedOut extends Schema.TaggedErrorClass<DirectoryCheckTimedOut>()(
@@ -139,7 +158,11 @@ export class DirectoryCheckTimedOut extends Schema.TaggedErrorClass<DirectoryChe
       "The directory check did not complete within its bounded timeout. Retryable — a timeout is not proof the path is missing.",
     httpApiStatus: 422,
   },
-) {}
+) {
+  override get message(): string {
+    return `the check of directory ${this.path} timed out; retry`
+  }
+}
 
 const projectIdParam = { projectId: Schema.String }
 

--- a/app-server/src/api.ts
+++ b/app-server/src/api.ts
@@ -30,6 +30,119 @@ export const VersionResponse = Schema.Struct({
   description: "Build and contract version information for the running server.",
 })
 
+/** A server-host absolute path. */
+export const AbsolutePath = Schema.String.check(
+  Schema.isStartsWith("/", { description: "a server-host absolute path (starting with /)" }),
+)
+
+export const ProjectName = Schema.NonEmptyString.annotate({
+  description: "Human-readable project name.",
+})
+
+export const Project = Schema.Struct({
+  id: Schema.String.annotate({ description: "UUIDv7 project id." }),
+  name: ProjectName,
+  defaultWorkingDirectory: Schema.String.annotate({
+    description: "Canonical (symlink-resolved) absolute path new Threads and Terminals default to.",
+  }),
+  createdAt: Schema.String.annotate({ description: "Creation time (ISO 8601 UTC)." }),
+  updatedAt: Schema.String.annotate({ description: "Last update time (ISO 8601 UTC)." }),
+}).annotate({
+  identifier: "Project",
+  description: "A Project: the user-facing container organizing a body of work.",
+})
+
+export const ProjectList = Schema.Array(Project).annotate({
+  identifier: "ProjectList",
+  description: "All projects, newest first.",
+})
+
+export const CreateProjectRequest = Schema.Struct({
+  name: ProjectName,
+  defaultWorkingDirectory: AbsolutePath.annotate({
+    description: "Existing directory; stored canonicalized (symlinks resolved).",
+  }),
+}).annotate({
+  identifier: "CreateProjectRequest",
+  description: "Payload for creating a project.",
+})
+
+export const UpdateProjectRequest = Schema.Struct({
+  name: Schema.optional(ProjectName),
+  defaultWorkingDirectory: Schema.optional(
+    AbsolutePath.annotate({
+      description: "Existing directory; stored canonicalized (symlinks resolved).",
+    }),
+  ),
+}).annotate({
+  identifier: "UpdateProjectRequest",
+  description: "Partial update; affects future Threads and Terminals only.",
+})
+
+export const DirectoryState = Schema.Literals([
+  "available",
+  "missing",
+  "inaccessible",
+  "not_directory",
+  "unknown",
+]).annotate({
+  identifier: "DirectoryState",
+  description: "Tagged result of a demand-driven directory health check.",
+})
+
+export const FsCheckResponse = Schema.Struct({
+  path: Schema.String.annotate({
+    description: "The checked path (canonicalized when the directory is available).",
+  }),
+  state: DirectoryState,
+  checkedAt: Schema.String.annotate({ description: "Check time (ISO 8601 UTC)." }),
+  reason: Schema.NullOr(Schema.String).annotate({
+    description: 'Why the state is not conclusive (e.g. "timeout" for unknown).',
+  }),
+}).annotate({
+  identifier: "FsCheckResponse",
+  description: "Result of a directory health check. Never persisted.",
+})
+
+/** Unknown project id. */
+export class ProjectNotFound extends Schema.TaggedErrorClass<ProjectNotFound>()(
+  "ProjectNotFound",
+  { projectId: Schema.String },
+  {
+    identifier: "ProjectNotFound",
+    description: "No project exists with the given id.",
+    httpApiStatus: 404,
+  },
+) {}
+
+/** The directory failed validation; `state` carries the tagged failure. */
+export class DirectoryUnavailable extends Schema.TaggedErrorClass<DirectoryUnavailable>()(
+  "DirectoryUnavailable",
+  {
+    path: Schema.String,
+    state: Schema.Literals(["missing", "inaccessible", "not_directory"]),
+  },
+  {
+    identifier: "DirectoryUnavailable",
+    description: "The directory does not exist, is not a directory, or cannot be read/traversed.",
+    httpApiStatus: 422,
+  },
+) {}
+
+/** The bounded directory check did not complete; retryable, fail-closed. */
+export class DirectoryCheckTimedOut extends Schema.TaggedErrorClass<DirectoryCheckTimedOut>()(
+  "DirectoryCheckTimedOut",
+  { path: Schema.String },
+  {
+    identifier: "DirectoryCheckTimedOut",
+    description:
+      "The directory check did not complete within its bounded timeout. Retryable — a timeout is not proof the path is missing.",
+    httpApiStatus: 422,
+  },
+) {}
+
+const projectIdParam = { projectId: Schema.String }
+
 export class V1 extends HttpApiGroup.make("v1")
   .add(
     HttpApiEndpoint.get("health", "/health", { success: HealthResponse })
@@ -38,6 +151,58 @@ export class V1 extends HttpApiGroup.make("v1")
     HttpApiEndpoint.get("version", "/version", { success: VersionResponse })
       .annotate(OpenApi.Identifier, "getVersion")
       .annotate(OpenApi.Description, "Report the server's build metadata and API version."),
+    HttpApiEndpoint.get("listProjects", "/projects", { success: ProjectList })
+      .annotate(OpenApi.Identifier, "listProjects")
+      .annotate(OpenApi.Description, "List all projects."),
+    // Create returns 200 with the resource body (not 201): a per-endpoint
+    // status annotation on the shared named Project schema would fork it into
+    // a duplicate component in the document and every generated client.
+    HttpApiEndpoint.post("createProject", "/projects", {
+      payload: CreateProjectRequest,
+      success: Project,
+      error: [DirectoryUnavailable, DirectoryCheckTimedOut],
+    })
+      .annotate(OpenApi.Identifier, "createProject")
+      .annotate(
+        OpenApi.Description,
+        "Create a project. The default working directory must be an existing, readable directory; it is stored canonicalized and never created by ATC.",
+      ),
+    HttpApiEndpoint.get("getProject", "/projects/:projectId", {
+      params: projectIdParam,
+      success: Project,
+      error: ProjectNotFound,
+    })
+      .annotate(OpenApi.Identifier, "getProject")
+      .annotate(OpenApi.Description, "Fetch one project by id."),
+    HttpApiEndpoint.patch("updateProject", "/projects/:projectId", {
+      params: projectIdParam,
+      payload: UpdateProjectRequest,
+      success: Project,
+      error: [ProjectNotFound, DirectoryUnavailable, DirectoryCheckTimedOut],
+    })
+      .annotate(OpenApi.Identifier, "updateProject")
+      .annotate(
+        OpenApi.Description,
+        "Update a project's name and/or default working directory. Directory changes affect future Threads and Terminals only.",
+      ),
+    HttpApiEndpoint.delete("deleteProject", "/projects/:projectId", {
+      params: projectIdParam,
+      error: ProjectNotFound,
+    })
+      .annotate(OpenApi.Identifier, "deleteProject")
+      .annotate(
+        OpenApi.Description,
+        "Delete the project record. Never touches the filesystem or any directory.",
+      ),
+    HttpApiEndpoint.get("checkDirectory", "/fs/check", {
+      query: { path: AbsolutePath },
+      success: FsCheckResponse,
+    })
+      .annotate(OpenApi.Identifier, "checkDirectory")
+      .annotate(
+        OpenApi.Description,
+        "Demand-driven directory health check with a bounded timeout. Takes a server-host absolute path; the result is never persisted.",
+      ),
   )
   // .prefix only applies to endpoints added above it — add new endpoints
   // before this line so they stay under /api/v1.

--- a/app-server/src/cli.ts
+++ b/app-server/src/cli.ts
@@ -1,18 +1,25 @@
 import { BunHttpClient } from "@effect/platform-bun"
-import { Console, Effect, Layer, Runtime, Schema } from "effect"
-import { Command, Flag } from "effect/unstable/cli"
-import { DEFAULT_PORT } from "./api.ts"
+import { Console, Effect, Layer, Option, Runtime, Schema } from "effect"
+import { Argument, Command, Flag } from "effect/unstable/cli"
+import * as path from "node:path"
 import * as Client from "./client.ts"
+import { AppConfig, ConfigLoadError, layer as appConfigLayer } from "./config.ts"
+import * as Directories from "./directories.ts"
+import * as Logging from "./logging.ts"
+import * as Persistence from "./persistence.ts"
+import * as ProjectRepository from "./projectRepository.ts"
 import * as Server from "./server.ts"
 import { smoke } from "./smoke.ts"
 
-/** The one reusable port contract for CLI (and later config/API) inputs. */
+/** The one reusable port contract for CLI (and config/API) inputs. */
 export const Port = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 65535 }))
 
 export const port = Flag.integer("port").pipe(
-  Flag.withDefault(DEFAULT_PORT),
   Flag.withSchema(Port),
-  Flag.withDescription(`TCP port to listen on (loopback only, default ${DEFAULT_PORT})`),
+  Flag.optional,
+  Flag.withDescription(
+    "TCP port to listen on (loopback only; overrides ATC_PORT/config.toml/default)",
+  ),
 )
 
 /** Failure already shown to the user; the marker stops runMain from logging it again. */
@@ -32,64 +39,203 @@ const failReported = (message: string) => {
   return Console.error(line).pipe(Effect.andThen(Effect.fail(new ReportedError({ message: line }))))
 }
 
+const describeError = (error: unknown): string =>
+  error instanceof ConfigLoadError
+    ? `${error.source}: ${error.message}`
+    : error instanceof Error
+      ? error.message
+      : String(error)
+
 // System errors carry a syscall code (EADDRINUSE, EACCES, ...). Those are
-// environment problems and become one friendly line; anything else is a bug
-// and re-dies so it keeps the default loud report.
+// environment problems and become one friendly line; a migration failure is
+// deliberately a defect that halts boot and gets the same treatment (the
+// diagnostic names the migration); anything else is a bug and re-dies so it
+// keeps the default loud report.
 const isSystemError = (defect: unknown): defect is Error & { code: string } =>
   defect instanceof Error && typeof (defect as { code?: unknown }).code === "string"
 
+const isMigrationError = (defect: unknown): defect is Error =>
+  defect instanceof Error && (defect as { _tag?: unknown })._tag === "MigrationError"
+
 const serve = Command.make("serve", { port }, ({ port }) =>
-  Layer.launch(Server.layer({ port })).pipe(
+  Effect.gen(function* () {
+    const config = yield* AppConfig
+    // The flag level of the precedence rule: flags > env > file > defaults.
+    const effectivePort = Option.getOrElse(port, () => config.port)
+    yield* Layer.launch(
+      Server.layer({ port: effectivePort }).pipe(
+        Layer.provide([ProjectRepository.layer, Directories.layer]),
+        Layer.provide(Persistence.layer),
+        Layer.provide(Logging.layer),
+      ),
+    )
+  }).pipe(
+    Effect.provide(appConfigLayer),
+    Effect.catch((error) => failReported(`atc serve: ${describeError(error)}`)),
     Effect.catchDefect((defect) =>
-      isSystemError(defect) ? failReported(`atc serve: ${defect.message}`) : Effect.die(defect),
+      isSystemError(defect) || isMigrationError(defect)
+        ? failReported(`atc serve: ${defect.message}`)
+        : Effect.die(defect),
     ),
   ),
 ).pipe(Command.withDescription("Run the App Server in the foreground until interrupted"))
 
-const url = Flag.string("url").pipe(
-  Flag.withSchema(Schema.URLFromString),
-  Flag.withDescription(`Base URL of the App Server (e.g. http://127.0.0.1:${DEFAULT_PORT})`),
-)
-
-// Base-URL resolution seam for client commands: the explicit --url flag is the
-// only source today. Connection profiles and configuration precedence are
-// later work and should change only this resolution, not the commands.
-const resolveBaseUrl = (flags: { readonly url: URL }): URL => flags.url
+// Base-URL resolution seam for client commands: derived from the settled
+// configuration (ATC_PORT > config.toml port > default) — the same pipeline
+// the server reads, so port changes just work with zero connection flags.
+// Remote endpoint addressing (endpoint + token) is later, auth-pass work and
+// should change only this resolution, not the commands.
+const resolveBaseUrl = Effect.gen(function* () {
+  const config = yield* AppConfig
+  return new URL(`http://127.0.0.1:${config.port}`)
+})
 
 /**
  * A CLI command backed by the contract-derived client: JSON result on stdout,
- * exit 0; any request/decode failure becomes one `atc <name>:` line on stderr
- * and exit 1.
+ * exit 0; any config/request/decode failure becomes one `atc <name>:` line on
+ * stderr and exit 1.
  */
-const clientCommand = <A>(
-  name: string,
+const clientCommand = <const Name extends string, Params extends Command.Command.Config, A>(
+  name: Name,
   description: string,
-  call: (client: Client.AppServerClient) => Effect.Effect<A, Error>,
+  params: Params,
+  call: (
+    client: Client.AppServerClient,
+    params: Command.Command.Config.Infer<Params>,
+  ) => Effect.Effect<A, unknown>,
+  diagnosticName = name,
 ) =>
-  Command.make(name, { url }, (flags) =>
+  Command.make(name, params, (parsed) =>
     Effect.gen(function* () {
-      const client = yield* Client.make({ baseUrl: resolveBaseUrl(flags) })
-      const result = yield* call(client)
+      const baseUrl = yield* resolveBaseUrl
+      const client = yield* Client.make({ baseUrl })
+      const result = yield* call(client, parsed)
       yield* Console.log(JSON.stringify(result, null, 2))
     }).pipe(
-      Effect.catch((error) => failReported(`atc ${name}: ${error.message}`)),
-      Effect.provide(BunHttpClient.layer),
+      Effect.provide([BunHttpClient.layer, appConfigLayer]),
+      Effect.catch((error) => failReported(`atc ${diagnosticName}: ${describeError(error)}`)),
     ),
   ).pipe(Command.withDescription(description))
 
 const health = clientCommand(
   "health",
   "Check that an App Server is reachable and healthy",
+  {},
   (client) => client.v1.health(),
 )
 
 const version = clientCommand(
   "version",
   "Report an App Server's build metadata and API version",
+  {},
   (client) => client.v1.version(),
+)
+
+// Directory arguments may be relative (e.g. "."): the CLI shares a filesystem
+// with the local server, so they resolve against the caller's cwd before the
+// API sees them. The API itself takes server-host absolute paths only.
+const directoryFlag = Flag.string("directory").pipe(
+  Flag.withDescription("Project default working directory (must already exist; may be relative)"),
+)
+
+const nameFlag = Flag.string("name").pipe(Flag.withDescription("Project name"))
+
+const projectIdArgument = Argument.string("project-id")
+
+const projectList = clientCommand(
+  "list",
+  "List all projects",
+  {},
+  (client) => client.v1.listProjects(),
+  "project list",
+)
+
+const projectGet = clientCommand(
+  "get",
+  "Fetch one project by id",
+  { projectId: projectIdArgument },
+  (client, { projectId }) => client.v1.getProject({ params: { projectId } }),
+  "project get",
+)
+
+const projectCreate = clientCommand(
+  "create",
+  "Create a project (the directory must already exist; ATC never creates it)",
+  { name: nameFlag, directory: directoryFlag },
+  (client, { name, directory }) =>
+    client.v1.createProject({
+      payload: { name, defaultWorkingDirectory: path.resolve(directory) },
+    }),
+  "project create",
+)
+
+const projectUpdate = clientCommand(
+  "update",
+  "Update a project's name and/or default working directory",
+  {
+    projectId: projectIdArgument,
+    name: Flag.optional(nameFlag),
+    directory: Flag.optional(directoryFlag),
+  },
+  (client, { projectId, name, directory }) =>
+    client.v1.updateProject({
+      params: { projectId },
+      payload: {
+        name: Option.getOrUndefined(name),
+        defaultWorkingDirectory: Option.getOrUndefined(
+          Option.map(directory, (d) => path.resolve(d)),
+        ),
+      },
+    }),
+  "project update",
+)
+
+const yesFlag = Flag.boolean("yes").pipe(
+  Flag.withDescription("Confirm the deletion (required; the CLI never prompts)"),
+)
+
+const projectDelete = Command.make(
+  "delete",
+  { projectId: projectIdArgument, yes: yesFlag },
+  ({ projectId, yes }) =>
+    Effect.gen(function* () {
+      if (!yes) {
+        return yield* failReported(
+          "atc project delete: refusing to delete without --yes (deletes the project record only, never the directory)",
+        )
+      }
+      const baseUrl = yield* resolveBaseUrl
+      const client = yield* Client.make({ baseUrl })
+      yield* client.v1.deleteProject({ params: { projectId } })
+    }).pipe(
+      Effect.provide([BunHttpClient.layer, appConfigLayer]),
+      Effect.catch((error) =>
+        error instanceof ReportedError
+          ? Effect.fail(error)
+          : failReported(`atc project delete: ${describeError(error)}`),
+      ),
+    ),
+).pipe(Command.withDescription("Delete a project record (never touches the filesystem)"))
+
+const project = Command.make("project").pipe(
+  Command.withDescription("Manage projects"),
+  Command.withSubcommands([projectList, projectGet, projectCreate, projectUpdate, projectDelete]),
+)
+
+const fsCheck = clientCommand(
+  "check",
+  "Check a directory's health (available, missing, inaccessible, not_directory, unknown)",
+  { path: Argument.string("path") },
+  (client, args) => client.v1.checkDirectory({ query: { path: path.resolve(args.path) } }),
+  "fs check",
+)
+
+const fs = Command.make("fs").pipe(
+  Command.withDescription("Read-only filesystem operations on the server host"),
+  Command.withSubcommands([fsCheck]),
 )
 
 export const atc = Command.make("atc").pipe(
   Command.withDescription("ATC App Server"),
-  Command.withSubcommands([serve, health, version, smoke]),
+  Command.withSubcommands([serve, health, version, project, fs, smoke]),
 )

--- a/app-server/src/cli.ts
+++ b/app-server/src/cli.ts
@@ -185,11 +185,12 @@ const projectUpdate = clientCommand(
   (client, { projectId, name, directory }) =>
     client.v1.updateProject({
       params: { projectId },
+      // The contract uses absent keys (not undefined/null) for omitted fields.
       payload: {
-        name: Option.getOrUndefined(name),
-        defaultWorkingDirectory: Option.getOrUndefined(
-          Option.map(directory, (d) => path.resolve(d)),
-        ),
+        ...(Option.isSome(name) ? { name: name.value } : {}),
+        ...(Option.isSome(directory)
+          ? { defaultWorkingDirectory: path.resolve(directory.value) }
+          : {}),
       },
     }),
   "project update",

--- a/app-server/src/cli.ts
+++ b/app-server/src/cli.ts
@@ -39,10 +39,12 @@ const failReported = (message: string) => {
   return Console.error(line).pipe(Effect.andThen(Effect.fail(new ReportedError({ message: line }))))
 }
 
+// Contract error classes carry human messages (api.ts); the String fallback
+// covers any Error subclass whose message is empty.
 const describeError = (error: unknown): string =>
   error instanceof ConfigLoadError
     ? `${error.source}: ${error.message}`
-    : error instanceof Error
+    : error instanceof Error && error.message !== ""
       ? error.message
       : String(error)
 
@@ -110,7 +112,10 @@ const clientCommand = <const Name extends string, Params extends Command.Command
       const baseUrl = yield* resolveBaseUrl
       const client = yield* Client.make({ baseUrl })
       const result = yield* call(client, parsed)
-      yield* Console.log(JSON.stringify(result, null, 2))
+      // Void results (e.g. delete) print nothing — stdout stays pure JSON.
+      if (result !== undefined) {
+        yield* Console.log(JSON.stringify(result, null, 2))
+      }
     }).pipe(
       Effect.provide([BunHttpClient.layer, appConfigLayer]),
       Effect.catch((error) => failReported(`atc ${diagnosticName}: ${describeError(error)}`)),
@@ -194,28 +199,20 @@ const yesFlag = Flag.boolean("yes").pipe(
   Flag.withDescription("Confirm the deletion (required; the CLI never prompts)"),
 )
 
-const projectDelete = Command.make(
+const projectDelete = clientCommand(
   "delete",
+  "Delete a project record (never touches the filesystem)",
   { projectId: projectIdArgument, yes: yesFlag },
-  ({ projectId, yes }) =>
-    Effect.gen(function* () {
-      if (!yes) {
-        return yield* failReported(
-          "atc project delete: refusing to delete without --yes (deletes the project record only, never the directory)",
-        )
-      }
-      const baseUrl = yield* resolveBaseUrl
-      const client = yield* Client.make({ baseUrl })
-      yield* client.v1.deleteProject({ params: { projectId } })
-    }).pipe(
-      Effect.provide([BunHttpClient.layer, appConfigLayer]),
-      Effect.catch((error) =>
-        error instanceof ReportedError
-          ? Effect.fail(error)
-          : failReported(`atc project delete: ${describeError(error)}`),
-      ),
-    ),
-).pipe(Command.withDescription("Delete a project record (never touches the filesystem)"))
+  (client, { projectId, yes }) =>
+    yes
+      ? client.v1.deleteProject({ params: { projectId } })
+      : Effect.fail(
+          new Error(
+            "refusing to delete without --yes (deletes the project record only, never the directory)",
+          ),
+        ),
+  "project delete",
+)
 
 const project = Command.make("project").pipe(
   Command.withDescription("Manage projects"),

--- a/app-server/src/config.ts
+++ b/app-server/src/config.ts
@@ -139,15 +139,21 @@ export const load = (
   env: Env,
 ): Effect.Effect<AppConfig["Service"], ConfigLoadError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
-    const configFile = configFilePath(env)
-    if (!configFile.startsWith("/")) {
-      return yield* Effect.fail(
-        new ConfigLoadError({
-          source: "ATC_CONFIG / XDG_CONFIG_HOME",
-          message: `config file path must be absolute, got "${configFile}"`,
-        }),
-      )
-    }
+    // Every settled location must be absolute: a relative path would make the
+    // config file, database, or log file depend on the working directory —
+    // compiled behavior never may.
+    const requireAbsolute = (value: string, what: string, source: string) =>
+      value.startsWith("/")
+        ? Effect.succeed(value)
+        : Effect.fail(
+            new ConfigLoadError({ source, message: `${what} must be absolute, got "${value}"` }),
+          )
+
+    const configFile = yield* requireAbsolute(
+      configFilePath(env),
+      "config file path",
+      "ATC_CONFIG / XDG_CONFIG_HOME",
+    )
     const fs = yield* FileSystem.FileSystem
 
     const fileTable = yield* fs.readFileString(configFile).pipe(
@@ -188,25 +194,23 @@ export const load = (
       ),
     )
 
-    // A relative data directory would silently fork the database by working
-    // directory — compiled behavior must never depend on the cwd.
-    if (!settings.dataDir.startsWith("/")) {
-      return yield* Effect.fail(
-        new ConfigLoadError({
-          source: `${configFile} / ATC_DATA_DIR`,
-          message: `dataDir must be an absolute path, got "${settings.dataDir}"`,
-        }),
-      )
-    }
-
-    const stateDir = xdgDir(env, "XDG_STATE_HOME", [".local", "state"])
+    const dataDir = yield* requireAbsolute(
+      settings.dataDir,
+      "dataDir",
+      `${configFile} / ATC_DATA_DIR`,
+    )
+    const stateDir = yield* requireAbsolute(
+      xdgDir(env, "XDG_STATE_HOME", [".local", "state"]),
+      "state directory",
+      "XDG_STATE_HOME",
+    )
     return {
       port: settings.port,
       logLevel: settings.logLevel,
       configFile,
-      dataDir: settings.dataDir,
+      dataDir,
       stateDir,
-      dbFile: path.join(settings.dataDir, "atc.db"),
+      dbFile: path.join(dataDir, "atc.db"),
       logFile: path.join(stateDir, "atc.log"),
     }
   })

--- a/app-server/src/config.ts
+++ b/app-server/src/config.ts
@@ -1,0 +1,190 @@
+import { Config, ConfigProvider, Context, Effect, FileSystem, Layer, Option, Schema } from "effect"
+import type { LogLevel } from "effect"
+import * as SchemaIssue from "effect/SchemaIssue"
+import * as os from "node:os"
+import * as path from "node:path"
+import { DEFAULT_PORT } from "./api.ts"
+
+// The settled configuration pipeline (ATC-121). One precedence rule:
+// command flags > environment (flat ATC_<KEY>) > config file (TOML) > defaults.
+// Flags apply at the command seam in cli.ts; everything below the flag level
+// resolves here, so the server and API-backed CLI commands read identical
+// settings. Paths follow one XDG rule on every platform (macOS included),
+// honoring XDG_* overrides:
+//
+//   config  $XDG_CONFIG_HOME/atc/config.toml  (~/.config/atc/config.toml)
+//   data    $XDG_DATA_HOME/atc                (~/.local/share/atc)  -> atc.db
+//   state   $XDG_STATE_HOME/atc               (~/.local/state/atc)  -> atc.log
+//
+// ATC_CONFIG overrides the config file path; ATC_DATA_DIR the data directory.
+// The TOML format never leaks past this module.
+
+/** Environment shape consumed by the pipeline; tests inject their own. */
+export type Env = Record<string, string | undefined>
+
+/** Invalid or malformed configuration. `source` names the offending origin. */
+export class ConfigLoadError extends Schema.TaggedErrorClass<ConfigLoadError>()("ConfigLoadError", {
+  source: Schema.String,
+  message: Schema.String,
+}) {}
+
+/**
+ * The settled application configuration and data locations. Persistence,
+ * logging, the server, and the CLI consume this service instead of re-deriving
+ * locations or reading the environment themselves.
+ */
+export class AppConfig extends Context.Service<
+  AppConfig,
+  {
+    /** TCP port the server listens on / the CLI connects to. */
+    readonly port: number
+    /** Minimum log level. */
+    readonly logLevel: LogLevel.LogLevel
+    /** Config file path that was consulted (it may not exist). */
+    readonly configFile: string
+    /** Directory holding durable data (the SQLite database). */
+    readonly dataDir: string
+    /** Directory holding server state (the log file). */
+    readonly stateDir: string
+    /** SQLite database file path. */
+    readonly dbFile: string
+    /** Structured JSON log file path. */
+    readonly logFile: string
+  }
+>()("app-server/AppConfig") {}
+
+const xdgDir = (env: Env, xdgVar: string, homeFallback: ReadonlyArray<string>) => {
+  const base = env[xdgVar]
+  return base !== undefined && base !== ""
+    ? path.join(base, "atc")
+    : path.join(os.homedir(), ...homeFallback, "atc")
+}
+
+/** The config file path: ATC_CONFIG, or the XDG config location. */
+const configFilePath = (env: Env) =>
+  env["ATC_CONFIG"] ?? path.join(xdgDir(env, "XDG_CONFIG_HOME", [".config"]), "config.toml")
+
+// The settings a config.toml may define. Keys are camelCase, matching the
+// system-wide JSON convention; unknown keys fail fast (a typo silently
+// falling back to a default would be a partial boot).
+const FILE_KEYS = ["port", "logLevel", "dataDir"] as const
+
+const parseToml = (source: string, text: string) =>
+  Effect.try({
+    try: () => Bun.TOML.parse(text) as Record<string, unknown>,
+    catch: (error) =>
+      new ConfigLoadError({ source, message: error instanceof Error ? error.message : `${error}` }),
+  }).pipe(
+    Effect.filterOrFail(
+      (table): table is Record<string, unknown> => typeof table === "object" && table !== null,
+      () => new ConfigLoadError({ source, message: "config file must be a TOML table" }),
+    ),
+    Effect.tap((table) => {
+      const unknown = Object.keys(table).filter(
+        (key) => !(FILE_KEYS as ReadonlyArray<string>).includes(key),
+      )
+      return unknown.length === 0
+        ? Effect.void
+        : Effect.fail(
+            new ConfigLoadError({
+              source,
+              message: `unknown key "${unknown[0]}" (known keys: ${FILE_KEYS.join(", ")})`,
+            }),
+          )
+    }),
+  )
+
+/** Case-insensitive log level ("debug", "Info", "WARN", ...). */
+const LOG_LEVELS: ReadonlyArray<LogLevel.LogLevel> = [
+  "All",
+  "Fatal",
+  "Error",
+  "Warn",
+  "Info",
+  "Debug",
+  "Trace",
+  "None",
+]
+
+const logLevelConfig = Config.string("logLevel").pipe(
+  Config.mapOrFail((raw) => {
+    const level = LOG_LEVELS.find((known) => known.toLowerCase() === raw.toLowerCase())
+    return level !== undefined
+      ? Effect.succeed(level)
+      : Effect.fail(
+          new Config.ConfigError(
+            new Schema.SchemaError(
+              new SchemaIssue.InvalidValue(Option.some(raw), {
+                message: `logLevel must be one of ${LOG_LEVELS.map((l) => l.toLowerCase()).join(", ")}, got "${raw}"`,
+              }),
+            ),
+          ),
+        )
+  }),
+  Config.withDefault<LogLevel.LogLevel>("Info"),
+)
+
+/**
+ * Load the settled configuration from `env` (environment precedence) and the
+ * config file (file precedence), applying defaults last. Fails with
+ * `ConfigLoadError` naming the offending source — never a partial result.
+ */
+export const load = (
+  env: Env,
+): Effect.Effect<AppConfig["Service"], ConfigLoadError, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const configFile = configFilePath(env)
+    const fs = yield* FileSystem.FileSystem
+
+    const fileTable = yield* fs.readFileString(configFile).pipe(
+      Effect.flatMap((text) => parseToml(configFile, text)),
+      Effect.catchTag("PlatformError", (error) =>
+        error.reason._tag === "NotFound"
+          ? Effect.succeed({} as Record<string, unknown>)
+          : Effect.fail(new ConfigLoadError({ source: configFile, message: error.message })),
+      ),
+    )
+
+    // Environment first, config file second; defaults per key. camelCase keys
+    // map to CONSTANT_CASE env vars under the flat ATC_ prefix (port ->
+    // ATC_PORT, logLevel -> ATC_LOG_LEVEL).
+    const provider = ConfigProvider.orElse(
+      ConfigProvider.fromEnv({ env: env as Record<string, string> }).pipe(
+        ConfigProvider.nested("ATC"),
+        ConfigProvider.constantCase,
+      ),
+      ConfigProvider.fromUnknown(fileTable),
+    )
+
+    const settings = yield* Config.all({
+      port: Config.port("port").pipe(Config.withDefault(DEFAULT_PORT)),
+      logLevel: logLevelConfig,
+      dataDir: Config.string("dataDir").pipe(
+        Config.withDefault(xdgDir(env, "XDG_DATA_HOME", [".local", "share"])),
+      ),
+    }).pipe(
+      Effect.provideService(ConfigProvider.ConfigProvider, provider),
+      Effect.catchTag("ConfigError", (error) =>
+        Effect.fail(
+          new ConfigLoadError({
+            source: `${configFile} / ATC_* environment`,
+            message: error.message.replace(/\s*\n\s*/g, " "),
+          }),
+        ),
+      ),
+    )
+
+    const stateDir = xdgDir(env, "XDG_STATE_HOME", [".local", "state"])
+    return {
+      port: settings.port,
+      logLevel: settings.logLevel,
+      configFile,
+      dataDir: settings.dataDir,
+      stateDir,
+      dbFile: path.join(settings.dataDir, "atc.db"),
+      logFile: path.join(stateDir, "atc.log"),
+    }
+  })
+
+/** Production layer: loads from the real process environment. */
+export const layer = Layer.effect(AppConfig)(load(process.env))

--- a/app-server/src/config.ts
+++ b/app-server/src/config.ts
@@ -53,16 +53,22 @@ export class AppConfig extends Context.Service<
   }
 >()("app-server/AppConfig") {}
 
+// Empty environment values mean "unset" everywhere in the pipeline, matching
+// how ConfigProvider.fromEnv treats them for the ATC_* settings.
+const nonEmpty = (value: string | undefined) =>
+  value !== undefined && value !== "" ? value : undefined
+
 const xdgDir = (env: Env, xdgVar: string, homeFallback: ReadonlyArray<string>) => {
-  const base = env[xdgVar]
-  return base !== undefined && base !== ""
+  const base = nonEmpty(env[xdgVar])
+  return base !== undefined
     ? path.join(base, "atc")
-    : path.join(os.homedir(), ...homeFallback, "atc")
+    : path.join(nonEmpty(env["HOME"]) ?? os.homedir(), ...homeFallback, "atc")
 }
 
 /** The config file path: ATC_CONFIG, or the XDG config location. */
 const configFilePath = (env: Env) =>
-  env["ATC_CONFIG"] ?? path.join(xdgDir(env, "XDG_CONFIG_HOME", [".config"]), "config.toml")
+  nonEmpty(env["ATC_CONFIG"]) ??
+  path.join(xdgDir(env, "XDG_CONFIG_HOME", [".config"]), "config.toml")
 
 // The settings a config.toml may define. Keys are camelCase, matching the
 // system-wide JSON convention; unknown keys fail fast (a typo silently
@@ -134,6 +140,14 @@ export const load = (
 ): Effect.Effect<AppConfig["Service"], ConfigLoadError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const configFile = configFilePath(env)
+    if (!configFile.startsWith("/")) {
+      return yield* Effect.fail(
+        new ConfigLoadError({
+          source: "ATC_CONFIG / XDG_CONFIG_HOME",
+          message: `config file path must be absolute, got "${configFile}"`,
+        }),
+      )
+    }
     const fs = yield* FileSystem.FileSystem
 
     const fileTable = yield* fs.readFileString(configFile).pipe(
@@ -173,6 +187,17 @@ export const load = (
         ),
       ),
     )
+
+    // A relative data directory would silently fork the database by working
+    // directory — compiled behavior must never depend on the cwd.
+    if (!settings.dataDir.startsWith("/")) {
+      return yield* Effect.fail(
+        new ConfigLoadError({
+          source: `${configFile} / ATC_DATA_DIR`,
+          message: `dataDir must be an absolute path, got "${settings.dataDir}"`,
+        }),
+      )
+    }
 
     const stateDir = xdgDir(env, "XDG_STATE_HOME", [".local", "state"])
     return {

--- a/app-server/src/directories.ts
+++ b/app-server/src/directories.ts
@@ -18,7 +18,8 @@ export type DirectoryCheckResult = {
   readonly path: string
   readonly state: typeof DirectoryState.Type
   readonly checkedAt: string
-  readonly reason: string | null
+  /** Present only when the state is not conclusive (e.g. "timeout"). */
+  readonly reason?: string
 }
 
 export class Directories extends Context.Service<
@@ -104,7 +105,6 @@ export const layer = Layer.succeed(Directories)({
         path: result.ok ? result.canonical : path,
         state: result.ok ? "available" : result.state,
         checkedAt: new Date().toISOString(),
-        reason: null,
       })),
       Effect.catch(() =>
         Effect.succeed<DirectoryCheckResult>({

--- a/app-server/src/directories.ts
+++ b/app-server/src/directories.ts
@@ -1,7 +1,7 @@
 import { Context, Effect, Layer } from "effect"
 import { constants } from "node:fs"
 import * as fs from "node:fs/promises"
-import { DirectoryCheckTimedOut, DirectoryUnavailable } from "./api.ts"
+import { DirectoryCheckTimedOut, DirectoryUnavailable, DirectoryState } from "./api.ts"
 
 // Demand-driven directory health (ATC-121, Domain Model rules): checks run
 // only when an operation needs a directory or a client asks explicitly —
@@ -16,7 +16,7 @@ export const CHECK_TIMEOUT_MILLIS = 2000
 
 export type DirectoryCheckResult = {
   readonly path: string
-  readonly state: "available" | "missing" | "inaccessible" | "not_directory" | "unknown"
+  readonly state: typeof DirectoryState.Type
   readonly checkedAt: string
   readonly reason: string | null
 }
@@ -42,7 +42,7 @@ export class Directories extends Context.Service<
 
 type Probe =
   | { readonly ok: true; readonly canonical: string }
-  | { readonly ok: false; readonly state: "missing" | "inaccessible" | "not_directory" }
+  | { readonly ok: false; readonly state: DirectoryUnavailable["state"] }
 
 // One filesystem probe: canonicalize, require a directory, require
 // read+traversal. Node errno codes map onto the tagged states.
@@ -52,9 +52,15 @@ const probe = (path: string): Promise<Probe> =>
     try {
       canonical = await fs.realpath(path)
     } catch (error) {
+      // ENOTDIR: a path component exists but is not a directory.
       return {
         ok: false as const,
-        state: errno(error) === "ENOENT" || errno(error) === "ENOTDIR" ? "missing" : "inaccessible",
+        state:
+          errno(error) === "ENOENT"
+            ? "missing"
+            : errno(error) === "ENOTDIR"
+              ? "not_directory"
+              : "inaccessible",
       }
     }
     let isDirectory: boolean

--- a/app-server/src/directories.ts
+++ b/app-server/src/directories.ts
@@ -1,0 +1,112 @@
+import { Context, Effect, Layer } from "effect"
+import { constants } from "node:fs"
+import * as fs from "node:fs/promises"
+import { DirectoryCheckTimedOut, DirectoryUnavailable } from "./api.ts"
+
+// Demand-driven directory health (ATC-121, Domain Model rules): checks run
+// only when an operation needs a directory or a client asks explicitly —
+// results are never persisted and normal reads never touch the filesystem.
+// Validation requires an existing directory with read+traversal access
+// (deliberately not write: testing writability at registration is worse than
+// surfacing a write failure at first use). Identity is the symlink-resolved
+// canonical absolute path; nothing else is stored.
+
+/** Bounded time for any filesystem probe; fail closed beyond it. */
+export const CHECK_TIMEOUT_MILLIS = 2000
+
+export type DirectoryCheckResult = {
+  readonly path: string
+  readonly state: "available" | "missing" | "inaccessible" | "not_directory" | "unknown"
+  readonly checkedAt: string
+  readonly reason: string | null
+}
+
+export class Directories extends Context.Service<
+  Directories,
+  {
+    /**
+     * Validate `path` as a usable directory and return its canonical form.
+     * Fails closed: `DirectoryUnavailable` with the tagged state, or
+     * `DirectoryCheckTimedOut` when the probe exceeds the bounded timeout.
+     */
+    readonly canonicalize: (
+      path: string,
+    ) => Effect.Effect<string, DirectoryUnavailable | DirectoryCheckTimedOut>
+    /**
+     * Explicit health check: never fails — a timeout is reported as
+     * `unknown` with a reason, because it is not proof the path is missing.
+     */
+    readonly check: (path: string) => Effect.Effect<DirectoryCheckResult>
+  }
+>()("app-server/Directories") {}
+
+type Probe =
+  | { readonly ok: true; readonly canonical: string }
+  | { readonly ok: false; readonly state: "missing" | "inaccessible" | "not_directory" }
+
+// One filesystem probe: canonicalize, require a directory, require
+// read+traversal. Node errno codes map onto the tagged states.
+const probe = (path: string): Promise<Probe> =>
+  (async () => {
+    let canonical: string
+    try {
+      canonical = await fs.realpath(path)
+    } catch (error) {
+      return {
+        ok: false as const,
+        state: errno(error) === "ENOENT" || errno(error) === "ENOTDIR" ? "missing" : "inaccessible",
+      }
+    }
+    let isDirectory: boolean
+    try {
+      isDirectory = (await fs.stat(canonical)).isDirectory()
+    } catch {
+      return { ok: false as const, state: "inaccessible" }
+    }
+    if (!isDirectory) return { ok: false as const, state: "not_directory" }
+    try {
+      await fs.access(canonical, constants.R_OK | constants.X_OK)
+    } catch {
+      return { ok: false as const, state: "inaccessible" }
+    }
+    return { ok: true as const, canonical }
+  })()
+
+const errno = (error: unknown): string | undefined =>
+  error instanceof Error && "code" in error ? String(error.code) : undefined
+
+const timedProbe = (path: string) =>
+  Effect.promise(() => probe(path)).pipe(
+    Effect.timeoutOrElse({
+      duration: CHECK_TIMEOUT_MILLIS,
+      orElse: () => Effect.fail(new DirectoryCheckTimedOut({ path })),
+    }),
+  )
+
+export const layer = Layer.succeed(Directories)({
+  canonicalize: (path) =>
+    timedProbe(path).pipe(
+      Effect.flatMap((result) =>
+        result.ok
+          ? Effect.succeed(result.canonical)
+          : Effect.fail(new DirectoryUnavailable({ path, state: result.state })),
+      ),
+    ),
+  check: (path) =>
+    timedProbe(path).pipe(
+      Effect.map((result): DirectoryCheckResult => ({
+        path: result.ok ? result.canonical : path,
+        state: result.ok ? "available" : result.state,
+        checkedAt: new Date().toISOString(),
+        reason: null,
+      })),
+      Effect.catch(() =>
+        Effect.succeed<DirectoryCheckResult>({
+          path,
+          state: "unknown",
+          checkedAt: new Date().toISOString(),
+          reason: "timeout",
+        }),
+      ),
+    ),
+})

--- a/app-server/src/handlers.ts
+++ b/app-server/src/handlers.ts
@@ -1,7 +1,9 @@
-import { Effect } from "effect"
+import { Effect, Option } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
-import { Api } from "./api.ts"
+import { Api, ProjectNotFound } from "./api.ts"
 import { BuildInfo } from "./buildInfo.ts"
+import { Directories } from "./directories.ts"
+import { ProjectRepository } from "./projectRepository.ts"
 
 /** Implements the /api/v1 contract. App construction only — no listener. */
 export const V1Handlers = HttpApiBuilder.group(
@@ -9,6 +11,15 @@ export const V1Handlers = HttpApiBuilder.group(
   "v1",
   Effect.fnUntraced(function* (handlers) {
     const build = yield* BuildInfo
+    const projects = yield* ProjectRepository
+    const directories = yield* Directories
+
+    const requireProject = <A>(projectId: string, found: Option.Option<A>) =>
+      Option.match(found, {
+        onNone: () => Effect.fail(new ProjectNotFound({ projectId })),
+        onSome: Effect.succeed,
+      })
+
     return handlers
       .handle("health", () => Effect.succeed({ status: "ok" } as const))
       .handle("version", () =>
@@ -19,5 +30,45 @@ export const V1Handlers = HttpApiBuilder.group(
           builtAt: build.builtAt,
         } as const),
       )
+      .handle("listProjects", () => projects.list())
+      .handle("createProject", ({ payload }) =>
+        Effect.gen(function* () {
+          const canonical = yield* directories.canonicalize(payload.defaultWorkingDirectory)
+          return yield* projects.create({
+            name: payload.name,
+            defaultWorkingDirectory: canonical,
+          })
+        }),
+      )
+      .handle("getProject", ({ params }) =>
+        projects
+          .get(params.projectId)
+          .pipe(Effect.flatMap((found) => requireProject(params.projectId, found))),
+      )
+      .handle("updateProject", ({ params, payload }) =>
+        Effect.gen(function* () {
+          const canonical =
+            payload.defaultWorkingDirectory !== undefined
+              ? yield* directories.canonicalize(payload.defaultWorkingDirectory)
+              : undefined
+          const updated = yield* projects.update(params.projectId, {
+            name: payload.name,
+            defaultWorkingDirectory: canonical,
+          })
+          return yield* requireProject(params.projectId, updated)
+        }),
+      )
+      .handle("deleteProject", ({ params }) =>
+        projects
+          .delete(params.projectId)
+          .pipe(
+            Effect.flatMap((deleted) =>
+              deleted
+                ? Effect.void
+                : Effect.fail(new ProjectNotFound({ projectId: params.projectId })),
+            ),
+          ),
+      )
+      .handle("checkDirectory", ({ query }) => directories.check(query.path))
   }),
 )

--- a/app-server/src/localTrust.ts
+++ b/app-server/src/localTrust.ts
@@ -8,6 +8,9 @@ import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstab
 // page's request carries its Origin). Requests must present a recognized
 // loopback Host, and browser requests (Origin present) must come from a
 // loopback origin. Non-browser clients send no Origin and pass untouched.
+// Origin-less browser requests (e.g. a cross-site <img>) can only be simple
+// GETs — safe while every GET is side-effect-free and responses are
+// unreadable cross-origin; revisit if a GET ever gains a side effect.
 // The remote-auth pass later relaxes this deliberately for tokened clients.
 
 const LOOPBACK_NAMES = new Set(["localhost", "127.0.0.1", "[::1]"])

--- a/app-server/src/localTrust.ts
+++ b/app-server/src/localTrust.ts
@@ -1,0 +1,65 @@
+import { Effect, Option } from "effect"
+import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+
+// Local trust for the loopback listener (ATC-121): the server only ever binds
+// 127.0.0.1, and this middleware rejects the one attack class that still
+// reaches a loopback control plane from a browser — DNS rebinding (a hostile
+// name resolving to 127.0.0.1 puts its own name in Host) and CSRF (a hostile
+// page's request carries its Origin). Requests must present a recognized
+// loopback Host, and browser requests (Origin present) must come from a
+// loopback origin. Non-browser clients send no Origin and pass untouched.
+// The remote-auth pass later relaxes this deliberately for tokened clients.
+
+const LOOPBACK_NAMES = new Set(["localhost", "127.0.0.1", "[::1]"])
+
+/** `Host` header values that identify this loopback server (optional port). */
+export const isLoopbackHost = (host: string | undefined): boolean => {
+  if (host === undefined) return false
+  // Split a trailing :port, respecting the [::1]:port bracket form.
+  const name = host.startsWith("[") ? host.replace(/\]:\d+$/, "]") : host.replace(/:\d+$/, "")
+  return LOOPBACK_NAMES.has(name.toLowerCase())
+}
+
+/** `Origin` header values acceptable on a loopback control plane. */
+export const isLoopbackOrigin = (origin: string): boolean => {
+  let url: URL
+  try {
+    url = new URL(origin)
+  } catch {
+    // Includes the opaque "null" origin (sandboxed iframes, file://): those
+    // are exactly the anonymous browser contexts this guard exists to stop.
+    return false
+  }
+  return (url.protocol === "http:" || url.protocol === "https:") && LOOPBACK_NAMES.has(url.hostname)
+}
+
+/**
+ * Global route middleware: reject spoofed-`Host`/cross-`Origin` requests with
+ * an empty 403, and annotate every log line in an accepted request with the
+ * request span ids so file logs correlate per request.
+ */
+export const middleware = HttpRouter.middleware(
+  Effect.fnUntraced(function* <E, R>(
+    httpEffect: Effect.Effect<
+      HttpServerResponse.HttpServerResponse,
+      E,
+      HttpServerRequest.HttpServerRequest | R
+    >,
+  ) {
+    const request = yield* HttpServerRequest.HttpServerRequest
+    const origin = request.headers["origin"]
+    if (
+      !isLoopbackHost(request.headers["host"]) ||
+      (origin !== undefined && !isLoopbackOrigin(origin))
+    ) {
+      return HttpServerResponse.empty({ status: 403 })
+    }
+    const span = yield* Effect.option(Effect.currentParentSpan)
+    return yield* Option.match(span, {
+      onNone: () => httpEffect,
+      onSome: (current) =>
+        Effect.annotateLogs(httpEffect, { traceId: current.traceId, spanId: current.spanId }),
+    })
+  }),
+  { global: true },
+)

--- a/app-server/src/logging.ts
+++ b/app-server/src/logging.ts
@@ -1,0 +1,37 @@
+import { Effect, FileSystem, Layer, Logger, References } from "effect"
+import { BuildInfo } from "./buildInfo.ts"
+import { AppConfig } from "./config.ts"
+
+// The structured logging baseline (ATC-121): every server log line goes to a
+// JSON-lines file in the settled state directory; dev runs (running from
+// source, BuildInfo.commit === "dev") additionally get a pretty stderr
+// logger. The minimum level comes from the settled configuration
+// (ATC_LOG_LEVEL / config.toml logLevel). Rotation and redaction are
+// deliberately out of scope until there are secrets and consumers.
+
+/**
+ * Server logging: JSON file + dev stderr + span correlation, with the
+ * configured minimum level. Provided to the serve stack only — CLI client
+ * commands keep the default logger for unexpected defects and print their own
+ * one-line diagnostics.
+ */
+export const layer: Layer.Layer<never, unknown, AppConfig | BuildInfo | FileSystem.FileSystem> =
+  Layer.unwrap(
+    Effect.gen(function* () {
+      const config = yield* AppConfig
+      const build = yield* BuildInfo
+      const fs = yield* FileSystem.FileSystem
+      yield* fs.makeDirectory(config.stateDir, { recursive: true })
+
+      const loggers = [
+        Logger.toFile(Logger.formatJson, config.logFile, { flag: "a" }),
+        // Keeps log lines attached to the active request span as span events.
+        Logger.tracerLogger,
+        ...(build.commit === "dev" ? [Logger.consolePretty({ stderr: true })] : []),
+      ]
+      return Layer.mergeAll(
+        Logger.layer(loggers, { mergeWithExisting: false }),
+        Layer.succeed(References.MinimumLogLevel, config.logLevel),
+      )
+    }),
+  )

--- a/app-server/src/logging.ts
+++ b/app-server/src/logging.ts
@@ -27,11 +27,14 @@ export const layer: Layer.Layer<never, unknown, AppConfig | BuildInfo | FileSyst
         Logger.toFile(Logger.formatJson, config.logFile, { flag: "a" }),
         // Keeps log lines attached to the active request span as span events.
         Logger.tracerLogger,
-        ...(build.commit === "dev" ? [Logger.consolePretty({ stderr: true })] : []),
+        ...(build.commit === "dev" ? [Logger.consolePretty()] : []),
       ]
       return Layer.mergeAll(
         Logger.layer(loggers, { mergeWithExisting: false }),
         Layer.succeed(References.MinimumLogLevel, config.logLevel),
+        // consolePretty ignores its own stderr option; this reference is what
+        // actually routes console loggers to stderr, keeping stdout clean.
+        Layer.succeed(References.LogToStderr, true),
       )
     }),
   )

--- a/app-server/src/migrations.ts
+++ b/app-server/src/migrations.ts
@@ -8,7 +8,7 @@ import { SqlClient } from "effect/unstable/sql"
 // without any filesystem dependency.
 //
 // `Migrator.fromRecord` silently drops keys that don't match /^(\d+)_(.+)$/;
-// migrations.test.ts asserts the loaded count equals the record size so a
+// persistence.test.ts asserts the loaded count equals the record size so a
 // malformed key cannot silently skip a migration.
 
 export const migrations: Record<string, Effect.Effect<void, unknown, SqlClient.SqlClient>> = {

--- a/app-server/src/migrations.ts
+++ b/app-server/src/migrations.ts
@@ -1,0 +1,27 @@
+import { Effect } from "effect"
+import { SqlClient } from "effect/unstable/sql"
+
+// The checked-in, append-only migration record (ATC-121). Keys are
+// `<id>_<name>` (zero-padded for readability; the loader parses the numeric
+// id). Never edit or remove an entry once it has shipped — append a new one.
+// The record is imported into the binary, so the compiled executable migrates
+// without any filesystem dependency.
+//
+// `Migrator.fromRecord` silently drops keys that don't match /^(\d+)_(.+)$/;
+// migrations.test.ts asserts the loaded count equals the record size so a
+// malformed key cannot silently skip a migration.
+
+export const migrations: Record<string, Effect.Effect<void, unknown, SqlClient.SqlClient>> = {
+  "0001_init": Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+    yield* sql`
+      CREATE TABLE projects (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        default_working_directory TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      ) STRICT
+    `
+  }),
+}

--- a/app-server/src/openapi.ts
+++ b/app-server/src/openapi.ts
@@ -4,7 +4,41 @@ import { Api } from "./api.ts"
 // The OpenAPI document derived from the contract. This module is pure — no
 // server, no side effects — so generation works anywhere the contract compiles.
 
-export const openApiDocument = OpenApi.fromApi(Api)
+/**
+ * Hoist single-fragment `allOf` wrappers into their parent schema, e.g.
+ * `{ type: "string", allOf: [{ minLength: 1 }] }` becomes
+ * `{ type: "string", minLength: 1 }` — identical JSON Schema semantics.
+ *
+ * Effect renders every schema check as an `allOf` fragment, and the pinned
+ * Swift OpenAPI generator turns any `allOf`-wrapped property into a nested
+ * single-value wrapper type (`NamePayload(value1:)`) instead of a plain
+ * `String`. Hoisting is applied only when nothing collides, so a future
+ * genuinely-composite `allOf` passes through untouched.
+ */
+const hoistSingleAllOf = (node: unknown): unknown => {
+  if (Array.isArray(node)) return node.map(hoistSingleAllOf)
+  if (typeof node !== "object" || node === null) return node
+  const schema = Object.fromEntries(
+    Object.entries(node).map(([key, value]) => [key, hoistSingleAllOf(value)]),
+  )
+  const allOf = schema["allOf"]
+  if (
+    Array.isArray(allOf) &&
+    allOf.length === 1 &&
+    typeof allOf[0] === "object" &&
+    allOf[0] !== null &&
+    !Array.isArray(allOf[0]) &&
+    Object.keys(allOf[0]).every((key) => !(key in schema) || key === "allOf")
+  ) {
+    const { allOf: _, ...rest } = schema
+    return { ...rest, ...(allOf[0] as Record<string, unknown>) }
+  }
+  return schema
+}
+
+export const openApiDocument = hoistSingleAllOf(OpenApi.fromApi(Api)) as ReturnType<
+  typeof OpenApi.fromApi
+>
 
 /**
  * The canonical serialized form of the document: 2-space indentation and a

--- a/app-server/src/persistence.ts
+++ b/app-server/src/persistence.ts
@@ -1,0 +1,50 @@
+import { SqliteClient, SqliteMigrator } from "@effect/sql-sqlite-bun"
+import { Effect, FileSystem, Layer } from "effect"
+import { Migrator, SqlClient } from "effect/unstable/sql"
+import { AppConfig } from "./config.ts"
+import { migrations } from "./migrations.ts"
+
+// The persistence foundation (ATC-121): a SQLite database in the settled data
+// directory, exposed as the `SqlClient` service with the checked-in migration
+// record already applied. `SqlClient` is the persistence boundary —
+// repositories consume it and own their row types; `sql.withTransaction` is
+// the transaction boundary. Nothing outside a repository speaks SQL.
+//
+// Deliberate SQLite settings:
+//   journal_mode = WAL   concurrent readers during writes (driver default)
+//   busy_timeout = 5s    writers wait instead of failing fast on a locked db
+//   foreign_keys = ON    enforce references once cross-resource tables land
+//
+// Migrations run transactionally at layer build with library bookkeeping
+// (effect_sql_migrations), duplicate-id detection, and concurrent-run
+// locking. A failed migration rolls back and halts boot as a defect naming
+// the migration; the CLI boundary maps it to the one-line stderr contract.
+
+/** PRAGMAs then migration application on top of an existing `SqlClient`. */
+const setup = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+    yield* sql`PRAGMA busy_timeout = 5000`
+    yield* sql`PRAGMA foreign_keys = ON`
+    yield* SqliteMigrator.run({ loader: Migrator.fromRecord(migrations) })
+  }),
+)
+
+/** The migrated `SqlClient` at `file` (test layers point this at temp files). */
+export const layerFile = (file: string): Layer.Layer<SqlClient.SqlClient, unknown, never> =>
+  setup.pipe(Layer.provideMerge(SqliteClient.layer({ filename: file })))
+
+/**
+ * Production persistence: the database at the configured location, creating
+ * the data directory on first run (the directory, never user directories —
+ * see the Domain Model's "ATC never creates or deletes directories" rule,
+ * which is about project working directories).
+ */
+export const layer = Layer.unwrap(
+  Effect.gen(function* () {
+    const config = yield* AppConfig
+    const fs = yield* FileSystem.FileSystem
+    yield* fs.makeDirectory(config.dataDir, { recursive: true })
+    return layerFile(config.dbFile)
+  }),
+)

--- a/app-server/src/projectRepository.ts
+++ b/app-server/src/projectRepository.ts
@@ -1,0 +1,138 @@
+import { Context, Effect, Layer, Option, Schema } from "effect"
+import { SqlClient, SqlSchema } from "effect/unstable/sql"
+import type { Project as ProjectSchema } from "./api.ts"
+
+// The Projects repository (ATC-121): the only module that speaks SQL for
+// projects. Row types stay here — handlers and the contract see plain
+// camelCase project objects shaped like the contract's Project schema.
+
+export type Project = typeof ProjectSchema.Type
+
+/** Internal row shape (snake_case columns, as stored). */
+const ProjectRow = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String,
+  default_working_directory: Schema.String,
+  created_at: Schema.String,
+  updated_at: Schema.String,
+})
+
+const toProject = (row: typeof ProjectRow.Type): Project => ({
+  id: row.id,
+  name: row.name,
+  defaultWorkingDirectory: row.default_working_directory,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+})
+
+export class ProjectRepository extends Context.Service<
+  ProjectRepository,
+  {
+    /** All projects, newest first (UUIDv7 ids are time-ordered). */
+    readonly list: () => Effect.Effect<ReadonlyArray<Project>>
+    readonly create: (input: {
+      readonly name: string
+      readonly defaultWorkingDirectory: string
+    }) => Effect.Effect<Project>
+    readonly get: (id: string) => Effect.Effect<Option.Option<Project>>
+    /** Applies the provided fields and bumps `updatedAt`; `None` if unknown. */
+    readonly update: (
+      id: string,
+      patch: {
+        readonly name?: string | undefined
+        readonly defaultWorkingDirectory?: string | undefined
+      },
+    ) => Effect.Effect<Option.Option<Project>>
+    /** `false` if no such project existed. */
+    readonly delete: (id: string) => Effect.Effect<boolean>
+  }
+>()("app-server/ProjectRepository") {}
+
+// Database failures are defects, not domain errors: the API surfaces them as
+// 500s and the one-line CLI contract reports them; nothing can handle them.
+export const layer = Layer.effect(ProjectRepository)(
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+
+    const listRows = SqlSchema.findAll({
+      Request: Schema.Void,
+      Result: ProjectRow,
+      execute: () => sql`SELECT * FROM projects ORDER BY id DESC`,
+    })
+
+    const getRows = SqlSchema.findAll({
+      Request: Schema.String,
+      Result: ProjectRow,
+      execute: (id) => sql`SELECT * FROM projects WHERE id = ${id}`,
+    })
+
+    const insertRow = SqlSchema.void({
+      Request: ProjectRow,
+      execute: (row) => sql`INSERT INTO projects ${sql.insert(row)}`,
+    })
+
+    const updateRows = SqlSchema.findAll({
+      Request: Schema.Struct({
+        id: Schema.String,
+        name: Schema.NullOr(Schema.String),
+        default_working_directory: Schema.NullOr(Schema.String),
+        updated_at: Schema.String,
+      }),
+      Result: ProjectRow,
+      execute: (patch) => sql`
+        UPDATE projects SET
+          name = COALESCE(${patch.name}, name),
+          default_working_directory = COALESCE(${patch.default_working_directory}, default_working_directory),
+          updated_at = ${patch.updated_at}
+        WHERE id = ${patch.id}
+        RETURNING *
+      `,
+    })
+
+    const deleteRows = SqlSchema.findAll({
+      Request: Schema.String,
+      Result: Schema.Struct({ id: Schema.String }),
+      execute: (id) => sql`DELETE FROM projects WHERE id = ${id} RETURNING id`,
+    })
+
+    return {
+      list: () =>
+        listRows().pipe(
+          Effect.map((rows) => rows.map(toProject)),
+          Effect.orDie,
+        ),
+      create: (input) =>
+        Effect.suspend(() => {
+          const now = new Date().toISOString()
+          const row = {
+            id: Bun.randomUUIDv7(),
+            name: input.name,
+            default_working_directory: input.defaultWorkingDirectory,
+            created_at: now,
+            updated_at: now,
+          }
+          return insertRow(row).pipe(Effect.as(toProject(row)), Effect.orDie)
+        }),
+      get: (id) =>
+        getRows(id).pipe(
+          Effect.map((rows) => Option.fromNullishOr(rows[0]).pipe(Option.map(toProject))),
+          Effect.orDie,
+        ),
+      update: (id, patch) =>
+        updateRows({
+          id,
+          name: patch.name ?? null,
+          default_working_directory: patch.defaultWorkingDirectory ?? null,
+          updated_at: new Date().toISOString(),
+        }).pipe(
+          Effect.map((rows) => Option.fromNullishOr(rows[0]).pipe(Option.map(toProject))),
+          Effect.orDie,
+        ),
+      delete: (id) =>
+        deleteRows(id).pipe(
+          Effect.map((rows) => rows.length > 0),
+          Effect.orDie,
+        ),
+    }
+  }),
+)

--- a/app-server/src/projectRepository.ts
+++ b/app-server/src/projectRepository.ts
@@ -95,39 +95,39 @@ export const layer = Layer.effect(ProjectRepository)(
       execute: (id) => sql`DELETE FROM projects WHERE id = ${id} RETURNING id`,
     })
 
+    const firstProject = (rows: ReadonlyArray<typeof ProjectRow.Type>) =>
+      Option.fromNullishOr(rows[0]).pipe(Option.map(toProject))
+
+    const get = (id: string) => getRows(id).pipe(Effect.map(firstProject), Effect.orDie)
+
     return {
       list: () =>
         listRows().pipe(
           Effect.map((rows) => rows.map(toProject)),
           Effect.orDie,
         ),
-      create: (input) =>
-        Effect.suspend(() => {
-          const now = new Date().toISOString()
-          const row = {
-            id: Bun.randomUUIDv7(),
-            name: input.name,
-            default_working_directory: input.defaultWorkingDirectory,
-            created_at: now,
-            updated_at: now,
-          }
-          return insertRow(row).pipe(Effect.as(toProject(row)), Effect.orDie)
-        }),
-      get: (id) =>
-        getRows(id).pipe(
-          Effect.map((rows) => Option.fromNullishOr(rows[0]).pipe(Option.map(toProject))),
-          Effect.orDie,
-        ),
+      create: (input) => {
+        const now = new Date().toISOString()
+        const row = {
+          id: Bun.randomUUIDv7(),
+          name: input.name,
+          default_working_directory: input.defaultWorkingDirectory,
+          created_at: now,
+          updated_at: now,
+        }
+        return insertRow(row).pipe(Effect.as(toProject(row)), Effect.orDie)
+      },
+      get,
       update: (id, patch) =>
-        updateRows({
-          id,
-          name: patch.name ?? null,
-          default_working_directory: patch.defaultWorkingDirectory ?? null,
-          updated_at: new Date().toISOString(),
-        }).pipe(
-          Effect.map((rows) => Option.fromNullishOr(rows[0]).pipe(Option.map(toProject))),
-          Effect.orDie,
-        ),
+        // An empty patch changes nothing — including updatedAt.
+        patch.name === undefined && patch.defaultWorkingDirectory === undefined
+          ? get(id)
+          : updateRows({
+              id,
+              name: patch.name ?? null,
+              default_working_directory: patch.defaultWorkingDirectory ?? null,
+              updated_at: new Date().toISOString(),
+            }).pipe(Effect.map(firstProject), Effect.orDie),
       delete: (id) =>
         deleteRows(id).pipe(
           Effect.map((rows) => rows.length > 0),

--- a/app-server/src/server.ts
+++ b/app-server/src/server.ts
@@ -1,19 +1,28 @@
 import { BunHttpServer } from "@effect/platform-bun"
 import { Layer } from "effect"
-import { HttpRouter } from "effect/unstable/http"
+import { HttpMiddleware, HttpRouter } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { Api } from "./api.ts"
 import { V1Handlers } from "./handlers.ts"
-
-/** All HTTP routes, independent of any listener. Requires BuildInfo. */
-export const routes = HttpApiBuilder.layer(Api).pipe(Layer.provide(V1Handlers))
+import * as LocalTrust from "./localTrust.ts"
 
 /**
- * The full server: routes on a loopback TCP listener. The layer's scope owns
- * the listener, so closing the scope (e.g. on SIGINT/SIGTERM interruption)
- * stops the server and releases the port.
+ * All HTTP routes with the local-trust guard applied, independent of any
+ * listener. Requires the handler services (BuildInfo, ProjectRepository,
+ * Directories).
+ */
+export const routes = Layer.mergeAll(
+  HttpApiBuilder.layer(Api).pipe(Layer.provide(V1Handlers)),
+  LocalTrust.middleware,
+)
+
+/**
+ * The full server: guarded routes on a loopback TCP listener, each request
+ * wrapped in a tracer span (the correlation id source for logs). The layer's
+ * scope owns the listener, so closing the scope (e.g. on SIGINT/SIGTERM
+ * interruption) stops the server and releases the port.
  */
 export const layer = (options: { readonly port: number }) =>
-  HttpRouter.serve(routes).pipe(
+  HttpRouter.serve(routes, { middleware: HttpMiddleware.tracer }).pipe(
     Layer.provideMerge(BunHttpServer.layer({ port: options.port, hostname: "127.0.0.1" })),
   )

--- a/app-server/test/api.test.ts
+++ b/app-server/test/api.test.ts
@@ -176,7 +176,8 @@ describe("/api/v1/fs/check", () => {
       const available = yield* client.v1.checkDirectory({ query: { path: linkedDir } })
       assert.strictEqual(available.state, "available")
       assert.strictEqual(available.path, realDir)
-      assert.isNull(available.reason)
+      // reason is an absent key (never null) when the state is conclusive.
+      assert.isUndefined(available.reason)
       assert.isFalse(Number.isNaN(Date.parse(available.checkedAt)))
 
       const missing = yield* client.v1.checkDirectory({

--- a/app-server/test/api.test.ts
+++ b/app-server/test/api.test.ts
@@ -2,14 +2,20 @@ import { assert, describe, it } from "@effect/vitest"
 import { BunHttpServer } from "@effect/platform-bun"
 import { Effect, Layer } from "effect"
 import { HttpApiTest } from "effect/unstable/httpapi"
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { realpathSync } from "node:fs"
+import { afterAll } from "vitest"
 import { Api } from "../src/api.ts"
 import { V1Handlers } from "../src/handlers.ts"
 import { TestBuildInfoLayer, testBuildInfo } from "./testBuildInfo.ts"
+import { TestRepositoryLayers } from "./testLayers.ts"
 
 // In-process contract tests: the same encode/route/decode pipeline as the real
 // server, but no listener.
 const TestLayer = Layer.mergeAll(
-  V1Handlers.pipe(Layer.provide(TestBuildInfoLayer)),
+  V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, TestRepositoryLayers])),
   BunHttpServer.layerHttpServices,
 )
 
@@ -32,6 +38,155 @@ describe("/api/v1", () => {
         commit: testBuildInfo.commit,
         builtAt: testBuildInfo.builtAt,
       })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+})
+
+// Real directories for validation coverage. macOS tmpdir is itself behind a
+// symlink, so expectations always go through realpathSync.
+const scratch = mkdtempSync(join(tmpdir(), "atc-api-test-"))
+afterAll(() => rmSync(scratch, { recursive: true, force: true }))
+
+const realDir = realpathSync(scratch)
+const linkedDir = join(scratch, "linked")
+symlinkSync(realDir, linkedDir)
+const filePath = join(scratch, "a-file")
+writeFileSync(filePath, "not a directory")
+mkdirSync(join(scratch, "second"))
+
+describe("/api/v1/projects", () => {
+  it.effect("creates, lists, gets, updates, and deletes a project", () =>
+    Effect.gen(function* () {
+      const client = yield* HttpApiTest.groups(Api, ["v1"])
+
+      // Create canonicalizes the symlinked directory to its real path.
+      const created = yield* client.v1.createProject({
+        payload: { name: "Atelier", defaultWorkingDirectory: linkedDir },
+      })
+      assert.strictEqual(created.name, "Atelier")
+      assert.strictEqual(created.defaultWorkingDirectory, realDir)
+      assert.match(
+        created.id,
+        /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+        "UUIDv7 id",
+      )
+      assert.strictEqual(created.createdAt, created.updatedAt)
+
+      assert.deepStrictEqual(yield* client.v1.listProjects(), [created])
+      assert.deepStrictEqual(
+        yield* client.v1.getProject({ params: { projectId: created.id } }),
+        created,
+      )
+
+      const renamed = yield* client.v1.updateProject({
+        params: { projectId: created.id },
+        payload: { name: "Renamed" },
+      })
+      assert.strictEqual(renamed.name, "Renamed")
+      assert.strictEqual(renamed.defaultWorkingDirectory, realDir)
+      assert.isAtLeast(Date.parse(renamed.updatedAt), Date.parse(created.updatedAt))
+
+      const moved = yield* client.v1.updateProject({
+        params: { projectId: created.id },
+        payload: { defaultWorkingDirectory: join(realDir, "second") },
+      })
+      assert.strictEqual(moved.name, "Renamed")
+      assert.strictEqual(moved.defaultWorkingDirectory, join(realDir, "second"))
+
+      yield* client.v1.deleteProject({ params: { projectId: created.id } })
+      assert.deepStrictEqual(yield* client.v1.listProjects(), [])
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("unknown ids are ProjectNotFound on get, update, and delete", () =>
+    Effect.gen(function* () {
+      const client = yield* HttpApiTest.groups(Api, ["v1"])
+      for (const attempt of [
+        client.v1.getProject({ params: { projectId: "missing" } }),
+        client.v1.updateProject({ params: { projectId: "missing" }, payload: { name: "x" } }),
+        client.v1.deleteProject({ params: { projectId: "missing" } }),
+      ]) {
+        const error = yield* Effect.flip(attempt)
+        assert.strictEqual(error._tag, "ProjectNotFound")
+        if (error._tag === "ProjectNotFound") assert.strictEqual(error.projectId, "missing")
+      }
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("rejects unusable directories with the tagged state, touching nothing", () =>
+    Effect.gen(function* () {
+      const client = yield* HttpApiTest.groups(Api, ["v1"])
+
+      const missing = yield* Effect.flip(
+        client.v1.createProject({
+          payload: { name: "P", defaultWorkingDirectory: join(realDir, "nope") },
+        }),
+      )
+      assert.strictEqual(missing._tag, "DirectoryUnavailable")
+      if (missing._tag === "DirectoryUnavailable") assert.strictEqual(missing.state, "missing")
+
+      const notDirectory = yield* Effect.flip(
+        client.v1.createProject({ payload: { name: "P", defaultWorkingDirectory: filePath } }),
+      )
+      assert.strictEqual(notDirectory._tag, "DirectoryUnavailable")
+      if (notDirectory._tag === "DirectoryUnavailable") {
+        assert.strictEqual(notDirectory.state, "not_directory")
+      }
+
+      // A failed create leaves nothing behind, and an update rejection leaves
+      // the stored directory unchanged.
+      assert.deepStrictEqual(yield* client.v1.listProjects(), [])
+      const created = yield* client.v1.createProject({
+        payload: { name: "P", defaultWorkingDirectory: realDir },
+      })
+      const rejected = yield* Effect.flip(
+        client.v1.updateProject({
+          params: { projectId: created.id },
+          payload: { defaultWorkingDirectory: join(realDir, "nope") },
+        }),
+      )
+      assert.strictEqual(rejected._tag, "DirectoryUnavailable")
+      assert.deepStrictEqual(
+        yield* client.v1.getProject({ params: { projectId: created.id } }),
+        created,
+      )
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("rejects relative paths at the schema boundary", () =>
+    Effect.gen(function* () {
+      const client = yield* HttpApiTest.groups(Api, ["v1"])
+      const error = yield* Effect.flip(
+        client.v1.createProject({
+          payload: { name: "P", defaultWorkingDirectory: "relative/path" },
+        }),
+      )
+      // Encoding fails client-side before any request: the contract's
+      // AbsolutePath check applies to the typed client too.
+      assert.strictEqual(error._tag, "SchemaError")
+    }).pipe(Effect.provide(TestLayer)),
+  )
+})
+
+describe("/api/v1/fs/check", () => {
+  it.effect("reports the tagged directory states", () =>
+    Effect.gen(function* () {
+      const client = yield* HttpApiTest.groups(Api, ["v1"])
+
+      const available = yield* client.v1.checkDirectory({ query: { path: linkedDir } })
+      assert.strictEqual(available.state, "available")
+      assert.strictEqual(available.path, realDir)
+      assert.isNull(available.reason)
+      assert.isFalse(Number.isNaN(Date.parse(available.checkedAt)))
+
+      const missing = yield* client.v1.checkDirectory({
+        query: { path: join(realDir, "nope") },
+      })
+      assert.strictEqual(missing.state, "missing")
+      assert.strictEqual(missing.path, join(realDir, "nope"))
+
+      const notDirectory = yield* client.v1.checkDirectory({ query: { path: filePath } })
+      assert.strictEqual(notDirectory.state, "not_directory")
     }).pipe(Effect.provide(TestLayer)),
   )
 })

--- a/app-server/test/api.test.ts
+++ b/app-server/test/api.test.ts
@@ -187,6 +187,12 @@ describe("/api/v1/fs/check", () => {
 
       const notDirectory = yield* client.v1.checkDirectory({ query: { path: filePath } })
       assert.strictEqual(notDirectory.state, "not_directory")
+
+      // A path component that exists but is a file (ENOTDIR), not ENOENT.
+      const throughFile = yield* client.v1.checkDirectory({
+        query: { path: join(filePath, "sub") },
+      })
+      assert.strictEqual(throughFile.state, "not_directory")
     }).pipe(Effect.provide(TestLayer)),
   )
 })

--- a/app-server/test/blackbox.ts
+++ b/app-server/test/blackbox.ts
@@ -10,14 +10,29 @@ export const appServerRoot = fileURLToPath(new URL("..", import.meta.url))
 export const compiledBinaryPath =
   process.env["ATC_COMPILED_BIN"] ?? `${appServerRoot}dist/atc-${process.platform}-${process.arch}`
 
+/**
+ * Environment pointing every settled location (config, data, state) into
+ * `dir`, so spawned servers and CLI commands never touch the real user
+ * locations on the machine running the tests.
+ */
+export const isolatedEnv = (dir: string, extra: Record<string, string> = {}) => ({
+  ...process.env,
+  XDG_CONFIG_HOME: `${dir}/config`,
+  XDG_DATA_HOME: `${dir}/data`,
+  XDG_STATE_HOME: `${dir}/state`,
+  ...extra,
+})
+
 /** Spawn `<command> serve --port <port>`; `command` is the program plus any leading args. */
 export const spawnServe = (
   command: ReadonlyArray<string>,
   port: number,
   cwd: string = appServerRoot,
+  env: Record<string, string | undefined> = process.env,
 ) =>
   Bun.spawn([...command, "serve", "--port", String(port)], {
     cwd,
+    env,
     stdout: "pipe",
     stderr: "pipe",
   })
@@ -31,8 +46,9 @@ export const runCli = async (
   command: ReadonlyArray<string>,
   args: ReadonlyArray<string>,
   cwd: string,
+  env: Record<string, string | undefined> = process.env,
 ) => {
-  const proc = Bun.spawn([...command, ...args], { cwd, stdout: "pipe", stderr: "pipe" })
+  const proc = Bun.spawn([...command, ...args], { cwd, env, stdout: "pipe", stderr: "pipe" })
   const [stdout, stderr, exitCode] = await Promise.all([
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),

--- a/app-server/test/cli.blackbox.test.ts
+++ b/app-server/test/cli.blackbox.test.ts
@@ -1,43 +1,58 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { afterAll, beforeAll, describe, expect, test } from "vitest"
 import packageJson from "../package.json"
-import { appServerRoot, freePort, runCli, spawnServe, waitForHealth } from "./blackbox.ts"
+import {
+  appServerRoot,
+  freePort,
+  isolatedEnv,
+  runCli,
+  spawnServe,
+  waitForHealth,
+} from "./blackbox.ts"
 
 // Black-box tests of the client-backed CLI commands: exact stdout, stderr,
 // and exit codes, against a real `atc serve` spawned from source.
 //
-// Contract: success prints the JSON payload (2-space indented) on stdout and
-// exits 0 with empty stderr; request failures print one `atc <command>:` line
+// Contract: API-backed commands take zero connection flags — the base URL is
+// derived from the settled configuration (ATC_PORT > config.toml > default).
+// Success prints the JSON payload (2-space indented) on stdout and exits 0
+// with empty stderr; config/request failures print one `atc <command>:` line
 // on stderr and exit 1 with empty stdout; invalid usage prints an ERROR block
 // on stderr (help goes to stdout) and exits 1.
 
-const cli = (args: ReadonlyArray<string>) =>
-  runCli([process.execPath, "src/main.ts"], args, appServerRoot)
-
+const scratch = mkdtempSync(join(tmpdir(), "atc-cli-blackbox-"))
 let serverPort: number
-let base: string
+let env: Record<string, string | undefined>
+
+const cli = (args: ReadonlyArray<string>, extraEnv: Record<string, string> = {}) =>
+  runCli([process.execPath, "src/main.ts"], args, appServerRoot, { ...env, ...extraEnv })
+
 let server: Bun.Subprocess
 
 beforeAll(async () => {
   serverPort = await freePort()
-  base = `http://127.0.0.1:${serverPort}`
-  server = spawnServe([process.execPath, "src/main.ts"], serverPort, appServerRoot)
-  await waitForHealth(base, server)
+  env = isolatedEnv(scratch, { ATC_PORT: String(serverPort) })
+  server = spawnServe([process.execPath, "src/main.ts"], serverPort, appServerRoot, env)
+  await waitForHealth(`http://127.0.0.1:${serverPort}`, server)
 })
 
 afterAll(() => {
   server.kill()
+  rmSync(scratch, { recursive: true, force: true })
 })
 
 describe("atc health/version (black box)", () => {
-  test("health prints the payload JSON and exits 0", async () => {
-    const result = await cli(["health", "--url", base])
+  test("health resolves the server from ATC_PORT and exits 0", async () => {
+    const result = await cli(["health"])
     expect(result.stdout).toBe('{\n  "status": "ok"\n}\n')
     expect(result.stderr).toBe("")
     expect(result.exitCode).toBe(0)
   })
 
   test("version prints the payload JSON and exits 0", async () => {
-    const result = await cli(["version", "--url", base])
+    const result = await cli(["version"])
     // Running from source, build metadata is deterministic dev placeholders.
     const expected = {
       version: packageJson.version,
@@ -50,11 +65,27 @@ describe("atc health/version (black box)", () => {
     expect(result.exitCode).toBe(0)
   })
 
+  test("the config file supplies the port when the environment is silent", async () => {
+    const configFile = join(scratch, "config.toml")
+    await Bun.write(configFile, `port = ${serverPort}\n`)
+    const result = await cli(["health"], { ATC_PORT: "", ATC_CONFIG: configFile })
+    expect(result.stdout).toBe('{\n  "status": "ok"\n}\n')
+    expect(result.exitCode).toBe(0)
+  })
+
   test("an unreachable server is one stderr line and exit 1", async () => {
     // Port 1 is privileged and never bound by tests, so refusal is
     // deterministic — unlike a released ephemeral port, which another
     // parallel test worker could rebind.
-    const result = await cli(["health", "--url", "http://127.0.0.1:1"])
+    const result = await cli(["health"], { ATC_PORT: "1" })
+    expect(result.stdout).toBe("")
+    expect(result.stderr).toMatch(/^atc health: /)
+    expect(result.stderr.trim().split("\n")).toHaveLength(1)
+    expect(result.exitCode).toBe(1)
+  })
+
+  test("invalid configuration is one stderr line naming the source and exit 1", async () => {
+    const result = await cli(["health"], { ATC_PORT: "70000" })
     expect(result.stdout).toBe("")
     expect(result.stderr).toMatch(/^atc health: /)
     expect(result.stderr.trim().split("\n")).toHaveLength(1)
@@ -68,7 +99,7 @@ describe("atc health/version (black box)", () => {
       fetch: () => Response.json({ status: "degraded" }),
     })
     try {
-      const result = await cli(["health", "--url", `http://127.0.0.1:${misbehaving.port}`])
+      const result = await cli(["health"], { ATC_PORT: String(misbehaving.port) })
       expect(result.stdout).toBe("")
       expect(result.stderr).toMatch(/^atc health: /)
       // Schema decode errors are multi-line by default; the CLI must collapse
@@ -80,16 +111,68 @@ describe("atc health/version (black box)", () => {
     }
   })
 
-  test("a missing --url flag is invalid usage: help on stdout, error on stderr, exit 1", async () => {
-    const result = await cli(["health"])
-    expect(result.stdout).toContain("USAGE")
+  test("the removed --url flag is invalid usage and exits 1", async () => {
+    const result = await cli(["health", "--url", "http://127.0.0.1:1"])
     expect(result.stderr).toContain("--url")
     expect(result.exitCode).toBe(1)
   })
+})
 
-  test("a malformed --url value is invalid usage and exits 1", async () => {
-    const result = await cli(["version", "--url", "not a url"])
-    expect(result.stderr).toContain("--url")
+describe("atc project / atc fs (black box)", () => {
+  test("the server created and migrated the database in the configured data directory", () => {
+    expect(existsSync(join(scratch, "data", "atc", "atc.db"))).toBe(true)
+  })
+
+  test("project lifecycle: create, list, get, update, delete", async () => {
+    const created = await cli(["project", "create", "--name", "BlackBox", "--directory", scratch])
+    expect(created.stderr).toBe("")
+    expect(created.exitCode).toBe(0)
+    const project = JSON.parse(created.stdout) as { id: string; name: string }
+    expect(project.name).toBe("BlackBox")
+
+    const listed = await cli(["project", "list"])
+    expect(JSON.parse(listed.stdout)).toEqual([project])
+
+    const fetched = await cli(["project", "get", project.id])
+    expect(JSON.parse(fetched.stdout)).toEqual(project)
+
+    const updated = await cli(["project", "update", project.id, "--name", "Renamed"])
+    expect((JSON.parse(updated.stdout) as { name: string }).name).toBe("Renamed")
+
+    // Deletion requires explicit confirmation; the CLI never prompts.
+    const refused = await cli(["project", "delete", project.id])
+    expect(refused.stderr).toContain("--yes")
+    expect(refused.exitCode).toBe(1)
+
+    const deleted = await cli(["project", "delete", project.id, "--yes"])
+    expect(deleted.stderr).toBe("")
+    expect(deleted.exitCode).toBe(0)
+
+    const empty = await cli(["project", "list"])
+    expect(JSON.parse(empty.stdout)).toEqual([])
+  })
+
+  test("a missing directory is one stderr line and exit 1", async () => {
+    const result = await cli([
+      "project",
+      "create",
+      "--name",
+      "Nope",
+      "--directory",
+      join(scratch, "does-not-exist"),
+    ])
+    expect(result.stdout).toBe("")
+    expect(result.stderr).toMatch(/^atc project create: /)
     expect(result.exitCode).toBe(1)
+  })
+
+  test("fs check resolves relative paths client-side and reports health", async () => {
+    const available = await cli(["fs", "check", "."])
+    expect(available.exitCode).toBe(0)
+    expect((JSON.parse(available.stdout) as { state: string }).state).toBe("available")
+
+    const missing = await cli(["fs", "check", join(scratch, "does-not-exist")])
+    expect(missing.exitCode).toBe(0)
+    expect((JSON.parse(missing.stdout) as { state: string }).state).toBe("missing")
   })
 })

--- a/app-server/test/cli.blackbox.test.ts
+++ b/app-server/test/cli.blackbox.test.ts
@@ -79,7 +79,7 @@ describe("atc health/version (black box)", () => {
     // parallel test worker could rebind.
     const result = await cli(["health"], { ATC_PORT: "1" })
     expect(result.stdout).toBe("")
-    expect(result.stderr).toMatch(/^atc health: /)
+    expect(result.stderr).toMatch(/^atc health: \S/)
     expect(result.stderr.trim().split("\n")).toHaveLength(1)
     expect(result.exitCode).toBe(1)
   })
@@ -87,7 +87,8 @@ describe("atc health/version (black box)", () => {
   test("invalid configuration is one stderr line naming the source and exit 1", async () => {
     const result = await cli(["health"], { ATC_PORT: "70000" })
     expect(result.stdout).toBe("")
-    expect(result.stderr).toMatch(/^atc health: /)
+    expect(result.stderr).toMatch(/^atc health: \S/)
+    expect(result.stderr).toContain("65535")
     expect(result.stderr.trim().split("\n")).toHaveLength(1)
     expect(result.exitCode).toBe(1)
   })
@@ -101,7 +102,7 @@ describe("atc health/version (black box)", () => {
     try {
       const result = await cli(["health"], { ATC_PORT: String(misbehaving.port) })
       expect(result.stdout).toBe("")
-      expect(result.stderr).toMatch(/^atc health: /)
+      expect(result.stderr).toMatch(/^atc health: \S/)
       // Schema decode errors are multi-line by default; the CLI must collapse
       // them to keep the one-line diagnostic contract.
       expect(result.stderr.trim().split("\n")).toHaveLength(1)
@@ -145,8 +146,14 @@ describe("atc project / atc fs (black box)", () => {
     expect(refused.exitCode).toBe(1)
 
     const deleted = await cli(["project", "delete", project.id, "--yes"])
+    expect(deleted.stdout).toBe("")
     expect(deleted.stderr).toBe("")
     expect(deleted.exitCode).toBe(0)
+
+    // A second delete of the same id is a real diagnostic, not an empty line.
+    const gone = await cli(["project", "delete", project.id, "--yes"])
+    expect(gone.stderr.trim()).toBe(`atc project delete: no project with id ${project.id}`)
+    expect(gone.exitCode).toBe(1)
 
     const empty = await cli(["project", "list"])
     expect(JSON.parse(empty.stdout)).toEqual([])
@@ -162,7 +169,9 @@ describe("atc project / atc fs (black box)", () => {
       join(scratch, "does-not-exist"),
     ])
     expect(result.stdout).toBe("")
-    expect(result.stderr).toMatch(/^atc project create: /)
+    // The tagged API error surfaces as a human diagnostic, never a bare tag
+    // or an empty line.
+    expect(result.stderr).toMatch(/^atc project create: directory .* does not exist$/m)
     expect(result.exitCode).toBe(1)
   })
 

--- a/app-server/test/cli.test.ts
+++ b/app-server/test/cli.test.ts
@@ -1,15 +1,14 @@
 import { assert, describe, it } from "@effect/vitest"
 import { BunServices } from "@effect/platform-bun"
-import { Effect } from "effect"
+import { Effect, Option } from "effect"
 import { CliError, Command } from "effect/unstable/cli"
-import { DEFAULT_PORT } from "../src/api.ts"
 import { port } from "../src/cli.ts"
 
 // Parse the real --port flag against a probe command so validation is tested
 // without starting a server.
 const parsePort = (args: ReadonlyArray<string>) =>
   Effect.gen(function* () {
-    let parsed: number | undefined
+    let parsed: Option.Option<number> | undefined
     const probe = Command.make("probe", { port }, ({ port }) =>
       Effect.sync(() => {
         parsed = port
@@ -20,17 +19,20 @@ const parsePort = (args: ReadonlyArray<string>) =>
   }).pipe(Effect.provide(BunServices.layer))
 
 describe("serve --port validation", () => {
-  it.effect("defaults to the dev port", () =>
+  // The flag is optional: absent means "use the configured port", so the
+  // configuration pipeline (flags > env > file > default) stays the single
+  // source of the effective port.
+  it.effect("is absent by default", () =>
     Effect.gen(function* () {
       const { parsed } = yield* parsePort([])
-      assert.strictEqual(parsed, DEFAULT_PORT)
+      assert.deepStrictEqual(parsed, Option.none())
     }),
   )
 
   it.effect("accepts a valid port", () =>
     Effect.gen(function* () {
       const { parsed } = yield* parsePort(["--port", "8080"])
-      assert.strictEqual(parsed, 8080)
+      assert.deepStrictEqual(parsed, Option.some(8080))
     }),
   )
 

--- a/app-server/test/client.test.ts
+++ b/app-server/test/client.test.ts
@@ -5,6 +5,7 @@ import * as Client from "../src/client.ts"
 import * as Server from "../src/server.ts"
 import { freePort } from "./blackbox.ts"
 import { TestBuildInfoLayer, testBuildInfo } from "./testBuildInfo.ts"
+import { TestRepositoryLayers } from "./testLayers.ts"
 
 // The contract-derived client against a real ephemeral App Server: a live
 // loopback listener, real HTTP, schema-decoded responses.
@@ -12,7 +13,9 @@ import { TestBuildInfoLayer, testBuildInfo } from "./testBuildInfo.ts"
 const withServer = <A, E, R>(run: (baseUrl: string) => Effect.Effect<A, E, R>) =>
   Effect.gen(function* () {
     const port = yield* Effect.promise(freePort)
-    yield* Layer.build(Server.layer({ port }).pipe(Layer.provide(TestBuildInfoLayer)))
+    yield* Layer.build(
+      Server.layer({ port }).pipe(Layer.provide([TestBuildInfoLayer, TestRepositoryLayers])),
+    )
     return yield* run(`http://127.0.0.1:${port}`)
   }).pipe(Effect.scoped)
 

--- a/app-server/test/compiled.blackbox.test.ts
+++ b/app-server/test/compiled.blackbox.test.ts
@@ -3,11 +3,21 @@ import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { describe, expect, test } from "vitest"
-import { compiledBinaryPath, freePort, runCli, spawnServe, waitForHealth } from "./blackbox.ts"
+import {
+  compiledBinaryPath,
+  freePort,
+  isolatedEnv,
+  runCli,
+  spawnServe,
+  waitForHealth,
+} from "./blackbox.ts"
 
 // Black-box validation of the compiled artifact: the standalone executable
-// must serve health/version with real injected build metadata and shut down
-// cleanly, all from a working directory outside the repository.
+// must serve health/version with real injected build metadata, create and
+// migrate its database in the configured data directory, survive a restart as
+// a clean no-op, resolve flag-less CLI commands from the same configuration,
+// enforce the loopback trust boundary, and shut down cleanly — all from a
+// working directory outside the repository.
 //
 // Opt-in (mise run test:compiled) so the default fast suite never depends on
 // a build; CI runs it natively on macOS arm64 and Linux x64.
@@ -16,22 +26,30 @@ const enabled =
   process.env["ATC_COMPILED_TEST"] === "1" || process.env["ATC_COMPILED_BIN"] !== undefined
 
 describe.skipIf(!enabled)("compiled atc artifact (opt-in: mise run test:compiled)", () => {
-  test("serves health/version with injected build metadata from outside the repository and exits cleanly on SIGTERM", async () => {
+  test("serves, persists, restarts cleanly, and enforces local trust from outside the repository", async () => {
     expect(
       existsSync(compiledBinaryPath),
       `missing compiled artifact at ${compiledBinaryPath}; run \`mise run build\``,
     ).toBe(true)
 
-    // A scratch cwd outside the repository: compiled behavior must not
-    // depend on the repository working directory.
+    // A scratch cwd and isolated XDG locations outside the repository:
+    // compiled behavior must depend on neither the working directory nor the
+    // developer's real config/data/state.
     const outsideCwd = mkdtempSync(join(tmpdir(), "atc-compiled-"))
     const port = await freePort()
+    const env = isolatedEnv(outsideCwd, { ATC_PORT: String(port) })
     const base = `http://127.0.0.1:${port}`
-    const proc = spawnServe([compiledBinaryPath], port, outsideCwd)
+    const dbFile = join(outsideCwd, "data", "atc", "atc.db")
+    let proc = spawnServe([compiledBinaryPath], port, outsideCwd, env)
     try {
       const health = await waitForHealth(base, proc)
       expect(health.status).toBe(200)
       expect(await health.json()).toEqual({ status: "ok" })
+
+      // First boot created and migrated the database in the configured
+      // data directory, and the log file landed in the state directory.
+      expect(existsSync(dbFile)).toBe(true)
+      expect(existsSync(join(outsideCwd, "state", "atc", "atc.log"))).toBe(true)
 
       const version = await fetch(`${base}/api/v1/version`)
       expect(version.status).toBe(200)
@@ -47,17 +65,47 @@ describe.skipIf(!enabled)("compiled atc artifact (opt-in: mise run test:compiled
       expect(body.commit).toMatch(/^[0-9a-f]{40}(-dirty)?$/)
       expect(Number.isNaN(Date.parse(body.builtAt))).toBe(false)
 
-      // The client-backed commands ship in the same executable and must work
-      // against a live server from outside the repository too.
-      const healthCli = await runCli([compiledBinaryPath], ["health", "--url", base], outsideCwd)
+      // The local trust boundary ships in the executable: cross-origin
+      // browser requests are rejected.
+      const crossOrigin = await fetch(`${base}/api/v1/health`, {
+        headers: { Origin: "http://evil.example" },
+      })
+      expect(crossOrigin.status).toBe(403)
+
+      // Flag-less CLI commands resolve the server from the same settled
+      // configuration the server booted from.
+      const healthCli = await runCli([compiledBinaryPath], ["health"], outsideCwd, env)
       expect(healthCli.stdout).toBe('{\n  "status": "ok"\n}\n')
       expect(healthCli.stderr).toBe("")
       expect(healthCli.exitCode).toBe(0)
 
-      const versionCli = await runCli([compiledBinaryPath], ["version", "--url", base], outsideCwd)
+      const versionCli = await runCli([compiledBinaryPath], ["version"], outsideCwd, env)
       expect(JSON.parse(versionCli.stdout)).toEqual(body)
-      expect(versionCli.stderr).toBe("")
       expect(versionCli.exitCode).toBe(0)
+
+      // The full persistence stack works in the compiled binary.
+      const created = await runCli(
+        [compiledBinaryPath],
+        ["project", "create", "--name", "Compiled", "--directory", outsideCwd],
+        outsideCwd,
+        env,
+      )
+      expect(created.stderr).toBe("")
+      expect(created.exitCode).toBe(0)
+      const project = JSON.parse(created.stdout) as { id: string }
+
+      proc.kill("SIGTERM")
+      expect(await proc.exited).toBe(130)
+
+      // Restart against the same data directory: migrations are a clean
+      // no-op and the durable record is still there.
+      proc = spawnServe([compiledBinaryPath], port, outsideCwd, env)
+      const restarted = await waitForHealth(base, proc)
+      expect(restarted.status).toBe(200)
+      const listed = await runCli([compiledBinaryPath], ["project", "list"], outsideCwd, env)
+      expect((JSON.parse(listed.stdout) as Array<{ id: string }>).map((p) => p.id)).toEqual([
+        project.id,
+      ])
 
       proc.kill("SIGTERM")
       expect(await proc.exited).toBe(130)
@@ -65,5 +113,5 @@ describe.skipIf(!enabled)("compiled atc artifact (opt-in: mise run test:compiled
       proc.kill()
       rmSync(outsideCwd, { recursive: true, force: true })
     }
-  }, 30_000)
+  }, 60_000)
 })

--- a/app-server/test/config.test.ts
+++ b/app-server/test/config.test.ts
@@ -154,4 +154,12 @@ describe("configuration", () => {
       assert.include(error.message, "absolute")
     }),
   )
+
+  it.effect("a relative state directory is rejected", () =>
+    Effect.gen(function* () {
+      const error = yield* loadError({ XDG_STATE_HOME: "relative-state" })
+      assert.include(error.message, "absolute")
+      assert.include(error.source, "XDG_STATE_HOME")
+    }),
+  )
 })

--- a/app-server/test/config.test.ts
+++ b/app-server/test/config.test.ts
@@ -2,7 +2,7 @@ import { assert, describe, it } from "@effect/vitest"
 import { BunFileSystem } from "@effect/platform-bun"
 import { Effect } from "effect"
 import { mkdtempSync, rmSync } from "node:fs"
-import { tmpdir, homedir } from "node:os"
+import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterAll } from "vitest"
 import { DEFAULT_PORT } from "../src/api.ts"
@@ -21,22 +21,27 @@ const writeConfig = (contents: string) => {
   return file
 }
 
-const load = (env: Config.Env) => Config.load(env).pipe(Effect.provide(BunFileSystem.layer))
+// Every test injects HOME so results never depend on the developer's real
+// ~/.config/atc/config.toml.
+const home = join(scratch, "home")
+
+const load = (env: Config.Env) =>
+  Config.load({ HOME: home, ...env }).pipe(Effect.provide(BunFileSystem.layer))
 
 const loadError = (env: Config.Env) =>
-  Config.load(env).pipe(Effect.flip, Effect.provide(BunFileSystem.layer))
+  Config.load({ HOME: home, ...env }).pipe(Effect.flip, Effect.provide(BunFileSystem.layer))
 
 describe("configuration", () => {
-  it.effect("defaults: XDG locations and default port", () =>
+  it.effect("defaults: XDG locations under HOME and the default port", () =>
     Effect.gen(function* () {
       const config = yield* load({})
       assert.strictEqual(config.port, DEFAULT_PORT)
       assert.strictEqual(config.logLevel, "Info")
-      assert.strictEqual(config.configFile, join(homedir(), ".config", "atc", "config.toml"))
-      assert.strictEqual(config.dataDir, join(homedir(), ".local", "share", "atc"))
-      assert.strictEqual(config.stateDir, join(homedir(), ".local", "state", "atc"))
-      assert.strictEqual(config.dbFile, join(homedir(), ".local", "share", "atc", "atc.db"))
-      assert.strictEqual(config.logFile, join(homedir(), ".local", "state", "atc", "atc.log"))
+      assert.strictEqual(config.configFile, join(home, ".config", "atc", "config.toml"))
+      assert.strictEqual(config.dataDir, join(home, ".local", "share", "atc"))
+      assert.strictEqual(config.stateDir, join(home, ".local", "state", "atc"))
+      assert.strictEqual(config.dbFile, join(home, ".local", "share", "atc", "atc.db"))
+      assert.strictEqual(config.logFile, join(home, ".local", "state", "atc", "atc.log"))
     }),
   )
 
@@ -124,6 +129,29 @@ describe("configuration", () => {
     Effect.gen(function* () {
       const config = yield* load({ ATC_LOG_LEVEL: "ERROR" })
       assert.strictEqual(config.logLevel, "Error")
+    }),
+  )
+
+  it.effect("empty environment values mean unset, including ATC_CONFIG", () =>
+    Effect.gen(function* () {
+      const config = yield* load({ ATC_CONFIG: "", ATC_PORT: "" })
+      assert.strictEqual(config.configFile, join(home, ".config", "atc", "config.toml"))
+      assert.strictEqual(config.port, DEFAULT_PORT)
+    }),
+  )
+
+  it.effect("a relative data directory is rejected (never cwd-dependent)", () =>
+    Effect.gen(function* () {
+      const error = yield* loadError({ ATC_DATA_DIR: "relative/data" })
+      assert.include(error.message, "absolute")
+      assert.include(error.source, "ATC_DATA_DIR")
+    }),
+  )
+
+  it.effect("a relative config file path is rejected", () =>
+    Effect.gen(function* () {
+      const error = yield* loadError({ ATC_CONFIG: "relative.toml" })
+      assert.include(error.message, "absolute")
     }),
   )
 })

--- a/app-server/test/config.test.ts
+++ b/app-server/test/config.test.ts
@@ -1,0 +1,129 @@
+import { assert, describe, it } from "@effect/vitest"
+import { BunFileSystem } from "@effect/platform-bun"
+import { Effect } from "effect"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir, homedir } from "node:os"
+import { join } from "node:path"
+import { afterAll } from "vitest"
+import { DEFAULT_PORT } from "../src/api.ts"
+import * as Config from "../src/config.ts"
+
+// The settled configuration pipeline: XDG paths, ATC_* environment, TOML file,
+// precedence, and fail-fast diagnostics naming the offending source.
+
+const scratch = mkdtempSync(join(tmpdir(), "atc-config-test-"))
+afterAll(() => rmSync(scratch, { recursive: true, force: true }))
+
+let caseId = 0
+const writeConfig = (contents: string) => {
+  const file = join(scratch, `config-${caseId++}.toml`)
+  Bun.write(file, contents)
+  return file
+}
+
+const load = (env: Config.Env) => Config.load(env).pipe(Effect.provide(BunFileSystem.layer))
+
+const loadError = (env: Config.Env) =>
+  Config.load(env).pipe(Effect.flip, Effect.provide(BunFileSystem.layer))
+
+describe("configuration", () => {
+  it.effect("defaults: XDG locations and default port", () =>
+    Effect.gen(function* () {
+      const config = yield* load({})
+      assert.strictEqual(config.port, DEFAULT_PORT)
+      assert.strictEqual(config.logLevel, "Info")
+      assert.strictEqual(config.configFile, join(homedir(), ".config", "atc", "config.toml"))
+      assert.strictEqual(config.dataDir, join(homedir(), ".local", "share", "atc"))
+      assert.strictEqual(config.stateDir, join(homedir(), ".local", "state", "atc"))
+      assert.strictEqual(config.dbFile, join(homedir(), ".local", "share", "atc", "atc.db"))
+      assert.strictEqual(config.logFile, join(homedir(), ".local", "state", "atc", "atc.log"))
+    }),
+  )
+
+  it.effect("XDG_* overrides move every location", () =>
+    Effect.gen(function* () {
+      const config = yield* load({
+        XDG_CONFIG_HOME: join(scratch, "cfg"),
+        XDG_DATA_HOME: join(scratch, "data"),
+        XDG_STATE_HOME: join(scratch, "state"),
+      })
+      assert.strictEqual(config.configFile, join(scratch, "cfg", "atc", "config.toml"))
+      assert.strictEqual(config.dataDir, join(scratch, "data", "atc"))
+      assert.strictEqual(config.stateDir, join(scratch, "state", "atc"))
+    }),
+  )
+
+  it.effect("config file values apply when the environment is silent", () =>
+    Effect.gen(function* () {
+      const file = writeConfig(`port = 9100\nlogLevel = "debug"\ndataDir = "${scratch}/d"\n`)
+      const config = yield* load({ ATC_CONFIG: file })
+      assert.strictEqual(config.port, 9100)
+      assert.strictEqual(config.logLevel, "Debug")
+      assert.strictEqual(config.dataDir, `${scratch}/d`)
+      assert.strictEqual(config.dbFile, `${scratch}/d/atc.db`)
+    }),
+  )
+
+  it.effect("environment beats the config file", () =>
+    Effect.gen(function* () {
+      const file = writeConfig(`port = 9100\nlogLevel = "debug"\n`)
+      const config = yield* load({
+        ATC_CONFIG: file,
+        ATC_PORT: "9200",
+        ATC_LOG_LEVEL: "warn",
+        ATC_DATA_DIR: join(scratch, "env-data"),
+      })
+      assert.strictEqual(config.port, 9200)
+      assert.strictEqual(config.logLevel, "Warn")
+      assert.strictEqual(config.dataDir, join(scratch, "env-data"))
+    }),
+  )
+
+  it.effect("a missing config file is not an error", () =>
+    Effect.gen(function* () {
+      const config = yield* load({ ATC_CONFIG: join(scratch, "does-not-exist.toml") })
+      assert.strictEqual(config.port, DEFAULT_PORT)
+    }),
+  )
+
+  it.effect("malformed TOML fails naming the file", () =>
+    Effect.gen(function* () {
+      const file = writeConfig("port = [not toml")
+      const error = yield* loadError({ ATC_CONFIG: file })
+      assert.strictEqual(error._tag, "ConfigLoadError")
+      assert.strictEqual(error.source, file)
+    }),
+  )
+
+  it.effect("an unknown key fails naming the key", () =>
+    Effect.gen(function* () {
+      const file = writeConfig(`prot = 9100\n`)
+      const error = yield* loadError({ ATC_CONFIG: file })
+      assert.strictEqual(error.source, file)
+      assert.include(error.message, '"prot"')
+    }),
+  )
+
+  it.effect("an invalid port in the environment fails with a one-line diagnostic", () =>
+    Effect.gen(function* () {
+      const error = yield* loadError({ ATC_PORT: "70000" })
+      assert.strictEqual(error._tag, "ConfigLoadError")
+      assert.notInclude(error.message, "\n")
+    }),
+  )
+
+  it.effect("an invalid log level names the accepted values", () =>
+    Effect.gen(function* () {
+      const error = yield* loadError({ ATC_LOG_LEVEL: "verbose" })
+      assert.include(error.message, "verbose")
+      assert.include(error.message, "debug")
+    }),
+  )
+
+  it.effect("log level is case-insensitive", () =>
+    Effect.gen(function* () {
+      const config = yield* load({ ATC_LOG_LEVEL: "ERROR" })
+      assert.strictEqual(config.logLevel, "Error")
+    }),
+  )
+})

--- a/app-server/test/localTrust.test.ts
+++ b/app-server/test/localTrust.test.ts
@@ -1,0 +1,116 @@
+import { assert, describe, it } from "@effect/vitest"
+import { BunServices } from "@effect/platform-bun"
+import { Effect, Layer } from "effect"
+import { isLoopbackHost, isLoopbackOrigin } from "../src/localTrust.ts"
+import * as Server from "../src/server.ts"
+import { freePort } from "./blackbox.ts"
+import { TestBuildInfoLayer } from "./testBuildInfo.ts"
+
+// Listener hardening: spoofed-Host / cross-Origin requests are rejected with
+// 403 while ordinary local requests pass. Runs against a real loopback
+// listener because the guard sits on the HTTP layer, not in the handlers.
+
+const withServer = <A, E, R>(run: (port: number) => Effect.Effect<A, E, R>) =>
+  Effect.gen(function* () {
+    const port = yield* Effect.promise(freePort)
+    yield* Layer.build(Server.layer({ port }).pipe(Layer.provide(TestBuildInfoLayer)))
+    return yield* run(port)
+  }).pipe(Effect.scoped, Effect.provide(BunServices.layer))
+
+/** Raw HTTP exchange so tests can send arbitrary Host headers (fetch can't). */
+const rawStatus = (port: number, headers: ReadonlyArray<string>): Promise<number> =>
+  new Promise((resolve, reject) => {
+    let data = ""
+    Bun.connect({
+      hostname: "127.0.0.1",
+      port,
+      socket: {
+        open(socket) {
+          socket.write(
+            ["GET /api/v1/health HTTP/1.1", ...headers, "Connection: close", "", ""].join("\r\n"),
+          )
+        },
+        data(socket, chunk) {
+          data += chunk.toString()
+          const match = data.match(/^HTTP\/1\.1 (\d{3})/)
+          if (match) {
+            socket.end()
+            resolve(Number(match[1]))
+          }
+        },
+        error(_socket, error) {
+          reject(error)
+        },
+      },
+    }).catch(reject)
+  })
+
+describe("host validation", () => {
+  it("accepts loopback hosts and rejects everything else", () => {
+    assert.isTrue(isLoopbackHost("127.0.0.1:7332"))
+    assert.isTrue(isLoopbackHost("127.0.0.1"))
+    assert.isTrue(isLoopbackHost("localhost:7332"))
+    assert.isTrue(isLoopbackHost("LOCALHOST:7332"))
+    assert.isTrue(isLoopbackHost("[::1]:7332"))
+    assert.isTrue(isLoopbackHost("[::1]"))
+    assert.isFalse(isLoopbackHost(undefined))
+    assert.isFalse(isLoopbackHost("evil.example:7332"))
+    assert.isFalse(isLoopbackHost("127.0.0.1.evil.example"))
+    assert.isFalse(isLoopbackHost("localhost.evil.example"))
+    assert.isFalse(isLoopbackHost("192.168.1.10:7332"))
+  })
+
+  it("accepts loopback origins and rejects everything else", () => {
+    assert.isTrue(isLoopbackOrigin("http://localhost:5173"))
+    assert.isTrue(isLoopbackOrigin("http://127.0.0.1:7332"))
+    assert.isTrue(isLoopbackOrigin("http://[::1]:7332"))
+    assert.isTrue(isLoopbackOrigin("https://localhost"))
+    assert.isFalse(isLoopbackOrigin("http://evil.example"))
+    assert.isFalse(isLoopbackOrigin("https://localhost.evil.example"))
+    assert.isFalse(isLoopbackOrigin("null"))
+    assert.isFalse(isLoopbackOrigin("file:///etc/passwd"))
+  })
+})
+
+describe("hardened listener", () => {
+  it.effect("accepts plain local requests and browser requests from loopback origins", () =>
+    withServer((port) =>
+      Effect.promise(async () => {
+        const plain = await fetch(`http://127.0.0.1:${port}/api/v1/health`)
+        assert.strictEqual(plain.status, 200)
+
+        const sameOrigin = await fetch(`http://127.0.0.1:${port}/api/v1/health`, {
+          headers: { Origin: `http://localhost:5173` },
+        })
+        assert.strictEqual(sameOrigin.status, 200)
+      }),
+    ),
+  )
+
+  it.effect("rejects a spoofed Host (DNS rebinding) with 403", () =>
+    withServer((port) =>
+      Effect.promise(async () => {
+        assert.strictEqual(await rawStatus(port, ["Host: evil.example"]), 403)
+        assert.strictEqual(await rawStatus(port, ["Host: 127.0.0.1.evil.example"]), 403)
+        assert.strictEqual(await rawStatus(port, [`Host: 127.0.0.1:${port}`]), 200)
+      }),
+    ),
+  )
+
+  it.effect("rejects cross-origin browser requests (CSRF) with 403", () =>
+    withServer((port) =>
+      Effect.promise(async () => {
+        const crossOrigin = await fetch(`http://127.0.0.1:${port}/api/v1/health`, {
+          headers: { Origin: "http://evil.example" },
+        })
+        assert.strictEqual(crossOrigin.status, 403)
+        assert.strictEqual(await crossOrigin.text(), "")
+
+        const nullOrigin = await fetch(`http://127.0.0.1:${port}/api/v1/health`, {
+          headers: { Origin: "null" },
+        })
+        assert.strictEqual(nullOrigin.status, 403)
+      }),
+    ),
+  )
+})

--- a/app-server/test/localTrust.test.ts
+++ b/app-server/test/localTrust.test.ts
@@ -5,6 +5,7 @@ import { isLoopbackHost, isLoopbackOrigin } from "../src/localTrust.ts"
 import * as Server from "../src/server.ts"
 import { freePort } from "./blackbox.ts"
 import { TestBuildInfoLayer } from "./testBuildInfo.ts"
+import { TestRepositoryLayers } from "./testLayers.ts"
 
 // Listener hardening: spoofed-Host / cross-Origin requests are rejected with
 // 403 while ordinary local requests pass. Runs against a real loopback
@@ -13,7 +14,9 @@ import { TestBuildInfoLayer } from "./testBuildInfo.ts"
 const withServer = <A, E, R>(run: (port: number) => Effect.Effect<A, E, R>) =>
   Effect.gen(function* () {
     const port = yield* Effect.promise(freePort)
-    yield* Layer.build(Server.layer({ port }).pipe(Layer.provide(TestBuildInfoLayer)))
+    yield* Layer.build(
+      Server.layer({ port }).pipe(Layer.provide([TestBuildInfoLayer, TestRepositoryLayers])),
+    )
     return yield* run(port)
   }).pipe(Effect.scoped, Effect.provide(BunServices.layer))
 

--- a/app-server/test/openapi.test.ts
+++ b/app-server/test/openapi.test.ts
@@ -1,13 +1,21 @@
 import { assert, describe, it } from "@effect/vitest"
 import { BunHttpServer } from "@effect/platform-bun"
 import { Context, Effect, Layer } from "effect"
-import { HttpClient, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import {
+  HttpBody,
+  HttpClient,
+  HttpClientRequest,
+  HttpRouter,
+  HttpServerRequest,
+  HttpServerResponse,
+} from "effect/unstable/http"
 import { HttpApi, OpenApi } from "effect/unstable/httpapi"
 import { Api, DEFAULT_PORT } from "../src/api.ts"
 import { openApiDocument, openApiJson } from "../src/openapi.ts"
 import * as Server from "../src/server.ts"
 import { appServerRoot } from "./blackbox.ts"
 import { TestBuildInfoLayer, testBuildInfo } from "./testBuildInfo.ts"
+import { TestRepositoryLayers } from "./testLayers.ts"
 
 // Contract-generation tests: the document must be deterministic, match the
 // checked-in artifact, cover every contract operation, and agree with what
@@ -15,8 +23,9 @@ import { TestBuildInfoLayer, testBuildInfo } from "./testBuildInfo.ts"
 // separately in api.test.ts, so failures here point at the document, not the
 // handlers.
 
-const operation = (path: string) =>
-  (openApiDocument.paths[path]?.get ?? assert.fail(`no GET operation documented for ${path}`)) as {
+const operation = (path: string, method = "get") =>
+  ((openApiDocument.paths[path] as Record<string, unknown>)?.[method] ??
+    assert.fail(`no ${method.toUpperCase()} operation documented for ${path}`)) as {
     readonly operationId: string
     readonly responses: Record<string, { content: Record<string, { schema: { $ref?: string } }> }>
   }
@@ -85,8 +94,8 @@ describe("openapi document", () => {
     )
     assert.sameDeepMembers(documented, expected)
 
-    const operationIds = Object.keys(openApiDocument.paths).map((path) => {
-      const id = operation(path).operationId
+    const operationIds = documented.map(({ path, method }) => {
+      const id = operation(path, method).operationId
       // Derived ids look like "v1.health" — a forgotten OpenApi.Identifier
       // annotation would ship a bad id whose later fix breaks clients (see
       // AGENTS.md "OpenAPI Contract").
@@ -102,11 +111,15 @@ describe("openapi document", () => {
 // see the raw wire payload instead of contract-decoded values.
 const rawClient = Effect.gen(function* () {
   const handler = yield* HttpRouter.toHttpEffect(
-    Server.routes.pipe(Layer.provide(TestBuildInfoLayer)),
+    Server.routes.pipe(Layer.provide([TestBuildInfoLayer, TestRepositoryLayers])),
   )
   return HttpClient.make(
     Effect.fnUntraced(function* (request) {
-      const serverRequest = HttpServerRequest.fromClientRequest(request)
+      // fromClientRequest synthesizes no Host header; the local-trust guard in
+      // Server.routes requires a loopback one just like a real client sends.
+      const serverRequest = HttpServerRequest.fromClientRequest(
+        HttpClientRequest.setHeader(request, "host", "127.0.0.1"),
+      )
       const response = yield* handler.pipe(
         Effect.provideService(HttpServerRequest.HttpServerRequest, serverRequest),
         Effect.orDie,
@@ -122,12 +135,18 @@ const rawClient = Effect.gen(function* () {
 // here force a new case whenever the contract grows.
 describe("openapi document vs runtime", () => {
   it("these tests cover every documented path", () => {
-    assert.sameMembers(Object.keys(openApiDocument.paths), ["/api/v1/health", "/api/v1/version"])
+    assert.sameMembers(Object.keys(openApiDocument.paths), [
+      "/api/v1/health",
+      "/api/v1/version",
+      "/api/v1/projects",
+      "/api/v1/projects/{projectId}",
+      "/api/v1/fs/check",
+    ])
   })
 
   it.effect("GET /api/v1/health returns the documented payload", () =>
     Effect.gen(function* () {
-      const response = yield* (yield* rawClient).get("http://in-process/api/v1/health")
+      const response = yield* (yield* rawClient).get("http://127.0.0.1/api/v1/health")
       assert.strictEqual(response.status, 200)
       assert.deepStrictEqual(yield* response.json, { status: "ok" })
 
@@ -141,7 +160,7 @@ describe("openapi document vs runtime", () => {
 
   it.effect("GET /api/v1/version returns the documented payload", () =>
     Effect.gen(function* () {
-      const response = yield* (yield* rawClient).get("http://in-process/api/v1/version")
+      const response = yield* (yield* rawClient).get("http://127.0.0.1/api/v1/version")
       assert.strictEqual(response.status, 200)
       assert.deepStrictEqual(yield* response.json, {
         version: testBuildInfo.version,
@@ -160,6 +179,62 @@ describe("openapi document vs runtime", () => {
         "builtAt",
       ])
       assert.sameMembers([...schema.required], ["version", "apiVersion", "commit", "builtAt"])
+    }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
+  )
+
+  it.effect("/api/v1/projects: created and listed payloads match the documented schemas", () =>
+    Effect.gen(function* () {
+      const client = yield* rawClient
+      const created = yield* client.post("http://127.0.0.1/api/v1/projects", {
+        body: HttpBody.jsonUnsafe({ name: "Doc Test", defaultWorkingDirectory: "/tmp" }),
+      })
+      assert.strictEqual(created.status, 200)
+      const createdBody = (yield* created.json) as Record<string, unknown>
+      const schema = componentSchema("Project")
+      assert.sameMembers(Object.keys(schema.properties), Object.keys(createdBody))
+      assert.sameMembers([...schema.required], Object.keys(createdBody))
+      assert.deepStrictEqual(
+        operation("/api/v1/projects", "post").responses["200"]!.content["application/json"]!.schema,
+        { $ref: "#/components/schemas/Project" },
+      )
+
+      const listed = yield* client.get("http://127.0.0.1/api/v1/projects")
+      assert.strictEqual(listed.status, 200)
+      assert.deepStrictEqual(yield* listed.json, [createdBody] as unknown)
+      assert.deepStrictEqual(
+        operation("/api/v1/projects").responses["200"]!.content["application/json"]!.schema,
+        { $ref: "#/components/schemas/ProjectList" },
+      )
+    }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
+  )
+
+  it.effect("GET /api/v1/projects/{projectId} documents and returns the 404 error payload", () =>
+    Effect.gen(function* () {
+      const response = yield* (yield* rawClient).get("http://127.0.0.1/api/v1/projects/nope")
+      assert.strictEqual(response.status, 404)
+      assert.deepStrictEqual(yield* response.json, { _tag: "ProjectNotFound", projectId: "nope" })
+      assert.deepStrictEqual(
+        operation("/api/v1/projects/{projectId}").responses["404"]!.content["application/json"]!
+          .schema,
+        { $ref: "#/components/schemas/ProjectNotFoundJsonEncoding" },
+      )
+    }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
+  )
+
+  it.effect("GET /api/v1/fs/check returns the documented payload", () =>
+    Effect.gen(function* () {
+      const response = yield* (yield* rawClient).get(
+        "http://127.0.0.1/api/v1/fs/check?path=/definitely/not/here",
+      )
+      assert.strictEqual(response.status, 200)
+      const body = (yield* response.json) as Record<string, unknown>
+      assert.strictEqual(body["state"], "missing")
+      const ref =
+        operation("/api/v1/fs/check").responses["200"]!.content["application/json"]!.schema
+      assert.deepStrictEqual(ref, { $ref: "#/components/schemas/FsCheckResponse" })
+      const schema = componentSchema("FsCheckResponse")
+      assert.sameMembers(Object.keys(schema.properties), ["path", "state", "checkedAt", "reason"])
+      assert.sameMembers([...schema.required], ["path", "state", "checkedAt", "reason"])
     }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
   )
 })

--- a/app-server/test/openapi.test.ts
+++ b/app-server/test/openapi.test.ts
@@ -234,7 +234,9 @@ describe("openapi document vs runtime", () => {
       assert.deepStrictEqual(ref, { $ref: "#/components/schemas/FsCheckResponse" })
       const schema = componentSchema("FsCheckResponse")
       assert.sameMembers(Object.keys(schema.properties), ["path", "state", "checkedAt", "reason"])
-      assert.sameMembers([...schema.required], ["path", "state", "checkedAt", "reason"])
+      // reason is optional (absent when conclusive) — and deliberately not a
+      // nullable required field, which the pinned Swift generator would drop.
+      assert.sameMembers([...schema.required], ["path", "state", "checkedAt"])
     }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
   )
 })

--- a/app-server/test/persistence.test.ts
+++ b/app-server/test/persistence.test.ts
@@ -1,0 +1,140 @@
+import { assert, describe, it } from "@effect/vitest"
+import { SqliteClient, SqliteMigrator } from "@effect/sql-sqlite-bun"
+import { Effect, Layer } from "effect"
+import { Migrator, SqlClient } from "effect/unstable/sql"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll } from "vitest"
+import { migrations } from "../src/migrations.ts"
+import * as Persistence from "../src/persistence.ts"
+
+const scratch = mkdtempSync(join(tmpdir(), "atc-persistence-test-"))
+afterAll(() => rmSync(scratch, { recursive: true, force: true }))
+
+let dbId = 0
+const freshDbFile = () => join(scratch, `test-${dbId++}.db`)
+
+/** Run `effect` against one boot of the migrated database at `file`; the
+ * client closes when the effect finishes, so sequential calls model restarts. */
+const withDb = <A, E>(file: string, effect: Effect.Effect<A, E, SqlClient.SqlClient>) =>
+  effect.pipe(Effect.provide(Persistence.layerFile(file)))
+
+const tableNames = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+  const rows = yield* sql<{ name: string }>`
+    SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name
+  `
+  return rows.map((row) => row.name)
+})
+
+const appliedCount = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+  const rows = yield* sql<{ count: number }>`
+    SELECT COUNT(*) AS count FROM effect_sql_migrations
+  `
+  return Number(rows[0]!.count)
+})
+
+describe("persistence", () => {
+  it.effect("creates and migrates a fresh database", () =>
+    Effect.gen(function* () {
+      const names = yield* withDb(freshDbFile(), tableNames)
+      assert.include(names, "projects")
+      assert.include(names, "effect_sql_migrations")
+    }),
+  )
+
+  // fromRecord silently drops keys that don't match /^(\d+)_(.+)$/ — this
+  // pins the whole record to the loader so a malformed key cannot silently
+  // skip a migration.
+  it.effect("the loader resolves every migration in the record", () =>
+    Effect.gen(function* () {
+      const resolved = yield* Migrator.fromRecord(migrations)
+      assert.strictEqual(resolved.length, Object.keys(migrations).length)
+    }),
+  )
+
+  it.effect("a restart is a clean no-op", () => {
+    const file = freshDbFile()
+    return Effect.gen(function* () {
+      yield* withDb(file, Effect.void)
+      const count = yield* withDb(file, appliedCount)
+      assert.strictEqual(count, Object.keys(migrations).length)
+    })
+  })
+
+  it.effect("applies the documented SQLite settings", () =>
+    withDb(
+      freshDbFile(),
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient
+        const journalMode = yield* sql<{ journal_mode: string }>`PRAGMA journal_mode`
+        const busyTimeout = yield* sql<{ timeout: number }>`PRAGMA busy_timeout`
+        const foreignKeys = yield* sql<{ foreign_keys: number }>`PRAGMA foreign_keys`
+        assert.strictEqual(journalMode[0]!.journal_mode, "wal")
+        assert.strictEqual(Number(busyTimeout[0]!.timeout), 5000)
+        assert.strictEqual(Number(foreignKeys[0]!.foreign_keys), 1)
+      }),
+    ),
+  )
+
+  it.effect("a failed migration halts boot naming the migration and rolls back", () => {
+    const file = freshDbFile()
+    const broken = {
+      ...migrations,
+      "0002_explode": Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient
+        yield* sql`CREATE TABLE half_done (id TEXT PRIMARY KEY)`
+        yield* sql`THIS IS NOT SQL`
+      }),
+    }
+    const brokenBoot = Effect.void.pipe(
+      Effect.provide(
+        Layer.effectDiscard(SqliteMigrator.run({ loader: Migrator.fromRecord(broken) })).pipe(
+          Layer.provideMerge(SqliteClient.layer({ filename: file })),
+        ),
+      ),
+    )
+    return Effect.gen(function* () {
+      const exit = yield* Effect.exit(brokenBoot)
+      assert.strictEqual(exit._tag, "Failure")
+      // The diagnostic names the migration (the loader parses the numeric id,
+      // so zero padding drops out of the rendered name).
+      assert.include(String(exit), 'Migration "2_explode" failed')
+
+      // The failed migration's DDL and bookkeeping rolled back together:
+      // booting again with the fixed record succeeds and sees no leftovers.
+      const names = yield* withDb(file, tableNames)
+      assert.notInclude(names, "half_done")
+      const count = yield* withDb(file, appliedCount)
+      assert.strictEqual(count, Object.keys(migrations).length)
+    })
+  })
+
+  it.effect("withTransaction commits on success and rolls back on failure", () =>
+    withDb(
+      freshDbFile(),
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient
+
+        yield* sql.withTransaction(
+          sql`INSERT INTO projects (id, name, default_working_directory, created_at, updated_at)
+              VALUES ('a', 'kept', '/tmp', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')`,
+        )
+        yield* sql`INSERT INTO projects (id, name, default_working_directory, created_at, updated_at)
+                   VALUES ('b', 'dropped', '/tmp', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')`.pipe(
+          Effect.andThen(Effect.fail("boom" as const)),
+          sql.withTransaction,
+          Effect.ignore,
+        )
+
+        const rows = yield* sql<{ id: string }>`SELECT id FROM projects ORDER BY id`
+        assert.deepStrictEqual(
+          rows.map((row) => row.id),
+          ["a"],
+        )
+      }),
+    ),
+  )
+})

--- a/app-server/test/serve.blackbox.test.ts
+++ b/app-server/test/serve.blackbox.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, test } from "vitest"
-import { appServerRoot, freePort, spawnServe, waitForHealth } from "./blackbox.ts"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll, describe, expect, test } from "vitest"
+import { appServerRoot, freePort, isolatedEnv, spawnServe, waitForHealth } from "./blackbox.ts"
 
 // Black-box tests of the real entrypoint: spawn `bun src/main.ts serve` on a
 // loopback port, exercise both endpoints over TCP, and verify clean shutdown
@@ -7,9 +10,13 @@ import { appServerRoot, freePort, spawnServe, waitForHealth } from "./blackbox.t
 // open half-sent request at signal time.
 
 // Tests run under `bun --bun vitest`, so execPath is the pinned bun binary —
-// no PATH lookup for the child.
+// no PATH lookup for the child. Isolated locations keep the spawned server's
+// database and log file out of the real user directories.
+const scratch = mkdtempSync(join(tmpdir(), "atc-serve-blackbox-"))
+afterAll(() => rmSync(scratch, { recursive: true, force: true }))
+
 const spawnFromSource = (port: number) =>
-  spawnServe([process.execPath, "src/main.ts"], port, appServerRoot)
+  spawnServe([process.execPath, "src/main.ts"], port, appServerRoot, isolatedEnv(scratch))
 
 describe("atc serve (black box)", () => {
   test.each(["SIGTERM", "SIGINT"] as const)(

--- a/app-server/test/server.test.ts
+++ b/app-server/test/server.test.ts
@@ -3,6 +3,7 @@ import { Context, Effect, Exit, Layer, Scope } from "effect"
 import { HttpServer } from "effect/unstable/http"
 import * as Server from "../src/server.ts"
 import { TestBuildInfoLayer } from "./testBuildInfo.ts"
+import { TestRepositoryLayers } from "./testLayers.ts"
 
 describe("server layer", () => {
   // it.live: this test does real socket I/O, and the platform's shutdown
@@ -14,7 +15,7 @@ describe("server layer", () => {
       const scope = yield* Scope.make()
       yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
       const context = yield* Layer.build(
-        Server.layer({ port: 0 }).pipe(Layer.provide(TestBuildInfoLayer)),
+        Server.layer({ port: 0 }).pipe(Layer.provide([TestBuildInfoLayer, TestRepositoryLayers])),
       ).pipe(Effect.provideService(Scope.Scope, scope))
 
       const address = Context.get(context, HttpServer.HttpServer).address

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -1,0 +1,11 @@
+import { Layer } from "effect"
+import * as Directories from "../src/directories.ts"
+import * as Persistence from "../src/persistence.ts"
+import * as ProjectRepository from "../src/projectRepository.ts"
+
+// Handler dependencies for in-process and ephemeral-listener tests: a real
+// repository over a fresh in-memory database, and real directory checks.
+export const TestRepositoryLayers = Layer.mergeAll(
+  ProjectRepository.layer.pipe(Layer.provide(Persistence.layerFile(":memory:"))),
+  Directories.layer,
+)

--- a/packages/ATCKit/Tests/ATCAppServerAPITests/ClientTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerAPITests/ClientTests.swift
@@ -71,14 +71,15 @@ struct ClientTests {
         #expect(try Servers.Server1.url() == URL(string: "http://127.0.0.1:7332"))
     }
 
-    // Regression: optional contract fields must survive generation. An earlier
-    // schema shape (nullable unions) made the pinned generator silently drop
-    // them — UpdateProjectRequest generated as an empty struct.
-    @Test("updateProject can send both PATCH fields")
+    // Regression: optional contract fields must survive generation as plain
+    // strings. Earlier schema shapes made the pinned generator either drop
+    // the fields entirely (nullable unions) or wrap them in single-value
+    // payload structs (allOf check fragments).
+    @Test("updateProject can send both PATCH fields as plain strings")
     func updateProjectFields() throws {
         let payload = Components.Schemas.UpdateProjectRequest(
-            name: .init(value1: "Renamed"),
-            defaultWorkingDirectory: .init(value1: "/code/atc")
+            name: "Renamed",
+            defaultWorkingDirectory: "/code/atc"
         )
         let encoded = try JSONEncoder().encode(payload)
         let json = try JSONSerialization.jsonObject(with: encoded) as? [String: String]

--- a/packages/ATCKit/Tests/ATCAppServerAPITests/ClientTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerAPITests/ClientTests.swift
@@ -70,4 +70,42 @@ struct ClientTests {
     func defaultServer() throws {
         #expect(try Servers.Server1.url() == URL(string: "http://127.0.0.1:7332"))
     }
+
+    // Regression: optional contract fields must survive generation. An earlier
+    // schema shape (nullable unions) made the pinned generator silently drop
+    // them — UpdateProjectRequest generated as an empty struct.
+    @Test("updateProject can send both PATCH fields")
+    func updateProjectFields() throws {
+        let payload = Components.Schemas.UpdateProjectRequest(
+            name: .init(value1: "Renamed"),
+            defaultWorkingDirectory: .init(value1: "/code/atc")
+        )
+        let encoded = try JSONEncoder().encode(payload)
+        let json = try JSONSerialization.jsonObject(with: encoded) as? [String: String]
+        #expect(json == ["name": "Renamed", "defaultWorkingDirectory": "/code/atc"])
+    }
+
+    @Test("fs check decodes payloads with and without a reason")
+    func fsCheckReason() throws {
+        let decoder = JSONDecoder()
+        let conclusive = try decoder.decode(
+            Components.Schemas.FsCheckResponse.self,
+            from: Data(
+                #"{"path":"/code/atc","state":"available","checkedAt":"2026-08-02T12:00:00Z"}"#
+                    .utf8
+            )
+        )
+        #expect(conclusive.state == .available)
+        #expect(conclusive.reason == nil)
+
+        let timedOut = try decoder.decode(
+            Components.Schemas.FsCheckResponse.self,
+            from: Data(
+                #"{"path":"/code/atc","state":"unknown","checkedAt":"2026-08-02T12:00:00Z","reason":"timeout"}"#
+                    .utf8
+            )
+        )
+        #expect(timedOut.state == .unknown)
+        #expect(timedOut.reason == "timeout")
+    }
 }


### PR DESCRIPTION
Implements [ATC-121](https://linear.app/elevenideas/issue/ATC-121/core-persistence-configuration-diagnostics-and-authentication): the durable control-plane substrate — settled configuration and data locations, transactional SQLite persistence with checked-in migrations, a structured logging baseline, a hardened loopback listener, and the first domain resource (Projects) end to end through the contract, clients, and CLI.

## What's here (one commit per area)

- **Configuration** (`src/config.ts`): one precedence rule — flags > environment (flat `ATC_<KEY>`) > `config.toml` (Bun-native TOML, camelCase keys, unknown keys rejected) > defaults — via composed `ConfigProvider`s. One XDG path rule on every platform (`~/.config/atc/config.toml`, `~/.local/share/atc/atc.db`, `~/.local/state/atc/atc.log`), honoring `XDG_*` overrides plus `ATC_CONFIG`/`ATC_DATA_DIR`. Invalid config fails fast with one stderr line naming the offending source; relative data/config paths are rejected so compiled behavior never depends on the cwd.
- **Persistence** (`src/persistence.ts`, `src/migrations.ts`): `@effect/sql-sqlite-bun@4.0.0-beta.102` (exact-pinned, same line as `effect`). In-code append-only `Migrator.fromRecord` record (`"0001_init"`), applied transactionally at startup with library bookkeeping and concurrent-run locking; a failed migration rolls back DDL+bookkeeping together and halts boot naming the migration. Documented pragmas: WAL (driver default), `busy_timeout=5000`, `foreign_keys=ON`. A test pins loader count to record size (`fromRecord` silently drops malformed keys).
- **Logging** (`src/logging.ts`): JSON-lines file in the state dir + pretty stderr in dev (`commit === "dev"`), level from `ATC_LOG_LEVEL`/config (case-insensitive), request spans via `HttpMiddleware.tracer` with trace/span ids annotated onto handler logs.
- **Listener hardening** (`src/localTrust.ts`): loopback-only bind plus `Host`/`Origin` validation on every request — spoofed hosts (DNS rebinding) and cross-origin browser requests (CSRF) get an empty 403. Covered by unit predicates, real-listener tests (raw-socket Host spoofing), and the compiled black-box suite.
- **Projects + fs.check** (`src/api.ts`, `src/handlers.ts`, `src/projectRepository.ts`, `src/directories.ts`): full CRUD per the Domain Model — UUIDv7 ids, required mutable `defaultWorkingDirectory` stored symlink-resolved canonical, validation requiring an existing readable+traversable directory (deliberately not writable), tagged errors with `httpApiStatus` (404/422) and human messages, simple record delete. `GET /api/v1/fs/check?path=` returns the tagged health states with a 2s bounded timeout (`unknown`/timeout for explicit checks; fail-closed retryable error inside operations); never persisted. Row types stay behind the repository.
- **CLI** (`src/cli.ts`): `--url` is gone — API-backed commands derive `http://127.0.0.1:<port>` from the same settled config the server reads (single resolution seam kept for the future remote/auth work). New `atc project list|get|create|update|delete` (delete requires `--yes`) and `atc fs check`; relative directories resolve client-side. JSON stdout / one-line stderr diagnostics / exit-code contract preserved and black-box tested.
- **Contract artifacts**: `openapi.json` regenerated; Swift client (`ATCAppServerAPI`) builds and its tests pass via `mise run contract:check`.
- **Docs**: README + AGENTS.md document the settled locations, precedence rule, persistence conventions, and local-trust architecture.

## Notable decisions

- `createProject` returns **200 with the body**, not 201: in this Effect version a per-endpoint status annotation on a shared named schema forks it into a duplicate OpenAPI component (and a duplicate generated Swift type). The archived contract doc's success-code table predates the Effect stack decision.
- Known contract-polish gap (deliberate, follow-up material): generated request schemas say `additionalProperties: false` but the runtime ignores excess JSON keys, and schema-validation 400s (empty body) are undocumented.

## Review

Two adversarial sub-agent reviews (correctness, simplicity) ran against the branch; all accepted findings are applied in the final commit — including a real bug where every API tagged error printed an empty CLI diagnostic (now human messages, with tightened black-box assertions that can no longer pass vacuously).

## Test plan

- `mise run app-server:check` — fmt, strict types, 80 tests, OpenAPI drift ✅
- `mise run contract:check` — + Swift client build/tests ✅
- `mise run -C app-server test:compiled` — compiled artifact: creates+migrates DB in a fresh data dir, restart is a clean no-op, flag-less CLI against the running server, 403 on cross-origin, clean SIGTERM ✅

https://claude.ai/code/session_01GwZRRGJnPmgbTnSNwuBT3j
