### PR TITLE
ATC-134: Claude provider adapter with fixtures and smoke tests

### DIFF
--- a/app-server/mise.toml
+++ b/app-server/mise.toml
@@ -71,7 +71,7 @@ run = "ATC_COMPILED_TEST=1 bun --bun vitest run test/compiled.blackbox.test.ts"
 [tasks."test:smoke"]
 description = "Opt-in live provider smoke tests (requires Codex CLI and Claude Code credentials)"
 depends = ["build"]
-run = "ATC_SMOKE=1 bun --bun vitest run test/provider.smoke.test.ts test/codexAdapter.smoke.test.ts"
+run = "ATC_SMOKE=1 bun --bun vitest run test/provider.smoke.test.ts test/codexAdapter.smoke.test.ts test/claudeAdapter.smoke.test.ts"
 
 [tasks."test:zmx"]
 description = "Opt-in tests against the real installed zmx: adapter smoke and compiled restart recovery"

--- a/app-server/src/agentAdapter.ts
+++ b/app-server/src/agentAdapter.ts
@@ -1,6 +1,6 @@
 import { Effect, Schema, Stream } from "effect"
 import type { Scope } from "effect"
-import { existsSync } from "node:fs"
+import { existsSync, realpathSync } from "node:fs"
 import type { Subprocess } from "./subprocess.ts"
 import { resolveExecutable } from "./subprocess.ts"
 
@@ -304,19 +304,36 @@ export const resolveProviderExecutable = (
     )
   })
 
+/** Symlink-tolerant path equality (macOS tmpdir lives behind /private). */
+export const samePath = (left: string, right: string): boolean => {
+  const canonical = (value: string): string => {
+    try {
+      return realpathSync(value)
+    } catch {
+      return value
+    }
+  }
+  return canonical(left) === canonical(right)
+}
+
 /**
- * The shared version-drift rule (record + warn, never block): read the
- * installed provider version via `--version`, log one actionable warning
- * when it is below the floor the adapter was validated against. Any failure
- * to determine the version is itself just a warning.
+ * The shared version-drift rule (record + warn, never block), memoized to
+ * one check per adapter: resolve the configured executable, read the
+ * installed version via `--version`, and log one actionable warning when
+ * it is below the floor the adapter was validated against. Any failure to
+ * determine the version is itself just a warning.
  */
