### PR TITLE
ATC-133: Codex provider adapter with fixtures and smoke tests

### DIFF
--- a/app-server/mise.toml
+++ b/app-server/mise.toml
@@ -71,7 +71,7 @@ run = "ATC_COMPILED_TEST=1 bun --bun vitest run test/compiled.blackbox.test.ts"
 [tasks."test:smoke"]
 description = "Opt-in live provider smoke tests (requires Codex CLI and Claude Code credentials)"
 depends = ["build"]
-run = "ATC_SMOKE=1 bun --bun vitest run test/provider.smoke.test.ts"
+run = "ATC_SMOKE=1 bun --bun vitest run test/provider.smoke.test.ts test/codexAdapter.smoke.test.ts"
 
 [tasks."test:zmx"]
 description = "Opt-in tests against the real installed zmx: adapter smoke and compiled restart recovery"

--- a/app-server/src/codexAdapter.ts
+++ b/app-server/src/codexAdapter.ts
@@ -1,0 +1,591 @@
+import { Cause, Context, Effect, Layer, Queue, Schema, Semaphore, Stream } from "effect"
+import { realpathSync } from "node:fs"
+import type { AgentActivity, AgentAdapter, AgentConnection, AgentEvent } from "./agentAdapter.ts"
+import {
+  AgentConflict,
+  AgentIdentityMismatch,
+  AgentProtocolError,
+  AgentResumeFailed,
+  AgentUnavailable,
+  resolveProviderExecutable,
+  warnIfBelowTestedVersion,
+} from "./agentAdapter.ts"
+import * as BuildInfo from "./buildInfo.ts"
+import * as CodexServer from "./codexServer.ts"
+import { AppConfig } from "./config.ts"
+import * as Subprocess from "./subprocess.ts"
+
+// The Codex AgentAdapter (ATC-123): one WebSocket JSON-RPC client of the
+// profile's supervised, detached app-server (codexServer.ts), multiplexing
+// every thread over that single shared connection — which is what makes
+// TUI-driven turns observable on our feed. Invariants beyond the seam's:
+//
+//   - One writer per thread is enforced HERE (the app-server would accept a
+//     concurrent second writer, and concurrent writers corrupt provider
+//     turn attribution — ATC-83 evidence).
+//   - Server-initiated requests (approvals, questions) are surfaced on the
+//     feed and answered with an immediate JSON-RPC rejection — never left
+//     hanging. Real responses are ATC-124 work.
+//   - A lost server connection fails every live session's feed loudly; the
+//     next create/resume reconnects. Sessions never survive their socket.
+//   - Wire shapes stay private to this module; raw events are logged at
+//     debug level only.
+
+/** The codex-cli version this adapter was validated against (record + warn). */
+export const CODEX_TESTED_VERSION = "0.146.0"
+
+const REQUEST_TIMEOUT = "30 seconds"
+
+export class CodexAdapter extends Context.Service<CodexAdapter, AgentAdapter>()(
+  "app-server/CodexAdapter",
+) {}
+
+const unavailable = (reason: string) => new AgentUnavailable({ provider: "codex", reason })
+const protocolError = (reason: string) => new AgentProtocolError({ provider: "codex", reason })
+const conflict = (reason: string) => new AgentConflict({ provider: "codex", reason })
+
+/** A JSON-RPC error response — mapped per call site (resume vs the rest). */
+class RpcError extends Schema.TaggedErrorClass<RpcError>()("RpcError", {
+  code: Schema.NullOr(Schema.Number),
+  text: Schema.String,
+}) {}
+
+const ThreadReply = Schema.Struct({
+  thread: Schema.Struct({
+    id: Schema.String,
+    cwd: Schema.String,
+    status: Schema.optional(Schema.Unknown),
+  }),
+})
+
+const TurnReply = Schema.Struct({ turn: Schema.Struct({ id: Schema.String }) })
+
+/** Symlink-tolerant path equality (macOS tmpdir lives behind /private). */
+const samePath = (left: string, right: string): boolean => {
+  const canonical = (value: string): string => {
+    try {
+      return realpathSync(value)
+    } catch {
+      return value
+    }
+  }
+  return canonical(left) === canonical(right)
+}
+
+const statusToActivity = (status: unknown): AgentActivity => {
+  if (typeof status !== "object" || status === null) return "unknown"
+  const record = status as { type?: unknown; activeFlags?: unknown }
+  if (record.type === "idle") return "idle"
+  if (record.type !== "active") return "unknown"
+  const flags = Array.isArray(record.activeFlags) ? record.activeFlags : []
+  return flags.includes("waitingOnUserInput") || flags.includes("waitingOnApproval")
+    ? "needs_input"
+    : "working"
+}
+
+const SERVER_REQUEST_KINDS: Record<string, "approval" | "question"> = {
+  "item/commandExecution/requestApproval": "approval",
+  "item/tool/requestUserInput": "question",
+}
+
+interface LiveSession {
+  readonly threadId: string
+  readonly queue: Queue.Queue<AgentEvent, AgentProtocolError | Cause.Done>
+  activity: AgentActivity
+  /** Any live turn on the thread — ours or an external writer's (a TUI). */
+  activeTurn: string | null
+  /** The turn THIS client started, if any — the only one whose provider
+   * requests we may answer. */
+  ownTurn: string | null
+  /** Set when the transport died underneath the session (vs. caller close). */
+  failed: boolean
+}
+
+/** Reserves the active-turn slot between the local check and the RPC reply. */
+const PENDING_TURN = "(pending)"
+
+interface PendingReply {
+  readonly succeed: (result: unknown) => void
+  readonly fail: (error: RpcError | AgentProtocolError) => void
+}
+
+interface ClientState {
+  readonly socket: WebSocket
+  readonly url: string
+  readonly pending: Map<number, PendingReply>
+  nextId: number
+  alive: boolean
+}
+
+export const layer = Layer.effect(CodexAdapter)(
+  Effect.gen(function* () {
+    const config = yield* AppConfig
+    const build = yield* BuildInfo.BuildInfo
+    const codexServer = yield* CodexServer.CodexServer
+    const subprocess = yield* Subprocess.Subprocess
+
+    // All live writer sessions, keyed by thread id. They always belong to
+    // `current`; a connection teardown fails and clears every one of them.
+    const sessions = new Map<string, LiveSession>()
+    const connectLock = yield* Semaphore.make(1)
+    const resumeLock = yield* Semaphore.make(1)
+    let current: ClientState | null = null
+    let versionChecked = false
+
+    const emit = (session: LiveSession, event: AgentEvent): void => {
+      Queue.offerUnsafe(session.queue, event)
+    }
+
+    const teardown = (state: ClientState, reason: string): void => {
+      if (!state.alive) return
+      state.alive = false
+      const error = protocolError(reason)
+      for (const reply of state.pending.values()) reply.fail(error)
+      state.pending.clear()
+      // Sessions belong to the CURRENT connection only — tearing down a
+      // stale socket (e.g. a failed handshake) must not touch them.
+      if (current === state) {
+        current = null
+        for (const session of sessions.values()) {
+          session.failed = true
+          Queue.failCauseUnsafe(session.queue, Cause.fail(error))
+        }
+        sessions.clear()
+      }
+      state.socket.close()
+    }
+
+    const handleServerRequest = (
+      state: ClientState,
+      message: {
+        id: number | string
+        method: string
+        params: Record<string, unknown> | undefined
+      },
+    ): void => {
+      const kind = SERVER_REQUEST_KINDS[message.method]
+      const threadId = message.params?.["threadId"]
+      const turnId = message.params?.["turnId"]
+      const session = typeof threadId === "string" ? sessions.get(threadId) : undefined
+      // Only answer requests for turns THIS client started: a shared-server
+      // request belonging to another writer (a TUI's approval prompt) is
+      // never ours to reject. Requests for our turns are surfaced, then
+      // answered with an immediate rejection — never left hanging. Real
+      // responses are ATC-124.
+      if (session === undefined || session.ownTurn !== turnId) return
+      if (kind !== undefined) {
+        const requestId = String(message.id)
+        emit(session, { type: "requestOpened", requestId, kind })
+        emit(session, { type: "requestClosed", requestId })
+      }
+      state.socket.send(
+        JSON.stringify({
+          id: message.id,
+          error: { code: -32601, message: "atc does not answer provider requests yet (ATC-124)" },
+        }),
+      )
+    }
+
+    const handleNotification = (message: {
+      method: string
+      params: Record<string, unknown> | undefined
+    }): void => {
+      const params = message.params ?? {}
+      const threadId = params["threadId"]
+      if (typeof threadId !== "string") return
+      const session = sessions.get(threadId)
+      if (session === undefined) return
+      switch (message.method) {
+        case "thread/status/changed": {
+          const activity = statusToActivity(params["status"])
+          if (activity !== session.activity) {
+            session.activity = activity
+            emit(session, { type: "activity", activity })
+          }
+          return
+        }
+        case "turn/started": {
+          const turnId = (params["turn"] as { id?: unknown } | undefined)?.id
+          if (typeof turnId !== "string") return
+          session.activeTurn = turnId
+          emit(session, { type: "turnStarted", turnId })
+          return
+        }
+        case "turn/completed": {
+          const turn = params["turn"] as { id?: unknown; status?: unknown } | undefined
+          const turnId = turn?.id
+          if (typeof turnId !== "string") return
+          if (session.activeTurn === turnId) session.activeTurn = null
+          if (session.ownTurn === turnId) session.ownTurn = null
+          const status = turn?.status
+          const outcome =
+            status === "completed"
+              ? "completed"
+              : status === "interrupted"
+                ? "interrupted"
+                : "failed"
+          emit(
+            session,
+            outcome === "failed"
+              ? { type: "turnCompleted", turnId, outcome, detail: String(status) }
+              : { type: "turnCompleted", turnId, outcome },
+          )
+          return
+        }
+        default:
+          // Item deltas, token usage, MCP startup noise: not status facts.
+          return
+      }
+    }
+
+    const dispatch = (state: ClientState, raw: string): void => {
+      let message: {
+        id?: number | string
+        method?: string
+        params?: Record<string, unknown>
+        result?: unknown
+        error?: { code?: number; message?: string } | null
+      }
+      try {
+        message = JSON.parse(raw) as typeof message
+      } catch {
+        teardown(state, "codex app-server sent invalid JSON")
+        return
+      }
+      if (message.id !== undefined && message.method === undefined) {
+        // Ids we send are numeric; tolerate a string echo of one.
+        const id = typeof message.id === "number" ? message.id : Number(message.id)
+        const reply = Number.isInteger(id) ? state.pending.get(id) : undefined
+        if (reply === undefined) return
+        state.pending.delete(id)
+        if (message.error !== undefined && message.error !== null) {
+          reply.fail(
+            new RpcError({
+              code: message.error.code ?? null,
+              text: message.error.message ?? "unknown error",
+            }),
+          )
+          return
+        }
+        reply.succeed(message.result ?? {})
+        return
+      }
+      // Requests and notifications only make sense from the connection the
+      // sessions belong to; a stale socket's frames must not touch them.
+      if (current !== state) return
+      if (message.id !== undefined && message.method !== undefined) {
+        handleServerRequest(state, {
+          id: message.id,
+          method: message.method,
+          params: message.params,
+        })
+        return
+      }
+      if (message.method !== undefined)
+        handleNotification({ method: message.method, params: message.params })
+    }
+
+    const request = (
+      state: ClientState,
+      method: string,
+      params: Record<string, unknown>,
+    ): Effect.Effect<unknown, RpcError | AgentProtocolError> =>
+      Effect.callback<unknown, RpcError | AgentProtocolError>((resume) => {
+        if (!state.alive) {
+          resume(Effect.fail(protocolError("the app-server connection is closed")))
+          return
+        }
+        const id = state.nextId++
+        state.pending.set(id, {
+          succeed: (result) => resume(Effect.succeed(result)),
+          fail: (error) => resume(Effect.fail(error)),
+        })
+        state.socket.send(JSON.stringify({ id, method, params }))
+        return Effect.sync(() => state.pending.delete(id))
+      }).pipe(
+        Effect.timeoutOrElse({
+          duration: REQUEST_TIMEOUT,
+          orElse: () => Effect.fail(protocolError(`${method} timed out`)),
+        }),
+      )
+
+    /** Every non-resume call site: an RPC error is a protocol failure. */
+    const rpcToProtocol = (error: RpcError | AgentProtocolError): AgentProtocolError =>
+      error._tag === "RpcError" ? protocolError(error.text) : error
+
+    const decodeReply = <S extends Schema.Top>(schema: S, reply: unknown) =>
+      Schema.decodeUnknownEffect(schema)(reply).pipe(
+        Effect.mapError((error) => protocolError(`unexpected reply shape: ${error.message}`)),
+      )
+
+    // Record + warn version drift, once, on first use (never blocks).
+    const versionCheck = Effect.gen(function* () {
+      if (versionChecked) return
+      versionChecked = true
+      const executable = yield* resolveProviderExecutable("codex", config.codexExecutable)
+      yield* warnIfBelowTestedVersion(subprocess, "codex", executable, CODEX_TESTED_VERSION)
+    })
+
+    const openSocket = (url: string): Effect.Effect<ClientState, AgentUnavailable> =>
+      Effect.callback<ClientState, AgentUnavailable>((resume) => {
+        const socket = new WebSocket(url)
+        const state: ClientState = { socket, url, pending: new Map(), nextId: 1, alive: true }
+        socket.onopen = () => resume(Effect.succeed(state))
+        socket.onerror = () => {
+          teardown(state, "connection failed")
+          resume(Effect.fail(unavailable(`could not connect to ${url}`)))
+        }
+        socket.onclose = () => teardown(state, "the codex app-server connection closed")
+        socket.onmessage = (event) => dispatch(state, String(event.data))
+        return Effect.sync(() => {
+          if (current !== state) teardown(state, "connection attempt interrupted")
+        })
+      }).pipe(
+        Effect.timeoutOrElse({
+          duration: "5 seconds",
+          orElse: () => Effect.fail(unavailable(`timed out connecting to ${url}`)),
+        }),
+      )
+
+    /** The shared connection: reuse, or ensure the server and handshake. */
+    const getClient = connectLock.withPermits(1)(
+      Effect.gen(function* () {
+        if (current !== null && current.alive) return current
+        yield* versionCheck
+        const info = yield* codexServer.ensure()
+        const state = yield* openSocket(info.url)
+        // A failed or interrupted handshake must close this socket: a
+        // half-open connection would double-deliver broadcasts and, on its
+        // eventual death, could not be told apart from the live one.
+        yield* request(state, "initialize", {
+          clientInfo: { name: "atc", title: "ATC App Server", version: build.version },
+          capabilities: null,
+        }).pipe(
+          Effect.mapError(rpcToProtocol),
+          Effect.onExit((exit) =>
+            Effect.sync(() => {
+              if (exit._tag === "Failure") teardown(state, "the handshake failed")
+            }),
+          ),
+        )
+        state.socket.send(JSON.stringify({ method: "initialized", params: {} }))
+        current = state
+        return state
+      }),
+    )
+
+    // Close the socket with the layer; the detached server itself lives on.
+    yield* Effect.addFinalizer(() =>
+      Effect.sync(() => {
+        if (current !== null) teardown(current, "atc is shutting down")
+      }),
+    )
+
+    const registerSession = (
+      state: ClientState,
+      threadId: string,
+      cwd: string,
+      initialStatus: unknown,
+    ) =>
+      Effect.gen(function* () {
+        const queue = yield* Queue.make<AgentEvent, AgentProtocolError | Cause.Done>()
+        const session: LiveSession = {
+          threadId,
+          queue,
+          // Seeded from the provider's own thread status — never a guess.
+          activity: statusToActivity(initialStatus),
+          activeTurn: null,
+          ownTurn: null,
+          failed: false,
+        }
+        sessions.set(threadId, session)
+        const unregister = (): void => {
+          if (sessions.get(threadId) !== session) return
+          sessions.delete(threadId)
+          Queue.endUnsafe(queue)
+          if (state.alive) {
+            state.socket.send(
+              JSON.stringify({
+                id: state.nextId++,
+                method: "thread/unsubscribe",
+                params: { threadId },
+              }),
+            )
+          }
+        }
+        yield* Effect.addFinalizer(() => Effect.sync(unregister))
+
+        // A dead transport is the retryable AgentUnavailable; only a
+        // caller-closed connection is a conflict.
+        const requireLive = Effect.suspend(
+          (): Effect.Effect<void, AgentConflict | AgentUnavailable> =>
+            session.failed || !state.alive
+              ? Effect.fail(
+                  new AgentUnavailable({
+                    provider: "codex",
+                    reason: "the app-server connection was lost; resume the session",
+                  }),
+                )
+              : sessions.get(threadId) === session
+                ? Effect.void
+                : Effect.fail(conflict("the connection is closed")),
+        )
+
+        const connection: AgentConnection = {
+          providerSessionId: threadId,
+          cwd,
+          activity: Effect.sync(() => session.activity),
+          events: Stream.fromQueue(queue),
+          startTurn: (input) =>
+            Effect.gen(function* () {
+              yield* requireLive
+              if (session.activeTurn !== null) {
+                return yield* Effect.fail(conflict(`turn ${session.activeTurn} is still active`))
+              }
+              // Reserve the slot before suspending on the RPC, or two
+              // concurrent startTurn calls would both pass the check.
+              session.activeTurn = PENDING_TURN
+              session.ownTurn = PENDING_TURN
+              const decoded = yield* request(state, "turn/start", {
+                threadId,
+                input: [{ type: "text", text: input }],
+              }).pipe(
+                Effect.mapError(rpcToProtocol),
+                Effect.flatMap((reply) => decodeReply(TurnReply, reply)),
+                Effect.onExit((exit) =>
+                  Effect.sync(() => {
+                    if (exit._tag !== "Failure") return
+                    if (session.activeTurn === PENDING_TURN) session.activeTurn = null
+                    if (session.ownTurn === PENDING_TURN) session.ownTurn = null
+                  }),
+                ),
+              )
+              // turn/started may have landed first with the real id.
+              if (session.activeTurn === PENDING_TURN) session.activeTurn = decoded.turn.id
+              session.ownTurn = decoded.turn.id
+              return { turnId: decoded.turn.id }
+            }),
+          interrupt: (turn) =>
+            Effect.gen(function* () {
+              yield* requireLive
+              if (session.activeTurn !== turn.turnId) {
+                return yield* Effect.fail(conflict(`turn ${turn.turnId} is not the active turn`))
+              }
+              // A provider-side rejection means the target went stale in
+              // flight — the same conflict as losing the local race.
+              yield* request(state, "turn/interrupt", { threadId, turnId: turn.turnId }).pipe(
+                Effect.mapError((error) =>
+                  error._tag === "RpcError" ? conflict(error.text) : error,
+                ),
+              )
+            }),
+        }
+        return { connection, unregister }
+      })
+
+    const adapter: AgentAdapter = {
+      provider: "codex",
+      capabilities: { testedVersion: CODEX_TESTED_VERSION, tuiObservation: "shared-server" },
+      createSession: (options) =>
+        Effect.gen(function* () {
+          const state = yield* getClient
+          const reply = yield* request(state, "thread/start", {
+            cwd: options.cwd,
+            approvalPolicy: "never",
+            sandbox: "workspace-write",
+          }).pipe(Effect.mapError(rpcToProtocol))
+          const decoded = yield* decodeReply(ThreadReply, reply)
+          if (!samePath(decoded.thread.cwd, options.cwd)) {
+            return yield* Effect.fail(
+              new AgentIdentityMismatch({
+                provider: "codex",
+                field: "cwd",
+                expected: options.cwd,
+                actual: decoded.thread.cwd,
+              }),
+            )
+          }
+          const { connection, unregister } = yield* registerSession(
+            state,
+            decoded.thread.id,
+            options.cwd,
+            decoded.thread.status,
+          )
+          // The seam widens startTurn's errors for deferred-verification
+          // providers; codex verified above, so those tags are impossible.
+          // A failed first turn releases the writer slot — the caller got
+          // no connection handle, so nothing must stay claimed.
+          const turn = yield* connection.startTurn(options.input).pipe(
+            Effect.catchTag("AgentResumeFailed", (error) => Effect.die(error)),
+            Effect.tapError(() => Effect.sync(unregister)),
+          )
+          return { connection, turn }
+        }),
+      resumeSession: (options) =>
+        // Serialized so two concurrent resumes of one thread cannot both
+        // pass the single-writer check while the RPC is in flight.
+        resumeLock.withPermits(1)(
+          Effect.gen(function* () {
+            const state = yield* getClient
+            if (sessions.has(options.providerSessionId)) {
+              return yield* Effect.fail(
+                conflict(`a writer is already connected to ${options.providerSessionId}`),
+              )
+            }
+            const reply = yield* request(state, "thread/resume", {
+              threadId: options.providerSessionId,
+              cwd: options.cwd,
+            }).pipe(
+              Effect.mapError((error) =>
+                error._tag === "RpcError" && error.code === -32600
+                  ? new AgentResumeFailed({
+                      provider: "codex",
+                      providerSessionId: options.providerSessionId,
+                      reason: error.text,
+                    })
+                  : rpcToProtocol(error),
+              ),
+            )
+            const decoded = yield* decodeReply(ThreadReply, reply)
+            if (decoded.thread.id !== options.providerSessionId) {
+              return yield* Effect.fail(
+                new AgentIdentityMismatch({
+                  provider: "codex",
+                  field: "sessionId",
+                  expected: options.providerSessionId,
+                  actual: decoded.thread.id,
+                }),
+              )
+            }
+            if (!samePath(decoded.thread.cwd, options.cwd)) {
+              return yield* Effect.fail(
+                new AgentIdentityMismatch({
+                  provider: "codex",
+                  field: "cwd",
+                  expected: options.cwd,
+                  actual: decoded.thread.cwd,
+                }),
+              )
+            }
+            const { connection } = yield* registerSession(
+              state,
+              decoded.thread.id,
+              options.cwd,
+              decoded.thread.status,
+            )
+            return connection
+          }),
+        ),
+      tuiLaunch: (options) =>
+        Effect.gen(function* () {
+          const executable = yield* resolveProviderExecutable("codex", config.codexExecutable)
+          const info = yield* codexServer.ensure()
+          return {
+            command: [executable, "resume", "--remote", info.url, options.providerSessionId],
+            env: {},
+          }
+        }),
+    }
+    return adapter
+  }),
+)

