### PR TITLE
ATC-132: AgentAdapter seam, provider config, fake adapter, codex app-server supervision

### DIFF
--- a/app-server/README.md
+++ b/app-server/README.md
@@ -39,14 +39,17 @@ overrides:
 | State dir   | `~/.local/state/atc/`       | JSON log (`atc.log`), zmx sockets (`terminals/`) |
 
 Environment variables are flat `ATC_<KEY>`: `ATC_PORT`, `ATC_LOG_LEVEL`,
-`ATC_DATA_DIR`, `ATC_ZMX_EXECUTABLE`, and `ATC_CONFIG` (path to an alternate
-config file). The config file may set `port`, `logLevel` (case-insensitive),
-`dataDir`, and `zmxExecutable`; unknown keys are rejected. `atc serve --port`
-overrides the configured port for that server only.
+`ATC_DATA_DIR`, `ATC_ZMX_EXECUTABLE`, `ATC_CODEX_EXECUTABLE`,
+`ATC_CLAUDE_EXECUTABLE`, and `ATC_CONFIG` (path to an alternate config file).
+The config file may set `port`, `logLevel` (case-insensitive), `dataDir`,
+`zmxExecutable`, `codexExecutable`, and `claudeExecutable`; unknown keys are
+rejected. `atc serve --port` overrides the configured port for that server
+only.
 
