### PR TITLE
ATC-131: Reframe the CLI as an agent gateway over the canonical API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,10 +60,13 @@ that:
 The server stands on its own and is meant as a flexible resource that other
 apps can connect to and be built on top of. The Web UI is more admin interface
 than API client. It's meant as a place to manage all aspects of the server and
-document the CLI and API. The CLI is a thin client of the API; its purpose is
-to give agents and scripts access to the app's functionality. Design its
-command surface for that job — it does not need to mirror the API
-operation-for-operation, and no tooling should enforce such a mapping.
+document the CLI and API. The HTTP API is the complete canonical App Server
+interface; the CLI is an agent gateway over it — `atc api` gives complete
+access to every API operation, and a named command earns its place only by composing
+a workflow, needing local process/filesystem/TTY/streaming behavior, or
+materially improving on supplying raw JSON, never by merely renaming an
+endpoint. CLI commands never duplicate server domain logic, and no tooling
+should enforce an API-to-CLI mapping.
 
 ## The ways to hurt yourself
 

--- a/app-server/README.md
+++ b/app-server/README.md
@@ -32,10 +32,10 @@ naming the offending source — never a partial boot.
 Paths follow one XDG rule on every platform (macOS included), honoring `XDG_*`
 overrides:
 
-| Location    | Default                     | Holds                                       |
-| ----------- | --------------------------- | ------------------------------------------- |
-| Config file | `~/.config/atc/config.toml` | Settings (TOML, camelCase)                  |
-| Data dir    | `~/.local/share/atc/`       | SQLite database (`atc.db`)                  |
+| Location    | Default                     | Holds                                            |
+| ----------- | --------------------------- | ------------------------------------------------ |
+| Config file | `~/.config/atc/config.toml` | Settings (TOML, camelCase)                       |
+| Data dir    | `~/.local/share/atc/`       | SQLite database (`atc.db`)                       |
 | State dir   | `~/.local/state/atc/`       | JSON log (`atc.log`), zmx sockets (`terminals/`) |
 
 Environment variables are flat `ATC_<KEY>`: `ATC_PORT`, `ATC_LOG_LEVEL`,
@@ -51,37 +51,39 @@ bundle — install it yourself. It resolves from `ATC_ZMX_EXECUTABLE` or
 ## CLI
 
 `atc serve` runs the server (it creates and migrates the database on boot).
-Everything else is a client. Run `atc --help` for the current command surface;
-the groups are:
+Everything else is a client of the HTTP API, which is the complete canonical
+interface: `atc api <method> <path>` (GET, POST, PUT, PATCH, DELETE) reaches
+every operation, and curated commands exist only where they add local
+behavior (relative-path resolution, TTY attach, `--yes` delete guards). Run
+`atc --help` for the command surface and `atc capabilities --json` for the
+machine-readable summary.
 
-| Command   | Purpose                                                          |
-| --------- | ---------------------------------------------------------------- |
-| `health`  | Liveness of a running server                                      |
-| `version` | Server build metadata and `apiVersion`                            |
-| `project` | Projects CRUD (`list`, `get`, `create`, `update`, `delete`)       |
-| `terminal`| Durable project-scoped terminals (`list`, `get`, `create`, `rename`, `delete`, `attach`) |
-| `fs`      | Read-only filesystem checks on the server host                    |
+API-backed commands take zero connection flags — `ATC_ENDPOINT` (a full base
+URL, set automatically in the environment of ATC-launched terminal sessions)
+wins when present; otherwise they derive `http://127.0.0.1:<port>` from the
+same settled configuration the server reads, so port changes just work.
+Relative directory arguments resolve against the caller's working directory
+before the API (which takes absolute paths only) sees them. `atc --version`
+reports this executable's own version; `atc version` reports the version of a
+running server.
 