--- a/app-server/test/agentTestKit.ts
+++ b/app-server/test/agentTestKit.ts
@@ -1,0 +1,105 @@
+import { assert } from "@effect/vitest"
+import { BunServices } from "@effect/platform-bun"
+import { Duration, Effect, Layer, Stream } from "effect"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import { fileURLToPath } from "node:url"
+import type { AgentEvent } from "../src/agentAdapter.ts"
+import * as CodexAdapter from "../src/codexAdapter.ts"
+import * as CodexServer from "../src/codexServer.ts"
+import * as Subprocess from "../src/subprocess.ts"
+import { trackTempDir } from "./blackbox.ts"
+import { testAppConfig } from "./testLayers.ts"
+import { TestBuildInfoLayer } from "./testBuildInfo.ts"
+
+// Shared scaffolding for agent-provider tests (ATC-123): the fake-codex
+// sandbox (wrapper-script seam, like makeFakeZmxSandbox), the layer stacks
+// under supervision/adapter tests, and the event-feed helpers every adapter
+// test asserts with.
+
+const fakeCodexFixture = fileURLToPath(new URL("fixtures/fake-codex-listener.ts", import.meta.url))
+
+/**
+ * A per-test fake-codex sandbox: the wrapper script is the configured codex
+ * executable, per-test fixture configuration is baked into it, and the
+ * fixture records its pid for reap assertions.
+ */
+export const makeCodexSandbox = (vars: Record<string, string> = {}) => {
+  const base = trackTempDir(fs.mkdtempSync(path.join(os.tmpdir(), "atc-codex-")))
+  const stateDir = path.join(base, "state")
+  const cwd = path.join(base, "work")
+  fs.mkdirSync(cwd, { recursive: true })
+  const pidFile = path.join(base, "fixture.pid")
+  const wrapper = path.join(base, "fake-codex")
+  const assignments = Object.entries({ FAKE_CODEX_PID_FILE: pidFile, ...vars })
+    .map(([key, value]) => `${key}='${value}'`)
+    .join(" ")
+  fs.writeFileSync(
+    wrapper,
+    `#!/bin/sh\n${assignments} exec "${process.execPath}" "${fakeCodexFixture}" "$@"\n`,
+  )
+  fs.chmodSync(wrapper, 0o755)
+  return {
+    base,
+    stateDir,
+    cwd,
+    wrapper,
+    pidFile,
+    identityFile: path.join(stateDir, "codex-app-server.json"),
+  }
+}
+
+/** The platform stack under every codex supervision/adapter test. */
+const codexPlatform = (sandbox: { readonly stateDir: string; readonly wrapper: string }) =>
+  Layer.mergeAll(
+    Subprocess.layer.pipe(Layer.provide(BunServices.layer)),
+    testAppConfig({ codexExecutable: sandbox.wrapper, stateDir: sandbox.stateDir }),
+    TestBuildInfoLayer,
+    BunServices.layer,
+  )
+
+/** The supervision module over a sandbox wrapper (codexServer tests). */
+export const codexServerLayer = (
+  sandbox: { readonly stateDir: string; readonly wrapper: string },
+  options: CodexServer.CodexServerOptions = {},
+): Layer.Layer<CodexServer.CodexServer, unknown> =>
+  CodexServer.layerWith(options).pipe(Layer.provide(codexPlatform(sandbox)))
+
+/** Adapter + supervision over a sandbox wrapper (codexAdapter tests). */
+export const codexAdapterLayer = (sandbox: {
+  readonly stateDir: string
+  readonly wrapper: string
+}): Layer.Layer<CodexAdapter.CodexAdapter | CodexServer.CodexServer, unknown> => {
+  const platform = codexPlatform(sandbox)
+  // `server` appears twice in the graph but is memoized to one instance.
+  const server = CodexServer.layerWith({}).pipe(Layer.provide(platform))
+  const adapter = CodexAdapter.layer.pipe(Layer.provide(server), Layer.provide(platform))
+  return Layer.mergeAll(adapter, server)
+}
+
+/** Collect an agent event feed into a sink in the background (scoped). */
+export const collectAgentEvents = (events: Stream.Stream<AgentEvent, unknown>) =>
+  Effect.gen(function* () {
+    const sink: Array<AgentEvent> = []
+    yield* events.pipe(
+      Stream.runForEach((event) => Effect.sync(() => sink.push(event))),
+      Effect.ignore,
+      Effect.forkScoped,
+    )
+    return sink
+  })
+
+/** Poll (real clock) until the sink holds a matching event; bounded. */
+export const waitForAgentEvent = (
+  sink: Array<AgentEvent>,
+  predicate: (event: AgentEvent) => boolean,
+  options?: { readonly attempts?: number; readonly interval?: Duration.Input },
+) =>
+  Effect.gen(function* () {
+    const attempts = options?.attempts ?? 200
+    for (let attempt = 0; !sink.some(predicate); attempt++) {
+      assert.isBelow(attempt, attempts, `never saw expected event in ${JSON.stringify(sink)}`)
+      yield* Effect.sleep(options?.interval ?? "25 millis")
+    }
+  })