-Terminals require [zmx](https://github.com/neurosnap/zmx), which atc does not
-bundle — install it yourself. It resolves from `ATC_ZMX_EXECUTABLE` or
-`zmxExecutable`, else `zmx` on PATH.
+atc bundles no third-party binaries — install them yourself. Terminals
+require [zmx](https://github.com/neurosnap/zmx); the agent integrations use
+the Codex CLI and Claude Code. Each resolves from its `ATC_*_EXECUTABLE`
+variable or config key, else its bare name on PATH.
 
 ## CLI
 

--- a/app-server/src/agentAdapter.ts
+++ b/app-server/src/agentAdapter.ts
@@ -1,0 +1,348 @@
+import { Effect, Schema, Stream } from "effect"
+import type { Scope } from "effect"
+import { existsSync } from "node:fs"
+import type { Subprocess } from "./subprocess.ts"
+import { resolveExecutable } from "./subprocess.ts"
+
+// The shared provider seam (ATC-123): how ATC drives coding-agent providers
+// (Codex app-server, Claude Agent SDK). Adapters own provider transports,
+// wire shapes, and version details; everything above the seam sees only
+// stable provider identity, exact-session create/resume, truthful normalized
+// status, and safe control flow. Invariants every adapter must hold:
+//
+//   - Create and resume are distinct; neither ever falls back to the other.
+//     Resume verifies the exact provider session id and working directory
+//     from provider evidence and fails closed on any mismatch — a changed
+//     identity is never adopted as a repair.
+//   - Exactly one active writer per provider session. Connections are
+//     writers; observation never opens a second writer.
+//   - Status is derived from structured provider events only — never from
+//     transcript or terminal-output parsing.
+//   - Responding to provider requests (approvals, questions) is deferred to
+//     ATC-124: adapters surface `requestOpened` and answer the provider
+//     conservatively (reject) so a turn can never hang on ATC.
+//
+// The fake adapter for tests lives in test/fakeAgentAdapter.ts; per-provider
+// service tags live with their adapters (codexAdapter.ts, claudeAdapter.ts).
+
+export const AGENT_PROVIDERS = ["codex", "claude"] as const
+
+export type AgentProvider = (typeof AGENT_PROVIDERS)[number]
+
+/**
+ * Normalized activity for one provider session. `unknown` means no evidence
+ * — never a guess. A pending provider request always wins over the
+ * provider's more general running state (`needs_input` beats `working`).
+ */
+export type AgentActivity = "idle" | "working" | "needs_input" | "unknown"
+
+export type AgentTurnOutcome = "completed" | "interrupted" | "failed"
+
+export type AgentRequestKind = "approval" | "question"
+
+/**
+ * One entry of the normalized status feed. Turn and request ids are
+ * adapter-scoped correlation ids — provider-native where the provider has
+ * them (Codex), adapter-minted and process-local where it does not
+ * (Claude); never persist them as durable identity. `turnStarted` always
+ * precedes its `turnCompleted`. Raw provider events stay inside the
+ * adapters (logged there for diagnostics, never re-parsed above the seam).
+ */
+export type AgentEvent =
+  | { readonly type: "activity"; readonly activity: AgentActivity }
+  | { readonly type: "turnStarted"; readonly turnId: string }
+  | {
+      readonly type: "turnCompleted"
+      readonly turnId: string
+      readonly outcome: AgentTurnOutcome
+      /** Human-readable failure/interrupt detail, for diagnostics only. */
+      readonly detail?: string
+    }
+  | { readonly type: "requestOpened"; readonly requestId: string; readonly kind: AgentRequestKind }
+  | { readonly type: "requestClosed"; readonly requestId: string }
+
+/** Correlation handle for exactly one turn — interrupt targets this turn. */
+export interface AgentTurn {
+  readonly turnId: string
+}
+
+/** What an adapter supports, for callers that must not guess. */
+export interface AgentCapabilities {
+  /** Provider version the adapter was validated against (drift warns, never blocks). */
+  readonly testedVersion: string
+  /**
+   * How live activity is observed while a TUI drives the session:
+   * `shared-server` = full event fan-out from the multiplexed provider
+   * server; `hooks` = provider hook callbacks (coarser).
+   */
+  readonly tuiObservation: "shared-server" | "hooks"
+}
+
+/**
+ * How to launch the provider's TUI attached to an existing session. The
+ * caller owns the actual launch (a Terminal session); the adapter owns argv
+ * so provider flags never leak above the seam.
+ */
+export interface TuiLaunchSpec {
+  /** Full argv; argv[0] is the resolved provider executable. */
+  readonly command: ReadonlyArray<string>
+  /** Environment the TUI needs on top of the terminal's own. */
+  readonly env: Readonly<Record<string, string>>
+}
+
+/**
+ * A live writer connection to one provider session. Lives in a Scope:
+ * closing the scope stops the driver (releasing the writer role) and never
+ * deletes provider history.
+ *
+ * A connection can also end BEFORE its scope closes: transport loss, or a
+ * provider whose sessions terminate with a non-success turn (Claude). The
+ * uniform contract for consumers: `AgentUnavailable` from a control call
+ * means "this session is over — resume it for a fresh connection";
+ * `AgentConflict` means the target itself is invalid (busy/stale turn, or
+ * a handle the caller already closed).
+ */
+export interface AgentConnection {
+  /**
+   * The provider session identity. Exact and verified as soon as provider
+   * evidence exists; for a deferred-verification provider (Claude resume)
+   * it is the expected id until the first turn verifies it fail-closed.
+   */
+  readonly providerSessionId: string
+  /** Verified canonical working directory. */
+  readonly cwd: string
+  /** Current normalized activity snapshot. */
+  readonly activity: Effect.Effect<AgentActivity>
+  /**
+   * The normalized status feed. Single-consumer. Ends cleanly when the
+   * caller closes the connection scope, or after delivering a terminal
+   * `turnCompleted` on a provider whose connections end with non-success
+   * turns; FAILS with `AgentProtocolError` when the connection dies with
+   * no truthful terminal event (transport loss, failed verification).
+   * Fan-out to multiple observers happens above the seam.
+   */
+  readonly events: Stream.Stream<AgentEvent, AgentProtocolError>
+  /**
+   * Start exactly one turn with user input. Fails with `AgentConflict`
+   * while another turn is active on this connection; completion arrives on
+   * the feed as `turnCompleted`. A provider whose resume verification is
+   * deferred (Claude) completes it here on the connection's first turn, so
+   * `AgentResumeFailed` / `AgentIdentityMismatch` can surface fail-closed.
+   */
+  readonly startTurn: (
+    input: string,
+  ) => Effect.Effect<
+    AgentTurn,
+    | AgentConflict
+    | AgentUnavailable
+    | AgentResumeFailed
+    | AgentIdentityMismatch
+    | AgentProtocolError
+  >
+  /**
+   * Interrupt exactly `turn`. A stale or unknown target fails with
+   * `AgentConflict` — never "interrupt whatever is active". Success means
+   * the provider accepted the interrupt; the truthful outcome is the feed's
+   * `turnCompleted` with outcome `interrupted`.
+   */
+  readonly interrupt: (
+    turn: AgentTurn,
+  ) => Effect.Effect<void, AgentConflict | AgentUnavailable | AgentProtocolError>
+}
+
+/** A successful create: the connection plus the already-started first turn. */
+export interface AgentSessionStart {
+  readonly connection: AgentConnection
+  readonly turn: AgentTurn
+}
+
+/**
+ * The shared adapter interface. Create requires initial input because both
+ * providers establish durable identity while starting a turn (and a Codex
+ * thread with zero completed turns is not restart-resumable), so a created
+ * session is durable only once its first turn completes.
+ */
+export interface AgentAdapter {
+  readonly provider: AgentProvider
+  readonly capabilities: AgentCapabilities
+  /**
+   * Create a new provider session in `cwd` and start its first turn. The
+   * provider's echoed working directory is verified like resume's — a
+   * disagreeing echo is `AgentIdentityMismatch`, never adopted.
+   */
+  readonly createSession: (options: {
+    readonly cwd: string
+    readonly input: string
+  }) => Effect.Effect<
+    AgentSessionStart,
+    AgentUnavailable | AgentConflict | AgentIdentityMismatch | AgentProtocolError,
+    Scope.Scope
+  >
+  /**
+   * Resume the exact existing session. Never creates one: an unknown id is
+   * `AgentResumeFailed`, and evidence disagreeing with the expected id or
+   * cwd is `AgentIdentityMismatch`. Verification uses the earliest provider
+   * evidence available: Codex verifies here (thread/resume echoes identity);
+   * the Claude SDK emits no identity evidence until a turn starts (probed
+   * 2026-08-03), so its verification completes — still fail-closed — at the
+   * connection's first `startTurn`.
+   */
+  readonly resumeSession: (options: {
+    readonly providerSessionId: string
+    readonly cwd: string
+  }) => Effect.Effect<
+    AgentConnection,
+    | AgentUnavailable
+    | AgentConflict
+    | AgentResumeFailed
+    | AgentIdentityMismatch
+    | AgentProtocolError,
+    Scope.Scope
+  >
+  /** How to launch the provider TUI attached to an existing session. */
+  readonly tuiLaunch: (options: {
+    readonly providerSessionId: string
+    readonly cwd: string
+  }) => Effect.Effect<TuiLaunchSpec, AgentUnavailable>
+}
+
+// Internal-only failures (ATC-123): not part of the HTTP contract, so no
+// httpApiStatus annotations. ATC-124 maps them to public errors when agent
+// sessions become an API surface.
+
+/** Provider missing, not ready, or gone — retryable once the cause is fixed. */
+export class AgentUnavailable extends Schema.TaggedErrorClass<AgentUnavailable>()(
+  "AgentUnavailable",
+  { provider: Schema.Literals(AGENT_PROVIDERS), reason: Schema.String },
+) {
+  override get message(): string {
+    return `${this.provider} unavailable: ${this.reason}`
+  }
+}
+
+/** The provider rejected the exact persisted session id (fail closed). */
+export class AgentResumeFailed extends Schema.TaggedErrorClass<AgentResumeFailed>()(
+  "AgentResumeFailed",
+  {
+    provider: Schema.Literals(AGENT_PROVIDERS),
+    providerSessionId: Schema.String,
+    reason: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `${this.provider} resume of ${this.providerSessionId} failed: ${this.reason}`
+  }
+}
+
+/** Provider evidence disagrees with the expected identity — never adopted. */
+export class AgentIdentityMismatch extends Schema.TaggedErrorClass<AgentIdentityMismatch>()(
+  "AgentIdentityMismatch",
+  {
+    provider: Schema.Literals(AGENT_PROVIDERS),
+    field: Schema.Literals(["sessionId", "cwd"]),
+    expected: Schema.String,
+    actual: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `${this.provider} ${this.field} mismatch: expected ${this.expected}, got ${this.actual}`
+  }
+}
+
+/** Required structured evidence was absent or invalid, or the transport broke. */
+export class AgentProtocolError extends Schema.TaggedErrorClass<AgentProtocolError>()(
+  "AgentProtocolError",
+  { provider: Schema.Literals(AGENT_PROVIDERS), reason: Schema.String },
+) {
+  override get message(): string {
+    return `${this.provider} protocol error: ${this.reason}`
+  }
+}
+
+/** Writer or turn-target conflict: the control target is not (or no longer) valid. */
+export class AgentConflict extends Schema.TaggedErrorClass<AgentConflict>()("AgentConflict", {
+  provider: Schema.Literals(AGENT_PROVIDERS),
+  reason: Schema.String,
+}) {
+  override get message(): string {
+    return `${this.provider} conflict: ${this.reason}`
+  }
+}
+
+const INSTALL_HINTS: Record<AgentProvider, string> = {
+  codex: "install the Codex CLI",
+  claude: "install and authenticate Claude Code",
+}
+
+const CONFIG_KEYS: Record<AgentProvider, string> = {
+  codex: "codexExecutable",
+  claude: "claudeExecutable",
+}
+
+/**
+ * Resolve a provider executable from its settled configuration value
+ * (AppConfig `codexExecutable` / `claudeExecutable`), or fail with the one
+ * actionable install-or-configure diagnostic. Configured paths are
+ * existence-checked here so a typo'd path fails as this diagnostic, not as
+ * a downstream launch timeout.
+ */
+export const resolveProviderExecutable = (
+  provider: AgentProvider,
+  configured: string,
+): Effect.Effect<string, AgentUnavailable> =>
+  Effect.suspend(() => {
+    const found = resolveExecutable(configured)
+    if (found !== null && existsSync(found)) return Effect.succeed(found)
+    const key = CONFIG_KEYS[provider]
+    return Effect.fail(
+      new AgentUnavailable({
+        provider,
+        reason:
+          `${configured} not found; ${INSTALL_HINTS[provider]} ` +
+          `or set ${key} in config.toml / ATC_${provider.toUpperCase()}_EXECUTABLE`,
+      }),
+    )
+  })
+
+/**
+ * The shared version-drift rule (record + warn, never block): read the
+ * installed provider version via `--version`, log one actionable warning
+ * when it is below the floor the adapter was validated against. Any failure
+ * to determine the version is itself just a warning.
+ */
+export const warnIfBelowTestedVersion = (
+  subprocess: Subprocess["Service"],
+  provider: AgentProvider,
+  executable: string,
+  testedVersion: string,
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const output = yield* Effect.scoped(
+      Effect.gen(function* () {
+        const child = yield* subprocess.spawn({
+          executable,
+          args: ["--version"],
+          env: {},
+          extendEnv: true,
+        })
+        const lines = yield* Stream.runCollect(child.stdoutLines)
+        yield* child.exitCode
+        return lines.join(" ")
+      }),
+    ).pipe(Effect.orElseSucceed(() => ""))
+    const match = output.match(/(\d+)\.(\d+)\.(\d+)/)
+    if (match === null) {
+      return yield* Effect.logWarning(
+        `could not determine the installed ${provider} version (tested against ${testedVersion})`,
+      )
+    }
+    // Components are small; packing keeps the comparison one expression.
+    const pack = (parts: ReadonlyArray<number>) =>
+      (parts[0] ?? 0) * 1_000_000 + (parts[1] ?? 0) * 1_000 + (parts[2] ?? 0)
+    const installed = [Number(match[1]), Number(match[2]), Number(match[3])]
+    if (pack(installed) < pack(testedVersion.split(".").map(Number))) {
+      yield* Effect.logWarning(
+        `installed ${provider} ${installed.join(".")} is older than the tested ${testedVersion}; proceeding, but upgrade it if provider behavior misbehaves`,
+      )
+    }
+  })

--- a/app-server/src/codexServer.ts
+++ b/app-server/src/codexServer.ts
@@ -1,0 +1,428 @@
+import {
+  Context,
+  Duration,
+  Effect,
+  FiberHandle,
+  FileSystem,
+  Layer,
+  Option,
+  Ref,
+  Schedule,
+  Schema,
+  Semaphore,
+  Stream,
+} from "effect"
+import * as path from "node:path"
+import { AgentUnavailable, resolveProviderExecutable } from "./agentAdapter.ts"
+import { AppConfig } from "./config.ts"
+import * as Subprocess from "./subprocess.ts"
+
+// Supervision for the single long-lived `codex app-server` per ATC profile
+// (ATC-123). Invariants that are invisible from the call sites:
+//
+//   - The server is spawned DETACHED (reparented through an intermediate sh,
+//     zmx-style) because a live `codex resume --remote` TUI dies the moment
+//     its app-server dies, with no reconnect loop. A scoped child would kill
+//     every attached TUI on every ATC restart — so ATC shutdown deliberately
+//     leaves the server running, and boot re-adopts it from the persisted
+//     identity file + /readyz. Adopt-or-replace, never accumulate.
+//   - Exactly one server per profile, always ATC's own `--listen` listener —
+//     never the machine-wide `codex app-server proxy` daemon (externally
+//     owned; observed held by the Codex desktop integration).
+//   - A persisted pid is only trusted (and only ever signaled) after its
+//     command line still looks like an app-server: pids get recycled, and
+//     SIGKILLing a stranger is worse than leaking a server.
+//   - `stop` is the only intentional-kill path. The exit watcher restarts a
+//     server that died underneath us (with backoff); interrupting the
+//     watcher (layer shutdown) never touches the process itself.
+
+/** Persisted identity of the detached server, in stateDir. */
+const ServerIdentity = Schema.Struct({
+  pid: Schema.Number,
+  port: Schema.Number,
+  startedAt: Schema.String,
+})
+
+export interface CodexServerInfo {
+  readonly pid: number
+  readonly port: number
+  /** JSON-RPC WebSocket endpoint (also the TUI `--remote` endpoint). */
+  readonly url: string
+}
+
+export interface CodexServerOptions {
+  /** Readiness window for a freshly spawned server. */
+  readonly readyTimeout?: Duration.Input
+  /**
+   * Readiness window when adopting an already-running pid. Deliberately
+   * generous by default: concluding a live server is dead kills every
+   * attached TUI, so patience is the cheaper error.
+   */
+  readonly adoptTimeout?: Duration.Input
+  /** Exit-watcher poll interval. */
+  readonly watchInterval?: Duration.Input
+}
+
+/** Restart attempts after an unexpected server death, then give up until next use. */
+const RESTART_RETRIES = 5
+
+export class CodexServer extends Context.Service<
+  CodexServer,
+  {
+    /**
+     * The profile's ready app-server: adopt the persisted one when it is
+     * alive and answers /readyz, replace it otherwise, spawn fresh when
+     * there is none. Serialized — concurrent callers get the same server.
+     */
+    readonly ensure: () => Effect.Effect<CodexServerInfo, AgentUnavailable>
+    /**
+     * Intentionally stop the detached server and clear its identity. Live
+     * TUIs attached to it will exit — callers own that decision. Stopping
+     * an already-stopped server succeeds.
+     */
+    readonly stop: () => Effect.Effect<void, AgentUnavailable>
+  }
+>()("app-server/CodexServer") {}
+
+const unavailable = (reason: string) => new AgentUnavailable({ provider: "codex", reason })
+
+/** Readiness-gate failure that must stop the retry loop: the pid is gone. */
+class ServerExited extends Schema.TaggedErrorClass<ServerExited>()("ServerExited", {
+  pid: Schema.Number,
+}) {}
+
+const infoFor = (pid: number, port: number): CodexServerInfo => ({
+  pid,
+  port,
+  url: `ws://127.0.0.1:${port}`,
+})
+
+/** An OS-assigned free loopback port; the tiny claim race is acceptable. */
+const freePort = Effect.try({
+  try: () => {
+    const listener = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: { data: () => {} },
+    })
+    const port = listener.port
+    listener.stop(true)
+    return port
+  },
+  catch: (error) => unavailable(`could not allocate a listen port: ${error}`),
+})
+
+/** One /readyz probe; any failure (refused, non-2xx, >1s) is "not ready". */
+const probeReady = (port: number): Effect.Effect<void, AgentUnavailable> =>
+  Effect.tryPromise({
+    try: (signal) => fetch(`http://127.0.0.1:${port}/readyz`, { signal }),
+    catch: () => unavailable(`not answering /readyz on port ${port}`),
+  }).pipe(
+    Effect.timeoutOrElse({
+      duration: "1 second",
+      orElse: () => Effect.fail(unavailable(`/readyz probe timed out on port ${port}`)),
+    }),
+    Effect.flatMap((response) =>
+      response.ok
+        ? Effect.void
+        : Effect.fail(unavailable(`/readyz answered ${response.status} on port ${port}`)),
+    ),
+  )
+
+/** SIGTERM → bounded wait → SIGKILL → verified gone. Absent pid succeeds. */
+const terminate = (pid: number): Effect.Effect<void, AgentUnavailable> =>
+  Effect.gen(function* () {
+    const signal = (name: NodeJS.Signals) =>
+      Effect.sync(() => {
+        try {
+          process.kill(pid, name)
+        } catch {
+          // Already gone.
+        }
+      })
+    yield* signal("SIGTERM")
+    if (yield* Subprocess.waitForProcessExit(pid)) return
+    yield* signal("SIGKILL")
+    if (yield* Subprocess.waitForProcessExit(pid)) return
+    return yield* Effect.fail(unavailable(`process ${pid} survived SIGTERM and SIGKILL`))
+  })
+
+export const layerWith = (options: CodexServerOptions) =>
+  Layer.effect(CodexServer)(
+    Effect.gen(function* () {
+      const config = yield* AppConfig
+      const subprocess = yield* Subprocess.Subprocess
+      const fs = yield* FileSystem.FileSystem
+      const identityFile = path.join(config.stateDir, "codex-app-server.json")
+      const logFile = path.join(config.stateDir, "codex-app-server.log")
+      const readyTimeout = options.readyTimeout ?? "15 seconds"
+      const adoptTimeout = options.adoptTimeout ?? "10 seconds"
+      const watchInterval = options.watchInterval ?? "1 second"
+      const readySchedule = Schedule.exponential("100 millis").pipe(Schedule.jittered)
+
+      const current = yield* Ref.make<CodexServerInfo | null>(null)
+      const lock = yield* Semaphore.make(1)
+      const watcher = yield* FiberHandle.make()
+
+      /**
+       * Whether `pid` still looks like the app-server we recorded. Guards
+       * every adoption and every signal against pid recycling. The check is
+       * for an exact `app-server` argv token (a substring would match any
+       * command whose path merely contains "app-server"). `ps` exits
+       * non-zero for a missing pid, which lands in the not-ours branch.
+       */
+      const isOurServer = (pid: number) =>
+        Effect.scoped(
+          Effect.gen(function* () {
+            const ps = yield* subprocess.spawn({
+              executable: "ps",
+              args: ["-p", String(pid), "-o", "command="],
+              env: {},
+              extendEnv: true,
+            })
+            const lines = yield* Stream.runCollect(ps.stdoutLines)
+            yield* ps.exitCode
+            return lines
+              .join(" ")
+              .split(/\s+/)
+              .some((token) => token === "app-server")
+          }),
+        ).pipe(Effect.orElseSucceed(() => false))
+
+      /** Terminate `pid` only if it is provably still our server. */
+      const terminateOurs = (pid: number) =>
+        Effect.gen(function* () {
+          if (yield* isOurServer(pid)) yield* terminate(pid)
+        })
+
+      /** Last log lines, for actionable spawn/readiness diagnostics. */
+      const logTail = fs.readFileString(logFile).pipe(
+        Effect.map((text) => {
+          const lines = text.trimEnd().split("\n").slice(-10).join("\n")
+          return lines === "" ? "" : `\ncodex app-server log:\n${lines}`
+        }),
+        Effect.orElseSucceed(() => ""),
+      )
+
+      /**
+       * Poll /readyz until ready, the window elapses, or the pid dies —
+       * a dead pid fails immediately instead of burning the whole window
+       * (the lock is held while this runs).
+       */
+      const awaitReady = (pid: number, port: number, window: Duration.Input) =>
+        Effect.suspend((): Effect.Effect<void, AgentUnavailable | ServerExited> =>
+          Subprocess.isProcessAlive(pid)
+            ? probeReady(port)
+            : Effect.fail(new ServerExited({ pid })),
+        ).pipe(
+          Effect.retry({
+            schedule: readySchedule,
+            while: (error): error is AgentUnavailable => error._tag === "AgentUnavailable",
+          }),
+          Effect.timeoutOrElse({
+            duration: window,
+            orElse: () => Effect.fail(unavailable(`gave up waiting for /readyz on port ${port}`)),
+          }),
+          Effect.catch((error) =>
+            Effect.gen(function* () {
+              const tail = yield* logTail
+              const cause =
+                error._tag === "ServerExited"
+                  ? `process ${pid} exited before becoming ready`
+                  : `not ready within ${Duration.format(Duration.fromInputUnsafe(window))} on port ${port}`
+              return yield* Effect.fail(unavailable(cause + tail))
+            }),
+          ),
+        )
+
+      const readIdentity = fs.readFileString(identityFile).pipe(
+        Effect.flatMap((text) =>
+          Effect.try({ try: () => JSON.parse(text) as unknown, catch: (error) => error }),
+        ),
+        Effect.flatMap((json) => Schema.decodeUnknownEffect(ServerIdentity)(json)),
+        Effect.map(Option.some),
+        // Absent or corrupt identity is "no server" — replaced, never trusted.
+        Effect.orElseSucceed(() => Option.none<typeof ServerIdentity.Type>()),
+      )
+
+      const writeIdentity = (pid: number, port: number) =>
+        fs
+          .writeFileString(
+            identityFile,
+            JSON.stringify({ pid, port, startedAt: new Date().toISOString() }, null, 2),
+          )
+          .pipe(
+            Effect.mapError((error) => unavailable(`could not persist identity: ${error.message}`)),
+          )
+
+      const clearIdentity = fs.remove(identityFile).pipe(Effect.ignore)
+
+      // Detached spawn, zmx-style: an intermediate sh backgrounds the server
+      // (reparenting it away from ATC, stdin from /dev/null so it can never
+      // see EOF when ATC exits) and echoes the server's pid. The sh itself
+      // is a normal scoped child that exits immediately.
+      const spawnDetached = Effect.gen(function* () {
+        const executable = yield* resolveProviderExecutable("codex", config.codexExecutable)
+        const port = yield* freePort
+        yield* fs
+          .makeDirectory(config.stateDir, { recursive: true })
+          .pipe(
+            Effect.mapError((error) => unavailable(`could not create stateDir: ${error.message}`)),
+          )
+        const pidText = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const child = yield* subprocess.spawn({
+              executable: "/bin/sh",
+              args: [
+                "-c",
+                `nohup "$1" app-server --listen "$2" >"$3" 2>&1 </dev/null & echo $!`,
+                "sh",
+                executable,
+                `ws://127.0.0.1:${port}`,
+                logFile,
+              ],
+              env: {},
+              // The server needs the user's full environment (auth state).
+              extendEnv: true,
+            })
+            const lines = yield* Stream.runCollect(child.stdoutLines)
+            yield* child.exitCode
+            return lines[0]?.trim() ?? ""
+          }),
+        ).pipe(Effect.mapError((error) => unavailable(`detached spawn failed: ${error.message}`)))
+        const pid = Number.parseInt(pidText, 10)
+        if (!Number.isInteger(pid) || pid <= 0) {
+          return yield* Effect.fail(
+            unavailable(`detached spawn did not report a pid: "${pidText}"`),
+          )
+        }
+        // From here the detached server exists: any non-success exit —
+        // identity write failure, readiness failure, interruption — must
+        // reap it, or "never accumulate" is broken.
+        yield* Effect.gen(function* () {
+          yield* writeIdentity(pid, port)
+          yield* awaitReady(pid, port, readyTimeout)
+        }).pipe(
+          Effect.onExit((exit) =>
+            exit._tag === "Failure"
+              ? terminate(pid).pipe(Effect.ignore, Effect.andThen(clearIdentity))
+              : Effect.void,
+          ),
+        )
+        yield* Effect.logInfo("codex app-server started").pipe(Effect.annotateLogs({ pid, port }))
+        return infoFor(pid, port)
+      })
+
+      // Adopt-or-replace against the persisted identity, then spawn fresh if
+      // nothing was adoptable. Callers hold the lock.
+      const acquire = Effect.gen(function* () {
+        const persisted = yield* readIdentity
+        if (Option.isSome(persisted)) {
+          const { pid, port } = persisted.value
+          if (yield* isOurServer(pid)) {
+            const adopted = yield* awaitReady(pid, port, adoptTimeout).pipe(
+              Effect.as(true),
+              Effect.orElseSucceed(() => false),
+            )
+            if (adopted) {
+              yield* Effect.logInfo("codex app-server adopted").pipe(
+                Effect.annotateLogs({ pid, port }),
+              )
+              return infoFor(pid, port)
+            }
+            // Alive but not answering: replace it rather than accumulate.
+            yield* terminate(pid)
+          }
+          yield* clearIdentity
+        }
+        return yield* spawnDetached
+      })
+
+      const watchLoop: Effect.Effect<void> = Effect.gen(function* () {
+        while (true) {
+          const info = yield* Ref.get(current)
+          if (info === null) return
+          if (Subprocess.isProcessAlive(info.pid)) {
+            yield* Effect.sleep(watchInterval)
+            continue
+          }
+          yield* Effect.logWarning("codex app-server exited unexpectedly; restarting").pipe(
+            Effect.annotateLogs({ pid: info.pid }),
+          )
+          yield* Ref.set(current, null)
+          const restarted = yield* lock
+            .withPermits(1)(
+              Effect.gen(function* () {
+                const next = yield* acquire
+                yield* Ref.set(current, next)
+                return next
+              }),
+            )
+            .pipe(
+              Effect.retry({
+                schedule: Schedule.exponential("500 millis").pipe(Schedule.jittered),
+                times: RESTART_RETRIES,
+              }),
+              Effect.option,
+            )
+          if (Option.isNone(restarted)) {
+            yield* Effect.logError(
+              "codex app-server could not be restarted; giving up until next use",
+            )
+            return
+          }
+        }
+      })
+
+      const ensureWatching = FiberHandle.run(watcher, watchLoop, { onlyIfMissing: true }).pipe(
+        Effect.asVoid,
+      )
+
+      const ensure = () =>
+        lock
+          .withPermits(1)(
+            Effect.gen(function* () {
+              const cached = yield* Ref.get(current)
+              if (cached !== null && Subprocess.isProcessAlive(cached.pid)) {
+                const stillReady = yield* probeReady(cached.port).pipe(
+                  Effect.as(true),
+                  Effect.orElseSucceed(() => false),
+                )
+                // Not ready ≠ dead: acquire re-probes within adoptTimeout
+                // before concluding anything drastic.
+                if (stillReady) return cached
+              }
+              yield* Ref.set(current, null)
+              const info = yield* acquire
+              yield* Ref.set(current, info)
+              return info
+            }),
+          )
+          .pipe(Effect.tap(() => ensureWatching))
+
+      const stop = () =>
+        Effect.gen(function* () {
+          // Interrupt the watcher first so it cannot resurrect the server.
+          yield* FiberHandle.clear(watcher)
+          yield* lock.withPermits(1)(
+            Effect.gen(function* () {
+              // Cache and file normally agree; if they diverged (another
+              // process rewrote the file), reap both — an unrecorded server
+              // would be unadoptable forever.
+              const cached = yield* Ref.get(current)
+              const persisted = yield* readIdentity
+              const pids = new Set<number>()
+              if (cached !== null) pids.add(cached.pid)
+              if (Option.isSome(persisted)) pids.add(persisted.value.pid)
+              for (const pid of pids) yield* terminateOurs(pid)
+              yield* clearIdentity
+              yield* Ref.set(current, null)
+            }),
+          )
+        })
+
+      return { ensure, stop }
+    }),
+  )
+
+export const layer = layerWith({})