-export const warnIfBelowTestedVersion = (
+export const makeVersionGate = (
   subprocess: Subprocess["Service"],
   provider: AgentProvider,
-  executable: string,
+  configured: string,
   testedVersion: string,
-): Effect.Effect<void> =>
-  Effect.gen(function* () {
+): Effect.Effect<void, AgentUnavailable> => {
+  let checked = false
+  return Effect.gen(function* () {
+    if (checked) return
+    checked = true
+    const executable = yield* resolveProviderExecutable(provider, configured)
     const output = yield* Effect.scoped(
       Effect.gen(function* () {
         const child = yield* subprocess.spawn({
@@ -346,3 +363,4 @@ export const warnIfBelowTestedVersion = (
       )
     }
   })
+}

--- a/app-server/src/claudeAdapter.ts
+++ b/app-server/src/claudeAdapter.ts
@@ -1,0 +1,637 @@
+import type {
+  CanUseTool,
+  HookCallbackMatcher,
+  HookEvent,
+  Options,
+  SDKMessage,
+  SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk"
+import { query } from "@anthropic-ai/claude-agent-sdk"
+import {
+  Cause,
+  Context,
+  Deferred,
+  Duration,
+  Effect,
+  FileSystem,
+  Layer,
+  Queue,
+  Stream,
+} from "effect"
+import type { AgentActivity, AgentAdapter, AgentConnection, AgentEvent } from "./agentAdapter.ts"
+import {
+  AgentConflict,
+  AgentIdentityMismatch,
+  AgentProtocolError,
+  AgentResumeFailed,
+  AgentUnavailable,
+  makeVersionGate,
+  resolveProviderExecutable,
+  samePath,
+} from "./agentAdapter.ts"
+import * as path from "node:path"
+import * as ClaudeHooks from "./claudeHooks.ts"
+import { AppConfig } from "./config.ts"
+import * as Subprocess from "./subprocess.ts"
+
+// The Claude AgentAdapter (ATC-123): sessions are held in-process Agent SDK
+// `query()` calls with streaming input (the only mode that can interrupt),
+// no child supervision needed. Invariants beyond the seam's:
+//
+//   - The SDK emits NO identity evidence until the first user message
+//     (probed 2026-08-03), so resume verification completes at the first
+//     startTurn: an unknown id surfaces there as AgentResumeFailed (the
+//     provider's single error result, no replacement session created), a
+//     disagreeing session_id or cwd as AgentIdentityMismatch. Create sends
+//     its initial input immediately, so create verifies before returning.
+//   - Error-path idle derives from the `result` message itself — Stop /
+//     StopFailure hooks do NOT fire on error results, and the SDK iterator
+//     throws after one; both are normal turn-end shapes here, never
+//     transport defects.
+//   - A turn that ends in anything but success ends the connection (the
+//     interrupted/failed outcome is emitted first); callers re-resume.
+//     Success keeps the held query open for further turns.
+//   - The SDK is the one sanctioned exception to two repo invariants: it
+//     spawns the claude child itself (not via Subprocess) and the child
+//     env is built from process.env directly — the SDK owns that process,
+//     and the env must carry the user's credentials verbatim.
+//   - One writer per session id, enforced here. Webhook hook activity is
+//     NOT bridged into these feeds: a TUI-driven session has no adapter
+//     connection by definition, and while ATC drives, the same vocabulary
+//     already arrives as in-process SDK callbacks — a webhook delivery for
+//     a live connection could only be stale or spoofed. TUI-side consumers
+//     subscribe to claudeHooks directly (ATC-124).
+
+/** The Claude Code version this adapter was validated against. */
+export const CLAUDE_TESTED_VERSION = "2.1.221"
+
+export class ClaudeAdapter extends Context.Service<ClaudeAdapter, AgentAdapter>()(
+  "app-server/ClaudeAdapter",
+) {}
+
+/** The query() seam, injectable so fixture tests can script SDK streams. */
+export type ClaudeQueryFn = (args: {
+  readonly prompt: AsyncIterable<SDKUserMessage>
+  readonly options: Options
+}) => AsyncIterable<SDKMessage> & { readonly interrupt: () => Promise<unknown> }
+
+export interface ClaudeAdapterOptions {
+  readonly queryFn?: ClaudeQueryFn
+  /** How long create/first-turn waits for the SDK's identity evidence. */
+  readonly initTimeout?: Duration.Input
+}
+
+const protocolError = (reason: string) => new AgentProtocolError({ provider: "claude", reason })
+const conflict = (reason: string) => new AgentConflict({ provider: "claude", reason })
+
+/**
+ * Environment for the SDK child: the user's environment (credentials) plus
+ * the state-events opt-in, minus the nested-session markers a dev-mode ATC
+ * would otherwise pass down (they silently disable transcript persistence,
+ * which breaks resume).
+ */
+const NESTED_SESSION_VARIABLES = [
+  "CLAUDE_CODE_CHILD_SESSION",
+  "CLAUDECODE",
+  "CLAUDE_CODE_ENTRYPOINT",
+  "CLAUDE_CODE_SSE_PORT",
+  "CLAUDE_CODE_SESSION_ID",
+  "CLAUDE_CODE_BRIDGE_SESSION_ID",
+  "CLAUDE_PID",
+]
+
+const claudeEnvironment = (): Record<string, string> => {
+  const env: Record<string, string> = {}
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) env[key] = value
+  }
+  env["CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS"] = "1"
+  for (const name of NESTED_SESSION_VARIABLES) delete env[name]
+  return env
+}
+
+/** The hook vocabulary delivered in-process while ATC drives (and via the
+ * webhook while a TUI drives — same normalization, claudeHooks.ts). */
+const HOOK_EVENTS: ReadonlyArray<HookEvent> = [
+  "UserPromptSubmit",
+  "PreToolUse",
+  "PostToolUse",
+  "Stop",
+  "StopFailure",
+  "Notification",
+  "PermissionRequest",
+]
+
+const userMessage = (text: string): SDKUserMessage => ({
+  type: "user",
+  message: { role: "user", content: text },
+  parent_tool_use_id: null,
+})
+
+/** An async input queue the held query() drains; push feeds it more turns. */
+const makeInputQueue = () => {
+  const pending: Array<SDKUserMessage> = []
+  let wake: (() => void) | null = null
+  let closed = false
+  const push = (message: SDKUserMessage): void => {
+    pending.push(message)
+    wake?.()
+  }
+  const close = (): void => {
+    closed = true
+    wake?.()
+  }
+  async function* stream(): AsyncGenerator<SDKUserMessage> {
+    while (true) {
+      const next = pending.shift()
+      if (next !== undefined) {
+        yield next
+        continue
+      }
+      if (closed) return
+      await new Promise<void>((resolve) => {
+        wake = () => {
+          wake = null
+          resolve()
+        }
+      })
+    }
+  }
+  return { push, close, stream }
+}
+
+type GateError = AgentResumeFailed | AgentIdentityMismatch | AgentProtocolError
+
+interface LiveSession {
+  /** The id resume promised (null for create — any id is acceptable). */
+  readonly expectedSessionId: string | null
+  readonly cwd: string
+  readonly queue: Queue.Queue<AgentEvent, AgentProtocolError | Cause.Done>
+  readonly abort: AbortController
+  readonly pushInput: (text: string) => void
+  readonly closeInput: () => void
+  readonly initGate: Deferred.Deferred<void, GateError>
+  interrupt: () => Promise<unknown>
+  sessionId: string | null
+  activity: AgentActivity
+  activeTurn: string | null
+  interruptRequested: boolean
+  closed: boolean
+  /** The session itself ended (terminal turn, transport, failed
+   * verification) — as opposed to the caller closing its handle. */
+  over: boolean
+}
+
+export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
+  Layer.effect(ClaudeAdapter)(
+    Effect.gen(function* () {
+      const config = yield* AppConfig
+      const subprocess = yield* Subprocess.Subprocess
+      const fs = yield* FileSystem.FileSystem
+      const hooks = yield* ClaudeHooks.ClaudeHooks
+      const queryFn: ClaudeQueryFn = adapterOptions.queryFn ?? (query as unknown as ClaudeQueryFn)
+      const initTimeout = adapterOptions.initTimeout ?? "60 seconds"
+
+      /** Live sessions by verified (and, for resumes, expected) session id. */
+      const sessions = new Map<string, LiveSession>()
+      let nextTurn = 1
+
+      const emit = (session: LiveSession, event: AgentEvent): void => {
+        Queue.offerUnsafe(session.queue, event)
+      }
+
+      const setActivity = (session: LiveSession, activity: AgentActivity): void => {
+        if (session.closed || session.activity === activity) return
+        session.activity = activity
+        emit(session, { type: "activity", activity })
+      }
+
+      const dropFromRegistry = (session: LiveSession): void => {
+        for (const key of [session.expectedSessionId, session.sessionId]) {
+          if (key !== null && sessions.get(key) === session) sessions.delete(key)
+        }
+      }
+
+      const closeSession = (session: LiveSession, failure?: AgentProtocolError): void => {
+        if (session.closed) return
+        session.closed = true
+        dropFromRegistry(session)
+        if (failure !== undefined) {
+          Queue.failCauseUnsafe(session.queue, Cause.fail(failure))
+        } else {
+          Queue.endUnsafe(session.queue)
+        }
+        session.closeInput()
+        session.abort.abort()
+      }
+
+      const failGate = (session: LiveSession, error: GateError): void => {
+        session.over = true
+        Deferred.doneUnsafe(session.initGate, Effect.fail(error))
+        // The feed fails loudly too: a consumer holding only `events` must
+        // not mistake a dead session for a clean end.
+        closeSession(session, protocolError(error.message))
+      }
+
+      const handleMessage = (session: LiveSession, message: SDKMessage): void => {
+        if (session.closed) return
+        if (message.type === "system" && message.subtype === "init") {
+          if (
+            session.expectedSessionId !== null &&
+            message.session_id !== session.expectedSessionId
+          ) {
+            return failGate(
+              session,
+              new AgentIdentityMismatch({
+                provider: "claude",
+                field: "sessionId",
+                expected: session.expectedSessionId,
+                actual: message.session_id,
+              }),
+            )
+          }
+          if (!samePath(message.cwd, session.cwd)) {
+            return failGate(
+              session,
+              new AgentIdentityMismatch({
+                provider: "claude",
+                field: "cwd",
+                expected: session.cwd,
+                actual: message.cwd,
+              }),
+            )
+          }
+          session.sessionId = message.session_id
+          if (!sessions.has(message.session_id)) sessions.set(message.session_id, session)
+          Deferred.doneUnsafe(session.initGate, Effect.void)
+          return
+        }
+        if (message.type === "system" && message.subtype === "session_state_changed") {
+          const state = (message as { state?: unknown }).state
+          if (state === "running") setActivity(session, "working")
+          if (state === "idle") setActivity(session, "idle")
+          if (state === "requires_action") setActivity(session, "needs_input")
+          return
+        }
+        if (message.type === "result") {
+          const errors = (message as { errors?: ReadonlyArray<string> }).errors ?? []
+          if (session.sessionId === null) {
+            // The invalid-resume shape: one error result, no init, no
+            // replacement session — the fail-closed contract. Classified
+            // structurally (an error result before any identity evidence on
+            // a resume), not by matching provider prose.
+            const text = errors.join("; ")
+            return failGate(
+              session,
+              session.expectedSessionId !== null && message.subtype !== "success"
+                ? new AgentResumeFailed({
+                    provider: "claude",
+                    providerSessionId: session.expectedSessionId,
+                    reason: text,
+                  })
+                : protocolError(`the session ended before identity evidence: ${text}`),
+            )
+          }
+          const outcome =
+            message.subtype === "success"
+              ? "completed"
+              : session.interruptRequested
+                ? "interrupted"
+                : "failed"
+          const turnId = session.activeTurn
+          session.activeTurn = null
+          session.interruptRequested = false
+          if (turnId !== null) {
+            emit(
+              session,
+              outcome === "failed"
+                ? {
+                    type: "turnCompleted",
+                    turnId,
+                    outcome,
+                    detail: `${message.subtype}: ${errors.join("; ")}`,
+                  }
+                : { type: "turnCompleted", turnId, outcome },
+            )
+          }
+          // Error-path idle derives from the result itself (probe finding:
+          // Stop/StopFailure do not fire here).
+          setActivity(session, "idle")
+          if (outcome !== "completed") {
+            session.over = true
+            closeSession(session)
+          }
+          return
+        }
+      }
+
+      const consume = (session: LiveSession, source: AsyncIterable<SDKMessage>) =>
+        Effect.tryPromise({
+          try: async () => {
+            for await (const message of source) {
+              handleMessage(session, message)
+              if (session.closed) return
+            }
+          },
+          catch: (error) => (error instanceof Error ? error.message : String(error)),
+        }).pipe(
+          Effect.catch((reason) =>
+            Effect.sync(() => {
+              // The SDK iterator throws after an error result; when the
+              // result was already handled the session is closed and this
+              // is expected. Otherwise it is the turn's failure.
+              if (session.closed) return
+              if (session.sessionId === null) {
+                return failGate(session, protocolError(`the SDK stream failed: ${reason}`))
+              }
+              const turnId = session.activeTurn
+              session.activeTurn = null
+              if (turnId !== null) {
+                emit(session, {
+                  type: "turnCompleted",
+                  turnId,
+                  outcome: session.interruptRequested ? "interrupted" : "failed",
+                  detail: reason,
+                })
+              }
+              setActivity(session, "idle")
+              session.over = true
+              closeSession(session)
+            }),
+          ),
+          Effect.ensuring(Effect.sync(() => closeSession(session))),
+        )
+
+      const makeCanUseTool =
+        (session: LiveSession): CanUseTool =>
+        (toolName, _input, options) => {
+          // Activity is NOT touched here: requires_action state events carry
+          // that truthfully, and a synchronous needs_input/working round
+          // trip would clobber overlapping callbacks once responses become
+          // asynchronous (ATC-124).
+          if (!session.closed) {
+            const requestId = options.requestId
+            const kind = toolName === "AskUserQuestion" ? "question" : "approval"
+            emit(session, { type: "requestOpened", requestId, kind })
+            emit(session, { type: "requestClosed", requestId })
+          }
+          return Promise.resolve({
+            behavior: "deny",
+            message: "atc does not answer provider requests yet (ATC-124)",
+          })
+        }
+
+      const makeHooks = (
+        session: LiveSession,
+      ): Partial<Record<HookEvent, Array<HookCallbackMatcher>>> =>
+        Object.fromEntries(
+          HOOK_EVENTS.map((event) => [
+            event,
+            [
+              {
+                hooks: [
+                  (input: { hook_event_name: string }) => {
+                    const activity = ClaudeHooks.hookActivity(
+                      input.hook_event_name,
+                      input as unknown as Record<string, unknown>,
+                    )
+                    if (activity !== null && !session.closed) setActivity(session, activity)
+                    return Promise.resolve({ continue: true as const })
+                  },
+                ],
+              },
+            ],
+          ]),
+        )
+
+      const versionCheck = makeVersionGate(
+        subprocess,
+        "claude",
+        config.claudeExecutable,
+        CLAUDE_TESTED_VERSION,
+      )
+
+      const openSession = (options: { readonly cwd: string; readonly resume?: string }) =>
+        Effect.gen(function* () {
+          const executable = yield* resolveProviderExecutable("claude", config.claudeExecutable)
+          yield* versionCheck
+          const input = makeInputQueue()
+          const queue = yield* Queue.make<AgentEvent, AgentProtocolError | Cause.Done>()
+          const initGate = yield* Deferred.make<void, GateError>()
+          const session: LiveSession = {
+            expectedSessionId: options.resume ?? null,
+            cwd: options.cwd,
+            queue,
+            abort: new AbortController(),
+            pushInput: (text) => input.push(userMessage(text)),
+            closeInput: input.close,
+            initGate,
+            interrupt: () => Promise.resolve(),
+            sessionId: null,
+            activity: "unknown",
+            activeTurn: null,
+            interruptRequested: false,
+            closed: false,
+            over: false,
+          }
+          if (options.resume !== undefined) {
+            if (sessions.has(options.resume)) {
+              return yield* Effect.fail(
+                conflict(`a writer is already connected to ${options.resume}`),
+              )
+            }
+            sessions.set(options.resume, session)
+          }
+          // Registered before queryFn can fail: an uncleaned registry entry
+          // would lock the session id out of resume for the process's life.
+          yield* Effect.addFinalizer(() => Effect.sync(() => closeSession(session)))
+          const handle = queryFn({
+            prompt: input.stream(),
+            options: {
+              abortController: session.abort,
+              cwd: options.cwd,
+              env: claudeEnvironment(),
+              pathToClaudeCodeExecutable: executable,
+              ...(options.resume !== undefined ? { resume: options.resume } : {}),
+              settingSources: [],
+              permissionMode: "default",
+              persistSession: true,
+              canUseTool: makeCanUseTool(session),
+              hooks: makeHooks(session),
+            },
+          })
+          session.interrupt = () => handle.interrupt()
+          yield* consume(session, handle).pipe(Effect.forkScoped)
+          return session
+        })
+
+      const awaitVerified = (session: LiveSession) =>
+        Deferred.await(session.initGate).pipe(
+          Effect.timeoutOrElse({
+            duration: initTimeout,
+            orElse: () =>
+              Effect.sync(() => {
+                const error = protocolError(
+                  `no identity evidence within ${Duration.format(Duration.fromInputUnsafe(initTimeout))}`,
+                )
+                // Keep the gate and the session in agreement.
+                Deferred.doneUnsafe(session.initGate, Effect.fail(error))
+                closeSession(session, error)
+                return error
+              }).pipe(Effect.flatMap(Effect.fail)),
+          }),
+        )
+
+      const makeConnection = (session: LiveSession): AgentConnection => {
+        // The seam's uniform rule: a session that ended underneath the
+        // caller is AgentUnavailable ("resume it"); a handle the caller
+        // already closed is a conflict.
+        const requireOpen = Effect.suspend(
+          (): Effect.Effect<void, AgentConflict | AgentUnavailable> =>
+            session.over
+              ? Effect.fail(
+                  new AgentUnavailable({
+                    provider: "claude",
+                    reason: "the session ended; resume it for a fresh connection",
+                  }),
+                )
+              : session.closed
+                ? Effect.fail(conflict("the connection is closed"))
+                : Effect.void,
+        )
+        return {
+          get providerSessionId() {
+            return session.sessionId ?? session.expectedSessionId ?? ""
+          },
+          cwd: session.cwd,
+          activity: Effect.sync(() => session.activity),
+          events: Stream.fromQueue(session.queue),
+          startTurn: (text) =>
+            Effect.gen(function* () {
+              yield* requireOpen
+              if (session.activeTurn !== null) {
+                return yield* Effect.fail(conflict(`turn ${session.activeTurn} is still active`))
+              }
+              const turnId = `claude-turn-${nextTurn++}`
+              session.activeTurn = turnId
+              // Emitted before anything can await: the consume fiber may
+              // deliver this turn's result on the very next microtask, and
+              // turnStarted must precede turnCompleted on the feed.
+              emit(session, { type: "turnStarted", turnId })
+              session.pushInput(text)
+              if (session.sessionId === null) {
+                // First turn after a resume: this is where the deferred
+                // identity verification lands (see the module header).
+                yield* awaitVerified(session).pipe(
+                  Effect.tapError(() =>
+                    Effect.sync(() => {
+                      session.activeTurn = null
+                    }),
+                  ),
+                )
+              }
+              return { turnId }
+            }),
+          interrupt: (turn) =>
+            Effect.gen(function* () {
+              yield* requireOpen
+              if (session.activeTurn !== turn.turnId) {
+                return yield* Effect.fail(conflict(`turn ${turn.turnId} is not the active turn`))
+              }
+              session.interruptRequested = true
+              yield* Effect.tryPromise({
+                try: () => session.interrupt(),
+                catch: (error) => protocolError(`interrupt failed: ${error}`),
+              }).pipe(
+                // A failed interrupt must not relabel the turn's real
+                // outcome as "interrupted" later.
+                Effect.tapError(() =>
+                  Effect.sync(() => {
+                    session.interruptRequested = false
+                  }),
+                ),
+              )
+            }),
+        }
+      }
+
+      const adapter: AgentAdapter = {
+        provider: "claude",
+        capabilities: { testedVersion: CLAUDE_TESTED_VERSION, tuiObservation: "hooks" },
+        createSession: (options) =>
+          Effect.gen(function* () {
+            const session = yield* openSession({ cwd: options.cwd })
+            const turnId = `claude-turn-${nextTurn++}`
+            session.activeTurn = turnId
+            emit(session, { type: "turnStarted", turnId })
+            session.pushInput(options.input)
+            // A create has no expected id, so AgentResumeFailed cannot
+            // happen here — same rule as the codex adapter.
+            yield* awaitVerified(session).pipe(
+              Effect.catchTag("AgentResumeFailed", (error) => Effect.die(error)),
+            )
+            return { connection: makeConnection(session), turn: { turnId } }
+          }),
+        resumeSession: (options) =>
+          Effect.gen(function* () {
+            const session = yield* openSession({
+              cwd: options.cwd,
+              resume: options.providerSessionId,
+            })
+            return makeConnection(session)
+          }),
+        tuiLaunch: (options) =>
+          Effect.gen(function* () {
+            const executable = yield* resolveProviderExecutable("claude", config.claudeExecutable)
+            const secret = yield* hooks.registerSecret(options.providerSessionId)
+            // The secret only ever lives in 0600 files: the settings file
+            // and a curl header file (`-H @file`) — never in any argv (ps
+            // would show it, including curl's) and never in the URL
+            // (request paths land in tracer span names). Both files are
+            // overwritten per launch; tying their lifetime to the TUI
+            // terminal session is ATC-124 work.
+            const url = `http://127.0.0.1:${config.port}/internal/claude/hooks`
+            const headerFile = path.join(
+              config.stateDir,
+              `claude-hooks-${options.providerSessionId}.header`,
+            )
+            const command =
+              `curl -fsS -m 5 -X POST -H 'Content-Type: application/json' ` +
+              `-H @'${headerFile}' --data-binary @- '${url}'`
+            const hookConfig = Object.fromEntries(
+              HOOK_EVENTS.map((event) => [event, [{ hooks: [{ type: "command", command }] }]]),
+            )
+            const settingsFile = path.join(
+              config.stateDir,
+              `claude-hooks-${options.providerSessionId}.json`,
+            )
+            const write = (file: string, content: string) =>
+              fs.writeFileString(file, content).pipe(Effect.andThen(fs.chmod(file, 0o600)))
+            yield* fs.makeDirectory(config.stateDir, { recursive: true }).pipe(
+              Effect.andThen(write(headerFile, `${ClaudeHooks.SECRET_HEADER}: ${secret}`)),
+              Effect.andThen(write(settingsFile, JSON.stringify({ hooks: hookConfig }))),
+              Effect.mapError(
+                (error) =>
+                  new AgentUnavailable({
+                    provider: "claude",
+                    reason: `could not write the hook settings files: ${error.message}`,
+                  }),
+              ),
+            )
+            return {
+              command: [
+                executable,
+                "--resume",
+                options.providerSessionId,
+                "--settings",
+                settingsFile,
+              ],
+              env: {},
+            }
+          }),
+      }
+      return adapter
+    }),
+  )
+
+export const layer = layerWith({})

--- a/app-server/src/claudeHooks.ts
+++ b/app-server/src/claudeHooks.ts
@@ -1,0 +1,150 @@
+import { Context, Effect, Layer, Schema } from "effect"
+import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import type { AgentActivity } from "./agentAdapter.ts"
+
+// Claude hook ingestion (ATC-123): one normalization of Claude Code's hook
+// vocabulary into activity signals, fed from two transports — in-process
+// SDK callbacks while ATC drives a session (claudeAdapter.ts), and the
+// internal webhook below while a TUI drives one. TUI-driven sessions have
+// no adapter connection (one-writer rule), so webhook activity is consumed
+// via `subscribe` by whatever owns TUI session state — ATC-124's job; in
+// ATC-123 deliveries are validated and then dropped. The webhook is
+// machine-to-machine plumbing whose payload shape Claude Code owns, so it
+// is deliberately NOT in the public contract or openapi.json. Spoofing is
+// guarded by a per-session secret carried in the x-atc-hook-secret header
+// (minted at TUI launch; a re-mint invalidates the session's prior secret);
+// a payload whose session_id disagrees with the secret's registration is
+// dropped. Hooks carry no turn or request correlation ids, so they
+// normalize to activity only — never to turn or request events.
+
+/** What one hook event says about the session's activity, if anything. */
+export const hookActivity = (
+  eventName: string,
+  payload: Record<string, unknown>,
+): AgentActivity | null => {
+  switch (eventName) {
+    case "UserPromptSubmit":
+    case "PreToolUse":
+    case "PostToolUse":
+      return "working"
+    case "Stop":
+    case "StopFailure":
+      return "idle"
+    case "PermissionRequest":
+      return "needs_input"
+    case "Notification": {
+      const kind = payload["notification_type"]
+      if (kind === "idle_prompt") return "idle"
+      if (
+        kind === "permission_prompt" ||
+        kind === "elicitation_dialog" ||
+        kind === "agent_needs_input"
+      ) {
+        return "needs_input"
+      }
+      return null
+    }
+    default:
+      // Lifecycle events (SessionStart/SessionEnd, ...) are ATC-owned facts
+      // elsewhere; everything unrecognized is ignored, never guessed at.
+      return null
+  }
+}
+
+/** The only fields the receiver reads; Claude Code owns everything else. */
+const HookPayload = Schema.Struct({
+  session_id: Schema.String,
+  hook_event_name: Schema.String,
+})
+
+export type HookListener = (providerSessionId: string, activity: AgentActivity) => void
+
+export class ClaudeHooks extends Context.Service<
+  ClaudeHooks,
+  {
+    /**
+     * Mint and register the webhook secret for one provider session,
+     * replacing (and invalidating) any prior secret for that session. The
+     * registration lives until replaced; scoping secrets to the TUI
+     * terminal session's lifetime is ATC-124 work.
+     */
+    readonly registerSecret: (providerSessionId: string) => Effect.Effect<string>
+    /**
+     * Subscribe to normalized webhook activity for TUI-driven sessions
+     * (nothing subscribes in ATC-123). Scoped: closing unsubscribes.
+     */
+    readonly subscribe: (
+      listener: HookListener,
+    ) => Effect.Effect<void, never, import("effect").Scope.Scope>
+    /**
+     * One webhook delivery. Returns the HTTP status to answer with: 204
+     * accepted, 404 unknown secret (nothing is leaked about why), 400
+     * malformed payload or session mismatch.
+     */
+    readonly deliver: (secret: string, payload: unknown) => Effect.Effect<204 | 400 | 404>
+  }
+>()("app-server/ClaudeHooks") {}
+
+export const layer = Layer.effect(ClaudeHooks)(
+  Effect.sync(() => {
+    const secrets = new Map<string, string>()
+    const secretForSession = new Map<string, string>()
+    const listeners = new Set<HookListener>()
+    return {
+      registerSecret: (providerSessionId: string) =>
+        Effect.sync(() => {
+          const previous = secretForSession.get(providerSessionId)
+          if (previous !== undefined) secrets.delete(previous)
+          const secret =
+            crypto.randomUUID().replaceAll("-", "") + crypto.randomUUID().replaceAll("-", "")
+          secrets.set(secret, providerSessionId)
+          secretForSession.set(providerSessionId, secret)
+          return secret
+        }),
+      subscribe: (listener: HookListener) =>
+        Effect.gen(function* () {
+          listeners.add(listener)
+          yield* Effect.addFinalizer(() => Effect.sync(() => listeners.delete(listener)))
+        }),
+      deliver: (secret: string, payload: unknown) =>
+        Effect.gen(function* () {
+          const providerSessionId = secrets.get(secret)
+          if (providerSessionId === undefined) return 404 as const
+          const decoded = yield* Schema.decodeUnknownEffect(HookPayload)(payload).pipe(
+            Effect.option,
+          )
+          if (decoded._tag === "None") return 400 as const
+          if (decoded.value.session_id !== providerSessionId) return 400 as const
+          const activity = hookActivity(
+            decoded.value.hook_event_name,
+            payload as Record<string, unknown>,
+          )
+          if (activity !== null) {
+            for (const listener of listeners) listener(providerSessionId, activity)
+          }
+          return 204 as const
+        }),
+    }
+  }),
+)
+
+/** The header carrying the per-session secret (never the URL: request
+ * paths land in tracer span names and logs). */
+export const SECRET_HEADER = "x-atc-hook-secret"
+
+/**
+ * The internal webhook route. Not part of the public contract: it exists
+ * for Claude Code's hook commands only, and its shape may change with the
+ * provider. Mounted by server.ts alongside the contract routes.
+ */
+export const route = HttpRouter.add(
+  "POST",
+  "/internal/claude/hooks",
+  Effect.gen(function* () {
+    const hooks = yield* ClaudeHooks
+    const request = yield* HttpServerRequest.HttpServerRequest
+    const payload = yield* request.json.pipe(Effect.orElseSucceed(() => null))
+    const status = yield* hooks.deliver(request.headers[SECRET_HEADER] ?? "", payload)
+    return HttpServerResponse.empty({ status })
+  }),
+)

--- a/app-server/src/cli.ts
+++ b/app-server/src/cli.ts
@@ -5,6 +5,7 @@ import { HttpClient, HttpClientRequest } from "effect/unstable/http"
 import * as path from "node:path"
 import * as AttachClient from "./attachClient.ts"
 import { attachUrl, CLOSE_DETACH } from "./attachProtocol.ts"
+import * as ClaudeHooks from "./claudeHooks.ts"
 import * as Client from "./client.ts"
 import { AppConfig, ConfigLoadError, CONTEXT_VARIABLES, layer as appConfigLayer } from "./config.ts"
 import * as Directories from "./directories.ts"
@@ -81,6 +82,7 @@ const serve = Command.make("serve", { port }, ({ port }) =>
           TerminalRepository.layer,
           Directories.layer,
           Zmx.layer,
+          ClaudeHooks.layer,
         ]),
         Layer.provide(Persistence.layer),
         Layer.provide(Logging.layer),

--- a/app-server/src/codexAdapter.ts
+++ b/app-server/src/codexAdapter.ts
@@ -1,5 +1,4 @@
 import { Cause, Context, Effect, Layer, Queue, Schema, Semaphore, Stream } from "effect"
-import { realpathSync } from "node:fs"
 import type { AgentActivity, AgentAdapter, AgentConnection, AgentEvent } from "./agentAdapter.ts"
 import {
   AgentConflict,
@@ -7,8 +6,9 @@ import {
   AgentProtocolError,
   AgentResumeFailed,
   AgentUnavailable,
+  makeVersionGate,
   resolveProviderExecutable,
-  warnIfBelowTestedVersion,
+  samePath,
 } from "./agentAdapter.ts"
 import * as BuildInfo from "./buildInfo.ts"
 import * as CodexServer from "./codexServer.ts"
@@ -59,18 +59,6 @@ const ThreadReply = Schema.Struct({
 })
 
 const TurnReply = Schema.Struct({ turn: Schema.Struct({ id: Schema.String }) })
-
-/** Symlink-tolerant path equality (macOS tmpdir lives behind /private). */
-const samePath = (left: string, right: string): boolean => {
-  const canonical = (value: string): string => {
-    try {
-      return realpathSync(value)
-    } catch {
-      return value
-    }
-  }
-  return canonical(left) === canonical(right)
-}
 
 const statusToActivity = (status: unknown): AgentActivity => {
   if (typeof status !== "object" || status === null) return "unknown"
@@ -130,7 +118,6 @@ export const layer = Layer.effect(CodexAdapter)(
     const connectLock = yield* Semaphore.make(1)
     const resumeLock = yield* Semaphore.make(1)
     let current: ClientState | null = null
-    let versionChecked = false
 
     const emit = (session: LiveSession, event: AgentEvent): void => {
       Queue.offerUnsafe(session.queue, event)
@@ -319,12 +306,12 @@ export const layer = Layer.effect(CodexAdapter)(
       )
 
     // Record + warn version drift, once, on first use (never blocks).
-    const versionCheck = Effect.gen(function* () {
-      if (versionChecked) return
-      versionChecked = true
-      const executable = yield* resolveProviderExecutable("codex", config.codexExecutable)
-      yield* warnIfBelowTestedVersion(subprocess, "codex", executable, CODEX_TESTED_VERSION)
-    })
+    const versionCheck = makeVersionGate(
+      subprocess,
+      "codex",
+      config.codexExecutable,
+      CODEX_TESTED_VERSION,
+    )
 
     const openSocket = (url: string): Effect.Effect<ClientState, AgentUnavailable> =>
       Effect.callback<ClientState, AgentUnavailable>((resume) => {

--- a/app-server/src/server.ts
+++ b/app-server/src/server.ts
@@ -3,6 +3,7 @@ import { Layer } from "effect"
 import { HttpMiddleware, HttpRouter, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { Api } from "./api.ts"
+import * as ClaudeHooks from "./claudeHooks.ts"
 import { V1Handlers } from "./handlers.ts"
 import * as LocalTrust from "./localTrust.ts"
 import { openApiJson } from "./openapi.ts"
@@ -21,11 +22,13 @@ const openApiRoute = HttpRouter.add(
 /**
  * All HTTP routes with the local-trust guard applied, independent of any
  * listener. Requires the handler services (BuildInfo, ProjectRepository,
- * Directories, Terminals).
+ * Directories, Terminals, ClaudeHooks). The Claude hook webhook is an
+ * internal route (claudeHooks.ts), deliberately outside the contract.
  */
 export const routes = Layer.mergeAll(
   HttpApiBuilder.layer(Api).pipe(Layer.provide(V1Handlers)),
   openApiRoute,
+  ClaudeHooks.route,
   LocalTrust.middleware,
 )
 

--- a/app-server/test/agentTestKit.ts
+++ b/app-server/test/agentTestKit.ts
@@ -6,6 +6,8 @@ import * as os from "node:os"
 import * as path from "node:path"
 import { fileURLToPath } from "node:url"
 import type { AgentEvent } from "../src/agentAdapter.ts"
+import * as ClaudeAdapter from "../src/claudeAdapter.ts"
+import * as ClaudeHooks from "../src/claudeHooks.ts"
 import * as CodexAdapter from "../src/codexAdapter.ts"
 import * as CodexServer from "../src/codexServer.ts"
 import * as Subprocess from "../src/subprocess.ts"
@@ -77,6 +79,22 @@ export const codexAdapterLayer = (sandbox: {
   const adapter = CodexAdapter.layer.pipe(Layer.provide(server), Layer.provide(platform))
   return Layer.mergeAll(adapter, server)
 }
+
+/**
+ * The Claude adapter stack (with ClaudeHooks exposed for webhook tests).
+ * claudeExecutable defaults to /bin/echo so resolution succeeds without a
+ * Claude install — fixture tests inject a scripted queryFn and never spawn.
+ */
+export const claudeAdapterLayer = (
+  options: ClaudeAdapter.ClaudeAdapterOptions = {},
+  executable = "/bin/echo",
+): Layer.Layer<ClaudeAdapter.ClaudeAdapter | ClaudeHooks.ClaudeHooks, unknown> =>
+  ClaudeAdapter.layerWith(options).pipe(
+    Layer.provideMerge(ClaudeHooks.layer),
+    Layer.provide(testAppConfig({ claudeExecutable: executable })),
+    Layer.provide(Subprocess.layer),
+    Layer.provideMerge(BunServices.layer),
+  )
 
 /** Collect an agent event feed into a sink in the background (scoped). */
 export const collectAgentEvents = (events: Stream.Stream<AgentEvent, unknown>) =>

--- a/app-server/test/claudeAdapter.smoke.test.ts
+++ b/app-server/test/claudeAdapter.smoke.test.ts
@@ -1,0 +1,116 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import * as ClaudeAdapter from "../src/claudeAdapter.ts"
+import { claudeAdapterLayer, collectAgentEvents, waitForAgentEvent } from "./agentTestKit.ts"
+import { trackTempDir } from "./blackbox.ts"
+
+// Live Claude adapter smoke (opt-in: mise run test:smoke): the real Agent
+// SDK end to end — create with verified identity, exact resume with
+// deferred verification at the first turn, interrupt with a truthful
+// interrupted outcome. Needs an installed, authenticated Claude Code; runs
+// real (cheap) turns from a directory outside any repository.
+
+const enabled = process.env["ATC_SMOKE"] === "1"
+
+describe.skipIf(!enabled)("live claude adapter smoke (opt-in)", () => {
+  it.live(
+    "create → resume → turn → interrupt against real Claude Code",
+    () =>
+      Effect.gen(function* () {
+        const cwd = trackTempDir(fs.mkdtempSync(path.join(os.tmpdir(), "atc-claude-smoke-")))
+        const layer = claudeAdapterLayer({}, "claude")
+        const slow = { attempts: 900, interval: "200 millis" } as const
+
+        yield* Effect.gen(function* () {
+          const adapter = yield* ClaudeAdapter.ClaudeAdapter
+
+          // Create + first turn.
+          const sessionId = yield* Effect.scoped(
+            Effect.gen(function* () {
+              const { connection, turn } = yield* adapter.createSession({
+                cwd,
+                input: "Reply with exactly: SMOKE-OK",
+              })
+              const sink = yield* collectAgentEvents(connection.events)
+              yield* waitForAgentEvent(
+                sink,
+                (event) =>
+                  event.type === "turnCompleted" &&
+                  event.turnId === turn.turnId &&
+                  event.outcome === "completed",
+                slow,
+              )
+              return connection.providerSessionId
+            }),
+          )
+
+          // Exact resume; verification completes at the first turn.
+          yield* Effect.scoped(
+            Effect.gen(function* () {
+              const connection = yield* adapter.resumeSession({
+                providerSessionId: sessionId,
+                cwd,
+              })
+              const sink = yield* collectAgentEvents(connection.events)
+              const turn = yield* connection.startTurn(
+                "What exact text did I ask you to reply with earlier? Answer with just that text.",
+              )
+              assert.strictEqual(connection.providerSessionId, sessionId)
+              yield* waitForAgentEvent(
+                sink,
+                (event) =>
+                  event.type === "turnCompleted" &&
+                  event.turnId === turn.turnId &&
+                  event.outcome === "completed",
+                slow,
+              )
+            }),
+          )
+
+          // Interrupt a long-running turn; the outcome must be truthful.
+          yield* Effect.scoped(
+            Effect.gen(function* () {
+              const connection = yield* adapter.resumeSession({
+                providerSessionId: sessionId,
+                cwd,
+              })
+              const sink = yield* collectAgentEvents(connection.events)
+              const turn = yield* connection.startTurn(
+                "Count from 1 to 500, one number per line. Do not stop early.",
+              )
+              yield* waitForAgentEvent(
+                sink,
+                (event) => event.type === "activity" && event.activity === "working",
+                slow,
+              )
+              yield* connection.interrupt(turn)
+              yield* waitForAgentEvent(
+                sink,
+                (event) =>
+                  event.type === "turnCompleted" &&
+                  event.turnId === turn.turnId &&
+                  event.outcome === "interrupted",
+                slow,
+              )
+            }),
+          )
+
+          // An unknown session still fails closed against the real SDK.
+          const failure = yield* Effect.scoped(
+            Effect.gen(function* () {
+              const connection = yield* adapter.resumeSession({
+                providerSessionId: "00000000-0000-4000-8000-000000000000",
+                cwd,
+              })
+              return yield* Effect.flip(connection.startTurn("hello?"))
+            }),
+          )
+          assert.strictEqual(failure._tag, "AgentResumeFailed")
+        }).pipe(Effect.provide(layer))
+      }),
+    300_000,
+  )
+})

--- a/app-server/test/claudeAdapter.test.ts
+++ b/app-server/test/claudeAdapter.test.ts
@@ -1,0 +1,354 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import * as ClaudeAdapter from "../src/claudeAdapter.ts"
+import * as ClaudeHooks from "../src/claudeHooks.ts"
+import { claudeAdapterLayer, collectAgentEvents, waitForAgentEvent } from "./agentTestKit.ts"
+import { trackTempDir } from "./blackbox.ts"
+import { makeFakeClaudeQuery } from "./fakeClaudeQuery.ts"
+import type { FakeClaudeQueryOptions } from "./fakeClaudeQuery.ts"
+
+// Claude adapter tests over the scripted query() seam (fakeClaudeQuery.ts):
+// the SDK's probed behaviors — init only after the first message, invalid
+// resume as a single error result, iterator throw after error results —
+// drive the adapter's deferred verification and truthful turn outcomes.
+// claudeExecutable points at /bin/echo so resolution succeeds without a
+// Claude install (the fake never spawns anything).
+
+const workDir = () => trackTempDir(fs.mkdtempSync(path.join(os.tmpdir(), "atc-claude-test-")))
+
+const adapterStack = (options: FakeClaudeQueryOptions = {}) => {
+  const fake = makeFakeClaudeQuery(options)
+  const layer = claudeAdapterLayer({ queryFn: fake.queryFn, initTimeout: "5 seconds" })
+  return { fake, layer }
+}
+
+describe("ClaudeAdapter", () => {
+  it.live("create: identity verified from init, turn completes on the feed", () =>
+    Effect.gen(function* () {
+      const cwd = workDir()
+      const { layer } = adapterStack({ sessionId: "session-a" })
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const { connection, turn } = yield* adapter.createSession({ cwd, input: "hello" })
+            assert.strictEqual(connection.providerSessionId, "session-a")
+            assert.strictEqual(connection.cwd, cwd)
+            const sink = yield* collectAgentEvents(connection.events)
+            yield* waitForAgentEvent(
+              sink,
+              (event) =>
+                event.type === "turnCompleted" &&
+                event.turnId === turn.turnId &&
+                event.outcome === "completed",
+            )
+            assert.strictEqual(yield* connection.activity, "idle")
+          }),
+        )
+      }).pipe(Effect.provide(layer))
+    }),
+  )
+
+  it.live("create with a lying cwd fails closed", () =>
+    Effect.gen(function* () {
+      const { layer } = adapterStack({ wrongCwd: true })
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        const failure = yield* Effect.scoped(
+          Effect.flip(adapter.createSession({ cwd: workDir(), input: "hello" })),
+        )
+        assert.strictEqual(failure._tag, "AgentIdentityMismatch")
+        if (failure._tag === "AgentIdentityMismatch") assert.strictEqual(failure.field, "cwd")
+      }).pipe(Effect.provide(layer))
+    }),
+  )
+
+  it.live("resume: deferred verification completes at the first turn", () =>
+    Effect.gen(function* () {
+      const cwd = workDir()
+      const { layer } = adapterStack({ knownSessions: ["session-b"] })
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const connection = yield* adapter.resumeSession({
+              providerSessionId: "session-b",
+              cwd,
+            })
+            // No identity evidence yet — the SDK sends none until a turn.
+            assert.strictEqual(yield* connection.activity, "unknown")
+            const sink = yield* collectAgentEvents(connection.events)
+            const turn = yield* connection.startTurn("continue please")
+            assert.strictEqual(connection.providerSessionId, "session-b")
+            yield* waitForAgentEvent(
+              sink,
+              (event) =>
+                event.type === "turnCompleted" &&
+                event.turnId === turn.turnId &&
+                event.outcome === "completed",
+            )
+          }),
+        )
+      }).pipe(Effect.provide(layer))
+    }),
+  )
+
+  it.live("resume of an unknown session fails closed at the first turn", () =>
+    Effect.gen(function* () {
+      const { layer } = adapterStack({ knownSessions: [] })
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        const failure = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const connection = yield* adapter.resumeSession({
+              providerSessionId: "missing-session",
+              cwd: workDir(),
+            })
+            return yield* Effect.flip(connection.startTurn("hello?"))
+          }),
+        )
+        assert.strictEqual(failure._tag, "AgentResumeFailed")
+      }).pipe(Effect.provide(layer))
+    }),
+  )
+
+  it.live("a disagreeing session id in the evidence is a mismatch, never adopted", () =>
+    Effect.gen(function* () {
+      const { layer } = adapterStack({
+        knownSessions: ["session-c"],
+        reportSessionId: "some-other-session",
+      })
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        const failure = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const connection = yield* adapter.resumeSession({
+              providerSessionId: "session-c",
+              cwd: workDir(),
+            })
+            return yield* Effect.flip(connection.startTurn("hello?"))
+          }),
+        )
+        assert.strictEqual(failure._tag, "AgentIdentityMismatch")
+        if (failure._tag === "AgentIdentityMismatch") {
+          assert.strictEqual(failure.field, "sessionId")
+        }
+      }).pipe(Effect.provide(layer))
+    }),
+  )
+
+  it.live("one writer per session id", () =>
+    Effect.gen(function* () {
+      const cwd = workDir()
+      const { layer } = adapterStack({ knownSessions: ["session-d"] })
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            yield* adapter.resumeSession({ providerSessionId: "session-d", cwd })
+            const failure = yield* Effect.flip(
+              adapter.resumeSession({ providerSessionId: "session-d", cwd }),
+            )
+            assert.strictEqual(failure._tag, "AgentConflict")
+          }),
+        )
+        // The writer role is released with the scope.
+        yield* Effect.scoped(adapter.resumeSession({ providerSessionId: "session-d", cwd }))
+      }).pipe(Effect.provide(layer))
+    }),
+  )
+
+  it.live("interrupt: truthful interrupted outcome, then the connection ends", () =>
+    Effect.gen(function* () {
+      const cwd = workDir()
+      const { fake, layer } = adapterStack()
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const { connection, turn } = yield* adapter.createSession({
+              cwd,
+              input: "HANG until told otherwise",
+            })
+            const sink = yield* collectAgentEvents(connection.events)
+            const stale = yield* Effect.flip(connection.interrupt({ turnId: "wrong-turn" }))
+            assert.strictEqual(stale._tag, "AgentConflict")
+
+            yield* connection.interrupt(turn)
+            assert.deepStrictEqual(fake.interrupts.length, 1)
+            yield* waitForAgentEvent(
+              sink,
+              (event) =>
+                event.type === "turnCompleted" &&
+                event.turnId === turn.turnId &&
+                event.outcome === "interrupted",
+            )
+            // An interrupted turn ends the held query; the session is over
+            // (AgentUnavailable — the seam's "resume it" signal), not a
+            // caller-side handle conflict.
+            const closed = yield* Effect.flip(connection.startTurn("another"))
+            assert.strictEqual(closed._tag, "AgentUnavailable")
+          }),
+        )
+      }).pipe(Effect.provide(layer))
+    }),
+  )
+
+  it.live("an error result is a failed turn, not a transport defect", () =>
+    Effect.gen(function* () {
+      const cwd = workDir()
+      const { layer } = adapterStack()
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const { connection, turn } = yield* adapter.createSession({
+              cwd,
+              input: "FAILTURN please",
+            })
+            const sink = yield* collectAgentEvents(connection.events)
+            yield* waitForAgentEvent(
+              sink,
+              (event) =>
+                event.type === "turnCompleted" &&
+                event.turnId === turn.turnId &&
+                event.outcome === "failed" &&
+                (event.detail ?? "").includes("error_max_turns"),
+            )
+            // Error-path idle derived from the result message itself.
+            assert.strictEqual(yield* connection.activity, "idle")
+          }),
+        )
+      }).pipe(Effect.provide(layer))
+    }),
+  )
+
+  it.live("permission callbacks surface as request events and are denied", () =>
+    Effect.gen(function* () {
+      const cwd = workDir()
+      const { fake, layer } = adapterStack()
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const { connection, turn } = yield* adapter.createSession({
+              cwd,
+              input: "needs PERMISSION for a tool",
+            })
+            const sink = yield* collectAgentEvents(connection.events)
+            yield* waitForAgentEvent(
+              sink,
+              (event) => event.type === "requestOpened" && event.kind === "approval",
+            )
+            yield* waitForAgentEvent(sink, (event) => event.type === "requestClosed")
+            yield* waitForAgentEvent(
+              sink,
+              (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
+            )
+            assert.deepStrictEqual(fake.denials, [{ toolName: "Bash", behavior: "deny" }])
+            assert.isTrue(
+              sink.some((event) => event.type === "activity" && event.activity === "needs_input"),
+            )
+          }),
+        )
+      }).pipe(Effect.provide(layer))
+    }),
+  )
+
+  it.live("in-process hook callbacks alone still drive the activity feed", () =>
+    Effect.gen(function* () {
+      const cwd = workDir()
+      // No session_state_changed events at all: activity must come from
+      // the SDK hook callbacks (UserPromptSubmit → working, Stop → idle).
+      const { layer } = adapterStack({ stateEvents: false })
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const { connection, turn } = yield* adapter.createSession({ cwd, input: "hello" })
+            const sink = yield* collectAgentEvents(connection.events)
+            yield* waitForAgentEvent(
+              sink,
+              (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
+            )
+            assert.isTrue(
+              sink.some((event) => event.type === "activity" && event.activity === "working"),
+            )
+            assert.strictEqual(yield* connection.activity, "idle")
+          }),
+        )
+      }).pipe(Effect.provide(layer))
+    }),
+  )
+
+  it.live("AskUserQuestion surfaces as a question, not an approval", () =>
+    Effect.gen(function* () {
+      const cwd = workDir()
+      const { fake, layer } = adapterStack()
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const { connection, turn } = yield* adapter.createSession({
+              cwd,
+              input: "ASK me something",
+            })
+            const sink = yield* collectAgentEvents(connection.events)
+            yield* waitForAgentEvent(
+              sink,
+              (event) => event.type === "requestOpened" && event.kind === "question",
+            )
+            yield* waitForAgentEvent(
+              sink,
+              (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
+            )
+            assert.deepStrictEqual(fake.denials, [
+              { toolName: "AskUserQuestion", behavior: "deny" },
+            ])
+          }),
+        )
+      }).pipe(Effect.provide(layer))
+    }),
+  )
+
+  it.live("tuiLaunch registers a webhook secret and builds the hooks settings", () =>
+    Effect.gen(function* () {
+      const { layer } = adapterStack()
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        const hooks = yield* ClaudeHooks.ClaudeHooks
+        const spec = yield* adapter.tuiLaunch({ providerSessionId: "session-t", cwd: "/w" })
+        assert.strictEqual(spec.command[0], "/bin/echo")
+        assert.deepStrictEqual(spec.command.slice(1, 3), ["--resume", "session-t"])
+        assert.strictEqual(spec.command[3], "--settings")
+        // The settings live in a 0600 file, never in argv.
+        const settingsFile = spec.command[4] ?? ""
+        assert.strictEqual((fs.statSync(settingsFile).mode & 0o777).toString(8), "600")
+        const settings = JSON.parse(fs.readFileSync(settingsFile, "utf8")) as {
+          hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>
+        }
+        assert.includeMembers(Object.keys(settings.hooks), ["Stop", "PermissionRequest"])
+        const command = settings.hooks["Stop"]?.[0]?.hooks[0]?.command ?? ""
+        assert.include(command, "/internal/claude/hooks")
+        // The secret lives only in the 0600 header file, never in the
+        // curl command line itself.
+        const headerFile = /-H @'([^']+)'/.exec(command)?.[1] ?? ""
+        assert.strictEqual((fs.statSync(headerFile).mode & 0o777).toString(8), "600")
+        const header = fs.readFileSync(headerFile, "utf8")
+        const secret =
+          new RegExp(`${ClaudeHooks.SECRET_HEADER}: ([a-f0-9]+)`).exec(header)?.[1] ?? ""
+        assert.isAbove(secret.length, 30)
+        assert.notInclude(command, secret)
+        // The secret is live: a delivery for the registered session lands.
+        const status = yield* hooks.deliver(secret, {
+          session_id: "session-t",
+          hook_event_name: "Stop",
+        })
+        assert.strictEqual(status, 204)
+      }).pipe(Effect.provide(layer))
+    }),
+  )
+})

