### PR TITLE
ATC-130: Terminal resources, WebSocket attach transport, CLI, and reconciliation (PR 2 of 2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,8 +268,10 @@ bytes; policy and transports live above it.
 - The WebSocket attach endpoint is contract-declared (`attachTerminal`)
   and marked `OpenApi.Exclude`, so it never enters the serialized OpenAPI
   document (REST clients and the Swift generator cannot represent it). Wire protocol
-  and close vocabulary live in the contract description and
-  `src/terminalAttach.ts`: binary frames are bytes, text frames are JSON
+  and close vocabulary have one code home, `src/attachProtocol.ts` (Schema-typed
+  control frames, close reasons, the attach URL builder), consumed by both the
+  server bridge (`src/terminalAttach.ts`) and the CLI client and documented in
+  prose on the contract endpoint: binary frames are bytes, text frames are JSON
   control (`resize`, `ping`/`pong`), close 1000 `terminal_ended` is
   authoritative, 1011 reasons are retryable. Attach bridges are forked into
   the handler layer's scope — Bun aborts the upgraded request's fiber — and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,12 +127,15 @@ Both public clients derive from the same contract:
   unchanged and coexists until the app migrates.
 
 CLI commands backed by API operations use the contract-derived TypeScript
-client (`atc health`, `atc version`, `atc project …`, `atc fs check`): JSON
-payload on stdout and exit 0 on success; diagnostics on stderr with exit 1 on
-invalid usage, configuration, or request failure. API-backed commands take
-zero connection flags: the base URL derives from the settled configuration
-(`http://127.0.0.1:<port>`), resolved in the single seam in `cli.ts` — remote
-endpoint addressing (endpoint + token) lands there with the auth work. The
+client (`atc health`, `atc version`, `atc project …`, `atc terminal …`,
+`atc fs check`): JSON payload on stdout and exit 0 on success; diagnostics on
+stderr with exit 1 on invalid usage, configuration, or request failure.
+`atc terminal attach` is the one non-JSON command: it bridges the local
+TTY onto the WebSocket attach endpoint in raw mode (detach with Ctrl-]).
+API-backed commands take zero connection flags: the base URL derives from
+the settled configuration (`http://127.0.0.1:<port>`), resolved in the
+single seam in `cli.ts` — remote endpoint addressing (endpoint + token)
+lands there with the auth work. The
 CLI may resolve relative directory arguments client-side before calling the
 API (which takes server-host absolute paths only).
 
@@ -157,12 +160,13 @@ naming the offending source; never a partial boot.
 
 - Paths: one XDG rule on every platform (macOS included), honoring `XDG_*`
   overrides. Config `~/.config/atc/config.toml`; data (SQLite `atc.db`)
-  `~/.local/share/atc/`; state (log file `atc.log`) `~/.local/state/atc/`.
+  `~/.local/share/atc/`; state (log file `atc.log`, zmx sockets
+  `terminals/`) `~/.local/state/atc/`.
 - Environment variables are flat `ATC_<KEY>` (`ATC_PORT`, `ATC_LOG_LEVEL`,
-  `ATC_DATA_DIR`, `ATC_CONFIG`). No sectioned naming.
+  `ATC_DATA_DIR`, `ATC_CONFIG`, `ATC_ZMX_EXECUTABLE`). No sectioned naming.
 - The config file is TOML with camelCase keys (`port`, `logLevel`,
-  `dataDir`); unknown keys are rejected. The TOML format never leaks past
-  `config.ts`.
+  `dataDir`, `zmxExecutable`); unknown keys are rejected. The TOML format
+  never leaks past `config.ts`.
 - Compiled behavior never depends on the working directory; tests isolate
   themselves by pointing `XDG_*`/`ATC_*` at temp dirs (`test/blackbox.ts`
   `isolatedEnv`).
@@ -250,9 +254,31 @@ bytes; policy and transports live above it.
   entry proves a live session) are documented where they are enforced — the
   header of `src/zmxAdapter.ts`, derived from the pinned source in
   `repos/zmx`.
-- Coverage: deterministic tests drive the adapter against the
-  `test/fixtures/fake-zmx.ts` stand-in; `mise run -C app-server test:zmx`
-  opts into smoke tests against the real installed zmx.
+- Terminals are durable, project-scoped records (`src/terminals.ts`,
+  `src/terminalRepository.ts`): UUIDv7 id, immutable command argv and
+  canonicalized initial working directory, mutable label, public states
+  `live`/`ended` (tombstones persist until explicit delete; `starting` is an
+  internal crash-mid-create marker). Create starts the zmx session; a failed
+  launch leaves no record; project deletion is restricted while terminals
+  exist. Reconciliation is demand-driven (startup during layer build, and on
+  list/read/attach): only a complete inventory marks anything ended, an
+  unavailable inventory leaves stored state untouched (`ZmxUnavailable`,
+  503, retryable), and startup also cleans orphan sessions in the private
+  dir.
+- The WebSocket attach endpoint is contract-declared (`attachTerminal`)
+  and marked `OpenApi.Exclude`, so it never enters the serialized OpenAPI
+  document (REST clients and the Swift generator cannot represent it). Wire protocol
+  and close vocabulary live in the contract description and
+  `src/terminalAttach.ts`: binary frames are bytes, text frames are JSON
+  control (`resize`, `ping`/`pong`), close 1000 `terminal_ended` is
+  authoritative, 1011 reasons are retryable. Attach bridges are forked into
+  the handler layer's scope — Bun aborts the upgraded request's fiber — and
+  server shutdown reaps them.
+- Coverage: deterministic tests drive the adapter and the whole transport
+  against the `test/fixtures/fake-zmx.ts` stand-in (a spawned serve with
+  `ATC_ZMX_EXECUTABLE` pointed at the fixture wrapper);
+  `mise run -C app-server test:zmx` opts into real-zmx smoke plus compiled
+  restart-recovery tests.
 
 ## Code Style
 

--- a/app-server/mise.toml
+++ b/app-server/mise.toml
@@ -74,6 +74,6 @@ depends = ["build"]
 run = "ATC_SMOKE=1 bun --bun vitest run test/provider.smoke.test.ts"
 
 [tasks."test:zmx"]
-description = "Opt-in smoke tests against the real installed zmx binary"
-depends = ["install"]
-run = "ATC_ZMX_SMOKE=1 bun --bun vitest run test/zmxSmoke.test.ts"
+description = "Opt-in tests against the real installed zmx: adapter smoke and compiled restart recovery"
+depends = ["build"]
+run = "ATC_ZMX_SMOKE=1 bun --bun vitest run test/zmxSmoke.test.ts test/zmxRecovery.blackbox.test.ts"

--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -259,9 +259,258 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "The project still owns terminals (live or ended); delete them first.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectHasTerminalsJsonEncoding"
+                }
+              }
+            }
           }
         },
-        "description": "Delete the project record. Never touches the filesystem or any directory."
+        "description": "Delete the project record. Restricted while the project still owns terminals; never touches the filesystem or any directory."
+      }
+    },
+    "/api/v1/terminals": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "listTerminals",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "description": "Restrict the listing to one project."
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Terminals, newest first.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TerminalList"
+                }
+              }
+            }
+          }
+        },
+        "description": "List terminals, reconciled against the zmx inventory on a best-effort basis (an unavailable inventory returns the stored state untouched)."
+      },
+      "post": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "createTerminal",
+        "parameters": [],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "A durable, project-scoped terminal backed by a zmx session.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Terminal"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No project exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectNotFoundJsonEncoding"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The directory does not exist, is not a directory, or cannot be read/traversed. | The directory check did not complete within its bounded timeout. Retryable — a timeout is not proof the path is missing. | The terminal's zmx session failed to launch (bad command, immediate exit, or settle failure). The failed launch leaves no terminal record.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/DirectoryUnavailableJsonEncoding"
+                    },
+                    {
+                      "$ref": "#/components/schemas/DirectoryCheckTimedOutJsonEncoding"
+                    },
+                    {
+                      "$ref": "#/components/schemas/TerminalLaunchFailedJsonEncoding"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The zmx multiplexer cannot be consulted right now. Retryable; stored terminal state is untouched.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ZmxUnavailableJsonEncoding"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create a terminal and start its zmx session immediately (an interactive login shell, or the exec-style command argv). A failed launch leaves no record.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTerminalRequest"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v1/terminals/{terminalId}": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "getTerminal",
+        "parameters": [
+          {
+            "name": "terminalId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "A durable, project-scoped terminal backed by a zmx session.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Terminal"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No terminal exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TerminalNotFoundJsonEncoding"
+                }
+              }
+            }
+          }
+        },
+        "description": "Fetch one terminal by id, reconciled on read."
+      },
+      "patch": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "updateTerminal",
+        "parameters": [
+          {
+            "name": "terminalId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "A durable, project-scoped terminal backed by a zmx session.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Terminal"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No terminal exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TerminalNotFoundJsonEncoding"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update a terminal's display label (the only mutable field).",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTerminalRequest"
+              }
+            }
+          },
+          "required": true
+        }
+      },
+      "delete": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "deleteTerminal",
+        "parameters": [
+          {
+            "name": "terminalId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "204": {
+            "description": "<No Content>"
+          },
+          "404": {
+            "description": "No terminal exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TerminalNotFoundJsonEncoding"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The zmx multiplexer cannot be consulted right now. Retryable; stored terminal state is untouched.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ZmxUnavailableJsonEncoding"
+                }
+              }
+            }
+          }
+        },
+        "description": "Delete a terminal: kill its zmx session if present, verify absence, then remove the record (tombstones included)."
       }
     },
     "/api/v1/fs/check": {
@@ -493,6 +742,197 @@
         },
         "additionalProperties": false,
         "description": "Partial update; affects future Threads and Terminals only."
+      },
+      "ProjectHasTerminalsJsonEncoding": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": [
+              "ProjectHasTerminals"
+            ]
+          },
+          "projectId": {
+            "type": "string"
+          },
+          "terminalCount": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "_tag",
+          "projectId",
+          "terminalCount"
+        ],
+        "additionalProperties": false
+      },
+      "TerminalStatus": {
+        "type": "string",
+        "enum": [
+          "live",
+          "ended"
+        ],
+        "description": "Public terminal lifecycle state: live (zmx session running) or ended (tombstone until deleted)."
+      },
+      "Terminal": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "UUIDv7 terminal id."
+          },
+          "projectId": {
+            "type": "string",
+            "description": "Owning project id."
+          },
+          "name": {
+            "type": "string",
+            "description": "Mutable display label."
+          },
+          "command": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "description": "Immutable exec-style argv the terminal was launched with; absent for an interactive login shell."
+          },
+          "initialWorkingDirectory": {
+            "type": "string",
+            "description": "Canonical directory the terminal was launched in (immutable)."
+          },
+          "status": {
+            "$ref": "#/components/schemas/TerminalStatus"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation time (ISO 8601 UTC)."
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Last update time (ISO 8601 UTC)."
+          },
+          "endedAt": {
+            "type": "string",
+            "description": "When the terminal was observed ended (ISO 8601 UTC); absent while live."
+          }
+        },
+        "required": [
+          "id",
+          "projectId",
+          "initialWorkingDirectory",
+          "status",
+          "createdAt",
+          "updatedAt"
+        ],
+        "additionalProperties": false,
+        "description": "A durable, project-scoped terminal backed by a zmx session."
+      },
+      "TerminalList": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Terminal"
+        },
+        "description": "Terminals, newest first."
+      },
+      "CreateTerminalRequest": {
+        "type": "object",
+        "properties": {
+          "projectId": {
+            "type": "string",
+            "description": "Owning project id."
+          },
+          "name": {
+            "type": "string",
+            "description": "Display label."
+          },
+          "command": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "description": "Exec-style argv to run instead of an interactive login shell."
+          },
+          "workingDirectory": {
+            "type": "string",
+            "pattern": "^\\/",
+            "description": "Directory to launch in; defaults to the project's default working directory. Stored canonicalized."
+          }
+        },
+        "required": [
+          "projectId"
+        ],
+        "additionalProperties": false,
+        "description": "Payload for creating a terminal. Creation starts the zmx session immediately."
+      },
+      "TerminalLaunchFailedJsonEncoding": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": [
+              "TerminalLaunchFailed"
+            ]
+          },
+          "reason": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "_tag",
+          "reason"
+        ],
+        "additionalProperties": false
+      },
+      "ZmxUnavailableJsonEncoding": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": [
+              "ZmxUnavailable"
+            ]
+          },
+          "reason": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "_tag",
+          "reason"
+        ],
+        "additionalProperties": false
+      },
+      "TerminalNotFoundJsonEncoding": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": [
+              "TerminalNotFound"
+            ]
+          },
+          "terminalId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "_tag",
+          "terminalId"
+        ],
+        "additionalProperties": false
+      },
+      "UpdateTerminalRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "New display label."
+          }
+        },
+        "additionalProperties": false,
+        "description": "Partial update; only the display label is mutable."
       },
       "DirectoryState": {
         "type": "string",

--- a/app-server/src/api.ts
+++ b/app-server/src/api.ts
@@ -111,6 +111,74 @@ export const FsCheckResponse = Schema.Struct({
   description: "Result of a directory health check. Never persisted.",
 })
 
+export const TerminalStatus = Schema.Literals(["live", "ended"]).annotate({
+  identifier: "TerminalStatus",
+  description:
+    "Public terminal lifecycle state: live (zmx session running) or ended (tombstone until deleted).",
+})
+
+export const TerminalCommand = Schema.Array(Schema.String).check(
+  Schema.isMinLength(1, { description: "an exec-style argv with at least the program name" }),
+)
+
+export const Terminal = Schema.Struct({
+  id: Schema.String.annotate({ description: "UUIDv7 terminal id." }),
+  projectId: Schema.String.annotate({ description: "Owning project id." }),
+  // Absent keys (not null) for optional fields — see UpdateProjectRequest.
+  name: Schema.optionalKey(Schema.String.annotate({ description: "Mutable display label." })),
+  command: Schema.optionalKey(
+    TerminalCommand.annotate({
+      description:
+        "Immutable exec-style argv the terminal was launched with; absent for an interactive login shell.",
+    }),
+  ),
+  initialWorkingDirectory: Schema.String.annotate({
+    description: "Canonical directory the terminal was launched in (immutable).",
+  }),
+  status: TerminalStatus,
+  createdAt: Schema.String.annotate({ description: "Creation time (ISO 8601 UTC)." }),
+  updatedAt: Schema.String.annotate({ description: "Last update time (ISO 8601 UTC)." }),
+  endedAt: Schema.optionalKey(
+    Schema.String.annotate({
+      description: "When the terminal was observed ended (ISO 8601 UTC); absent while live.",
+    }),
+  ),
+}).annotate({
+  identifier: "Terminal",
+  description: "A durable, project-scoped terminal backed by a zmx session.",
+})
+
+export const TerminalList = Schema.Array(Terminal).annotate({
+  identifier: "TerminalList",
+  description: "Terminals, newest first.",
+})
+
+export const CreateTerminalRequest = Schema.Struct({
+  projectId: Schema.String.annotate({ description: "Owning project id." }),
+  name: Schema.optionalKey(Schema.String.annotate({ description: "Display label." })),
+  command: Schema.optionalKey(
+    TerminalCommand.annotate({
+      description: "Exec-style argv to run instead of an interactive login shell.",
+    }),
+  ),
+  workingDirectory: Schema.optionalKey(
+    AbsolutePath.annotate({
+      description:
+        "Directory to launch in; defaults to the project's default working directory. Stored canonicalized.",
+    }),
+  ),
+}).annotate({
+  identifier: "CreateTerminalRequest",
+  description: "Payload for creating a terminal. Creation starts the zmx session immediately.",
+})
+
+export const UpdateTerminalRequest = Schema.Struct({
+  name: Schema.optionalKey(Schema.String.annotate({ description: "New display label." })),
+}).annotate({
+  identifier: "UpdateTerminalRequest",
+  description: "Partial update; only the display label is mutable.",
+})
+
 // The error classes carry human `message`s so every consumer (the CLI above
 // all) can print a real diagnostic — a TaggedErrorClass message is otherwise
 // empty.
@@ -171,7 +239,74 @@ export class DirectoryCheckTimedOut extends Schema.TaggedErrorClass<DirectoryChe
   }
 }
 
+/** Unknown terminal id. */
+export class TerminalNotFound extends Schema.TaggedErrorClass<TerminalNotFound>()(
+  "TerminalNotFound",
+  { terminalId: Schema.String },
+  {
+    identifier: "TerminalNotFound",
+    description: "No terminal exists with the given id.",
+    httpApiStatus: 404,
+  },
+) {
+  override get message(): string {
+    return `no terminal with id ${this.terminalId}`
+  }
+}
+
+/**
+ * The zmx multiplexer cannot be consulted (executable missing, inventory
+ * failed, command timed out). Retryable: it says nothing about any
+ * terminal's existence, so stored state stays untouched.
+ */
+export class ZmxUnavailable extends Schema.TaggedErrorClass<ZmxUnavailable>()(
+  "ZmxUnavailable",
+  { reason: Schema.String },
+  {
+    identifier: "ZmxUnavailable",
+    description:
+      "The zmx multiplexer cannot be consulted right now. Retryable; stored terminal state is untouched.",
+    httpApiStatus: 503,
+  },
+) {
+  override get message(): string {
+    return this.reason
+  }
+}
+
+/** The zmx session for a new terminal failed to launch; conclusive. */
+export class TerminalLaunchFailed extends Schema.TaggedErrorClass<TerminalLaunchFailed>()(
+  "TerminalLaunchFailed",
+  { reason: Schema.String },
+  {
+    identifier: "TerminalLaunchFailed",
+    description:
+      "The terminal's zmx session failed to launch (bad command, immediate exit, or settle failure). The failed launch leaves no terminal record.",
+    httpApiStatus: 422,
+  },
+) {
+  override get message(): string {
+    return this.reason
+  }
+}
+
+/** Project deletion is restricted while it still owns terminals. */
+export class ProjectHasTerminals extends Schema.TaggedErrorClass<ProjectHasTerminals>()(
+  "ProjectHasTerminals",
+  { projectId: Schema.String, terminalCount: Schema.Int },
+  {
+    identifier: "ProjectHasTerminals",
+    description: "The project still owns terminals (live or ended); delete them first.",
+    httpApiStatus: 409,
+  },
+) {
+  override get message(): string {
+    return `project ${this.projectId} still owns ${this.terminalCount} terminal(s); delete them first`
+  }
+}
+
 const projectIdParam = { projectId: Schema.String }
+const terminalIdParam = { terminalId: Schema.String }
 
 export class V1 extends HttpApiGroup.make("v1")
   .add(
@@ -217,12 +352,93 @@ export class V1 extends HttpApiGroup.make("v1")
       ),
     HttpApiEndpoint.delete("deleteProject", "/projects/:projectId", {
       params: projectIdParam,
-      error: ProjectNotFound,
+      error: [ProjectNotFound, ProjectHasTerminals],
     })
       .annotate(OpenApi.Identifier, "deleteProject")
       .annotate(
         OpenApi.Description,
-        "Delete the project record. Never touches the filesystem or any directory.",
+        "Delete the project record. Restricted while the project still owns terminals; never touches the filesystem or any directory.",
+      ),
+    HttpApiEndpoint.get("listTerminals", "/terminals", {
+      query: {
+        projectId: Schema.optionalKey(
+          Schema.String.annotate({ description: "Restrict the listing to one project." }),
+        ),
+      },
+      success: TerminalList,
+    })
+      .annotate(OpenApi.Identifier, "listTerminals")
+      .annotate(
+        OpenApi.Description,
+        "List terminals, reconciled against the zmx inventory on a best-effort basis (an unavailable inventory returns the stored state untouched).",
+      ),
+    HttpApiEndpoint.post("createTerminal", "/terminals", {
+      payload: CreateTerminalRequest,
+      success: Terminal,
+      error: [
+        ProjectNotFound,
+        DirectoryUnavailable,
+        DirectoryCheckTimedOut,
+        ZmxUnavailable,
+        TerminalLaunchFailed,
+      ],
+    })
+      .annotate(OpenApi.Identifier, "createTerminal")
+      .annotate(
+        OpenApi.Description,
+        "Create a terminal and start its zmx session immediately (an interactive login shell, or the exec-style command argv). A failed launch leaves no record.",
+      ),
+    HttpApiEndpoint.get("getTerminal", "/terminals/:terminalId", {
+      params: terminalIdParam,
+      success: Terminal,
+      error: TerminalNotFound,
+    })
+      .annotate(OpenApi.Identifier, "getTerminal")
+      .annotate(OpenApi.Description, "Fetch one terminal by id, reconciled on read."),
+    HttpApiEndpoint.patch("updateTerminal", "/terminals/:terminalId", {
+      params: terminalIdParam,
+      payload: UpdateTerminalRequest,
+      success: Terminal,
+      error: TerminalNotFound,
+    })
+      .annotate(OpenApi.Identifier, "updateTerminal")
+      .annotate(OpenApi.Description, "Update a terminal's display label (the only mutable field)."),
+    HttpApiEndpoint.delete("deleteTerminal", "/terminals/:terminalId", {
+      params: terminalIdParam,
+      error: [TerminalNotFound, ZmxUnavailable],
+    })
+      .annotate(OpenApi.Identifier, "deleteTerminal")
+      .annotate(
+        OpenApi.Description,
+        "Delete a terminal: kill its zmx session if present, verify absence, then remove the record (tombstones included).",
+      ),
+    // WebSocket upgrade endpoint: declared in the contract for the typed
+    // route tree and params, excluded from the OpenAPI document (REST
+    // clients and the Swift generator cannot represent an upgrade). Wire
+    // protocol: binary frames are terminal bytes both ways; text frames are
+    // JSON control messages ({"type":"resize","cols","rows"} from the
+    // client; {"type":"ping"}/{"type":"pong"} keepalives). Close
+    // vocabulary — the single statement of it, mirrored by the bridge: 1000
+    // terminal_ended is authoritative (confirmed absent, tombstone
+    // written); 1011 attach_failed / zmx_unavailable / ping_timeout are
+    // retryable and say nothing about the terminal's existence. Clients
+    // detach by closing 1000 "detach" (the session keeps running).
+    HttpApiEndpoint.get("attachTerminal", "/terminals/:terminalId/attach", {
+      params: terminalIdParam,
+      query: {
+        cols: Schema.optionalKey(
+          Schema.String.annotate({ description: "Initial terminal width (columns)." }),
+        ),
+        rows: Schema.optionalKey(
+          Schema.String.annotate({ description: "Initial terminal height (rows)." }),
+        ),
+      },
+    })
+      .annotate(OpenApi.Identifier, "attachTerminal")
+      .annotate(OpenApi.Exclude, true)
+      .annotate(
+        OpenApi.Description,
+        "WebSocket attach: upgrade to a live bidirectional bridge onto the terminal's zmx session.",
       ),
     HttpApiEndpoint.get("checkDirectory", "/fs/check", {
       query: { path: AbsolutePath },

--- a/app-server/src/attachClient.ts
+++ b/app-server/src/attachClient.ts
@@ -1,0 +1,102 @@
+import { Effect } from "effect"
+
+// The CLI side of `atc terminal attach` (ATC-130): a raw-terminal WebSocket
+// client bridging the local TTY onto the server's attach endpoint — the
+// e2e vehicle for the whole terminal transport. Binary frames are terminal
+// bytes both ways; text frames are the JSON control protocol (resize from
+// us, ping/pong keepalive from the server). Ctrl-] detaches locally
+// (the session keeps running server-side).
+
+const DETACH_BYTE = 0x1d // Ctrl-]
+
+export interface AttachResult {
+  readonly code: number
+  readonly reason: string
+}
+
+/**
+ * Run one attach session over `url` until the socket closes or the user
+ * detaches. Puts stdin into raw mode for the duration when it is a TTY.
+ * Callers pre-flight the terminal over the typed API, so a handshake
+ * failure here really is a connection problem.
+ */
+export const runAttach = (url: URL): Effect.Effect<AttachResult, Error> =>
+  Effect.callback<AttachResult, Error>((resume) => {
+    const stdin = process.stdin
+    const wasRaw = stdin.isTTY === true && stdin.isRaw
+    const socket = new WebSocket(url)
+    socket.binaryType = "arraybuffer"
+
+    let done = false
+    const cleanup = () => {
+      if (done) return
+      done = true
+      if (stdin.isTTY === true) stdin.setRawMode(wasRaw)
+      stdin.pause()
+      stdin.off("data", onStdin)
+      process.off("SIGWINCH", onResize)
+      if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
+        socket.close(1000, "detach")
+      }
+    }
+    const succeed = (result: AttachResult) => {
+      const first = !done
+      cleanup()
+      if (first) resume(Effect.succeed(result))
+    }
+    const fail = (error: Error) => {
+      const first = !done
+      cleanup()
+      if (first) resume(Effect.fail(error))
+    }
+
+    const onStdin = (chunk: Buffer) => {
+      const detachAt = chunk.indexOf(DETACH_BYTE)
+      const payload = detachAt === -1 ? chunk : chunk.subarray(0, detachAt)
+      if (payload.length > 0 && socket.readyState === WebSocket.OPEN) {
+        socket.send(new Uint8Array(payload))
+      }
+      if (detachAt !== -1) succeed({ code: 1000, reason: "detach" })
+    }
+
+    const onResize = () => {
+      if (socket.readyState === WebSocket.OPEN && process.stdout.isTTY === true) {
+        socket.send(
+          JSON.stringify({
+            type: "resize",
+            cols: process.stdout.columns,
+            rows: process.stdout.rows,
+          }),
+        )
+      }
+    }
+
+    socket.onopen = () => {
+      if (stdin.isTTY === true) stdin.setRawMode(true)
+      stdin.resume()
+      stdin.on("data", onStdin)
+      process.on("SIGWINCH", onResize)
+    }
+    socket.onmessage = (event) => {
+      if (typeof event.data === "string") {
+        try {
+          const control = JSON.parse(event.data) as { type?: string }
+          if (control.type === "ping") socket.send(JSON.stringify({ type: "pong" }))
+        } catch {
+          // Unknown control frames are ignored.
+        }
+        return
+      }
+      process.stdout.write(new Uint8Array(event.data as ArrayBuffer))
+    }
+    socket.onerror = () => {
+      fail(new Error(`cannot connect to ${url.host}; is the App Server running?`))
+    }
+    socket.onclose = (event) => {
+      succeed({ code: event.code, reason: event.reason })
+    }
+
+    // Interruption (e.g. SIGINT through runMain): restore the terminal and
+    // release the socket; the fiber's own exit reports the interruption.
+    return Effect.sync(cleanup)
+  })

--- a/app-server/src/attachClient.ts
+++ b/app-server/src/attachClient.ts
@@ -1,11 +1,12 @@
 import { Effect } from "effect"
+import { CLOSE_DETACH, decodeControlFrame, encodeControlFrame } from "./attachProtocol.ts"
 
 // The CLI side of `atc terminal attach` (ATC-130): a raw-terminal WebSocket
 // client bridging the local TTY onto the server's attach endpoint — the
-// e2e vehicle for the whole terminal transport. Binary frames are terminal
-// bytes both ways; text frames are the JSON control protocol (resize from
-// us, ping/pong keepalive from the server). Ctrl-] detaches locally
-// (the session keeps running server-side).
+// e2e vehicle for the whole terminal transport. The wire protocol lives in
+// attachProtocol.ts (binary frames are terminal bytes both ways; text
+// frames are JSON control: resize from us, ping/pong keepalive from the
+// server). Ctrl-] detaches locally (the session keeps running server-side).
 
 const DETACH_BYTE = 0x1d // Ctrl-]
 
@@ -36,18 +37,14 @@ export const runAttach = (url: URL): Effect.Effect<AttachResult, Error> =>
       stdin.off("data", onStdin)
       process.off("SIGWINCH", onResize)
       if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
-        socket.close(1000, "detach")
+        socket.close(1000, CLOSE_DETACH)
       }
     }