--- a/app-server/src/config.ts
+++ b/app-server/src/config.ts
@@ -79,6 +79,10 @@ export class AppConfig extends Context.Service<
     readonly logFile: string
     /** zmx executable: an absolute path, or a name resolved on PATH. */
     readonly zmxExecutable: string
+    /** Codex CLI executable: an absolute path, or a name resolved on PATH. */
+    readonly codexExecutable: string
+    /** Claude Code executable: an absolute path, or a name resolved on PATH. */
+    readonly claudeExecutable: string
     /**
      * ATC-private zmx socket directory (ZMX_DIR for every zmx child). Only
      * ATC-owned sessions live here, so the inventory is authoritative and
@@ -108,7 +112,14 @@ const configFilePath = (env: Env) =>
 // The settings a config.toml may define. Keys are camelCase, matching the
 // system-wide JSON convention; unknown keys fail fast (a typo silently
 // falling back to a default would be a partial boot).
-const FILE_KEYS = ["port", "logLevel", "dataDir", "zmxExecutable"] as const
+const FILE_KEYS = [
+  "port",
+  "logLevel",
+  "dataDir",
+  "zmxExecutable",
+  "codexExecutable",
+  "claudeExecutable",
+] as const
 
 const parseToml = (source: string, text: string) =>
   Effect.try({
@@ -218,6 +229,8 @@ export const load = (
         Config.withDefault(xdgDir(env, "XDG_DATA_HOME", [".local", "share"])),
       ),
       zmxExecutable: Config.string("zmxExecutable").pipe(Config.withDefault("zmx")),
+      codexExecutable: Config.string("codexExecutable").pipe(Config.withDefault("codex")),
+      claudeExecutable: Config.string("claudeExecutable").pipe(Config.withDefault("claude")),
     }).pipe(
       Effect.provideService(ConfigProvider.ConfigProvider, provider),
       Effect.catchTag("ConfigError", (error) =>
@@ -232,13 +245,20 @@ export const load = (
 
     // A relative executable path would resolve against the working
     // directory — compiled behavior never may. Bare names resolve on PATH.
-    if (settings.zmxExecutable.includes("/") && !settings.zmxExecutable.startsWith("/")) {
-      return yield* Effect.fail(
-        new ConfigLoadError({
-          source: `${configFile} / ATC_ZMX_EXECUTABLE`,
-          message: `zmxExecutable must be a bare name or an absolute path, got "${settings.zmxExecutable}"`,
-        }),
-      )
+    const executables = [
+      ["zmxExecutable", "ATC_ZMX_EXECUTABLE", settings.zmxExecutable],
+      ["codexExecutable", "ATC_CODEX_EXECUTABLE", settings.codexExecutable],
+      ["claudeExecutable", "ATC_CLAUDE_EXECUTABLE", settings.claudeExecutable],
+    ] as const
+    for (const [key, envVar, value] of executables) {
+      if (value.includes("/") && !value.startsWith("/")) {
+        return yield* Effect.fail(
+          new ConfigLoadError({
+            source: `${configFile} / ${envVar}`,
+            message: `${key} must be a bare name or an absolute path, got "${value}"`,
+          }),
+        )
+      }
     }
 
     // Agent context is captured verbatim (present means non-empty). Only
@@ -283,6 +303,8 @@ export const load = (
       dbFile: path.join(dataDir, "atc.db"),
       logFile: path.join(stateDir, "atc.log"),
       zmxExecutable: settings.zmxExecutable,
+      codexExecutable: settings.codexExecutable,
+      claudeExecutable: settings.claudeExecutable,
       terminalSocketDir: path.join(stateDir, "terminals"),
     }
   })

--- a/app-server/src/smoke.ts
+++ b/app-server/src/smoke.ts
@@ -4,7 +4,9 @@ import { Command } from "effect/unstable/cli"
 import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { AgentUnavailable, resolveProviderExecutable } from "./agentAdapter.ts"
 import * as BuildInfo from "./buildInfo.ts"
+import { AppConfig, ConfigLoadError, layer as appConfigLayer } from "./config.ts"
 import * as Subprocess from "./subprocess.ts"
 
 // Unstable provider smoke checks (ATC-88). `atc smoke ...` proves that the
@@ -22,48 +24,6 @@ export class SmokeError extends Schema.TaggedErrorClass<SmokeError>()("SmokeErro
 class SmokeReported extends Schema.TaggedErrorClass<SmokeReported>()("SmokeReported", {}) {
   override readonly [Runtime.errorReported] = false
 }
-
-// --- Executable resolution ---------------------------------------------------
-
-/** Env override first, then PATH — the shared resolveExecutable rule. */
-const resolveProvider = (
-  provider: SmokeError["provider"],
-  name: string,
-  envVar: string,
-  installHint: string,
-) =>
-  Effect.suspend(() => {
-    const override = process.env[envVar]
-    const found = Subprocess.resolveExecutable(
-      override !== undefined && override !== "" ? override : name,
-    )
-    if (found !== null) return Effect.succeed(found)
-    return Effect.fail(
-      new SmokeError({
-        provider,
-        message: `${name} not found on PATH; ${installHint} or set ${envVar}`,
-      }),
-    )
-  })
-
-export const resolveCodexExecutable = resolveProvider(
-  "codex",
-  "codex",
-  "ATC_CODEX_EXECUTABLE",
-  "install the Codex CLI",
-)
-
-/**
- * Claude Code: the same bring-your-own-CLI rule as codex. atc does not ship
- * a Claude Code binary; the user's install also carries the credentials the
- * SDK needs.
- */
-export const resolveClaudeCodeExecutable = resolveProvider(
-  "claude",
-  "claude",
-  "ATC_CLAUDE_CODE_EXECUTABLE",
-  "install and authenticate Claude Code",
-)
 
 // --- Shared termination checks ----------------------------------------------
 