--- a/app-server/test/claudeHooks.test.ts
+++ b/app-server/test/claudeHooks.test.ts
@@ -1,0 +1,131 @@
+import { assert, describe, it } from "@effect/vitest"
+import { BunHttpServer } from "@effect/platform-bun"
+import { Effect, Layer } from "effect"
+import { HttpBody, HttpClientRequest, HttpRouter, HttpServerRequest } from "effect/unstable/http"
+import * as fs from "node:fs"
+import { fileURLToPath } from "node:url"
+import type { AgentActivity } from "../src/agentAdapter.ts"
+import * as ClaudeHooks from "../src/claudeHooks.ts"
+import * as Server from "../src/server.ts"
+import { TestBuildInfoLayer } from "./testBuildInfo.ts"
+import { TestRepositoryLayers } from "./testLayers.ts"
+
+// The Claude hook receiver, exercised with payloads RECORDED from a real
+// Claude Code 2.1.221 run (fixtures/claude-hook-payloads.json): secret
+// gating, session_id agreement, and activity normalization. One black-box
+// case proves the internal route is actually mounted on a real serve.
+
+const recorded = JSON.parse(
+  fs.readFileSync(
+    fileURLToPath(new URL("fixtures/claude-hook-payloads.json", import.meta.url)),
+    "utf8",
+  ),
+) as Array<Record<string, unknown>>
+
+const RECORDED_SESSION = "8825b7a5-b6a4-4dc1-9daf-e45904303e62"
+
+describe("claude hook activity normalization", () => {
+  it("maps the recorded vocabulary and the notification subtypes", () => {
+    assert.strictEqual(ClaudeHooks.hookActivity("UserPromptSubmit", {}), "working")
+    assert.strictEqual(ClaudeHooks.hookActivity("PreToolUse", {}), "working")
+    assert.strictEqual(ClaudeHooks.hookActivity("PostToolUse", {}), "working")
+    assert.strictEqual(ClaudeHooks.hookActivity("Stop", {}), "idle")
+    assert.strictEqual(ClaudeHooks.hookActivity("StopFailure", {}), "idle")
+    assert.strictEqual(ClaudeHooks.hookActivity("PermissionRequest", {}), "needs_input")
+    assert.strictEqual(
+      ClaudeHooks.hookActivity("Notification", { notification_type: "permission_prompt" }),
+      "needs_input",
+    )
+    assert.strictEqual(
+      ClaudeHooks.hookActivity("Notification", { notification_type: "agent_needs_input" }),
+      "needs_input",
+    )
+    assert.strictEqual(
+      ClaudeHooks.hookActivity("Notification", { notification_type: "idle_prompt" }),
+      "idle",
+    )
+    // Lifecycle and unknown events are never guessed at.
+    assert.isNull(ClaudeHooks.hookActivity("SessionEnd", {}))
+    assert.isNull(ClaudeHooks.hookActivity("SomethingNew", {}))
+    assert.isNull(ClaudeHooks.hookActivity("Notification", { notification_type: "mystery" }))
+  })
+})
+
+describe("claude hook webhook delivery", () => {
+  it.effect("recorded payloads flow to subscribers under the right secret", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const hooks = yield* ClaudeHooks.ClaudeHooks
+        const seen: Array<{ sessionId: string; activity: AgentActivity }> = []
+        yield* hooks.subscribe((sessionId, activity) => seen.push({ sessionId, activity }))
+        const secret = yield* hooks.registerSecret(RECORDED_SESSION)
+
+        for (const payload of recorded) {
+          assert.strictEqual(yield* hooks.deliver(secret, payload), 204)
+        }
+        // UserPromptSubmit/PreToolUse/PostToolUse → working, Stop → idle.
+        assert.deepStrictEqual(
+          seen.map((entry) => entry.activity),
+          ["working", "working", "working", "idle"],
+        )
+        assert.isTrue(seen.every((entry) => entry.sessionId === RECORDED_SESSION))
+      }),
+    ).pipe(Effect.provide(ClaudeHooks.layer)),
+  )
+
+  it.effect("unknown secrets, spoofed sessions, and junk are rejected", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const hooks = yield* ClaudeHooks.ClaudeHooks
+        const seen: Array<string> = []
+        yield* hooks.subscribe((sessionId) => seen.push(sessionId))
+        const secret = yield* hooks.registerSecret(RECORDED_SESSION)
+
+        assert.strictEqual(yield* hooks.deliver("not-a-secret", recorded[0]), 404)
+        // A valid secret with a payload for a DIFFERENT session is spoofing.
+        assert.strictEqual(
+          yield* hooks.deliver(secret, { session_id: "intruder", hook_event_name: "Stop" }),
+          400,
+        )
+        assert.strictEqual(yield* hooks.deliver(secret, { nonsense: true }), 400)
+        assert.strictEqual(yield* hooks.deliver(secret, null), 400)
+        assert.deepStrictEqual(seen, [])
+      }),
+    ).pipe(Effect.provide(ClaudeHooks.layer)),
+  )
+
+  // In-process over the real routes layer, sharing ONE ClaudeHooks instance
+  // between registration and the route: proves the mount actually delivers
+  // (a 404 alone could come from an unmounted path just as well).
+  it.effect("the internal route is mounted and delivers to the registry", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const hooks = yield* ClaudeHooks.ClaudeHooks
+        const seen: Array<AgentActivity> = []
+        yield* hooks.subscribe((_sessionId, activity) => seen.push(activity))
+        const secret = yield* hooks.registerSecret(RECORDED_SESSION)
+        const handler = yield* HttpRouter.toHttpEffect(
+          Server.routes.pipe(Layer.provide([TestBuildInfoLayer, TestRepositoryLayers])),
+        )
+        const post = (headerSecret: string) =>
+          handler.pipe(
+            Effect.provideService(
+              HttpServerRequest.HttpServerRequest,
+              HttpServerRequest.fromClientRequest(
+                HttpClientRequest.post("http://127.0.0.1/internal/claude/hooks").pipe(
+                  HttpClientRequest.setHeader("host", "127.0.0.1"),
+                  HttpClientRequest.setHeader(ClaudeHooks.SECRET_HEADER, headerSecret),
+                  HttpClientRequest.setBody(HttpBody.jsonUnsafe(recorded[3])),
+                ),
+              ),
+            ),
+            Effect.provideService(ClaudeHooks.ClaudeHooks, hooks),
+            Effect.orDie,
+          )
+        assert.strictEqual((yield* post(secret)).status, 204)
+        assert.deepStrictEqual(seen, ["idle"])
+        assert.strictEqual((yield* post("bogus")).status, 404)
+      }),
+    ).pipe(Effect.provide([ClaudeHooks.layer, BunHttpServer.layerHttpServices])),
+  )
+})