--- a/app-server/test/codexAdapter.smoke.test.ts
+++ b/app-server/test/codexAdapter.smoke.test.ts
@@ -1,0 +1,119 @@
+import { assert, describe, it } from "@effect/vitest"
+import { BunServices } from "@effect/platform-bun"
+import { Effect, Layer } from "effect"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import * as CodexAdapter from "../src/codexAdapter.ts"
+import * as CodexServer from "../src/codexServer.ts"
+import * as Subprocess from "../src/subprocess.ts"
+import { collectAgentEvents, waitForAgentEvent } from "./agentTestKit.ts"
+import { testAppConfig } from "./testLayers.ts"
+import { TestBuildInfoLayer } from "./testBuildInfo.ts"
+
+// Live codex adapter smoke (opt-in: mise run test:smoke): the full accepted
+// topology against the real Codex CLI — detached app-server spawn, adopt,
+// create with verified identity, exact resume, interrupt, explicit stop.
+// Needs an installed, authenticated codex; runs real (cheap) model turns.
+// The stateDir is STABLE across runs on purpose: if a run is killed hard
+// and orphans the detached server, the next run adopts and stops it
+// (adopt-or-replace is the cleanup story, not temp-dir tracking).
+
+const enabled = process.env["ATC_SMOKE"] === "1"
+
+const stateDir = path.join(os.tmpdir(), "atc-codex-smoke-state")
+
+describe.skipIf(!enabled)("live codex adapter smoke (opt-in)", () => {
+  it.live(
+    "create → resume → turn → interrupt → stop against real codex",
+    () =>
+      Effect.gen(function* () {
+        const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "atc-codex-smoke-work-"))
+        const platform = Layer.mergeAll(
+          Subprocess.layer.pipe(Layer.provide(BunServices.layer)),
+          testAppConfig({ stateDir }),
+          TestBuildInfoLayer,
+          BunServices.layer,
+        )
+        const server = CodexServer.layerWith({}).pipe(Layer.provide(platform))
+        const layer = Layer.mergeAll(
+          CodexAdapter.layer.pipe(Layer.provide(server), Layer.provide(platform)),
+          server,
+        )
+
+        yield* Effect.gen(function* () {
+          const adapter = yield* CodexAdapter.CodexAdapter
+          const codexServer = yield* CodexServer.CodexServer
+
+          const run = Effect.gen(function* () {
+            const slow = { attempts: 600, interval: "200 millis" } as const
+
+            // Create + first turn.
+            const threadId = yield* Effect.scoped(
+              Effect.gen(function* () {
+                const { connection, turn } = yield* adapter.createSession({
+                  cwd,
+                  input: "Reply with exactly: SMOKE-OK",
+                })
+                const sink = yield* collectAgentEvents(connection.events)
+                yield* waitForAgentEvent(
+                  sink,
+                  (event) =>
+                    event.type === "turnCompleted" &&
+                    event.turnId === turn.turnId &&
+                    event.outcome === "completed",
+                  slow,
+                )
+                return connection.providerSessionId
+              }),
+            )
+
+            // Exact resume + interrupt cycle.
+            yield* Effect.scoped(
+              Effect.gen(function* () {
+                const connection = yield* adapter.resumeSession({
+                  providerSessionId: threadId,
+                  cwd,
+                })
+                assert.strictEqual(connection.providerSessionId, threadId)
+                const sink = yield* collectAgentEvents(connection.events)
+                const turn = yield* connection.startTurn(
+                  "Count from 1 to 200, one number per line. Do not stop early.",
+                )
+                yield* waitForAgentEvent(
+                  sink,
+                  (event) => event.type === "activity" && event.activity === "working",
+                  slow,
+                )
+                yield* connection.interrupt(turn)
+                yield* waitForAgentEvent(
+                  sink,
+                  (event) =>
+                    event.type === "turnCompleted" &&
+                    event.turnId === turn.turnId &&
+                    event.outcome === "interrupted",
+                  slow,
+                )
+              }),
+            )
+
+            // The identity survives for a third connection (exact resume).
+            yield* Effect.scoped(
+              Effect.gen(function* () {
+                const connection = yield* adapter.resumeSession({
+                  providerSessionId: threadId,
+                  cwd,
+                })
+                assert.strictEqual(connection.providerSessionId, threadId)
+              }),
+            )
+          })
+
+          // Whatever happens, the detached real codex server must be
+          // stopped — never left running on the developer's machine.
+          yield* Effect.ensuring(run, Effect.orDie(codexServer.stop()))
+        }).pipe(Effect.provide(layer))
+      }),
+    300_000,
+  )
+})