@@ -402,22 +362,34 @@ export const claudeSmoke = (claudeExecutable: string) =>
 
 /** Print the failure as actionable diagnostics, then fail quietly. */
 const reportFailures = <A, R>(
-  effect: Effect.Effect<A, SmokeError | Subprocess.SubprocessError, R>,
+  effect: Effect.Effect<
+    A,
+    SmokeError | Subprocess.SubprocessError | AgentUnavailable | ConfigLoadError,
+    R
+  >,
 ) =>
   effect.pipe(
-    Effect.catchTag(["SmokeError", "SubprocessError"], (error) =>
-      Console.error(
-        error._tag === "SmokeError"
-          ? `atc smoke ${error.provider}: ${error.message}`
-          : `atc smoke: ${error.executable} ${error.operation} failed: ${error.message}`,
-      ).pipe(Effect.andThen(Effect.fail(new SmokeReported()))),
+    Effect.catchTag(
+      ["SmokeError", "SubprocessError", "AgentUnavailable", "ConfigLoadError"],
+      (error) =>
+        Console.error(
+          error._tag === "SubprocessError"
+            ? `atc smoke: ${error.executable} ${error.operation} failed: ${error.message}`
+            : error._tag === "ConfigLoadError"
+              ? `atc smoke: ${error.source}: ${error.message}`
+              : `atc smoke ${error.provider}: ${error.message}`,
+        ).pipe(Effect.andThen(Effect.fail(new SmokeReported()))),
     ),
   )
 
+// Provider executables come from the settled configuration (AppConfig
+// codexExecutable / claudeExecutable) — the same values the production
+// adapters read, so a smoke pass proves the configured provider works.
 const codexCommand = Command.make("codex", {}, () =>
   reportFailures(
     Effect.gen(function* () {
-      const executable = yield* resolveCodexExecutable
+      const config = yield* AppConfig
+      const executable = yield* resolveProviderExecutable("codex", config.codexExecutable)
       yield* codexSmoke({
         executable,
         args: ["app-server", "--stdio"],
@@ -425,16 +397,17 @@ const codexCommand = Command.make("codex", {}, () =>
         extendEnv: true,
         forceKillAfter: "2 seconds",
       })
-    }),
+    }).pipe(Effect.provide(appConfigLayer)),
   ),
 ).pipe(Command.withDescription("[unstable] Codex app-server launch and initialize round trip"))
 
 const claudeCommand = Command.make("claude", {}, () =>
   reportFailures(
     Effect.gen(function* () {
-      const executable = yield* resolveClaudeCodeExecutable
+      const config = yield* AppConfig
+      const executable = yield* resolveProviderExecutable("claude", config.claudeExecutable)
       yield* claudeSmoke(executable)
-    }),
+    }).pipe(Effect.provide(appConfigLayer)),
   ),
 ).pipe(
   Command.withDescription("[unstable] Claude Agent SDK round trip via the packaged executable"),

--- a/app-server/test/agentAdapter.test.ts
+++ b/app-server/test/agentAdapter.test.ts
@@ -1,0 +1,161 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Stream } from "effect"
+import type { AgentEvent } from "../src/agentAdapter.ts"
+import { makeFakeAgentAdapter } from "./fakeAgentAdapter.ts"
+
+// Seam-semantics tests over the fake adapter: the observable rules every
+// real adapter must hold (fail-closed resume, single writer, single active
+// turn, exact interrupt targets, truthful status feed). PR2/PR3 hold the
+// real adapters to the same shape against provider fixtures.
+
+/** Collect events in the background; assertions poll the sink. */
+const collectEvents = (events: Stream.Stream<AgentEvent, unknown>) =>
+  Effect.gen(function* () {
+    const sink: Array<AgentEvent> = []
+    yield* events.pipe(
+      Stream.runForEach((event) => Effect.sync(() => sink.push(event))),
+      Effect.ignore,
+      Effect.forkScoped,
+    )
+    return sink
+  })
+
+const waitForEvent = (sink: Array<AgentEvent>, predicate: (event: AgentEvent) => boolean) =>
+  Effect.gen(function* () {
+    for (let attempt = 0; !sink.some(predicate); attempt++) {
+      assert.isBelow(attempt, 100, `never saw expected event in ${JSON.stringify(sink)}`)
+      yield* Effect.yieldNow
+    }
+  })
+
+describe("AgentAdapter seam semantics (fake adapter)", () => {
+  it.effect("create starts the first turn and the feed tells the truth", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeAgentAdapter()
+      const { connection, turn } = yield* fake.adapter.createSession({
+        cwd: "/work",
+        input: "do the thing",
+      })
+      const sink = yield* collectEvents(connection.events)
+      assert.strictEqual(yield* connection.activity, "working")
+      assert.deepStrictEqual(fake.sessions.get(connection.providerSessionId)?.inputs, [
+        "do the thing",
+      ])
+
+      fake.completeTurn(connection.providerSessionId, "completed")
+      yield* waitForEvent(
+        sink,
+        (event) =>
+          event.type === "turnCompleted" &&
+          event.turnId === turn.turnId &&
+          event.outcome === "completed",
+      )
+      assert.strictEqual(yield* connection.activity, "idle")
+    }).pipe(Effect.scoped),
+  )
+
+  it.effect("a second turn while one is active is a conflict", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeAgentAdapter()
+      const { connection } = yield* fake.adapter.createSession({ cwd: "/work", input: "one" })
+      const second = yield* Effect.flip(connection.startTurn("two"))
+      assert.strictEqual(second._tag, "AgentConflict")
+    }).pipe(Effect.scoped),
+  )
+
+  it.effect("resume of an unknown session fails closed", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeAgentAdapter()
+      const failure = yield* Effect.flip(
+        fake.adapter.resumeSession({ providerSessionId: "nope", cwd: "/work" }),
+      )
+      assert.strictEqual(failure._tag, "AgentResumeFailed")
+    }).pipe(Effect.scoped),
+  )
+
+  it.effect("resume with a mismatched cwd is an identity mismatch, never adopted", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeAgentAdapter()
+      fake.seed("session-1", "/original")
+      const failure = yield* Effect.flip(
+        fake.adapter.resumeSession({ providerSessionId: "session-1", cwd: "/elsewhere" }),
+      )
+      assert.strictEqual(failure._tag, "AgentIdentityMismatch")
+    }).pipe(Effect.scoped),
+  )
+
+  it.effect("one writer per session: a concurrent second connection conflicts", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeAgentAdapter()
+      fake.seed("session-1", "/work")
+      yield* fake.adapter.resumeSession({ providerSessionId: "session-1", cwd: "/work" })
+      const second = yield* Effect.flip(
+        fake.adapter.resumeSession({ providerSessionId: "session-1", cwd: "/work" }),
+      )
+      assert.strictEqual(second._tag, "AgentConflict")
+    }).pipe(Effect.scoped),
+  )
+
+  it.effect("closing the connection releases the writer role", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeAgentAdapter()
+      fake.seed("session-1", "/work")
+      yield* Effect.scoped(
+        fake.adapter.resumeSession({ providerSessionId: "session-1", cwd: "/work" }),
+      )
+      // The first writer's scope closed, so a new writer may connect.
+      const connection = yield* fake.adapter.resumeSession({
+        providerSessionId: "session-1",
+        cwd: "/work",
+      })
+      assert.strictEqual(connection.providerSessionId, "session-1")
+    }).pipe(Effect.scoped),
+  )
+
+  it.effect("interrupt targets the exact turn; stale targets conflict", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeAgentAdapter()
+      const { connection, turn } = yield* fake.adapter.createSession({
+        cwd: "/work",
+        input: "long task",
+      })
+      const sink = yield* collectEvents(connection.events)
+      yield* connection.interrupt(turn)
+      yield* waitForEvent(
+        sink,
+        (event) =>
+          event.type === "turnCompleted" &&
+          event.turnId === turn.turnId &&
+          event.outcome === "interrupted",
+      )
+      // The turn is over; interrupting it again is stale, not idempotent.
+      const stale = yield* Effect.flip(connection.interrupt(turn))
+      assert.strictEqual(stale._tag, "AgentConflict")
+    }).pipe(Effect.scoped),
+  )
+
+  it.effect("a pending provider request wins: needs_input beats working", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeAgentAdapter()
+      const { connection } = yield* fake.adapter.createSession({ cwd: "/work", input: "ask me" })
+      const sink = yield* collectEvents(connection.events)
+      const requestId = fake.openRequest(connection.providerSessionId, "approval")
+      yield* waitForEvent(
+        sink,
+        (event) => event.type === "requestOpened" && event.requestId === requestId,
+      )
+      assert.strictEqual(yield* connection.activity, "needs_input")
+      fake.closeRequest(connection.providerSessionId, requestId)
+      assert.strictEqual(yield* connection.activity, "working")
+    }).pipe(Effect.scoped),
+  )
+
+  it.effect("unavailability is injected everywhere", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeAgentAdapter()
+      fake.setUnavailable("fake outage")
+      const failure = yield* Effect.flip(fake.adapter.createSession({ cwd: "/work", input: "hi" }))
+      assert.strictEqual(failure._tag, "AgentUnavailable")
+    }).pipe(Effect.scoped),
+  )
+})