--- a/app-server/test/fakeClaudeQuery.ts
+++ b/app-server/test/fakeClaudeQuery.ts
@@ -1,0 +1,204 @@
+import type { SDKMessage, SDKUserMessage } from "@anthropic-ai/claude-agent-sdk"
+import type { ClaudeQueryFn } from "../src/claudeAdapter.ts"
+
+// A scripted stand-in for the Agent SDK's query() (the ClaudeQueryFn seam):
+// consumes the streaming prompt like the real SDK, emits the message shapes
+// the probes recorded (system/init only after the first user message —
+// the load-bearing timing fact), and mimics the SDK's throw-after-error-
+// result iterator behavior. Turn behavior keys off the input text:
+//   "HANG"       — stays running until interrupt()
+//   "PERMISSION" — invokes canUseTool (Bash) before finishing
+//   "ASK"        — invokes canUseTool (AskUserQuestion) before finishing
+//   "FAILTURN"   — ends with error_max_turns, then the iterator throws
+
+export interface FakeClaudeQueryOptions {
+  /** session_id for created sessions (resumes echo the resume id). */
+  readonly sessionId?: string
+  /** Session ids that resume finds; anything else fails closed. */
+  readonly knownSessions?: ReadonlyArray<string>
+  /** Lie about the cwd in system/init. */
+  readonly wrongCwd?: boolean
+  /** Report this session_id in init regardless of the resume id. */
+  readonly reportSessionId?: string
+  /**
+   * Suppress session_state_changed events (the un-opted-in SDK shape), so
+   * tests can prove activity flows from the in-process hook callbacks too.
+   */
+  readonly stateEvents?: boolean
+}
+
+export interface FakeClaudeQuery {
+  readonly queryFn: ClaudeQueryFn
+  /** Deny results canUseTool handed back, for assertions. */
+  readonly denials: Array<{ toolName: string; behavior: string }>
+  /** Interrupt calls observed. */
+  readonly interrupts: Array<string>
+}
+
+export const makeFakeClaudeQuery = (options: FakeClaudeQueryOptions = {}): FakeClaudeQuery => {
+  const denials: FakeClaudeQuery["denials"] = []
+  const interrupts: Array<string> = []
+
+  const queryFn: ClaudeQueryFn = (args) => {
+    const output: Array<SDKMessage> = []
+    let wake: (() => void) | null = null
+    let done = false
+    let throwNext: string | null = null
+    let hanging: string | null = null
+    const resumeId = (args.options as { resume?: string }).resume
+    const sessionId =
+      options.reportSessionId ?? resumeId ?? options.sessionId ?? "fake-claude-session"
+    const cwd = (options.wrongCwd ? "/somewhere/else" : args.options.cwd) ?? "/"
+
+    const push = (message: Record<string, unknown>): void => {
+      output.push(message as unknown as SDKMessage)
+      wake?.()
+    }
+    const finish = (): void => {
+      done = true
+      wake?.()
+    }
+    const state = (value: string): void => {
+      if (options.stateEvents === false) return
+      push({
+        type: "system",
+        subtype: "session_state_changed",
+        session_id: sessionId,
+        state: value,
+      })
+    }
+    // Deliver the in-process hook vocabulary exactly like the SDK: the
+    // registered callback for the event, with the hook payload shape.
+    const fireHook = async (eventName: string): Promise<void> => {
+      const matchers = (
+        args.options.hooks as
+          Record<string, Array<{ hooks: Array<(input: unknown) => Promise<unknown>> }>> | undefined
+      )?.[eventName]
+      for (const matcher of matchers ?? []) {
+        for (const callback of matcher.hooks) {
+          await callback({ session_id: sessionId, hook_event_name: eventName })
+        }
+      }
+    }
+    const initOnce = (() => {
+      let sent = false
+      return () => {
+        if (sent) return
+        sent = true
+        push({ type: "system", subtype: "init", session_id: sessionId, cwd })
+      }
+    })()
+
+    const runTurn = async (text: string): Promise<void> => {
+      // Invalid resume: exactly one error result, no init, no new session.
+      if (resumeId !== undefined && !(options.knownSessions ?? []).includes(resumeId)) {
+        push({
+          type: "result",
+          subtype: "error_during_execution",
+          session_id: resumeId,
+          is_error: true,
+          errors: ["No conversation found with session ID"],
+        })
+        finish()
+        return
+      }
+      initOnce()
+      state("running")
+      await fireHook("UserPromptSubmit")
+      if (text.includes("HANG")) {
+        hanging = text
+        return
+      }
+      if (text.includes("PERMISSION") || text.includes("ASK")) {
+        const toolName = text.includes("ASK") ? "AskUserQuestion" : "Bash"
+        state("requires_action")
+        const result = await args.options.canUseTool?.(
+          toolName,
+          { command: "pwd" },
+          {
+            signal: new AbortController().signal,
+            requestId: "fake-request-1",
+            toolUseID: "fake-tool-use-1",
+          },
+        )
+        denials.push({ toolName, behavior: (result as { behavior: string }).behavior })
+        state("running")
+      }
+      if (text.includes("FAILTURN")) {
+        push({
+          type: "result",
+          subtype: "error_max_turns",
+          session_id: sessionId,
+          is_error: true,
+          errors: ["Reached maximum number of turns (1)"],
+        })
+        throwNext = "Claude Code returned an error result: Reached maximum number of turns (1)"
+        finish()
+        return
+      }
+      await fireHook("Stop")
+      push({
+        type: "result",
+        subtype: "success",
+        session_id: sessionId,
+        is_error: false,
+        result: `fake: ${text}`,
+      })
+      state("idle")
+    }
+
+    // Drain the prompt stream like the real SDK does.
+    void (async () => {
+      for await (const message of args.prompt) {
+        const content = (message as SDKUserMessage).message.content
+        await runTurn(typeof content === "string" ? content : JSON.stringify(content))
+        if (done) return
+      }
+    })()
+
+    args.options.abortController?.signal.addEventListener("abort", () => finish())
+
+    const iterator: AsyncIterable<SDKMessage> & { interrupt: () => Promise<unknown> } = {
+      interrupt: () => {
+        interrupts.push(hanging ?? "(no hanging turn)")
+        if (hanging !== null) {
+          hanging = null
+          push({
+            type: "result",
+            subtype: "error_during_execution",
+            session_id: sessionId,
+            is_error: true,
+            errors: ["aborted_streaming"],
+          })
+          finish()
+        }
+        return Promise.resolve({ still_queued: [] })
+      },
+      [Symbol.asyncIterator]() {
+        return {
+          async next(): Promise<IteratorResult<SDKMessage>> {
+            while (true) {
+              const message = output.shift()
+              if (message !== undefined) return { done: false, value: message }
+              if (throwNext !== null && output.length === 0) {
+                const reason = throwNext
+                throwNext = null
+                throw new Error(reason)
+              }
+              if (done) return { done: true, value: undefined }
+              await new Promise<void>((resolve) => {
+                wake = () => {
+                  wake = null
+                  resolve()
+                }
+              })
+            }
+          },
+        }
+      },
+    }
+    return iterator
+  }
+
+  return { queryFn, denials, interrupts }
+}