--- a/app-server/test/codexAdapter.test.ts
+++ b/app-server/test/codexAdapter.test.ts
@@ -1,0 +1,358 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import * as fs from "node:fs"
+import * as path from "node:path"
+import * as CodexAdapter from "../src/codexAdapter.ts"
+import * as CodexServer from "../src/codexServer.ts"
+import {
+  codexAdapterLayer,
+  collectAgentEvents,
+  makeCodexSandbox,
+  waitForAgentEvent,
+} from "./agentTestKit.ts"
+
+// Codex adapter tests against the fake app-server fixture, through the real
+// supervision module (ensure → detached fixture → WebSocket → adapter). All
+// it.live: real processes, sockets, and clock. Each test block ends with
+// CodexServer.stop() via `withAdapter` so no detached fixture leaks.
+
+/** Run `use` with the adapter, then always stop the detached server. */
+const withAdapter = (
+  sandbox: { readonly stateDir: string; readonly wrapper: string },
+  use: (adapter: CodexAdapter.CodexAdapter["Service"]) => Effect.Effect<void, unknown, never>,
+) =>
+  Effect.gen(function* () {
+    const adapter = yield* CodexAdapter.CodexAdapter
+    const codexServer = yield* CodexServer.CodexServer
+    yield* Effect.ensuring(use(adapter), Effect.orDie(codexServer.stop()))
+  }).pipe(Effect.provide(codexAdapterLayer(sandbox)))
+
+describe("CodexAdapter", () => {
+  it.live(
+    "create: verified identity, truthful feed, first turn completes",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.scoped(
+            Effect.gen(function* () {
+              const { connection, turn } = yield* adapter.createSession({
+                cwd: sandbox.cwd,
+                input: "hello",
+              })
+              assert.isString(connection.providerSessionId)
+              assert.strictEqual(connection.cwd, sandbox.cwd)
+              const sink = yield* collectAgentEvents(connection.events)
+              yield* waitForAgentEvent(
+                sink,
+                (event) =>
+                  event.type === "turnCompleted" &&
+                  event.turnId === turn.turnId &&
+                  event.outcome === "completed",
+              )
+              yield* waitForAgentEvent(
+                sink,
+                (event) => event.type === "activity" && event.activity === "idle",
+              )
+              assert.strictEqual(yield* connection.activity, "idle")
+            }),
+          ),
+        )
+      }),
+    30_000,
+  )
+
+  it.live(
+    "resume: exact identity round trip; unknown id fails closed",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.gen(function* () {
+            const threadId = yield* Effect.scoped(
+              Effect.gen(function* () {
+                const { connection, turn } = yield* adapter.createSession({
+                  cwd: sandbox.cwd,
+                  input: "seed",
+                })
+                const sink = yield* collectAgentEvents(connection.events)
+                yield* waitForAgentEvent(
+                  sink,
+                  (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
+                )
+                return connection.providerSessionId
+              }),
+            )
+
+            yield* Effect.scoped(
+              Effect.gen(function* () {
+                const resumed = yield* adapter.resumeSession({
+                  providerSessionId: threadId,
+                  cwd: sandbox.cwd,
+                })
+                assert.strictEqual(resumed.providerSessionId, threadId)
+              }),
+            )
+
+            const failure = yield* Effect.scoped(
+              Effect.flip(
+                adapter.resumeSession({
+                  providerSessionId: "00000000-0000-7000-8000-000000000000",
+                  cwd: sandbox.cwd,
+                }),
+              ),
+            )
+            assert.strictEqual(failure._tag, "AgentResumeFailed")
+          }),
+        )
+      }),
+    30_000,
+  )
+
+  it.live(
+    "create with a lying cwd is an identity mismatch, never adopted",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox({ FAKE_CODEX_WRONG_CWD: "start" })
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.gen(function* () {
+            const failure = yield* Effect.scoped(
+              Effect.flip(adapter.createSession({ cwd: sandbox.cwd, input: "hello" })),
+            )
+            assert.strictEqual(failure._tag, "AgentIdentityMismatch")
+            if (failure._tag === "AgentIdentityMismatch") {
+              assert.strictEqual(failure.field, "cwd")
+            }
+          }),
+        )
+      }),
+    30_000,
+  )
+
+  it.live(
+    "resume with a lying cwd is an identity mismatch, never adopted",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox({ FAKE_CODEX_WRONG_CWD: "resume" })
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.gen(function* () {
+            const threadId = yield* Effect.scoped(
+              Effect.gen(function* () {
+                const { connection, turn } = yield* adapter.createSession({
+                  cwd: sandbox.cwd,
+                  input: "seed",
+                })
+                const sink = yield* collectAgentEvents(connection.events)
+                yield* waitForAgentEvent(
+                  sink,
+                  (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
+                )
+                return connection.providerSessionId
+              }),
+            )
+            const failure = yield* Effect.scoped(
+              Effect.flip(adapter.resumeSession({ providerSessionId: threadId, cwd: sandbox.cwd })),
+            )
+            assert.strictEqual(failure._tag, "AgentIdentityMismatch")
+            if (failure._tag === "AgentIdentityMismatch") {
+              assert.strictEqual(failure.field, "cwd")
+            }
+          }),
+        )
+      }),
+    30_000,
+  )
+
+  it.live(
+    "single writer per thread: a concurrent second connection conflicts",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.scoped(
+            Effect.gen(function* () {
+              const { connection } = yield* adapter.createSession({
+                cwd: sandbox.cwd,
+                input: "HANG on",
+              })
+              const failure = yield* Effect.flip(
+                adapter.resumeSession({
+                  providerSessionId: connection.providerSessionId,
+                  cwd: sandbox.cwd,
+                }),
+              )
+              assert.strictEqual(failure._tag, "AgentConflict")
+            }),
+          ),
+        )
+      }),
+    30_000,
+  )
+
+  it.live(
+    "interrupt: exact turn only, truthful interrupted outcome",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.scoped(
+            Effect.gen(function* () {
+              const { connection, turn } = yield* adapter.createSession({
+                cwd: sandbox.cwd,
+                input: "HANG until interrupted",
+              })
+              const sink = yield* collectAgentEvents(connection.events)
+              yield* waitForAgentEvent(
+                sink,
+                (event) => event.type === "activity" && event.activity === "working",
+              )
+              // A stale/foreign target is refused before anything is sent.
+              const stale = yield* Effect.flip(connection.interrupt({ turnId: "not-a-turn" }))
+              assert.strictEqual(stale._tag, "AgentConflict")
+
+              yield* connection.interrupt(turn)
+              yield* waitForAgentEvent(
+                sink,
+                (event) =>
+                  event.type === "turnCompleted" &&
+                  event.turnId === turn.turnId &&
+                  event.outcome === "interrupted",
+              )
+              assert.strictEqual(yield* connection.activity, "idle")
+            }),
+          ),
+        )
+      }),
+    30_000,
+  )
+
+  it.live(
+    "provider approval requests surface on the feed and are auto-rejected",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.scoped(
+            Effect.gen(function* () {
+              const { connection, turn } = yield* adapter.createSession({
+                cwd: sandbox.cwd,
+                input: "needs APPROVAL for this",
+              })
+              const sink = yield* collectAgentEvents(connection.events)
+              yield* waitForAgentEvent(sink, (event) => event.type === "requestOpened")
+              const opened = sink.find((event) => event.type === "requestOpened")
+              assert.strictEqual(opened?.type === "requestOpened" ? opened.kind : "", "approval")
+              yield* waitForAgentEvent(sink, (event) => event.type === "requestClosed")
+              // The reject unblocks the fixture, so the turn still completes.
+              yield* waitForAgentEvent(
+                sink,
+                (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
+              )
+              // needs_input was truthfully reported while the request hung.
+              assert.isTrue(
+                sink.some((event) => event.type === "activity" && event.activity === "needs_input"),
+              )
+            }),
+          ),
+        )
+      }),
+    30_000,
+  )
+
+  it.live(
+    "TUI-driven turns on the shared server appear on our feed",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.scoped(
+            Effect.gen(function* () {
+              const { connection, turn } = yield* adapter.createSession({
+                cwd: sandbox.cwd,
+                input: "seed",
+              })
+              const sink = yield* collectAgentEvents(connection.events)
+              yield* waitForAgentEvent(
+                sink,
+                (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
+              )
+
+              // A second client of the same shared server (the TUI stand-in)
+              // drives a turn on the same thread.
+              const identity = JSON.parse(
+                fs.readFileSync(path.join(sandbox.stateDir, "codex-app-server.json"), "utf8"),
+              ) as { port: number }
+              const external = new WebSocket(`ws://127.0.0.1:${identity.port}`)
+              yield* Effect.callback<void>((resume) => {
+                external.onopen = () => resume(Effect.void)
+              })
+              external.send(
+                JSON.stringify({
+                  id: 1,
+                  method: "turn/start",
+                  params: {
+                    threadId: connection.providerSessionId,
+                    input: [{ type: "text", text: "external turn" }],
+                  },
+                }),
+              )
+              yield* waitForAgentEvent(
+                sink,
+                (event) =>
+                  event.type === "turnCompleted" &&
+                  event.turnId !== turn.turnId &&
+                  event.outcome === "completed",
+              )
+              external.close()
+            }),
+          ),
+        )
+      }),
+    30_000,
+  )
+
+  it.live(
+    "tuiLaunch hands back the exact remote-resume argv",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.gen(function* () {
+            const spec = yield* adapter.tuiLaunch({
+              providerSessionId: "some-thread",
+              cwd: sandbox.cwd,
+            })
+            assert.strictEqual(spec.command[0], sandbox.wrapper)
+            assert.deepStrictEqual(spec.command.slice(1, 3), ["resume", "--remote"])
+            assert.match(spec.command[3] ?? "", /^ws:\/\/127\.0\.0\.1:\d+$/)
+            assert.strictEqual(spec.command[4], "some-thread")
+          }),
+        )
+      }),
+    30_000,
+  )
+
+  it.live(
+    "an older installed codex warns but still works",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox({ FAKE_CODEX_VERSION: "0.1.0" })
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.scoped(
+            Effect.gen(function* () {
+              const { connection, turn } = yield* adapter.createSession({
+                cwd: sandbox.cwd,
+                input: "hello",
+              })
+              const sink = yield* collectAgentEvents(connection.events)
+              yield* waitForAgentEvent(
+                sink,
+                (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
+              )
+            }),
+          ),
+        )
+      }),
+    30_000,
+  )
+})