--- a/app-server/test/codexServer.test.ts
+++ b/app-server/test/codexServer.test.ts
@@ -1,0 +1,253 @@
+import { assert, describe, it } from "@effect/vitest"
+import { BunServices } from "@effect/platform-bun"
+import { Effect, Layer } from "effect"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import { fileURLToPath } from "node:url"
+import * as CodexServer from "../src/codexServer.ts"
+import * as Subprocess from "../src/subprocess.ts"
+import { freePort, trackTempDir } from "./blackbox.ts"
+import { testAppConfig } from "./testLayers.ts"
+
+// Supervision tests against the fake-codex-listener fixture (a Bun script
+// that binds the requested --listen port and answers /readyz). All tests are
+// it.live: they spawn real detached processes and need the real clock for
+// readiness retries. Every path ends in stop() so no detached fixture
+// outlives its test; the fixture's TTL self-exit is the backstop.
+
+const fixturePath = fileURLToPath(new URL("fixtures/fake-codex-listener.ts", import.meta.url))
+
+/** A sandbox whose wrapper script is the configured codex executable. */
+const makeSandbox = (vars: Record<string, string> = {}) => {
+  const base = trackTempDir(fs.mkdtempSync(path.join(os.tmpdir(), "atc-codex-")))
+  const stateDir = path.join(base, "state")
+  const wrapper = path.join(base, "fake-codex")
+  const pidFile = path.join(base, "fixture.pid")
+  const assignments = Object.entries({ FAKE_CODEX_PID_FILE: pidFile, ...vars })
+    .map(([key, value]) => `${key}='${value}'`)
+    .join(" ")
+  fs.writeFileSync(
+    wrapper,
+    `#!/bin/sh\n${assignments} exec "${process.execPath}" "${fixturePath}" "$@"\n`,
+  )
+  fs.chmodSync(wrapper, 0o755)
+  return {
+    base,
+    stateDir,
+    wrapper,
+    pidFile,
+    identityFile: path.join(stateDir, "codex-app-server.json"),
+  }
+}
+
+/** The pid the most recently launched fixture recorded. */
+const fixturePid = (sandbox: { readonly pidFile: string }): number =>
+  Number.parseInt(fs.readFileSync(sandbox.pidFile, "utf8"), 10)
+
+const serverLayer = (
+  sandbox: { readonly stateDir: string; readonly wrapper: string },
+  options: CodexServer.CodexServerOptions = {},
+) =>
+  CodexServer.layerWith(options).pipe(
+    Layer.provide(testAppConfig({ codexExecutable: sandbox.wrapper, stateDir: sandbox.stateDir })),
+    Layer.provide(Subprocess.layer),
+    Layer.provideMerge(BunServices.layer),
+  )
+
+const readIdentity = (identityFile: string): { pid: number; port: number } =>
+  JSON.parse(fs.readFileSync(identityFile, "utf8")) as { pid: number; port: number }
+
+/** Poll a real condition; assertion-bounded, never a bare sleep. */
+const waitFor = (what: string, check: () => boolean, attempts = 200) =>
+  Effect.gen(function* () {
+    for (let attempt = 0; !check(); attempt++) {
+      assert.isBelow(attempt, attempts, `never observed: ${what}`)
+      yield* Effect.sleep("50 millis")
+    }
+  })
+
+describe("CodexServer", () => {
+  it.live(
+    "spawns detached, persists identity, adopts from a fresh service, and stops",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeSandbox()
+
+        // First service instance spawns the server.
+        const first = yield* Effect.gen(function* () {
+          const codex = yield* CodexServer.CodexServer
+          return yield* codex.ensure()
+        }).pipe(Effect.provide(serverLayer(sandbox)))
+        assert.isTrue(Subprocess.isProcessAlive(first.pid))
+        assert.strictEqual(first.url, `ws://127.0.0.1:${first.port}`)
+        const persisted = readIdentity(sandbox.identityFile)
+        assert.strictEqual(persisted.pid, first.pid)
+        assert.strictEqual(persisted.port, first.port)
+
+        // The first service's layer scope is closed now — the detached
+        // server must have survived it (the whole point of detaching).
+        assert.isTrue(Subprocess.isProcessAlive(first.pid))
+
+        // A fresh service instance adopts the same server instead of
+        // spawning a second one, then stop() reaps it and clears identity.
+        yield* Effect.gen(function* () {
+          const codex = yield* CodexServer.CodexServer
+          const adopted = yield* codex.ensure()
+          assert.strictEqual(adopted.pid, first.pid)
+          assert.strictEqual(adopted.port, first.port)
+          yield* codex.stop()
+        }).pipe(Effect.provide(serverLayer(sandbox)))
+        assert.isTrue(yield* Subprocess.waitForProcessExit(first.pid))
+        assert.isFalse(fs.existsSync(sandbox.identityFile))
+      }),
+    30_000,
+  )
+
+  it.live(
+    "replaces a dead persisted pid instead of failing",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeSandbox()
+        // A pid that is certainly dead: spawn a no-op and wait for it.
+        const gone = Bun.spawnSync(["true"])
+        fs.mkdirSync(sandbox.stateDir, { recursive: true })
+        fs.writeFileSync(
+          sandbox.identityFile,
+          JSON.stringify({ pid: gone.pid ?? 999999, port: 1, startedAt: "then" }),
+        )
+        yield* Effect.gen(function* () {
+          const codex = yield* CodexServer.CodexServer
+          const info = yield* codex.ensure()
+          assert.isTrue(Subprocess.isProcessAlive(info.pid))
+          assert.notStrictEqual(info.port, 1)
+          yield* codex.stop()
+        }).pipe(Effect.provide(serverLayer(sandbox)))
+      }),
+    30_000,
+  )
+
+  it.live(
+    "replaces an alive-but-unready server (adopt-or-replace, never accumulate)",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeSandbox()
+        // A live process that IS an app-server by command line but never
+        // becomes ready: the never-ready fixture launched by hand.
+        const stalePort = yield* Effect.promise(() => freePort())
+        const stale = Bun.spawn(
+          [process.execPath, fixturePath, "app-server", "--listen", `ws://127.0.0.1:${stalePort}`],
+          { env: { ...process.env, FAKE_CODEX_MODE: "never-ready" } },
+        )
+        try {
+          fs.mkdirSync(sandbox.stateDir, { recursive: true })
+          fs.writeFileSync(
+            sandbox.identityFile,
+            JSON.stringify({ pid: stale.pid, port: stalePort, startedAt: "then" }),
+          )
+          yield* Effect.gen(function* () {
+            const codex = yield* CodexServer.CodexServer
+            const info = yield* codex.ensure()
+            // The stale claimant was killed; the new server is ready.
+            assert.isTrue(yield* Subprocess.waitForProcessExit(stale.pid))
+            assert.isTrue(Subprocess.isProcessAlive(info.pid))
+            yield* codex.stop()
+          }).pipe(Effect.provide(serverLayer(sandbox, { adoptTimeout: "500 millis" })))
+        } finally {
+          stale.kill()
+        }
+      }),
+    30_000,
+  )
+
+  it.live(
+    "a recycled pid that is not an app-server is abandoned, never signaled",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeSandbox()
+        // A live process whose command line is NOT an app-server — models a
+        // pid recycled to an innocent process after a reboot.
+        const bystander = Bun.spawn([
+          process.execPath,
+          fileURLToPath(new URL("fixtures/sleep-forever.ts", import.meta.url)),
+        ])
+        try {
+          fs.mkdirSync(sandbox.stateDir, { recursive: true })
+          fs.writeFileSync(
+            sandbox.identityFile,
+            JSON.stringify({ pid: bystander.pid, port: 1, startedAt: "then" }),
+          )
+          yield* Effect.gen(function* () {
+            const codex = yield* CodexServer.CodexServer
+            const info = yield* codex.ensure()
+            // A fresh server was spawned and the bystander was left alone.
+            assert.isTrue(Subprocess.isProcessAlive(info.pid))
+            assert.isTrue(Subprocess.isProcessAlive(bystander.pid))
+            yield* codex.stop()
+          }).pipe(Effect.provide(serverLayer(sandbox)))
+          assert.isTrue(Subprocess.isProcessAlive(bystander.pid))
+        } finally {
+          bystander.kill()
+        }
+      }),
+    30_000,
+  )
+
+  it.live(
+    "a server that never becomes ready is reaped and reported actionably",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeSandbox({ FAKE_CODEX_MODE: "never-ready" })
+        const failure = yield* Effect.gen(function* () {
+          const codex = yield* CodexServer.CodexServer
+          return yield* Effect.flip(codex.ensure())
+        }).pipe(Effect.provide(serverLayer(sandbox, { readyTimeout: "700 millis" })))
+        assert.include(failure.message, "not ready")
+        // The failed spawn was cleaned up: no identity, no stray process.
+        assert.isFalse(fs.existsSync(sandbox.identityFile))
+        assert.isTrue(yield* Subprocess.waitForProcessExit(fixturePid(sandbox)))
+      }),
+    30_000,
+  )
+
+  it.live(
+    "a missing executable is one actionable diagnostic",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeSandbox()
+        const failure = yield* Effect.gen(function* () {
+          const codex = yield* CodexServer.CodexServer
+          return yield* Effect.flip(codex.ensure())
+        }).pipe(
+          Effect.provide(
+            serverLayer({ stateDir: sandbox.stateDir, wrapper: "atc-test-definitely-not-codex" }),
+          ),
+        )
+        assert.include(failure.message, "install the Codex CLI")
+        assert.include(failure.message, "ATC_CODEX_EXECUTABLE")
+      }),
+    30_000,
+  )
+
+  it.live(
+    "the exit watcher restarts a server that died underneath us",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeSandbox()
+        yield* Effect.gen(function* () {
+          const codex = yield* CodexServer.CodexServer
+          const info = yield* codex.ensure()
+          process.kill(info.pid, "SIGKILL")
+          yield* waitFor("watcher restarted the server with a new live pid", () => {
+            if (!fs.existsSync(sandbox.identityFile)) return false
+            const identity = readIdentity(sandbox.identityFile)
+            return identity.pid !== info.pid && Subprocess.isProcessAlive(identity.pid)
+          })
+          const replacement = yield* codex.ensure()
+          assert.notStrictEqual(replacement.pid, info.pid)
+          yield* codex.stop()
+        }).pipe(Effect.provide(serverLayer(sandbox, { watchInterval: "50 millis" })))
+      }),
+    30_000,
+  )
+})