--- a/app-server/test/fixtures/claude-hook-payloads.json
+++ b/app-server/test/fixtures/claude-hook-payloads.json
@@ -1,0 +1,68 @@
+[
+  {
+    "session_id": "8825b7a5-b6a4-4dc1-9daf-e45904303e62",
+    "transcript_path": "/home/user/.claude/projects/-private-tmp-atc-hook-recording/8825b7a5.jsonl",
+    "cwd": "/private/tmp/atc-hook-recording",
+    "prompt_id": "1dc0b99c-d4a1-4095-8fda-c88c13f5f287",
+    "permission_mode": "auto",
+    "hook_event_name": "UserPromptSubmit",
+    "prompt": "Run the bash command `pwd` and then reply with exactly: HOOKS-OK"
+  },
+  {
+    "session_id": "8825b7a5-b6a4-4dc1-9daf-e45904303e62",
+    "transcript_path": "/home/user/.claude/projects/-private-tmp-atc-hook-recording/8825b7a5.jsonl",
+    "cwd": "/private/tmp/atc-hook-recording",
+    "prompt_id": "1dc0b99c-d4a1-4095-8fda-c88c13f5f287",
+    "permission_mode": "auto",
+    "effort": {
+      "level": "high"
+    },
+    "hook_event_name": "PreToolUse",
+    "tool_name": "Bash",
+    "tool_input": {
+      "command": "pwd",
+      "description": "Print working directory"
+    },
+    "tool_use_id": "toolu_01BSw7uAkxscZf2oiLbTvQyC"
+  },
+  {
+    "session_id": "8825b7a5-b6a4-4dc1-9daf-e45904303e62",
+    "transcript_path": "/home/user/.claude/projects/-private-tmp-atc-hook-recording/8825b7a5.jsonl",
+    "cwd": "/private/tmp/atc-hook-recording",
+    "prompt_id": "1dc0b99c-d4a1-4095-8fda-c88c13f5f287",
+    "permission_mode": "auto",
+    "effort": {
+      "level": "high"
+    },
+    "hook_event_name": "PostToolUse",
+    "tool_name": "Bash",
+    "tool_input": {
+      "command": "pwd",
+      "description": "Print working directory"
+    },
+    "tool_response": {
+      "stdout": "/private/var/folders/n3/phvtrhq513dfv9sngyztqztr0000gn/T/atc-hook-rec-Kw0gfG",
+      "stderr": "",
+      "interrupted": false,
+      "isImage": false,
+      "noOutputExpected": false
+    },
+    "tool_use_id": "toolu_01BSw7uAkxscZf2oiLbTvQyC",
+    "duration_ms": 132
+  },
+  {
+    "session_id": "8825b7a5-b6a4-4dc1-9daf-e45904303e62",
+    "transcript_path": "/home/user/.claude/projects/-private-tmp-atc-hook-recording/8825b7a5.jsonl",
+    "cwd": "/private/tmp/atc-hook-recording",
+    "prompt_id": "1dc0b99c-d4a1-4095-8fda-c88c13f5f287",
+    "permission_mode": "auto",
+    "effort": {
+      "level": "high"
+    },
+    "hook_event_name": "Stop",
+    "stop_hook_active": false,
+    "last_assistant_message": "HOOKS-OK",
+    "background_tasks": [],
+    "session_crons": []
+  }
+]