--- a/app-server/test/codexServer.test.ts
+++ b/app-server/test/codexServer.test.ts
@@ -1,14 +1,11 @@
 import { assert, describe, it } from "@effect/vitest"
-import { BunServices } from "@effect/platform-bun"
-import { Effect, Layer } from "effect"
+import { Effect } from "effect"
 import * as fs from "node:fs"
-import * as os from "node:os"
-import * as path from "node:path"
 import { fileURLToPath } from "node:url"
 import * as CodexServer from "../src/codexServer.ts"
 import * as Subprocess from "../src/subprocess.ts"
-import { freePort, trackTempDir } from "./blackbox.ts"
-import { testAppConfig } from "./testLayers.ts"
+import { freePort } from "./blackbox.ts"
+import { codexServerLayer, makeCodexSandbox } from "./agentTestKit.ts"
 
 // Supervision tests against the fake-codex-listener fixture (a Bun script
 // that binds the requested --listen port and answers /readyz). All tests are
@@ -18,42 +15,9 @@ import { testAppConfig } from "./testLayers.ts"
 
 const fixturePath = fileURLToPath(new URL("fixtures/fake-codex-listener.ts", import.meta.url))
 
-/** A sandbox whose wrapper script is the configured codex executable. */
-const makeSandbox = (vars: Record<string, string> = {}) => {
-  const base = trackTempDir(fs.mkdtempSync(path.join(os.tmpdir(), "atc-codex-")))
-  const stateDir = path.join(base, "state")
-  const wrapper = path.join(base, "fake-codex")
-  const pidFile = path.join(base, "fixture.pid")
-  const assignments = Object.entries({ FAKE_CODEX_PID_FILE: pidFile, ...vars })
-    .map(([key, value]) => `${key}='${value}'`)
-    .join(" ")
-  fs.writeFileSync(
-    wrapper,
-    `#!/bin/sh\n${assignments} exec "${process.execPath}" "${fixturePath}" "$@"\n`,
-  )
-  fs.chmodSync(wrapper, 0o755)
-  return {
-    base,
-    stateDir,
-    wrapper,
-    pidFile,
-    identityFile: path.join(stateDir, "codex-app-server.json"),
-  }
-}
-
 /** The pid the most recently launched fixture recorded. */
 const fixturePid = (sandbox: { readonly pidFile: string }): number =>
   Number.parseInt(fs.readFileSync(sandbox.pidFile, "utf8"), 10)