--- a/app-server/test/config.test.ts
+++ b/app-server/test/config.test.ts
@@ -43,10 +43,36 @@ describe("configuration", () => {
       assert.strictEqual(config.dbFile, join(home, ".local", "share", "atc", "atc.db"))
       assert.strictEqual(config.logFile, join(home, ".local", "state", "atc", "atc.log"))
       assert.strictEqual(config.zmxExecutable, "zmx")
+      assert.strictEqual(config.codexExecutable, "codex")
+      assert.strictEqual(config.claudeExecutable, "claude")
       assert.strictEqual(
         config.terminalSocketDir,
         join(home, ".local", "state", "atc", "terminals"),
       )
+    }),
+  )
+
+  it.effect("provider executables follow the precedence rule and reject relative paths", () =>
+    Effect.gen(function* () {
+      const file = writeConfig(
+        `codexExecutable = "/opt/from-file/codex"\nclaudeExecutable = "/opt/from-file/claude"\n`,
+      )
+      const fromFile = yield* load({ ATC_CONFIG: file })
+      assert.strictEqual(fromFile.codexExecutable, "/opt/from-file/codex")
+      assert.strictEqual(fromFile.claudeExecutable, "/opt/from-file/claude")
+      const fromEnv = yield* load({
+        ATC_CONFIG: file,
+        ATC_CODEX_EXECUTABLE: "/opt/from-env/codex",
+        ATC_CLAUDE_EXECUTABLE: "/opt/from-env/claude",
+      })
+      assert.strictEqual(fromEnv.codexExecutable, "/opt/from-env/codex")
+      assert.strictEqual(fromEnv.claudeExecutable, "/opt/from-env/claude")
+
+      const codexError = yield* loadError({ ATC_CODEX_EXECUTABLE: "bin/codex" })
+      assert.include(codexError.message, "bare name or an absolute path")
+      assert.include(codexError.source, "ATC_CODEX_EXECUTABLE")
+      const claudeError = yield* loadError({ ATC_CLAUDE_EXECUTABLE: "bin/claude" })
+      assert.include(claudeError.source, "ATC_CLAUDE_EXECUTABLE")
     }),
   )
 

