### PR TITLE
ATC-129: zmx TerminalAdapter, Subprocess PTY extension, and fake-adapter seam (PR 1 of 2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,7 +211,9 @@ then.
 - All child processes go through the `Subprocess` service
   (`src/subprocess.ts`): scoped acquisition (scope close terminates the child,
   SIGTERM escalating to SIGKILL), bounded stderr diagnostics, explicit
-  environment. No ad-hoc `Bun.spawn` in server code.
+  environment. No ad-hoc `Bun.spawn` in server code. The PTY variant
+  (`spawnPty`, Bun native `terminal:`) carries the same scope guarantees and
+  is the only sanctioned pseudo-terminal path.
 - atc ships no provider binaries: the user installs and authenticates the
   Codex CLI and Claude Code themselves. Provider executables resolve
   explicitly, never implicitly: env override first (`ATC_CODEX_EXECUTABLE` /
@@ -224,6 +226,33 @@ then.
 - After upgrading Bun, Effect, or the Claude Agent SDK, rerun
   `mise run -C app-server test:compiled` and the opt-in live
   `mise run -C app-server test:smoke` suite.
+
+## Terminals and zmx (App Server)
+
+Terminals are backed by the user-installed zmx multiplexer (never bundled),
+reached exclusively through the narrow `TerminalAdapter` seam
+(`src/terminalAdapter.ts`; zmx implementation `src/zmxAdapter.ts`; in-memory
+fake `test/fakeTerminalAdapter.ts`). The seam speaks derived session names
+(`atc-` + the terminal id's 32 hex chars — never persisted) and terminal
+bytes; policy and transports live above it.
+
+- The executable resolves explicitly: `ATC_ZMX_EXECUTABLE` / config
+  `zmxExecutable`, else `zmx` on PATH; a missing install is one actionable
+  diagnostic (`ZmxUnavailable`), never a crash.
+- Every zmx child runs with ATC's private socket directory
+  (`<stateDir>/terminals` as `ZMX_DIR`) and a scrubbed environment:
+  `ZMX_SESSION` and `ZMX_SESSION_PREFIX` are always cleared (nested-client
+  trap; silent name rewriting). Socket-path length (103-byte unix cap) is
+  validated at adapter boot. Debug the same inventory with
+  `ZMX_DIR=~/.local/state/atc/terminals zmx list`.
+- The zmx behavioral guards the adapter encodes (attach auto-creates, exit
+  codes prove nothing, kill returns before death, only a reachable inventory
+  entry proves a live session) are documented where they are enforced — the
+  header of `src/zmxAdapter.ts`, derived from the pinned source in
+  `repos/zmx`.
+- Coverage: deterministic tests drive the adapter against the
+  `test/fixtures/fake-zmx.ts` stand-in; `mise run -C app-server test:zmx`
+  opts into smoke tests against the real installed zmx.
 
 ## Code Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,10 @@ CMUX (https://github.com/manaflow-ai/cmux): Agentic coding focused terminal base
 ## Reference Source Checkouts
 
 `mise run refs` shallow-clones read-only reference source into `repos/` (gitignored):
-the Effect monorepo pinned to the app-server's Effect version, plus T3Code and
-OpenCode (https://github.com/sst/opencode) as Effect architecture references.
+the Effect monorepo pinned to the app-server's Effect version, T3Code and
+OpenCode (https://github.com/sst/opencode) as Effect architecture references, and
+zmx (https://github.com/neurosnap/zmx) pinned to the installed zmx version as the
+terminal-multiplexer behavior reference.
 
 - Treat everything under `repos/` as read-only reference material. Never import
   from it, edit it, or copy files out of it wholesale.

--- a/app-server/mise.toml
+++ b/app-server/mise.toml
@@ -72,3 +72,8 @@ run = "ATC_COMPILED_TEST=1 bun --bun vitest run test/compiled.blackbox.test.ts"
 description = "Opt-in live provider smoke tests (requires Codex CLI and Claude Code credentials)"
 depends = ["build"]
 run = "ATC_SMOKE=1 bun --bun vitest run test/provider.smoke.test.ts"
+
+[tasks."test:zmx"]
+description = "Opt-in smoke tests against the real installed zmx binary"
+depends = ["install"]
+run = "ATC_ZMX_SMOKE=1 bun --bun vitest run test/zmxSmoke.test.ts"

--- a/app-server/src/config.ts
+++ b/app-server/src/config.ts
@@ -14,7 +14,8 @@ import { DEFAULT_PORT } from "./api.ts"
 //
 //   config  $XDG_CONFIG_HOME/atc/config.toml  (~/.config/atc/config.toml)
 //   data    $XDG_DATA_HOME/atc                (~/.local/share/atc)  -> atc.db
-//   state   $XDG_STATE_HOME/atc               (~/.local/state/atc)  -> atc.log
+//   state   $XDG_STATE_HOME/atc               (~/.local/state/atc)  -> atc.log,
+//                                             terminals/ (zmx sockets)
 //
 // ATC_CONFIG overrides the config file path; ATC_DATA_DIR the data directory.
 // The TOML format never leaks past this module.
@@ -50,6 +51,14 @@ export class AppConfig extends Context.Service<
     readonly dbFile: string
     /** Structured JSON log file path. */
     readonly logFile: string
+    /** zmx executable: an absolute path, or a name resolved on PATH. */
+    readonly zmxExecutable: string
+    /**
+     * ATC-private zmx socket directory (ZMX_DIR for every zmx child). Only
+     * ATC-owned sessions live here, so the inventory is authoritative and
+     * orphan sockets are provably ours. Debug with `ZMX_DIR=<dir> zmx list`.
+     */
+    readonly terminalSocketDir: string
   }
 >()("app-server/AppConfig") {}
 
@@ -73,7 +82,7 @@ const configFilePath = (env: Env) =>
 // The settings a config.toml may define. Keys are camelCase, matching the
 // system-wide JSON convention; unknown keys fail fast (a typo silently
 // falling back to a default would be a partial boot).
-const FILE_KEYS = ["port", "logLevel", "dataDir"] as const
+const FILE_KEYS = ["port", "logLevel", "dataDir", "zmxExecutable"] as const
 
 const parseToml = (source: string, text: string) =>
   Effect.try({
@@ -182,6 +191,7 @@ export const load = (
       dataDir: Config.string("dataDir").pipe(
         Config.withDefault(xdgDir(env, "XDG_DATA_HOME", [".local", "share"])),
       ),
+      zmxExecutable: Config.string("zmxExecutable").pipe(Config.withDefault("zmx")),
     }).pipe(
       Effect.provideService(ConfigProvider.ConfigProvider, provider),
       Effect.catchTag("ConfigError", (error) =>
@@ -193,6 +203,17 @@ export const load = (
         ),
       ),
     )
+
+    // A relative executable path would resolve against the working
+    // directory — compiled behavior never may. Bare names resolve on PATH.
+    if (settings.zmxExecutable.includes("/") && !settings.zmxExecutable.startsWith("/")) {
+      return yield* Effect.fail(
+        new ConfigLoadError({
+          source: `${configFile} / ATC_ZMX_EXECUTABLE`,
+          message: `zmxExecutable must be a bare name or an absolute path, got "${settings.zmxExecutable}"`,
+        }),
+      )
+    }
 
     const dataDir = yield* requireAbsolute(
       settings.dataDir,
@@ -212,6 +233,8 @@ export const load = (
       stateDir,
       dbFile: path.join(dataDir, "atc.db"),
       logFile: path.join(stateDir, "atc.log"),
+      zmxExecutable: settings.zmxExecutable,
+      terminalSocketDir: path.join(stateDir, "terminals"),
     }
   })
 

--- a/app-server/src/subprocess.ts
+++ b/app-server/src/subprocess.ts
@@ -1,5 +1,15 @@
-import { Cause, Context, Duration, Effect, Layer, Queue, Schema, Scope, Stream } from "effect"
-import type { PlatformError } from "effect/PlatformError"
+import {
+  Cause,
+  Context,
+  Deferred,
+  Duration,
+  Effect,
+  Layer,
+  Queue,
+  Schema,
+  Scope,
+  Stream,
+} from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 
 // The generic subprocess seam: how the App Server launches and supervises
@@ -12,10 +22,18 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 const STDERR_TAIL_LINES = 100
 /** Individual captured lines are truncated to keep diagnostics bounded. */
 const MAX_CAPTURED_LINE_LENGTH = 2_000
+/** How much recent PTY output (UTF-16 units) to keep for diagnostics. */
+const PTY_OUTPUT_TAIL_LENGTH = 2_000
+/**
+ * PTY output chunks buffered ahead of the consumer. Terminals are lossy on
+ * overflow by nature (the multiplexer repaints on reattach), so the oldest
+ * chunks slide out rather than growing memory without bound.
+ */
+const PTY_OUTPUT_QUEUE_CAPACITY = 1_024
 
 export class SubprocessError extends Schema.TaggedErrorClass<SubprocessError>()("SubprocessError", {
   executable: Schema.String,
-  operation: Schema.Literals(["spawn", "stdin", "stdout", "exit"]),
+  operation: Schema.Literals(["spawn", "stdin", "stdout", "exit", "resize"]),
   message: Schema.String,
 }) {}
 
@@ -31,6 +49,16 @@ export interface SpawnSpec {
   /** Grace period before SIGKILL when the child ignores SIGTERM at cleanup. */
   readonly forceKillAfter?: Duration.Input
 }
+
+export interface PtySpawnSpec extends SpawnSpec {
+  /** Initial pseudo-terminal size. */
+  readonly cols?: number
+  readonly rows?: number
+}
+
+/** Default PTY size when the caller has no client-provided dimensions yet. */
+export const DEFAULT_PTY_COLS = 80
+export const DEFAULT_PTY_ROWS = 24
 
 export interface Child {
   readonly pid: number
@@ -49,10 +77,38 @@ export interface Child {
   readonly exitCode: Effect.Effect<number, SubprocessError>
 }
 
+export interface PtyChild {
+  readonly pid: number
+  /**
+   * Raw terminal output (the child's stdout and stderr interleaved through
+   * the PTY). Single-consumer: run it exactly once; it ends at PTY EOF. A
+   * consumer slower than the child loses the oldest chunks once the bounded
+   * buffer fills.
+   */
+  readonly output: Stream.Stream<Uint8Array, SubprocessError>
+  /** Snapshot of recent decoded output, for failure diagnostics. */
+  readonly outputTail: Effect.Effect<string>
+  /** Write raw bytes to the PTY — the child sees them as terminal input. */
+  readonly write: (data: Uint8Array | string) => Effect.Effect<void, SubprocessError>
+  /** Resize the PTY; the child observes it as a window-size change. */
+  readonly resize: (size: {
+    readonly cols: number
+    readonly rows: number
+  }) => Effect.Effect<void, SubprocessError>
+  /** Await exit. Fails if the child was terminated by a signal. */
+  readonly exitCode: Effect.Effect<number, SubprocessError>
+}
+
 export class Subprocess extends Context.Service<
   Subprocess,
   {
     readonly spawn: (spec: SpawnSpec) => Effect.Effect<Child, SubprocessError, Scope.Scope>
+    /**
+     * Spawn under a Bun-native pseudo-terminal, with the same scope
+     * guarantees as `spawn`: closing the scope terminates the child (SIGTERM
+     * escalating to SIGKILL) and releases the PTY.
+     */
+    readonly spawnPty: (spec: PtySpawnSpec) => Effect.Effect<PtyChild, SubprocessError, Scope.Scope>
   }
 >()("app-server/Subprocess") {}
 
@@ -86,10 +142,15 @@ export const waitForProcessExit = (
 const truncate = (line: string): string =>
   line.length > MAX_CAPTURED_LINE_LENGTH ? `${line.slice(0, MAX_CAPTURED_LINE_LENGTH)}…` : line
 
-const mapPlatformError =
+/** The one place a SubprocessError is built from an arbitrary cause. */
+const subprocessError =
   (executable: string, operation: SubprocessError["operation"]) =>
-  (error: PlatformError): SubprocessError =>
-    new SubprocessError({ executable, operation, message: error.message })
+  (error: unknown): SubprocessError =>
+    new SubprocessError({
+      executable,
+      operation,
+      message: error instanceof Error ? error.message : String(error),
+    })
 
 const spawn = Effect.fnUntraced(function* (
   spawner: ChildProcessSpawner.ChildProcessSpawner["Service"],
@@ -108,7 +169,7 @@ const spawn = Effect.fnUntraced(function* (
         forceKillAfter: spec.forceKillAfter ?? "2 seconds",
       }),
     )
-    .pipe(Effect.mapError(mapPlatformError(spec.executable, "spawn")))
+    .pipe(Effect.mapError(subprocessError(spec.executable, "spawn")))
 
   // End stdin once the child exits so later writes fail loudly instead of
   // vanishing into a dead pipe. (A write in the instant between exit and its
@@ -120,6 +181,7 @@ const spawn = Effect.fnUntraced(function* (
   // split by hand rather than with Stream.splitLines so the pending fragment
   // stays capped even when the child never writes a newline.
   const stderrTail: Array<string> = []
+  const stderrDrained = yield* Deferred.make<void>()
   const pushLine = (line: string): void => {
     stderrTail.push(truncate(line))
     if (stderrTail.length > STDERR_TAIL_LINES) stderrTail.shift()
@@ -145,14 +207,18 @@ const spawn = Effect.fnUntraced(function* (
       ),
     )
     if (pendingLine !== "") pushLine(pendingLine)
-  }).pipe(Effect.ignore, Effect.forkScoped)
+  }).pipe(
+    Effect.ensuring(Deferred.succeed(stderrDrained, void 0)),
+    Effect.ignore,
+    Effect.forkScoped,
+  )
 
   const child: Child = {
     pid: handle.pid,
     stdoutLines: handle.stdout.pipe(
       Stream.decodeText,
       Stream.splitLines,
-      Stream.mapError(mapPlatformError(spec.executable, "stdout")),
+      Stream.mapError(subprocessError(spec.executable, "stdout")),
     ),
     stderrTail: Effect.sync(() => [...stderrTail]),
     writeLine: (line) =>
@@ -170,9 +236,125 @@ const spawn = Effect.fnUntraced(function* (
         ),
       ),
     endInput: Effect.asVoid(Queue.end(stdin)),
+    // Exit alone does not mean the final stderr lines have been observed;
+    // wait (bounded — a grandchild could hold the pipe open) for the drain
+    // so an immediate stderrTail read after exit sees the diagnostics.
     exitCode: handle.exitCode.pipe(
       Effect.map((code) => code as number),
-      Effect.mapError(mapPlatformError(spec.executable, "exit")),
+      Effect.mapError(subprocessError(spec.executable, "exit")),
+      Effect.tap(() =>
+        Deferred.await(stderrDrained).pipe(Effect.timeout("1 second"), Effect.ignore),
+      ),
+    ),
+  }
+  return child
+})
+
+// The PTY variant uses Bun's native pseudo-terminal (Bun.spawn `terminal:`),
+// which Effect's ChildProcessSpawner does not model. This module is the one
+// place allowed to call Bun.spawn, so the scoped kill+reap guarantees stay
+// uniform across both variants.
+const spawnPty = Effect.fnUntraced(function* (spec: PtySpawnSpec) {
+  const output = yield* Queue.make<Uint8Array, Cause.Done>({
+    capacity: PTY_OUTPUT_QUEUE_CAPACITY,
+    strategy: "sliding",
+  })
+  const decoder = new TextDecoder("utf-8", { fatal: false })
+  let outputTail = ""
+  // Closure is tracked explicitly because Bun's terminal.write can keep
+  // reporting full byte counts briefly after the child exits (observed on
+  // Linux), which would let writes vanish while claiming success.
+  let ptyClosed = false
+  const markClosed = () => {
+    ptyClosed = true
+    Queue.endUnsafe(output)
+  }
+
+  const proc = yield* Effect.acquireRelease(
+    Effect.try({
+      try: () =>
+        Bun.spawn([spec.executable, ...(spec.args ?? [])], {
+          ...(spec.cwd !== undefined ? { cwd: spec.cwd } : {}),
+          env: spec.extendEnv === true ? { ...process.env, ...spec.env } : (spec.env ?? {}),
+          terminal: {
+            cols: spec.cols ?? DEFAULT_PTY_COLS,
+            rows: spec.rows ?? DEFAULT_PTY_ROWS,
+            // Bun may reuse the buffer between callbacks; copy before queueing.
+            data: (_terminal, data) => {
+              Queue.offerUnsafe(output, Uint8Array.from(data))
+              outputTail = (outputTail + decoder.decode(data, { stream: true })).slice(
+                -PTY_OUTPUT_TAIL_LENGTH,
+              )
+            },
+            exit: () => {
+              markClosed()
+            },
+          },
+        }),
+      catch: subprocessError(spec.executable, "spawn"),
+    }),
+    (proc) =>
+      Effect.promise(async () => {
+        proc.kill("SIGTERM")
+        const escalation = setTimeout(
+          () => proc.kill("SIGKILL"),
+          Duration.toMillis(spec.forceKillAfter ?? "2 seconds"),
+        )
+        await proc.exited.catch(() => {})
+        clearTimeout(escalation)
+        try {
+          proc.terminal?.close()
+        } catch {
+          // Already closed by the PTY EOF path.
+        }
+      }),
+  )
+
+  // The PTY exit callback covers EOF; this covers any exit path where the
+  // callback never fires, so consumers of `output` cannot hang. Registered
+  // before `exitCode` can be awaited, so a caller that has observed exit
+  // always sees the PTY as closed.
+  proc.exited.finally(markClosed).catch(() => {})
+
+  const terminal = proc.terminal
+  const terminalOp = (
+    operation: SubprocessError["operation"],
+    run: () => void,
+  ): Effect.Effect<void, SubprocessError> =>
+    Effect.try({ try: run, catch: subprocessError(spec.executable, operation) })
+
+  const child: PtyChild = {
+    pid: proc.pid,
+    output: Stream.fromQueue(output),
+    outputTail: Effect.sync(() => outputTail),
+    write: (data) =>
+      terminalOp("stdin", () => {
+        // terminal.write cannot be trusted after exit (see markClosed).
+        if (ptyClosed) {
+          throw new Error("terminal is closed (child exited)")
+        }
+        const length = typeof data === "string" ? Buffer.byteLength(data) : data.byteLength
+        const written = terminal?.write(data) ?? 0
+        // Bun buffers internally, so a short write signals a real problem
+        // rather than ordinary backpressure; losing keystrokes silently is
+        // worse than failing the write.
+        if (written < length) {
+          throw new Error(`short write: ${written} of ${length} bytes accepted`)
+        }
+      }),
+    resize: (size) => terminalOp("resize", () => terminal?.resize(size.cols, size.rows)),
+    exitCode: Effect.promise(() => proc.exited).pipe(
+      Effect.flatMap((code) =>
+        proc.signalCode !== null
+          ? Effect.fail(
+              new SubprocessError({
+                executable: spec.executable,
+                operation: "exit",
+                message: `terminated by ${proc.signalCode}`,
+              }),
+            )
+          : Effect.succeed(code),
+      ),
     ),
   }
   return child
@@ -181,6 +363,6 @@ const spawn = Effect.fnUntraced(function* (
 export const layer = Layer.effect(Subprocess)(
   Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
-    return { spawn: (spec) => spawn(spawner, spec) }
+    return { spawn: (spec) => spawn(spawner, spec), spawnPty }
   }),
 )

--- a/app-server/src/terminalAdapter.ts
+++ b/app-server/src/terminalAdapter.ts
@@ -1,0 +1,139 @@
+import { Context, Schema } from "effect"
+import type { Effect, Scope, Stream } from "effect"
+import type { SubprocessError } from "./subprocess.ts"
+
+// The narrow seam through which ATC talks to the terminal multiplexer
+// (ATC-122). The adapter deals only in derived session names and terminal
+// bytes; Terminal records, reconciliation policy, and transports live above
+// it. Confining multiplexer invocation here keeps it swappable and gives
+// tests a fake-adapter seam (test/fakeTerminalAdapter.ts).
+
+/** Prefix marking a zmx session as ATC-owned inside ATC's private ZMX_DIR. */
+export const SESSION_NAME_PREFIX = "atc-"
+
+/**
+ * The derived (never persisted) session name for a terminal id:
+ * `atc-` + the UUID's 32 hex chars — reversible for debugging.
+ */
+export const sessionNameForTerminalId = (terminalId: string): string =>
+  SESSION_NAME_PREFIX + terminalId.replaceAll("-", "").toLowerCase()
+
+/** Reverse of `sessionNameForTerminalId`; undefined for foreign names. */
+export const terminalIdForSessionName = (sessionName: string): string | undefined => {
+  const hex = sessionName.startsWith(SESSION_NAME_PREFIX)
+    ? sessionName.slice(SESSION_NAME_PREFIX.length)
+    : undefined
+  if (hex === undefined || !/^[0-9a-f]{32}$/.test(hex)) return undefined
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}
+
+/**
+ * One entry of a complete session inventory. `reachable: false` marks a
+ * session whose daemon did not answer the multiplexer's probe — it exists,
+ * so it must never be treated as absent.
+ */
+export interface SessionInfo {
+  readonly name: string
+  readonly reachable: boolean
+  /** Daemon pid — the session's identity across a name reuse. */
+  readonly pid?: number
+  /** Creation time as reported by the multiplexer (epoch seconds). */
+  readonly createdAt?: number
+}
+
+export interface SessionSize {
+  readonly cols: number
+  readonly rows: number
+}
+
+/** A live, bidirectional attach client bound to one session. */
+export interface SessionConnection {
+  /** Raw terminal output. Single-consumer; ends when the client detaches. */
+  readonly output: Stream.Stream<Uint8Array, SubprocessError>
+  /** Raw terminal input (keystrokes/bytes) to the session. */
+  readonly write: (data: Uint8Array | string) => Effect.Effect<void, SubprocessError>
+  readonly resize: (size: SessionSize) => Effect.Effect<void, SubprocessError>
+  /** Await this attach client's exit (never the session's). */
+  readonly exitCode: Effect.Effect<number, SubprocessError>
+}
+
+/**
+ * The multiplexer cannot be consulted (executable missing, inventory
+ * failed). Retryable: it says nothing about any session's existence, so
+ * stored state must stay untouched.
+ */
+export class ZmxUnavailable extends Schema.TaggedErrorClass<ZmxUnavailable>()("ZmxUnavailable", {
+  reason: Schema.String,
+}) {
+  override get message(): string {
+    return this.reason
+  }
+}
+
+/** A session operation failed conclusively (with diagnostics). */
+export class SessionOperationFailed extends Schema.TaggedErrorClass<SessionOperationFailed>()(
+  "SessionOperationFailed",
+  {
+    operation: Schema.Literals(["create", "kill", "attach"]),
+    sessionName: Schema.String,
+    reason: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `zmx ${this.operation} ${this.sessionName}: ${this.reason}`
+  }
+}
+
+/** Attach pre-flight: the session is not in a complete inventory. */
+export class SessionNotFound extends Schema.TaggedErrorClass<SessionNotFound>()("SessionNotFound", {
+  sessionName: Schema.String,
+}) {
+  override get message(): string {
+    return `no session named ${this.sessionName}`
+  }
+}
+
+export class TerminalAdapter extends Context.Service<
+  TerminalAdapter,
+  {
+    /**
+     * Create the persistent session `name` (working directory `cwd`,
+     * exec-style `command` argv, or an interactive login shell when absent)
+     * and return once it is settled and detached. Succeeds only when a
+     * reachable session is confirmed in the inventory; fails when `name`
+     * already exists (creating is never silently attaching), and a command
+     * that finishes before the session settles is a failed launch.
+     */
+    readonly createSession: (options: {
+      readonly name: string
+      readonly cwd: string
+      readonly command?: ReadonlyArray<string> | undefined
+    }) => Effect.Effect<void, ZmxUnavailable | SessionOperationFailed>
+    /**
+     * A complete inventory of ATC's private session directory. Any failure
+     * is `ZmxUnavailable` — a partial listing never masquerades as absence.
+     */
+    readonly listSessions: () => Effect.Effect<ReadonlyArray<SessionInfo>, ZmxUnavailable>
+    /**
+     * Kill `name` and verify its absence from the inventory (the multiplexer
+     * returns before death, and its exit codes are not existence proof).
+     * Killing an absent session succeeds — the goal state already holds.
+     */
+    readonly killSession: (
+      name: string,
+    ) => Effect.Effect<void, ZmxUnavailable | SessionOperationFailed>
+    /**
+     * Attach to the existing session `name`. Pre-flights the inventory
+     * (attach would otherwise auto-create). The connection lives in the
+     * Scope; closing it detaches the client, never the session.
+     */
+    readonly attachSession: (
+      name: string,
+      size: SessionSize,
+    ) => Effect.Effect<
+      SessionConnection,
+      ZmxUnavailable | SessionNotFound | SessionOperationFailed,
+      Scope.Scope
+    >
+  }
+>()("app-server/TerminalAdapter") {}

--- a/app-server/src/zmxAdapter.ts
+++ b/app-server/src/zmxAdapter.ts
@@ -1,0 +1,361 @@
+import { Effect, FileSystem, Layer, Schema, Stream } from "effect"
+import type { Duration } from "effect"
+import * as path from "node:path"
+import { AppConfig } from "./config.ts"
+import { Subprocess } from "./subprocess.ts"
+import type { SubprocessError } from "./subprocess.ts"
+import {
+  SESSION_NAME_PREFIX,
+  SessionNotFound,
+  SessionOperationFailed,
+  TerminalAdapter,
+  ZmxUnavailable,
+} from "./terminalAdapter.ts"
+import type { SessionInfo } from "./terminalAdapter.ts"
+
+// The zmx implementation of the TerminalAdapter seam (ATC-122), built on the
+// pinned zmx v0.6.0 behavior (repos/zmx):
+//
+//   - Every zmx child gets ATC's private ZMX_DIR (only ATC sessions live
+//     there) and a scrubbed environment: ZMX_SESSION would turn `attach`
+//     into a session switch whose error path can kill the target session,
+//     and ZMX_SESSION_PREFIX silently rewrites every name.
+//   - `attach`/`run` auto-create, so attach pre-flights the inventory and
+//     verifies (by daemon pid) that it reached the original session, never
+//     a silently resurrected one.
+//   - Exit codes are not existence proof, and `kill` returns before death
+//     (~500ms SIGHUP→SIGKILL); absence is verified by polling the inventory.
+//   - `zmx list` parsing is tolerant: malformed lines are skipped, `err=`
+//     lines count as existing-but-unreachable. Only a *reachable* entry
+//     proves a live session; only a complete inventory proves absence.
+//
+// Manual debugging against the same inventory: `ZMX_DIR=<stateDir>/terminals
+// zmx list`.
+
+const SESSION_TERM_TYPE = "xterm-256color"
+/** Longest usable unix socket path (sun_path minus the NUL terminator). */
+const MAX_SOCKET_PATH_BYTES = process.platform === "linux" ? 107 : 103
+/** Bound on a single zmx command; beyond it the inventory is unavailable. */
+const RUN_TIMEOUT: Duration.Input = "10 seconds"
+
+/**
+ * Inventory-polling bounds; tests tighten them, production uses defaults.
+ * Verification counts complete inventory passes, not wall time, so a slow
+ * inventory extends the wait instead of manufacturing a conclusive failure.
+ */
+export interface ZmxOptions {
+  readonly pollInterval?: Duration.Input
+  readonly verifyPasses?: number
+}
+
+/** Boot-time misconfiguration of the adapter; fails serve, names the fix. */
+export class ZmxConfigError extends Schema.TaggedErrorClass<ZmxConfigError>()("ZmxConfigError", {
+  reason: Schema.String,
+}) {
+  override get message(): string {
+    return this.reason
+  }
+}
+
+/**
+ * Parse `zmx list` output. Lines are tab-separated `key=value` fields after
+ * an optional reachability marker; lines without a `name` are skipped so one
+ * broken entry never fails the whole inventory. `err=` entries exist but did
+ * not answer the probe.
+ */
+export const parseSessionList = (stdout: ReadonlyArray<string>): Array<SessionInfo> => {
+  const sessions: Array<SessionInfo> = []
+  for (const raw of stdout) {
+    const line = raw.trim().replace(/^→\s*/, "")
+    if (line === "") continue
+    const fields = new Map<string, string>()
+    for (const field of line.split("\t")) {
+      const separator = field.indexOf("=")
+      if (separator > 0) fields.set(field.slice(0, separator), field.slice(separator + 1))
+    }
+    const name = fields.get("name")
+    if (name === undefined || name === "") continue
+    const pid = Number.parseInt(fields.get("pid") ?? "", 10)
+    const createdAt = Number.parseInt(fields.get("created") ?? "", 10)
+    sessions.push({
+      name,
+      reachable: !fields.has("err"),
+      ...(Number.isNaN(pid) ? {} : { pid }),
+      ...(Number.isNaN(createdAt) ? {} : { createdAt }),
+    })
+  }
+  return sessions
+}
+
+/**
+ * The environment for every zmx child: the parent environment with the
+ * mandatory scrubs applied and ATC's private socket directory pinned.
+ */
+export const zmxChildEnv = (
+  socketDir: string,
+  parent: Record<string, string | undefined> = process.env,
+): Record<string, string> => {
+  const env: Record<string, string> = {}
+  for (const [key, value] of Object.entries(parent)) {
+    if (value !== undefined) env[key] = value
+  }
+  delete env["ZMX_SESSION"]
+  delete env["ZMX_SESSION_PREFIX"]
+  env["ZMX_DIR"] = socketDir
+  env["TERM"] = SESSION_TERM_TYPE
+  return env
+}
+
+/** Printable diagnostic from raw terminal output: control bytes stripped. */
+const printableTail = (tail: string): string =>
+  tail.replace(/\x1b\[[0-9;?]*[a-zA-Z]|[\x00-\x09\x0b-\x1f]/g, "").trim()
+
+export const layerWith = (options: ZmxOptions) =>
+  Layer.effect(TerminalAdapter)(
+    Effect.gen(function* () {
+      const pollInterval = options.pollInterval ?? "250 millis"
+      const verifyPasses = options.verifyPasses ?? 20
+      const config = yield* AppConfig
+      const subprocess = yield* Subprocess
+      const fs = yield* FileSystem.FileSystem
+
+      const socketDir = config.terminalSocketDir
+      // Socket paths must fit sun_path; validated at boot so a deep state
+      // dir fails serve with one actionable line, not on every create.
+      const longestSocketPath = path.join(socketDir, `${SESSION_NAME_PREFIX}${"0".repeat(32)}`)
+      if (Buffer.byteLength(longestSocketPath) > MAX_SOCKET_PATH_BYTES) {
+        return yield* Effect.fail(
+          new ZmxConfigError({
+            reason:
+              `terminal socket directory ${socketDir} is too deep: socket paths would exceed ` +
+              `${MAX_SOCKET_PATH_BYTES} bytes; move the state directory (XDG_STATE_HOME)`,
+          }),
+        )
+      }
+      // Private: sockets grant full read/write on the user's terminals.
+      // mkdir's mode only applies when it creates the directory, so a
+      // pre-existing permissive one is explicitly tightened.
+      yield* fs.makeDirectory(socketDir, { recursive: true, mode: 0o700 })
+      yield* fs.chmod(socketDir, 0o700)
+
+      const childEnv = zmxChildEnv(socketDir)
+
+      // Explicit resolution, never implicit: a bare name resolves on PATH
+      // here so a missing install fails with one actionable diagnostic.
+      // Memoized on success — a resolved install does not move mid-run.
+      let resolvedExecutable: string | undefined
+      const resolveExecutable = Effect.suspend(() => {
+        if (resolvedExecutable !== undefined) return Effect.succeed(resolvedExecutable)
+        const configured = config.zmxExecutable
+        const resolved = configured.includes("/") ? configured : Bun.which(configured)
+        if (resolved !== null) {
+          resolvedExecutable = resolved
+          return Effect.succeed(resolved)
+        }
+        return Effect.fail(
+          new ZmxUnavailable({
+            reason:
+              `zmx executable "${configured}" not found; install zmx on PATH or set ` +
+              `zmxExecutable in config.toml / ATC_ZMX_EXECUTABLE`,
+          }),
+        )
+      })
+
+      const unavailable = (error: SubprocessError): ZmxUnavailable =>
+        new ZmxUnavailable({
+          reason: `cannot run zmx (${error.operation}): ${error.message}`,
+        })
+
+      /** Run a run-to-completion zmx command, capturing stdout + exit code. */
+      const runZmx = (args: ReadonlyArray<string>) =>
+        Effect.gen(function* () {
+          const executable = yield* resolveExecutable
+          const child = yield* subprocess.spawn({ executable, args, env: childEnv })
+          yield* child.endInput
+          const stdout = yield* Stream.runCollect(child.stdoutLines)
+          const exitCode = yield* child.exitCode
+          const stderr = yield* child.stderrTail
+          return { stdout, exitCode, stderr }
+        }).pipe(
+          Effect.scoped,
+          Effect.catchTag("SubprocessError", (e) => Effect.fail(unavailable(e))),
+          // A hung zmx must not hang its caller; slowness is unavailability.
+          Effect.timeoutOrElse({
+            duration: RUN_TIMEOUT,
+            orElse: () => Effect.fail(new ZmxUnavailable({ reason: `zmx ${args[0]} timed out` })),
+          }),
+        )
+
+      const listSessions = () =>
+        runZmx(["list"]).pipe(
+          Effect.flatMap(({ exitCode, stderr, stdout }) =>
+            // "no sessions" is exit 0 with empty stdout (a note on stderr);
+            // any non-zero exit means the inventory is not trustworthy.
+            exitCode === 0
+              ? Effect.succeed(parseSessionList(stdout))
+              : Effect.fail(
+                  new ZmxUnavailable({
+                    reason: `zmx list exited with code ${exitCode}: ${stderr.join(" ") || "(no stderr)"}`,
+                  }),
+                ),
+          ),
+        )
+
+      const findSession = (name: string) =>
+        listSessions().pipe(Effect.map((sessions) => sessions.find((s) => s.name === name)))
+
+      /**
+       * Up to `verifyPasses` complete inventory passes until `predicate`
+       * accepts one; resolves to whether it ever did.
+       */
+      const pollInventory = (predicate: (sessions: ReadonlyArray<SessionInfo>) => boolean) =>
+        Effect.gen(function* () {
+          for (let pass = 0; pass < verifyPasses; pass++) {
+            if (pass > 0) yield* Effect.sleep(pollInterval)
+            if (predicate(yield* listSessions())) return true
+          }
+          return false
+        })
+
+      const liveSession = (name: string) => (sessions: ReadonlyArray<SessionInfo>) =>
+        sessions.some((s) => s.name === name && s.reachable)
+
+      const createSession: TerminalAdapter["Service"]["createSession"] = (options) =>
+        Effect.gen(function* () {
+          const executable = yield* resolveExecutable
+          const fail = (reason: string) =>
+            Effect.fail(
+              new SessionOperationFailed({
+                operation: "create",
+                sessionName: options.name,
+                reason,
+              }),
+            )
+
+          // A bad working directory is the caller's conclusive error, not
+          // multiplexer unavailability (the spawn would report a confusing
+          // retryable ENOENT).
+          const cwdInfo = yield* fs
+            .stat(options.cwd)
+            .pipe(Effect.catch(() => fail(`working directory ${options.cwd} does not exist`)))
+          if (cwdInfo.type !== "Directory") {
+            return yield* fail(`working directory ${options.cwd} is not a directory`)
+          }
+
+          // Creating is never silently attaching: `zmx attach` on an
+          // existing name ignores cwd and command entirely. An unreachable
+          // leftover with this name blocks creation the same way — it holds
+          // the socket path.
+          if ((yield* findSession(options.name)) !== undefined) {
+            return yield* fail("session already exists")
+          }
+
+          // The short-lived creation client: a PTY running `zmx attach
+          // <name> [command…]` (attach auto-creates). Once a *reachable*
+          // session is in the inventory the scope closes, detaching the
+          // client; the session daemon persists. Exec-style commands come
+          // from a Schema-typed argv — never a shell string.
+          const client = yield* Effect.gen(function* () {
+            const child = yield* subprocess
+              .spawnPty({
+                executable,
+                args: ["attach", options.name, ...(options.command ?? [])],
+                cwd: options.cwd,
+                env: childEnv,
+              })
+              .pipe(Effect.catchTag("SubprocessError", (e) => Effect.fail(unavailable(e))))
+            const settled = yield* Effect.raceFirst(
+              pollInventory(liveSession(options.name)),
+              // A client that dies first (bad command, zmx error) ends the
+              // wait early; the final check below stays the authority.
+              child.exitCode.pipe(
+                Effect.as(false),
+                Effect.catchTag("SubprocessError", () => Effect.succeed(false)),
+              ),
+            )
+            return { settled, tail: yield* child.outputTail }
+          }).pipe(Effect.scoped)
+
+          if (client.settled) return
+          // The client is gone (exited or detached by the closing scope).
+          // One final inventory check is the authority: the session may have
+          // settled in the instant the client died, but a session that is
+          // not reachable now is not a live terminal.
+          if (liveSession(options.name)(yield* listSessions())) return
+          const detail = printableTail(client.tail)
+          return yield* fail(`the session never settled${detail === "" ? "" : `: ${detail}`}`)
+        })
+
+      const killSession: TerminalAdapter["Service"]["killSession"] = (name) =>
+        Effect.gen(function* () {
+          // Killing an absent session succeeds: the goal state holds.
+          if ((yield* findSession(name)) === undefined) return
+          // Exit code deliberately ignored: kill's codes are not existence
+          // proof. The inventory is the only authority.
+          yield* runZmx(["kill", name])
+          const gone = yield* pollInventory((sessions) => !sessions.some((s) => s.name === name))
+          if (!gone) {
+            return yield* Effect.fail(
+              new SessionOperationFailed({
+                operation: "kill",
+                sessionName: name,
+                reason: `session still present after ${verifyPasses} inventory passes`,
+              }),
+            )
+          }
+        })
+
+      const attachSession: TerminalAdapter["Service"]["attachSession"] = (name, size) =>
+        Effect.gen(function* () {
+          // Pre-flight: attach auto-creates, so absence must be checked
+          // first, and only a reachable session can be attached (attaching
+          // an unreachable one would clean its stale socket and resurrect).
+          const before = yield* findSession(name)
+          if (before === undefined) {
+            return yield* Effect.fail(new SessionNotFound({ sessionName: name }))
+          }
+          if (!before.reachable) {
+            return yield* Effect.fail(
+              new SessionOperationFailed({
+                operation: "attach",
+                sessionName: name,
+                reason: "session exists but is unreachable; retry",
+              }),
+            )
+          }
+          const executable = yield* resolveExecutable
+          const child = yield* subprocess
+            .spawnPty({
+              executable,
+              args: ["attach", name],
+              env: childEnv,
+              cols: size.cols,
+              rows: size.rows,
+            })
+            .pipe(Effect.catchTag("SubprocessError", (e) => Effect.fail(unavailable(e))))
+
+          // TOCTOU guard: if the session died between pre-flight and spawn,
+          // attach silently created a fresh one. The daemon pid is the
+          // session's identity — a changed pid means a resurrected phantom,
+          // which is killed and reported as the original being gone.
+          const settled = yield* pollInventory(liveSession(name))
+          const after = settled ? yield* findSession(name) : undefined
+          if (after === undefined || after.pid !== before.pid) {
+            yield* runZmx(["kill", name]).pipe(Effect.ignore)
+            return yield* Effect.fail(new SessionNotFound({ sessionName: name }))
+          }
+
+          return {
+            output: child.output,
+            write: child.write,
+            resize: child.resize,
+            exitCode: child.exitCode,
+          }
+        })
+
+      return { createSession, listSessions, killSession, attachSession }
+    }),
+  )
+
+/** Production adapter with the default polling bounds. */
+export const layer = layerWith({})

--- a/app-server/test/config.test.ts
+++ b/app-server/test/config.test.ts
@@ -42,6 +42,32 @@ describe("configuration", () => {
       assert.strictEqual(config.stateDir, join(home, ".local", "state", "atc"))
       assert.strictEqual(config.dbFile, join(home, ".local", "share", "atc", "atc.db"))
       assert.strictEqual(config.logFile, join(home, ".local", "state", "atc", "atc.log"))
+      assert.strictEqual(config.zmxExecutable, "zmx")
+      assert.strictEqual(
+        config.terminalSocketDir,
+        join(home, ".local", "state", "atc", "terminals"),
+      )
+    }),
+  )
+
+  it.effect("zmxExecutable follows the precedence rule: env beats file", () =>
+    Effect.gen(function* () {
+      const file = writeConfig(`zmxExecutable = "/opt/from-file/zmx"\n`)
+      assert.strictEqual((yield* load({ ATC_CONFIG: file })).zmxExecutable, "/opt/from-file/zmx")
+      assert.strictEqual(
+        (yield* load({ ATC_CONFIG: file, ATC_ZMX_EXECUTABLE: "/opt/from-env/zmx" })).zmxExecutable,
+        "/opt/from-env/zmx",
+      )
+    }),
+  )
+
+  it.effect("a relative zmxExecutable path is rejected (never cwd-dependent)", () =>
+    Effect.gen(function* () {
+      const error = yield* loadError({ ATC_ZMX_EXECUTABLE: "bin/zmx" })
+      assert.include(error.message, "bare name or an absolute path")
+      assert.include(error.source, "ATC_ZMX_EXECUTABLE")
+      // Bare names stay valid — they resolve on PATH.
+      assert.strictEqual((yield* load({ ATC_ZMX_EXECUTABLE: "my-zmx" })).zmxExecutable, "my-zmx")
     }),
   )
 

--- a/app-server/test/fakeTerminalAdapter.ts
+++ b/app-server/test/fakeTerminalAdapter.ts
@@ -1,0 +1,136 @@
+import { Cause, Effect, Layer, Queue, Stream } from "effect"
+import type { SessionConnection, SessionInfo, SessionSize } from "../src/terminalAdapter.ts"
+import {
+  SessionNotFound,
+  SessionOperationFailed,
+  TerminalAdapter,
+  ZmxUnavailable,
+} from "../src/terminalAdapter.ts"
+
+// The fake-adapter test seam (ATC-122): an in-memory TerminalAdapter with
+// the same observable semantics as the zmx adapter — inventory-authoritative
+// absence, create-never-attaches, idempotent kill, pre-flighted attach that
+// refuses unreachable sessions — plus switches to inject the failures
+// reconciliation must survive.
+
+export interface FakeSession {
+  readonly name: string
+  readonly cwd: string
+  readonly command: ReadonlyArray<string> | undefined
+  /** Everything written to an attached connection, for assertions. */
+  readonly written: Array<Uint8Array | string>
+  lastResize: SessionSize | undefined
+  /** Flip to false to model an existing-but-unresponsive daemon. */
+  reachable: boolean
+}
+
+export interface FakeTerminalAdapter {
+  readonly layer: Layer.Layer<TerminalAdapter>
+  readonly sessions: Map<string, FakeSession>
+  /** While true, every inventory-consulting operation is ZmxUnavailable. */
+  readonly setUnavailable: (unavailable: boolean) => void
+  /** Emit output bytes to every open connection of `name`. */
+  readonly emitOutput: (name: string, data: Uint8Array) => void
+}
+
+export const makeFakeAdapter = (): FakeTerminalAdapter => {
+  const sessions = new Map<string, FakeSession>()
+  const connections = new Map<string, Set<Queue.Queue<Uint8Array, Cause.Done>>>()
+  let unavailable = false
+
+  const requireAvailable = Effect.suspend(() =>
+    unavailable
+      ? Effect.fail(new ZmxUnavailable({ reason: "fake adapter set unavailable" }))
+      : Effect.void,
+  )
+
+  const service: TerminalAdapter["Service"] = {
+    createSession: (options) =>
+      Effect.gen(function* () {
+        yield* requireAvailable
+        if (sessions.has(options.name)) {
+          return yield* Effect.fail(
+            new SessionOperationFailed({
+              operation: "create",
+              sessionName: options.name,
+              reason: "session already exists",
+            }),
+          )
+        }
+        sessions.set(options.name, {
+          name: options.name,
+          cwd: options.cwd,
+          command: options.command,
+          written: [],
+          lastResize: undefined,
+          reachable: true,
+        })
+      }),
+    listSessions: () =>
+      requireAvailable.pipe(
+        Effect.map((): Array<SessionInfo> =>
+          [...sessions.values()].map((session) => ({
+            name: session.name,
+            reachable: session.reachable,
+          })),
+        ),
+      ),
+    killSession: (name) =>
+      requireAvailable.pipe(
+        Effect.map(() => {
+          sessions.delete(name)
+          for (const queue of connections.get(name) ?? []) Queue.endUnsafe(queue)
+          connections.delete(name)
+        }),
+      ),
+    attachSession: (name, size) =>
+      Effect.gen(function* () {
+        yield* requireAvailable
+        const session = sessions.get(name)
+        if (session === undefined) {
+          return yield* Effect.fail(new SessionNotFound({ sessionName: name }))
+        }
+        if (!session.reachable) {
+          return yield* Effect.fail(
+            new SessionOperationFailed({
+              operation: "attach",
+              sessionName: name,
+              reason: "session exists but is unreachable; retry",
+            }),
+          )
+        }
+        session.lastResize = size
+        const output = yield* Queue.make<Uint8Array, Cause.Done>()
+        const open = connections.get(name) ?? new Set()
+        open.add(output)
+        connections.set(name, open)
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            open.delete(output)
+            Queue.endUnsafe(output)
+          }),
+        )
+        const connection: SessionConnection = {
+          output: Stream.fromQueue(output),
+          write: (data) => Effect.sync(() => session.written.push(data)),
+          resize: (next) =>
+            Effect.sync(() => {
+              session.lastResize = next
+            }),
+          exitCode: Effect.never,
+        }
+        return connection
+      }),
+  }
+
+  return {
+    layer: Layer.succeed(TerminalAdapter)(service),
+    sessions,
+    setUnavailable: (value) => {
+      unavailable = value
+    },
+    emitOutput: (name, data) => {
+      for (const queue of connections.get(name) ?? []) Queue.offerUnsafe(queue, data)
+    },
+  }
+}

--- a/app-server/test/fixtures/fake-zmx.ts
+++ b/app-server/test/fixtures/fake-zmx.ts
@@ -1,0 +1,124 @@
+import * as fs from "node:fs"
+import * as path from "node:path"
+
+// A deterministic stand-in for the zmx binary, driven by environment
+// variables (baked into the per-test wrapper script) so the TerminalAdapter
+// can be tested without a live zmx:
+//
+//   FAKE_ZMX_STATE          directory of session files (required)
+//   FAKE_ZMX_LIST_MODE      "fail" exits 1
+//   FAKE_ZMX_UNREACHABLE    a session name always listed as an err= entry
+//                           (exists but does not answer the probe)
+//   FAKE_ZMX_ATTACH_MODE    "exit" ends right after creating the session
+//                           (a command that finished); "fail-fast" prints an
+//                           error and exits 1 without creating anything
+//   FAKE_ZMX_SETTLE_MS      delay before the created session becomes listed
+//   FAKE_ZMX_KILL_MODE      "ignore" leaves the session alive
+//   FAKE_ZMX_KILL_MS        delay between kill returning and the session
+//                           leaving the inventory (zmx returns before death)
+//
+// Sessions are JSON files named after the session. A `diesAt` timestamp
+// models delayed death: list omits sessions whose time has passed.
+
+const stateDir = process.env["FAKE_ZMX_STATE"]
+if (stateDir === undefined) {
+  console.error("fake-zmx: FAKE_ZMX_STATE is not set")
+  process.exit(2)
+}
+fs.mkdirSync(stateDir, { recursive: true })
+
+const sessionFile = (name: string) => path.join(stateDir, name)
+
+type SessionRecord = {
+  name: string
+  pid: number
+  created: number
+  startDir: string
+  command: Array<string>
+  env: Record<string, string | undefined>
+  diesAt?: number
+}
+
+const readSessions = (): Array<SessionRecord> =>
+  fs
+    .readdirSync(stateDir)
+    .map((entry) => JSON.parse(fs.readFileSync(sessionFile(entry), "utf8")) as SessionRecord)
+    .filter((record) => {
+      if (record.diesAt !== undefined && record.diesAt <= Date.now()) {
+        fs.rmSync(sessionFile(record.name), { force: true })
+        return false
+      }
+      return true
+    })
+
+const [command = "", name = "", ...rest] = process.argv.slice(2)
+
+switch (command) {
+  case "list": {
+    if (process.env["FAKE_ZMX_LIST_MODE"] === "fail") {
+      console.error("fake-zmx: inventory unavailable")
+      process.exit(1)
+    }
+    const unreachable = process.env["FAKE_ZMX_UNREACHABLE"]
+    if (unreachable !== undefined && unreachable !== "") {
+      console.log(`  name=${unreachable}\terr=Timeout\tstatus=unreachable`)
+    }
+    for (const record of readSessions()) {
+      if (record.name === unreachable) continue
+      console.log(
+        `  name=${record.name}\tpid=${record.pid}\tclients=0\tcreated=${record.created}\tstart_dir=${record.startDir}`,
+      )
+    }
+    process.exit(0)
+  }
+  case "attach": {
+    if (name === "") process.exit(2)
+    const mode = process.env["FAKE_ZMX_ATTACH_MODE"]
+    if (mode === "fail-fast") {
+      console.error("fake-zmx: cannot create session")
+      process.exit(1)
+    }
+    const settleMs = Number(process.env["FAKE_ZMX_SETTLE_MS"] ?? "0")
+    await Bun.sleep(settleMs)
+    // Like zmx: attaching to an existing session never re-creates it (the
+    // command and cwd of a second attach are silently ignored).
+    if (!fs.existsSync(sessionFile(name))) {
+      const record: SessionRecord = {
+        name,
+        pid: process.pid,
+        created: Math.floor(Date.now() / 1000),
+        startDir: process.cwd(),
+        command: rest,
+        env: {
+          ZMX_SESSION: process.env["ZMX_SESSION"],
+          ZMX_SESSION_PREFIX: process.env["ZMX_SESSION_PREFIX"],
+          ZMX_DIR: process.env["ZMX_DIR"],
+          TERM: process.env["TERM"],
+        },
+      }
+      fs.writeFileSync(sessionFile(name), JSON.stringify(record))
+    }
+    if (mode === "exit") process.exit(0)
+    // Attached client: echo terminal input back until detached (killed).
+    process.stdout.write("attached\n")
+    const decoder = new TextDecoder()
+    for await (const chunk of Bun.stdin.stream()) {
+      process.stdout.write(`echo:${decoder.decode(chunk)}`)
+    }
+    break
+  }
+  case "kill": {
+    if (name === "") process.exit(2)
+    // Like zmx: exit codes prove nothing, and death happens after return.
+    if (process.env["FAKE_ZMX_KILL_MODE"] !== "ignore" && fs.existsSync(sessionFile(name))) {
+      const record = JSON.parse(fs.readFileSync(sessionFile(name), "utf8")) as SessionRecord
+      record.diesAt = Date.now() + Number(process.env["FAKE_ZMX_KILL_MS"] ?? "0")
+      fs.writeFileSync(sessionFile(name), JSON.stringify(record))
+    }
+    process.exit(0)
+  }
+  default: {
+    console.error(`fake-zmx: unknown command "${command}"`)
+    process.exit(2)
+  }
+}

--- a/app-server/test/fixtures/pty-report.ts
+++ b/app-server/test/fixtures/pty-report.ts
@@ -1,0 +1,16 @@
+// PTY fixture: reports whether it runs under a real terminal, echoes input,
+// reports window-size changes, and exits on command — the deterministic
+// counterpart for the Subprocess PTY seam tests.
+
+console.log(`tty:${process.stdout.isTTY === true}`)
+
+process.on("SIGWINCH", () => {
+  console.log(`resize:${process.stdout.columns}x${process.stdout.rows}`)
+})
+
+const decoder = new TextDecoder()
+for await (const chunk of Bun.stdin.stream()) {
+  const text = decoder.decode(chunk)
+  if (text.includes("q")) process.exit(7)
+  process.stdout.write(`in:${text.trim()}\n`)
+}

--- a/app-server/test/subprocessPty.test.ts
+++ b/app-server/test/subprocessPty.test.ts
@@ -1,0 +1,113 @@
+import { assert, describe, it } from "@effect/vitest"
+import { BunServices } from "@effect/platform-bun"
+import { Effect, Exit, Layer, Scope, Stream } from "effect"
+import { fileURLToPath } from "node:url"
+import * as Subprocess from "../src/subprocess.ts"
+import { collectText, waitForText } from "./testLayers.ts"
+
+// The PTY variant of the Subprocess seam against the pty-report fixture.
+// All tests are it.live: real processes, real pseudo-terminals, real clock.
+// Note the PTY runs in canonical mode, so input reaches the child on "\n".
+
+const appServerRoot = fileURLToPath(new URL("..", import.meta.url))
+
+const TestLayer = Subprocess.layer.pipe(Layer.provideMerge(BunServices.layer))
+
+const fixture: Subprocess.PtySpawnSpec = {
+  executable: process.execPath,
+  args: ["test/fixtures/pty-report.ts"],
+  cwd: appServerRoot,
+  env: {},
+}
+
+describe("Subprocess.spawnPty", () => {
+  it.live("gives the child a real terminal and round-trips bytes", () =>
+    Effect.gen(function* () {
+      const subprocess = yield* Subprocess.Subprocess
+      const child = yield* subprocess.spawnPty(fixture)
+      const sink = yield* collectText(child.output)
+      yield* waitForText(sink, "tty:true")
+      yield* child.write("ping\n")
+      yield* waitForText(sink, "in:ping")
+      // The diagnostic tail sees the same bytes as the stream.
+      assert.include(yield* child.outputTail, "in:ping")
+    }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+  )
+
+  it.live("reports the exit code when the child exits by itself", () =>
+    Effect.gen(function* () {
+      const subprocess = yield* Subprocess.Subprocess
+      const child = yield* subprocess.spawnPty(fixture)
+      const sink = yield* collectText(child.output)
+      yield* waitForText(sink, "tty:true")
+      yield* child.write("q\n")
+      assert.strictEqual(yield* child.exitCode, 7)
+    }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+  )
+
+  it.live("resizes the PTY and the child observes the window change", () =>
+    Effect.gen(function* () {
+      const subprocess = yield* Subprocess.Subprocess
+      const child = yield* subprocess.spawnPty({ ...fixture, cols: 80, rows: 24 })
+      const sink = yield* collectText(child.output)
+      yield* waitForText(sink, "tty:true")
+      yield* child.resize({ cols: 132, rows: 43 })
+      yield* waitForText(sink, "resize:132x43")
+    }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+  )
+
+  it.live("terminates the child when the scope closes", () =>
+    Effect.gen(function* () {
+      const scope = yield* Scope.make()
+      const child = yield* Effect.gen(function* () {
+        const subprocess = yield* Subprocess.Subprocess
+        return yield* subprocess.spawnPty(fixture)
+      }).pipe(Scope.provide(scope))
+      assert.strictEqual(Subprocess.isProcessAlive(child.pid), true)
+      yield* Scope.close(scope, Exit.void)
+      assert.strictEqual(yield* Subprocess.waitForProcessExit(child.pid), true)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.live("ends the output stream when the child exits", () =>
+    Effect.gen(function* () {
+      const subprocess = yield* Subprocess.Subprocess
+      const child = yield* subprocess.spawnPty(fixture)
+      yield* child.write("q\n")
+      // Draining to completion proves the stream ends rather than hanging.
+      yield* Stream.runDrain(child.output).pipe(Effect.timeout("5 seconds"))
+    }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+  )
+
+  it.live("fails to spawn a missing executable with a tagged error", () =>
+    Effect.gen(function* () {
+      const subprocess = yield* Subprocess.Subprocess
+      const result = yield* Effect.result(
+        subprocess.spawnPty({ executable: "/nonexistent/definitely-not-here", env: {} }),
+      )
+      assert.strictEqual(result._tag, "Failure")
+      if (result._tag === "Failure") {
+        assert.strictEqual(result.failure._tag, "SubprocessError")
+        assert.strictEqual(result.failure.operation, "spawn")
+      }
+    }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+  )
+
+  it.live("fails writes after the terminal closes instead of dropping them", () =>
+    Effect.gen(function* () {
+      const subprocess = yield* Subprocess.Subprocess
+      const child = yield* subprocess.spawnPty(fixture)
+      yield* child.write("q\n")
+      assert.strictEqual(yield* child.exitCode, 7)
+      for (let attempt = 0; ; attempt++) {
+        const result = yield* Effect.result(child.write("after-death"))
+        if (result._tag === "Failure") {
+          assert.strictEqual(result.failure.operation, "stdin")
+          break
+        }
+        assert.isBelow(attempt, 50, "write kept succeeding after child exit")
+        yield* Effect.sleep("20 millis")
+      }
+    }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+  )
+})

--- a/app-server/test/terminalAdapter.test.ts
+++ b/app-server/test/terminalAdapter.test.ts
@@ -1,0 +1,456 @@
+import { assert, describe, it } from "@effect/vitest"
+import { BunServices } from "@effect/platform-bun"
+import { Effect, Layer, Stream } from "effect"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterAll } from "vitest"
+import * as Subprocess from "../src/subprocess.ts"
+import {
+  sessionNameForTerminalId,
+  TerminalAdapter,
+  terminalIdForSessionName,
+} from "../src/terminalAdapter.ts"
+import * as Zmx from "../src/zmxAdapter.ts"
+import { makeFakeAdapter } from "./fakeTerminalAdapter.ts"
+import {
+  cleanupTempDirs,
+  collectText,
+  makeShortSocketDir,
+  testAppConfig,
+  trackTempDir,
+  waitForText,
+} from "./testLayers.ts"
+
+// TerminalAdapter coverage: pure helpers, the zmx adapter against the
+// fake-zmx fixture (deterministic, no zmx install), and the fake in-memory
+// adapter's honesty tests. The real zmx binary is exercised by the opt-in
+// zmxSmoke tests.
+
+const fixturePath = fileURLToPath(new URL("fixtures/fake-zmx.ts", import.meta.url))
+
+afterAll(cleanupTempDirs)
+
+/**
+ * Per-test sandbox. The wrapper script is the configured "zmx executable":
+ * the adapter owns argv and environment, so per-test fixture configuration
+ * is baked into the wrapper itself — no process.env mutation anywhere.
+ */
+const makeSandbox = (vars: Record<string, string> = {}) => {
+  const base = trackTempDir(fs.mkdtempSync(path.join(os.tmpdir(), "atc-zmx-")))
+  const stateDir = path.join(base, "state")
+  const wrapper = path.join(base, "fake-zmx")
+  const assignments = Object.entries({ FAKE_ZMX_STATE: stateDir, ...vars })
+    .map(([key, value]) => `${key}='${value}'`)
+    .join(" ")
+  fs.writeFileSync(
+    wrapper,
+    `#!/bin/sh\n${assignments} exec "${process.execPath}" "${fixturePath}" "$@"\n`,
+  )
+  fs.chmodSync(wrapper, 0o755)
+  return { base, stateDir, wrapper, socketDir: makeShortSocketDir() }
+}
+
+const TIGHT: Zmx.ZmxOptions = { pollInterval: "25 millis", verifyPasses: 8 }
+
+const adapterLayer = (
+  sandbox: ReturnType<typeof makeSandbox>,
+  options: Zmx.ZmxOptions = TIGHT,
+  zmxExecutable: string = sandbox.wrapper,
+) =>
+  Zmx.layerWith(options).pipe(
+    Layer.provide(testAppConfig({ zmxExecutable, terminalSocketDir: sandbox.socketDir })),
+    Layer.provide(Subprocess.layer),
+    Layer.provideMerge(BunServices.layer),
+  )
+
+const readSessionRecord = (sandbox: ReturnType<typeof makeSandbox>, name: string) =>
+  JSON.parse(fs.readFileSync(path.join(sandbox.stateDir, name), "utf8")) as {
+    startDir: string
+    command: Array<string>
+    env: Record<string, string | undefined>
+  }
+
+describe("session name derivation", () => {
+  it("derives and reverses the private session name", () => {
+    const id = "01890a5d-ac96-774b-bcce-b302099a8057"
+    const name = sessionNameForTerminalId(id)
+    assert.strictEqual(name, "atc-01890a5dac96774bbcceb302099a8057")
+    assert.strictEqual(terminalIdForSessionName(name), id)
+    // Uppercase ids normalize instead of producing an irreversible name.
+    assert.strictEqual(sessionNameForTerminalId(id.toUpperCase()), name)
+  })
+
+  it("rejects foreign names", () => {
+    assert.isUndefined(terminalIdForSessionName("my-shell"))
+    assert.isUndefined(terminalIdForSessionName("atc-nothex"))
+    assert.isUndefined(terminalIdForSessionName("atc-01890a5dac96774bbcceb302099a80"))
+  })
+})
+
+describe("parseSessionList", () => {
+  it("parses real zmx list lines, tolerating markers and noise", () => {
+    const sessions = Zmx.parseSessionList([
+      "  name=atc-0123\tpid=85174\tclients=0\tcreated=1785707091\tstart_dir=/w",
+      "→ name=other\tpid=12\tclients=1\tcreated=5",
+      "name=broken\terr=Timeout\tstatus=unreachable",
+      "not a session line",
+      "pid=42\tcreated=7",
+      "",
+    ])
+    assert.deepStrictEqual(sessions, [
+      { name: "atc-0123", reachable: true, pid: 85174, createdAt: 1785707091 },
+      { name: "other", reachable: true, pid: 12, createdAt: 5 },
+      { name: "broken", reachable: false },
+    ])
+  })
+
+  it("parses an empty inventory", () => {
+    assert.deepStrictEqual(Zmx.parseSessionList([]), [])
+  })
+})
+
+describe("zmxChildEnv", () => {
+  it("scrubs the nested-client traps and pins ZMX_DIR and TERM", () => {
+    const env = Zmx.zmxChildEnv("/sockets", {
+      PATH: "/usr/bin",
+      HOME: "/home/u",
+      ZMX_SESSION: "evil",
+      ZMX_SESSION_PREFIX: "pre-",
+      EMPTY: undefined,
+    })
+    assert.deepStrictEqual(env, {
+      PATH: "/usr/bin",
+      HOME: "/home/u",
+      ZMX_DIR: "/sockets",
+      TERM: "xterm-256color",
+    })
+  })
+})
+
+describe("zmx adapter against fake-zmx", () => {
+  it.live("creates a session, settles, and detaches the creation client", () => {
+    const sandbox = makeSandbox()
+    return Effect.gen(function* () {
+      const adapter = yield* TerminalAdapter
+      yield* adapter.createSession({ name: "atc-aaaa", cwd: sandbox.base })
+      const sessions = yield* adapter.listSessions()
+      assert.deepStrictEqual(
+        sessions.map((s) => s.name),
+        ["atc-aaaa"],
+      )
+      // The creation client ran with the private dir pinned and the session
+      // TERM set (the scrub itself is pinned by the zmxChildEnv unit test).
+      const record = readSessionRecord(sandbox, "atc-aaaa")
+      assert.strictEqual(record.env["ZMX_DIR"], sandbox.socketDir)
+      assert.strictEqual(record.env["TERM"], "xterm-256color")
+      assert.strictEqual(record.startDir, fs.realpathSync(sandbox.base))
+    }).pipe(Effect.provide(adapterLayer(sandbox)))
+  })
+
+  it.live("re-tightens a pre-existing permissive socket directory at boot", () => {
+    const sandbox = makeSandbox()
+    // A prior or manual zmx invocation could have left the directory more
+    // open than ATC's guarantee; boot must restore 0700, not just claim it.
+    fs.chmodSync(sandbox.socketDir, 0o755)
+    return Effect.gen(function* () {
+      yield* TerminalAdapter
+      assert.strictEqual(fs.statSync(sandbox.socketDir).mode & 0o777, 0o700)
+    }).pipe(Effect.provide(adapterLayer(sandbox)))
+  })
+
+  it.live("passes an exec-style argv through and accepts a finished command", () => {
+    const sandbox = makeSandbox({ FAKE_ZMX_ATTACH_MODE: "exit" })
+    return Effect.gen(function* () {
+      const adapter = yield* TerminalAdapter
+      yield* adapter.createSession({
+        name: "atc-bbbb",
+        cwd: sandbox.base,
+        command: ["echo", "hi there"],
+      })
+      assert.deepStrictEqual(readSessionRecord(sandbox, "atc-bbbb").command, ["echo", "hi there"])
+    }).pipe(Effect.provide(adapterLayer(sandbox)))
+  })
+
+  it.live("refuses to create over an existing session", () => {
+    const sandbox = makeSandbox()
+    return Effect.gen(function* () {
+      const adapter = yield* TerminalAdapter
+      yield* adapter.createSession({ name: "atc-dupe", cwd: sandbox.base })
+      const result = yield* Effect.result(
+        adapter.createSession({ name: "atc-dupe", cwd: sandbox.base, command: ["other"] }),
+      )
+      assert.strictEqual(result._tag, "Failure")
+      if (result._tag === "Failure") {
+        assert.strictEqual(result.failure._tag, "SessionOperationFailed")
+        assert.match(result.failure.message, /already exists/)
+      }
+    }).pipe(Effect.provide(adapterLayer(sandbox)))
+  })
+
+  it.live("never treats an unreachable inventory entry as a settled create", () => {
+    // Regression: a wedged socket produces an err= entry; creating that name
+    // must fail (the path is held), not silently report success.
+    const sandbox = makeSandbox({ FAKE_ZMX_UNREACHABLE: "atc-wedged" })
+    return Effect.gen(function* () {
+      const adapter = yield* TerminalAdapter
+      const result = yield* Effect.result(
+        adapter.createSession({ name: "atc-wedged", cwd: sandbox.base }),
+      )
+      assert.strictEqual(result._tag, "Failure")
+      if (result._tag === "Failure") {
+        assert.strictEqual(result.failure._tag, "SessionOperationFailed")
+        assert.match(result.failure.message, /already exists/)
+      }
+    }).pipe(Effect.provide(adapterLayer(sandbox)))
+  })
+
+  it.live("fails a launch whose session never appears, with diagnostics", () => {
+    const sandbox = makeSandbox({ FAKE_ZMX_ATTACH_MODE: "fail-fast" })
+    return Effect.gen(function* () {
+      const adapter = yield* TerminalAdapter
+      const result = yield* Effect.result(
+        adapter.createSession({ name: "atc-cccc", cwd: sandbox.base }),
+      )
+      assert.strictEqual(result._tag, "Failure")
+      if (result._tag === "Failure") {
+        assert.strictEqual(result.failure._tag, "SessionOperationFailed")
+        assert.match(result.failure.message, /cannot create session/)
+      }
+    }).pipe(Effect.provide(adapterLayer(sandbox)))
+  })
+
+  it.live("fails a launch that never settles within the verification passes", () => {
+    const sandbox = makeSandbox({ FAKE_ZMX_SETTLE_MS: "60000" })
+    return Effect.gen(function* () {
+      const adapter = yield* TerminalAdapter
+      const result = yield* Effect.result(
+        adapter.createSession({ name: "atc-eeee", cwd: sandbox.base }),
+      )
+      assert.strictEqual(result._tag, "Failure")
+      if (result._tag === "Failure") {
+        assert.strictEqual(result.failure._tag, "SessionOperationFailed")
+        assert.match(result.failure.message, /never settled/)
+      }
+    }).pipe(Effect.provide(adapterLayer(sandbox)))
+  })
+
+  it.live("rejects a working directory that does not exist as a conclusive failure", () => {
+    const sandbox = makeSandbox()
+    return Effect.gen(function* () {
+      const adapter = yield* TerminalAdapter
+      const result = yield* Effect.result(
+        adapter.createSession({ name: "atc-ffff", cwd: path.join(sandbox.base, "nope") }),
+      )
+      assert.strictEqual(result._tag, "Failure")
+      if (result._tag === "Failure") {
+        assert.strictEqual(result.failure._tag, "SessionOperationFailed")
+        assert.match(result.failure.message, /working directory/)
+      }
+    }).pipe(Effect.provide(adapterLayer(sandbox)))
+  })
+
+  it.live("reports an unavailable inventory instead of guessing", () => {
+    const sandbox = makeSandbox({ FAKE_ZMX_LIST_MODE: "fail" })
+    return Effect.gen(function* () {
+      const adapter = yield* TerminalAdapter
+      const result = yield* Effect.result(adapter.listSessions())
+      assert.strictEqual(result._tag, "Failure")
+      if (result._tag === "Failure") {
+        assert.strictEqual(result.failure._tag, "ZmxUnavailable")
+        assert.match(result.failure.message, /inventory unavailable/)
+      }
+    }).pipe(Effect.provide(adapterLayer(sandbox)))
+  })
+
+  it.live("kills a session and verifies its delayed disappearance", () => {
+    const sandbox = makeSandbox({ FAKE_ZMX_ATTACH_MODE: "exit", FAKE_ZMX_KILL_MS: "200" })
+    return Effect.gen(function* () {
+      const adapter = yield* TerminalAdapter
+      yield* adapter.createSession({ name: "atc-gggg", cwd: sandbox.base })
+      yield* adapter.killSession("atc-gggg")
+      assert.deepStrictEqual(yield* adapter.listSessions(), [])
+    }).pipe(Effect.provide(adapterLayer(sandbox, { pollInterval: "50 millis", verifyPasses: 10 })))
+  })
+
+  it.live("treats killing an absent session as success", () => {
+    const sandbox = makeSandbox()
+    return Effect.gen(function* () {
+      const adapter = yield* TerminalAdapter
+      yield* adapter.killSession("atc-not-there")
+    }).pipe(Effect.provide(adapterLayer(sandbox)))
+  })
+
+  it.live("fails kill when the session refuses to die", () => {
+    const sandbox = makeSandbox({ FAKE_ZMX_ATTACH_MODE: "exit", FAKE_ZMX_KILL_MODE: "ignore" })
+    return Effect.gen(function* () {
+      const adapter = yield* TerminalAdapter
+      yield* adapter.createSession({ name: "atc-hhhh", cwd: sandbox.base })
+      const result = yield* Effect.result(adapter.killSession("atc-hhhh"))
+      assert.strictEqual(result._tag, "Failure")
+      if (result._tag === "Failure") {
+        assert.strictEqual(result.failure._tag, "SessionOperationFailed")
+        assert.match(result.failure.message, /still present/)
+      }
+    }).pipe(Effect.provide(adapterLayer(sandbox)))
+  })
+
+  it.live("refuses to attach to a session missing from the inventory", () => {
+    const sandbox = makeSandbox()
+    return Effect.gen(function* () {
+      const adapter = yield* TerminalAdapter
+      const result = yield* Effect.result(
+        adapter.attachSession("atc-nope", { cols: 80, rows: 24 }).pipe(Effect.scoped),
+      )
+      assert.strictEqual(result._tag, "Failure")
+      if (result._tag === "Failure") {
+        assert.strictEqual(result.failure._tag, "SessionNotFound")
+      }
+    }).pipe(Effect.provide(adapterLayer(sandbox)))
+  })
+
+  it.live("refuses to attach to an unreachable session (it would resurrect it)", () => {
+    const sandbox = makeSandbox({ FAKE_ZMX_UNREACHABLE: "atc-wedged" })
+    return Effect.gen(function* () {
+      const adapter = yield* TerminalAdapter
+      const result = yield* Effect.result(
+        adapter.attachSession("atc-wedged", { cols: 80, rows: 24 }).pipe(Effect.scoped),
+      )
+      assert.strictEqual(result._tag, "Failure")
+      if (result._tag === "Failure") {
+        assert.strictEqual(result.failure._tag, "SessionOperationFailed")
+        assert.match(result.failure.message, /unreachable/)
+      }
+    }).pipe(Effect.provide(adapterLayer(sandbox)))
+  })
+
+  it.live("attaches and round-trips terminal bytes", () => {
+    const sandbox = makeSandbox()
+    return Effect.gen(function* () {
+      const adapter = yield* TerminalAdapter
+      yield* adapter.createSession({ name: "atc-iiii", cwd: sandbox.base })
+      yield* Effect.gen(function* () {
+        const connection = yield* adapter.attachSession("atc-iiii", { cols: 80, rows: 24 })
+        const sink = yield* collectText(connection.output)
+        yield* connection.write("hello\n")
+        yield* waitForText(sink, "echo:hello")
+      }).pipe(Effect.scoped)
+    }).pipe(Effect.provide(adapterLayer(sandbox)))
+  })
+
+  it.live("fails with one actionable line when the executable is missing", () => {
+    const sandbox = makeSandbox()
+    return Effect.gen(function* () {
+      const adapter = yield* TerminalAdapter
+      const result = yield* Effect.result(adapter.listSessions())
+      assert.strictEqual(result._tag, "Failure")
+      if (result._tag === "Failure") {
+        assert.strictEqual(result.failure._tag, "ZmxUnavailable")
+        assert.match(result.failure.message, /install zmx on PATH|ATC_ZMX_EXECUTABLE/)
+      }
+    }).pipe(Effect.provide(adapterLayer(sandbox, TIGHT, "definitely-not-a-real-zmx-executable")))
+  })
+
+  it.live("refuses to boot when socket paths would exceed the unix limit", () => {
+    const sandbox = makeSandbox()
+    const deepDir = path.join(sandbox.base, "x".repeat(120))
+    return Effect.gen(function* () {
+      const result = yield* Effect.result(
+        Layer.build(
+          Zmx.layerWith(TIGHT).pipe(
+            Layer.provide(
+              testAppConfig({ zmxExecutable: sandbox.wrapper, terminalSocketDir: deepDir }),
+            ),
+            Layer.provide(Subprocess.layer),
+            Layer.provideMerge(BunServices.layer),
+          ),
+        ),
+      )
+      assert.strictEqual(result._tag, "Failure")
+      if (result._tag === "Failure") {
+        assert.match(String(result.failure), /too deep|exceed/)
+      }
+    }).pipe(Effect.scoped)
+  })
+})
+
+describe("fake adapter honesty", () => {
+  it.effect("mirrors the adapter contract: create, list, attach, kill", () => {
+    const fake = makeFakeAdapter()
+    return Effect.gen(function* () {
+      const adapter = yield* TerminalAdapter
+      yield* adapter.createSession({ name: "atc-1111", cwd: "/w", command: ["vim"] })
+      assert.deepStrictEqual(
+        (yield* adapter.listSessions()).map((s) => s.name),
+        ["atc-1111"],
+      )
+      // Creating is never silently attaching, like the real adapter.
+      const duplicate = yield* Effect.result(
+        adapter.createSession({ name: "atc-1111", cwd: "/other" }),
+      )
+      assert.strictEqual(duplicate._tag, "Failure")
+      yield* Effect.gen(function* () {
+        const connection = yield* adapter.attachSession("atc-1111", { cols: 100, rows: 30 })
+        yield* connection.write("keys")
+        yield* connection.resize({ cols: 120, rows: 40 })
+        fake.emitOutput("atc-1111", new TextEncoder().encode("out"))
+        const first = yield* Stream.runHead(connection.output)
+        assert.strictEqual(first._tag, "Some")
+        const session = fake.sessions.get("atc-1111")
+        assert.deepStrictEqual(session?.written, ["keys"])
+        assert.deepStrictEqual(session?.lastResize, { cols: 120, rows: 40 })
+      }).pipe(Effect.scoped)
+      yield* adapter.killSession("atc-1111")
+      assert.deepStrictEqual(yield* adapter.listSessions(), [])
+      // Idempotent: killing the absent session still succeeds.
+      yield* adapter.killSession("atc-1111")
+    }).pipe(Effect.provide(fake.layer))
+  })
+
+  it.effect("fails attach like the real adapter: missing and unreachable", () => {
+    const fake = makeFakeAdapter()
+    return Effect.gen(function* () {
+      const adapter = yield* TerminalAdapter
+      const missing = yield* Effect.result(
+        adapter.attachSession("atc-none", { cols: 80, rows: 24 }).pipe(Effect.scoped),
+      )
+      assert.strictEqual(missing._tag, "Failure")
+      if (missing._tag === "Failure") {
+        assert.strictEqual(missing.failure._tag, "SessionNotFound")
+      }
+      yield* adapter.createSession({ name: "atc-2222", cwd: "/w" })
+      fake.sessions.get("atc-2222")!.reachable = false
+      assert.deepStrictEqual(yield* adapter.listSessions(), [
+        { name: "atc-2222", reachable: false },
+      ])
+      const unreachable = yield* Effect.result(
+        adapter.attachSession("atc-2222", { cols: 80, rows: 24 }).pipe(Effect.scoped),
+      )
+      assert.strictEqual(unreachable._tag, "Failure")
+      if (unreachable._tag === "Failure") {
+        assert.strictEqual(unreachable.failure._tag, "SessionOperationFailed")
+      }
+    }).pipe(Effect.provide(fake.layer))
+  })
+
+  it.effect("switches every inventory consumer to ZmxUnavailable", () => {
+    const fake = makeFakeAdapter()
+    fake.setUnavailable(true)
+    return Effect.gen(function* () {
+      const adapter = yield* TerminalAdapter
+      for (const operation of [
+        Effect.asVoid(adapter.listSessions()),
+        adapter.createSession({ name: "atc-3333", cwd: "/w" }),
+        adapter.killSession("atc-3333"),
+        Effect.asVoid(Effect.scoped(adapter.attachSession("atc-3333", { cols: 1, rows: 1 }))),
+      ]) {
+        const result = yield* Effect.result(operation)
+        assert.strictEqual(result._tag, "Failure")
+        if (result._tag === "Failure") {
+          assert.strictEqual((result.failure as { _tag: string })._tag, "ZmxUnavailable")
+        }
+      }
+    }).pipe(Effect.provide(fake.layer))
+  })
+})

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -1,4 +1,7 @@
-import { Layer } from "effect"
+import { assert } from "@effect/vitest"
+import { Effect, Layer, Stream } from "effect"
+import * as fs from "node:fs"
+import { AppConfig } from "../src/config.ts"
 import * as Directories from "../src/directories.ts"
 import * as Persistence from "../src/persistence.ts"
 import * as ProjectRepository from "../src/projectRepository.ts"
@@ -9,3 +12,62 @@ export const TestRepositoryLayers = Layer.mergeAll(
   ProjectRepository.layer.pipe(Layer.provide(Persistence.layerFile(":memory:"))),
   Directories.layer,
 )
+
+/** A settled AppConfig for tests that only need a few fields overridden. */
+export const testAppConfig = (overrides: Partial<AppConfig["Service"]>): Layer.Layer<AppConfig> =>
+  Layer.succeed(AppConfig)({
+    port: 0,
+    logLevel: "Info",
+    configFile: "/dev/null",
+    dataDir: "/tmp",
+    stateDir: "/tmp",
+    dbFile: "/tmp/atc.db",
+    logFile: "/tmp/atc.log",
+    zmxExecutable: "zmx",
+    terminalSocketDir: "/tmp/atc-sockets",
+    ...overrides,
+  })
+
+const tempDirs: Array<string> = []
+
+/** Track `dir` for removal by `cleanupTempDirs` (call it from afterAll). */
+export const trackTempDir = (dir: string): string => {
+  tempDirs.push(dir)
+  return dir
+}
+
+/**
+ * A throwaway socket directory short enough for the unix socket-path budget
+ * (~103 bytes) — macOS os.tmpdir() (/var/folders/…) is too deep, /tmp is not.
+ */
+export const makeShortSocketDir = (): string => trackTempDir(fs.mkdtempSync("/tmp/atc-zs-"))
+
+export const cleanupTempDirs = (): void => {
+  for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true })
+}
+
+/** Collect a byte stream into a text sink in the background (scoped). */
+export const collectText = (output: Stream.Stream<Uint8Array, unknown>) =>
+  Effect.gen(function* () {
+    const decoder = new TextDecoder()
+    const sink = { text: "" }
+    yield* output.pipe(
+      Stream.runForEach((chunk) =>
+        Effect.sync(() => {
+          sink.text += decoder.decode(chunk, { stream: true })
+        }),
+      ),
+      Effect.ignore,
+      Effect.forkScoped,
+    )
+    return sink
+  })
+
+/** Poll until `pattern` shows up in the sink; assertion-bounded. */
+export const waitForText = (sink: { text: string }, pattern: string) =>
+  Effect.gen(function* () {
+    for (let attempt = 0; !sink.text.includes(pattern); attempt++) {
+      assert.isBelow(attempt, 100, `never saw ${JSON.stringify(pattern)} in ${sink.text}`)
+      yield* Effect.sleep("50 millis")
+    }
+  })

--- a/app-server/test/zmxSmoke.test.ts
+++ b/app-server/test/zmxSmoke.test.ts
@@ -1,0 +1,88 @@
+import { assert, describe, it } from "@effect/vitest"
+import { BunServices } from "@effect/platform-bun"
+import { Effect, Layer } from "effect"
+import { afterAll } from "vitest"
+import * as Subprocess from "../src/subprocess.ts"
+import { TerminalAdapter } from "../src/terminalAdapter.ts"
+import * as Zmx from "../src/zmxAdapter.ts"
+import {
+  cleanupTempDirs,
+  collectText,
+  makeShortSocketDir,
+  testAppConfig,
+  waitForText,
+} from "./testLayers.ts"
+
+// Opt-in smoke tests against the real, user-installed zmx binary
+// (mise run test:zmx). They prove the pinned behavioral assumptions — attach
+// auto-creates, kill-then-poll, private ZMX_DIR isolation — on the real
+// multiplexer, inside a throwaway socket directory.
+
+const enabled = process.env["ATC_ZMX_SMOKE"] === "1"
+
+afterAll(cleanupTempDirs)
+
+const makeLayer = () =>
+  Zmx.layer.pipe(
+    Layer.provide(
+      testAppConfig({
+        zmxExecutable: process.env["ATC_ZMX_EXECUTABLE"] ?? "zmx",
+        terminalSocketDir: makeShortSocketDir(),
+      }),
+    ),
+    Layer.provide(Subprocess.layer),
+    Layer.provideMerge(BunServices.layer),
+  )
+
+describe.skipIf(!enabled)("real zmx smoke (opt-in: mise run test:zmx)", () => {
+  it.live(
+    "runs the full interactive lifecycle: create, list, attach, kill",
+    () =>
+      Effect.gen(function* () {
+        const adapter = yield* TerminalAdapter
+        const name = `atc-${"5".repeat(32)}`
+        yield* Effect.gen(function* () {
+          yield* adapter.createSession({ name, cwd: "/tmp" })
+          const sessions = yield* adapter.listSessions()
+          assert.deepStrictEqual(
+            sessions.map((s) => s.name),
+            [name],
+          )
+
+          yield* Effect.gen(function* () {
+            const connection = yield* adapter.attachSession(name, { cols: 100, rows: 30 })
+            const sink = yield* collectText(connection.output)
+            yield* connection.write("printf 'MARKER-%s\\n' smoke\n")
+            yield* waitForText(sink, "MARKER-smoke")
+          }).pipe(Effect.scoped)
+
+          // Detaching must not have ended the session.
+          assert.deepStrictEqual(
+            (yield* adapter.listSessions()).map((s) => s.name),
+            [name],
+          )
+        }).pipe(Effect.ensuring(Effect.ignore(adapter.killSession(name))))
+        assert.deepStrictEqual(yield* adapter.listSessions(), [])
+      }).pipe(Effect.provide(makeLayer())),
+    30_000,
+  )
+
+  it.live(
+    "creates an exec-style command session and kills it",
+    () =>
+      Effect.gen(function* () {
+        const adapter = yield* TerminalAdapter
+        const name = `atc-${"6".repeat(32)}`
+        yield* Effect.gen(function* () {
+          yield* adapter.createSession({ name, cwd: "/tmp", command: ["sleep", "120"] })
+          const sessions = yield* adapter.listSessions()
+          assert.deepStrictEqual(
+            sessions.map((s) => s.name),
+            [name],
+          )
+        }).pipe(Effect.ensuring(Effect.ignore(adapter.killSession(name))))
+        assert.deepStrictEqual(yield* adapter.listSessions(), [])
+      }).pipe(Effect.provide(makeLayer())),
+    30_000,
+  )
+})

--- a/mise.toml
+++ b/mise.toml
@@ -95,6 +95,8 @@ clone() {
 clone effect --branch 'effect@4.0.0-beta.102' https://github.com/Effect-TS/effect.git
 clone t3code https://github.com/pingdotgg/t3code.git
 clone opencode https://github.com/sst/opencode.git
+# Keep the zmx tag in sync with the installed zmx binary (brew info zmx).
+clone zmx --branch 'v0.6.0' https://github.com/neurosnap/zmx.git
 """
 
 [tasks."macos:release-dev"]


### PR DESCRIPTION
The structural core of zmx-backed Terminal support ([ATC-129](https://linear.app/elevenideas/issue/ATC-129), part of [ATC-122](https://linear.app/elevenideas/issue/ATC-122)) — stacked PR 1 of 2. PR 2 (Terminal resources, WebSocket attach transport, CLI, reconciliation) builds on this branch.

## What's here

- **`Subprocess` PTY extension** (`src/subprocess.ts`): `spawnPty` on the existing seam using Bun's native PTY (`Bun.spawn` + `terminal:`), with the same scoped kill+reap guarantees (SIGTERM → SIGKILL escalation, PTY released on scope close). Bounded sliding output queue, decoded `outputTail` for diagnostics, short-write detection.
- **`TerminalAdapter` seam** (`src/terminalAdapter.ts`): the narrow interface the rest of the app talks to — derived session names (`atc-` + terminal id's 32 hex chars, reversible, never persisted), `ZmxUnavailable` (retryable, "inventory says nothing") vs `SessionOperationFailed` (conclusive) vs `SessionNotFound` error vocabulary.
- **zmx implementation** (`src/zmxAdapter.ts`): private `ZMX_DIR` under the state dir (0700), mandatory env scrubbing (`ZMX_SESSION`, `ZMX_SESSION_PREFIX`), socket-path length validated at boot (103/107 bytes by platform), explicit executable resolution with one actionable diagnostic, tolerant `zmx list` parsing where `err=` entries are existing-but-unreachable.
- **Config** (`src/config.ts`): `zmxExecutable` key (file / `ATC_ZMX_EXECUTABLE`, default `zmx` on PATH; bare-name-or-absolute validated) and `terminalSocketDir`.
- **Tests**: deterministic adapter suite against a `fake-zmx` fixture (per-test wrapper scripts, no `process.env` mutation), PTY seam tests, fake in-memory adapter for PR 2 consumers with honesty tests, and opt-in real-zmx smoke tests (`mise run -C app-server test:zmx`, verified green against zmx 0.6.0).

## Behavioral invariants encoded (from the ATC-122 decision record)

- Only a **complete inventory** proves absence; only a **reachable** entry proves a live session. Exit codes, PTY EOF, and attach failures never mark anything ended.
- `zmx attach` auto-creates, so: create pre-flights (creating is never silently attaching — a name collision fails conclusively), attach pre-flights and then verifies by daemon pid that it reached the original session, killing a silently resurrected phantom.
- `zmx kill` returns before death: absence is verified by polling complete inventory passes. Verification is **pass-counted, not wall-clock**, so a slow inventory extends the wait instead of manufacturing a conclusive failure; each zmx command has its own timeout mapping to retryable `ZmxUnavailable`.
- A command that finishes before its session settles is a failed launch (with a captured output tail as the diagnostic).

## Boundary note for reviewers

`ZmxUnavailable` is defined in `terminalAdapter.ts` here; PR 2 moves it into the contract (`api.ts`, 503) because the API surfaces it directly. Likewise the temp-dir test helpers and the `test:zmx` task grow in PR 2 (recovery suite, compiled-binary dependency). Reviewed in isolation, those placements are intentional way-points, not final homes.

## Review process

Implemented, then adversarially reviewed by two independent reviewers (correctness, simplicity). The correctness review reproduced a critical bug against real zmx (an unreachable `err=` inventory entry satisfied the create settle-poll) which is fixed here with the reachable-qualified predicate plus a regression test; also fixed: create-over-existing silently attaching, attach TOCTOU resurrection, latency-as-failure in verification, bad-cwd misclassified as retryable, world-readable socket dir, Linux socket-path limit. The simplicity review drove the spec dedup (`PtySpawnSpec extends SpawnSpec`), the shared `outputTail`, wrapper-baked fixture config, and shared test helpers.

Known coverage gap: the attach TOCTOU resurrection guard has no deterministic unit test (the race window can't be scripted with the fixture); it is exercised structurally and against real zmx in the smoke suite.

https://claude.ai/code/session_01GwZRRGJnPmgbTnSNwuBT3j