-
-const serverLayer = (
-  sandbox: { readonly stateDir: string; readonly wrapper: string },
-  options: CodexServer.CodexServerOptions = {},
-) =>
-  CodexServer.layerWith(options).pipe(
-    Layer.provide(testAppConfig({ codexExecutable: sandbox.wrapper, stateDir: sandbox.stateDir })),
-    Layer.provide(Subprocess.layer),
-    Layer.provideMerge(BunServices.layer),
-  )
 
 const readIdentity = (identityFile: string): { pid: number; port: number } =>
   JSON.parse(fs.readFileSync(identityFile, "utf8")) as { pid: number; port: number }
@@ -72,13 +36,13 @@ describe("CodexServer", () => {
     "spawns detached, persists identity, adopts from a fresh service, and stops",
     () =>
       Effect.gen(function* () {
-        const sandbox = makeSandbox()
+        const sandbox = makeCodexSandbox()
 
         // First service instance spawns the server.
         const first = yield* Effect.gen(function* () {
           const codex = yield* CodexServer.CodexServer
           return yield* codex.ensure()
-        }).pipe(Effect.provide(serverLayer(sandbox)))
+        }).pipe(Effect.provide(codexServerLayer(sandbox)))
         assert.isTrue(Subprocess.isProcessAlive(first.pid))
         assert.strictEqual(first.url, `ws://127.0.0.1:${first.port}`)
         const persisted = readIdentity(sandbox.identityFile)
@@ -97,7 +61,7 @@ describe("CodexServer", () => {
           assert.strictEqual(adopted.pid, first.pid)
           assert.strictEqual(adopted.port, first.port)
           yield* codex.stop()
-        }).pipe(Effect.provide(serverLayer(sandbox)))
+        }).pipe(Effect.provide(codexServerLayer(sandbox)))
         assert.isTrue(yield* Subprocess.waitForProcessExit(first.pid))
         assert.isFalse(fs.existsSync(sandbox.identityFile))
       }),
@@ -108,7 +72,7 @@ describe("CodexServer", () => {
     "replaces a dead persisted pid instead of failing",
     () =>
       Effect.gen(function* () {
-        const sandbox = makeSandbox()
+        const sandbox = makeCodexSandbox()
         // A pid that is certainly dead: spawn a no-op and wait for it.
         const gone = Bun.spawnSync(["true"])
         fs.mkdirSync(sandbox.stateDir, { recursive: true })
@@ -122,7 +86,7 @@ describe("CodexServer", () => {
           assert.isTrue(Subprocess.isProcessAlive(info.pid))
           assert.notStrictEqual(info.port, 1)
           yield* codex.stop()
-        }).pipe(Effect.provide(serverLayer(sandbox)))
+        }).pipe(Effect.provide(codexServerLayer(sandbox)))
       }),
     30_000,
   )