--- a/app-server/test/fakeAgentAdapter.ts
+++ b/app-server/test/fakeAgentAdapter.ts
@@ -1,0 +1,274 @@
+import { Cause, Effect, Queue, Stream } from "effect"
+import type {
+  AgentActivity,
+  AgentAdapter,
+  AgentConnection,
+  AgentEvent,
+  AgentRequestKind,
+  AgentTurn,
+  AgentTurnOutcome,
+} from "../src/agentAdapter.ts"
+import {
+  AgentConflict,
+  AgentIdentityMismatch,
+  AgentProtocolError,
+  AgentResumeFailed,
+  AgentUnavailable,
+} from "../src/agentAdapter.ts"
+
+// The fake-adapter test seam (ATC-123): an in-memory AgentAdapter with the
+// same observable semantics the real adapters must hold — create and resume
+// are distinct, resume fails closed on unknown ids and mismatched cwd, one
+// active writer per session, one active turn per connection, stale interrupt
+// targets rejected — plus controls to script turn outcomes and provider
+// requests and switches to inject unavailability.
+//
+// It models the EAGER-verification, connection-survives-failed-turns flavor
+// (Codex). Claude differs on both axes (verification at first turn,
+// connection ends after non-success turns) — consumers exercising those
+// paths must test against the real adapters' fixtures, not this fake.
+
+export interface FakeAgentSession {
+  readonly providerSessionId: string
+  readonly cwd: string
+  /** Inputs received via createSession/startTurn, for assertions. */
+  readonly inputs: Array<string>
+}
+
+export interface FakeAgentAdapter {
+  readonly adapter: AgentAdapter
+  readonly sessions: Map<string, FakeAgentSession>
+  /** While set, every operation fails with AgentUnavailable(reason). */
+  readonly setUnavailable: (reason: string | null) => void
+  /** Insert a resumable session directly (no createSession). */
+  readonly seed: (providerSessionId: string, cwd: string) => FakeAgentSession
+  /** Complete the active turn of `providerSessionId` with `outcome`. */
+  readonly completeTurn: (providerSessionId: string, outcome: AgentTurnOutcome) => void
+  /** Open a provider request on the active turn; activity → needs_input. */
+  readonly openRequest: (providerSessionId: string, kind: AgentRequestKind) => string
+  /** Close a previously opened request; activity → working. */
+  readonly closeRequest: (providerSessionId: string, requestId: string) => void
+}
+
+interface LiveConnection {
+  readonly events: Queue.Queue<AgentEvent, Cause.Done>
+  activity: AgentActivity
+  activeTurn: string | null
+  closed: boolean
+  readonly openRequests: Set<string>
+}
+
+export const makeFakeAgentAdapter = (): FakeAgentAdapter => {
+  const sessions = new Map<string, FakeAgentSession>()
+  // One live connection per session — the single-writer rule.
+  const connections = new Map<string, LiveConnection>()
+  let unavailableReason: string | null = null
+  let nextSessionId = 1
+  let nextTurnId = 1
+  let nextRequestId = 1
+
+  const requireAvailable = Effect.suspend(() =>
+    unavailableReason !== null
+      ? Effect.fail(new AgentUnavailable({ provider: "codex", reason: unavailableReason }))
+      : Effect.void,
+  )
+
+  const emit = (live: LiveConnection, event: AgentEvent): void => {
+    Queue.offerUnsafe(live.events, event)
+  }
+
+  const setActivity = (live: LiveConnection, activity: AgentActivity): void => {
+    live.activity = activity
+    emit(live, { type: "activity", activity })
+  }
+
+  const requireLive = (providerSessionId: string): LiveConnection => {
+    const live = connections.get(providerSessionId)
+    if (live === undefined) {
+      throw new Error(`fake adapter: no live connection for ${providerSessionId}`)
+    }
+    return live
+  }
+
+  const openConnection = (session: FakeAgentSession) =>
+    Effect.gen(function* () {
+      if (connections.has(session.providerSessionId)) {
+        return yield* Effect.fail(
+          new AgentConflict({
+            provider: "codex",
+            reason: `a writer is already connected to ${session.providerSessionId}`,
+          }),
+        )
+      }
+      const events = yield* Queue.make<AgentEvent, Cause.Done>()
+      const live: LiveConnection = {
+        events,
+        activity: "idle",
+        activeTurn: null,
+        closed: false,
+        openRequests: new Set(),
+      }
+      connections.set(session.providerSessionId, live)
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          live.closed = true
+          connections.delete(session.providerSessionId)
+          Queue.endUnsafe(events)
+        }),
+      )
+
+      const requireOpen = Effect.suspend(() =>
+        live.closed
+          ? Effect.fail(
+              new AgentConflict({ provider: "codex", reason: "the connection is closed" }),
+            )
+          : Effect.void,
+      )
+
+      const startTurn = (input: string) =>
+        Effect.gen(function* () {
+          yield* requireAvailable
+          yield* requireOpen
+          if (live.activeTurn !== null) {
+            return yield* Effect.fail(
+              new AgentConflict({
+                provider: "codex",
+                reason: `turn ${live.activeTurn} is still active`,
+              }),
+            )
+          }
+          session.inputs.push(input)
+          const turnId = `fake-turn-${nextTurnId++}`
+          live.activeTurn = turnId
+          emit(live, { type: "turnStarted", turnId })
+          setActivity(live, "working")
+          return { turnId }
+        })
+
+      const connection: AgentConnection = {
+        providerSessionId: session.providerSessionId,
+        cwd: session.cwd,
+        activity: Effect.sync(() => live.activity),
+        events: Stream.fromQueue(events).pipe(
+          Stream.mapError(
+            (cause) => new AgentProtocolError({ provider: "codex", reason: String(cause) }),
+          ),
+        ),
+        startTurn,
+        interrupt: (turn: AgentTurn) =>
+          Effect.gen(function* () {
+            yield* requireAvailable
+            yield* requireOpen
+            if (live.activeTurn !== turn.turnId) {
+              return yield* Effect.fail(
+                new AgentConflict({
+                  provider: "codex",
+                  reason: `turn ${turn.turnId} is not the active turn`,
+                }),
+              )
+            }
+            finishTurn(session.providerSessionId, "interrupted")
+          }),
+      }
+      return connection
+    })
+
+  const finishTurn = (providerSessionId: string, outcome: AgentTurnOutcome): void => {
+    const live = requireLive(providerSessionId)
+    if (live.activeTurn === null) {
+      throw new Error(`fake adapter: no active turn on ${providerSessionId}`)
+    }
+    const turnId = live.activeTurn
+    live.activeTurn = null
+    for (const requestId of live.openRequests) {
+      emit(live, { type: "requestClosed", requestId })
+    }
+    live.openRequests.clear()
+    emit(live, { type: "turnCompleted", turnId, outcome })
+    setActivity(live, "idle")
+  }
+
+  const adapter: AgentAdapter = {
+    provider: "codex",
+    capabilities: { testedVersion: "0.0.0-fake", tuiObservation: "shared-server" },
+    createSession: (options) =>
+      Effect.gen(function* () {
+        yield* requireAvailable
+        const session: FakeAgentSession = {
+          providerSessionId: `fake-session-${nextSessionId++}`,
+          cwd: options.cwd,
+          inputs: [],
+        }
+        sessions.set(session.providerSessionId, session)
+        const connection = yield* openConnection(session)
+        // The fake verifies eagerly, so deferred-verification tags cannot
+        // occur on its first turn.
+        const turn = yield* connection
+          .startTurn(options.input)
+          .pipe(Effect.catchTag("AgentResumeFailed", (error) => Effect.die(error)))
+        return { connection, turn }
+      }),
+    resumeSession: (options) =>
+      Effect.gen(function* () {
+        yield* requireAvailable
+        const session = sessions.get(options.providerSessionId)
+        if (session === undefined) {
+          return yield* Effect.fail(
+            new AgentResumeFailed({
+              provider: "codex",
+              providerSessionId: options.providerSessionId,
+              reason: "no session found for id",
+            }),
+          )
+        }
+        if (session.cwd !== options.cwd) {
+          return yield* Effect.fail(
+            new AgentIdentityMismatch({
+              provider: "codex",
+              field: "cwd",
+              expected: options.cwd,
+              actual: session.cwd,
+            }),
+          )
+        }
+        return yield* openConnection(session)
+      }),
+    tuiLaunch: (options) =>
+      requireAvailable.pipe(
+        Effect.as({
+          command: ["fake-agent", "resume", options.providerSessionId],
+          env: {},
+        }),
+      ),
+  }
+
+  return {
+    adapter,
+    sessions,
+    setUnavailable: (reason) => {
+      unavailableReason = reason
+    },
+    seed: (providerSessionId, cwd) => {
+      const session: FakeAgentSession = { providerSessionId, cwd, inputs: [] }
+      sessions.set(providerSessionId, session)
+      return session
+    },
+    completeTurn: (providerSessionId, outcome) => finishTurn(providerSessionId, outcome),
+    openRequest: (providerSessionId, kind) => {
+      const live = requireLive(providerSessionId)
+      const requestId = `fake-request-${nextRequestId++}`
+      live.openRequests.add(requestId)
+      emit(live, { type: "requestOpened", requestId, kind })
+      setActivity(live, "needs_input")
+      return requestId
+    },
+    closeRequest: (providerSessionId, requestId) => {
+      const live = requireLive(providerSessionId)
+      if (!live.openRequests.delete(requestId)) {
+        throw new Error(`fake adapter: request ${requestId} is not open`)
+      }
+      emit(live, { type: "requestClosed", requestId })
+      setActivity(live, "working")
+    },
+  }
+}

--- a/app-server/test/fixtures/fake-codex-listener.ts
+++ b/app-server/test/fixtures/fake-codex-listener.ts
@@ -1,0 +1,34 @@
+// Fixture stand-in for `codex app-server --listen ws://127.0.0.1:<port>`:
+// binds the requested port and answers /readyz so codexServer supervision
+// can be exercised without a real Codex install. FAKE_CODEX_MODE selects a
+// behavior: "ok" (default) answers /readyz 200, "never-ready" answers 503.
+// FAKE_CODEX_PID_FILE records this pid so tests can assert the process was
+// reaped even on paths that clear the identity file. FAKE_CODEX_TTL_MS
+// (default 120s) self-terminates the process so a test that fails to stop()
+// a detached fixture can never leak it for long.
+
+const listenArg = process.argv.find((arg) => arg.startsWith("ws://"))
+if (listenArg === undefined) {
+  console.error("fake-codex-listener: no ws:// listen argument")
+  process.exit(64)
+}
+const port = Number.parseInt(new URL(listenArg).port, 10)
+const mode = process.env["FAKE_CODEX_MODE"] ?? "ok"
+const ttl = Number.parseInt(process.env["FAKE_CODEX_TTL_MS"] ?? "120000", 10)
+const pidFile = process.env["FAKE_CODEX_PID_FILE"]
+if (pidFile !== undefined && pidFile !== "") {
+  await Bun.write(pidFile, String(process.pid))
+}
+
+Bun.serve({
+  hostname: "127.0.0.1",
+  port,
+  fetch(request) {
+    if (new URL(request.url).pathname === "/readyz" && mode === "ok") {
+      return new Response("ok", { status: 200 })
+    }
+    return new Response("not ready", { status: 503 })
+  },
+})
+
+setTimeout(() => process.exit(0), ttl)