-    const succeed = (result: AttachResult) => {
-      const first = !done
+    /** Resolve exactly once, restoring the terminal first. */
+    const finish = (outcome: Effect.Effect<AttachResult, Error>) => {
+      if (done) return
       cleanup()
-      if (first) resume(Effect.succeed(result))
-    }
-    const fail = (error: Error) => {
-      const first = !done
-      cleanup()
-      if (first) resume(Effect.fail(error))
+      resume(outcome)
     }
 
     const onStdin = (chunk: Buffer) => {
@@ -56,13 +53,13 @@ export const runAttach = (url: URL): Effect.Effect<AttachResult, Error> =>
       if (payload.length > 0 && socket.readyState === WebSocket.OPEN) {
         socket.send(new Uint8Array(payload))
       }
-      if (detachAt !== -1) succeed({ code: 1000, reason: "detach" })
+      if (detachAt !== -1) finish(Effect.succeed({ code: 1000, reason: CLOSE_DETACH }))
     }
 
     const onResize = () => {
       if (socket.readyState === WebSocket.OPEN && process.stdout.isTTY === true) {
         socket.send(
-          JSON.stringify({
+          encodeControlFrame({
             type: "resize",
             cols: process.stdout.columns,
             rows: process.stdout.rows,
@@ -79,21 +76,18 @@ export const runAttach = (url: URL): Effect.Effect<AttachResult, Error> =>
     }
     socket.onmessage = (event) => {
       if (typeof event.data === "string") {
-        try {
-          const control = JSON.parse(event.data) as { type?: string }
-          if (control.type === "ping") socket.send(JSON.stringify({ type: "pong" }))
-        } catch {
-          // Unknown control frames are ignored.
+        if (decodeControlFrame(event.data)?.type === "ping") {
+          socket.send(encodeControlFrame({ type: "pong" }))
         }
         return
       }
       process.stdout.write(new Uint8Array(event.data as ArrayBuffer))
     }
     socket.onerror = () => {
-      fail(new Error(`cannot connect to ${url.host}; is the App Server running?`))
+      finish(Effect.fail(new Error(`cannot connect to ${url.host}; is the App Server running?`)))
     }
     socket.onclose = (event) => {
-      succeed({ code: event.code, reason: event.reason })
+      finish(Effect.succeed({ code: event.code, reason: event.reason }))
     }
 
     // Interruption (e.g. SIGINT through runMain): restore the terminal and

--- a/app-server/src/attachProtocol.ts
+++ b/app-server/src/attachProtocol.ts
@@ -1,0 +1,66 @@
+import { Option, Schema } from "effect"
+import type { SessionSize } from "./terminalAdapter.ts"
+
+// The attach wire protocol (ATC-130), stated once for every side of the
+// socket: the server bridge (terminalAttach.ts), the CLI client
+// (attachClient.ts), and any future client. The contract endpoint
+// description (api.ts `attachTerminal`) documents it in prose; this module
+// is the code authority both sides import.
+//
+// Binary frames are terminal bytes in both directions. Text frames are the
+// JSON control frames below. Close vocabulary: 1000 `terminal_ended` is
+// authoritative (a complete inventory proved the terminal ended) and 1000
+// `detach` is a deliberate client detach; 1011 reasons are retryable.
+
+const ControlFrame = Schema.Union([
+  Schema.Struct({ type: Schema.Literal("resize"), cols: Schema.Number, rows: Schema.Number }),
+  /** Server keepalive; a client answers with pong. */
+  Schema.Struct({ type: Schema.Literal("ping") }),
+  Schema.Struct({ type: Schema.Literal("pong") }),
+])
+export type ControlFrame = typeof ControlFrame.Type
+
+const decodeFrame = Schema.decodeUnknownOption(ControlFrame)
+
+/** Decode one text frame; unknown or malformed frames are undefined, never fatal. */
+export const decodeControlFrame = (text: string): ControlFrame | undefined => {
+  try {
+    return Option.getOrUndefined(decodeFrame(JSON.parse(text)))
+  } catch {
+    return undefined
+  }
+}
+
+export const encodeControlFrame = (frame: ControlFrame): string => JSON.stringify(frame)
+
+/**
+ * The one dimension rule for resize frames and `cols`/`rows` query params:
+ * missing or malformed values take the fallback, everything else is floored
+ * and clamped into [1, 1000].
+ */
+export const clampDimension = (raw: string | number | undefined, fallback: number): number => {
+  const parsed = typeof raw === "number" ? raw : Number.parseInt(raw ?? "", 10)
+  return Number.isNaN(parsed) ? fallback : Math.max(1, Math.min(1_000, Math.floor(parsed)))
+}
+
+/** Close (1000) reason proving the terminal ended — not retryable. */
+export const CLOSE_TERMINAL_ENDED = "terminal_ended"
+/** Close (1000) reason for a deliberate client detach. */
+export const CLOSE_DETACH = "detach"
+/** Retryable close (1011) reason: the attach could not be completed. */
+export const CLOSE_ATTACH_FAILED = "attach_failed"
+/** Retryable close (1011) reason: the multiplexer could not be consulted. */
+export const CLOSE_ZMX_UNAVAILABLE = "zmx_unavailable"
+/** Retryable close (1011) reason: the client stopped answering pings. */
+export const CLOSE_PING_TIMEOUT = "ping_timeout"
+
+/** The contract's `attachTerminal` route as a WebSocket URL. */
+export const attachUrl = (baseUrl: URL, terminalId: string, size?: SessionSize): URL => {
+  const url = new URL(`/api/v1/terminals/${encodeURIComponent(terminalId)}/attach`, baseUrl)
+  url.protocol = baseUrl.protocol === "https:" ? "wss:" : "ws:"
+  if (size !== undefined) {
+    url.searchParams.set("cols", String(size.cols))
+    url.searchParams.set("rows", String(size.rows))
+  }
+  return url
+}

--- a/app-server/src/cli.ts
+++ b/app-server/src/cli.ts
@@ -1,7 +1,10 @@
 import { BunHttpClient } from "@effect/platform-bun"
 import { Console, Effect, Layer, Option, Runtime, Schema } from "effect"
+import type { FileSystem } from "effect"
 import { Argument, Command, Flag } from "effect/unstable/cli"
+import type { HttpClient } from "effect/unstable/http"
 import * as path from "node:path"
+import * as AttachClient from "./attachClient.ts"
 import * as Client from "./client.ts"
 import { AppConfig, ConfigLoadError, layer as appConfigLayer } from "./config.ts"
 import * as Directories from "./directories.ts"
@@ -10,6 +13,9 @@ import * as Persistence from "./persistence.ts"
 import * as ProjectRepository from "./projectRepository.ts"
 import * as Server from "./server.ts"
 import { smoke } from "./smoke.ts"
+import * as TerminalRepository from "./terminalRepository.ts"
+import * as Terminals from "./terminals.ts"
+import * as Zmx from "./zmxAdapter.ts"
 
 /** The one reusable port contract for CLI (and config/API) inputs. */
 export const Port = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 65535 }))
@@ -66,7 +72,13 @@ const serve = Command.make("serve", { port }, ({ port }) =>
     const effectivePort = Option.getOrElse(port, () => config.port)
     yield* Layer.launch(
       Server.layer({ port: effectivePort }).pipe(
-        Layer.provide([ProjectRepository.layer, Directories.layer]),
+        Layer.provide(Terminals.layer),
+        Layer.provide([
+          ProjectRepository.layer,
+          TerminalRepository.layer,
+          Directories.layer,
+          Zmx.layer,
+        ]),
         Layer.provide(Persistence.layer),
         Layer.provide(Logging.layer),
       ),
@@ -93,32 +105,45 @@ const resolveBaseUrl = Effect.gen(function* () {
 })
 
 /**
- * A CLI command backed by the contract-derived client: JSON result on stdout,
- * exit 0; any config/request/decode failure becomes one `atc <name>:` line on
- * stderr and exit 1.
+ * The shared tail of every client-backed command: settled configuration,
+ * HTTP client, and the one-line `atc <name>:` stderr diagnostic on any
+ * config/request/decode failure.
  */
-const clientCommand = <const Name extends string, Params extends Command.Command.Config, A>(
-  name: Name,
+const withCliContext = <E>(
+  diagnosticName: string,
+  effect: Effect.Effect<void, E, HttpClient.HttpClient | AppConfig>,
+): Effect.Effect<void, ReportedError, FileSystem.FileSystem> =>
+  effect.pipe(
+    Effect.provide([BunHttpClient.layer, appConfigLayer]),
+    Effect.catch((error) => failReported(`atc ${diagnosticName}: ${describeError(error)}`)),
+  )
+
+/**
+ * A CLI command backed by the contract-derived client: JSON result on
+ * stdout, exit 0. `diagnosticName` is the full command path ("terminal
+ * list"); the subcommand name is its last word, so the two can't drift.
+ */
+const clientCommand = <Params extends Command.Command.Config, A>(
+  diagnosticName: string,
   description: string,
   params: Params,
   call: (
     client: Client.AppServerClient,
     params: Command.Command.Config.Infer<Params>,
   ) => Effect.Effect<A, unknown>,
-  diagnosticName = name,
 ) =>
-  Command.make(name, params, (parsed) =>
-    Effect.gen(function* () {
-      const baseUrl = yield* resolveBaseUrl
-      const client = yield* Client.make({ baseUrl })
-      const result = yield* call(client, parsed)
-      // Void results (e.g. delete) print nothing — stdout stays pure JSON.
-      if (result !== undefined) {
-        yield* Console.log(JSON.stringify(result, null, 2))
-      }
-    }).pipe(
-      Effect.provide([BunHttpClient.layer, appConfigLayer]),
-      Effect.catch((error) => failReported(`atc ${diagnosticName}: ${describeError(error)}`)),
+  Command.make(diagnosticName.split(" ").at(-1)!, params, (parsed) =>
+    withCliContext(
+      diagnosticName,
+      Effect.gen(function* () {
+        const baseUrl = yield* resolveBaseUrl
+        const client = yield* Client.make({ baseUrl })
+        const result = yield* call(client, parsed)
+        // Void results (e.g. delete) print nothing — stdout stays pure JSON.
+        if (result !== undefined) {
+          yield* Console.log(JSON.stringify(result, null, 2))
+        }
+      }),
     ),
   ).pipe(Command.withDescription(description))
 
@@ -147,35 +172,29 @@ const nameFlag = Flag.string("name").pipe(Flag.withDescription("Project name"))
 
 const projectIdArgument = Argument.string("project-id")
 
-const projectList = clientCommand(
-  "list",
-  "List all projects",
-  {},
-  (client) => client.v1.listProjects(),
-  "project list",
+const projectList = clientCommand("project list", "List all projects", {}, (client) =>
+  client.v1.listProjects(),
 )
 
 const projectGet = clientCommand(
-  "get",
+  "project get",
   "Fetch one project by id",
   { projectId: projectIdArgument },
   (client, { projectId }) => client.v1.getProject({ params: { projectId } }),
-  "project get",
 )
 
 const projectCreate = clientCommand(
-  "create",
+  "project create",
   "Create a project (the directory must already exist; ATC never creates it)",
   { name: nameFlag, directory: directoryFlag },
   (client, { name, directory }) =>
     client.v1.createProject({
       payload: { name, defaultWorkingDirectory: path.resolve(directory) },
     }),
-  "project create",
 )
 
 const projectUpdate = clientCommand(
-  "update",
+  "project update",
   "Update a project's name and/or default working directory",
   {
     projectId: projectIdArgument,
@@ -193,7 +212,6 @@ const projectUpdate = clientCommand(
           : {}),
       },
     }),
-  "project update",
 )
 
 const yesFlag = Flag.boolean("yes").pipe(
@@ -201,7 +219,7 @@ const yesFlag = Flag.boolean("yes").pipe(
 )
 
 const projectDelete = clientCommand(
-  "delete",
+  "project delete",
   "Delete a project record (never touches the filesystem)",
   { projectId: projectIdArgument, yes: yesFlag },
   (client, { projectId, yes }) =>
@@ -212,7 +230,6 @@ const projectDelete = clientCommand(
             "refusing to delete without --yes (deletes the project record only, never the directory)",
           ),
         ),
-  "project delete",
 )
 
 const project = Command.make("project").pipe(
@@ -220,12 +237,132 @@ const project = Command.make("project").pipe(
   Command.withSubcommands([projectList, projectGet, projectCreate, projectUpdate, projectDelete]),
 )
 
+const terminalIdArgument = Argument.string("terminal-id")
+
+const projectFlag = Flag.string("project").pipe(Flag.withDescription("Project id"))
+
+const terminalList = clientCommand(
+  "terminal list",
+  "List terminals (reconciled against the zmx inventory)",
+  { project: Flag.optional(projectFlag) },
+  (client, { project }) =>
+    client.v1.listTerminals({
+      query: Option.isSome(project) ? { projectId: project.value } : {},
+    }),
+)
+
+const terminalGet = clientCommand(
+  "terminal get",
+  "Fetch one terminal by id",
+  { terminalId: terminalIdArgument },
+  (client, { terminalId }) => client.v1.getTerminal({ params: { terminalId } }),
+)
+
+const terminalCreate = clientCommand(
+  "terminal create",
+  "Create a terminal and start its zmx session (an interactive shell, or the given command argv)",
+  {
+    project: projectFlag,
+    name: Flag.optional(Flag.string("name").pipe(Flag.withDescription("Display label"))),
+    directory: Flag.optional(
+      Flag.string("directory").pipe(
+        Flag.withDescription(
+          "Working directory (may be relative; defaults to the project's default)",
+        ),
+      ),
+    ),
+    command: Argument.string("command").pipe(
+      Argument.atLeast(0),
+      Argument.withDescription("Exec-style argv to run instead of an interactive login shell"),
+    ),
+  },
+  (client, { project, name, directory, command }) =>
+    client.v1.createTerminal({
+      payload: {
+        projectId: project,
+        ...(Option.isSome(name) ? { name: name.value } : {}),
+        ...(Option.isSome(directory) ? { workingDirectory: path.resolve(directory.value) } : {}),
+        ...(command.length > 0 ? { command } : {}),
+      },
+    }),
+)
+
+const terminalRename = clientCommand(
+  "terminal rename",
+  "Update a terminal's display label",
+  { terminalId: terminalIdArgument, name: Flag.string("name") },
+  (client, { terminalId, name }) =>
+    client.v1.updateTerminal({ params: { terminalId }, payload: { name } }),
+)
+
+const terminalDelete = clientCommand(
+  "terminal delete",
+  "Delete a terminal: kill its zmx session, verify absence, remove the record",
+  { terminalId: terminalIdArgument, yes: yesFlag },
+  (client, { terminalId, yes }) =>
+    yes
+      ? client.v1.deleteTerminal({ params: { terminalId } })
+      : Effect.fail(new Error("refusing to delete without --yes (kills the running session)")),
+)
+
+const terminalAttach = Command.make(
+  "attach",
+  { terminalId: terminalIdArgument },
+  ({ terminalId }) =>
+    withCliContext(
+      "terminal attach",
+      Effect.gen(function* () {
+        const baseUrl = yield* resolveBaseUrl
+        // Pre-flight over the typed API: the WebSocket handshake cannot carry
+        // the contract's diagnostics (a browser-style client only sees
+        // "connection failed"), so unknown or ended terminals are reported
+        // here, with the real error, before any socket opens.
+        const client = yield* Client.make({ baseUrl })
+        const terminal = yield* client.v1.getTerminal({ params: { terminalId } })
+        if (terminal.status === "ended") {
+          return yield* Effect.fail(new Error(`terminal ${terminalId} has ended`))
+        }
+        const url = new URL(`/api/v1/terminals/${encodeURIComponent(terminalId)}/attach`, baseUrl)
+        url.protocol = "ws:"
+        if (process.stdout.isTTY === true) {
+          url.searchParams.set("cols", String(process.stdout.columns))
+          url.searchParams.set("rows", String(process.stdout.rows))
+        }
+        const result = yield* AttachClient.runAttach(url)
+        if (result.code === 1000 && result.reason === "detach") {
+          yield* Console.error("detached (session keeps running)")
+        } else if (result.code === 1000) {
+          yield* Console.error("terminal ended")
+        } else {
+          return yield* Effect.fail(
+            new Error(`connection closed (${result.code} ${result.reason || "no reason"})`),
+          )
+        }
+      }),
+    ),
+).pipe(
+  Command.withDescription(
+    "Attach this terminal to a live session in raw mode (detach with Ctrl-])",
+  ),
+)
+
+const terminal = Command.make("terminal").pipe(
+  Command.withDescription("Manage durable, project-scoped terminals"),
+  Command.withSubcommands([
+    terminalList,
+    terminalGet,
+    terminalCreate,
+    terminalRename,
+    terminalDelete,
+    terminalAttach,
+  ]),
+)
+
 const fsCheck = clientCommand(
-  "check",
+  "fs check",
   "Check a directory's health (available, missing, inaccessible, not_directory, unknown)",
   { path: Argument.string("path") },
   (client, args) => client.v1.checkDirectory({ query: { path: path.resolve(args.path) } }),
-  "fs check",
 )
 
 const fs = Command.make("fs").pipe(
@@ -235,5 +372,5 @@ const fs = Command.make("fs").pipe(
 
 export const atc = Command.make("atc").pipe(
   Command.withDescription("ATC App Server"),
-  Command.withSubcommands([serve, health, version, project, fs, smoke]),
+  Command.withSubcommands([serve, health, version, project, terminal, fs, smoke]),
 )

--- a/app-server/src/cli.ts
+++ b/app-server/src/cli.ts
@@ -5,6 +5,7 @@ import { Argument, Command, Flag } from "effect/unstable/cli"
 import type { HttpClient } from "effect/unstable/http"
 import * as path from "node:path"
 import * as AttachClient from "./attachClient.ts"
+import { attachUrl, CLOSE_DETACH } from "./attachProtocol.ts"
 import * as Client from "./client.ts"
 import { AppConfig, ConfigLoadError, layer as appConfigLayer } from "./config.ts"
 import * as Directories from "./directories.ts"
@@ -119,6 +120,27 @@ const withCliContext = <E>(
   )
 
 /**
+ * The one place a server connection is constructed: settled configuration,
+ * base URL, contract-derived client, and the `withCliContext` diagnostic.
+ * Remote endpoint addressing lands here, not in the commands.
+ */
+const withClient = <E>(
+  diagnosticName: string,
+  use: (
+    client: Client.AppServerClient,
+    baseUrl: URL,
+  ) => Effect.Effect<void, E, HttpClient.HttpClient>,
+) =>
+  withCliContext(
+    diagnosticName,
+    Effect.gen(function* () {
+      const baseUrl = yield* resolveBaseUrl
+      const client = yield* Client.make({ baseUrl })
+      yield* use(client, baseUrl)
+    }),
+  )
+
+/**
  * A CLI command backed by the contract-derived client: JSON result on
  * stdout, exit 0. `diagnosticName` is the full command path ("terminal
  * list"); the subcommand name is its last word, so the two can't drift.
@@ -133,11 +155,8 @@ const clientCommand = <Params extends Command.Command.Config, A>(
   ) => Effect.Effect<A, unknown>,
 ) =>
   Command.make(diagnosticName.split(" ").at(-1)!, params, (parsed) =>
-    withCliContext(
-      diagnosticName,
+    withClient(diagnosticName, (client) =>
       Effect.gen(function* () {
-        const baseUrl = yield* resolveBaseUrl
-        const client = yield* Client.make({ baseUrl })
         const result = yield* call(client, parsed)
         // Void results (e.g. delete) print nothing — stdout stays pure JSON.
         if (result !== undefined) {
@@ -164,11 +183,15 @@ const version = clientCommand(
 // Directory arguments may be relative (e.g. "."): the CLI shares a filesystem
 // with the local server, so they resolve against the caller's cwd before the
 // API sees them. The API itself takes server-host absolute paths only.
-const directoryFlag = Flag.string("directory").pipe(
-  Flag.withDescription("Project default working directory (must already exist; may be relative)"),
-)
+const directoryFlag = (description: string) =>
+  Flag.string("directory").pipe(Flag.withDescription(description))
 
-const nameFlag = Flag.string("name").pipe(Flag.withDescription("Project name"))
+const nameFlag = (description: string) =>
+  Flag.string("name").pipe(Flag.withDescription(description))
+
+const projectDirectoryFlag = directoryFlag(
+  "Project default working directory (must already exist; may be relative)",
+)
 
 const projectIdArgument = Argument.string("project-id")
 
@@ -186,7 +209,7 @@ const projectGet = clientCommand(
 const projectCreate = clientCommand(
   "project create",
   "Create a project (the directory must already exist; ATC never creates it)",
-  { name: nameFlag, directory: directoryFlag },
+  { name: nameFlag("Project name"), directory: projectDirectoryFlag },
   (client, { name, directory }) =>
     client.v1.createProject({
       payload: { name, defaultWorkingDirectory: path.resolve(directory) },
@@ -198,8 +221,8 @@ const projectUpdate = clientCommand(
   "Update a project's name and/or default working directory",
   {
     projectId: projectIdArgument,
-    name: Flag.optional(nameFlag),
-    directory: Flag.optional(directoryFlag),
+    name: Flag.optional(nameFlag("Project name")),
+    directory: Flag.optional(projectDirectoryFlag),
   },
   (client, { projectId, name, directory }) =>
     client.v1.updateProject({
@@ -263,13 +286,9 @@ const terminalCreate = clientCommand(
   "Create a terminal and start its zmx session (an interactive shell, or the given command argv)",
   {
     project: projectFlag,
-    name: Flag.optional(Flag.string("name").pipe(Flag.withDescription("Display label"))),
+    name: Flag.optional(nameFlag("Display label")),
     directory: Flag.optional(
-      Flag.string("directory").pipe(
-        Flag.withDescription(
-          "Working directory (may be relative; defaults to the project's default)",
-        ),
-      ),
+      directoryFlag("Working directory (may be relative; defaults to the project's default)"),
     ),
     command: Argument.string("command").pipe(
       Argument.atLeast(0),
@@ -290,7 +309,7 @@ const terminalCreate = clientCommand(
 const terminalRename = clientCommand(
   "terminal rename",
   "Update a terminal's display label",
-  { terminalId: terminalIdArgument, name: Flag.string("name") },
+  { terminalId: terminalIdArgument, name: nameFlag("New display label") },
   (client, { terminalId, name }) =>
     client.v1.updateTerminal({ params: { terminalId }, payload: { name } }),
 )
@@ -309,27 +328,22 @@ const terminalAttach = Command.make(
   "attach",
   { terminalId: terminalIdArgument },
   ({ terminalId }) =>
-    withCliContext(
-      "terminal attach",
+    withClient("terminal attach", (client, baseUrl) =>
       Effect.gen(function* () {
-        const baseUrl = yield* resolveBaseUrl
         // Pre-flight over the typed API: the WebSocket handshake cannot carry
         // the contract's diagnostics (a browser-style client only sees
         // "connection failed"), so unknown or ended terminals are reported
         // here, with the real error, before any socket opens.
-        const client = yield* Client.make({ baseUrl })
         const terminal = yield* client.v1.getTerminal({ params: { terminalId } })
         if (terminal.status === "ended") {
           return yield* Effect.fail(new Error(`terminal ${terminalId} has ended`))
         }
-        const url = new URL(`/api/v1/terminals/${encodeURIComponent(terminalId)}/attach`, baseUrl)
-        url.protocol = "ws:"
-        if (process.stdout.isTTY === true) {
-          url.searchParams.set("cols", String(process.stdout.columns))
-          url.searchParams.set("rows", String(process.stdout.rows))
-        }
-        const result = yield* AttachClient.runAttach(url)
-        if (result.code === 1000 && result.reason === "detach") {
+        const size =
+          process.stdout.isTTY === true
+            ? { cols: process.stdout.columns, rows: process.stdout.rows }
+            : undefined
+        const result = yield* AttachClient.runAttach(attachUrl(baseUrl, terminalId, size))
+        if (result.code === 1000 && result.reason === CLOSE_DETACH) {
           yield* Console.error("detached (session keeps running)")
         } else if (result.code === 1000) {
           yield* Console.error("terminal ended")

--- a/app-server/src/handlers.ts
+++ b/app-server/src/handlers.ts
@@ -1,9 +1,11 @@
 import { Effect, Option } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
-import { Api, ProjectNotFound } from "./api.ts"
+import { Api, ProjectHasTerminals, ProjectNotFound } from "./api.ts"
 import { BuildInfo } from "./buildInfo.ts"
 import { Directories } from "./directories.ts"
 import { ProjectRepository } from "./projectRepository.ts"
+import { attachTerminal } from "./terminalAttach.ts"
+import { Terminals } from "./terminals.ts"
 
 /** Implements the /api/v1 contract. App construction only — no listener. */
 export const V1Handlers = HttpApiBuilder.group(
@@ -13,12 +15,11 @@ export const V1Handlers = HttpApiBuilder.group(
     const build = yield* BuildInfo
     const projects = yield* ProjectRepository
     const directories = yield* Directories
-
-    const requireProject = <A>(projectId: string, found: Option.Option<A>) =>
-      Option.match(found, {
-        onNone: () => Effect.fail(new ProjectNotFound({ projectId })),
-        onSome: Effect.succeed,
-      })
+    const terminals = yield* Terminals
+    // Attach bridges outlive their originating requests (Bun aborts the
+    // request on protocol switch); they live in the handler layer's scope,
+    // so server shutdown still reaps every bridge and its PTY client.
+    const bridgeScope = yield* Effect.scope
 
     return handlers
       .handle("health", () => Effect.succeed({ status: "ok" } as const))
@@ -40,11 +41,7 @@ export const V1Handlers = HttpApiBuilder.group(
           })
         }),
       )
-      .handle("getProject", ({ params }) =>
-        projects
-          .get(params.projectId)
-          .pipe(Effect.flatMap((found) => requireProject(params.projectId, found))),
-      )
+      .handle("getProject", ({ params }) => projects.require(params.projectId))
       .handle("updateProject", ({ params, payload }) =>
         Effect.gen(function* () {
           const canonical =
@@ -55,20 +52,40 @@ export const V1Handlers = HttpApiBuilder.group(
             name: payload.name,
             defaultWorkingDirectory: canonical,
           })
-          return yield* requireProject(params.projectId, updated)
+          return yield* Option.match(updated, {
+            onNone: () => Effect.fail(new ProjectNotFound({ projectId: params.projectId })),
+            onSome: Effect.succeed,
+          })
         }),
       )
       .handle("deleteProject", ({ params }) =>
-        projects
-          .delete(params.projectId)
-          .pipe(
-            Effect.flatMap((deleted) =>
-              deleted
-                ? Effect.void
-                : Effect.fail(new ProjectNotFound({ projectId: params.projectId })),
-            ),
-          ),
+        Effect.gen(function* () {
+          // RESTRICT while terminals exist (tombstones included): the
+          // simplest correct rule for a single-user app. Not transactional
+          // with the delete below — a concurrently created terminal falls
+          // back to the migration's FK RESTRICT (a defect, not a 409).
+          const terminalCount = yield* terminals.countForProject(params.projectId)
+          if (terminalCount > 0) {
+            return yield* Effect.fail(
+              new ProjectHasTerminals({ projectId: params.projectId, terminalCount }),
+            )
+          }
+          const deleted = yield* projects.delete(params.projectId)
+          if (!deleted) {
+            return yield* Effect.fail(new ProjectNotFound({ projectId: params.projectId }))
+          }
+        }),
       )
       .handle("checkDirectory", ({ query }) => directories.check(query.path))
+      .handle("listTerminals", ({ query }) => terminals.list(query.projectId))
+      .handle("createTerminal", ({ payload }) => terminals.create(payload))
+      .handle("getTerminal", ({ params }) => terminals.get(params.terminalId))
+      .handle("updateTerminal", ({ params, payload }) =>
+        payload.name === undefined
+          ? terminals.get(params.terminalId)
+          : terminals.rename(params.terminalId, payload.name),
+      )
+      .handle("deleteTerminal", ({ params }) => terminals.delete(params.terminalId))
+      .handleRaw("attachTerminal", attachTerminal({ terminals, bridgeScope }))
   }),
 )

--- a/app-server/src/handlers.ts
+++ b/app-server/src/handlers.ts
@@ -81,9 +81,7 @@ export const V1Handlers = HttpApiBuilder.group(
       .handle("createTerminal", ({ payload }) => terminals.create(payload))
       .handle("getTerminal", ({ params }) => terminals.get(params.terminalId))
       .handle("updateTerminal", ({ params, payload }) =>
-        payload.name === undefined
-          ? terminals.get(params.terminalId)
-          : terminals.rename(params.terminalId, payload.name),
+        terminals.update(params.terminalId, payload),
       )
       .handle("deleteTerminal", ({ params }) => terminals.delete(params.terminalId))
       .handleRaw("attachTerminal", attachTerminal({ terminals, bridgeScope }))

--- a/app-server/src/migrations.ts
+++ b/app-server/src/migrations.ts
@@ -24,4 +24,25 @@ export const migrations: Record<string, Effect.Effect<void, unknown, SqlClient.S
       ) STRICT
     `
   }),
+  // `command` is a JSON argv array or NULL (interactive login shell).
+  // `status` is 'starting' (internal, crash-mid-create marker), 'live', or
+  // 'ended' (tombstone until deleted). ON DELETE RESTRICT enforces the
+  // project-deletion rule at the storage layer too.
+  "0002_terminals": Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+    yield* sql`
+      CREATE TABLE terminals (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE RESTRICT,
+        name TEXT,
+        command TEXT,
+        initial_working_directory TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN ('starting', 'live', 'ended')),
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        ended_at TEXT
+      ) STRICT
+    `
+    yield* sql`CREATE INDEX terminals_project_id ON terminals(project_id)`
+  }),
 }

--- a/app-server/src/projectRepository.ts
+++ b/app-server/src/projectRepository.ts
@@ -1,5 +1,6 @@
 import { Context, Effect, Layer, Option, Schema } from "effect"
 import { SqlClient, SqlSchema } from "effect/unstable/sql"
+import { ProjectNotFound } from "./api.ts"
 import type { Project as ProjectSchema } from "./api.ts"
 
 // The Projects repository (ATC-121): the only module that speaks SQL for
@@ -35,6 +36,8 @@ export class ProjectRepository extends Context.Service<
       readonly defaultWorkingDirectory: string
     }) => Effect.Effect<Project>
     readonly get: (id: string) => Effect.Effect<Option.Option<Project>>
+    /** `get` with the contract's not-found error already applied. */
+    readonly require: (id: string) => Effect.Effect<Project, ProjectNotFound>
     /** Applies the provided fields and bumps `updatedAt`; `None` if unknown. */
     readonly update: (
       id: string,
@@ -118,6 +121,15 @@ export const layer = Layer.effect(ProjectRepository)(
         return insertRow(row).pipe(Effect.as(toProject(row)), Effect.orDie)
       },
       get,
+      require: (id) =>
+        get(id).pipe(
+          Effect.flatMap(
+            Option.match({
+              onNone: () => Effect.fail(new ProjectNotFound({ projectId: id })),
+              onSome: Effect.succeed,
+            }),
+          ),
+        ),
       update: (id, patch) =>
         // An empty patch changes nothing — including updatedAt.
         patch.name === undefined && patch.defaultWorkingDirectory === undefined

--- a/app-server/src/server.ts
+++ b/app-server/src/server.ts
@@ -9,7 +9,7 @@ import * as LocalTrust from "./localTrust.ts"
 /**
  * All HTTP routes with the local-trust guard applied, independent of any
  * listener. Requires the handler services (BuildInfo, ProjectRepository,
- * Directories).
+ * Directories, Terminals).
  */
 export const routes = Layer.mergeAll(
   HttpApiBuilder.layer(Api).pipe(Layer.provide(V1Handlers)),
@@ -24,5 +24,15 @@ export const routes = Layer.mergeAll(
  */
 export const layer = (options: { readonly port: number }) =>
   HttpRouter.serve(routes, { middleware: HttpMiddleware.tracer }).pipe(
-    Layer.provideMerge(BunHttpServer.layer({ port: options.port, hostname: "127.0.0.1" })),
+    Layer.provideMerge(
+      BunHttpServer.layer({
+        port: options.port,
+        hostname: "127.0.0.1",
+        // Bun never finishes a graceful stop once the server has initiated
+        // a WebSocket close (the connection stays in its bookkeeping), so a
+        // long grace period turns every shutdown after a terminal attach
+        // into a hang. Requests are local and short; two seconds is plenty.
+        gracefulShutdownTimeout: "2 seconds",
+      }),
+    ),
   )

--- a/app-server/src/smoke.ts
+++ b/app-server/src/smoke.ts
@@ -25,40 +25,45 @@ class SmokeReported extends Schema.TaggedErrorClass<SmokeReported>()("SmokeRepor
 
 // --- Executable resolution ---------------------------------------------------
 
-/** Codex: explicit env override, then PATH. */
-export const resolveCodexExecutable = Effect.suspend(() => {
-  const override = process.env["ATC_CODEX_EXECUTABLE"]
-  if (override !== undefined && override !== "") return Effect.succeed(override)
-  const found = Bun.which("codex")
-  if (found !== null) return Effect.succeed(found)
-  return Effect.fail(
-    new SmokeError({
-      provider: "codex",
-      message: "codex not found on PATH; install the Codex CLI or set ATC_CODEX_EXECUTABLE",
-    }),
-  )
-})
+/** Env override first, then PATH — the shared resolveExecutable rule. */
+const resolveProvider = (
+  provider: SmokeError["provider"],
+  name: string,
+  envVar: string,
+  installHint: string,
+) =>
+  Effect.suspend(() => {
+    const override = process.env[envVar]
+    const found = Subprocess.resolveExecutable(
+      override !== undefined && override !== "" ? override : name,
+    )
+    if (found !== null) return Effect.succeed(found)
+    return Effect.fail(
+      new SmokeError({
+        provider,
+        message: `${name} not found on PATH; ${installHint} or set ${envVar}`,
+      }),
+    )
+  })
+
+export const resolveCodexExecutable = resolveProvider(
+  "codex",
+  "codex",
+  "ATC_CODEX_EXECUTABLE",
+  "install the Codex CLI",
+)
 
 /**
- * Claude Code: explicit env override, then the user's installed `claude` on
- * PATH — the same bring-your-own-CLI rule as codex. atc does not ship a
- * Claude Code binary; the user's install also carries the credentials the
+ * Claude Code: the same bring-your-own-CLI rule as codex. atc does not ship
+ * a Claude Code binary; the user's install also carries the credentials the
  * SDK needs.
  */
-export const resolveClaudeCodeExecutable = Effect.suspend(() => {
-  const override = process.env["ATC_CLAUDE_CODE_EXECUTABLE"]
-  if (override !== undefined && override !== "") return Effect.succeed(override)
-  const found = Bun.which("claude")
-  if (found !== null) return Effect.succeed(found)
-  return Effect.fail(
-    new SmokeError({
-      provider: "claude",
-      message:
-        "claude not found on PATH; install and authenticate Claude Code " +
-        "or set ATC_CLAUDE_CODE_EXECUTABLE",
-    }),
-  )
-})
+export const resolveClaudeCodeExecutable = resolveProvider(
+  "claude",
+  "claude",
+  "ATC_CLAUDE_CODE_EXECUTABLE",
+  "install and authenticate Claude Code",
+)
 
 // --- Shared termination checks ----------------------------------------------
 

--- a/app-server/src/subprocess.ts
+++ b/app-server/src/subprocess.ts
@@ -54,6 +54,13 @@ export interface PtySpawnSpec extends SpawnSpec {
   /** Initial pseudo-terminal size. */
   readonly cols?: number
   readonly rows?: number
+  /**
+   * Capture a decoded tail of recent output for failure diagnostics
+   * (`PtyChild.outputTail`). Off by default: the tail costs a decode pass
+   * and string churn on every output chunk, which long-lived attach clients
+   * must not pay.
+   */
+  readonly captureOutputTail?: boolean
 }
 
 /** Default PTY size when the caller has no client-provided dimensions yet. */
@@ -86,7 +93,7 @@ export interface PtyChild {
    * buffer fills.
    */
   readonly output: Stream.Stream<Uint8Array, SubprocessError>
-  /** Snapshot of recent decoded output, for failure diagnostics. */
+  /** Snapshot of recent decoded output; empty unless `captureOutputTail`. */
   readonly outputTail: Effect.Effect<string>
   /** Write raw bytes to the PTY — the child sees them as terminal input. */
   readonly write: (data: Uint8Array | string) => Effect.Effect<void, SubprocessError>
@@ -111,6 +118,16 @@ export class Subprocess extends Context.Service<
     readonly spawnPty: (spec: PtySpawnSpec) => Effect.Effect<PtyChild, SubprocessError, Scope.Scope>
   }
 >()("app-server/Subprocess") {}
+
+/**
+ * The one explicit-resolution rule for user-installed executables (zmx,
+ * provider CLIs): a configured value containing a slash is used verbatim
+ * (config validation already rejects relative paths), a bare name resolves
+ * on PATH. Returns null when nothing resolves — the caller owns the one
+ * actionable "install it or set <setting>" diagnostic.
+ */
+export const resolveExecutable = (configured: string): string | null =>
+  configured.includes("/") ? configured : Bun.which(configured)
 
 /** True while `pid` refers to a live (or not yet reaped) process. */
 export const isProcessAlive = (pid: number): boolean => {
@@ -259,7 +276,8 @@ const spawnPty = Effect.fnUntraced(function* (spec: PtySpawnSpec) {
     capacity: PTY_OUTPUT_QUEUE_CAPACITY,
     strategy: "sliding",
   })
-  const decoder = new TextDecoder("utf-8", { fatal: false })
+  const decoder =
+    spec.captureOutputTail === true ? new TextDecoder("utf-8", { fatal: false }) : null
   let outputTail = ""
   // Closure is tracked explicitly because Bun's terminal.write can keep
   // reporting full byte counts briefly after the child exits (observed on
@@ -281,10 +299,12 @@ const spawnPty = Effect.fnUntraced(function* (spec: PtySpawnSpec) {
             rows: spec.rows ?? DEFAULT_PTY_ROWS,
             // Bun may reuse the buffer between callbacks; copy before queueing.
             data: (_terminal, data) => {
-              Queue.offerUnsafe(output, Uint8Array.from(data))
-              outputTail = (outputTail + decoder.decode(data, { stream: true })).slice(
-                -PTY_OUTPUT_TAIL_LENGTH,
-              )
+              Queue.offerUnsafe(output, data.slice())
+              if (decoder !== null) {
+                outputTail = (outputTail + decoder.decode(data, { stream: true })).slice(
+                  -PTY_OUTPUT_TAIL_LENGTH,
+                )
+              }
             },
             exit: () => {
               markClosed()

--- a/app-server/src/terminalAdapter.ts
+++ b/app-server/src/terminalAdapter.ts
@@ -1,5 +1,6 @@
 import { Context, Schema } from "effect"
 import type { Effect, Scope, Stream } from "effect"
+import type { ZmxUnavailable } from "./api.ts"
 import type { SubprocessError } from "./subprocess.ts"
 
 // The narrow seam through which ATC talks to the terminal multiplexer
@@ -57,18 +58,9 @@ export interface SessionConnection {
   readonly exitCode: Effect.Effect<number, SubprocessError>
 }
 
-/**
- * The multiplexer cannot be consulted (executable missing, inventory
- * failed). Retryable: it says nothing about any session's existence, so
- * stored state must stay untouched.
- */
-export class ZmxUnavailable extends Schema.TaggedErrorClass<ZmxUnavailable>()("ZmxUnavailable", {
-  reason: Schema.String,
-}) {
-  override get message(): string {
-    return this.reason
-  }
-}
+// `ZmxUnavailable` (retryable: the multiplexer cannot be consulted, stored
+// state must stay untouched) lives in the contract (api.ts) — the API
+// surfaces it directly.
 
 /** A session operation failed conclusively (with diagnostics). */
 export class SessionOperationFailed extends Schema.TaggedErrorClass<SessionOperationFailed>()(

--- a/app-server/src/terminalAdapter.ts
+++ b/app-server/src/terminalAdapter.ts
@@ -14,19 +14,14 @@ export const SESSION_NAME_PREFIX = "atc-"
 
 /**
  * The derived (never persisted) session name for a terminal id:
- * `atc-` + the UUID's 32 hex chars — reversible for debugging.
+ * `atc-` + the UUID's 32 hex chars — reversible for debugging (strip the
+ * prefix, re-insert the dashes).
  */
 export const sessionNameForTerminalId = (terminalId: string): string =>
   SESSION_NAME_PREFIX + terminalId.replaceAll("-", "").toLowerCase()
 
-/** Reverse of `sessionNameForTerminalId`; undefined for foreign names. */
-export const terminalIdForSessionName = (sessionName: string): string | undefined => {
-  const hex = sessionName.startsWith(SESSION_NAME_PREFIX)
-    ? sessionName.slice(SESSION_NAME_PREFIX.length)
-    : undefined
-  if (hex === undefined || !/^[0-9a-f]{32}$/.test(hex)) return undefined
-  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
-}
+/** The longest name the derivation produces — the socket-path length guard. */
+export const LONGEST_SESSION_NAME = sessionNameForTerminalId("00000000-0000-0000-0000-000000000000")
 
 /**
  * One entry of a complete session inventory. `reachable: false` marks a
@@ -38,8 +33,6 @@ export interface SessionInfo {
   readonly reachable: boolean
   /** Daemon pid — the session's identity across a name reuse. */
   readonly pid?: number
-  /** Creation time as reported by the multiplexer (epoch seconds). */
-  readonly createdAt?: number
 }
 
 export interface SessionSize {

--- a/app-server/src/terminalAttach.ts
+++ b/app-server/src/terminalAttach.ts
@@ -3,13 +3,24 @@ import type { Scope } from "effect"
 import type { HttpServerRequest } from "effect/unstable/http"
 import { HttpServerResponse } from "effect/unstable/http"
 import * as Socket from "effect/unstable/socket/Socket"
+import {
+  clampDimension,
+  CLOSE_ATTACH_FAILED,
+  CLOSE_PING_TIMEOUT,
+  CLOSE_TERMINAL_ENDED,
+  CLOSE_ZMX_UNAVAILABLE,
+  decodeControlFrame,
+  encodeControlFrame,
+} from "./attachProtocol.ts"
 import { DEFAULT_PTY_COLS, DEFAULT_PTY_ROWS } from "./subprocess.ts"
+import type { SessionSize } from "./terminalAdapter.ts"
 import type { Terminals } from "./terminals.ts"
 
 // The WebSocket attach bridge (ATC-130): one upgraded socket bridged onto
-// one scoped `zmx attach` PTY client. Wire protocol and close vocabulary
-// are stated once, on the contract endpoint (api.ts `attachTerminal`);
-// this module implements them.
+// one scoped `zmx attach` PTY client. The wire protocol and close
+// vocabulary live in attachProtocol.ts (documented in prose on the contract
+// endpoint, api.ts `attachTerminal`); this module implements the server
+// side.
 //
 // Flow control: Bun's WS writer exposes no send-backpressure signal, so a
 // slow client cannot throttle the PTY. Memory stays bounded anyway — the
@@ -23,34 +34,6 @@ const PING_INTERVAL_MILLIS = 30_000
 const PONG_TIMEOUT_MILLIS = 120_000
 /** Outbound frames buffered ahead of the socket writer. */
 const OUTBOX_CAPACITY = 256
-
-const clampDimension = (raw: string | number | undefined, fallback: number): number => {
-  const parsed = typeof raw === "number" ? raw : Number.parseInt(raw ?? "", 10)
-  return Number.isNaN(parsed) ? fallback : Math.max(1, Math.min(1_000, Math.floor(parsed)))
-}
-
-const decodeControl = (
-  text: string,
-): { type: "resize"; cols: number; rows: number } | { type: "pong" } | { type: "ignored" } => {
-  try {
-    const parsed = JSON.parse(text) as { type?: string; cols?: number; rows?: number }
-    if (
-      parsed.type === "resize" &&
-      typeof parsed.cols === "number" &&
-      typeof parsed.rows === "number"
-    ) {
-      return {
-        type: "resize",
-        cols: clampDimension(parsed.cols, DEFAULT_PTY_COLS),
-        rows: clampDimension(parsed.rows, DEFAULT_PTY_ROWS),
-      }
-    }
-    if (parsed.type === "pong") return { type: "pong" }
-  } catch {
-    // Unknown or malformed control frames are ignored, never fatal.
-  }
-  return { type: "ignored" }
-}
 
 /**
  * The raw handler implementing the contract's `attachTerminal` endpoint.
@@ -120,7 +103,7 @@ export const attachTerminal =
 export const runBridge = (
   terminals: Terminals["Service"],
   terminalId: string,
-  size: { readonly cols: number; readonly rows: number },
+  size: SessionSize,
   socket: Socket.Socket,
 ) =>
   Effect.gen(function* () {
@@ -142,11 +125,11 @@ export const runBridge = (
       terminals.confirmEnded(terminalId).pipe(
         Effect.map((ended) =>
           ended
-            ? new Socket.CloseEvent(1000, "terminal_ended")
+            ? new Socket.CloseEvent(1000, CLOSE_TERMINAL_ENDED)
             : new Socket.CloseEvent(1011, fallbackReason),
         ),
         Effect.catchTag("ZmxUnavailable", () =>
-          Effect.succeed(new Socket.CloseEvent(1011, "zmx_unavailable")),
+          Effect.succeed(new Socket.CloseEvent(1011, CLOSE_ZMX_UNAVAILABLE)),
         ),
       )
 
@@ -157,10 +140,11 @@ export const runBridge = (
       Effect.catchTags({
         // The pre-flight said live but the session is gone: confirm and
         // close with the authoritative code when possible.
-        SessionNotFound: () => bail(closeConfirming("attach_failed")),
-        ZmxUnavailable: () => bail(Effect.succeed(new Socket.CloseEvent(1011, "zmx_unavailable"))),
+        SessionNotFound: () => bail(closeConfirming(CLOSE_ATTACH_FAILED)),
+        ZmxUnavailable: () =>
+          bail(Effect.succeed(new Socket.CloseEvent(1011, CLOSE_ZMX_UNAVAILABLE))),
         SessionOperationFailed: () =>
-          bail(Effect.succeed(new Socket.CloseEvent(1011, "attach_failed"))),
+          bail(Effect.succeed(new Socket.CloseEvent(1011, CLOSE_ATTACH_FAILED))),
       }),
     )
     if (connection === undefined) return
@@ -177,7 +161,7 @@ export const runBridge = (
     yield* connection.output.pipe(
       Stream.runForEach((chunk) => Queue.offer(outbox, chunk)),
       Effect.catchTag("SubprocessError", () => Effect.void),
-      Effect.andThen(closeConfirming("attach_failed")),
+      Effect.andThen(closeConfirming(CLOSE_ATTACH_FAILED)),
       Effect.flatMap((event) => Queue.offer(outbox, event)),
       Effect.forkScoped,
     )
@@ -187,10 +171,10 @@ export const runBridge = (
       for (;;) {
         yield* Effect.sleep(PING_INTERVAL_MILLIS)
         if (Date.now() - lastPong > PONG_TIMEOUT_MILLIS) {
-          yield* Queue.offer(outbox, new Socket.CloseEvent(1011, "ping_timeout"))
+          yield* Queue.offer(outbox, new Socket.CloseEvent(1011, CLOSE_PING_TIMEOUT))
           return
         }
-        yield* Queue.offer(outbox, JSON.stringify({ type: "ping" }))
+        yield* Queue.offer(outbox, encodeControlFrame({ type: "ping" }))
       }
     }).pipe(Effect.forkScoped)
 
@@ -208,18 +192,23 @@ export const runBridge = (
     // without inferring the terminal ended, which only an inventory proves.
     const readSocket = socket.runRaw((message) => {
       if (typeof message === "string") {
-        const control = decodeControl(message)
-        if (control.type === "resize") {
-          return Effect.ignore(connection.resize({ cols: control.cols, rows: control.rows }))
+        const control = decodeControlFrame(message)
+        if (control?.type === "resize") {
+          return Effect.ignore(
+            connection.resize({
+              cols: clampDimension(control.cols, DEFAULT_PTY_COLS),
+              rows: clampDimension(control.rows, DEFAULT_PTY_ROWS),
+            }),
+          )
         }
-        if (control.type === "pong") lastPong = Date.now()
+        if (control?.type === "pong") lastPong = Date.now()
         return undefined
       }
       return connection
         .write(message)
         .pipe(
           Effect.catch(() =>
-            Effect.asVoid(Queue.offer(outbox, new Socket.CloseEvent(1011, "attach_failed"))),
+            Effect.asVoid(Queue.offer(outbox, new Socket.CloseEvent(1011, CLOSE_ATTACH_FAILED))),
           ),
         )
     })

--- a/app-server/src/terminalAttach.ts
+++ b/app-server/src/terminalAttach.ts
@@ -1,0 +1,231 @@
+import { Cause, Effect, Queue, Stream } from "effect"
+import type { Scope } from "effect"
+import type { HttpServerRequest } from "effect/unstable/http"
+import { HttpServerResponse } from "effect/unstable/http"
+import * as Socket from "effect/unstable/socket/Socket"
+import { DEFAULT_PTY_COLS, DEFAULT_PTY_ROWS } from "./subprocess.ts"
+import type { Terminals } from "./terminals.ts"
+
+// The WebSocket attach bridge (ATC-130): one upgraded socket bridged onto
+// one scoped `zmx attach` PTY client. Wire protocol and close vocabulary
+// are stated once, on the contract endpoint (api.ts `attachTerminal`);
+// this module implements them.
+//
+// Flow control: Bun's WS writer exposes no send-backpressure signal, so a
+// slow client cannot throttle the PTY. Memory stays bounded anyway — the
+// PTY output queue is bounded and sliding (oldest chunks drop; zmx repaints
+// the full screen on reattach, so lost history is self-healing) — and a
+// client that stops answering the app-level pings is closed, its PTY client
+// reaped by the closing scope.
+
+const PING_INTERVAL_MILLIS = 30_000
+/** A client is dead once it has ignored pings for this long. */
+const PONG_TIMEOUT_MILLIS = 120_000
+/** Outbound frames buffered ahead of the socket writer. */
+const OUTBOX_CAPACITY = 256
+
+const clampDimension = (raw: string | number | undefined, fallback: number): number => {
+  const parsed = typeof raw === "number" ? raw : Number.parseInt(raw ?? "", 10)
+  return Number.isNaN(parsed) ? fallback : Math.max(1, Math.min(1_000, Math.floor(parsed)))
+}
+
+const decodeControl = (
+  text: string,
+): { type: "resize"; cols: number; rows: number } | { type: "pong" } | { type: "ignored" } => {
+  try {
+    const parsed = JSON.parse(text) as { type?: string; cols?: number; rows?: number }
+    if (
+      parsed.type === "resize" &&
+      typeof parsed.cols === "number" &&
+      typeof parsed.rows === "number"
+    ) {
+      return {
+        type: "resize",
+        cols: clampDimension(parsed.cols, DEFAULT_PTY_COLS),
+        rows: clampDimension(parsed.rows, DEFAULT_PTY_ROWS),
+      }
+    }
+    if (parsed.type === "pong") return { type: "pong" }
+  } catch {
+    // Unknown or malformed control frames are ignored, never fatal.
+  }
+  return { type: "ignored" }
+}
+
+/**
+ * The raw handler implementing the contract's `attachTerminal` endpoint.
+ * Services (and the long-lived bridge scope) are resolved at handler-group
+ * build so the request effect has no requirements of its own.
+ *
+ * The bridge is forked into the server's scope rather than run inside the
+ * request effect: Bun aborts the original HTTP request once the protocol
+ * switches, and the adapter interrupts the request fiber on abort — a
+ * bridge living there would be torn down the moment it started.
+ */
+export const attachTerminal =
+  (services: { readonly terminals: Terminals["Service"]; readonly bridgeScope: Scope.Scope }) =>
+  (ctx: {
+    readonly params: { readonly terminalId: string }
+    readonly query: { readonly cols?: string; readonly rows?: string }
+    readonly request: HttpServerRequest.HttpServerRequest
+  }) =>
+    Effect.gen(function* () {
+      const { terminals } = services
+
+      // Pre-upgrade rejection with a real HTTP status: a reconciled read, so
+      // a terminal whose session died since the last look is already a
+      // tombstone here. No zmx child is spawned for a failed handshake.
+      const terminal = yield* terminals
+        .get(ctx.params.terminalId)
+        .pipe(Effect.catchTag("TerminalNotFound", () => Effect.succeed(undefined)))
+      if (terminal === undefined) return HttpServerResponse.empty({ status: 404 })
+      if (terminal.status === "ended") return HttpServerResponse.empty({ status: 410 })
+      if (ctx.request.headers["upgrade"]?.toLowerCase() !== "websocket") {
+        return HttpServerResponse.empty({ status: 426 })
+      }
+
+      const size = {
+        cols: clampDimension(ctx.query.cols, DEFAULT_PTY_COLS),
+        rows: clampDimension(ctx.query.rows, DEFAULT_PTY_ROWS),
+      }
+
+      // Uninterruptible across upgrade-and-fork: the abort that follows the
+      // protocol switch must find the bridge already out of this fiber.
+      const upgraded = yield* Effect.uninterruptible(
+        Effect.gen(function* () {
+          const socket = yield* ctx.request.upgrade.pipe(
+            Effect.catch(() => Effect.succeed(undefined)),
+          )
+          if (socket === undefined) return false
+          yield* runBridge(terminals, ctx.params.terminalId, size, socket).pipe(
+            Effect.scoped,
+            Effect.catchCause((cause) =>
+              Cause.hasInterruptsOnly(cause)
+                ? Effect.void
+                : Effect.logWarning("attach bridge ended abnormally").pipe(
+                    Effect.annotateLogs({ cause: String(cause) }),
+                  ),
+            ),
+            Effect.forkIn(services.bridgeScope),
+          )
+          return true
+        }),
+      )
+      return HttpServerResponse.empty({ status: upgraded ? 200 : 426 })
+    })
+
+/** The bridge proper. Exported for the deterministic in-process tests; the
+ * production entry is `attachTerminal`, which forks this into the server's
+ * bridge scope after the upgrade. */
+export const runBridge = (
+  terminals: Terminals["Service"],
+  terminalId: string,
+  size: { readonly cols: number; readonly rows: number },
+  socket: Socket.Socket,
+) =>
+  Effect.gen(function* () {
+    const write = yield* socket.writer
+
+    /** Close before the main loop has started (attach-time failures). */
+    const closeNow = (event: Socket.CloseEvent) =>
+      socket
+        .runRaw(() => undefined, {
+          onOpen: write(event).pipe(Effect.catch(() => Effect.void)),
+        })
+        .pipe(
+          Effect.timeout("1 second"),
+          Effect.catch(() => Effect.void),
+        )
+
+    /** 1000 terminal_ended iff absence is confirmed; retryable otherwise. */
+    const closeConfirming = (fallbackReason: string) =>
+      terminals.confirmEnded(terminalId).pipe(
+        Effect.map((ended) =>
+          ended
+            ? new Socket.CloseEvent(1000, "terminal_ended")
+            : new Socket.CloseEvent(1011, fallbackReason),
+        ),
+        Effect.catchTag("ZmxUnavailable", () =>
+          Effect.succeed(new Socket.CloseEvent(1011, "zmx_unavailable")),
+        ),
+      )
+
+    const bail = (event: Effect.Effect<Socket.CloseEvent>) =>
+      event.pipe(Effect.flatMap(closeNow), Effect.as(undefined))
+
+    const connection = yield* terminals.attach(terminalId, size).pipe(
+      Effect.catchTags({
+        // The pre-flight said live but the session is gone: confirm and
+        // close with the authoritative code when possible.
+        SessionNotFound: () => bail(closeConfirming("attach_failed")),
+        ZmxUnavailable: () => bail(Effect.succeed(new Socket.CloseEvent(1011, "zmx_unavailable"))),
+        SessionOperationFailed: () =>
+          bail(Effect.succeed(new Socket.CloseEvent(1011, "attach_failed"))),
+      }),
+    )
+    if (connection === undefined) return
+
+    // One writer drains one ordered outbox so terminal bytes, keepalives,
+    // and the close frame cannot interleave.
+    const outbox = yield* Queue.make<Uint8Array | string | Socket.CloseEvent>({
+      capacity: OUTBOX_CAPACITY,
+    })
+    let lastPong = Date.now()
+
+    // PTY -> outbox. The stream ending means this attach client died —
+    // never proof the session ended; confirm before saying so.
+    yield* connection.output.pipe(
+      Stream.runForEach((chunk) => Queue.offer(outbox, chunk)),
+      Effect.catchTag("SubprocessError", () => Effect.void),
+      Effect.andThen(closeConfirming("attach_failed")),
+      Effect.flatMap((event) => Queue.offer(outbox, event)),
+      Effect.forkScoped,
+    )
+
+    // Keepalive: dead clients must not hold a PTY client forever.
+    yield* Effect.gen(function* () {
+      for (;;) {
+        yield* Effect.sleep(PING_INTERVAL_MILLIS)
+        if (Date.now() - lastPong > PONG_TIMEOUT_MILLIS) {
+          yield* Queue.offer(outbox, new Socket.CloseEvent(1011, "ping_timeout"))
+          return
+        }
+        yield* Queue.offer(outbox, JSON.stringify({ type: "ping" }))
+      }
+    }).pipe(Effect.forkScoped)
+
+    const drainOutbox = Effect.gen(function* () {
+      for (;;) {
+        const item = yield* Queue.take(outbox)
+        yield* write(item)
+        if (item instanceof Socket.CloseEvent) return
+      }
+    })
+
+    // Socket -> PTY: binary frames are keystrokes, text frames control.
+    // A failed write means input is being discarded (dead PTY client, short
+    // write): end the bridge retryably rather than swallowing keystrokes —
+    // without inferring the terminal ended, which only an inventory proves.
+    const readSocket = socket.runRaw((message) => {
+      if (typeof message === "string") {
+        const control = decodeControl(message)
+        if (control.type === "resize") {
+          return Effect.ignore(connection.resize({ cols: control.cols, rows: control.rows }))
+        }
+        if (control.type === "pong") lastPong = Date.now()
+        return undefined
+      }
+      return connection
+        .write(message)
+        .pipe(
+          Effect.catch(() =>
+            Effect.asVoid(Queue.offer(outbox, new Socket.CloseEvent(1011, "attach_failed"))),
+          ),
+        )
+    })
+
+    // Whichever side finishes first ends the bridge; the closing scope
+    // detaches the PTY client (never the session). Socket closes — even
+    // clean ones — surface as errors here and are normal endings.
+    yield* Effect.raceFirst(drainOutbox, readSocket).pipe(Effect.catch(() => Effect.void))
+  })

--- a/app-server/src/terminalRepository.ts
+++ b/app-server/src/terminalRepository.ts
@@ -1,5 +1,6 @@
 import { Context, Effect, Layer, Option, Schema } from "effect"
 import { SqlClient, SqlSchema } from "effect/unstable/sql"
+import { TerminalNotFound } from "./api.ts"
 
 // The Terminals repository (ATC-130): the only module that speaks SQL for
 // terminals. Row types stay here — the service and handlers see camelCase
@@ -58,17 +59,21 @@ export class TerminalRepository extends Context.Service<
     /** All records (every status), newest first; optionally one project's. */
     readonly list: (projectId?: string) => Effect.Effect<ReadonlyArray<TerminalRecord>>
     readonly get: (id: string) => Effect.Effect<Option.Option<TerminalRecord>>
+    readonly require: (id: string) => Effect.Effect<TerminalRecord, TerminalNotFound>
     /**
      * `starting` → `live`. Callers hold the record; a vanished row is a
      * defect, like every other database failure.
      */
     readonly markLive: (id: string) => Effect.Effect<TerminalRecord>
-    /** Tombstone: `ended` with `endedAt`; idempotent for already-ended. */
-    readonly markEnded: (id: string) => Effect.Effect<void>
+    /**
+     * Tombstone in one statement: `ended` with `endedAt`; idempotent for
+     * already-ended rows. Returns the `endedAt` stamp it wrote so callers
+     * can apply the same tombstone to records already in hand.
+     */
+    readonly markEnded: (ids: ReadonlyArray<string>) => Effect.Effect<string>
     /** Update the display label; callers hold the record (see markLive). */
     readonly rename: (id: string, name: string) => Effect.Effect<TerminalRecord>
-    /** `false` if no such terminal existed. */
-    readonly delete: (id: string) => Effect.Effect<boolean>
+    readonly delete: (id: string) => Effect.Effect<void>
     readonly countForProject: (projectId: string) => Effect.Effect<number>
   }
 >()("app-server/TerminalRepository") {}
@@ -112,13 +117,13 @@ export const layer = Layer.effect(TerminalRepository)(
     // Idempotent tombstoning: the first observation of death wins, so a
     // re-reconcile never rewrites endedAt.
     const markEndedRows = SqlSchema.void({
-      Request: Schema.Struct({ id: Schema.String, ended_at: Schema.String }),
+      Request: Schema.Struct({ ids: Schema.Array(Schema.String), ended_at: Schema.String }),
       execute: (patch) => sql`
         UPDATE terminals SET
           status = 'ended',
           ended_at = COALESCE(ended_at, ${patch.ended_at}),
           updated_at = CASE WHEN status = 'ended' THEN updated_at ELSE ${patch.ended_at} END
-        WHERE id = ${patch.id}
+        WHERE ${sql.in("id", patch.ids)}
       `,
     })
 
@@ -132,10 +137,9 @@ export const layer = Layer.effect(TerminalRepository)(
       `,
     })
 
-    const deleteRows = SqlSchema.findAll({
+    const deleteRows = SqlSchema.void({
       Request: Schema.String,
-      Result: Schema.Struct({ id: Schema.String }),
-      execute: (id) => sql`DELETE FROM terminals WHERE id = ${id} RETURNING id`,
+      execute: (id) => sql`DELETE FROM terminals WHERE id = ${id}`,
     })
 
     const countRows = SqlSchema.findAll({
@@ -154,45 +158,59 @@ export const layer = Layer.effect(TerminalRepository)(
         ? Effect.succeed(toRecord(rows[0]))
         : Effect.die(new Error(`${what}: terminal row vanished mid-update`))
 
+    const get = (id: string) => getRows(id).pipe(Effect.map(firstRecord), Effect.orDie)
+
+    // Timestamps (and the generated id) are captured inside Effect.suspend so
+    // an effect built early and run later stamps the run time, not the build
+    // time.
     return {
-      create: (input) => {
-        const now = new Date().toISOString()
-        const row: typeof TerminalRow.Type = {
-          id: Bun.randomUUIDv7(),
-          project_id: input.projectId,
-          name: input.name ?? null,
-          command: input.command !== undefined ? JSON.stringify(input.command) : null,
-          initial_working_directory: input.initialWorkingDirectory,
-          status: "starting",
-          created_at: now,
-          updated_at: now,
-          ended_at: null,
-        }
-        return insertRow(row).pipe(Effect.as(toRecord(row)), Effect.orDie)
-      },
+      create: (input) =>
+        Effect.suspend(() => {
+          const now = new Date().toISOString()
+          const row: typeof TerminalRow.Type = {
+            id: Bun.randomUUIDv7(),
+            project_id: input.projectId,
+            name: input.name ?? null,
+            command: input.command !== undefined ? JSON.stringify(input.command) : null,
+            initial_working_directory: input.initialWorkingDirectory,
+            status: "starting",
+            created_at: now,
+            updated_at: now,
+            ended_at: null,
+          }
+          return insertRow(row).pipe(Effect.as(toRecord(row)))
+        }).pipe(Effect.orDie),
       list: (projectId) =>
         listRows(projectId ?? null).pipe(
           Effect.map((rows) => rows.map(toRecord)),
           Effect.orDie,
         ),
-      get: (id) => getRows(id).pipe(Effect.map(firstRecord), Effect.orDie),
+      get,
+      require: (id) =>
+        get(id).pipe(
+          Effect.flatMap(
+            Option.match({
+              onNone: () => Effect.fail(new TerminalNotFound({ terminalId: id })),
+              onSome: Effect.succeed,
+            }),
+          ),
+        ),
       markLive: (id) =>
-        markLiveRows({ id, updated_at: new Date().toISOString() }).pipe(
+        Effect.suspend(() => markLiveRows({ id, updated_at: new Date().toISOString() })).pipe(
           Effect.orDie,
           Effect.flatMap(requireFirst("markLive")),
         ),
-      markEnded: (id) =>
-        markEndedRows({ id, ended_at: new Date().toISOString() }).pipe(Effect.orDie),
+      markEnded: (ids) =>
+        Effect.suspend(() => {
+          const endedAt = new Date().toISOString()
+          return markEndedRows({ ids, ended_at: endedAt }).pipe(Effect.as(endedAt))
+        }).pipe(Effect.orDie),
       rename: (id, name) =>
-        renameRows({ id, name, updated_at: new Date().toISOString() }).pipe(
+        Effect.suspend(() => renameRows({ id, name, updated_at: new Date().toISOString() })).pipe(
           Effect.orDie,
           Effect.flatMap(requireFirst("rename")),
         ),
-      delete: (id) =>
-        deleteRows(id).pipe(
-          Effect.map((rows) => rows.length > 0),
-          Effect.orDie,
-        ),
+      delete: (id) => deleteRows(id).pipe(Effect.orDie),
       countForProject: (projectId) =>
         countRows(projectId).pipe(
           Effect.map((rows) => rows[0]?.n ?? 0),

--- a/app-server/src/terminalRepository.ts
+++ b/app-server/src/terminalRepository.ts
@@ -1,0 +1,203 @@
+import { Context, Effect, Layer, Option, Schema } from "effect"
+import { SqlClient, SqlSchema } from "effect/unstable/sql"
+
+// The Terminals repository (ATC-130): the only module that speaks SQL for
+// terminals. Row types stay here — the service and handlers see camelCase
+// records. `starting` is the internal crash-mid-create marker; the public
+// contract only ever sees `live` and `ended`.
+
+export type TerminalStatus = "starting" | "live" | "ended"
+
+export interface TerminalRecord {
+  readonly id: string
+  readonly projectId: string
+  readonly name?: string
+  readonly command?: ReadonlyArray<string>
+  readonly initialWorkingDirectory: string
+  readonly status: TerminalStatus
+  readonly createdAt: string
+  readonly updatedAt: string
+  readonly endedAt?: string
+}
+
+/** Internal row shape (snake_case columns, as stored). */
+const TerminalRow = Schema.Struct({
+  id: Schema.String,
+  project_id: Schema.String,
+  name: Schema.NullOr(Schema.String),
+  command: Schema.NullOr(Schema.String),
+  initial_working_directory: Schema.String,
+  status: Schema.Literals(["starting", "live", "ended"]),
+  created_at: Schema.String,
+  updated_at: Schema.String,
+  ended_at: Schema.NullOr(Schema.String),
+})
+
+const toRecord = (row: typeof TerminalRow.Type): TerminalRecord => ({
+  id: row.id,
+  projectId: row.project_id,
+  ...(row.name !== null ? { name: row.name } : {}),
+  ...(row.command !== null ? { command: JSON.parse(row.command) as Array<string> } : {}),
+  initialWorkingDirectory: row.initial_working_directory,
+  status: row.status,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+  ...(row.ended_at !== null ? { endedAt: row.ended_at } : {}),
+})
+
+export class TerminalRepository extends Context.Service<
+  TerminalRepository,
+  {
+    /** Insert a new `starting` record and return it (id is generated). */
+    readonly create: (input: {
+      readonly projectId: string
+      readonly name?: string | undefined
+      readonly command?: ReadonlyArray<string> | undefined
+      readonly initialWorkingDirectory: string
+    }) => Effect.Effect<TerminalRecord>
+    /** All records (every status), newest first; optionally one project's. */
+    readonly list: (projectId?: string) => Effect.Effect<ReadonlyArray<TerminalRecord>>
+    readonly get: (id: string) => Effect.Effect<Option.Option<TerminalRecord>>
+    /**
+     * `starting` → `live`. Callers hold the record; a vanished row is a
+     * defect, like every other database failure.
+     */
+    readonly markLive: (id: string) => Effect.Effect<TerminalRecord>
+    /** Tombstone: `ended` with `endedAt`; idempotent for already-ended. */
+    readonly markEnded: (id: string) => Effect.Effect<void>
+    /** Update the display label; callers hold the record (see markLive). */
+    readonly rename: (id: string, name: string) => Effect.Effect<TerminalRecord>
+    /** `false` if no such terminal existed. */
+    readonly delete: (id: string) => Effect.Effect<boolean>
+    readonly countForProject: (projectId: string) => Effect.Effect<number>
+  }
+>()("app-server/TerminalRepository") {}
+
+// Database failures are defects, not domain errors: the API surfaces them as
+// 500s and the one-line CLI contract reports them; nothing can handle them.
+export const layer = Layer.effect(TerminalRepository)(
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+
+    const insertRow = SqlSchema.void({
+      Request: TerminalRow,
+      execute: (row) => sql`INSERT INTO terminals ${sql.insert(row)}`,
+    })
+
+    const listRows = SqlSchema.findAll({
+      Request: Schema.NullOr(Schema.String),
+      Result: TerminalRow,
+      execute: (projectId) =>
+        projectId === null
+          ? sql`SELECT * FROM terminals ORDER BY id DESC`
+          : sql`SELECT * FROM terminals WHERE project_id = ${projectId} ORDER BY id DESC`,
+    })
+
+    const getRows = SqlSchema.findAll({
+      Request: Schema.String,
+      Result: TerminalRow,
+      execute: (id) => sql`SELECT * FROM terminals WHERE id = ${id}`,
+    })
+
+    const markLiveRows = SqlSchema.findAll({
+      Request: Schema.Struct({ id: Schema.String, updated_at: Schema.String }),
+      Result: TerminalRow,
+      execute: (patch) => sql`
+        UPDATE terminals SET status = 'live', updated_at = ${patch.updated_at}
+        WHERE id = ${patch.id}
+        RETURNING *
+      `,
+    })
+
+    // Idempotent tombstoning: the first observation of death wins, so a
+    // re-reconcile never rewrites endedAt.
+    const markEndedRows = SqlSchema.void({
+      Request: Schema.Struct({ id: Schema.String, ended_at: Schema.String }),
+      execute: (patch) => sql`
+        UPDATE terminals SET
+          status = 'ended',
+          ended_at = COALESCE(ended_at, ${patch.ended_at}),
+          updated_at = CASE WHEN status = 'ended' THEN updated_at ELSE ${patch.ended_at} END
+        WHERE id = ${patch.id}
+      `,
+    })
+
+    const renameRows = SqlSchema.findAll({
+      Request: Schema.Struct({ id: Schema.String, name: Schema.String, updated_at: Schema.String }),
+      Result: TerminalRow,
+      execute: (patch) => sql`
+        UPDATE terminals SET name = ${patch.name}, updated_at = ${patch.updated_at}
+        WHERE id = ${patch.id}
+        RETURNING *
+      `,
+    })
+
+    const deleteRows = SqlSchema.findAll({
+      Request: Schema.String,
+      Result: Schema.Struct({ id: Schema.String }),
+      execute: (id) => sql`DELETE FROM terminals WHERE id = ${id} RETURNING id`,
+    })
+
+    const countRows = SqlSchema.findAll({
+      Request: Schema.String,
+      Result: Schema.Struct({ n: Schema.Int }),
+      execute: (projectId) =>
+        sql`SELECT COUNT(*) AS n FROM terminals WHERE project_id = ${projectId}`,
+    })
+
+    const firstRecord = (rows: ReadonlyArray<typeof TerminalRow.Type>) =>
+      Option.fromNullishOr(rows[0]).pipe(Option.map(toRecord))
+
+    /** For updates whose caller holds the record: a vanished row is a bug. */
+    const requireFirst = (what: string) => (rows: ReadonlyArray<typeof TerminalRow.Type>) =>
+      rows[0] !== undefined
+        ? Effect.succeed(toRecord(rows[0]))
+        : Effect.die(new Error(`${what}: terminal row vanished mid-update`))
+
+    return {
+      create: (input) => {
+        const now = new Date().toISOString()
+        const row: typeof TerminalRow.Type = {
+          id: Bun.randomUUIDv7(),
+          project_id: input.projectId,
+          name: input.name ?? null,
+          command: input.command !== undefined ? JSON.stringify(input.command) : null,
+          initial_working_directory: input.initialWorkingDirectory,
+          status: "starting",
+          created_at: now,
+          updated_at: now,
+          ended_at: null,
+        }
+        return insertRow(row).pipe(Effect.as(toRecord(row)), Effect.orDie)
+      },
+      list: (projectId) =>
+        listRows(projectId ?? null).pipe(
+          Effect.map((rows) => rows.map(toRecord)),
+          Effect.orDie,
+        ),
+      get: (id) => getRows(id).pipe(Effect.map(firstRecord), Effect.orDie),
+      markLive: (id) =>
+        markLiveRows({ id, updated_at: new Date().toISOString() }).pipe(
+          Effect.orDie,
+          Effect.flatMap(requireFirst("markLive")),
+        ),
+      markEnded: (id) =>
+        markEndedRows({ id, ended_at: new Date().toISOString() }).pipe(Effect.orDie),
+      rename: (id, name) =>
+        renameRows({ id, name, updated_at: new Date().toISOString() }).pipe(
+          Effect.orDie,
+          Effect.flatMap(requireFirst("rename")),
+        ),
+      delete: (id) =>
+        deleteRows(id).pipe(
+          Effect.map((rows) => rows.length > 0),
+          Effect.orDie,
+        ),
+      countForProject: (projectId) =>
+        countRows(projectId).pipe(
+          Effect.map((rows) => rows[0]?.n ?? 0),
+          Effect.orDie,
+        ),
+    }
+  }),
+)

--- a/app-server/src/terminals.ts
+++ b/app-server/src/terminals.ts
@@ -1,0 +1,285 @@
+import { Context, Effect, Layer, Option } from "effect"
+import type { Scope } from "effect"
+import {
+  ProjectNotFound,
+  Terminal as TerminalSchema,
+  TerminalLaunchFailed,
+  TerminalNotFound,
+  ZmxUnavailable,
+} from "./api.ts"
+import type { CreateTerminalRequest, DirectoryCheckTimedOut, DirectoryUnavailable } from "./api.ts"
+import { Directories } from "./directories.ts"
+import { ProjectRepository } from "./projectRepository.ts"
+import { sessionNameForTerminalId, TerminalAdapter } from "./terminalAdapter.ts"
+import type {
+  SessionConnection,
+  SessionNotFound,
+  SessionOperationFailed,
+  SessionSize,
+} from "./terminalAdapter.ts"
+import { TerminalRepository } from "./terminalRepository.ts"
+import type { TerminalRecord } from "./terminalRepository.ts"
+
+export type Terminal = typeof TerminalSchema.Type
+
+// The Terminals domain service (ATC-130): orchestrates the repository, the
+// TerminalAdapter, and directory validation under the ATC-122 reconciliation
+// invariants:
+//
+//   - Authoritative absence: only a successful, complete inventory taken
+//     *after* the row snapshot may mark a terminal ended (a row that was
+//     live before the inventory and absent from it is genuinely dead; the
+//     reverse order would tombstone a create that completed in between).
+//     Inventory unavailable ⇒ stored state untouched; operations requiring
+//     certainty fail with the retryable ZmxUnavailable.
+//   - Demand-driven: reconciliation runs at startup (during layer build,
+//     before the API can serve any request) and on list/read/attach — no
+//     background watcher.
+//   - `starting` rows are internal and owned by their in-flight create (or
+//     by startup recovery after a crash). Request-time reconciliation never
+//     touches them, which is why the startup pass and the request-time pass
+//     can never be one function: resolving `starting` rows is only safe
+//     while no create can be in flight.
+//   - Orphan cleanup: sessions in ATC's private socket dir that no stored
+//     terminal claims are provably ours and killed (best-effort) at startup.
+
+/**
+ * Contract shape for a repository record. Callers have already excluded
+ * `starting` (list filters, requireRecord rejects); the status here can
+ * only be live or ended.
+ */
+const toTerminal = (record: TerminalRecord): Terminal => ({
+  id: record.id,
+  projectId: record.projectId,
+  ...(record.name !== undefined ? { name: record.name } : {}),
+  ...(record.command !== undefined ? { command: record.command } : {}),
+  initialWorkingDirectory: record.initialWorkingDirectory,
+  status: record.status === "ended" ? "ended" : "live",
+  createdAt: record.createdAt,
+  updatedAt: record.updatedAt,
+  ...(record.endedAt !== undefined ? { endedAt: record.endedAt } : {}),
+})
+
+export class Terminals extends Context.Service<
+  Terminals,
+  {
+    /** Reconciled listing; an unavailable inventory returns stored state. */
+    readonly list: (projectId?: string) => Effect.Effect<ReadonlyArray<Terminal>>
+    /** Reconciled read. */
+    readonly get: (id: string) => Effect.Effect<Terminal, TerminalNotFound>
+    /** Create the record and start the zmx session (two-phase). */
+    readonly create: (
+      input: typeof CreateTerminalRequest.Type,
+    ) => Effect.Effect<
+      Terminal,
+      | ProjectNotFound
+      | DirectoryUnavailable
+      | DirectoryCheckTimedOut
+      | ZmxUnavailable
+      | TerminalLaunchFailed
+    >
+    readonly rename: (id: string, name: string) => Effect.Effect<Terminal, TerminalNotFound>
+    /** Kill if present → verify absence → remove the record. */
+    readonly delete: (id: string) => Effect.Effect<void, TerminalNotFound | ZmxUnavailable>
+    /** Open a live attach connection onto the terminal's session. */
+    readonly attach: (
+      id: string,
+      size: SessionSize,
+    ) => Effect.Effect<
+      SessionConnection,
+      ZmxUnavailable | SessionNotFound | SessionOperationFailed,
+      Scope.Scope
+    >
+    /**
+     * Authoritative-absence check for the attach bridge: true iff a
+     * complete inventory omits the terminal's session, in which case the
+     * tombstone is written. Unavailable inventories fail retryably.
+     */
+    readonly confirmEnded: (id: string) => Effect.Effect<boolean, ZmxUnavailable>
+    /** Every record (tombstones included) — the project-deletion guard. */
+    readonly countForProject: (projectId: string) => Effect.Effect<number>
+  }
+>()("app-server/Terminals") {}
+
+export const layer = Layer.effect(Terminals)(
+  Effect.gen(function* () {
+    const repository = yield* TerminalRepository
+    const adapter = yield* TerminalAdapter
+    const projects = yield* ProjectRepository
+    const directories = yield* Directories
+
+    const presentSessionNames = adapter
+      .listSessions()
+      .pipe(Effect.map((sessions) => new Set(sessions.map((s) => s.name))))
+
+    /**
+     * Tombstone every live row whose session a complete inventory omits.
+     * Rows are read first — see the header's authoritative-absence bullet.
+     */
+    const reconcile = Effect.gen(function* () {
+      const records = yield* repository.list()
+      const present = yield* presentSessionNames
+      for (const record of records) {
+        if (record.status === "live" && !present.has(sessionNameForTerminalId(record.id))) {
+          yield* repository.markEnded(record.id)
+        }
+      }
+    })
+
+    const reconcileBestEffort = reconcile.pipe(Effect.catchTag("ZmxUnavailable", () => Effect.void))
+
+    // Startup pass: additionally resolves crash-mid-create rows and cleans
+    // orphans — safe only here, while no create can be in flight. Runs
+    // during layer build, so no request can observe pre-reconcile state.
+    // Skipped wholesale when the inventory is unavailable.
+    const reconcileAtStartup = Effect.gen(function* () {
+      const records = yield* repository.list()
+      const sessions = yield* adapter.listSessions()
+      const present = new Set(sessions.map((s) => s.name))
+      const reachable = new Set(sessions.filter((s) => s.reachable).map((s) => s.name))
+      const claimed = new Set<string>()
+      for (const record of records) {
+        const sessionName = sessionNameForTerminalId(record.id)
+        switch (record.status) {
+          case "live":
+            if (!present.has(sessionName)) yield* repository.markEnded(record.id)
+            else claimed.add(sessionName)
+            break
+          case "starting":
+            // Crash mid-create: adopt the session if it made it — only a
+            // *reachable* entry proves it did (ATC-122). An unreachable
+            // match is neither alive nor absent: the row stays `starting`
+            // (hidden, resolved at a later startup) and the session is
+            // claimed so orphan cleanup does not kill it. Absent means the
+            // failed launch leaves no record.
+            if (reachable.has(sessionName)) {
+              yield* repository.markLive(record.id)
+              claimed.add(sessionName)
+            } else if (present.has(sessionName)) {
+              claimed.add(sessionName)
+              yield* Effect.logWarning("starting terminal left unresolved").pipe(
+                Effect.annotateLogs({ terminalId: record.id, reason: "session unreachable" }),
+              )
+            } else {
+              yield* repository.delete(record.id)
+            }
+            break
+          case "ended":
+            break
+        }
+      }
+      // Everything in ATC's private dir is provably ours: sessions no live
+      // record claims (foreign names included) are orphans. Best-effort —
+      // a kill that cannot be verified is logged and retried next startup.
+      for (const session of sessions) {
+        if (!claimed.has(session.name)) {
+          yield* adapter
+            .killSession(session.name)
+            .pipe(
+              Effect.catch((error) =>
+                Effect.logWarning("orphan zmx session not cleaned").pipe(
+                  Effect.annotateLogs({ session: session.name, reason: error.message }),
+                ),
+              ),
+            )
+        }
+      }
+    })
+
+    yield* reconcileAtStartup.pipe(
+      Effect.catchTag("ZmxUnavailable", (error) =>
+        Effect.logWarning("startup terminal reconciliation skipped").pipe(
+          Effect.annotateLogs({ reason: error.reason }),
+        ),
+      ),
+    )
+
+    const requireRecord = (id: string) =>
+      repository.get(id).pipe(
+        Effect.flatMap((found) =>
+          Option.match(found, {
+            // starting rows belong to their in-flight create.
+            onNone: () => Effect.fail(new TerminalNotFound({ terminalId: id })),
+            onSome: (record) =>
+              record.status === "starting"
+                ? Effect.fail(new TerminalNotFound({ terminalId: id }))
+                : Effect.succeed(record),
+          }),
+        ),
+      )
+
+    const create: Terminals["Service"]["create"] = (input) =>
+      Effect.gen(function* () {
+        const project = yield* projects.require(input.projectId)
+        const canonical = yield* directories.canonicalize(
+          input.workingDirectory ?? project.defaultWorkingDirectory,
+        )
+        // Two-phase: the starting row exists before the session so a crash
+        // mid-create is resolvable either way at the next startup.
+        const record = yield* repository.create({
+          projectId: input.projectId,
+          name: input.name,
+          command: input.command,
+          initialWorkingDirectory: canonical,
+        })
+        const sessionName = sessionNameForTerminalId(record.id)
+        // On any non-success exit — typed failure, defect, or interruption
+        // (a client abort interrupts the request fiber) — the launch leaves
+        // no record and, best-effort, no session.
+        const cleanup = adapter
+          .killSession(sessionName)
+          .pipe(Effect.ignore, Effect.andThen(repository.delete(record.id)))
+        const live = yield* adapter
+          .createSession({ name: sessionName, cwd: canonical, command: input.command })
+          .pipe(
+            Effect.catchTag("SessionOperationFailed", (error) =>
+              Effect.fail(new TerminalLaunchFailed({ reason: error.reason })),
+            ),
+            Effect.andThen(Effect.suspend(() => repository.markLive(record.id))),
+            Effect.onExit((exit) => (exit._tag === "Failure" ? cleanup : Effect.void)),
+          )
+        return toTerminal(live)
+      })
+
+    const del: Terminals["Service"]["delete"] = (id) =>
+      Effect.gen(function* () {
+        const record = yield* requireRecord(id)
+        // Kill requiring certainty: a kill that cannot verify death is
+        // reported retryably rather than deleting a record whose session
+        // may still be alive.
+        yield* adapter
+          .killSession(sessionNameForTerminalId(record.id))
+          .pipe(
+            Effect.catchTag("SessionOperationFailed", (error) =>
+              Effect.fail(new ZmxUnavailable({ reason: error.reason })),
+            ),
+          )
+        yield* repository.delete(id)
+      })
+
+    return {
+      list: (projectId) =>
+        reconcileBestEffort.pipe(
+          Effect.andThen(repository.list(projectId)),
+          Effect.map((records) =>
+            records.filter((record) => record.status !== "starting").map(toTerminal),
+          ),
+        ),
+      get: (id) =>
+        reconcileBestEffort.pipe(Effect.andThen(requireRecord(id)), Effect.map(toTerminal)),
+      create,
+      rename: (id, name) =>
+        requireRecord(id).pipe(Effect.andThen(repository.rename(id, name)), Effect.map(toTerminal)),
+      delete: del,
+      attach: (id, size) => adapter.attachSession(sessionNameForTerminalId(id), size),
+      confirmEnded: (id) =>
+        Effect.gen(function* () {
+          const present = yield* presentSessionNames
+          if (present.has(sessionNameForTerminalId(id))) return false
+          yield* repository.markEnded(id)
+          return true
+        }),
+      countForProject: (projectId) => repository.countForProject(projectId),
+    }
+  }),
+)

--- a/app-server/src/terminals.ts
+++ b/app-server/src/terminals.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer, Option } from "effect"
+import { Context, Effect, Layer } from "effect"
 import type { Scope } from "effect"
 import {
   ProjectNotFound,
@@ -33,8 +33,9 @@ export type Terminal = typeof TerminalSchema.Type
 //     Inventory unavailable ⇒ stored state untouched; operations requiring
 //     certainty fail with the retryable ZmxUnavailable.
 //   - Demand-driven: reconciliation runs at startup (during layer build,
-//     before the API can serve any request) and on list/read/attach — no
-//     background watcher.
+//     before the API can serve any request) and on list/read — attach
+//     reconciles through the bridge's pre-flight `get`, so `attach` itself
+//     is a bare pass-through. No background watcher.
 //   - `starting` rows are internal and owned by their in-flight create (or
 //     by startup recovery after a crash). Request-time reconciliation never
 //     touches them, which is why the startup pass and the request-time pass
@@ -49,15 +50,8 @@ export type Terminal = typeof TerminalSchema.Type
  * only be live or ended.
  */
 const toTerminal = (record: TerminalRecord): Terminal => ({
-  id: record.id,
-  projectId: record.projectId,
-  ...(record.name !== undefined ? { name: record.name } : {}),
-  ...(record.command !== undefined ? { command: record.command } : {}),
-  initialWorkingDirectory: record.initialWorkingDirectory,
+  ...record,
   status: record.status === "ended" ? "ended" : "live",
-  createdAt: record.createdAt,
-  updatedAt: record.updatedAt,
-  ...(record.endedAt !== undefined ? { endedAt: record.endedAt } : {}),
 })
 
 export class Terminals extends Context.Service<
@@ -78,7 +72,11 @@ export class Terminals extends Context.Service<
       | ZmxUnavailable
       | TerminalLaunchFailed
     >
-    readonly rename: (id: string, name: string) => Effect.Effect<Terminal, TerminalNotFound>
+    /** Patch mutable fields; an empty patch changes nothing, updatedAt included. */
+    readonly update: (
+      id: string,
+      patch: { readonly name?: string | undefined },
+    ) => Effect.Effect<Terminal, TerminalNotFound>
     /** Kill if present → verify absence → remove the record. */
     readonly delete: (id: string) => Effect.Effect<void, TerminalNotFound | ZmxUnavailable>
     /** Open a live attach connection onto the terminal's session. */
@@ -113,20 +111,45 @@ export const layer = Layer.effect(Terminals)(
       .pipe(Effect.map((sessions) => new Set(sessions.map((s) => s.name))))
 
     /**
-     * Tombstone every live row whose session a complete inventory omits.
-     * Rows are read first — see the header's authoritative-absence bullet.
+     * The one tombstoning step both reconciliation passes share: mark every
+     * live row whose session a complete inventory omits as ended (one batch
+     * statement) and return the records with the tombstones applied.
      */
-    const reconcile = Effect.gen(function* () {
-      const records = yield* repository.list()
-      const present = yield* presentSessionNames
-      for (const record of records) {
-        if (record.status === "live" && !present.has(sessionNameForTerminalId(record.id))) {
-          yield* repository.markEnded(record.id)
-        }
-      }
-    })
+    const tombstoneAbsent = (
+      records: ReadonlyArray<TerminalRecord>,
+      present: ReadonlySet<string>,
+    ): Effect.Effect<ReadonlyArray<TerminalRecord>> =>
+      Effect.gen(function* () {
+        const dead = new Set(
+          records
+            .filter((r) => r.status === "live" && !present.has(sessionNameForTerminalId(r.id)))
+            .map((r) => r.id),
+        )
+        if (dead.size === 0) return records
+        const endedAt = yield* repository.markEnded([...dead])
+        return records.map((record) =>
+          dead.has(record.id)
+            ? { ...record, status: "ended" as const, endedAt, updatedAt: endedAt }
+            : record,
+        )
+      })
 
-    const reconcileBestEffort = reconcile.pipe(Effect.catchTag("ZmxUnavailable", () => Effect.void))
+    /**
+     * Request-time pass: reconcile and return the post-reconcile records, so
+     * list/get never re-query what was just read. Rows are read first — see
+     * the header's authoritative-absence bullet. An unavailable inventory
+     * leaves stored state untouched and returns it as-is.
+     */
+    const reconciledRecords: Effect.Effect<ReadonlyArray<TerminalRecord>> = Effect.gen(
+      function* () {
+        const records = yield* repository.list()
+        const present = yield* presentSessionNames.pipe(
+          Effect.catchTag("ZmxUnavailable", () => Effect.succeed(undefined)),
+        )
+        if (present === undefined) return records
+        return yield* tombstoneAbsent(records, present)
+      },
+    )
 
     // Startup pass: additionally resolves crash-mid-create rows and cleans
     // orphans — safe only here, while no create can be in flight. Runs
@@ -137,13 +160,13 @@ export const layer = Layer.effect(Terminals)(
       const sessions = yield* adapter.listSessions()
       const present = new Set(sessions.map((s) => s.name))
       const reachable = new Set(sessions.filter((s) => s.reachable).map((s) => s.name))
+      yield* tombstoneAbsent(records, present)
       const claimed = new Set<string>()
       for (const record of records) {
         const sessionName = sessionNameForTerminalId(record.id)
         switch (record.status) {
           case "live":
-            if (!present.has(sessionName)) yield* repository.markEnded(record.id)
-            else claimed.add(sessionName)
+            if (present.has(sessionName)) claimed.add(sessionName)
             break
           case "starting":
             // Crash mid-create: adopt the session if it made it — only a
@@ -171,9 +194,12 @@ export const layer = Layer.effect(Terminals)(
       // Everything in ATC's private dir is provably ours: sessions no live
       // record claims (foreign names included) are orphans. Best-effort —
       // a kill that cannot be verified is logged and retried next startup.
-      for (const session of sessions) {
-        if (!claimed.has(session.name)) {
-          yield* adapter
+      // Kills are independent and mostly sleep in verification polling, so
+      // a bounded batch keeps a crash's worth of orphans off the boot time.
+      yield* Effect.forEach(
+        sessions.filter((session) => !claimed.has(session.name)),
+        (session) =>
+          adapter
             .killSession(session.name)
             .pipe(
               Effect.catch((error) =>
@@ -181,9 +207,9 @@ export const layer = Layer.effect(Terminals)(
                   Effect.annotateLogs({ session: session.name, reason: error.message }),
                 ),
               ),
-            )
-        }
-      }
+            ),
+        { concurrency: 4, discard: true },
+      )
     })
 
     yield* reconcileAtStartup.pipe(
@@ -194,17 +220,12 @@ export const layer = Layer.effect(Terminals)(
       ),
     )
 
+    // starting rows belong to their in-flight create, so they are invisible.
     const requireRecord = (id: string) =>
-      repository.get(id).pipe(
-        Effect.flatMap((found) =>
-          Option.match(found, {
-            // starting rows belong to their in-flight create.
-            onNone: () => Effect.fail(new TerminalNotFound({ terminalId: id })),
-            onSome: (record) =>
-              record.status === "starting"
-                ? Effect.fail(new TerminalNotFound({ terminalId: id }))
-                : Effect.succeed(record),
-          }),
+      repository.require(id).pipe(
+        Effect.filterOrFail(
+          (record) => record.status !== "starting",
+          () => new TerminalNotFound({ terminalId: id }),
         ),
       )
 
@@ -235,7 +256,7 @@ export const layer = Layer.effect(Terminals)(
             Effect.catchTag("SessionOperationFailed", (error) =>
               Effect.fail(new TerminalLaunchFailed({ reason: error.reason })),
             ),
-            Effect.andThen(Effect.suspend(() => repository.markLive(record.id))),
+            Effect.andThen(repository.markLive(record.id)),
             Effect.onExit((exit) => (exit._tag === "Failure" ? cleanup : Effect.void)),
           )
         return toTerminal(live)
@@ -259,24 +280,43 @@ export const layer = Layer.effect(Terminals)(
 
     return {
       list: (projectId) =>
-        reconcileBestEffort.pipe(
-          Effect.andThen(repository.list(projectId)),
+        reconciledRecords.pipe(
           Effect.map((records) =>
-            records.filter((record) => record.status !== "starting").map(toTerminal),
+            records
+              .filter(
+                (record) =>
+                  record.status !== "starting" &&
+                  (projectId === undefined || record.projectId === projectId),
+              )
+              .map(toTerminal),
           ),
         ),
       get: (id) =>
-        reconcileBestEffort.pipe(Effect.andThen(requireRecord(id)), Effect.map(toTerminal)),
+        reconciledRecords.pipe(
+          Effect.flatMap((records) => {
+            const record = records.find((r) => r.id === id)
+            return record === undefined || record.status === "starting"
+              ? Effect.fail(new TerminalNotFound({ terminalId: id }))
+              : Effect.succeed(toTerminal(record))
+          }),
+        ),
       create,
-      rename: (id, name) =>
-        requireRecord(id).pipe(Effect.andThen(repository.rename(id, name)), Effect.map(toTerminal)),
+      update: (id, patch) =>
+        // An empty patch changes nothing — including updatedAt (the same
+        // rule ProjectRepository.update applies).
+        patch.name === undefined
+          ? requireRecord(id).pipe(Effect.map(toTerminal))
+          : requireRecord(id).pipe(
+              Effect.andThen(repository.rename(id, patch.name)),
+              Effect.map(toTerminal),
+            ),
       delete: del,
       attach: (id, size) => adapter.attachSession(sessionNameForTerminalId(id), size),
       confirmEnded: (id) =>
         Effect.gen(function* () {
           const present = yield* presentSessionNames
           if (present.has(sessionNameForTerminalId(id))) return false
-          yield* repository.markEnded(id)
+          yield* repository.markEnded([id])
           return true
         }),
       countForProject: (projectId) => repository.countForProject(projectId),

--- a/app-server/src/zmxAdapter.ts
+++ b/app-server/src/zmxAdapter.ts
@@ -2,11 +2,11 @@ import { Effect, FileSystem, Layer, Schema, Stream } from "effect"
 import type { Duration } from "effect"
 import * as path from "node:path"
 import { AppConfig } from "./config.ts"
-import { Subprocess } from "./subprocess.ts"
+import { resolveExecutable as resolveExecutablePath, Subprocess } from "./subprocess.ts"
 import type { SubprocessError } from "./subprocess.ts"
 import { ZmxUnavailable } from "./api.ts"
 import {
-  SESSION_NAME_PREFIX,
+  LONGEST_SESSION_NAME,
   SessionNotFound,
   SessionOperationFailed,
   TerminalAdapter,
@@ -76,12 +76,10 @@ export const parseSessionList = (stdout: ReadonlyArray<string>): Array<SessionIn
     const name = fields.get("name")
     if (name === undefined || name === "") continue
     const pid = Number.parseInt(fields.get("pid") ?? "", 10)
-    const createdAt = Number.parseInt(fields.get("created") ?? "", 10)
     sessions.push({
       name,
       reachable: !fields.has("err"),
       ...(Number.isNaN(pid) ? {} : { pid }),
-      ...(Number.isNaN(createdAt) ? {} : { createdAt }),
     })
   }
   return sessions
@@ -122,7 +120,7 @@ export const layerWith = (options: ZmxOptions) =>
       const socketDir = config.terminalSocketDir
       // Socket paths must fit sun_path; validated at boot so a deep state
       // dir fails serve with one actionable line, not on every create.
-      const longestSocketPath = path.join(socketDir, `${SESSION_NAME_PREFIX}${"0".repeat(32)}`)
+      const longestSocketPath = path.join(socketDir, LONGEST_SESSION_NAME)
       if (Buffer.byteLength(longestSocketPath) > MAX_SOCKET_PATH_BYTES) {
         return yield* Effect.fail(
           new ZmxConfigError({
@@ -140,14 +138,13 @@ export const layerWith = (options: ZmxOptions) =>
 
       const childEnv = zmxChildEnv(socketDir)
 
-      // Explicit resolution, never implicit: a bare name resolves on PATH
-      // here so a missing install fails with one actionable diagnostic.
-      // Memoized on success — a resolved install does not move mid-run.
+      // Explicit resolution, never implicit (the shared resolveExecutable
+      // rule), memoized on success — a resolved install does not move mid-run.
       let resolvedExecutable: string | undefined
       const resolveExecutable = Effect.suspend(() => {
         if (resolvedExecutable !== undefined) return Effect.succeed(resolvedExecutable)
         const configured = config.zmxExecutable
-        const resolved = configured.includes("/") ? configured : Bun.which(configured)
+        const resolved = resolveExecutablePath(configured)
         if (resolved !== null) {
           resolvedExecutable = resolved
           return Effect.succeed(resolved)
@@ -206,15 +203,17 @@ export const layerWith = (options: ZmxOptions) =>
 
       /**
        * Up to `verifyPasses` complete inventory passes until `predicate`
-       * accepts one; resolves to whether it ever did.
+       * accepts one; resolves to the accepted inventory (so callers can read
+       * it without another `zmx list`), or undefined if none was accepted.
        */
       const pollInventory = (predicate: (sessions: ReadonlyArray<SessionInfo>) => boolean) =>
         Effect.gen(function* () {
           for (let pass = 0; pass < verifyPasses; pass++) {
             if (pass > 0) yield* Effect.sleep(pollInterval)
-            if (predicate(yield* listSessions())) return true
+            const sessions = yield* listSessions()
+            if (predicate(sessions)) return sessions
           }
-          return false
+          return undefined
         })
 
       const liveSession = (name: string) => (sessions: ReadonlyArray<SessionInfo>) =>
@@ -262,6 +261,8 @@ export const layerWith = (options: ZmxOptions) =>
                 args: ["attach", options.name, ...(options.command ?? [])],
                 cwd: options.cwd,
                 env: childEnv,
+                // The tail is the launch-failure diagnostic below.
+                captureOutputTail: true,
               })
               .pipe(Effect.catchTag("SubprocessError", (e) => Effect.fail(unavailable(e))))
             const settled = yield* Effect.raceFirst(
@@ -269,11 +270,11 @@ export const layerWith = (options: ZmxOptions) =>
               // A client that dies first (bad command, zmx error) ends the
               // wait early; the final check below stays the authority.
               child.exitCode.pipe(
-                Effect.as(false),
-                Effect.catchTag("SubprocessError", () => Effect.succeed(false)),
+                Effect.as(undefined),
+                Effect.catchTag("SubprocessError", () => Effect.succeed(undefined)),
               ),
             )
-            return { settled, tail: yield* child.outputTail }
+            return { settled: settled !== undefined, tail: yield* child.outputTail }
           }).pipe(Effect.scoped)
 
           if (client.settled) return
@@ -294,7 +295,7 @@ export const layerWith = (options: ZmxOptions) =>
           // proof. The inventory is the only authority.
           yield* runZmx(["kill", name])
           const gone = yield* pollInventory((sessions) => !sessions.some((s) => s.name === name))
-          if (!gone) {
+          if (gone === undefined) {
             return yield* Effect.fail(
               new SessionOperationFailed({
                 operation: "kill",
@@ -339,7 +340,7 @@ export const layerWith = (options: ZmxOptions) =>
           // session's identity — a changed pid means a resurrected phantom,
           // which is killed and reported as the original being gone.
           const settled = yield* pollInventory(liveSession(name))
-          const after = settled ? yield* findSession(name) : undefined
+          const after = settled?.find((s) => s.name === name)
           if (after === undefined || after.pid !== before.pid) {
             yield* runZmx(["kill", name]).pipe(Effect.ignore)
             return yield* Effect.fail(new SessionNotFound({ sessionName: name }))

--- a/app-server/src/zmxAdapter.ts
+++ b/app-server/src/zmxAdapter.ts
@@ -4,12 +4,12 @@ import * as path from "node:path"
 import { AppConfig } from "./config.ts"
 import { Subprocess } from "./subprocess.ts"
 import type { SubprocessError } from "./subprocess.ts"
+import { ZmxUnavailable } from "./api.ts"
 import {
   SESSION_NAME_PREFIX,
   SessionNotFound,
   SessionOperationFailed,
   TerminalAdapter,
-  ZmxUnavailable,
 } from "./terminalAdapter.ts"
 import type { SessionInfo } from "./terminalAdapter.ts"
 

--- a/app-server/test/api.test.ts
+++ b/app-server/test/api.test.ts
@@ -101,14 +101,15 @@ describe("/api/v1/projects", () => {
   it.effect("unknown ids are ProjectNotFound on get, update, and delete", () =>
     Effect.gen(function* () {
       const client = yield* HttpApiTest.groups(Api, ["v1"])
-      for (const attempt of [
+      const attempts: ReadonlyArray<Effect.Effect<unknown, unknown>> = [
         client.v1.getProject({ params: { projectId: "missing" } }),
         client.v1.updateProject({ params: { projectId: "missing" }, payload: { name: "x" } }),
         client.v1.deleteProject({ params: { projectId: "missing" } }),
-      ]) {
-        const error = yield* Effect.flip(attempt)
+      ]
+      for (const attempt of attempts) {
+        const error = (yield* Effect.flip(attempt)) as { _tag: string; projectId?: string }
         assert.strictEqual(error._tag, "ProjectNotFound")
-        if (error._tag === "ProjectNotFound") assert.strictEqual(error.projectId, "missing")
+        assert.strictEqual(error.projectId, "missing")
       }
     }).pipe(Effect.provide(TestLayer)),
   )
@@ -150,6 +151,28 @@ describe("/api/v1/projects", () => {
         yield* client.v1.getProject({ params: { projectId: created.id } }),
         created,
       )
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("restricts project deletion while terminals exist, tombstones included", () =>
+    Effect.gen(function* () {
+      const client = yield* HttpApiTest.groups(Api, ["v1"])
+      const project = yield* client.v1.createProject({
+        payload: { name: "Guarded", defaultWorkingDirectory: realDir },
+      })
+      const terminal = yield* client.v1.createTerminal({
+        payload: { projectId: project.id },
+      })
+      const restricted = yield* Effect.flip(
+        client.v1.deleteProject({ params: { projectId: project.id } }),
+      )
+      assert.strictEqual(restricted._tag, "ProjectHasTerminals")
+      if (restricted._tag === "ProjectHasTerminals") {
+        assert.strictEqual(restricted.terminalCount, 1)
+      }
+      // Deleting the terminal (record and session) releases the project.
+      yield* client.v1.deleteTerminal({ params: { terminalId: terminal.id } })
+      yield* client.v1.deleteProject({ params: { projectId: project.id } })
     }).pipe(Effect.provide(TestLayer)),
   )
 

--- a/app-server/test/blackbox.ts
+++ b/app-server/test/blackbox.ts
@@ -1,3 +1,5 @@
+import { expect } from "vitest"
+import { mkdtempSync, rmSync } from "node:fs"
 import { fileURLToPath } from "node:url"
 
 // Shared helpers for black-box tests that spawn a real `atc serve` process —
@@ -10,16 +12,41 @@ export const appServerRoot = fileURLToPath(new URL("..", import.meta.url))
 export const compiledBinaryPath =
   process.env["ATC_COMPILED_BIN"] ?? `${appServerRoot}dist/atc-${process.platform}-${process.arch}`
 
+const tempDirs: Array<string> = []
+
+/** Track `dir` for removal by `cleanupTempDirs`. */
+export const trackTempDir = (dir: string): string => {
+  tempDirs.push(dir)
+  return dir
+}
+
+export const cleanupTempDirs = (): void => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+}
+
+// Unconditional: suites that allocate tracked dirs (isolatedEnv does it
+// implicitly) must not leak them just because they forgot an afterAll.
+process.on("exit", cleanupTempDirs)
+
 /**
- * Environment pointing every settled location (config, data, state) into
- * `dir`, so spawned servers and CLI commands never touch the real user
- * locations on the machine running the tests.
+ * A throwaway directory short enough for the unix socket-path budget
+ * (~103 bytes) — macOS os.tmpdir() (/var/folders/…) is too deep, /tmp is not.
+ */
+export const makeShortSocketDir = (): string => trackTempDir(mkdtempSync("/tmp/atc-zs-"))
+
+/**
+ * Environment pointing every settled location (config, data, state) away
+ * from the real user locations on the machine running the tests. The state
+ * home gets its own short /tmp path rather than living under `dir`: the
+ * terminal socket directory lives under it and must fit the unix
+ * socket-path budget. Read the location back from the returned env when a
+ * test needs to inspect state files.
  */
 export const isolatedEnv = (dir: string, extra: Record<string, string> = {}) => ({
   ...process.env,
   XDG_CONFIG_HOME: `${dir}/config`,
   XDG_DATA_HOME: `${dir}/data`,
-  XDG_STATE_HOME: `${dir}/state`,
+  XDG_STATE_HOME: trackTempDir(mkdtempSync("/tmp/atc-st-")),
   ...extra,
 })
 
@@ -78,4 +105,23 @@ export const waitForHealth = async (base: string, proc: Bun.Subprocess): Promise
   proc.kill()
   const stderr = await new Response(proc.stderr as ReadableStream).text()
   throw new Error(`server at ${base} never became healthy; stderr:\n${stderr}`)
+}
+
+/** POST a JSON body and return the decoded JSON response (asserting 2xx). */
+export const postJson = async (base: string, pathName: string, body: unknown) => {
+  const response = await fetch(`${base}${pathName}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  })
+  expect(response.ok, `${pathName}: ${response.status} ${await response.clone().text()}`).toBe(true)
+  return (await response.json()) as Record<string, string>
+}
+
+/** Poll until `condition` holds; assertion-bounded. */
+export const waitUntil = async (condition: () => boolean | Promise<boolean>, what: string) => {
+  for (let attempt = 0; !(await condition()); attempt++) {
+    expect(attempt, `timed out waiting for ${what}`).toBeLessThan(200)
+    await Bun.sleep(25)
+  }
 }

--- a/app-server/test/blackbox.ts
+++ b/app-server/test/blackbox.ts
@@ -118,10 +118,47 @@ export const postJson = async (base: string, pathName: string, body: unknown) =>
   return (await response.json()) as Record<string, string>
 }
 
-/** Poll until `condition` holds; assertion-bounded. */
-export const waitUntil = async (condition: () => boolean | Promise<boolean>, what: string) => {
+/** Poll until `condition` holds; assertion-bounded (attempts × 25ms). */
+export const waitUntil = async (
+  condition: () => boolean | Promise<boolean>,
+  what: string,
+  attempts = 200,
+) => {
   for (let attempt = 0; !(await condition()); attempt++) {
-    expect(attempt, `timed out waiting for ${what}`).toBeLessThan(200)
+    expect(attempt, `timed out waiting for ${what}`).toBeLessThan(attempts)
     await Bun.sleep(25)
   }
 }
+
+/** One project owning one terminal — the seed for attach/recovery tests. */
+export const makeTerminal = async (base: string) => {
+  const project = await postJson(base, "/api/v1/projects", {
+    name: "P",
+    defaultWorkingDirectory: "/tmp",
+  })
+  return postJson(base, "/api/v1/terminals", { projectId: project["id"] })
+}
+
+export interface WsSession {
+  readonly socket: WebSocket
+  /** Decoded binary frames, in arrival order. Text frames are ignored. */
+  readonly received: Array<string>
+  readonly closed: Promise<{ code: number; reason: string }>
+}
+
+/** Open a WebSocket collecting decoded binary frames; resolves once open. */
+export const openSocket = (url: string): Promise<WsSession> =>
+  new Promise((resolve, reject) => {
+    const socket = new WebSocket(url)
+    socket.binaryType = "arraybuffer"
+    const received: Array<string> = []
+    const decoder = new TextDecoder()
+    const closed = new Promise<{ code: number; reason: string }>((resolveClose) => {
+      socket.onclose = (event) => resolveClose({ code: event.code, reason: event.reason })
+    })
+    socket.onmessage = (event) => {
+      if (typeof event.data !== "string") received.push(decoder.decode(event.data as ArrayBuffer))
+    }
+    socket.onopen = () => resolve({ socket, received, closed })
+    socket.onerror = () => reject(new Error(`websocket failed to open ${url}`))
+  })

--- a/app-server/test/cli.blackbox.test.ts
+++ b/app-server/test/cli.blackbox.test.ts
@@ -3,14 +3,8 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterAll, beforeAll, describe, expect, test } from "vitest"
 import packageJson from "../package.json"
-import {
-  appServerRoot,
-  freePort,
-  isolatedEnv,
-  runCli,
-  spawnServe,
-  waitForHealth,
-} from "./blackbox.ts"
+import { appServerRoot, cleanupTempDirs, runCli } from "./blackbox.ts"
+import { startFakeZmxServer } from "./testLayers.ts"
 
 // Black-box tests of the client-backed CLI commands: exact stdout, stderr,
 // and exit codes, against a real `atc serve` spawned from source.
@@ -25,22 +19,27 @@ import {
 const scratch = mkdtempSync(join(tmpdir(), "atc-cli-blackbox-"))
 let serverPort: number
 let env: Record<string, string | undefined>
+let dataRoot: string
 
 const cli = (args: ReadonlyArray<string>, extraEnv: Record<string, string> = {}) =>
   runCli([process.execPath, "src/main.ts"], args, appServerRoot, { ...env, ...extraEnv })
 
-let server: Bun.Subprocess
+let server: Awaited<ReturnType<typeof startFakeZmxServer>>
 
+// Terminal commands run against the deterministic fake-zmx stand-in, so
+// these tests need no zmx install anywhere they run.
 beforeAll(async () => {
-  serverPort = await freePort()
-  env = isolatedEnv(scratch, { ATC_PORT: String(serverPort) })
-  server = spawnServe([process.execPath, "src/main.ts"], serverPort, appServerRoot, env)
-  await waitForHealth(`http://127.0.0.1:${serverPort}`, server)
+  server = await startFakeZmxServer()
+  serverPort = server.port
+  env = server.env
+  dataRoot = server.sandbox.base
 })
 
-afterAll(() => {
-  server.kill()
+afterAll(async () => {
+  server.proc.kill()
+  await server.proc.exited
   rmSync(scratch, { recursive: true, force: true })
+  cleanupTempDirs()
 })
 
 describe("atc health/version (black box)", () => {
@@ -121,7 +120,7 @@ describe("atc health/version (black box)", () => {
 
 describe("atc project / atc fs (black box)", () => {
   test("the server created and migrated the database in the configured data directory", () => {
-    expect(existsSync(join(scratch, "data", "atc", "atc.db"))).toBe(true)
+    expect(existsSync(join(dataRoot, "data", "atc", "atc.db"))).toBe(true)
   })
 
   test("project lifecycle: create, list, get, update, delete", async () => {
@@ -157,7 +156,7 @@ describe("atc project / atc fs (black box)", () => {
 
     const empty = await cli(["project", "list"])
     expect(JSON.parse(empty.stdout)).toEqual([])
-  })
+  }, 30_000)
 
   test("a missing directory is one stderr line and exit 1", async () => {
     const result = await cli([
@@ -175,6 +174,99 @@ describe("atc project / atc fs (black box)", () => {
     expect(result.exitCode).toBe(1)
   })
 
+  test("terminal lifecycle: create with argv, list, get, rename, delete", async () => {
+    const project = JSON.parse(
+      (await cli(["project", "create", "--name", "Term", "--directory", scratch])).stdout,
+    ) as { id: string }
+
+    const created = await cli([
+      "terminal",
+      "create",
+      "--project",
+      project.id,
+      "--name",
+      "runner",
+      "bun",
+      "run",
+      "dev",
+    ])
+    expect(created.stderr).toBe("")
+    expect(created.exitCode).toBe(0)
+    const terminal = JSON.parse(created.stdout) as {
+      id: string
+      name: string
+      status: string
+      command: Array<string>
+    }
+    expect(terminal.status).toBe("live")
+    expect(terminal.name).toBe("runner")
+    expect(terminal.command).toEqual(["bun", "run", "dev"])
+
+    const listed = await cli(["terminal", "list", "--project", project.id])
+    expect((JSON.parse(listed.stdout) as Array<{ id: string }>).map((t) => t.id)).toEqual([
+      terminal.id,
+    ])
+
+    const fetched = await cli(["terminal", "get", terminal.id])
+    expect((JSON.parse(fetched.stdout) as { id: string }).id).toBe(terminal.id)
+
+    const renamed = await cli(["terminal", "rename", terminal.id, "--name", "logs"])
+    expect((JSON.parse(renamed.stdout) as { name: string }).name).toBe("logs")
+
+    const refused = await cli(["terminal", "delete", terminal.id])
+    expect(refused.stderr).toContain("--yes")
+    expect(refused.exitCode).toBe(1)
+
+    const deleted = await cli(["terminal", "delete", terminal.id, "--yes"])
+    expect(deleted.stderr).toBe("")
+    expect(deleted.exitCode).toBe(0)
+
+    const gone = await cli(["terminal", "get", terminal.id])
+    expect(gone.stderr.trim()).toBe(`atc terminal get: no terminal with id ${terminal.id}`)
+    expect(gone.exitCode).toBe(1)
+
+    // Release the project for later tests.
+    await cli(["project", "delete", project.id, "--yes"])
+  }, 30_000)
+
+  test("terminal attach bridges bytes and reports the ended terminal", async () => {
+    const project = JSON.parse(
+      (await cli(["project", "create", "--name", "Attach", "--directory", scratch])).stdout,
+    ) as { id: string }
+    const terminal = JSON.parse(
+      (await cli(["terminal", "create", "--project", project.id])).stdout,
+    ) as { id: string }
+
+    // Piped stdio (no TTY): the attach client still bridges bytes.
+    const attach = Bun.spawn([process.execPath, "src/main.ts", "terminal", "attach", terminal.id], {
+      cwd: appServerRoot,
+      env,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const reader = (attach.stdout as ReadableStream<Uint8Array>).getReader()
+    const decoder = new TextDecoder()
+    let seen = ""
+    const sawBanner = (async () => {
+      while (!seen.includes("attached")) {
+        const chunk = await reader.read()
+        if (chunk.done) break
+        seen += decoder.decode(chunk.value)
+      }
+    })()
+    await sawBanner
+
+    // Deleting the terminal closes the bridge with 1000 terminal_ended; the
+    // CLI reports it on stderr and exits 0.
+    await cli(["terminal", "delete", terminal.id, "--yes"])
+    expect(await attach.exited).toBe(0)
+    const stderr = await new Response(attach.stderr as ReadableStream).text()
+    expect(stderr).toContain("terminal ended")
+
+    await cli(["project", "delete", project.id, "--yes"])
+  }, 30_000)
+
   test("fs check resolves relative paths client-side and reports health", async () => {
     const available = await cli(["fs", "check", "."])
     expect(available.exitCode).toBe(0)
@@ -183,5 +275,5 @@ describe("atc project / atc fs (black box)", () => {
     const missing = await cli(["fs", "check", join(scratch, "does-not-exist")])
     expect(missing.exitCode).toBe(0)
     expect((JSON.parse(missing.stdout) as { state: string }).state).toBe("missing")
-  })
+  }, 30_000)
 })

--- a/app-server/test/compiled.blackbox.test.ts
+++ b/app-server/test/compiled.blackbox.test.ts
@@ -49,7 +49,7 @@ describe.skipIf(!enabled)("compiled atc artifact (opt-in: mise run test:compiled
       // First boot created and migrated the database in the configured
       // data directory, and the log file landed in the state directory.
       expect(existsSync(dbFile)).toBe(true)
-      expect(existsSync(join(outsideCwd, "state", "atc", "atc.log"))).toBe(true)
+      expect(existsSync(join(env.XDG_STATE_HOME, "atc", "atc.log"))).toBe(true)
 
       const version = await fetch(`${base}/api/v1/version`)
       expect(version.status).toBe(200)

--- a/app-server/test/fakeTerminalAdapter.ts
+++ b/app-server/test/fakeTerminalAdapter.ts
@@ -32,6 +32,8 @@ export interface FakeTerminalAdapter {
   readonly setCreateFails: (fails: boolean) => void
   /** Emit output bytes to every open connection of `name`. */
   readonly emitOutput: (name: string, data: Uint8Array) => void
+  /** Insert a session directly (no createSession), e.g. recovery seeding. */
+  readonly seed: (name: string, overrides?: Partial<Omit<FakeSession, "name">>) => FakeSession
 }
 
 export const makeFakeAdapter = (): FakeTerminalAdapter => {
@@ -159,6 +161,20 @@ export const makeFakeAdapter = (): FakeTerminalAdapter => {
     },
     emitOutput: (name, data) => {
       for (const queue of connections.get(name) ?? []) Queue.offerUnsafe(queue, data)
+    },
+    seed: (name, overrides) => {
+      const session: FakeSession = {
+        name,
+        cwd: "/",
+        command: undefined,
+        written: [],
+        lastResize: undefined,
+        reachable: true,
+        writeFails: false,
+        ...overrides,
+      }
+      sessions.set(name, session)
+      return session
     },
   }
 }

--- a/app-server/test/fakeTerminalAdapter.ts
+++ b/app-server/test/fakeTerminalAdapter.ts
@@ -1,11 +1,8 @@
 import { Cause, Effect, Layer, Queue, Stream } from "effect"
+import { ZmxUnavailable } from "../src/api.ts"
+import { SubprocessError } from "../src/subprocess.ts"
 import type { SessionConnection, SessionInfo, SessionSize } from "../src/terminalAdapter.ts"
-import {
-  SessionNotFound,
-  SessionOperationFailed,
-  TerminalAdapter,
-  ZmxUnavailable,
-} from "../src/terminalAdapter.ts"
+import { SessionNotFound, SessionOperationFailed, TerminalAdapter } from "../src/terminalAdapter.ts"
 
 // The fake-adapter test seam (ATC-122): an in-memory TerminalAdapter with
 // the same observable semantics as the zmx adapter — inventory-authoritative
@@ -22,6 +19,8 @@ export interface FakeSession {
   lastResize: SessionSize | undefined
   /** Flip to false to model an existing-but-unresponsive daemon. */
   reachable: boolean
+  /** Flip to true to model a dead attach-client PTY: writes fail. */
+  writeFails: boolean
 }
 
 export interface FakeTerminalAdapter {
@@ -29,6 +28,8 @@ export interface FakeTerminalAdapter {
   readonly sessions: Map<string, FakeSession>
   /** While true, every inventory-consulting operation is ZmxUnavailable. */
   readonly setUnavailable: (unavailable: boolean) => void
+  /** While true, createSession fails conclusively (a failed launch). */
+  readonly setCreateFails: (fails: boolean) => void
   /** Emit output bytes to every open connection of `name`. */
   readonly emitOutput: (name: string, data: Uint8Array) => void
 }
@@ -37,6 +38,7 @@ export const makeFakeAdapter = (): FakeTerminalAdapter => {
   const sessions = new Map<string, FakeSession>()
   const connections = new Map<string, Set<Queue.Queue<Uint8Array, Cause.Done>>>()
   let unavailable = false
+  let createFails = false
 
   const requireAvailable = Effect.suspend(() =>
     unavailable
@@ -48,6 +50,15 @@ export const makeFakeAdapter = (): FakeTerminalAdapter => {
     createSession: (options) =>
       Effect.gen(function* () {
         yield* requireAvailable
+        if (createFails) {
+          return yield* Effect.fail(
+            new SessionOperationFailed({
+              operation: "create",
+              sessionName: options.name,
+              reason: "fake adapter set to fail creation",
+            }),
+          )
+        }
         if (sessions.has(options.name)) {
           return yield* Effect.fail(
             new SessionOperationFailed({
@@ -64,6 +75,7 @@ export const makeFakeAdapter = (): FakeTerminalAdapter => {
           written: [],
           lastResize: undefined,
           reachable: true,
+          writeFails: false,
         })
       }),
     listSessions: () =>
@@ -112,7 +124,20 @@ export const makeFakeAdapter = (): FakeTerminalAdapter => {
         )
         const connection: SessionConnection = {
           output: Stream.fromQueue(output),
-          write: (data) => Effect.sync(() => session.written.push(data)),
+          write: (data) =>
+            Effect.suspend(() =>
+              session.writeFails
+                ? Effect.fail(
+                    new SubprocessError({
+                      executable: "fake-zmx",
+                      operation: "stdin",
+                      message: "terminal is closed (fake writeFails)",
+                    }),
+                  )
+                : Effect.sync(() => {
+                    session.written.push(data)
+                  }),
+            ),
           resize: (next) =>
             Effect.sync(() => {
               session.lastResize = next
@@ -128,6 +153,9 @@ export const makeFakeAdapter = (): FakeTerminalAdapter => {
     sessions,
     setUnavailable: (value) => {
       unavailable = value
+    },
+    setCreateFails: (value) => {
+      createFails = value
     },
     emitOutput: (name, data) => {
       for (const queue of connections.get(name) ?? []) Queue.offerUnsafe(queue, data)

--- a/app-server/test/fixtures/fake-zmx.ts
+++ b/app-server/test/fixtures/fake-zmx.ts
@@ -99,8 +99,18 @@ switch (command) {
       fs.writeFileSync(sessionFile(name), JSON.stringify(record))
     }
     if (mode === "exit") process.exit(0)
-    // Attached client: echo terminal input back until detached (killed).
+    // Attached client: echo terminal input back until detached (killed) or
+    // the session dies — like zmx, a client sees EOF when its daemon goes.
     process.stdout.write("attached\n")
+    const watcher = setInterval(() => {
+      try {
+        const record = JSON.parse(fs.readFileSync(sessionFile(name), "utf8")) as SessionRecord
+        if (record.diesAt !== undefined && record.diesAt <= Date.now()) process.exit(0)
+      } catch {
+        process.exit(0)
+      }
+    }, 50)
+    watcher.unref?.()
     const decoder = new TextDecoder()
     for await (const chunk of Bun.stdin.stream()) {
       process.stdout.write(`echo:${decoder.decode(chunk)}`)

--- a/app-server/test/openapi.test.ts
+++ b/app-server/test/openapi.test.ts
@@ -80,7 +80,8 @@ describe("openapi document", () => {
     HttpApi.reflect(Api, {
       onGroup() {},
       onEndpoint({ endpoint, mergedAnnotations }) {
-        // OpenApi.Exclude drops an endpoint from the document by design.
+        // OpenApi.Exclude drops an endpoint from the document by design
+        // (the WebSocket attach endpoint is the one current use).
         if (Context.get(mergedAnnotations, OpenApi.Exclude)) return
         expected.push({
           path: endpoint.path.replace(/:(\w+)\??/g, "{$1}"),
@@ -140,8 +141,13 @@ describe("openapi document vs runtime", () => {
       "/api/v1/version",
       "/api/v1/projects",
       "/api/v1/projects/{projectId}",
+      "/api/v1/terminals",
+      "/api/v1/terminals/{terminalId}",
       "/api/v1/fs/check",
     ])
+    // The WebSocket attach endpoint is contract-declared but excluded from
+    // the document — REST clients cannot represent an upgrade.
+    assert.notProperty(openApiDocument.paths, "/api/v1/terminals/{terminalId}/attach")
   })
 
   it.effect("GET /api/v1/health returns the documented payload", () =>
@@ -217,6 +223,57 @@ describe("openapi document vs runtime", () => {
         operation("/api/v1/projects/{projectId}").responses["404"]!.content["application/json"]!
           .schema,
         { $ref: "#/components/schemas/ProjectNotFoundJsonEncoding" },
+      )
+    }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
+  )
+
+  it.effect("/api/v1/terminals: created and listed payloads match the documented schemas", () =>
+    Effect.gen(function* () {
+      const client = yield* rawClient
+      const project = yield* client.post("http://127.0.0.1/api/v1/projects", {
+        body: HttpBody.jsonUnsafe({ name: "Terminal Docs", defaultWorkingDirectory: "/tmp" }),
+      })
+      const projectBody = (yield* project.json) as { id: string }
+
+      const created = yield* client.post("http://127.0.0.1/api/v1/terminals", {
+        body: HttpBody.jsonUnsafe({ projectId: projectBody.id }),
+      })
+      assert.strictEqual(created.status, 200)
+      const createdBody = (yield* created.json) as Record<string, unknown>
+      const schema = componentSchema("Terminal")
+      // A shell terminal without a label carries exactly the required keys;
+      // name/command/endedAt are absent optional keys, never null.
+      assert.sameMembers([...schema.required], Object.keys(createdBody))
+      assert.includeMembers(Object.keys(schema.properties), Object.keys(createdBody))
+      assert.strictEqual(createdBody["status"], "live")
+      assert.deepStrictEqual(
+        operation("/api/v1/terminals", "post").responses["200"]!.content["application/json"]!
+          .schema,
+        { $ref: "#/components/schemas/Terminal" },
+      )
+
+      const listed = yield* client.get("http://127.0.0.1/api/v1/terminals")
+      assert.strictEqual(listed.status, 200)
+      assert.deepStrictEqual(yield* listed.json, [createdBody] as unknown)
+      assert.deepStrictEqual(
+        operation("/api/v1/terminals").responses["200"]!.content["application/json"]!.schema,
+        { $ref: "#/components/schemas/TerminalList" },
+      )
+    }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
+  )
+
+  it.effect("GET /api/v1/terminals/{terminalId} documents and returns the 404 error payload", () =>
+    Effect.gen(function* () {
+      const response = yield* (yield* rawClient).get("http://127.0.0.1/api/v1/terminals/nope")
+      assert.strictEqual(response.status, 404)
+      assert.deepStrictEqual(yield* response.json, {
+        _tag: "TerminalNotFound",
+        terminalId: "nope",
+      })
+      assert.deepStrictEqual(
+        operation("/api/v1/terminals/{terminalId}").responses["404"]!.content["application/json"]!
+          .schema,
+        { $ref: "#/components/schemas/TerminalNotFoundJsonEncoding" },
       )
     }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
   )

--- a/app-server/test/persistence.test.ts
+++ b/app-server/test/persistence.test.ts
@@ -83,7 +83,7 @@ describe("persistence", () => {
     const file = freshDbFile()
     const broken = {
       ...migrations,
-      "0002_explode": Effect.gen(function* () {
+      "0099_explode": Effect.gen(function* () {
         const sql = yield* SqlClient.SqlClient
         yield* sql`CREATE TABLE half_done (id TEXT PRIMARY KEY)`
         yield* sql`THIS IS NOT SQL`
@@ -101,7 +101,7 @@ describe("persistence", () => {
       assert.strictEqual(exit._tag, "Failure")
       // The diagnostic names the migration (the loader parses the numeric id,
       // so zero padding drops out of the rendered name).
-      assert.include(String(exit), 'Migration "2_explode" failed')
+      assert.include(String(exit), 'Migration "99_explode" failed')
 
       // The failed migration's DDL and bookkeeping rolled back together:
       // booting again with the fixed record succeeds and sees no leftovers.

--- a/app-server/test/serve.blackbox.test.ts
+++ b/app-server/test/serve.blackbox.test.ts
@@ -2,7 +2,15 @@ import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterAll, describe, expect, test } from "vitest"
-import { appServerRoot, freePort, isolatedEnv, spawnServe, waitForHealth } from "./blackbox.ts"
+import {
+  appServerRoot,
+  cleanupTempDirs,
+  freePort,
+  isolatedEnv,
+  spawnServe,
+  waitForHealth,
+} from "./blackbox.ts"
+import { makeFakeZmxSandbox } from "./testLayers.ts"
 
 // Black-box tests of the real entrypoint: spawn `bun src/main.ts serve` on a
 // loopback port, exercise both endpoints over TCP, and verify clean shutdown
@@ -13,10 +21,22 @@ import { appServerRoot, freePort, isolatedEnv, spawnServe, waitForHealth } from 
 // no PATH lookup for the child. Isolated locations keep the spawned server's
 // database and log file out of the real user directories.
 const scratch = mkdtempSync(join(tmpdir(), "atc-serve-blackbox-"))
-afterAll(() => rmSync(scratch, { recursive: true, force: true }))
+afterAll(() => {
+  rmSync(scratch, { recursive: true, force: true })
+  cleanupTempDirs()
+})
 
+// Startup terminal reconciliation consults zmx: pin the executable to the
+// deterministic fake so these tests need no zmx install anywhere they run
+// (a missing install would add a startup warning line to stderr).
+const sandbox = makeFakeZmxSandbox()
 const spawnFromSource = (port: number) =>
-  spawnServe([process.execPath, "src/main.ts"], port, appServerRoot, isolatedEnv(scratch))
+  spawnServe(
+    [process.execPath, "src/main.ts"],
+    port,
+    appServerRoot,
+    isolatedEnv(scratch, { ATC_ZMX_EXECUTABLE: sandbox.wrapper }),
+  )
 
 describe("atc serve (black box)", () => {
   test.each(["SIGTERM", "SIGINT"] as const)(

--- a/app-server/test/subprocessPty.test.ts
+++ b/app-server/test/subprocessPty.test.ts
@@ -1,15 +1,13 @@
 import { assert, describe, it } from "@effect/vitest"
 import { BunServices } from "@effect/platform-bun"
 import { Effect, Exit, Layer, Scope, Stream } from "effect"
-import { fileURLToPath } from "node:url"
 import * as Subprocess from "../src/subprocess.ts"
+import { appServerRoot } from "./blackbox.ts"
 import { collectText, waitForText } from "./testLayers.ts"
 
 // The PTY variant of the Subprocess seam against the pty-report fixture.
 // All tests are it.live: real processes, real pseudo-terminals, real clock.
 // Note the PTY runs in canonical mode, so input reaches the child on "\n".
-
-const appServerRoot = fileURLToPath(new URL("..", import.meta.url))
 
 const TestLayer = Subprocess.layer.pipe(Layer.provideMerge(BunServices.layer))
 
@@ -24,12 +22,12 @@ describe("Subprocess.spawnPty", () => {
   it.live("gives the child a real terminal and round-trips bytes", () =>
     Effect.gen(function* () {
       const subprocess = yield* Subprocess.Subprocess
-      const child = yield* subprocess.spawnPty(fixture)
+      const child = yield* subprocess.spawnPty({ ...fixture, captureOutputTail: true })
       const sink = yield* collectText(child.output)
       yield* waitForText(sink, "tty:true")
       yield* child.write("ping\n")
       yield* waitForText(sink, "in:ping")
-      // The diagnostic tail sees the same bytes as the stream.
+      // The opt-in diagnostic tail sees the same bytes as the stream.
       assert.include(yield* child.outputTail, "in:ping")
     }).pipe(Effect.scoped, Effect.provide(TestLayer)),
   )
@@ -82,14 +80,11 @@ describe("Subprocess.spawnPty", () => {
   it.live("fails to spawn a missing executable with a tagged error", () =>
     Effect.gen(function* () {
       const subprocess = yield* Subprocess.Subprocess
-      const result = yield* Effect.result(
+      const failure = yield* Effect.flip(
         subprocess.spawnPty({ executable: "/nonexistent/definitely-not-here", env: {} }),
       )
-      assert.strictEqual(result._tag, "Failure")
-      if (result._tag === "Failure") {
-        assert.strictEqual(result.failure._tag, "SubprocessError")
-        assert.strictEqual(result.failure.operation, "spawn")
-      }
+      assert.strictEqual(failure._tag, "SubprocessError")
+      assert.strictEqual(failure.operation, "spawn")
     }).pipe(Effect.scoped, Effect.provide(TestLayer)),
   )
 

--- a/app-server/test/terminalAdapter.test.ts
+++ b/app-server/test/terminalAdapter.test.ts
@@ -1,19 +1,13 @@
 import { assert, describe, it } from "@effect/vitest"
-import { BunServices } from "@effect/platform-bun"
 import { Effect, Layer, Stream } from "effect"
 import * as fs from "node:fs"
 import * as path from "node:path"
 import { afterAll } from "vitest"
-import * as Subprocess from "../src/subprocess.ts"
-import {
-  sessionNameForTerminalId,
-  TerminalAdapter,
-  terminalIdForSessionName,
-} from "../src/terminalAdapter.ts"
+import { sessionNameForTerminalId, TerminalAdapter } from "../src/terminalAdapter.ts"
 import * as Zmx from "../src/zmxAdapter.ts"
 import { makeFakeAdapter } from "./fakeTerminalAdapter.ts"
-import { cleanupTempDirs } from "./blackbox.ts"
-import { collectText, makeFakeZmxSandbox, testAppConfig, waitForText } from "./testLayers.ts"
+import { cleanupTempDirs, makeShortSocketDir } from "./blackbox.ts"
+import { collectText, makeFakeZmxSandbox, waitForText, zmxAdapterLayer } from "./testLayers.ts"
 
 // TerminalAdapter coverage: pure helpers, the zmx adapter against the
 // fake-zmx fixture (deterministic, no zmx install), and the fake in-memory
@@ -24,18 +18,19 @@ afterAll(cleanupTempDirs)
 
 const TIGHT: Zmx.ZmxOptions = { pollInterval: "25 millis", verifyPasses: 8 }
 
+/** A fake-zmx sandbox plus the socket dir these in-process tests inspect. */
+const makeSandbox = (vars: Record<string, string> = {}) => ({
+  ...makeFakeZmxSandbox(vars),
+  socketDir: makeShortSocketDir(),
+})
+
 const adapterLayer = (
-  sandbox: ReturnType<typeof makeFakeZmxSandbox>,
+  sandbox: ReturnType<typeof makeSandbox>,
   options: Zmx.ZmxOptions = TIGHT,
   zmxExecutable: string = sandbox.wrapper,
-) =>
-  Zmx.layerWith(options).pipe(
-    Layer.provide(testAppConfig({ zmxExecutable, terminalSocketDir: sandbox.socketDir })),
-    Layer.provide(Subprocess.layer),
-    Layer.provideMerge(BunServices.layer),
-  )
+) => zmxAdapterLayer({ zmxExecutable, terminalSocketDir: sandbox.socketDir, zmx: options })
 
-const readSessionRecord = (sandbox: ReturnType<typeof makeFakeZmxSandbox>, name: string) =>
+const readSessionRecord = (sandbox: ReturnType<typeof makeSandbox>, name: string) =>
   JSON.parse(fs.readFileSync(path.join(sandbox.stateDir, name), "utf8")) as {
     startDir: string
     command: Array<string>
@@ -43,19 +38,12 @@ const readSessionRecord = (sandbox: ReturnType<typeof makeFakeZmxSandbox>, name:
   }
 
 describe("session name derivation", () => {
-  it("derives and reverses the private session name", () => {
+  it("derives the private session name", () => {
     const id = "01890a5d-ac96-774b-bcce-b302099a8057"
     const name = sessionNameForTerminalId(id)
     assert.strictEqual(name, "atc-01890a5dac96774bbcceb302099a8057")
-    assert.strictEqual(terminalIdForSessionName(name), id)
     // Uppercase ids normalize instead of producing an irreversible name.
     assert.strictEqual(sessionNameForTerminalId(id.toUpperCase()), name)
-  })
-
-  it("rejects foreign names", () => {
-    assert.isUndefined(terminalIdForSessionName("my-shell"))
-    assert.isUndefined(terminalIdForSessionName("atc-nothex"))
-    assert.isUndefined(terminalIdForSessionName("atc-01890a5dac96774bbcceb302099a80"))
   })
 })
 
@@ -70,8 +58,8 @@ describe("parseSessionList", () => {
       "",
     ])
     assert.deepStrictEqual(sessions, [
-      { name: "atc-0123", reachable: true, pid: 85174, createdAt: 1785707091 },
-      { name: "other", reachable: true, pid: 12, createdAt: 5 },
+      { name: "atc-0123", reachable: true, pid: 85174 },
+      { name: "other", reachable: true, pid: 12 },
       { name: "broken", reachable: false },
     ])
   })
@@ -101,7 +89,7 @@ describe("zmxChildEnv", () => {
 
 describe("zmx adapter against fake-zmx", () => {
   it.live("creates a session, settles, and detaches the creation client", () => {
-    const sandbox = makeFakeZmxSandbox()
+    const sandbox = makeSandbox()
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
       yield* adapter.createSession({ name: "atc-aaaa", cwd: sandbox.base })
@@ -120,7 +108,7 @@ describe("zmx adapter against fake-zmx", () => {
   })
 
   it.live("re-tightens a pre-existing permissive socket directory at boot", () => {
-    const sandbox = makeFakeZmxSandbox()
+    const sandbox = makeSandbox()
     // A prior or manual zmx invocation could have left the directory more
     // open than ATC's guarantee; boot must restore 0700, not just claim it.
     fs.chmodSync(sandbox.socketDir, 0o755)
@@ -131,7 +119,7 @@ describe("zmx adapter against fake-zmx", () => {
   })
 
   it.live("passes an exec-style argv through and accepts a finished command", () => {
-    const sandbox = makeFakeZmxSandbox({ FAKE_ZMX_ATTACH_MODE: "exit" })
+    const sandbox = makeSandbox({ FAKE_ZMX_ATTACH_MODE: "exit" })
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
       yield* adapter.createSession({
@@ -144,98 +132,80 @@ describe("zmx adapter against fake-zmx", () => {
   })
 
   it.live("refuses to create over an existing session", () => {
-    const sandbox = makeFakeZmxSandbox()
+    const sandbox = makeSandbox()
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
       yield* adapter.createSession({ name: "atc-dupe", cwd: sandbox.base })
-      const result = yield* Effect.result(
+      const failure = yield* Effect.flip(
         adapter.createSession({ name: "atc-dupe", cwd: sandbox.base, command: ["other"] }),
       )
-      assert.strictEqual(result._tag, "Failure")
-      if (result._tag === "Failure") {
-        assert.strictEqual(result.failure._tag, "SessionOperationFailed")
-        assert.match(result.failure.message, /already exists/)
-      }
+      assert.strictEqual(failure._tag, "SessionOperationFailed")
+      assert.match(failure.message, /already exists/)
     }).pipe(Effect.provide(adapterLayer(sandbox)))
   })
 
   it.live("never treats an unreachable inventory entry as a settled create", () => {
     // Regression: a wedged socket produces an err= entry; creating that name
     // must fail (the path is held), not silently report success.
-    const sandbox = makeFakeZmxSandbox({ FAKE_ZMX_UNREACHABLE: "atc-wedged" })
+    const sandbox = makeSandbox({ FAKE_ZMX_UNREACHABLE: "atc-wedged" })
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
-      const result = yield* Effect.result(
+      const failure = yield* Effect.flip(
         adapter.createSession({ name: "atc-wedged", cwd: sandbox.base }),
       )
-      assert.strictEqual(result._tag, "Failure")
-      if (result._tag === "Failure") {
-        assert.strictEqual(result.failure._tag, "SessionOperationFailed")
-        assert.match(result.failure.message, /already exists/)
-      }
+      assert.strictEqual(failure._tag, "SessionOperationFailed")
+      assert.match(failure.message, /already exists/)
     }).pipe(Effect.provide(adapterLayer(sandbox)))
   })
 
   it.live("fails a launch whose session never appears, with diagnostics", () => {
-    const sandbox = makeFakeZmxSandbox({ FAKE_ZMX_ATTACH_MODE: "fail-fast" })
+    const sandbox = makeSandbox({ FAKE_ZMX_ATTACH_MODE: "fail-fast" })
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
-      const result = yield* Effect.result(
+      const failure = yield* Effect.flip(
         adapter.createSession({ name: "atc-cccc", cwd: sandbox.base }),
       )
-      assert.strictEqual(result._tag, "Failure")
-      if (result._tag === "Failure") {
-        assert.strictEqual(result.failure._tag, "SessionOperationFailed")
-        assert.match(result.failure.message, /cannot create session/)
-      }
+      assert.strictEqual(failure._tag, "SessionOperationFailed")
+      assert.match(failure.message, /cannot create session/)
     }).pipe(Effect.provide(adapterLayer(sandbox)))
   })
 
   it.live("fails a launch that never settles within the verification passes", () => {
-    const sandbox = makeFakeZmxSandbox({ FAKE_ZMX_SETTLE_MS: "60000" })
+    const sandbox = makeSandbox({ FAKE_ZMX_SETTLE_MS: "60000" })
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
-      const result = yield* Effect.result(
+      const failure = yield* Effect.flip(
         adapter.createSession({ name: "atc-eeee", cwd: sandbox.base }),
       )
-      assert.strictEqual(result._tag, "Failure")
-      if (result._tag === "Failure") {
-        assert.strictEqual(result.failure._tag, "SessionOperationFailed")
-        assert.match(result.failure.message, /never settled/)
-      }
+      assert.strictEqual(failure._tag, "SessionOperationFailed")
+      assert.match(failure.message, /never settled/)
     }).pipe(Effect.provide(adapterLayer(sandbox)))
   })
 
   it.live("rejects a working directory that does not exist as a conclusive failure", () => {
-    const sandbox = makeFakeZmxSandbox()
+    const sandbox = makeSandbox()
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
-      const result = yield* Effect.result(
+      const failure = yield* Effect.flip(
         adapter.createSession({ name: "atc-ffff", cwd: path.join(sandbox.base, "nope") }),
       )
-      assert.strictEqual(result._tag, "Failure")
-      if (result._tag === "Failure") {
-        assert.strictEqual(result.failure._tag, "SessionOperationFailed")
-        assert.match(result.failure.message, /working directory/)
-      }
+      assert.strictEqual(failure._tag, "SessionOperationFailed")
+      assert.match(failure.message, /working directory/)
     }).pipe(Effect.provide(adapterLayer(sandbox)))
   })
 
   it.live("reports an unavailable inventory instead of guessing", () => {
-    const sandbox = makeFakeZmxSandbox({ FAKE_ZMX_LIST_MODE: "fail" })
+    const sandbox = makeSandbox({ FAKE_ZMX_LIST_MODE: "fail" })
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
-      const result = yield* Effect.result(adapter.listSessions())
-      assert.strictEqual(result._tag, "Failure")
-      if (result._tag === "Failure") {
-        assert.strictEqual(result.failure._tag, "ZmxUnavailable")
-        assert.match(result.failure.message, /inventory unavailable/)
-      }
+      const failure = yield* Effect.flip(adapter.listSessions())
+      assert.strictEqual(failure._tag, "ZmxUnavailable")
+      assert.match(failure.message, /inventory unavailable/)
     }).pipe(Effect.provide(adapterLayer(sandbox)))
   })
 
   it.live("kills a session and verifies its delayed disappearance", () => {
-    const sandbox = makeFakeZmxSandbox({ FAKE_ZMX_ATTACH_MODE: "exit", FAKE_ZMX_KILL_MS: "200" })
+    const sandbox = makeSandbox({ FAKE_ZMX_ATTACH_MODE: "exit", FAKE_ZMX_KILL_MS: "200" })
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
       yield* adapter.createSession({ name: "atc-gggg", cwd: sandbox.base })
@@ -245,7 +215,7 @@ describe("zmx adapter against fake-zmx", () => {
   })
 
   it.live("treats killing an absent session as success", () => {
-    const sandbox = makeFakeZmxSandbox()
+    const sandbox = makeSandbox()
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
       yield* adapter.killSession("atc-not-there")
@@ -253,53 +223,44 @@ describe("zmx adapter against fake-zmx", () => {
   })
 
   it.live("fails kill when the session refuses to die", () => {
-    const sandbox = makeFakeZmxSandbox({
+    const sandbox = makeSandbox({
       FAKE_ZMX_ATTACH_MODE: "exit",
       FAKE_ZMX_KILL_MODE: "ignore",
     })
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
       yield* adapter.createSession({ name: "atc-hhhh", cwd: sandbox.base })
-      const result = yield* Effect.result(adapter.killSession("atc-hhhh"))
-      assert.strictEqual(result._tag, "Failure")
-      if (result._tag === "Failure") {
-        assert.strictEqual(result.failure._tag, "SessionOperationFailed")
-        assert.match(result.failure.message, /still present/)
-      }
+      const failure = yield* Effect.flip(adapter.killSession("atc-hhhh"))
+      assert.strictEqual(failure._tag, "SessionOperationFailed")
+      assert.match(failure.message, /still present/)
     }).pipe(Effect.provide(adapterLayer(sandbox)))
   })
 
   it.live("refuses to attach to a session missing from the inventory", () => {
-    const sandbox = makeFakeZmxSandbox()
+    const sandbox = makeSandbox()
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
-      const result = yield* Effect.result(
+      const failure = yield* Effect.flip(
         adapter.attachSession("atc-nope", { cols: 80, rows: 24 }).pipe(Effect.scoped),
       )
-      assert.strictEqual(result._tag, "Failure")
-      if (result._tag === "Failure") {
-        assert.strictEqual(result.failure._tag, "SessionNotFound")
-      }
+      assert.strictEqual(failure._tag, "SessionNotFound")
     }).pipe(Effect.provide(adapterLayer(sandbox)))
   })
 
   it.live("refuses to attach to an unreachable session (it would resurrect it)", () => {
-    const sandbox = makeFakeZmxSandbox({ FAKE_ZMX_UNREACHABLE: "atc-wedged" })
+    const sandbox = makeSandbox({ FAKE_ZMX_UNREACHABLE: "atc-wedged" })
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
-      const result = yield* Effect.result(
+      const failure = yield* Effect.flip(
         adapter.attachSession("atc-wedged", { cols: 80, rows: 24 }).pipe(Effect.scoped),
       )
-      assert.strictEqual(result._tag, "Failure")
-      if (result._tag === "Failure") {
-        assert.strictEqual(result.failure._tag, "SessionOperationFailed")
-        assert.match(result.failure.message, /unreachable/)
-      }
+      assert.strictEqual(failure._tag, "SessionOperationFailed")
+      assert.match(failure.message, /unreachable/)
     }).pipe(Effect.provide(adapterLayer(sandbox)))
   })
 
   it.live("attaches and round-trips terminal bytes", () => {
-    const sandbox = makeFakeZmxSandbox()
+    const sandbox = makeSandbox()
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
       yield* adapter.createSession({ name: "atc-iiii", cwd: sandbox.base })
@@ -313,37 +274,29 @@ describe("zmx adapter against fake-zmx", () => {
   })
 
   it.live("fails with one actionable line when the executable is missing", () => {
-    const sandbox = makeFakeZmxSandbox()
+    const sandbox = makeSandbox()
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
-      const result = yield* Effect.result(adapter.listSessions())
-      assert.strictEqual(result._tag, "Failure")
-      if (result._tag === "Failure") {
-        assert.strictEqual(result.failure._tag, "ZmxUnavailable")
-        assert.match(result.failure.message, /install zmx on PATH|ATC_ZMX_EXECUTABLE/)
-      }
+      const failure = yield* Effect.flip(adapter.listSessions())
+      assert.strictEqual(failure._tag, "ZmxUnavailable")
+      assert.match(failure.message, /install zmx on PATH|ATC_ZMX_EXECUTABLE/)
     }).pipe(Effect.provide(adapterLayer(sandbox, TIGHT, "definitely-not-a-real-zmx-executable")))
   })
 
   it.live("refuses to boot when socket paths would exceed the unix limit", () => {
-    const sandbox = makeFakeZmxSandbox()
+    const sandbox = makeSandbox()
     const deepDir = path.join(sandbox.base, "x".repeat(120))
     return Effect.gen(function* () {
-      const result = yield* Effect.result(
+      const failure = yield* Effect.flip(
         Layer.build(
-          Zmx.layerWith(TIGHT).pipe(
-            Layer.provide(
-              testAppConfig({ zmxExecutable: sandbox.wrapper, terminalSocketDir: deepDir }),
-            ),
-            Layer.provide(Subprocess.layer),
-            Layer.provideMerge(BunServices.layer),
-          ),
+          zmxAdapterLayer({
+            zmxExecutable: sandbox.wrapper,
+            terminalSocketDir: deepDir,
+            zmx: TIGHT,
+          }),
         ),
       )
-      assert.strictEqual(result._tag, "Failure")
-      if (result._tag === "Failure") {
-        assert.match(String(result.failure), /too deep|exceed/)
-      }
+      assert.match(String(failure), /too deep|exceed/)
     }).pipe(Effect.scoped)
   })
 })
@@ -359,10 +312,10 @@ describe("fake adapter honesty", () => {
         ["atc-1111"],
       )
       // Creating is never silently attaching, like the real adapter.
-      const duplicate = yield* Effect.result(
+      const duplicate = yield* Effect.flip(
         adapter.createSession({ name: "atc-1111", cwd: "/other" }),
       )
-      assert.strictEqual(duplicate._tag, "Failure")
+      assert.strictEqual(duplicate._tag, "SessionOperationFailed")
       yield* Effect.gen(function* () {
         const connection = yield* adapter.attachSession("atc-1111", { cols: 100, rows: 30 })
         yield* connection.write("keys")
@@ -385,25 +338,19 @@ describe("fake adapter honesty", () => {
     const fake = makeFakeAdapter()
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
-      const missing = yield* Effect.result(
+      const missing = yield* Effect.flip(
         adapter.attachSession("atc-none", { cols: 80, rows: 24 }).pipe(Effect.scoped),
       )
-      assert.strictEqual(missing._tag, "Failure")
-      if (missing._tag === "Failure") {
-        assert.strictEqual(missing.failure._tag, "SessionNotFound")
-      }
+      assert.strictEqual(missing._tag, "SessionNotFound")
       yield* adapter.createSession({ name: "atc-2222", cwd: "/w" })
       fake.sessions.get("atc-2222")!.reachable = false
       assert.deepStrictEqual(yield* adapter.listSessions(), [
         { name: "atc-2222", reachable: false },
       ])
-      const unreachable = yield* Effect.result(
+      const unreachable = yield* Effect.flip(
         adapter.attachSession("atc-2222", { cols: 80, rows: 24 }).pipe(Effect.scoped),
       )
-      assert.strictEqual(unreachable._tag, "Failure")
-      if (unreachable._tag === "Failure") {
-        assert.strictEqual(unreachable.failure._tag, "SessionOperationFailed")
-      }
+      assert.strictEqual(unreachable._tag, "SessionOperationFailed")
     }).pipe(Effect.provide(fake.layer))
   })
 
@@ -418,11 +365,8 @@ describe("fake adapter honesty", () => {
         adapter.killSession("atc-3333"),
         Effect.asVoid(Effect.scoped(adapter.attachSession("atc-3333", { cols: 1, rows: 1 }))),
       ]) {
-        const result = yield* Effect.result(operation)
-        assert.strictEqual(result._tag, "Failure")
-        if (result._tag === "Failure") {
-          assert.strictEqual((result.failure as { _tag: string })._tag, "ZmxUnavailable")
-        }
+        const failure = yield* Effect.flip(operation)
+        assert.strictEqual((failure as { _tag: string })._tag, "ZmxUnavailable")
       }
     }).pipe(Effect.provide(fake.layer))
   })

--- a/app-server/test/terminalAdapter.test.ts
+++ b/app-server/test/terminalAdapter.test.ts
@@ -2,9 +2,7 @@ import { assert, describe, it } from "@effect/vitest"
 import { BunServices } from "@effect/platform-bun"
 import { Effect, Layer, Stream } from "effect"
 import * as fs from "node:fs"
-import * as os from "node:os"
 import * as path from "node:path"
-import { fileURLToPath } from "node:url"
 import { afterAll } from "vitest"
 import * as Subprocess from "../src/subprocess.ts"
 import {
@@ -14,48 +12,20 @@ import {
 } from "../src/terminalAdapter.ts"
 import * as Zmx from "../src/zmxAdapter.ts"
 import { makeFakeAdapter } from "./fakeTerminalAdapter.ts"
-import {
-  cleanupTempDirs,
-  collectText,
-  makeShortSocketDir,
-  testAppConfig,
-  trackTempDir,
-  waitForText,
-} from "./testLayers.ts"
+import { cleanupTempDirs } from "./blackbox.ts"
+import { collectText, makeFakeZmxSandbox, testAppConfig, waitForText } from "./testLayers.ts"
 
 // TerminalAdapter coverage: pure helpers, the zmx adapter against the
 // fake-zmx fixture (deterministic, no zmx install), and the fake in-memory
 // adapter's honesty tests. The real zmx binary is exercised by the opt-in
 // zmxSmoke tests.
 
-const fixturePath = fileURLToPath(new URL("fixtures/fake-zmx.ts", import.meta.url))
-
 afterAll(cleanupTempDirs)
-
-/**
- * Per-test sandbox. The wrapper script is the configured "zmx executable":
- * the adapter owns argv and environment, so per-test fixture configuration
- * is baked into the wrapper itself — no process.env mutation anywhere.
- */
-const makeSandbox = (vars: Record<string, string> = {}) => {
-  const base = trackTempDir(fs.mkdtempSync(path.join(os.tmpdir(), "atc-zmx-")))
-  const stateDir = path.join(base, "state")
-  const wrapper = path.join(base, "fake-zmx")
-  const assignments = Object.entries({ FAKE_ZMX_STATE: stateDir, ...vars })
-    .map(([key, value]) => `${key}='${value}'`)
-    .join(" ")
-  fs.writeFileSync(
-    wrapper,
-    `#!/bin/sh\n${assignments} exec "${process.execPath}" "${fixturePath}" "$@"\n`,
-  )
-  fs.chmodSync(wrapper, 0o755)
-  return { base, stateDir, wrapper, socketDir: makeShortSocketDir() }
-}
 
 const TIGHT: Zmx.ZmxOptions = { pollInterval: "25 millis", verifyPasses: 8 }
 
 const adapterLayer = (
-  sandbox: ReturnType<typeof makeSandbox>,
+  sandbox: ReturnType<typeof makeFakeZmxSandbox>,
   options: Zmx.ZmxOptions = TIGHT,
   zmxExecutable: string = sandbox.wrapper,
 ) =>
@@ -65,7 +35,7 @@ const adapterLayer = (
     Layer.provideMerge(BunServices.layer),
   )
 
-const readSessionRecord = (sandbox: ReturnType<typeof makeSandbox>, name: string) =>
+const readSessionRecord = (sandbox: ReturnType<typeof makeFakeZmxSandbox>, name: string) =>
   JSON.parse(fs.readFileSync(path.join(sandbox.stateDir, name), "utf8")) as {
     startDir: string
     command: Array<string>
@@ -131,7 +101,7 @@ describe("zmxChildEnv", () => {
 
 describe("zmx adapter against fake-zmx", () => {
   it.live("creates a session, settles, and detaches the creation client", () => {
-    const sandbox = makeSandbox()
+    const sandbox = makeFakeZmxSandbox()
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
       yield* adapter.createSession({ name: "atc-aaaa", cwd: sandbox.base })
@@ -150,7 +120,7 @@ describe("zmx adapter against fake-zmx", () => {
   })
 
   it.live("re-tightens a pre-existing permissive socket directory at boot", () => {
-    const sandbox = makeSandbox()
+    const sandbox = makeFakeZmxSandbox()
     // A prior or manual zmx invocation could have left the directory more
     // open than ATC's guarantee; boot must restore 0700, not just claim it.
     fs.chmodSync(sandbox.socketDir, 0o755)
@@ -161,7 +131,7 @@ describe("zmx adapter against fake-zmx", () => {
   })
 
   it.live("passes an exec-style argv through and accepts a finished command", () => {
-    const sandbox = makeSandbox({ FAKE_ZMX_ATTACH_MODE: "exit" })
+    const sandbox = makeFakeZmxSandbox({ FAKE_ZMX_ATTACH_MODE: "exit" })
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
       yield* adapter.createSession({
@@ -174,7 +144,7 @@ describe("zmx adapter against fake-zmx", () => {
   })
 
   it.live("refuses to create over an existing session", () => {
-    const sandbox = makeSandbox()
+    const sandbox = makeFakeZmxSandbox()
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
       yield* adapter.createSession({ name: "atc-dupe", cwd: sandbox.base })
@@ -192,7 +162,7 @@ describe("zmx adapter against fake-zmx", () => {
   it.live("never treats an unreachable inventory entry as a settled create", () => {
     // Regression: a wedged socket produces an err= entry; creating that name
     // must fail (the path is held), not silently report success.
-    const sandbox = makeSandbox({ FAKE_ZMX_UNREACHABLE: "atc-wedged" })
+    const sandbox = makeFakeZmxSandbox({ FAKE_ZMX_UNREACHABLE: "atc-wedged" })
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
       const result = yield* Effect.result(
@@ -207,7 +177,7 @@ describe("zmx adapter against fake-zmx", () => {
   })
 
   it.live("fails a launch whose session never appears, with diagnostics", () => {
-    const sandbox = makeSandbox({ FAKE_ZMX_ATTACH_MODE: "fail-fast" })
+    const sandbox = makeFakeZmxSandbox({ FAKE_ZMX_ATTACH_MODE: "fail-fast" })
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
       const result = yield* Effect.result(
@@ -222,7 +192,7 @@ describe("zmx adapter against fake-zmx", () => {
   })
 
   it.live("fails a launch that never settles within the verification passes", () => {
-    const sandbox = makeSandbox({ FAKE_ZMX_SETTLE_MS: "60000" })
+    const sandbox = makeFakeZmxSandbox({ FAKE_ZMX_SETTLE_MS: "60000" })
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
       const result = yield* Effect.result(
@@ -237,7 +207,7 @@ describe("zmx adapter against fake-zmx", () => {
   })
 
   it.live("rejects a working directory that does not exist as a conclusive failure", () => {
-    const sandbox = makeSandbox()
+    const sandbox = makeFakeZmxSandbox()
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
       const result = yield* Effect.result(
@@ -252,7 +222,7 @@ describe("zmx adapter against fake-zmx", () => {
   })
 
   it.live("reports an unavailable inventory instead of guessing", () => {
-    const sandbox = makeSandbox({ FAKE_ZMX_LIST_MODE: "fail" })
+    const sandbox = makeFakeZmxSandbox({ FAKE_ZMX_LIST_MODE: "fail" })
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
       const result = yield* Effect.result(adapter.listSessions())
@@ -265,7 +235,7 @@ describe("zmx adapter against fake-zmx", () => {
   })
 
   it.live("kills a session and verifies its delayed disappearance", () => {
-    const sandbox = makeSandbox({ FAKE_ZMX_ATTACH_MODE: "exit", FAKE_ZMX_KILL_MS: "200" })
+    const sandbox = makeFakeZmxSandbox({ FAKE_ZMX_ATTACH_MODE: "exit", FAKE_ZMX_KILL_MS: "200" })
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
       yield* adapter.createSession({ name: "atc-gggg", cwd: sandbox.base })
@@ -275,7 +245,7 @@ describe("zmx adapter against fake-zmx", () => {
   })
 
   it.live("treats killing an absent session as success", () => {
-    const sandbox = makeSandbox()
+    const sandbox = makeFakeZmxSandbox()
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
       yield* adapter.killSession("atc-not-there")
@@ -283,7 +253,10 @@ describe("zmx adapter against fake-zmx", () => {
   })
 
   it.live("fails kill when the session refuses to die", () => {
-    const sandbox = makeSandbox({ FAKE_ZMX_ATTACH_MODE: "exit", FAKE_ZMX_KILL_MODE: "ignore" })
+    const sandbox = makeFakeZmxSandbox({
+      FAKE_ZMX_ATTACH_MODE: "exit",
+      FAKE_ZMX_KILL_MODE: "ignore",
+    })
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
       yield* adapter.createSession({ name: "atc-hhhh", cwd: sandbox.base })
@@ -297,7 +270,7 @@ describe("zmx adapter against fake-zmx", () => {
   })
 
   it.live("refuses to attach to a session missing from the inventory", () => {
-    const sandbox = makeSandbox()
+    const sandbox = makeFakeZmxSandbox()
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
       const result = yield* Effect.result(
@@ -311,7 +284,7 @@ describe("zmx adapter against fake-zmx", () => {
   })
 
   it.live("refuses to attach to an unreachable session (it would resurrect it)", () => {
-    const sandbox = makeSandbox({ FAKE_ZMX_UNREACHABLE: "atc-wedged" })
+    const sandbox = makeFakeZmxSandbox({ FAKE_ZMX_UNREACHABLE: "atc-wedged" })
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
       const result = yield* Effect.result(
@@ -326,7 +299,7 @@ describe("zmx adapter against fake-zmx", () => {
   })
 
   it.live("attaches and round-trips terminal bytes", () => {
-    const sandbox = makeSandbox()
+    const sandbox = makeFakeZmxSandbox()
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
       yield* adapter.createSession({ name: "atc-iiii", cwd: sandbox.base })
@@ -340,7 +313,7 @@ describe("zmx adapter against fake-zmx", () => {
   })
 
   it.live("fails with one actionable line when the executable is missing", () => {
-    const sandbox = makeSandbox()
+    const sandbox = makeFakeZmxSandbox()
     return Effect.gen(function* () {
       const adapter = yield* TerminalAdapter
       const result = yield* Effect.result(adapter.listSessions())
@@ -353,7 +326,7 @@ describe("zmx adapter against fake-zmx", () => {
   })
 
   it.live("refuses to boot when socket paths would exceed the unix limit", () => {
-    const sandbox = makeSandbox()
+    const sandbox = makeFakeZmxSandbox()
     const deepDir = path.join(sandbox.base, "x".repeat(120))
     return Effect.gen(function* () {
       const result = yield* Effect.result(

--- a/app-server/test/terminalAttach.test.ts
+++ b/app-server/test/terminalAttach.test.ts
@@ -2,8 +2,8 @@ import { afterAll, describe, expect, test } from "vitest"
 import * as fs from "node:fs"
 import * as path from "node:path"
 import { sessionNameForTerminalId } from "../src/terminalAdapter.ts"
-import { cleanupTempDirs, postJson, waitUntil } from "./blackbox.ts"
-import { startFakeZmxServer } from "./testLayers.ts"
+import { cleanupTempDirs, makeTerminal, openSocket, waitUntil } from "./blackbox.ts"
+import { withFakeZmxServer } from "./testLayers.ts"
 
 // The WebSocket attach bridge, black-box: a real `atc serve` process whose
 // zmx executable is the fake-zmx wrapper, driven over loopback TCP and a
@@ -16,124 +16,95 @@ import { startFakeZmxServer } from "./testLayers.ts"
 
 afterAll(cleanupTempDirs)
 
-const makeTerminal = async (base: string) => {
-  const project = await postJson(base, "/api/v1/projects", {
-    name: "P",
-    defaultWorkingDirectory: "/tmp",
-  })
-  return postJson(base, "/api/v1/terminals", { projectId: project["id"] })
-}
-
-interface WsSession {
-  readonly socket: WebSocket
-  readonly received: Array<string>
-  readonly closed: Promise<{ code: number; reason: string }>
-}
-
-const openSocket = (url: string): Promise<WsSession> =>
-  new Promise((resolve, reject) => {
-    const socket = new WebSocket(url)
-    socket.binaryType = "arraybuffer"
-    const received: Array<string> = []
-    const decoder = new TextDecoder()
-    const closed = new Promise<{ code: number; reason: string }>((resolveClose) => {
-      socket.onclose = (event) => resolveClose({ code: event.code, reason: event.reason })
-    })
-    socket.onmessage = (event) => {
-      if (typeof event.data !== "string") received.push(decoder.decode(event.data as ArrayBuffer))
-    }
-    socket.onopen = () => resolve({ socket, received, closed })
-    socket.onerror = () => reject(new Error(`websocket failed to open ${url}`))
-  })
-
 describe("terminal attach bridge (black box)", () => {
-  test("bridges bytes and control frames, closing 1000 terminal_ended on delete", async () => {
-    const server = await startFakeZmxServer()
-    try {
-      const terminal = await makeTerminal(server.base)
-      const ws = await openSocket(
-        `${server.base.replace("http", "ws")}/api/v1/terminals/${terminal["id"]}/attach?cols=100&rows=30`,
-      )
+  test(
+    "bridges bytes and control frames, closing 1000 terminal_ended on delete",
+    () =>
+      withFakeZmxServer(async (server) => {
+        const terminal = await makeTerminal(server.base)
+        const ws = await openSocket(
+          `${server.base.replace("http", "ws")}/api/v1/terminals/${terminal["id"]}/attach?cols=100&rows=30`,
+        )
 
-      // Client -> session -> client: the fake-zmx attach client echoes its
-      // PTY input, so a round trip proves both directions through the real
-      // adapter and bridge.
-      await waitUntil(() => ws.received.join("").includes("attached"), "attach banner")
-      ws.socket.send(new TextEncoder().encode("hello\n"))
-      await waitUntil(() => ws.received.join("").includes("echo:hello"), "echo round trip")
+        // Client -> session -> client: the fake-zmx attach client echoes its
+        // PTY input, so a round trip proves both directions through the real
+        // adapter and bridge.
+        await waitUntil(() => ws.received.join("").includes("attached"), "attach banner")
+        ws.socket.send(new TextEncoder().encode("hello\n"))
+        await waitUntil(() => ws.received.join("").includes("echo:hello"), "echo round trip")
 
-      // Control frames are accepted (resize is a no-op for the fixture but
-      // must not disturb the bridge).
-      ws.socket.send(JSON.stringify({ type: "resize", cols: 132, rows: 43 }))
-      ws.socket.send(new TextEncoder().encode("again\n"))
-      await waitUntil(
-        () => ws.received.join("").includes("echo:again"),
-        "bridge alive after resize",
-      )
+        // Control frames are accepted (resize is a no-op for the fixture but
+        // must not disturb the bridge).
+        ws.socket.send(JSON.stringify({ type: "resize", cols: 132, rows: 43 }))
+        ws.socket.send(new TextEncoder().encode("again\n"))
+        await waitUntil(
+          () => ws.received.join("").includes("echo:again"),
+          "bridge alive after resize",
+        )
 
-      // Deleting the terminal kills the session; the bridge confirms
-      // absence against a complete inventory and closes authoritatively.
-      const deleted = await fetch(`${server.base}/api/v1/terminals/${terminal["id"]}`, {
-        method: "DELETE",
-      })
-      expect(deleted.status).toBe(204)
-      const closed = await ws.closed
-      expect(closed.code).toBe(1000)
-      expect(closed.reason).toBe("terminal_ended")
-    } finally {
-      server.proc.kill()
-      await server.proc.exited
-    }
-  }, 30_000)
+        // Deleting the terminal kills the session; the bridge confirms
+        // absence against a complete inventory and closes authoritatively.
+        const deleted = await fetch(`${server.base}/api/v1/terminals/${terminal["id"]}`, {
+          method: "DELETE",
+        })
+        expect(deleted.status).toBe(204)
+        const closed = await ws.closed
+        expect(closed.code).toBe(1000)
+        expect(closed.reason).toBe("terminal_ended")
+      }),
+    30_000,
+  )
 
-  test("rejects bad attaches before the upgrade with real HTTP statuses", async () => {
-    const server = await startFakeZmxServer()
-    try {
-      // Unknown terminal: 404 before any upgrade.
-      const missing = await fetch(`${server.base}/api/v1/terminals/nope/attach`)
-      expect(missing.status).toBe(404)
+  test(
+    "rejects bad attaches before the upgrade with real HTTP statuses",
+    () =>
+      withFakeZmxServer(async (server) => {
+        // Unknown terminal: 404 before any upgrade.
+        const missing = await fetch(`${server.base}/api/v1/terminals/nope/attach`)
+        expect(missing.status).toBe(404)
 
-      // Ended terminal: 410 (reconciliation wrote the tombstone after the
-      // session died behind the server's back).
-      const terminal = await makeTerminal(server.base)
-      fs.rmSync(path.join(server.sandbox.stateDir, sessionNameForTerminalId(terminal["id"] ?? "")))
-      const ended = await fetch(`${server.base}/api/v1/terminals/${terminal["id"]}/attach`)
-      expect(ended.status).toBe(410)
-      // The tombstone is now visible on the resource itself.
-      const record = await fetch(`${server.base}/api/v1/terminals/${terminal["id"]}`)
-      expect(((await record.json()) as { status: string }).status).toBe("ended")
+        // Ended terminal: 410 (reconciliation wrote the tombstone after the
+        // session died behind the server's back).
+        const terminal = await makeTerminal(server.base)
+        fs.rmSync(
+          path.join(server.sandbox.stateDir, sessionNameForTerminalId(terminal["id"] ?? "")),
+        )
+        const ended = await fetch(`${server.base}/api/v1/terminals/${terminal["id"]}/attach`)
+        expect(ended.status).toBe(410)
+        // The tombstone is now visible on the resource itself.
+        const record = await fetch(`${server.base}/api/v1/terminals/${terminal["id"]}`)
+        expect(((await record.json()) as { status: string }).status).toBe("ended")
 
-      // A live terminal without an upgrade handshake: 426, no session touched.
-      const second = await makeTerminal(server.base)
-      const noUpgrade = await fetch(`${server.base}/api/v1/terminals/${second["id"]}/attach`)
-      expect(noUpgrade.status).toBe(426)
-    } finally {
-      server.proc.kill()
-      await server.proc.exited
-    }
-  }, 30_000)
+        // A live terminal without an upgrade handshake: 426, no session touched.
+        const second = await makeTerminal(server.base)
+        const noUpgrade = await fetch(`${server.base}/api/v1/terminals/${second["id"]}/attach`)
+        expect(noUpgrade.status).toBe(426)
+      }),
+    30_000,
+  )
 
-  test("a session dying mid-attach closes 1000 only after confirmed absence", async () => {
-    const server = await startFakeZmxServer()
-    try {
-      const terminal = await makeTerminal(server.base)
-      const ws = await openSocket(
-        `${server.base.replace("http", "ws")}/api/v1/terminals/${terminal["id"]}/attach`,
-      )
-      await waitUntil(() => ws.received.join("").includes("attached"), "attach banner")
+  test(
+    "a session dying mid-attach closes 1000 only after confirmed absence",
+    () =>
+      withFakeZmxServer(async (server) => {
+        const terminal = await makeTerminal(server.base)
+        const ws = await openSocket(
+          `${server.base.replace("http", "ws")}/api/v1/terminals/${terminal["id"]}/attach`,
+        )
+        await waitUntil(() => ws.received.join("").includes("attached"), "attach banner")
 
-      // The session dies out from under the bridge: the attach client sees
-      // EOF and a complete inventory omits the session.
-      fs.rmSync(path.join(server.sandbox.stateDir, sessionNameForTerminalId(terminal["id"] ?? "")))
-      const closed = await ws.closed
-      expect(closed.code).toBe(1000)
-      expect(closed.reason).toBe("terminal_ended")
+        // The session dies out from under the bridge: the attach client sees
+        // EOF and a complete inventory omits the session.
+        fs.rmSync(
+          path.join(server.sandbox.stateDir, sessionNameForTerminalId(terminal["id"] ?? "")),
+        )
+        const closed = await ws.closed
+        expect(closed.code).toBe(1000)
+        expect(closed.reason).toBe("terminal_ended")
 
-      const record = await fetch(`${server.base}/api/v1/terminals/${terminal["id"]}`)
-      expect(((await record.json()) as { status: string }).status).toBe("ended")
-    } finally {
-      server.proc.kill()
-      await server.proc.exited
-    }
-  }, 30_000)
+        const record = await fetch(`${server.base}/api/v1/terminals/${terminal["id"]}`)
+        expect(((await record.json()) as { status: string }).status).toBe("ended")
+      }),
+    30_000,
+  )
 })

--- a/app-server/test/terminalAttach.test.ts
+++ b/app-server/test/terminalAttach.test.ts
@@ -1,0 +1,139 @@
+import { afterAll, describe, expect, test } from "vitest"
+import * as fs from "node:fs"
+import * as path from "node:path"
+import { sessionNameForTerminalId } from "../src/terminalAdapter.ts"
+import { cleanupTempDirs, postJson, waitUntil } from "./blackbox.ts"
+import { startFakeZmxServer } from "./testLayers.ts"
+
+// The WebSocket attach bridge, black-box: a real `atc serve` process whose
+// zmx executable is the fake-zmx wrapper, driven over loopback TCP and a
+// real WebSocket. (In-process WS upgrades through the Bun adapter do not
+// complete under the vitest runtime, and this shape exercises the real
+// adapter + PTY + bridge end to end anyway.) Covers pre-upgrade rejection,
+// byte bridging both ways, the resize control frame, and the close
+// vocabulary. The opt-in zmxRecovery suite runs the same transport against
+// real zmx.
+
+afterAll(cleanupTempDirs)
+
+const makeTerminal = async (base: string) => {
+  const project = await postJson(base, "/api/v1/projects", {
+    name: "P",
+    defaultWorkingDirectory: "/tmp",
+  })
+  return postJson(base, "/api/v1/terminals", { projectId: project["id"] })
+}
+
+interface WsSession {
+  readonly socket: WebSocket
+  readonly received: Array<string>
+  readonly closed: Promise<{ code: number; reason: string }>
+}
+
+const openSocket = (url: string): Promise<WsSession> =>
+  new Promise((resolve, reject) => {
+    const socket = new WebSocket(url)
+    socket.binaryType = "arraybuffer"
+    const received: Array<string> = []
+    const decoder = new TextDecoder()
+    const closed = new Promise<{ code: number; reason: string }>((resolveClose) => {
+      socket.onclose = (event) => resolveClose({ code: event.code, reason: event.reason })
+    })
+    socket.onmessage = (event) => {
+      if (typeof event.data !== "string") received.push(decoder.decode(event.data as ArrayBuffer))
+    }
+    socket.onopen = () => resolve({ socket, received, closed })
+    socket.onerror = () => reject(new Error(`websocket failed to open ${url}`))
+  })
+
+describe("terminal attach bridge (black box)", () => {
+  test("bridges bytes and control frames, closing 1000 terminal_ended on delete", async () => {
+    const server = await startFakeZmxServer()
+    try {
+      const terminal = await makeTerminal(server.base)
+      const ws = await openSocket(
+        `${server.base.replace("http", "ws")}/api/v1/terminals/${terminal["id"]}/attach?cols=100&rows=30`,
+      )
+
+      // Client -> session -> client: the fake-zmx attach client echoes its
+      // PTY input, so a round trip proves both directions through the real
+      // adapter and bridge.
+      await waitUntil(() => ws.received.join("").includes("attached"), "attach banner")
+      ws.socket.send(new TextEncoder().encode("hello\n"))
+      await waitUntil(() => ws.received.join("").includes("echo:hello"), "echo round trip")
+
+      // Control frames are accepted (resize is a no-op for the fixture but
+      // must not disturb the bridge).
+      ws.socket.send(JSON.stringify({ type: "resize", cols: 132, rows: 43 }))
+      ws.socket.send(new TextEncoder().encode("again\n"))
+      await waitUntil(
+        () => ws.received.join("").includes("echo:again"),
+        "bridge alive after resize",
+      )
+
+      // Deleting the terminal kills the session; the bridge confirms
+      // absence against a complete inventory and closes authoritatively.
+      const deleted = await fetch(`${server.base}/api/v1/terminals/${terminal["id"]}`, {
+        method: "DELETE",
+      })
+      expect(deleted.status).toBe(204)
+      const closed = await ws.closed
+      expect(closed.code).toBe(1000)
+      expect(closed.reason).toBe("terminal_ended")
+    } finally {
+      server.proc.kill()
+      await server.proc.exited
+    }
+  }, 30_000)
+
+  test("rejects bad attaches before the upgrade with real HTTP statuses", async () => {
+    const server = await startFakeZmxServer()
+    try {
+      // Unknown terminal: 404 before any upgrade.
+      const missing = await fetch(`${server.base}/api/v1/terminals/nope/attach`)
+      expect(missing.status).toBe(404)
+
+      // Ended terminal: 410 (reconciliation wrote the tombstone after the
+      // session died behind the server's back).
+      const terminal = await makeTerminal(server.base)
+      fs.rmSync(path.join(server.sandbox.stateDir, sessionNameForTerminalId(terminal["id"] ?? "")))
+      const ended = await fetch(`${server.base}/api/v1/terminals/${terminal["id"]}/attach`)
+      expect(ended.status).toBe(410)
+      // The tombstone is now visible on the resource itself.
+      const record = await fetch(`${server.base}/api/v1/terminals/${terminal["id"]}`)
+      expect(((await record.json()) as { status: string }).status).toBe("ended")
+
+      // A live terminal without an upgrade handshake: 426, no session touched.
+      const second = await makeTerminal(server.base)
+      const noUpgrade = await fetch(`${server.base}/api/v1/terminals/${second["id"]}/attach`)
+      expect(noUpgrade.status).toBe(426)
+    } finally {
+      server.proc.kill()
+      await server.proc.exited
+    }
+  }, 30_000)
+
+  test("a session dying mid-attach closes 1000 only after confirmed absence", async () => {
+    const server = await startFakeZmxServer()
+    try {
+      const terminal = await makeTerminal(server.base)
+      const ws = await openSocket(
+        `${server.base.replace("http", "ws")}/api/v1/terminals/${terminal["id"]}/attach`,
+      )
+      await waitUntil(() => ws.received.join("").includes("attached"), "attach banner")
+
+      // The session dies out from under the bridge: the attach client sees
+      // EOF and a complete inventory omits the session.
+      fs.rmSync(path.join(server.sandbox.stateDir, sessionNameForTerminalId(terminal["id"] ?? "")))
+      const closed = await ws.closed
+      expect(closed.code).toBe(1000)
+      expect(closed.reason).toBe("terminal_ended")
+
+      const record = await fetch(`${server.base}/api/v1/terminals/${terminal["id"]}`)
+      expect(((await record.json()) as { status: string }).status).toBe("ended")
+    } finally {
+      server.proc.kill()
+      await server.proc.exited
+    }
+  }, 30_000)
+})

--- a/app-server/test/terminalBridge.test.ts
+++ b/app-server/test/terminalBridge.test.ts
@@ -1,0 +1,65 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import * as Socket from "effect/unstable/socket/Socket"
+import * as ProjectRepository from "../src/projectRepository.ts"
+import { sessionNameForTerminalId } from "../src/terminalAdapter.ts"
+import { runBridge } from "../src/terminalAttach.ts"
+import * as Terminals from "../src/terminals.ts"
+import { makeTestServiceLayers } from "./testLayers.ts"
+
+// The attach bridge in-process, against the fake adapter and an in-memory
+// socket: deterministic coverage of bridge behavior the black-box suite
+// cannot isolate (terminalAttach.test.ts drives the real transport).
+
+/**
+ * An in-memory Socket plus levers: push client frames in, and observe the
+ * close events the bridge writes (fromTransformStream consumes CloseEvents
+ * internally, so they are recorded by wrapping the writer).
+ */
+const makeTestSocket = Effect.gen(function* () {
+  let push!: (frame: Uint8Array | string) => void
+  const readable = new ReadableStream<Uint8Array | string>({
+    start(controller) {
+      push = (frame) => controller.enqueue(frame)
+    },
+  })
+  const writable = new WritableStream<Uint8Array>()
+  const closes: Array<Socket.CloseEvent> = []
+  const inner = yield* Socket.fromTransformStream(Effect.succeed({ readable, writable }))
+  const socket: Socket.Socket = {
+    ...inner,
+    writer: Effect.map(inner.writer, (write) => (chunk) => {
+      if (chunk instanceof Socket.CloseEvent) closes.push(chunk)
+      return write(chunk)
+    }),
+  }
+  return { socket, push, closes }
+})
+
+describe("terminal attach bridge (in-process)", () => {
+  it.effect("a failing PTY write ends the bridge with 1011 attach_failed", () => {
+    const { fake, layer } = makeTestServiceLayers()
+    return Effect.gen(function* () {
+      const projects = yield* ProjectRepository.ProjectRepository
+      const project = yield* projects.create({ name: "P", defaultWorkingDirectory: "/tmp" })
+      const terminals = yield* Terminals.Terminals
+      const created = yield* terminals.create({ projectId: project.id })
+      // The attach client's PTY dies under the bridge: writes start failing
+      // while the session itself stays live and reachable.
+      const session = fake.sessions.get(sessionNameForTerminalId(created.id))!
+      session.writeFails = true
+
+      const { closes, push, socket } = yield* makeTestSocket
+      push(new TextEncoder().encode("x"))
+      yield* runBridge(terminals, created.id, { cols: 80, rows: 24 }, socket).pipe(Effect.scoped)
+
+      // Dropped input must end the bridge retryably — never silently, and
+      // never as 1000 terminal_ended (the session was not proven absent).
+      assert.deepStrictEqual(
+        closes.map((event) => [event.code, event.reason]),
+        [[1011, "attach_failed"]],
+      )
+      assert.strictEqual((yield* terminals.get(created.id)).status, "live")
+    }).pipe(Effect.provide(layer))
+  })
+})

--- a/app-server/test/terminals.test.ts
+++ b/app-server/test/terminals.test.ts
@@ -1,0 +1,287 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Layer, Option } from "effect"
+import { mkdtempSync, realpathSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll } from "vitest"
+import * as Directories from "../src/directories.ts"
+import * as Persistence from "../src/persistence.ts"
+import * as ProjectRepository from "../src/projectRepository.ts"
+import { sessionNameForTerminalId } from "../src/terminalAdapter.ts"
+import * as TerminalRepository from "../src/terminalRepository.ts"
+import * as Terminals from "../src/terminals.ts"
+import { makeFakeAdapter } from "./fakeTerminalAdapter.ts"
+import { makeTestServiceLayers } from "./testLayers.ts"
+
+// The Terminals domain service under the ATC-122 reconciliation invariants,
+// driven entirely through the fake adapter: authoritative absence, stored
+// state untouched on unavailability, two-phase create, tombstones, and
+// startup recovery.
+
+// Canonical (symlink-resolved) so repo-seeded and canonicalized paths agree.
+const scratch = realpathSync(mkdtempSync(join(tmpdir(), "atc-terminals-test-")))
+afterAll(() => rmSync(scratch, { recursive: true, force: true }))
+
+/** One project to own the terminals, created fresh per test layer. */
+const makeProject = Effect.gen(function* () {
+  const projects = yield* ProjectRepository.ProjectRepository
+  return yield* projects.create({ name: "P", defaultWorkingDirectory: scratch })
+})
+
+describe("Terminals service", () => {
+  it.effect("creates a live terminal whose session runs in the project directory", () => {
+    const { fake, layer } = makeTestServiceLayers()
+    return Effect.gen(function* () {
+      const project = yield* makeProject
+      const terminals = yield* Terminals.Terminals
+      const created = yield* terminals.create({
+        projectId: project.id,
+        name: "build",
+        command: ["bun", "run", "dev"],
+      })
+      assert.strictEqual(created.status, "live")
+      assert.strictEqual(created.name, "build")
+      assert.deepStrictEqual(created.command, ["bun", "run", "dev"])
+      assert.strictEqual(created.initialWorkingDirectory, project.defaultWorkingDirectory)
+      const session = fake.sessions.get(sessionNameForTerminalId(created.id))
+      assert.isDefined(session)
+      assert.strictEqual(session?.cwd, project.defaultWorkingDirectory)
+      assert.deepStrictEqual(session?.command, ["bun", "run", "dev"])
+
+      assert.deepStrictEqual(yield* terminals.list(), [created])
+      assert.deepStrictEqual(yield* terminals.get(created.id), created)
+    }).pipe(Effect.provide(layer))
+  })
+
+  it.effect("rejects a create for an unknown project", () => {
+    const { layer } = makeTestServiceLayers()
+    return Effect.gen(function* () {
+      const terminals = yield* Terminals.Terminals
+      const error = yield* Effect.flip(terminals.create({ projectId: "nope" }))
+      assert.strictEqual(error._tag, "ProjectNotFound")
+    }).pipe(Effect.provide(layer))
+  })
+
+  it.effect("rejects a create in an unusable working directory", () => {
+    const { layer } = makeTestServiceLayers()
+    return Effect.gen(function* () {
+      const project = yield* makeProject
+      const terminals = yield* Terminals.Terminals
+      const error = yield* Effect.flip(
+        terminals.create({ projectId: project.id, workingDirectory: join(scratch, "nope") }),
+      )
+      assert.strictEqual(error._tag, "DirectoryUnavailable")
+    }).pipe(Effect.provide(layer))
+  })
+
+  it.effect("a failed launch leaves no record", () => {
+    const { fake, layer } = makeTestServiceLayers()
+    return Effect.gen(function* () {
+      const project = yield* makeProject
+      const terminals = yield* Terminals.Terminals
+      fake.setCreateFails(true)
+      const error = yield* Effect.flip(terminals.create({ projectId: project.id }))
+      assert.strictEqual(error._tag, "TerminalLaunchFailed")
+      fake.setCreateFails(false)
+      assert.deepStrictEqual(yield* terminals.list(), [])
+    }).pipe(Effect.provide(layer))
+  })
+
+  it.effect("an unavailable multiplexer fails create retryably, leaving no record", () => {
+    const { fake, layer } = makeTestServiceLayers()
+    return Effect.gen(function* () {
+      const project = yield* makeProject
+      const terminals = yield* Terminals.Terminals
+      fake.setUnavailable(true)
+      const error = yield* Effect.flip(terminals.create({ projectId: project.id }))
+      assert.strictEqual(error._tag, "ZmxUnavailable")
+      fake.setUnavailable(false)
+      assert.deepStrictEqual(yield* terminals.list(), [])
+    }).pipe(Effect.provide(layer))
+  })
+
+  it.effect("reconciliation tombstones a terminal whose session died, and keeps it", () => {
+    const { fake, layer } = makeTestServiceLayers()
+    return Effect.gen(function* () {
+      const project = yield* makeProject
+      const terminals = yield* Terminals.Terminals
+      const created = yield* terminals.create({ projectId: project.id })
+      // The session dies out from under us (complete inventory omits it).
+      fake.sessions.delete(sessionNameForTerminalId(created.id))
+      const listed = yield* terminals.list()
+      assert.strictEqual(listed[0]?.status, "ended")
+      assert.isDefined(listed[0]?.endedAt)
+      // The tombstone persists until an explicit delete, with a stable
+      // endedAt across further reconciles.
+      const again = yield* terminals.get(created.id)
+      assert.strictEqual(again.status, "ended")
+      assert.strictEqual(again.endedAt, listed[0]?.endedAt)
+    }).pipe(Effect.provide(layer))
+  })
+
+  it.effect("an unavailable inventory leaves stored state untouched", () => {
+    const { fake, layer } = makeTestServiceLayers()
+    return Effect.gen(function* () {
+      const project = yield* makeProject
+      const terminals = yield* Terminals.Terminals
+      const created = yield* terminals.create({ projectId: project.id })
+      fake.sessions.delete(sessionNameForTerminalId(created.id))
+      fake.setUnavailable(true)
+      // The session is gone, but no complete inventory can prove it.
+      assert.strictEqual((yield* terminals.list())[0]?.status, "live")
+      assert.strictEqual((yield* terminals.get(created.id)).status, "live")
+    }).pipe(Effect.provide(layer))
+  })
+
+  it.effect("an unreachable session is never treated as absent", () => {
+    const { fake, layer } = makeTestServiceLayers()
+    return Effect.gen(function* () {
+      const project = yield* makeProject
+      const terminals = yield* Terminals.Terminals
+      const created = yield* terminals.create({ projectId: project.id })
+      fake.sessions.get(sessionNameForTerminalId(created.id))!.reachable = false
+      assert.strictEqual((yield* terminals.get(created.id)).status, "live")
+      assert.strictEqual(yield* terminals.confirmEnded(created.id), false)
+    }).pipe(Effect.provide(layer))
+  })
+
+  it.effect("rename updates the label and nothing else", () => {
+    const { layer } = makeTestServiceLayers()
+    return Effect.gen(function* () {
+      const project = yield* makeProject
+      const terminals = yield* Terminals.Terminals
+      const created = yield* terminals.create({ projectId: project.id })
+      const renamed = yield* terminals.rename(created.id, "logs")
+      assert.strictEqual(renamed.name, "logs")
+      assert.strictEqual(renamed.status, "live")
+      const missing = yield* Effect.flip(terminals.rename("nope", "x"))
+      assert.strictEqual(missing._tag, "TerminalNotFound")
+    }).pipe(Effect.provide(layer))
+  })
+
+  it.effect("delete kills the session and removes the record, tombstones included", () => {
+    const { fake, layer } = makeTestServiceLayers()
+    return Effect.gen(function* () {
+      const project = yield* makeProject
+      const terminals = yield* Terminals.Terminals
+      const created = yield* terminals.create({ projectId: project.id })
+      yield* terminals.delete(created.id)
+      assert.strictEqual(fake.sessions.size, 0)
+      assert.deepStrictEqual(yield* terminals.list(), [])
+
+      // A tombstone deletes without a session to kill.
+      const second = yield* terminals.create({ projectId: project.id })
+      fake.sessions.delete(sessionNameForTerminalId(second.id))
+      assert.strictEqual((yield* terminals.get(second.id)).status, "ended")
+      yield* terminals.delete(second.id)
+      assert.deepStrictEqual(yield* terminals.list(), [])
+
+      const missing = yield* Effect.flip(terminals.delete("nope"))
+      assert.strictEqual(missing._tag, "TerminalNotFound")
+    }).pipe(Effect.provide(layer))
+  })
+
+  it.effect("delete requires certainty: an unavailable inventory keeps the record", () => {
+    const { fake, layer } = makeTestServiceLayers()
+    return Effect.gen(function* () {
+      const project = yield* makeProject
+      const terminals = yield* Terminals.Terminals
+      const created = yield* terminals.create({ projectId: project.id })
+      fake.setUnavailable(true)
+      const error = yield* Effect.flip(terminals.delete(created.id))
+      assert.strictEqual(error._tag, "ZmxUnavailable")
+      fake.setUnavailable(false)
+      assert.strictEqual((yield* terminals.get(created.id)).status, "live")
+    }).pipe(Effect.provide(layer))
+  })
+
+  it.effect("confirmEnded writes the tombstone only on authoritative absence", () => {
+    const { fake, layer } = makeTestServiceLayers()
+    return Effect.gen(function* () {
+      const project = yield* makeProject
+      const terminals = yield* Terminals.Terminals
+      const created = yield* terminals.create({ projectId: project.id })
+      assert.strictEqual(yield* terminals.confirmEnded(created.id), false)
+      fake.sessions.delete(sessionNameForTerminalId(created.id))
+      assert.strictEqual(yield* terminals.confirmEnded(created.id), true)
+      assert.strictEqual((yield* terminals.get(created.id)).status, "ended")
+    }).pipe(Effect.provide(layer))
+  })
+})
+
+describe("Terminals startup reconciliation", () => {
+  it.effect("resolves live, starting, and orphan sessions before serving", () => {
+    const fake = makeFakeAdapter()
+    // A file-backed database so the seeding phase and the Terminals build
+    // (whose layer runs the startup pass) see the same rows across two
+    // separate provides.
+    const services = Layer.mergeAll(
+      Layer.mergeAll(ProjectRepository.layer, TerminalRepository.layer).pipe(
+        Layer.provide(Persistence.layerFile(join(scratch, "startup.db"))),
+      ),
+      Directories.layer,
+      fake.layer,
+    )
+    const fakeSession = (name: string) =>
+      fake.sessions.set(name, {
+        name,
+        cwd: scratch,
+        command: undefined,
+        written: [],
+        lastResize: undefined,
+        reachable: true,
+        writeFails: false,
+      })
+
+    // Phase 1 — seed the world a crash would leave behind.
+    const seeded = Effect.gen(function* () {
+      const repo = yield* TerminalRepository.TerminalRepository
+      const projects = yield* ProjectRepository.ProjectRepository
+      const project = yield* projects.create({ name: "P", defaultWorkingDirectory: scratch })
+      const seed = (name: string) =>
+        repo.create({ projectId: project.id, name, initialWorkingDirectory: scratch })
+      const survivor = yield* seed("survivor") // live row, session survives
+      yield* repo.markLive(survivor.id)
+      const dead = yield* seed("dead") // live row, session gone
+      yield* repo.markLive(dead.id)
+      const adopted = yield* seed("adopted") // starting row, session made it
+      const failed = yield* seed("failed") // starting row, session absent
+      const wedged = yield* seed("wedged") // starting row, session unreachable
+      fakeSession(sessionNameForTerminalId(survivor.id))
+      fakeSession(sessionNameForTerminalId(adopted.id))
+      fakeSession(sessionNameForTerminalId(wedged.id))
+      fake.sessions.get(sessionNameForTerminalId(wedged.id))!.reachable = false
+      // An orphan session no record claims (provably ours: private dir).
+      fakeSession("atc-orphan")
+      return { survivor, failed, wedged }
+    }).pipe(Effect.provide(services))
+
+    // Phase 2 — building Terminals.layer runs the startup pass. Sequenced
+    // after phase 1 so the seeding is on disk before the layer builds.
+    return seeded.pipe(
+      Effect.flatMap(({ failed, survivor, wedged }) =>
+        Effect.gen(function* () {
+          const terminals = yield* Terminals.Terminals
+          const repo = yield* TerminalRepository.TerminalRepository
+
+          const byName = new Map((yield* terminals.list()).map((t) => [t.name, t]))
+          assert.strictEqual(byName.get("survivor")?.status, "live")
+          assert.strictEqual(byName.get("dead")?.status, "ended")
+          assert.strictEqual(byName.get("adopted")?.status, "live")
+          // The failed launch left no record, and the orphan was cleaned.
+          assert.isTrue(Option.isNone(yield* repo.get(failed.id)))
+          assert.isFalse(fake.sessions.has("atc-orphan"))
+          assert.isTrue(fake.sessions.has(sessionNameForTerminalId(survivor.id)))
+          // An unreachable session proves nothing: the row stays `starting`
+          // (hidden from the API) and the session is spared orphan cleanup.
+          assert.isFalse(byName.has("wedged"))
+          const wedgedRow = yield* repo.get(wedged.id)
+          assert.strictEqual(Option.getOrUndefined(wedgedRow)?.status, "starting")
+          assert.isTrue(fake.sessions.has(sessionNameForTerminalId(wedged.id)))
+        }).pipe(
+          Effect.provide(Layer.mergeAll(services, Terminals.layer.pipe(Layer.provide(services)))),
+        ),
+      ),
+    )
+  })
+})

--- a/app-server/test/terminals.test.ts
+++ b/app-server/test/terminals.test.ts
@@ -1,16 +1,13 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Layer, Option } from "effect"
+import { Effect, Option } from "effect"
 import { mkdtempSync, realpathSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterAll } from "vitest"
-import * as Directories from "../src/directories.ts"
-import * as Persistence from "../src/persistence.ts"
 import * as ProjectRepository from "../src/projectRepository.ts"
 import { sessionNameForTerminalId } from "../src/terminalAdapter.ts"
 import * as TerminalRepository from "../src/terminalRepository.ts"
 import * as Terminals from "../src/terminals.ts"
-import { makeFakeAdapter } from "./fakeTerminalAdapter.ts"
 import { makeTestServiceLayers } from "./testLayers.ts"
 
 // The Terminals domain service under the ATC-122 reconciliation invariants,
@@ -145,16 +142,18 @@ describe("Terminals service", () => {
     }).pipe(Effect.provide(layer))
   })
 
-  it.effect("rename updates the label and nothing else", () => {
+  it.effect("update renames the label; an empty patch changes nothing", () => {
     const { layer } = makeTestServiceLayers()
     return Effect.gen(function* () {
       const project = yield* makeProject
       const terminals = yield* Terminals.Terminals
       const created = yield* terminals.create({ projectId: project.id })
-      const renamed = yield* terminals.rename(created.id, "logs")
+      const renamed = yield* terminals.update(created.id, { name: "logs" })
       assert.strictEqual(renamed.name, "logs")
       assert.strictEqual(renamed.status, "live")
-      const missing = yield* Effect.flip(terminals.rename("nope", "x"))
+      // An empty patch is a no-op read: same record, same updatedAt.
+      assert.deepStrictEqual(yield* terminals.update(created.id, {}), renamed)
+      const missing = yield* Effect.flip(terminals.update("nope", { name: "x" }))
       assert.strictEqual(missing._tag, "TerminalNotFound")
     }).pipe(Effect.provide(layer))
   })
@@ -211,27 +210,11 @@ describe("Terminals service", () => {
 
 describe("Terminals startup reconciliation", () => {
   it.effect("resolves live, starting, and orphan sessions before serving", () => {
-    const fake = makeFakeAdapter()
     // A file-backed database so the seeding phase and the Terminals build
     // (whose layer runs the startup pass) see the same rows across two
     // separate provides.
-    const services = Layer.mergeAll(
-      Layer.mergeAll(ProjectRepository.layer, TerminalRepository.layer).pipe(
-        Layer.provide(Persistence.layerFile(join(scratch, "startup.db"))),
-      ),
-      Directories.layer,
-      fake.layer,
-    )
-    const fakeSession = (name: string) =>
-      fake.sessions.set(name, {
-        name,
-        cwd: scratch,
-        command: undefined,
-        written: [],
-        lastResize: undefined,
-        reachable: true,
-        writeFails: false,
-      })
+    const { fake, services, layer } = makeTestServiceLayers(join(scratch, "startup.db"))
+    const fakeSession = (name: string) => fake.seed(name, { cwd: scratch })
 
     // Phase 1 — seed the world a crash would leave behind.
     const seeded = Effect.gen(function* () {
@@ -278,9 +261,7 @@ describe("Terminals startup reconciliation", () => {
           const wedgedRow = yield* repo.get(wedged.id)
           assert.strictEqual(Option.getOrUndefined(wedgedRow)?.status, "starting")
           assert.isTrue(fake.sessions.has(sessionNameForTerminalId(wedged.id)))
-        }).pipe(
-          Effect.provide(Layer.mergeAll(services, Terminals.layer.pipe(Layer.provide(services)))),
-        ),
+        }).pipe(Effect.provide(layer)),
       ),
     )
   })

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -1,4 +1,5 @@
 import { assert } from "@effect/vitest"
+import { BunServices } from "@effect/platform-bun"
 import { Effect, Layer, Stream } from "effect"
 import * as fs from "node:fs"
 import * as os from "node:os"
@@ -8,14 +9,15 @@ import { AppConfig } from "../src/config.ts"
 import * as Directories from "../src/directories.ts"
 import * as Persistence from "../src/persistence.ts"
 import * as ProjectRepository from "../src/projectRepository.ts"
+import * as Subprocess from "../src/subprocess.ts"
 import type { TerminalAdapter } from "../src/terminalAdapter.ts"
 import * as TerminalRepository from "../src/terminalRepository.ts"
 import * as Terminals from "../src/terminals.ts"
+import * as Zmx from "../src/zmxAdapter.ts"
 import {
   appServerRoot,
   freePort,
   isolatedEnv,
-  makeShortSocketDir,
   spawnServe,
   trackTempDir,
   waitForHealth,
@@ -23,30 +25,36 @@ import {
 import { makeFakeAdapter } from "./fakeTerminalAdapter.ts"
 import type { FakeTerminalAdapter } from "./fakeTerminalAdapter.ts"
 
+type ServiceLayer = Layer.Layer<
+  | ProjectRepository.ProjectRepository
+  | TerminalRepository.TerminalRepository
+  | Directories.Directories
+  | TerminalAdapter,
+  unknown
+>
+
 /**
  * Handler dependencies for in-process and ephemeral-listener tests: real
- * repositories over one fresh in-memory database, real directory checks,
- * and the fake in-memory terminal adapter (returned for failure injection
- * and assertions).
+ * repositories over one fresh database (in-memory unless a file is given),
+ * real directory checks, and the fake in-memory terminal adapter (returned
+ * for failure injection and assertions). `services` omits Terminals so
+ * startup-reconciliation tests can seed rows before its layer builds.
  */
-export const makeTestServiceLayers = (): {
+export const makeTestServiceLayers = (
+  dbFile = ":memory:",
+): {
   readonly fake: FakeTerminalAdapter
-  readonly layer: Layer.Layer<
-    | ProjectRepository.ProjectRepository
-    | TerminalRepository.TerminalRepository
-    | Terminals.Terminals
-    | Directories.Directories
-    | TerminalAdapter,
-    unknown
-  >
+  readonly services: ServiceLayer
+  readonly layer: Layer.Layer<Layer.Success<ServiceLayer> | Terminals.Terminals, unknown>
 } => {
   const fake = makeFakeAdapter()
   const base = Layer.mergeAll(ProjectRepository.layer, TerminalRepository.layer).pipe(
-    Layer.provide(Persistence.layerFile(":memory:")),
+    Layer.provide(Persistence.layerFile(dbFile)),
   )
   const services = Layer.mergeAll(base, Directories.layer, fake.layer)
   return {
     fake,
+    services,
     layer: Layer.mergeAll(services, Terminals.layer.pipe(Layer.provide(services))),
   }
 }
@@ -68,12 +76,30 @@ export const testAppConfig = (overrides: Partial<AppConfig["Service"]>): Layer.L
     ...overrides,
   })
 
+/** The full zmx-adapter layer stack shared by every in-process adapter test. */
+export const zmxAdapterLayer = (options: {
+  readonly zmxExecutable: string
+  readonly terminalSocketDir: string
+  readonly zmx?: Zmx.ZmxOptions
+}): Layer.Layer<TerminalAdapter, unknown> =>
+  Zmx.layerWith(options.zmx ?? {}).pipe(
+    Layer.provide(
+      testAppConfig({
+        zmxExecutable: options.zmxExecutable,
+        terminalSocketDir: options.terminalSocketDir,
+      }),
+    ),
+    Layer.provide(Subprocess.layer),
+    Layer.provideMerge(BunServices.layer),
+  )
+
 const fakeZmxFixture = fileURLToPath(new URL("fixtures/fake-zmx.ts", import.meta.url))
 
 /**
  * A real `atc serve` (from source) whose zmx executable is the fake-zmx
  * wrapper: the deterministic full-stack seam for black-box terminal tests.
- * Kill `proc` (and await `proc.exited`) when done.
+ * Kill `proc` (and await `proc.exited`) when done — or use
+ * `withFakeZmxServer`, which does it for you.
  */
 export const startFakeZmxServer = async (extraEnv: Record<string, string> = {}) => {
   const sandbox = makeFakeZmxSandbox()
@@ -86,6 +112,20 @@ export const startFakeZmxServer = async (extraEnv: Record<string, string> = {}) 
   const proc = spawnServe([process.execPath, "src/main.ts"], port, appServerRoot, env)
   await waitForHealth(`http://127.0.0.1:${port}`, proc)
   return { base: `http://127.0.0.1:${port}`, port, proc, sandbox, env }
+}
+
+/** Run `use` against a fake-zmx `atc serve`, always reaping the process. */
+export const withFakeZmxServer = async (
+  use: (server: Awaited<ReturnType<typeof startFakeZmxServer>>) => Promise<void>,
+  extraEnv: Record<string, string> = {},
+): Promise<void> => {
+  const server = await startFakeZmxServer(extraEnv)
+  try {
+    await use(server)
+  } finally {
+    server.proc.kill()
+    await server.proc.exited
+  }
 }
 
 /**
@@ -106,7 +146,7 @@ export const makeFakeZmxSandbox = (vars: Record<string, string> = {}) => {
     `#!/bin/sh\n${assignments} exec "${process.execPath}" "${fakeZmxFixture}" "$@"\n`,
   )
   fs.chmodSync(wrapper, 0o755)
-  return { base, stateDir, wrapper, socketDir: makeShortSocketDir() }
+  return { base, stateDir, wrapper }
 }
 
 /** Collect a byte stream into a text sink in the background (scoped). */

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -1,17 +1,57 @@
 import { assert } from "@effect/vitest"
 import { Effect, Layer, Stream } from "effect"
 import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import { fileURLToPath } from "node:url"
 import { AppConfig } from "../src/config.ts"
 import * as Directories from "../src/directories.ts"
 import * as Persistence from "../src/persistence.ts"
 import * as ProjectRepository from "../src/projectRepository.ts"
+import type { TerminalAdapter } from "../src/terminalAdapter.ts"
+import * as TerminalRepository from "../src/terminalRepository.ts"
+import * as Terminals from "../src/terminals.ts"
+import {
+  appServerRoot,
+  freePort,
+  isolatedEnv,
+  makeShortSocketDir,
+  spawnServe,
+  trackTempDir,
+  waitForHealth,
+} from "./blackbox.ts"
+import { makeFakeAdapter } from "./fakeTerminalAdapter.ts"
+import type { FakeTerminalAdapter } from "./fakeTerminalAdapter.ts"
 
-// Handler dependencies for in-process and ephemeral-listener tests: a real
-// repository over a fresh in-memory database, and real directory checks.
-export const TestRepositoryLayers = Layer.mergeAll(
-  ProjectRepository.layer.pipe(Layer.provide(Persistence.layerFile(":memory:"))),
-  Directories.layer,
-)
+/**
+ * Handler dependencies for in-process and ephemeral-listener tests: real
+ * repositories over one fresh in-memory database, real directory checks,
+ * and the fake in-memory terminal adapter (returned for failure injection
+ * and assertions).
+ */
+export const makeTestServiceLayers = (): {
+  readonly fake: FakeTerminalAdapter
+  readonly layer: Layer.Layer<
+    | ProjectRepository.ProjectRepository
+    | TerminalRepository.TerminalRepository
+    | Terminals.Terminals
+    | Directories.Directories
+    | TerminalAdapter,
+    unknown
+  >
+} => {
+  const fake = makeFakeAdapter()
+  const base = Layer.mergeAll(ProjectRepository.layer, TerminalRepository.layer).pipe(
+    Layer.provide(Persistence.layerFile(":memory:")),
+  )
+  const services = Layer.mergeAll(base, Directories.layer, fake.layer)
+  return {
+    fake,
+    layer: Layer.mergeAll(services, Terminals.layer.pipe(Layer.provide(services))),
+  }
+}
+
+export const TestRepositoryLayers = makeTestServiceLayers().layer
 
 /** A settled AppConfig for tests that only need a few fields overridden. */
 export const testAppConfig = (overrides: Partial<AppConfig["Service"]>): Layer.Layer<AppConfig> =>
@@ -28,22 +68,45 @@ export const testAppConfig = (overrides: Partial<AppConfig["Service"]>): Layer.L
     ...overrides,
   })
 
-const tempDirs: Array<string> = []
+const fakeZmxFixture = fileURLToPath(new URL("fixtures/fake-zmx.ts", import.meta.url))
 
-/** Track `dir` for removal by `cleanupTempDirs` (call it from afterAll). */
-export const trackTempDir = (dir: string): string => {
-  tempDirs.push(dir)
-  return dir
+/**
+ * A real `atc serve` (from source) whose zmx executable is the fake-zmx
+ * wrapper: the deterministic full-stack seam for black-box terminal tests.
+ * Kill `proc` (and await `proc.exited`) when done.
+ */
+export const startFakeZmxServer = async (extraEnv: Record<string, string> = {}) => {
+  const sandbox = makeFakeZmxSandbox()
+  const port = await freePort()
+  const env = isolatedEnv(sandbox.base, {
+    ATC_PORT: String(port),
+    ATC_ZMX_EXECUTABLE: sandbox.wrapper,
+    ...extraEnv,
+  })
+  const proc = spawnServe([process.execPath, "src/main.ts"], port, appServerRoot, env)
+  await waitForHealth(`http://127.0.0.1:${port}`, proc)
+  return { base: `http://127.0.0.1:${port}`, port, proc, sandbox, env }
 }
 
 /**
- * A throwaway socket directory short enough for the unix socket-path budget
- * (~103 bytes) — macOS os.tmpdir() (/var/folders/…) is too deep, /tmp is not.
+ * A per-test fake-zmx sandbox. The wrapper script is the configured "zmx
+ * executable": the adapter owns argv and environment, so per-test fixture
+ * configuration is baked into the wrapper itself — no process.env mutation
+ * anywhere.
  */
-export const makeShortSocketDir = (): string => trackTempDir(fs.mkdtempSync("/tmp/atc-zs-"))
-
-export const cleanupTempDirs = (): void => {
-  for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true })
+export const makeFakeZmxSandbox = (vars: Record<string, string> = {}) => {
+  const base = trackTempDir(fs.mkdtempSync(path.join(os.tmpdir(), "atc-zmx-")))
+  const stateDir = path.join(base, "state")
+  const wrapper = path.join(base, "fake-zmx")
+  const assignments = Object.entries({ FAKE_ZMX_STATE: stateDir, ...vars })
+    .map(([key, value]) => `${key}='${value}'`)
+    .join(" ")
+  fs.writeFileSync(
+    wrapper,
+    `#!/bin/sh\n${assignments} exec "${process.execPath}" "${fakeZmxFixture}" "$@"\n`,
+  )
+  fs.chmodSync(wrapper, 0o755)
+  return { base, stateDir, wrapper, socketDir: makeShortSocketDir() }
 }
 
 /** Collect a byte stream into a text sink in the background (scoped). */

--- a/app-server/test/zmxRecovery.blackbox.test.ts
+++ b/app-server/test/zmxRecovery.blackbox.test.ts
@@ -7,7 +7,8 @@ import {
   compiledBinaryPath,
   freePort,
   isolatedEnv,
-  postJson,
+  makeTerminal,
+  openSocket,
   spawnServe,
   waitForHealth,
   waitUntil,
@@ -45,11 +46,7 @@ describe.skipIf(!enabled)("terminal restart recovery (compiled, real zmx)", () =
     let server = spawnServe([compiledBinaryPath], port, scratch, env)
     try {
       await waitForHealth(base, server)
-      const project = await postJson(base, "/api/v1/projects", {
-        name: "Recovery",
-        defaultWorkingDirectory: "/tmp",
-      })
-      const terminal = await postJson(base, "/api/v1/terminals", { projectId: project["id"] })
+      const terminal = await makeTerminal(base)
       const sessionName = sessionNameForTerminalId(terminal["id"] ?? "")
       expect(zmxList(socketDir)).toContain(sessionName)
 
@@ -77,28 +74,13 @@ describe.skipIf(!enabled)("terminal restart recovery (compiled, real zmx)", () =
       expect(zmxList(socketDir)).toContain(sessionName)
 
       // The transport works against the recovered session.
-      const marker = await new Promise<string>((resolve, reject) => {
-        const ws = new WebSocket(`ws://127.0.0.1:${port}/api/v1/terminals/${terminal["id"]}/attach`)
-        ws.binaryType = "arraybuffer"
-        const decoder = new TextDecoder()
-        let seen = ""
-        const timer = setTimeout(() => reject(new Error(`no marker; saw ${seen}`)), 15_000)
-        ws.onopen = () => ws.send(new TextEncoder().encode("printf 'MARKER-%s\\n' recovered\n"))
-        ws.onmessage = (event) => {
-          if (typeof event.data === "string") return
-          seen += decoder.decode(event.data as ArrayBuffer)
-          if (seen.includes("MARKER-recovered")) {
-            clearTimeout(timer)
-            ws.close()
-            resolve(seen)
-          }
-        }
-        ws.onerror = () => {
-          clearTimeout(timer)
-          reject(new Error("websocket error"))
-        }
-      })
-      expect(marker).toContain("MARKER-recovered")
+      const ws = await openSocket(
+        `ws://127.0.0.1:${port}/api/v1/terminals/${terminal["id"]}/attach`,
+      )
+      ws.socket.send(new TextEncoder().encode("printf 'MARKER-%s\\n' recovered\n"))
+      // 600 × 25ms — a real login shell can be slow to come up.
+      await waitUntil(() => ws.received.join("").includes("MARKER-recovered"), "marker", 600)
+      ws.socket.close()
 
       // Delete kills the real session and verifies absence.
       const deleted = await fetch(`${base}/api/v1/terminals/${terminal["id"]}`, {
@@ -110,12 +92,10 @@ describe.skipIf(!enabled)("terminal restart recovery (compiled, real zmx)", () =
       server.kill()
       await server.exited
       // Best-effort: no zmx daemons may outlive the test.
-      for (const line of zmxList(join(env.XDG_STATE_HOME, "atc", "terminals")).split("\n")) {
+      for (const line of zmxList(socketDir).split("\n")) {
         const name = /name=(\S+)/.exec(line)?.[1]
         if (name !== undefined) {
-          Bun.spawnSync(["zmx", "kill", name], {
-            env: { ...process.env, ZMX_DIR: join(env.XDG_STATE_HOME, "atc", "terminals") },
-          })
+          Bun.spawnSync(["zmx", "kill", name], { env: { ...process.env, ZMX_DIR: socketDir } })
         }
       }
     }

--- a/app-server/test/zmxRecovery.blackbox.test.ts
+++ b/app-server/test/zmxRecovery.blackbox.test.ts
@@ -1,0 +1,123 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll, describe, expect, test } from "vitest"
+import { sessionNameForTerminalId } from "../src/terminalAdapter.ts"
+import {
+  compiledBinaryPath,
+  freePort,
+  isolatedEnv,
+  postJson,
+  spawnServe,
+  waitForHealth,
+  waitUntil,
+} from "./blackbox.ts"
+
+// Opt-in restart-recovery tests (mise run test:zmx): the compiled atc
+// executable against the real installed zmx. Terminals must survive a server
+// restart (the zmx sessions outlive the process), reconciliation must adopt
+// the surviving sessions and clean orphans, and the WebSocket transport must
+// work against a recovered session.
+
+const enabled = process.env["ATC_ZMX_SMOKE"] === "1"
+
+const scratch = mkdtempSync(join(tmpdir(), "atc-recovery-"))
+afterAll(() => rmSync(scratch, { recursive: true, force: true }))
+
+const zmxList = (socketDir: string): string =>
+  Bun.spawnSync(["zmx", "list"], {
+    env: { ...process.env, ZMX_DIR: socketDir, ZMX_SESSION: undefined },
+  }).stdout.toString()
+
+describe.skipIf(!enabled)("terminal restart recovery (compiled, real zmx)", () => {
+  test("terminals survive a restart; orphans are cleaned; attach works after recovery", async () => {
+    expect(
+      existsSync(compiledBinaryPath),
+      `missing compiled artifact at ${compiledBinaryPath}; run \`mise run build\``,
+    ).toBe(true)
+    expect(Bun.which("zmx"), "zmx not found on PATH").not.toBeNull()
+
+    const port = await freePort()
+    const env = isolatedEnv(scratch, { ATC_PORT: String(port) })
+    const socketDir = join(env.XDG_STATE_HOME, "atc", "terminals")
+    const base = `http://127.0.0.1:${port}`
+
+    let server = spawnServe([compiledBinaryPath], port, scratch, env)
+    try {
+      await waitForHealth(base, server)
+      const project = await postJson(base, "/api/v1/projects", {
+        name: "Recovery",
+        defaultWorkingDirectory: "/tmp",
+      })
+      const terminal = await postJson(base, "/api/v1/terminals", { projectId: project["id"] })
+      const sessionName = sessionNameForTerminalId(terminal["id"] ?? "")
+      expect(zmxList(socketDir)).toContain(sessionName)
+
+      // An orphan session in the private dir: provably ours, no record.
+      Bun.spawnSync(["zmx", "run", "atc-orphan-test", "-d", "sleep", "300"], {
+        env: { ...process.env, ZMX_DIR: socketDir },
+      })
+      await waitUntil(() => zmxList(socketDir).includes("atc-orphan-test"), "orphan session")
+
+      // Restart: the session daemons must survive the server's death.
+      server.kill("SIGTERM")
+      expect(await server.exited).toBe(130)
+      expect(zmxList(socketDir)).toContain(sessionName)
+
+      server = spawnServe([compiledBinaryPath], port, scratch, env)
+      await waitForHealth(base, server)
+
+      // Startup reconciliation adopted the survivor and killed the orphan.
+      const listed = (await (await fetch(`${base}/api/v1/terminals`)).json()) as Array<{
+        id: string
+        status: string
+      }>
+      expect(listed.map((t) => [t.id, t.status])).toEqual([[terminal["id"], "live"]])
+      await waitUntil(() => !zmxList(socketDir).includes("atc-orphan-test"), "orphan cleanup")
+      expect(zmxList(socketDir)).toContain(sessionName)
+
+      // The transport works against the recovered session.
+      const marker = await new Promise<string>((resolve, reject) => {
+        const ws = new WebSocket(`ws://127.0.0.1:${port}/api/v1/terminals/${terminal["id"]}/attach`)
+        ws.binaryType = "arraybuffer"
+        const decoder = new TextDecoder()
+        let seen = ""
+        const timer = setTimeout(() => reject(new Error(`no marker; saw ${seen}`)), 15_000)
+        ws.onopen = () => ws.send(new TextEncoder().encode("printf 'MARKER-%s\\n' recovered\n"))
+        ws.onmessage = (event) => {
+          if (typeof event.data === "string") return
+          seen += decoder.decode(event.data as ArrayBuffer)
+          if (seen.includes("MARKER-recovered")) {
+            clearTimeout(timer)
+            ws.close()
+            resolve(seen)
+          }
+        }
+        ws.onerror = () => {
+          clearTimeout(timer)
+          reject(new Error("websocket error"))
+        }
+      })
+      expect(marker).toContain("MARKER-recovered")
+
+      // Delete kills the real session and verifies absence.
+      const deleted = await fetch(`${base}/api/v1/terminals/${terminal["id"]}`, {
+        method: "DELETE",
+      })
+      expect(deleted.status).toBe(204)
+      expect(zmxList(socketDir)).not.toContain(sessionName)
+    } finally {
+      server.kill()
+      await server.exited
+      // Best-effort: no zmx daemons may outlive the test.
+      for (const line of zmxList(join(env.XDG_STATE_HOME, "atc", "terminals")).split("\n")) {
+        const name = /name=(\S+)/.exec(line)?.[1]
+        if (name !== undefined) {
+          Bun.spawnSync(["zmx", "kill", name], {
+            env: { ...process.env, ZMX_DIR: join(env.XDG_STATE_HOME, "atc", "terminals") },
+          })
+        }
+      }
+    }
+  }, 120_000)
+})

--- a/app-server/test/zmxSmoke.test.ts
+++ b/app-server/test/zmxSmoke.test.ts
@@ -5,13 +5,8 @@ import { afterAll } from "vitest"
 import * as Subprocess from "../src/subprocess.ts"
 import { TerminalAdapter } from "../src/terminalAdapter.ts"
 import * as Zmx from "../src/zmxAdapter.ts"
-import {
-  cleanupTempDirs,
-  collectText,
-  makeShortSocketDir,
-  testAppConfig,
-  waitForText,
-} from "./testLayers.ts"
+import { cleanupTempDirs, makeShortSocketDir } from "./blackbox.ts"
+import { collectText, testAppConfig, waitForText } from "./testLayers.ts"
 
 // Opt-in smoke tests against the real, user-installed zmx binary
 // (mise run test:zmx). They prove the pinned behavioral assumptions — attach

--- a/app-server/test/zmxSmoke.test.ts
+++ b/app-server/test/zmxSmoke.test.ts
@@ -1,12 +1,9 @@
 import { assert, describe, it } from "@effect/vitest"
-import { BunServices } from "@effect/platform-bun"
-import { Effect, Layer } from "effect"
+import { Effect } from "effect"
 import { afterAll } from "vitest"
-import * as Subprocess from "../src/subprocess.ts"
 import { TerminalAdapter } from "../src/terminalAdapter.ts"
-import * as Zmx from "../src/zmxAdapter.ts"
 import { cleanupTempDirs, makeShortSocketDir } from "./blackbox.ts"
-import { collectText, testAppConfig, waitForText } from "./testLayers.ts"
+import { collectText, waitForText, zmxAdapterLayer } from "./testLayers.ts"
 
 // Opt-in smoke tests against the real, user-installed zmx binary
 // (mise run test:zmx). They prove the pinned behavioral assumptions — attach
@@ -18,16 +15,10 @@ const enabled = process.env["ATC_ZMX_SMOKE"] === "1"
 afterAll(cleanupTempDirs)
 
 const makeLayer = () =>
-  Zmx.layer.pipe(
-    Layer.provide(
-      testAppConfig({
-        zmxExecutable: process.env["ATC_ZMX_EXECUTABLE"] ?? "zmx",
-        terminalSocketDir: makeShortSocketDir(),
-      }),
-    ),
-    Layer.provide(Subprocess.layer),
-    Layer.provideMerge(BunServices.layer),
-  )
+  zmxAdapterLayer({
+    zmxExecutable: process.env["ATC_ZMX_EXECUTABLE"] ?? "zmx",
+    terminalSocketDir: makeShortSocketDir(),
+  })
 
 describe.skipIf(!enabled)("real zmx smoke (opt-in: mise run test:zmx)", () => {
   it.live(


### PR DESCRIPTION
Terminal resources and transport on top of the ATC-129 adapter core ([ATC-130](https://linear.app/elevenideas/issue/ATC-130), part of [ATC-122](https://linear.app/elevenideas/issue/ATC-122)) — stacked PR 2 of 2, based on #128. **Merge #128 first, then retarget/merge this one.**

## What's here

- **Model + persistence**: migration `0002_terminals` (STRICT, FK `ON DELETE RESTRICT`), `TerminalRepository` (UUIDv7 id, immutable JSON command argv, canonicalized initial working directory, mutable label, `starting`/`live`/`ended` with idempotent tombstoning — the first observation of death wins).
- **Domain service** (`src/terminals.ts`): two-phase create (`starting` row → zmx session launch → `live`; any non-success exit including a client-abort interruption kills the session best-effort and leaves no record), demand-driven reconciliation (startup during layer build resolves live/starting rows and cleans orphan sessions in the private dir; request-time reconcile on list/read/attach only tombstones live rows — rows are snapshotted *before* the inventory so a concurrently completing create can never be falsely tombstoned), delete = kill → verify absence → remove (unverifiable kills fail retryably), `confirmEnded` as the bridge's authoritative-absence check.
- **Contract** (`api.ts` + regenerated `openapi.json`): Terminal CRUD with pinned operation ids, errors `TerminalNotFound` 404 / `ZmxUnavailable` 503 (retryable) / `TerminalLaunchFailed` 422 / `ProjectHasTerminals` 409 (project deletion RESTRICTed while terminals exist), and the WebSocket attach endpoint declared in the contract but `OpenApi.Exclude`d from the document (the Swift generator consumes the artifact directly). Swift client builds and passes against the new contract.
- **WS attach bridge** (`src/terminalAttach.ts`): pre-upgrade rejection with real HTTP statuses (404 / 410 tombstone / 426 no-upgrade), binary frames = bytes, text frames = JSON control (`resize`, app-level `ping`/`pong` — Bun exposes no transport ping), close vocabulary stated once on the contract endpoint (1000 `terminal_ended` only after confirmed absence; 1011 `attach_failed`/`zmx_unavailable`/`ping_timeout` retryable). Bridges are forked into the handler layer's scope because Bun aborts the upgraded request's fiber (found empirically); server shutdown reaps every bridge.
- **CLI**: `atc terminal list|get|create|rename|delete` via the contract client (create takes a trailing exec argv), and `atc terminal attach` in raw mode (Ctrl-] detaches) — pre-flighted over the typed API so unknown/ended terminals get real diagnostics instead of a generic connect error.
- **Tests**: service suite over the fake adapter (including startup recovery: adopt/tombstone/drop/orphan-clean), black-box WS bridge suite against a spawned serve with `ATC_ZMX_EXECUTABLE` pointed at the fake-zmx wrapper (in-process WS upgrades through the Bun adapter don't complete under vitest — and this exercises the real adapter + PTY + bridge end to end), CLI black-box additions including an attach e2e, and an opt-in compiled restart-recovery suite against real zmx (`mise run -C app-server test:zmx`): terminals survive a server restart, orphans are cleaned, attach works against a recovered session.

## Notable empirical findings encoded here

- Bun never completes a graceful `server.stop()` after a **server-initiated** WS close; the server layer now bounds graceful shutdown at 2s (comment in `server.ts`).
- Bun aborts the upgraded request's fiber (`ClientAbort`), so the bridge cannot live in the request effect.

## Review process

Implemented, then adversarially reviewed by two independent reviewers (correctness, simplicity); all majors fixed: reconcile row/inventory ordering (falsely-tombstoned concurrent create, reproduced), interrupted-create cleanup (invisible `starting` rows blocking project deletion, reproduced end-to-end), CLI attach diagnostics, plus ~30 smaller items (OpenApi.Exclude instead of a hand-rolled stripper, repository signature honesty, shared test helpers, temp-dir tracking). Known accepted gaps: `deleteProject`'s count-then-delete is not transactional (a racing create falls back to the FK RESTRICT defect — single-user app), and the bounded outbox cannot apply true send-backpressure because Bun's WS writer exposes none (memory stays bounded via the sliding PTY buffer; dead clients reaped by ping timeout).

https://claude.ai/code/session_01GwZRRGJnPmgbTnSNwuBT3j