-API-backed commands take zero connection flags — they derive
-`http://127.0.0.1:<port>` from the same settled configuration the server reads,
-so port changes just work. Relative directory arguments resolve against the
-caller's working directory before the API (which takes absolute paths only)
-sees them. `atc --version` reports this executable's own version; `atc version`
-reports the version of a running server.
-
-Success prints the JSON payload on stdout and exits `0`. Failures exit `1`:
-config/request failures print one `atc <command>: …` diagnostic line on stderr;
-invalid usage prints an `ERROR` block on stderr (help goes to stdout).
-`atc terminal attach` is the one exception — it bridges the local TTY onto the
-WebSocket attach endpoint in raw mode (detach with `Ctrl-]`).
+API-backed commands print the JSON payload on stdout and exit `0` (empty
+responses print nothing; `atc context` and `atc capabilities` print text by
+default and JSON with `--json`). Failures exit `1`: config/request failures
+print one `atc <command>: …` diagnostic line on stderr (`atc api` also
+relays the server's JSON error body there); invalid usage prints an `ERROR`
+block on stderr (help goes to stdout). `atc terminal attach` is the one
+exception — it bridges the local TTY onto the WebSocket attach endpoint in
+raw mode (detach with `Ctrl-]`).
 
 ## API
 
 Public HTTP routes are versioned under `/api/v1`. The contract module
 (`src/api.ts`) is the single source of truth; the generated
 [`openapi.json`](openapi.json) is the readable inventory of every endpoint and
-schema. Regenerate it with `mise run openapi` after any contract change — never
-edit it by hand. It is symlinked into `packages/ATCKit` to generate the Swift
+schema, and a running server serves the identical document at
+`GET /openapi.json`. Regenerate it with `mise run openapi` after any contract
+change — never edit it by hand. It is symlinked into `packages/ATCKit` to generate the Swift
 client, so the server, the TypeScript client (`src/client.ts`), and the Swift
 client all derive from the same definition.
 

--- a/app-server/src/cli.ts
+++ b/app-server/src/cli.ts
@@ -1,13 +1,12 @@
 import { BunHttpClient } from "@effect/platform-bun"
-import { Console, Effect, Layer, Option, Runtime, Schema } from "effect"
-import type { FileSystem } from "effect"
+import { Console, Effect, FileSystem, Layer, Option, Runtime, Schema } from "effect"
 import { Argument, Command, Flag } from "effect/unstable/cli"
-import type { HttpClient } from "effect/unstable/http"
+import { HttpClient, HttpClientRequest } from "effect/unstable/http"
 import * as path from "node:path"
 import * as AttachClient from "./attachClient.ts"
 import { attachUrl, CLOSE_DETACH } from "./attachProtocol.ts"
 import * as Client from "./client.ts"
-import { AppConfig, ConfigLoadError, layer as appConfigLayer } from "./config.ts"
+import { AppConfig, ConfigLoadError, CONTEXT_VARIABLES, layer as appConfigLayer } from "./config.ts"
 import * as Directories from "./directories.ts"
 import * as Logging from "./logging.ts"
 import * as Persistence from "./persistence.ts"
@@ -70,9 +69,12 @@ const serve = Command.make("serve", { port }, ({ port }) =>
   Effect.gen(function* () {
     const config = yield* AppConfig
     // The flag level of the precedence rule: flags > env > file > defaults.
-    const effectivePort = Option.getOrElse(port, () => config.port)
+    // The override is folded back into the AppConfig the server stack sees,
+    // so consumers of the settled port (e.g. the zmx adapter's ATC_ENDPOINT
+    // injection) always read the port actually being served.
+    const effective = { ...config, port: Option.getOrElse(port, () => config.port) }
     yield* Layer.launch(
-      Server.layer({ port: effectivePort }).pipe(
+      Server.layer({ port: effective.port }).pipe(
         Layer.provide(Terminals.layer),
         Layer.provide([
           ProjectRepository.layer,
@@ -83,7 +85,7 @@ const serve = Command.make("serve", { port }, ({ port }) =>
         Layer.provide(Persistence.layer),
         Layer.provide(Logging.layer),
       ),
-    )
+    ).pipe(Effect.provideService(AppConfig, effective))
   }).pipe(
     Effect.provide(appConfigLayer),
     Effect.catch((error) => failReported(`atc serve: ${describeError(error)}`)),
@@ -95,14 +97,17 @@ const serve = Command.make("serve", { port }, ({ port }) =>
   ),
 ).pipe(Command.withDescription("Run the App Server in the foreground until interrupted"))
 
-// Base-URL resolution seam for client commands: derived from the settled
-// configuration (ATC_PORT > config.toml port > default) — the same pipeline
-// the server reads, so port changes just work with zero connection flags.
-// Remote endpoint addressing (endpoint + token) is later, auth-pass work and
-// should change only this resolution, not the commands.
+// Base-URL resolution seam for client commands: ATC_ENDPOINT (set in the
+// environment of processes ATC launches) wins; otherwise the URL derives
+// from the settled configuration (ATC_PORT > config.toml port > default) —
+// the same pipeline the server reads, so port changes just work with zero
+// connection flags. Remote endpoint addressing (endpoint + token) is later,
+// auth-pass work and should change only this resolution, not the commands.
 const resolveBaseUrl = Effect.gen(function* () {
   const config = yield* AppConfig
-  return new URL(`http://127.0.0.1:${config.port}`)
+  return config.endpoint !== undefined
+    ? new URL(config.endpoint)
+    : new URL(`http://127.0.0.1:${config.port}`)
 })
 
 /**
@@ -112,7 +117,7 @@ const resolveBaseUrl = Effect.gen(function* () {
  */
 const withCliContext = <E>(
   diagnosticName: string,
-  effect: Effect.Effect<void, E, HttpClient.HttpClient | AppConfig>,
+  effect: Effect.Effect<void, E, HttpClient.HttpClient | AppConfig | FileSystem.FileSystem>,
 ): Effect.Effect<void, ReportedError, FileSystem.FileSystem> =>
   effect.pipe(
     Effect.provide([BunHttpClient.layer, appConfigLayer]),
@@ -384,7 +389,207 @@ const fs = Command.make("fs").pipe(
   Command.withSubcommands([fsCheck]),
 )
 
+// --- The agent gateway (ATC-131) ---------------------------------------
+//
+// The HTTP API is the complete, canonical App Server interface; `atc api`
+// gives agents and scripts method-and-path access to all of it, so a curated
+// command only exists where it genuinely improves on raw API access. The
+// gateway is a plain HTTP passthrough over the same base-URL seam the
+// curated commands use — the contract-derived client exposes only typed
+// per-operation functions, and the server validates every request against
+// the contract regardless of origin.
+
+const API_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const
+
+const methodArgument = Argument.string("method").pipe(
+  Argument.mapTryCatch(
+    (raw) => {
+      const method = raw.toUpperCase() as (typeof API_METHODS)[number]
+      if (!API_METHODS.includes(method)) throw new Error()
+      return method
+    },
+    () => `method must be one of ${API_METHODS.join(", ")} (case-insensitive)`,
+  ),
+  Argument.withDescription(`HTTP method: ${API_METHODS.join(", ")} (case-insensitive)`),
+)
+
+/**
+ * Join a server-relative path onto the configured base URL. Strict and
+ * fallible: network-path forms (`//host`, and `/\host` — the URL parser
+ * treats backslash as slash) would silently re-target the request to
+ * another origin, so they are rejected up front and the resolved origin is
+ * verified unchanged. An endpoint with a path prefix (e.g.
+ * `http://host:1234/prefix`) keeps it, matching the typed client's joining.
+ */
+const requestUrl = (baseUrl: URL, requestPath: string): Effect.Effect<URL, Error> => {
+  if (!requestPath.startsWith("/") || /^\/[/\\]/.test(requestPath)) {
+    return Effect.fail(
+      new Error(
+        `path must be server-relative (start with /, but not // or /\\), got "${requestPath}"`,
+      ),
+    )
+  }
+  const prefix = baseUrl.pathname.replace(/\/$/, "")
+  return Effect.try({
+    try: () => new URL(baseUrl.origin + prefix + requestPath),
+    catch: () => new Error(`cannot build a request URL from "${requestPath}"`),
+  }).pipe(
+    Effect.filterOrFail(
+      (url) => url.origin === baseUrl.origin,
+      () => new Error(`path "${requestPath}" escapes the configured endpoint`),
+    ),
+  )
+}
+
+/** Request body source: a file path, or "-" for stdin. */
+const readRequestBody = (source: string) =>
+  source === "-"
+    ? Effect.tryPromise({
+        try: () => Bun.stdin.text(),
+        catch: () => new Error("cannot read the request body from stdin"),
+      })
+    : Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem
+        return yield* fileSystem.readFileString(source)
+      })
+
+const api = Command.make(
+  "api",
+  {
+    method: methodArgument,
+    path: Argument.string("path").pipe(
+      Argument.withDescription("Server-relative request path (e.g. /api/v1/projects)"),
+    ),
+    input: Flag.string("input").pipe(
+      Flag.optional,
+      Flag.withDescription("JSON request body: a file path, or - to read stdin"),
+    ),
+  },
+  ({ method, path: requestPath, input }) =>
+    withCliContext(
+      "api",
+      Effect.gen(function* () {
+        const baseUrl = yield* resolveBaseUrl
+        const url = yield* requestUrl(baseUrl, requestPath)
+        const client = yield* HttpClient.HttpClient
+        const body = Option.isSome(input) ? yield* readRequestBody(input.value) : undefined
+        const request = HttpClientRequest.make(method)(url, {
+          acceptJson: true,
+        }).pipe((base) =>
+          body === undefined ? base : HttpClientRequest.bodyText(base, body, "application/json"),
+        )
+        const response = yield* client.execute(request)
+        const text = yield* response.text
+        if (response.status >= 200 && response.status < 300) {
+          // Success bodies pass through unchanged (plus the trailing
+          // newline); an empty response prints nothing.
+          if (text !== "") yield* Console.log(text)
+          return
+        }
+        // API failures: the machine-readable error body, then the one-line
+        // diagnostic — both on stderr, exit 1 like every other failure.
+        if (text !== "") yield* Console.error(text)
+        return yield* Effect.fail(new Error(`server returned HTTP ${response.status}`))
+      }),
+    ),
+).pipe(
+  Command.withDescription(
+    "Send one request to any App Server API endpoint (the generic gateway; see /openapi.json)",
+  ),
+)
+
+const jsonFlag = Flag.boolean("json").pipe(
+  Flag.withDescription("Emit machine-readable JSON instead of text"),
+)
+
+const context = Command.make("context", { json: jsonFlag }, ({ json }) =>
+  withCliContext(
+    "context",
+    Effect.gen(function* () {
+      const config = yield* AppConfig
+      // Reported in vocabulary order, present variables only — absent ones
+      // are omitted entirely, never invented.
+      if (json) {
+        yield* Console.log(JSON.stringify(config.context, null, 2))
+        return
+      }
+      for (const name of CONTEXT_VARIABLES) {
+        const value = config.context[name]
+        if (value !== undefined) yield* Console.log(`${name}=${value}`)
+      }
+    }),
+  ),
+).pipe(
+  Command.withDescription(
+    "Report the ATC_* agent-context variables present in this process's environment",
+  ),
+)
+
+/**
+ * The stable capability description for agents. Version the shape: additions
+ * bump nothing, breaking changes bump capabilitiesVersion.
+ */
+const CAPABILITIES = {
+  capabilitiesVersion: 1,
+  api: {
+    command: "atc api <method> <path> [--input <file|->]",
+    description:
+      "Complete access to the canonical App Server HTTP API: every operation via GET, POST, PUT, PATCH, or DELETE, JSON body from a file or stdin, the raw JSON response on stdout.",
+    example: "atc api GET /api/v1/projects",
+  },
+  openapi: {
+    path: "/openapi.json",
+    description:
+      "The full OpenAPI document (every operation and schema), served by the App Server.",
+    example: "atc api GET /openapi.json",
+  },
+  context: {
+    command: "atc context --json",
+    description: "The ATC_* context variables present in this process.",
+    variables: CONTEXT_VARIABLES,
+  },
+  workflows: [
+    { command: "atc serve", description: "Run the App Server in the foreground." },
+    {
+      command: "atc project create --name <name> --directory <dir>",
+      description: "Create a project (relative directories resolve against the caller's cwd).",
+    },
+    {
+      command: "atc terminal create --project <id> [command...]",
+      description: "Create a durable terminal and start its session immediately.",
+    },
+    {
+      command: "atc terminal attach <terminal-id>",
+      description: "Attach the local TTY to a live terminal session (detach with Ctrl-]).",
+    },
+  ],
+} as const
+
+const capabilities = Command.make("capabilities", { json: jsonFlag }, ({ json }) =>
+  json
+    ? Console.log(JSON.stringify(CAPABILITIES, null, 2))
+    : Console.log(
+        [
+          `${CAPABILITIES.api.command} — ${CAPABILITIES.api.description}`,
+          `${CAPABILITIES.openapi.example} — ${CAPABILITIES.openapi.description}`,
+          `${CAPABILITIES.context.command} — ${CAPABILITIES.context.description}`,
+          ...CAPABILITIES.workflows.map((w) => `${w.command} — ${w.description}`),
+        ].join("\n"),
+      ),
+).pipe(Command.withDescription("Describe the CLI's agent-facing capabilities (stable, versioned)"))
+
 export const atc = Command.make("atc").pipe(
   Command.withDescription("ATC App Server"),
-  Command.withSubcommands([serve, health, version, project, terminal, fs, smoke]),
+  Command.withSubcommands([
+    serve,
+    api,
+    context,
+    capabilities,
+    health,
+    version,
+    project,
+    terminal,
+    fs,
+    smoke,
+  ]),
 )

--- a/app-server/src/config.ts
+++ b/app-server/src/config.ts
@@ -23,6 +23,23 @@ import { DEFAULT_PORT } from "./api.ts"
 /** Environment shape consumed by the pipeline; tests inject their own. */
 export type Env = Record<string, string | undefined>
 
+/**
+ * The stable agent-context variable vocabulary (ATC-131). ATC sets these in
+ * the environment of processes it launches (terminal sessions above all);
+ * `atc context` reports whichever are present. ATC_WORKSPACE_ID and
+ * ATC_THREAD_ID are reserved for resources that do not exist yet — the names
+ * are fixed now so consumers never have to migrate.
+ */
+export const CONTEXT_VARIABLES = [
+  "ATC_ENDPOINT",
+  "ATC_PROJECT_ID",
+  "ATC_WORKSPACE_ID",
+  "ATC_THREAD_ID",
+  "ATC_TERMINAL_ID",
+] as const
+
+export type ContextVariable = (typeof CONTEXT_VARIABLES)[number]
+
 /** Invalid or malformed configuration. `source` names the offending origin. */
 export class ConfigLoadError extends Schema.TaggedErrorClass<ConfigLoadError>()("ConfigLoadError", {
   source: Schema.String,
@@ -39,6 +56,15 @@ export class AppConfig extends Context.Service<
   {
     /** TCP port the server listens on / the CLI connects to. */
     readonly port: number
+    /**
+     * App Server base URL from ATC_ENDPOINT (set for processes ATC
+     * launches); undefined means "derive from the local port". Environment
+     * only — never a config-file key, because it describes the launching
+     * process's context, not the user's configuration.
+     */
+    readonly endpoint: string | undefined
+    /** The ATC_* agent-context variables present in this process. */
+    readonly context: Readonly<Partial<Record<ContextVariable, string>>>
     /** Minimum log level. */
     readonly logLevel: LogLevel.LogLevel
     /** Config file path that was consulted (it may not exist). */
@@ -215,6 +241,27 @@ export const load = (
       )
     }
 
+    // Agent context is captured verbatim (present means non-empty). Only
+    // ATC_ENDPOINT is interpreted, so only it is validated: a malformed
+    // value would otherwise surface as a confusing request failure.
+    const context: Partial<Record<ContextVariable, string>> = {}
+    for (const name of CONTEXT_VARIABLES) {
+      const value = nonEmpty(env[name])
+      if (value !== undefined) context[name] = value
+    }
+    const endpoint = context.ATC_ENDPOINT
+    if (endpoint !== undefined) {
+      const parsed = URL.canParse(endpoint) ? new URL(endpoint) : undefined
+      if (parsed === undefined || (parsed.protocol !== "http:" && parsed.protocol !== "https:")) {
+        return yield* Effect.fail(
+          new ConfigLoadError({
+            source: "ATC_ENDPOINT",
+            message: `endpoint must be an http(s) URL, got "${endpoint}"`,
+          }),
+        )
+      }
+    }
+
     const dataDir = yield* requireAbsolute(
       settings.dataDir,
       "dataDir",
@@ -227,6 +274,8 @@ export const load = (
     )
     return {
       port: settings.port,
+      endpoint,
+      context,
       logLevel: settings.logLevel,
       configFile,
       dataDir,

--- a/app-server/src/server.ts
+++ b/app-server/src/server.ts
@@ -1,10 +1,22 @@
 import { BunHttpServer } from "@effect/platform-bun"
 import { Layer } from "effect"
-import { HttpMiddleware, HttpRouter } from "effect/unstable/http"
+import { HttpMiddleware, HttpRouter, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { Api } from "./api.ts"
 import { V1Handlers } from "./handlers.ts"
 import * as LocalTrust from "./localTrust.ts"
+import { openApiJson } from "./openapi.ts"
+
+// OpenAPI discovery (ATC-131): the contract-derived document at a stable
+// path. Served from the canonical serialization (openapi.ts) so the response
+// is byte-identical to the checked-in openapi.json — deliberately not
+// HttpApiBuilder's openapiPath option, which would emit the pre-transform
+// document and drift from the artifact.
+const openApiRoute = HttpRouter.add(
+  "GET",
+  "/openapi.json",
+  HttpServerResponse.text(openApiJson, { contentType: "application/json" }),
+)
 
 /**
  * All HTTP routes with the local-trust guard applied, independent of any
@@ -13,6 +25,7 @@ import * as LocalTrust from "./localTrust.ts"
  */
 export const routes = Layer.mergeAll(
   HttpApiBuilder.layer(Api).pipe(Layer.provide(V1Handlers)),
+  openApiRoute,
   LocalTrust.middleware,
 )
 

--- a/app-server/src/zmxAdapter.ts
+++ b/app-server/src/zmxAdapter.ts
@@ -1,7 +1,7 @@
 import { Effect, FileSystem, Layer, Schema, Stream } from "effect"
 import type { Duration } from "effect"
 import * as path from "node:path"
-import { AppConfig } from "./config.ts"
+import { AppConfig, CONTEXT_VARIABLES } from "./config.ts"
 import { resolveExecutable as resolveExecutablePath, Subprocess } from "./subprocess.ts"
 import type { SubprocessError } from "./subprocess.ts"
 import { ZmxUnavailable } from "./api.ts"
@@ -87,10 +87,16 @@ export const parseSessionList = (stdout: ReadonlyArray<string>): Array<SessionIn
 
 /**
  * The environment for every zmx child: the parent environment with the
- * mandatory scrubs applied and ATC's private socket directory pinned.
+ * mandatory scrubs applied, ATC's private socket directory pinned, and this
+ * server's ATC_ENDPOINT injected so agents inside launched sessions can
+ * reach the API (ATC-131 context propagation — no secrets, just the URL).
+ * Every inherited ATC_* context variable is scrubbed first: a server running
+ * inside another ATC session would otherwise leak that session's ids into
+ * every terminal it launches, and stale context is worse than none.
  */
 export const zmxChildEnv = (
   socketDir: string,
+  endpoint: string,
   parent: Record<string, string | undefined> = process.env,
 ): Record<string, string> => {
   const env: Record<string, string> = {}
@@ -99,8 +105,10 @@ export const zmxChildEnv = (
   }
   delete env["ZMX_SESSION"]
   delete env["ZMX_SESSION_PREFIX"]
+  for (const name of CONTEXT_VARIABLES) delete env[name]
   env["ZMX_DIR"] = socketDir
   env["TERM"] = SESSION_TERM_TYPE
+  env["ATC_ENDPOINT"] = endpoint
   return env
 }
 
@@ -136,7 +144,7 @@ export const layerWith = (options: ZmxOptions) =>
       yield* fs.makeDirectory(socketDir, { recursive: true, mode: 0o700 })
       yield* fs.chmod(socketDir, 0o700)
 
-      const childEnv = zmxChildEnv(socketDir)
+      const childEnv = zmxChildEnv(socketDir, `http://127.0.0.1:${config.port}`)
 
       // Explicit resolution, never implicit (the shared resolveExecutable
       // rule), memoized on success — a resolved install does not move mid-run.

--- a/app-server/test/blackbox.ts
+++ b/app-server/test/blackbox.ts
@@ -67,15 +67,23 @@ export const spawnServe = (
 /**
  * Run `<command> ...args` to completion, capturing stdout, stderr, and exit
  * code. `cwd` is required: compiled-artifact tests must run outside the
- * repository, so no caller should silently inherit the repo cwd.
+ * repository, so no caller should silently inherit the repo cwd. `stdin`
+ * (when given) is fed to the child and closed.
  */
 export const runCli = async (
   command: ReadonlyArray<string>,
   args: ReadonlyArray<string>,
   cwd: string,
   env: Record<string, string | undefined> = process.env,
+  stdin?: string,
 ) => {
-  const proc = Bun.spawn([...command, ...args], { cwd, env, stdout: "pipe", stderr: "pipe" })
+  const proc = Bun.spawn([...command, ...args], {
+    cwd,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+    ...(stdin === undefined ? {} : { stdin: Buffer.from(stdin) }),
+  })
   const [stdout, stderr, exitCode] = await Promise.all([
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),

--- a/app-server/test/cli.blackbox.test.ts
+++ b/app-server/test/cli.blackbox.test.ts
@@ -1,10 +1,10 @@
-import { existsSync, mkdtempSync, rmSync } from "node:fs"
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterAll, beforeAll, describe, expect, test } from "vitest"
 import packageJson from "../package.json"
-import { appServerRoot, cleanupTempDirs, runCli } from "./blackbox.ts"
-import { startFakeZmxServer } from "./testLayers.ts"
+import { appServerRoot, cleanupTempDirs, makeTerminal, runCli } from "./blackbox.ts"
+import { startFakeZmxServer, withFakeZmxServer } from "./testLayers.ts"
 
 // Black-box tests of the client-backed CLI commands: exact stdout, stderr,
 // and exit codes, against a real `atc serve` spawned from source.
@@ -21,8 +21,8 @@ let serverPort: number
 let env: Record<string, string | undefined>
 let dataRoot: string
 
-const cli = (args: ReadonlyArray<string>, extraEnv: Record<string, string> = {}) =>
-  runCli([process.execPath, "src/main.ts"], args, appServerRoot, { ...env, ...extraEnv })
+const cli = (args: ReadonlyArray<string>, extraEnv: Record<string, string> = {}, stdin?: string) =>
+  runCli([process.execPath, "src/main.ts"], args, appServerRoot, { ...env, ...extraEnv }, stdin)
 
 let server: Awaited<ReturnType<typeof startFakeZmxServer>>
 
@@ -275,5 +275,262 @@ describe("atc project / atc fs (black box)", () => {
     const missing = await cli(["fs", "check", join(scratch, "does-not-exist")])
     expect(missing.exitCode).toBe(0)
     expect((JSON.parse(missing.stdout) as { state: string }).state).toBe("missing")
+  }, 30_000)
+})
+
+// The five stable context variables, all explicitly unset (empty means
+// unset), so gateway tests never depend on the developer's environment.
+const noContext = {
+  ATC_ENDPOINT: "",
+  ATC_PROJECT_ID: "",
+  ATC_WORKSPACE_ID: "",
+  ATC_THREAD_ID: "",
+  ATC_TERMINAL_ID: "",
+}
+
+describe("atc api / context / capabilities (black box)", () => {
+  test("api GET passes the response body through unchanged", async () => {
+    const result = await cli(["api", "GET", "/api/v1/health"])
+    // The server's compact JSON, undecorated (plus the trailing newline).
+    expect(result.stdout).toBe('{"status":"ok"}\n')
+    expect(result.stderr).toBe("")
+    expect(result.exitCode).toBe(0)
+
+    // Methods are case-insensitive.
+    const lower = await cli(["api", "get", "/api/v1/health"])
+    expect(lower.stdout).toBe('{"status":"ok"}\n')
+    expect(lower.exitCode).toBe(0)
+  })
+
+  test("api sends JSON bodies from a file and from stdin; empty responses print nothing", async () => {
+    const bodyFile = join(scratch, "create-project.json")
+    await Bun.write(
+      bodyFile,
+      JSON.stringify({ name: "FromFile", defaultWorkingDirectory: scratch }),
+    )
+    const fromFile = await cli(["api", "POST", "/api/v1/projects", "--input", bodyFile])
+    expect(fromFile.stderr).toBe("")
+    expect(fromFile.exitCode).toBe(0)
+    const fileProject = JSON.parse(fromFile.stdout) as { id: string; name: string }
+    expect(fileProject.name).toBe("FromFile")
+
+    const fromStdin = await cli(
+      ["api", "POST", "/api/v1/projects", "--input", "-"],
+      {},
+      JSON.stringify({ name: "FromStdin", defaultWorkingDirectory: scratch }),
+    )
+    expect(fromStdin.exitCode).toBe(0)
+    const stdinProject = JSON.parse(fromStdin.stdout) as { id: string; name: string }
+    expect(stdinProject.name).toBe("FromStdin")
+
+    // DELETE answers 204: empty stdout, empty stderr, exit 0.
+    for (const id of [fileProject.id, stdinProject.id]) {
+      const deleted = await cli(["api", "DELETE", `/api/v1/projects/${id}`])
+      expect(deleted.stdout).toBe("")
+      expect(deleted.stderr).toBe("")
+      expect(deleted.exitCode).toBe(0)
+    }
+  }, 30_000)
+
+  test("api reports HTTP failures with the error body on stderr and exits 1", async () => {
+    const result = await cli(["api", "GET", "/api/v1/projects/nope"])
+    expect(result.stdout).toBe("")
+    expect(result.stderr).toContain('"_tag":"ProjectNotFound"')
+    expect(result.stderr).toContain("atc api: server returned HTTP 404")
+    expect(result.exitCode).toBe(1)
+  })
+
+  test("api transport failures are one stderr line and exit 1", async () => {
+    const result = await cli(["api", "GET", "/api/v1/health"], { ATC_PORT: "1" })
+    expect(result.stdout).toBe("")
+    expect(result.stderr).toMatch(/^atc api: \S/)
+    expect(result.stderr.trim().split("\n")).toHaveLength(1)
+    expect(result.exitCode).toBe(1)
+  })
+
+  test("api rejects paths that are not server-relative or would re-target the origin", async () => {
+    // Absolute URLs, network-path references (//host), and the backslash
+    // variant the URL parser treats as // must all fail before any request.
+    for (const bad of [
+      "http://evil.example/api/v1/health",
+      "//evil.example/api/v1/health",
+      "/\\evil.example/api/v1/health",
+      "//",
+    ]) {
+      const result = await cli(["api", "GET", bad])
+      expect(result.stdout).toBe("")
+      expect(result.stderr).toMatch(/^atc api: path must be server-relative/)
+      expect(result.exitCode).toBe(1)
+    }
+  })
+
+  test("api rejects unsupported methods as invalid usage", async () => {
+    const result = await cli(["api", "FROB", "/api/v1/health"])
+    expect(result.stderr).toContain("method must be one of GET, POST, PUT, PATCH, DELETE")
+    expect(result.exitCode).toBe(1)
+  })
+
+  test("an ATC_ENDPOINT path prefix is preserved when joining", async () => {
+    // A stand-in server that echoes the request path proves the join keeps
+    // the prefix instead of discarding it the way `new URL("/x", base)` would.
+    const echo = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: (request) => Response.json({ path: new URL(request.url).pathname }),
+    })
+    try {
+      const result = await cli(["api", "GET", "/api/v1/health"], {
+        ATC_ENDPOINT: `http://127.0.0.1:${echo.port}/prefix`,
+      })
+      expect(JSON.parse(result.stdout)).toEqual({ path: "/prefix/api/v1/health" })
+      expect(result.exitCode).toBe(0)
+    } finally {
+      await echo.stop(true)
+    }
+  })
+
+  test("ATC_ENDPOINT beats the configured port at the resolution seam", async () => {
+    // ATC_PORT points nowhere; the endpoint carries the real server.
+    const viaEndpoint = await cli(["health"], {
+      ATC_PORT: "1",
+      ATC_ENDPOINT: `http://127.0.0.1:${serverPort}`,
+    })
+    expect(viaEndpoint.stdout).toBe('{\n  "status": "ok"\n}\n')
+    expect(viaEndpoint.exitCode).toBe(0)
+
+    const malformed = await cli(["health"], { ATC_ENDPOINT: "not a url" })
+    expect(malformed.stderr).toMatch(/^atc health: ATC_ENDPOINT: /)
+    expect(malformed.exitCode).toBe(1)
+  })
+
+  test("context reports present variables only, in vocabulary order", async () => {
+    const absent = await cli(["context"], noContext)
+    expect(absent.stdout).toBe("")
+    expect(absent.stderr).toBe("")
+    expect(absent.exitCode).toBe(0)
+
+    const absentJson = await cli(["context", "--json"], noContext)
+    expect(absentJson.stdout).toBe("{}\n")
+    expect(absentJson.exitCode).toBe(0)
+
+    const partial = await cli(["context"], {
+      ...noContext,
+      ATC_TERMINAL_ID: "t-1",
+      ATC_PROJECT_ID: "p-1",
+    })
+    expect(partial.stdout).toBe("ATC_PROJECT_ID=p-1\nATC_TERMINAL_ID=t-1\n")
+    expect(partial.exitCode).toBe(0)
+
+    const full = await cli(["context", "--json"], {
+      ...noContext,
+      ATC_ENDPOINT: `http://127.0.0.1:${serverPort}`,
+      ATC_PROJECT_ID: "p-1",
+      ATC_WORKSPACE_ID: "w-1",
+      ATC_THREAD_ID: "th-1",
+      ATC_TERMINAL_ID: "t-1",
+    })
+    expect(JSON.parse(full.stdout)).toEqual({
+      ATC_ENDPOINT: `http://127.0.0.1:${serverPort}`,
+      ATC_PROJECT_ID: "p-1",
+      ATC_WORKSPACE_ID: "w-1",
+      ATC_THREAD_ID: "th-1",
+      ATC_TERMINAL_ID: "t-1",
+    })
+    expect(full.exitCode).toBe(0)
+  })
+
+  test("capabilities --json is stable, versioned, machine-readable output", async () => {
+    const result = await cli(["capabilities", "--json"])
+    expect(result.stderr).toBe("")
+    expect(result.exitCode).toBe(0)
+    // The complete v1 shape, pinned: any change here is a compatibility
+    // decision and must either be additive or bump capabilitiesVersion.
+    expect(JSON.parse(result.stdout)).toEqual({
+      capabilitiesVersion: 1,
+      api: {
+        command: "atc api <method> <path> [--input <file|->]",
+        description:
+          "Complete access to the canonical App Server HTTP API: every operation via GET, POST, PUT, PATCH, or DELETE, JSON body from a file or stdin, the raw JSON response on stdout.",
+        example: "atc api GET /api/v1/projects",
+      },
+      openapi: {
+        path: "/openapi.json",
+        description:
+          "The full OpenAPI document (every operation and schema), served by the App Server.",
+        example: "atc api GET /openapi.json",
+      },
+      context: {
+        command: "atc context --json",
+        description: "The ATC_* context variables present in this process.",
+        variables: [
+          "ATC_ENDPOINT",
+          "ATC_PROJECT_ID",
+          "ATC_WORKSPACE_ID",
+          "ATC_THREAD_ID",
+          "ATC_TERMINAL_ID",
+        ],
+      },
+      workflows: [
+        { command: "atc serve", description: "Run the App Server in the foreground." },
+        {
+          command: "atc project create --name <name> --directory <dir>",
+          description: "Create a project (relative directories resolve against the caller's cwd).",
+        },
+        {
+          command: "atc terminal create --project <id> [command...]",
+          description: "Create a durable terminal and start its session immediately.",
+        },
+        {
+          command: "atc terminal attach <terminal-id>",
+          description: "Attach the local TTY to a live terminal session (detach with Ctrl-]).",
+        },
+      ],
+    })
+
+    // The human rendering carries the same content, one line per capability.
+    const text = await cli(["capabilities"])
+    expect(text.exitCode).toBe(0)
+    expect(text.stdout).toContain("atc api")
+  })
+
+  test("launched terminal sessions receive this server's ATC_ENDPOINT", async () => {
+    const project = JSON.parse(
+      (await cli(["project", "create", "--name", "Ctx", "--directory", scratch])).stdout,
+    ) as { id: string }
+    const terminal = JSON.parse(
+      (await cli(["terminal", "create", "--project", project.id])).stdout,
+    ) as { id: string }
+
+    // The fake-zmx session record captures the environment the adapter
+    // launched with; the session name is atc-<uuid without dashes>.
+    const sessionFile = join(server.sandbox.stateDir, `atc-${terminal.id.replaceAll("-", "")}`)
+    const record = JSON.parse(readFileSync(sessionFile, "utf8")) as {
+      env: Record<string, string | undefined>
+    }
+    expect(record.env["ATC_ENDPOINT"]).toBe(`http://127.0.0.1:${serverPort}`)
+
+    await cli(["terminal", "delete", terminal.id, "--yes"])
+    await cli(["project", "delete", project.id, "--yes"])
+  }, 30_000)
+
+  test("serve --port folds the effective port into the injected ATC_ENDPOINT", async () => {
+    // ATC_PORT deliberately disagrees with the --port flag the server is
+    // launched with: the injected endpoint must reflect the flag (the port
+    // actually being served), proving the flag is folded back into the
+    // settled AppConfig rather than read from the environment level.
+    await withFakeZmxServer(
+      async (flagged) => {
+        const terminal = await makeTerminal(flagged.base)
+        const sessionFile = join(
+          flagged.sandbox.stateDir,
+          `atc-${(terminal["id"] as string).replaceAll("-", "")}`,
+        )
+        const record = JSON.parse(readFileSync(sessionFile, "utf8")) as {
+          env: Record<string, string | undefined>
+        }
+        expect(record.env["ATC_ENDPOINT"]).toBe(flagged.base)
+      },
+      { ATC_PORT: "1" },
+    )
   }, 30_000)
 })

--- a/app-server/test/config.test.ts
+++ b/app-server/test/config.test.ts
@@ -166,6 +166,41 @@ describe("configuration", () => {
     }),
   )
 
+  it.effect("ATC_ENDPOINT and the context variables are captured verbatim", () =>
+    Effect.gen(function* () {
+      const config = yield* load({
+        ATC_ENDPOINT: "http://127.0.0.1:9400",
+        ATC_PROJECT_ID: "p-1",
+        // Empty means unset, like every other environment value.
+        ATC_WORKSPACE_ID: "",
+      })
+      assert.strictEqual(config.endpoint, "http://127.0.0.1:9400")
+      assert.deepStrictEqual(config.context, {
+        ATC_ENDPOINT: "http://127.0.0.1:9400",
+        ATC_PROJECT_ID: "p-1",
+      })
+    }),
+  )
+
+  it.effect("absent context means no endpoint and an empty context", () =>
+    Effect.gen(function* () {
+      const config = yield* load({})
+      assert.strictEqual(config.endpoint, undefined)
+      assert.deepStrictEqual(config.context, {})
+    }),
+  )
+
+  it.effect("a malformed ATC_ENDPOINT fails naming the variable", () =>
+    Effect.gen(function* () {
+      const malformed = yield* loadError({ ATC_ENDPOINT: "not a url" })
+      assert.strictEqual(malformed.source, "ATC_ENDPOINT")
+      assert.include(malformed.message, "http(s)")
+      // Non-HTTP schemes are equally unusable as a base URL.
+      const scheme = yield* loadError({ ATC_ENDPOINT: "file:///tmp/api" })
+      assert.strictEqual(scheme.source, "ATC_ENDPOINT")
+    }),
+  )
+
   it.effect("a relative data directory is rejected (never cwd-dependent)", () =>
     Effect.gen(function* () {
       const error = yield* loadError({ ATC_DATA_DIR: "relative/data" })

--- a/app-server/test/fixtures/fake-zmx.ts
+++ b/app-server/test/fixtures/fake-zmx.ts
@@ -94,6 +94,7 @@ switch (command) {
           ZMX_SESSION_PREFIX: process.env["ZMX_SESSION_PREFIX"],
           ZMX_DIR: process.env["ZMX_DIR"],
           TERM: process.env["TERM"],
+          ATC_ENDPOINT: process.env["ATC_ENDPOINT"],
         },
       }
       fs.writeFileSync(sessionFile(name), JSON.stringify(record))

--- a/app-server/test/localTrust.test.ts
+++ b/app-server/test/localTrust.test.ts
@@ -2,6 +2,7 @@ import { assert, describe, it } from "@effect/vitest"
 import { BunServices } from "@effect/platform-bun"
 import { Effect, Layer } from "effect"
 import { isLoopbackHost, isLoopbackOrigin } from "../src/localTrust.ts"
+import { openApiJson } from "../src/openapi.ts"
 import * as Server from "../src/server.ts"
 import { freePort } from "./blackbox.ts"
 import { TestBuildInfoLayer } from "./testBuildInfo.ts"
@@ -21,7 +22,11 @@ const withServer = <A, E, R>(run: (port: number) => Effect.Effect<A, E, R>) =>
   }).pipe(Effect.scoped, Effect.provide(BunServices.layer))
 
 /** Raw HTTP exchange so tests can send arbitrary Host headers (fetch can't). */
-const rawStatus = (port: number, headers: ReadonlyArray<string>): Promise<number> =>
+const rawStatus = (
+  port: number,
+  headers: ReadonlyArray<string>,
+  path = "/api/v1/health",
+): Promise<number> =>
   new Promise((resolve, reject) => {
     let data = ""
     Bun.connect({
@@ -30,7 +35,7 @@ const rawStatus = (port: number, headers: ReadonlyArray<string>): Promise<number
       socket: {
         open(socket) {
           socket.write(
-            ["GET /api/v1/health HTTP/1.1", ...headers, "Connection: close", "", ""].join("\r\n"),
+            [`GET ${path} HTTP/1.1`, ...headers, "Connection: close", "", ""].join("\r\n"),
           )
         },
         data(socket, chunk) {
@@ -96,6 +101,21 @@ describe("hardened listener", () => {
         assert.strictEqual(await rawStatus(port, ["Host: evil.example"]), 403)
         assert.strictEqual(await rawStatus(port, ["Host: 127.0.0.1.evil.example"]), 403)
         assert.strictEqual(await rawStatus(port, [`Host: 127.0.0.1:${port}`]), 200)
+      }),
+    ),
+  )
+
+  it.effect("serves the canonical OpenAPI document at /openapi.json under the same guard", () =>
+    withServer((port) =>
+      Effect.promise(async () => {
+        const response = await fetch(`http://127.0.0.1:${port}/openapi.json`)
+        assert.strictEqual(response.status, 200)
+        assert.include(response.headers.get("content-type") ?? "", "application/json")
+        // Byte-identical to the canonical serialization — the same text the
+        // checked-in openapi.json artifact holds (openapi.test.ts pins that).
+        assert.strictEqual(await response.text(), openApiJson)
+
+        assert.strictEqual(await rawStatus(port, ["Host: evil.example"], "/openapi.json"), 403)
       }),
     ),
   )

--- a/app-server/test/terminalAdapter.test.ts
+++ b/app-server/test/terminalAdapter.test.ts
@@ -70,12 +70,17 @@ describe("parseSessionList", () => {
 })
 
 describe("zmxChildEnv", () => {
-  it("scrubs the nested-client traps and pins ZMX_DIR and TERM", () => {
-    const env = Zmx.zmxChildEnv("/sockets", {
+  it("scrubs the nested-client traps and stale ATC_* context; pins ZMX_DIR, TERM, ATC_ENDPOINT", () => {
+    const env = Zmx.zmxChildEnv("/sockets", "http://127.0.0.1:7332", {
       PATH: "/usr/bin",
       HOME: "/home/u",
       ZMX_SESSION: "evil",
       ZMX_SESSION_PREFIX: "pre-",
+      // A server running inside another ATC session inherits that session's
+      // context; none of it may leak into sessions this server launches.
+      ATC_ENDPOINT: "http://127.0.0.1:9999",
+      ATC_PROJECT_ID: "stale-project",
+      ATC_TERMINAL_ID: "stale-terminal",
       EMPTY: undefined,
     })
     assert.deepStrictEqual(env, {
@@ -83,6 +88,7 @@ describe("zmxChildEnv", () => {
       HOME: "/home/u",
       ZMX_DIR: "/sockets",
       TERM: "xterm-256color",
+      ATC_ENDPOINT: "http://127.0.0.1:7332",
     })
   })
 })

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -65,6 +65,8 @@ export const TestRepositoryLayers = makeTestServiceLayers().layer
 export const testAppConfig = (overrides: Partial<AppConfig["Service"]>): Layer.Layer<AppConfig> =>
   Layer.succeed(AppConfig)({
     port: 0,
+    endpoint: undefined,
+    context: {},
     logLevel: "Info",
     configFile: "/dev/null",
     dataDir: "/tmp",


### PR DESCRIPTION
Implements [ATC-131](https://linear.app/elevenideas/issue/ATC-131/reframe-the-cli-as-an-agent-gateway-over-the-canonical-api): the HTTP API stays the complete canonical App Server interface, and the CLI becomes a small agent gateway over it.

## What's new

**Generic API gateway — `atc api <method> <path> [--input <file|->]`**
A plain HTTP passthrough through the same base-URL resolution seam the curated commands use (never through or around the typed client — the server's contract schemas validate every request regardless of origin). Every API operation is reachable via GET, POST, PUT, PATCH, or DELETE (case-insensitive). Raw JSON responses go to stdout undecorated; empty 2xx responses print nothing; API failures put the machine-readable error body plus one `atc api:` diagnostic on stderr and exit 1; transport/config failures keep the existing one-line contract. Bodies come from a file or stdin (`--input -`). Request paths are strictly server-relative: network-path forms (`//host`, `/\host`) are rejected and the resolved origin is verified, so the gateway can never be steered off the configured endpoint; an `ATC_ENDPOINT` path prefix is preserved when joining.

**Agent context — `atc context [--json]`**
Reports whichever of the five stable context variables (`ATC_ENDPOINT`, `ATC_PROJECT_ID`, `ATC_WORKSPACE_ID`, `ATC_THREAD_ID`, `ATC_TERMINAL_ID`) are present in the process, in vocabulary order — absent variables are omitted, never invented. `ATC_WORKSPACE_ID`/`ATC_THREAD_ID` are reserved names; resource-id propagation is deferred to ATC-124.

**Capability discovery — `atc capabilities [--json]`**
Concise, stable output with `capabilitiesVersion: 1`: the gateway, context discovery, the OpenAPI endpoint, and the important curated workflows. The complete v1 shape is pinned by a deep-equality test.

**OpenAPI discovery — `GET /openapi.json`**
The running server serves the canonical serialization — byte-identical to the checked-in artifact (deliberately not `HttpApiBuilder`'s `openapiPath` option, which would emit the pre-transform document and drift from `openapi.json`). Sits under the local-trust guard like every route. No contract change; `openapi.json` is untouched.

**`ATC_ENDPOINT` resolution and propagation**
- Enters the settled configuration pipeline (env-only — it describes the launching process's context, not user configuration) and is validated fail-fast as an http(s) URL.
- Honored above the config-derived port at the single base-URL resolution seam in `cli.ts`; no command changed.
- Injected into every zmx child by the child-environment builder, which now also scrubs every inherited `ATC_*` context variable first — a server running inside another ATC session must not leak that session's ids into terminals it launches.
- `serve --port` folds the effective port back into the `AppConfig` provided to the server stack so the injected endpoint always matches the actual listener (pinned by a test where `ATC_PORT` deliberately disagrees with `--port`).

**Documentation**
AGENTS.md's Surfaces section now states the canonical-API / curated-CLI boundary, and the README's CLI section was reworked to stop enumerating commands (per the new README rule) and to state the output contract accurately. No agent skill is added here — documenting ATC for consuming agents is left to a separate change.

## Existing command audit

Applying the curated-command criteria to the current surface:

- **Clearly earned**: `serve` (the server), `terminal attach` (TTY + WebSocket bridging), `terminal create` (argv composition + client-side directory resolution), `project create`/`update` and `fs check` (client-side relative-path resolution), `project delete`/`terminal delete` (`--yes` guard workflow).
- **Simple mirrors, kept deliberately**: `health`, `version`, `project list/get`, `terminal list/get/rename` are thin renames of endpoints. They ship, they're covered, and removing working commands for architectural neatness is explicitly out of scope — but they set no precedent: future resources get `atc api` unless they meet the criteria.
- Nothing was removed; the ATC-87 parity registry was already gone (`7a2aba0`), and no replacement CI enforcement is added.

## Code review (Codex / GPT Sol, high reasoning)

A full external review was run and its findings addressed in this PR:

1. **Blocker — `atc api` path could re-target the origin** (`//evil.example/x`, `/\evil.example/x` resolve to a foreign host; `//` threw a defect): fixed with a strict, fallible request-URL join that rejects network-path/backslash forms, verifies the resolved origin, and preserves endpoint path prefixes; black-box tests cover all four cases plus the prefix.
2. **Should-fix — launched sessions inherited stale `ATC_*` ids** when the server itself runs inside an ATC session: `zmxChildEnv` now scrubs all context variables before injecting the endpoint; unit test pins it.
3. **Should-fix — "any method" overclaim**: docs and capabilities output now name the exact supported set; an unsupported-method usage test was added.
4. **Should-fix — tests didn't pin the capabilities shape or the `--port` folding**: the capabilities test now deep-compares the complete v1 object, and a dedicated test launches serve with `ATC_PORT` ≠ `--port` and asserts the injected endpoint follows the flag.
5. **Nit — README command table contradicted the no-enumeration rule**; replaced with prose pointing at `--help`/`capabilities`, and the output-contract paragraph corrected.
6. **Nit — namespace-import style**: not adopted; named value imports of own modules (`import { Api } from "./api.ts"`) are the established pattern across the codebase, and the namespace rule is applied to service modules as elsewhere.

## Testing

- Config: `ATC_ENDPOINT` capture/validation, context-variable capture, empty-means-unset.
- CLI black box: passthrough (exact stdout/stderr/exit), file + stdin bodies, empty 204, HTTP-failure and transport-failure shapes, origin-escape rejection, endpoint prefix joining, method validation, `ATC_ENDPOINT` precedence over `ATC_PORT`, malformed endpoint diagnostics, `context` absent/partial/complete in both renderings, pinned `capabilities` shape, `ATC_ENDPOINT` visible inside a launched (fake-zmx) session, and flag-folded endpoint injection.
- Local trust: `/openapi.json` served byte-identical to the canonical serialization and 403-guarded on spoofed Host.
- `mise run -C app-server check` green (fmt, typecheck, 152 tests, OpenAPI drift).

https://claude.ai/code/session_01GwZRRGJnPmgbTnSNwuBT3j