@@ -131,7 +95,7 @@ describe("CodexServer", () => {
     "replaces an alive-but-unready server (adopt-or-replace, never accumulate)",
     () =>
       Effect.gen(function* () {
-        const sandbox = makeSandbox()
+        const sandbox = makeCodexSandbox()
         // A live process that IS an app-server by command line but never
         // becomes ready: the never-ready fixture launched by hand.
         const stalePort = yield* Effect.promise(() => freePort())
@@ -152,7 +116,7 @@ describe("CodexServer", () => {
             assert.isTrue(yield* Subprocess.waitForProcessExit(stale.pid))
             assert.isTrue(Subprocess.isProcessAlive(info.pid))
             yield* codex.stop()
-          }).pipe(Effect.provide(serverLayer(sandbox, { adoptTimeout: "500 millis" })))
+          }).pipe(Effect.provide(codexServerLayer(sandbox, { adoptTimeout: "500 millis" })))
         } finally {
           stale.kill()
         }
@@ -164,7 +128,7 @@ describe("CodexServer", () => {
     "a recycled pid that is not an app-server is abandoned, never signaled",
     () =>
       Effect.gen(function* () {
-        const sandbox = makeSandbox()
+        const sandbox = makeCodexSandbox()
         // A live process whose command line is NOT an app-server — models a
         // pid recycled to an innocent process after a reboot.
         const bystander = Bun.spawn([
@@ -184,7 +148,7 @@ describe("CodexServer", () => {
             assert.isTrue(Subprocess.isProcessAlive(info.pid))
             assert.isTrue(Subprocess.isProcessAlive(bystander.pid))
             yield* codex.stop()
-          }).pipe(Effect.provide(serverLayer(sandbox)))
+          }).pipe(Effect.provide(codexServerLayer(sandbox)))
           assert.isTrue(Subprocess.isProcessAlive(bystander.pid))
         } finally {
           bystander.kill()
@@ -197,11 +161,11 @@ describe("CodexServer", () => {
     "a server that never becomes ready is reaped and reported actionably",
     () =>
       Effect.gen(function* () {
-        const sandbox = makeSandbox({ FAKE_CODEX_MODE: "never-ready" })
+        const sandbox = makeCodexSandbox({ FAKE_CODEX_MODE: "never-ready" })
         const failure = yield* Effect.gen(function* () {
           const codex = yield* CodexServer.CodexServer
           return yield* Effect.flip(codex.ensure())
-        }).pipe(Effect.provide(serverLayer(sandbox, { readyTimeout: "700 millis" })))
+        }).pipe(Effect.provide(codexServerLayer(sandbox, { readyTimeout: "700 millis" })))
         assert.include(failure.message, "not ready")
         // The failed spawn was cleaned up: no identity, no stray process.
         assert.isFalse(fs.existsSync(sandbox.identityFile))
@@ -214,13 +178,16 @@ describe("CodexServer", () => {
     "a missing executable is one actionable diagnostic",
     () =>
       Effect.gen(function* () {
-        const sandbox = makeSandbox()
+        const sandbox = makeCodexSandbox()
         const failure = yield* Effect.gen(function* () {
           const codex = yield* CodexServer.CodexServer
           return yield* Effect.flip(codex.ensure())
         }).pipe(
           Effect.provide(
-            serverLayer({ stateDir: sandbox.stateDir, wrapper: "atc-test-definitely-not-codex" }),
+            codexServerLayer({
+              stateDir: sandbox.stateDir,
+              wrapper: "atc-test-definitely-not-codex",
+            }),
           ),
         )
         assert.include(failure.message, "install the Codex CLI")
@@ -233,7 +200,7 @@ describe("CodexServer", () => {
     "the exit watcher restarts a server that died underneath us",
     () =>
       Effect.gen(function* () {
-        const sandbox = makeSandbox()
+        const sandbox = makeCodexSandbox()
         yield* Effect.gen(function* () {
           const codex = yield* CodexServer.CodexServer
           const info = yield* codex.ensure()
@@ -246,7 +213,7 @@ describe("CodexServer", () => {
           const replacement = yield* codex.ensure()
           assert.notStrictEqual(replacement.pid, info.pid)
           yield* codex.stop()
-        }).pipe(Effect.provide(serverLayer(sandbox, { watchInterval: "50 millis" })))
+        }).pipe(Effect.provide(codexServerLayer(sandbox, { watchInterval: "50 millis" })))
       }),
     30_000,
   )

--- a/app-server/test/fixtures/fake-codex-listener.ts
+++ b/app-server/test/fixtures/fake-codex-listener.ts
@@ -1,11 +1,25 @@
 // Fixture stand-in for `codex app-server --listen ws://127.0.0.1:<port>`:
-// binds the requested port and answers /readyz so codexServer supervision
-// can be exercised without a real Codex install. FAKE_CODEX_MODE selects a
-// behavior: "ok" (default) answers /readyz 200, "never-ready" answers 503.
-// FAKE_CODEX_PID_FILE records this pid so tests can assert the process was
-// reaped even on paths that clear the identity file. FAKE_CODEX_TTL_MS
-// (default 120s) self-terminates the process so a test that fails to stop()
-// a detached fixture can never leak it for long.
+// binds the requested port, answers /readyz, and speaks the JSON-RPC subset
+// the codex adapter uses (initialize, thread/start, thread/resume,
+// turn/start, turn/interrupt, thread/unsubscribe), broadcasting
+// notifications to every connected socket like the real shared app-server.
+//
+// Turn behavior is keyed off the input text: containing "HANG" leaves the
+// turn active until interrupted; containing "APPROVAL" first round-trips an
+// item/commandExecution/requestApproval server request.
+//
+// Env switches (baked into the wrapper script by tests):
+//   FAKE_CODEX_MODE       "ok" (default) | "never-ready" (503 /readyz)
+//   FAKE_CODEX_WRONG_CWD  "start" | "resume" — lie about cwd in that reply
+//   FAKE_CODEX_VERSION    printed for `--version` (default 0.146.0)
+//   FAKE_CODEX_PID_FILE   record this pid for reap assertions
+//   FAKE_CODEX_TTL_MS     self-exit backstop (default 120s) so a test that
+//                         fails to stop() a detached fixture cannot leak it
+
+if (process.argv.includes("--version")) {
+  console.log(`codex-cli ${process.env["FAKE_CODEX_VERSION"] ?? "0.146.0"}`)
+  process.exit(0)
+}
 
 const listenArg = process.argv.find((arg) => arg.startsWith("ws://"))
 if (listenArg === undefined) {
@@ -14,20 +28,177 @@ if (listenArg === undefined) {
 }
 const port = Number.parseInt(new URL(listenArg).port, 10)
 const mode = process.env["FAKE_CODEX_MODE"] ?? "ok"
+const wrongCwd = process.env["FAKE_CODEX_WRONG_CWD"]
 const ttl = Number.parseInt(process.env["FAKE_CODEX_TTL_MS"] ?? "120000", 10)
 const pidFile = process.env["FAKE_CODEX_PID_FILE"]
 if (pidFile !== undefined && pidFile !== "") {
   await Bun.write(pidFile, String(process.pid))
 }
 
+interface Thread {
+  readonly id: string
+  readonly cwd: string
+  readonly turns: Array<{ id: string; status: string }>
+}
+
+const threads = new Map<string, Thread>()
+const sockets = new Set<import("bun").ServerWebSocket<unknown>>()
+const hangingTurns = new Set<string>()
+const pendingServerRequests = new Map<number, () => void>()
+let nextServerRequestId = 1000
+
+const broadcast = (method: string, params: unknown) => {
+  const frame = JSON.stringify({ method, params })
+  for (const socket of sockets) socket.send(frame)
+}
+
+const threadShape = (thread: Thread, cwd: string) => ({
+  id: thread.id,
+  cwd,
+  status: { type: "idle" },
+  turns: thread.turns,
+})
+
+const finishTurn = (thread: Thread, turnId: string, text: string) => {
+  broadcast("item/completed", {
+    threadId: thread.id,
+    turnId,
+    item: { id: crypto.randomUUID(), type: "agentMessage", text: `fake: ${text}` },
+  })
+  broadcast("thread/status/changed", { threadId: thread.id, status: { type: "idle" } })
+  thread.turns.push({ id: turnId, status: "completed" })
+  broadcast("turn/completed", { threadId: thread.id, turn: { id: turnId, status: "completed" } })
+}
+
+const handle = (
+  socket: import("bun").ServerWebSocket<unknown>,
+  message: {
+    id?: number
+    method?: string
+    params?: Record<string, unknown>
+    result?: unknown
+    error?: unknown
+  },
+) => {
+  const respond = (result: unknown) => socket.send(JSON.stringify({ id: message.id, result }))
+  const respondError = (code: number, text: string) =>
+    socket.send(JSON.stringify({ id: message.id, error: { code, message: text } }))
+
+  // Responses to our server requests (approval round trip): any answer,
+  // result or error, unblocks the pending turn.
+  if (message.method === undefined && message.id !== undefined) {
+    const pending = pendingServerRequests.get(message.id)
+    if (pending !== undefined) {
+      pendingServerRequests.delete(message.id)
+      pending()
+    }
+    return
+  }
+
+  const params = message.params ?? {}
+  switch (message.method) {
+    case "initialize":
+      return respond({ userAgent: "fake-codex-app-server" })
+    case "initialized":
+      return
+    case "thread/start": {
+      const cwd = String(params["cwd"] ?? "/")
+      const thread: Thread = { id: crypto.randomUUID(), cwd, turns: [] }
+      threads.set(thread.id, thread)
+      const reported = wrongCwd === "start" ? `${cwd}-wrong` : cwd
+      respond({ thread: threadShape(thread, reported) })
+      return broadcast("thread/started", { thread: { id: thread.id, cwd: reported } })
+    }
+    case "thread/resume": {
+      const threadId = String(params["threadId"] ?? "")
+      const thread = threads.get(threadId)
+      if (thread === undefined) {
+        return respondError(-32600, `no rollout found for thread id ${threadId}`)
+      }
+      const reported = wrongCwd === "resume" ? `${thread.cwd}-wrong` : thread.cwd
+      return respond({ thread: threadShape(thread, reported) })
+    }
+    case "thread/unsubscribe":
+      return respond({ status: "unsubscribed" })
+    case "turn/start": {
+      const threadId = String(params["threadId"] ?? "")
+      const thread = threads.get(threadId)
+      if (thread === undefined) return respondError(-32600, `unknown thread ${threadId}`)
+      const input = params["input"] as Array<{ text?: string }> | undefined
+      const text = input?.[0]?.text ?? ""
+      const turnId = crypto.randomUUID()
+      respond({ turn: { id: turnId } })
+      broadcast("thread/status/changed", {
+        threadId,
+        status: { type: "active", activeFlags: [] },
+      })
+      broadcast("turn/started", { threadId, turn: { id: turnId } })
+      if (text.includes("HANG")) {
+        hangingTurns.add(threadId)
+        return
+      }
+      if (text.includes("APPROVAL")) {
+        const requestId = nextServerRequestId++
+        pendingServerRequests.set(requestId, () => {
+          broadcast("thread/status/changed", {
+            threadId,
+            status: { type: "active", activeFlags: [] },
+          })
+          finishTurn(thread, turnId, text)
+        })
+        socket.send(
+          JSON.stringify({
+            id: requestId,
+            method: "item/commandExecution/requestApproval",
+            params: { threadId, turnId, command: "/bin/sh -c pwd", cwd: thread.cwd },
+          }),
+        )
+        return broadcast("thread/status/changed", {
+          threadId,
+          status: { type: "active", activeFlags: ["waitingOnApproval"] },
+        })
+      }
+      return finishTurn(thread, turnId, text)
+    }
+    case "turn/interrupt": {
+      const threadId = String(params["threadId"] ?? "")
+      const turnId = String(params["turnId"] ?? "")
+      const thread = threads.get(threadId)
+      if (thread === undefined) return respondError(-32600, `unknown thread ${threadId}`)
+      respond({})
+      hangingTurns.delete(threadId)
+      broadcast("thread/status/changed", { threadId, status: { type: "idle" } })
+      thread.turns.push({ id: turnId, status: "interrupted" })
+      return broadcast("turn/completed", { threadId, turn: { id: turnId, status: "interrupted" } })
+    }
+    default:
+      if (message.id !== undefined) return respondError(-32601, `unknown method ${message.method}`)
+  }
+}
+
 Bun.serve({
   hostname: "127.0.0.1",
   port,
-  fetch(request) {
-    if (new URL(request.url).pathname === "/readyz" && mode === "ok") {
-      return new Response("ok", { status: 200 })
+  fetch(request, server) {
+    const url = new URL(request.url)
+    if (url.pathname === "/readyz") {
+      return mode === "ok"
+        ? new Response("ok", { status: 200 })
+        : new Response("not ready", { status: 503 })
     }
-    return new Response("not ready", { status: 503 })
+    if (server.upgrade(request)) return undefined
+    return new Response("not found", { status: 404 })
+  },
+  websocket: {
+    open(socket) {
+      sockets.add(socket)
+    },
+    close(socket) {
+      sockets.delete(socket)
+    },
+    message(socket, raw) {
+      handle(socket, JSON.parse(String(raw)) as Parameters<typeof handle>[1])
+    },
   },
 })
 


### PR DESCRIPTION
Second of three stacked PRs for [ATC-123](https://linear.app/elevenideas/issue/ATC-123/codex-and-claude-code-integrations) ([ATC-133](https://linear.app/elevenideas/issue/ATC-133)). **Stacked on #131** — merge that first, then retarget/merge this.

## What's here

- **`codexAdapter.ts`** — the Codex `AgentAdapter`: one WebSocket JSON-RPC client of the supervised detached app-server, multiplexing every thread over that single shared connection (which is what keeps TUI-driven turns observable on our feed).
  - Distinct create/resume; resume fails closed: `-32600 no rollout found` → `AgentResumeFailed`; a disagreeing echoed thread id or cwd (realpath-compared) → `AgentIdentityMismatch`, never adopted.
  - Single writer per thread enforced at the adapter (the provider would accept two; concurrent writers corrupt provider turn attribution — ATC-83 evidence). One active turn per connection with the slot reserved before the RPC (no TOCTOU).
  - Exact-turn interrupt; a provider-side stale-target rejection maps to `AgentConflict`.
  - Normalized activity from `thread/status/changed` (idle / working / needs_input from wait flags), seeded from the thread reply's own status — never a guess.
  - Server-initiated requests are surfaced as request events and answered with an immediate rejection, but **only for turns this client started** — a TUI's approval prompt on the shared server is never ours to answer. Real responses are ATC-124.
  - A failed or interrupted handshake tears down its own socket; a lost connection fails every live feed loudly and the next create/resume reconnects.
  - Version drift: tested floor codex-cli 0.146.0, one warning below it, never blocks.
- **Fixture**: `fake-codex-listener.ts` now speaks the JSON-RPC subset over WebSocket with shared-server broadcast; `test/agentTestKit.ts` holds the shared sandbox/layer/event-feed test scaffolding.
- **Tests**: create/resume/fail-closed/lying-cwd/single-writer/interrupt/approval-surfacing/external-writer-fan-out/tuiLaunch/version-drift against the fixture, plus an opt-in live smoke (`mise run test:smoke`) running detach → adopt → create → exact resume → interrupt → stop against real codex — verified passing on codex-cli 0.146.0.

## Wire details verified live before implementation

Minimal `turn/start` params, the `workspace-write` sandbox string, exact resume echo, and the `-32600` fail-closed error were probed against a real `codex app-server` before the adapter was written.

## Review process

Two adversarial sub-agent reviews (correctness on Opus, simplicity on Sonnet). Applied: handshake-failure socket teardown + per-connection frame gating (reproduced: a leaked half-open socket double-delivered events and killed healthy sessions), startTurn slot reservation (reproduced concurrent double-turn), activity seeding from provider status, writer-slot release when create's first turn fails, dead-transport errors as `AgentUnavailable` instead of `AgentConflict`, turn-ownership gating of server-request answers, string-id reply tolerance, and the shared test scaffolding extraction.

https://claude.ai/code/session_018Rd6RAK5eJMvN3EYfJyr17