--- a/app-server/test/openapi.test.ts
+++ b/app-server/test/openapi.test.ts
@@ -11,6 +11,7 @@ import {
 } from "effect/unstable/http"
 import { HttpApi, OpenApi } from "effect/unstable/httpapi"
 import { Api, DEFAULT_PORT } from "../src/api.ts"
+import * as ClaudeHooks from "../src/claudeHooks.ts"
 import { openApiDocument, openApiJson } from "../src/openapi.ts"
 import * as Server from "../src/server.ts"
 import { appServerRoot } from "./blackbox.ts"
@@ -123,6 +124,8 @@ const rawClient = Effect.gen(function* () {
       )
       const response = yield* handler.pipe(
         Effect.provideService(HttpServerRequest.HttpServerRequest, serverRequest),
+        // The internal Claude hook route resolves its service per request.
+        Effect.provide(ClaudeHooks.layer),
         Effect.orDie,
       )
       return HttpServerResponse.toClientResponse(response)

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -5,6 +5,7 @@ import * as fs from "node:fs"
 import * as os from "node:os"
 import * as path from "node:path"
 import { fileURLToPath } from "node:url"
+import * as ClaudeHooks from "../src/claudeHooks.ts"
 import { AppConfig } from "../src/config.ts"
 import * as Directories from "../src/directories.ts"
 import * as Persistence from "../src/persistence.ts"
@@ -29,7 +30,8 @@ type ServiceLayer = Layer.Layer<
   | ProjectRepository.ProjectRepository
   | TerminalRepository.TerminalRepository
   | Directories.Directories
-  | TerminalAdapter,
+  | TerminalAdapter
+  | ClaudeHooks.ClaudeHooks,
   unknown
 >
 
@@ -51,7 +53,7 @@ export const makeTestServiceLayers = (
   const base = Layer.mergeAll(ProjectRepository.layer, TerminalRepository.layer).pipe(
     Layer.provide(Persistence.layerFile(dbFile)),
   )
-  const services = Layer.mergeAll(base, Directories.layer, fake.layer)
+  const services = Layer.mergeAll(base, Directories.layer, fake.layer, ClaudeHooks.layer)
   return {
     fake,
     services,


### PR DESCRIPTION
Third of three stacked PRs for [ATC-123](https://linear.app/elevenideas/issue/ATC-123/codex-and-claude-code-integrations) ([ATC-134](https://linear.app/elevenideas/issue/ATC-134)). **Stacked on #132** (which stacks on #131) — merge in order.

## What's here

- **`claudeAdapter.ts`** — the Claude `AgentAdapter` over the in-process Agent SDK: one held streaming `query()` per session (the only interruptible mode), no child supervision.
  - **Deferred resume verification** (probed live, 2026-08-03): the SDK emits no identity evidence until the first user message, so resume verification completes — still fail-closed — at the connection's first `startTurn`: unknown id → `AgentResumeFailed` (classified structurally: an error result before any identity evidence, no provider-prose matching), disagreeing session_id/cwd → `AgentIdentityMismatch`. Create sends its input immediately and verifies before returning.
  - **Error-path idle derives from the `result` message itself** — `Stop`/`StopFailure` do not fire on error results, and the SDK iterator's throw after one is a turn-failed outcome, not a transport defect (probe findings). Any non-success turn ends the connection (outcome emitted first, feed failed loudly on pre-verification deaths); success keeps the held query open.
  - One writer per session id; permission callbacks surface as request events and are denied (real responses are ATC-124); interrupt is exact-turn with the truthful `interrupted` outcome and un-latches on a failed interrupt call.
- **`claudeHooks.ts`** — one normalization of the Claude hook vocabulary into activity signals, fed by in-process SDK callbacks while ATC drives and by the new **internal webhook** (`POST /internal/claude/hooks`, outside the public contract/openapi.json) while a TUI drives. The per-session secret travels in the `x-atc-hook-secret` header (never argv, never the URL — request paths land in tracer span names), lives in a 0600 settings file that `tuiLaunch` writes, and a re-mint invalidates the session's prior secret. Webhook activity is deliberately **not** bridged into adapter feeds — a TUI-driven session has no adapter connection, and a delivery for a live one could only be stale or spoofed; ATC-124's TUI session state subscribes to `claudeHooks` directly.
- Shared `samePath` / `makeVersionGate` extracted to the seam module (both adapters now use them); tested floor Claude Code 2.1.221.

## Tests

- Scripted `query()` seam (`fakeClaudeQuery.ts`) reproducing the probed SDK behaviors — init timing, invalid-resume shape, iterator throw, in-process hook callbacks — driving 11 adapter cases including a hooks-only activity feed (no state events).
- Hook payloads **recorded from a real Claude Code 2.1.221 run** exercise the receiver (secret gating, spoofed-session rejection, normalization), plus a black-box 404 over real HTTP proving the route is mounted.
- Opt-in live smoke (`mise run test:smoke`): create → exact resume with recall → interrupt → fail-closed unknown resume against the real SDK — verified passing.

## Review process

Two adversarial sub-agent reviews (correctness on Opus, simplicity on Sonnet). Applied: removed the inverted webhook→feed bridge (reproduced: a stale secret could flip a live ATC-driven session's activity mid-turn), writer-slot finalizer registered before `query()` can fail (reproduced permanent lockout), secret-per-session replacement + header/file transport, gate/session state agreement on init timeout, structural `AgentResumeFailed` classification, no same-tick activity round-trip in permission callbacks, and the shared-helper extraction.

https://claude.ai/code/session_018Rd6RAK5eJMvN3EYfJyr17