--- a/app-server/test/provider.smoke.test.ts
+++ b/app-server/test/provider.smoke.test.ts
@@ -48,10 +48,10 @@ describe.skipIf(!enabled)("live provider smoke (opt-in: mise run test:smoke)", (
 
   test("Claude Agent SDK round trip", async () => {
     const resolvable =
-      process.env["ATC_CLAUDE_CODE_EXECUTABLE"] !== undefined || Bun.which("claude") !== null
+      process.env["ATC_CLAUDE_EXECUTABLE"] !== undefined || Bun.which("claude") !== null
     expect(
       resolvable,
-      "claude not found; install and authenticate Claude Code or set ATC_CLAUDE_CODE_EXECUTABLE",
+      "claude not found; install and authenticate Claude Code or set ATC_CLAUDE_EXECUTABLE",
     ).toBe(true)
     await runSmoke("claude")
   }, 300_000)

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -74,6 +74,8 @@ export const testAppConfig = (overrides: Partial<AppConfig["Service"]>): Layer.L
     dbFile: "/tmp/atc.db",
     logFile: "/tmp/atc.log",
     zmxExecutable: "zmx",
+    codexExecutable: "codex",
+    claudeExecutable: "claude",
     terminalSocketDir: "/tmp/atc-sockets",
     ...overrides,
   })

--- a/experiments/provider-identity-resume/atc-123-probe-findings.md
+++ b/experiments/provider-identity-resume/atc-123-probe-findings.md
@@ -57,3 +57,29 @@ Bonus SDK behavior finding: the SDK's async iterator **throws** on an error
 result ("Claude Code returned an error result: Reached maximum number of
 turns (1)") — the adapter must treat that throw as a normal turn-failed
 outcome carrying the result, not as a transport defect.
+
+## 4. Detach → survive → adopt → resume → turn → stop: verified end-to-end
+
+The detached-server lifecycle decided in finding 1 was exercised as a full
+cycle across two separate processes (simulating an ATC restart):
+
+Phase A spawned `codex app-server --listen ws://127.0.0.1:17993` detached
+(`nohup`, backgrounded through an intermediate `sh` that exits immediately,
+so the server is reparented with no controlling terminal), seeded a thread
+with one completed turn, persisted `{pid, port, threadId, cwd}`, and exited
+without killing anything. Phase B, a fresh process started 5s later:
+
+- server pid still alive after the spawner's exit;
+- `/readyz` on the persisted port answered;
+- `thread/resume` returned the exact thread ID and cwd with 1 existing turn;
+- a turn driven over the adopted connection completed, with 21 correlated
+  events (`thread/status/changed`, `turn/started`, `item/started`,
+  `item/agentMessage/delta`, `item/completed`, `turn/completed`,
+  `thread/tokenUsage/updated`) — the full status feed works on an adopted
+  connection;
+- explicit `SIGTERM` stopped the server cleanly (the intentional-stop path).
+
+Verdict: PASS on first run. Every load-bearing behavior of the accepted
+Codex topology now has direct evidence: shared-server fan-out and real-TUI
+observation (ATC-83), identity/resume/fail-closed (ATC-68), TUI
+non-survival of server death (finding 1), and detached adoption (this).

--- a/experiments/provider-identity-resume/atc-123-probe-findings.md
+++ b/experiments/provider-identity-resume/atc-123-probe-findings.md
@@ -1,0 +1,59 @@
+# ATC-123 pre-implementation probe findings
+
+Date: 2026-08-03. Versions: codex-cli 0.146.0, Claude Code 2.1.221,
+`@anthropic-ai/claude-agent-sdk` 0.3.220 (app-server pinned), macOS arm64.
+
+Three probes run during the ATC-123 grilling session to close the questions
+the decision record left open. Probe scripts were session-scratch; the
+protocol recipes they used are the ones already recorded in this directory
+(`codex/app-server-client.ts`, `codex/held-connection.ts`).
+
+## 1. Codex TUI does NOT survive an app-server restart
+
+Setup: `codex app-server --listen ws://127.0.0.1:17987`, thread created and
+seeded with one completed turn over WebSocket JSON-RPC, writer disconnected,
+then `codex resume --remote ws://127.0.0.1:17987 <threadId>` spawned in a PTY
+(rendered the session, echoed the seed turn). Server killed with SIGKILL,
+then restarted on the same port 10s later.
+
+Result: the TUI exited (code 1) immediately on server death, printing:
+
+> ERROR: remote app server at `ws://127.0.0.1:17987/` transport failed:
+> WebSocket protocol error: Connection reset without closing handshake
+> To continue this session, run codex resume 019fcac1-d24c-7183-a30d-2560d2754fa3
+
+There is no reconnect loop in the TUI (v0.146.0). Restarting the server on
+the same port changed nothing; the process was already gone.
+
+**Consequence (settled in the ATC-123 decision record):** the codex
+app-server must be spawned detached, zmx-style — surviving ATC restarts,
+re-adopted on boot via persisted identity + `/readyz`, adopt-or-replace,
+never accumulate. A scoped child would kill every live Codex TUI on every
+ATC restart.
+
+## 2. Claude hooks fire as in-process callbacks in SDK mode (ATC-105 backfill)
+
+`query()` with the full hook set in `options.hooks`, nested-session env
+markers scrubbed, prompt "Reply with exactly: OK", `maxTurns: 2`:
+`UserPromptSubmit` and `Stop` fired as in-process callbacks with the correct
+`session_id`; result `success`. SDK-mode hook delivery is confirmed.
+
+## 3. StopFailure did NOT fire on error_max_turns (ATC-105 backfill — negative)
+
+`query()` with `maxTurns: 1` and a prompt forcing one Bash tool use
+(`bypassPermissions`): hooks fired `UserPromptSubmit`, `PreToolUse`,
+`PostToolUse`; the stream delivered `result: error_max_turns`; then **neither
+`Stop` nor `StopFailure` fired** (3s settle window).
+
+The architecture doc's claim "`Stop` does not fire when a turn ends on an
+error path — `StopFailure` does" did not reproduce for `error_max_turns` in
+SDK mode. Per ATC-105's instruction, the architecture doc is corrected rather
+than the requirement kept: the adapter must derive error-path idle in SDK
+mode from the `result` message, with the staleness/reconciliation path as
+backstop. Whether `StopFailure` fires for other error subtypes (e.g.
+`error_during_execution`) or in TUI mode remains unverified.
+
+Bonus SDK behavior finding: the SDK's async iterator **throws** on an error
+result ("Claude Code returned an error result: Reached maximum number of
+turns (1)") — the adapter must treat that throw as a normal turn-failed
+outcome carrying the result, not as a transport defect.


### PR DESCRIPTION
First of three stacked PRs for [ATC-123](https://linear.app/elevenideas/issue/ATC-123/codex-and-claude-code-integrations) ([ATC-132](https://linear.app/elevenideas/issue/ATC-132)). Internal only — no migrations, no public API group, no openapi change.

## What's here

- **`AppConfig` provider executables**: `codexExecutable` / `claudeExecutable` (flags > `ATC_*` env > config.toml > defaults, same bare-name-or-absolute rule as `zmxExecutable`). `smoke.ts` now reads these settled values; its ad-hoc `process.env` reads are gone (`ATC_CLAUDE_CODE_EXECUTABLE` → `ATC_CLAUDE_EXECUTABLE`, no compat shim).
- **`agentAdapter.ts`** — the shared `AgentAdapter` seam (TerminalAdapter pattern): distinct `createSession`/`resumeSession` with fail-closed identity + cwd verification, one writer per session, one active turn per connection, exact-turn interrupt, normalized status feed (`idle|working|needs_input|unknown`, turn/request events), TUI launch specs, capability reporting. Create requires initial input (both providers establish durable identity while starting a turn; a zero-turn Codex thread is not restart-resumable).
- **`test/fakeAgentAdapter.ts`** — in-memory fake enforcing the same observable semantics, plus seam-semantics tests.
- **`codexServer.ts`** — supervision of the single long-lived **detached** `codex app-server` per profile: persisted identity file, boot adoption via pid + `/readyz` (adopt-or-replace, never accumulate), jittered-exponential readiness gate that fails fast when the pid dies, exit-watcher restart with backoff, explicit `stop`. ATC shutdown deliberately leaves the server running — a live `codex resume --remote` TUI has no reconnect loop and dies with the server (probe finding, 2026-08-03). Pids are only trusted or signaled after an exact `app-server` argv-token check, so a recycled pid is abandoned, never killed.

## Review process

Two adversarial sub-agent reviews (correctness on Opus, simplicity on Sonnet) ran before this PR; applied fixes include: corrupt-identity-file decode failing as a typed error instead of a defect, the pid-recycling guard, closing two spawn-leak windows (identity-write failure / interruption mid-spawn), dead-pid fail-fast in the readiness gate, `</dev/null` stdin daemonization, reaping divergent cache/file pids on stop, configured-path existence checks, and closed-connection state in the fake.

## Verification

`mise run -C app-server check` green (169 tests). Supervision tests exercise real detached processes via a fake app-server fixture (spawn → adopt from a fresh service → stop; dead/unready/foreign persisted pids; watcher restart after SIGKILL; never-ready reap with pid-file proof).

https://claude.ai/code/session_018Rd6RAK5eJMvN3EYfJyr17
