### PR TITLE
ATC-139: Threads foundation — migration, repository, service, contract group, CLI

### DIFF
--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -261,17 +261,24 @@
             }
           },
           "409": {
-            "description": "The project still owns terminals (live or ended); delete them first.",
+            "description": "The project still owns terminals (live or ended); delete them first. | The project still owns threads (active or archived); delete them first.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProjectHasTerminalsJsonEncoding"
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ProjectHasTerminalsJsonEncoding"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ProjectHasThreadsJsonEncoding"
+                    }
+                  ]
                 }
               }
             }
           }
         },
-        "description": "Delete the project record. Restricted while the project still owns terminals; never touches the filesystem or any directory."
+        "description": "Delete the project record. Restricted while the project still owns terminals or threads; never touches the filesystem or any directory."
       }
     },
     "/api/v1/terminals": {
@@ -511,6 +518,339 @@
           }
         },
         "description": "Delete a terminal: kill its zmx session if present, verify absence, then remove the record (tombstones included)."
+      }
+    },
+    "/api/v1/threads": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "listThreads",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "description": "Restrict the listing to one project."
+            },
+            "required": false
+          },
+          {
+            "name": "archived",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ],
+              "description": "\"true\" lists archived threads only; the default lists active threads."
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Threads, newest first.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadList"
+                }
+              }
+            }
+          }
+        },
+        "description": "List threads, newest first. Archived threads are excluded unless requested."
+      },
+      "post": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "createThread",
+        "parameters": [],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "A durable Thread: the primary unit of agent work. Its ATC identity is separate from provider identity, and it never requires a Terminal.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Thread"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No project exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectNotFoundJsonEncoding"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The directory does not exist, is not a directory, or cannot be read/traversed. | The directory check did not complete within its bounded timeout. Retryable — a timeout is not proof the path is missing.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/DirectoryUnavailableJsonEncoding"
+                    },
+                    {
+                      "$ref": "#/components/schemas/DirectoryCheckTimedOutJsonEncoding"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Create a thread: a durable local record only. The provider session materializes on the thread's first interaction, from whichever surface initiates it.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateThreadRequest"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v1/threads/{threadId}": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "getThread",
+        "parameters": [
+          {
+            "name": "threadId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "A durable Thread: the primary unit of agent work. Its ATC identity is separate from provider identity, and it never requires a Terminal.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Thread"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No thread exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadNotFoundJsonEncoding"
+                }
+              }
+            }
+          }
+        },
+        "description": "Fetch one thread by id."
+      },
+      "patch": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "updateThread",
+        "parameters": [
+          {
+            "name": "threadId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "A durable Thread: the primary unit of agent work. Its ATC identity is separate from provider identity, and it never requires a Terminal.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Thread"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No thread exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadNotFoundJsonEncoding"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update a thread's display label (the only mutable field).",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateThreadRequest"
+              }
+            }
+          },
+          "required": true
+        }
+      },
+      "delete": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "deleteThread",
+        "parameters": [
+          {
+            "name": "threadId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "204": {
+            "description": "<No Content>"
+          },
+          "404": {
+            "description": "No thread exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadNotFoundJsonEncoding"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The zmx multiplexer cannot be consulted right now. Retryable; stored terminal state is untouched.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ZmxUnavailableJsonEncoding"
+                }
+              }
+            }
+          }
+        },
+        "description": "Delete the thread: kill its live linked terminal if one is open, then remove the record. Provider-owned conversation history is never touched."
+      }
+    },
+    "/api/v1/threads/{threadId}/archive": {
+      "post": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "archiveThread",
+        "parameters": [
+          {
+            "name": "threadId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "A durable Thread: the primary unit of agent work. Its ATC identity is separate from provider identity, and it never requires a Terminal.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Thread"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No thread exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadNotFoundJsonEncoding"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The thread's agent session is actively working; retry once the turn completes.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadBusyJsonEncoding"
+                }
+              }
+            }
+          }
+        },
+        "description": "Archive the thread (idempotent). Refused while the agent session is actively working."
+      }
+    },
+    "/api/v1/threads/{threadId}/unarchive": {
+      "post": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "unarchiveThread",
+        "parameters": [
+          {
+            "name": "threadId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "A durable Thread: the primary unit of agent work. Its ATC identity is separate from provider identity, and it never requires a Terminal.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Thread"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No thread exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadNotFoundJsonEncoding"
+                }
+              }
+            }
+          }
+        },
+        "description": "Restore an archived thread (idempotent)."
       }
     },
     "/api/v1/fs/check": {
@@ -766,6 +1106,29 @@
         ],
         "additionalProperties": false
       },
+      "ProjectHasThreadsJsonEncoding": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": [
+              "ProjectHasThreads"
+            ]
+          },
+          "projectId": {
+            "type": "string"
+          },
+          "threadCount": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "_tag",
+          "projectId",
+          "threadCount"
+        ],
+        "additionalProperties": false
+      },
       "TerminalStatus": {
         "type": "string",
         "enum": [
@@ -784,6 +1147,10 @@
           "projectId": {
             "type": "string",
             "description": "Owning project id."
+          },
+          "threadId": {
+            "type": "string",
+            "description": "Owning thread id when this terminal is a Thread's TUI terminal; absent otherwise."
           },
           "name": {
             "type": "string",
@@ -933,6 +1300,161 @@
         },
         "additionalProperties": false,
         "description": "Partial update; only the display label is mutable."
+      },
+      "AgentId": {
+        "type": "string",
+        "enum": [
+          "codex",
+          "claude-code"
+        ],
+        "description": "Built-in agent registry slug."
+      },
+      "ThreadActivityState": {
+        "type": "string",
+        "enum": [
+          "idle",
+          "working",
+          "needs_input",
+          "unknown"
+        ],
+        "description": "Normalized activity of the thread's agent session, derived from live provider evidence only; `unknown` means no evidence — never a guess."
+      },
+      "Thread": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "UUIDv7 thread id."
+          },
+          "projectId": {
+            "type": "string",
+            "description": "Owning project id."
+          },
+          "agentId": {
+            "$ref": "#/components/schemas/AgentId"
+          },
+          "name": {
+            "type": "string",
+            "description": "Mutable display label."
+          },
+          "workingDirectory": {
+            "type": "string",
+            "description": "Canonical directory the thread's agent session works in (immutable)."
+          },
+          "activityState": {
+            "$ref": "#/components/schemas/ThreadActivityState"
+          },
+          "linkedTerminalId": {
+            "type": "string",
+            "description": "The thread's live TUI terminal, when one is open (derived; never required)."
+          },
+          "archivedAt": {
+            "type": "string",
+            "description": "When the thread was archived (ISO 8601 UTC); absent while active."
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation time (ISO 8601 UTC)."
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Last update time (ISO 8601 UTC)."
+          }
+        },
+        "required": [
+          "id",
+          "projectId",
+          "agentId",
+          "workingDirectory",
+          "activityState",
+          "createdAt",
+          "updatedAt"
+        ],
+        "additionalProperties": false,
+        "description": "A durable Thread: the primary unit of agent work. Its ATC identity is separate from provider identity, and it never requires a Terminal."
+      },
+      "ThreadList": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Thread"
+        },
+        "description": "Threads, newest first."
+      },
+      "CreateThreadRequest": {
+        "type": "object",
+        "properties": {
+          "projectId": {
+            "type": "string",
+            "description": "Owning project id."
+          },
+          "agentId": {
+            "$ref": "#/components/schemas/AgentId"
+          },
+          "name": {
+            "type": "string",
+            "description": "Display label."
+          },
+          "workingDirectory": {
+            "type": "string",
+            "pattern": "^\\/",
+            "description": "Directory the agent session will work in; defaults to the project's default working directory. Stored canonicalized; immutable afterwards."
+          }
+        },
+        "required": [
+          "projectId",
+          "agentId"
+        ],
+        "additionalProperties": false,
+        "description": "Payload for creating a thread. Creation is local-only: the durable record is written and no provider session is created until the first interaction."
+      },
+      "ThreadNotFoundJsonEncoding": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": [
+              "ThreadNotFound"
+            ]
+          },
+          "threadId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "_tag",
+          "threadId"
+        ],
+        "additionalProperties": false
+      },
+      "UpdateThreadRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "New display label."
+          }
+        },
+        "additionalProperties": false,
+        "description": "Partial update; only the display label is mutable."
+      },
+      "ThreadBusyJsonEncoding": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": [
+              "ThreadBusy"
+            ]
+          },
+          "threadId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "_tag",
+          "threadId"
+        ],
+        "additionalProperties": false
       },
       "DirectoryState": {
         "type": "string",

--- a/app-server/src/agents/agentAdapter.ts
+++ b/app-server/src/agents/agentAdapter.ts
@@ -1,6 +1,7 @@
 import { Effect, Schema, Stream } from "effect"
 import type { Scope } from "effect"
 import { existsSync, realpathSync } from "node:fs"
+import type { AgentId } from "../api/contract.ts"
 import type { Subprocess } from "../platform/subprocess.ts"
 import { resolveExecutable } from "../platform/subprocess.ts"
 
@@ -28,6 +29,16 @@ import { resolveExecutable } from "../platform/subprocess.ts"
 export const AGENT_PROVIDERS = ["codex", "claude"] as const
 
 export type AgentProvider = (typeof AGENT_PROVIDERS)[number]
+
+/**
+ * Public registry slug (contract `AgentId`) → seam provider. The Record
+ * type makes an unmapped slug a compile error, so the public vocabulary
+ * and the seam's can never drift apart silently.
+ */
+export const PROVIDER_FOR_AGENT: Record<typeof AgentId.Type, AgentProvider> = {
+  codex: "codex",
+  "claude-code": "claude",
+}
 
 /**
  * Normalized activity for one provider session. `unknown` means no evidence

--- a/app-server/src/api/contract.ts
+++ b/app-server/src/api/contract.ts
@@ -125,6 +125,12 @@ export const Terminal = Schema.Struct({
   id: Schema.String.annotate({ description: "UUIDv7 terminal id." }),
   projectId: Schema.String.annotate({ description: "Owning project id." }),
   // Absent keys (not null) for optional fields — see UpdateProjectRequest.
+  threadId: Schema.optionalKey(
+    Schema.String.annotate({
+      description:
+        "Owning thread id when this terminal is a Thread's TUI terminal; absent otherwise.",
+    }),
+  ),
   name: Schema.optionalKey(Schema.String.annotate({ description: "Mutable display label." })),
   command: Schema.optionalKey(
     TerminalCommand.annotate({
@@ -176,6 +182,81 @@ export const UpdateTerminalRequest = Schema.Struct({
   name: Schema.optionalKey(Schema.String.annotate({ description: "New display label." })),
 }).annotate({
   identifier: "UpdateTerminalRequest",
+  description: "Partial update; only the display label is mutable.",
+})
+
+/** The built-in agent registry slugs (adding an agent extends this tuple). */
+export const AGENT_IDS = ["codex", "claude-code"] as const
+
+export const AgentId = Schema.Literals(AGENT_IDS).annotate({
+  identifier: "AgentId",
+  description: "Built-in agent registry slug.",
+})
+
+export const ThreadActivityState = Schema.Literals([
+  "idle",
+  "working",
+  "needs_input",
+  "unknown",
+]).annotate({
+  identifier: "ThreadActivityState",
+  description:
+    "Normalized activity of the thread's agent session, derived from live provider evidence only; `unknown` means no evidence — never a guess.",
+})
+
+export const Thread = Schema.Struct({
+  id: Schema.String.annotate({ description: "UUIDv7 thread id." }),
+  projectId: Schema.String.annotate({ description: "Owning project id." }),
+  agentId: AgentId,
+  // Absent keys (not null) for optional fields — see UpdateProjectRequest.
+  name: Schema.optionalKey(Schema.String.annotate({ description: "Mutable display label." })),
+  workingDirectory: Schema.String.annotate({
+    description: "Canonical directory the thread's agent session works in (immutable).",
+  }),
+  activityState: ThreadActivityState,
+  linkedTerminalId: Schema.optionalKey(
+    Schema.String.annotate({
+      description: "The thread's live TUI terminal, when one is open (derived; never required).",
+    }),
+  ),
+  archivedAt: Schema.optionalKey(
+    Schema.String.annotate({
+      description: "When the thread was archived (ISO 8601 UTC); absent while active.",
+    }),
+  ),
+  createdAt: Schema.String.annotate({ description: "Creation time (ISO 8601 UTC)." }),
+  updatedAt: Schema.String.annotate({ description: "Last update time (ISO 8601 UTC)." }),
+}).annotate({
+  identifier: "Thread",
+  description:
+    "A durable Thread: the primary unit of agent work. Its ATC identity is separate from provider identity, and it never requires a Terminal.",
+})
+
+export const ThreadList = Schema.Array(Thread).annotate({
+  identifier: "ThreadList",
+  description: "Threads, newest first.",
+})
+
+export const CreateThreadRequest = Schema.Struct({
+  projectId: Schema.String.annotate({ description: "Owning project id." }),
+  agentId: AgentId,
+  name: Schema.optionalKey(Schema.String.annotate({ description: "Display label." })),
+  workingDirectory: Schema.optionalKey(
+    AbsolutePath.annotate({
+      description:
+        "Directory the agent session will work in; defaults to the project's default working directory. Stored canonicalized; immutable afterwards.",
+    }),
+  ),
+}).annotate({
+  identifier: "CreateThreadRequest",
+  description:
+    "Payload for creating a thread. Creation is local-only: the durable record is written and no provider session is created until the first interaction.",
+})
+
+export const UpdateThreadRequest = Schema.Struct({
+  name: Schema.optionalKey(Schema.String.annotate({ description: "New display label." })),
+}).annotate({
+  identifier: "UpdateThreadRequest",
   description: "Partial update; only the display label is mutable.",
 })
 
@@ -305,8 +386,54 @@ export class ProjectHasTerminals extends Schema.TaggedErrorClass<ProjectHasTermi
   }
 }
 
+/** Project deletion is restricted while it still owns threads. */
+export class ProjectHasThreads extends Schema.TaggedErrorClass<ProjectHasThreads>()(
+  "ProjectHasThreads",
+  { projectId: Schema.String, threadCount: Schema.Int },
+  {
+    identifier: "ProjectHasThreads",
+    description: "The project still owns threads (active or archived); delete them first.",
+    httpApiStatus: 409,
+  },
+) {
+  override get message(): string {
+    return `project ${this.projectId} still owns ${this.threadCount} thread(s); delete them first`
+  }
+}
+
+/** Unknown thread id. */
+export class ThreadNotFound extends Schema.TaggedErrorClass<ThreadNotFound>()(
+  "ThreadNotFound",
+  { threadId: Schema.String },
+  {
+    identifier: "ThreadNotFound",
+    description: "No thread exists with the given id.",
+    httpApiStatus: 404,
+  },
+) {
+  override get message(): string {
+    return `no thread with id ${this.threadId}`
+  }
+}
+
+/** The thread's agent session is actively working; retry once the turn ends. */
+export class ThreadBusy extends Schema.TaggedErrorClass<ThreadBusy>()(
+  "ThreadBusy",
+  { threadId: Schema.String },
+  {
+    identifier: "ThreadBusy",
+    description: "The thread's agent session is actively working; retry once the turn completes.",
+    httpApiStatus: 409,
+  },
+) {
+  override get message(): string {
+    return `thread ${this.threadId} is working; retry once the turn completes`
+  }
+}
+
 const projectIdParam = { projectId: Schema.String }
 const terminalIdParam = { terminalId: Schema.String }
+const threadIdParam = { threadId: Schema.String }
 
 export class V1 extends HttpApiGroup.make("v1")
   .add(
@@ -352,12 +479,12 @@ export class V1 extends HttpApiGroup.make("v1")
       ),
     HttpApiEndpoint.delete("deleteProject", "/projects/:projectId", {
       params: projectIdParam,
-      error: [ProjectNotFound, ProjectHasTerminals],
+      error: [ProjectNotFound, ProjectHasTerminals, ProjectHasThreads],
     })
       .annotate(OpenApi.Identifier, "deleteProject")
       .annotate(
         OpenApi.Description,
-        "Delete the project record. Restricted while the project still owns terminals; never touches the filesystem or any directory.",
+        "Delete the project record. Restricted while the project still owns terminals or threads; never touches the filesystem or any directory.",
       ),
     HttpApiEndpoint.get("listTerminals", "/terminals", {
       query: {
@@ -439,6 +566,75 @@ export class V1 extends HttpApiGroup.make("v1")
       .annotate(
         OpenApi.Description,
         "WebSocket attach: upgrade to a live bidirectional bridge onto the terminal's zmx session.",
+      ),
+    HttpApiEndpoint.get("listThreads", "/threads", {
+      query: {
+        projectId: Schema.optionalKey(
+          Schema.String.annotate({ description: "Restrict the listing to one project." }),
+        ),
+        archived: Schema.optionalKey(
+          Schema.Literals(["true", "false"]).annotate({
+            description: '"true" lists archived threads only; the default lists active threads.',
+          }),
+        ),
+      },
+      success: ThreadList,
+    })
+      .annotate(OpenApi.Identifier, "listThreads")
+      .annotate(
+        OpenApi.Description,
+        "List threads, newest first. Archived threads are excluded unless requested.",
+      ),
+    HttpApiEndpoint.post("createThread", "/threads", {
+      payload: CreateThreadRequest,
+      success: Thread,
+      error: [ProjectNotFound, DirectoryUnavailable, DirectoryCheckTimedOut],
+    })
+      .annotate(OpenApi.Identifier, "createThread")
+      .annotate(
+        OpenApi.Description,
+        "Create a thread: a durable local record only. The provider session materializes on the thread's first interaction, from whichever surface initiates it.",
+      ),
+    HttpApiEndpoint.get("getThread", "/threads/:threadId", {
+      params: threadIdParam,
+      success: Thread,
+      error: ThreadNotFound,
+    })
+      .annotate(OpenApi.Identifier, "getThread")
+      .annotate(OpenApi.Description, "Fetch one thread by id."),
+    HttpApiEndpoint.patch("updateThread", "/threads/:threadId", {
+      params: threadIdParam,
+      payload: UpdateThreadRequest,
+      success: Thread,
+      error: ThreadNotFound,
+    })
+      .annotate(OpenApi.Identifier, "updateThread")
+      .annotate(OpenApi.Description, "Update a thread's display label (the only mutable field)."),
+    HttpApiEndpoint.post("archiveThread", "/threads/:threadId/archive", {
+      params: threadIdParam,
+      success: Thread,
+      error: [ThreadNotFound, ThreadBusy],
+    })
+      .annotate(OpenApi.Identifier, "archiveThread")
+      .annotate(
+        OpenApi.Description,
+        "Archive the thread (idempotent). Refused while the agent session is actively working.",
+      ),
+    HttpApiEndpoint.post("unarchiveThread", "/threads/:threadId/unarchive", {
+      params: threadIdParam,
+      success: Thread,
+      error: ThreadNotFound,
+    })
+      .annotate(OpenApi.Identifier, "unarchiveThread")
+      .annotate(OpenApi.Description, "Restore an archived thread (idempotent)."),
+    HttpApiEndpoint.delete("deleteThread", "/threads/:threadId", {
+      params: threadIdParam,
+      error: [ThreadNotFound, ZmxUnavailable],
+    })
+      .annotate(OpenApi.Identifier, "deleteThread")
+      .annotate(
+        OpenApi.Description,
+        "Delete the thread: kill its live linked terminal if one is open, then remove the record. Provider-owned conversation history is never touched.",
       ),
     HttpApiEndpoint.get("checkDirectory", "/fs/check", {
       query: { path: AbsolutePath },

--- a/app-server/src/api/handlers.ts
+++ b/app-server/src/api/handlers.ts
@@ -6,6 +6,7 @@ import { Directories } from "../platform/directories.ts"
 import { Projects } from "../projects/projects.ts"
 import { attachTerminal } from "../terminals/terminalAttach.ts"
 import { Terminals } from "../terminals/terminals.ts"
+import { Threads } from "../threads/threads.ts"
 
 /**
  * Implements the /api/v1 contract. App construction only — no listener, and
@@ -19,6 +20,7 @@ export const V1Handlers = HttpApiBuilder.group(
     const projects = yield* Projects
     const directories = yield* Directories
     const terminals = yield* Terminals
+    const threads = yield* Threads
     // Attach bridges outlive their originating requests (Bun aborts the
     // request on protocol switch); they live in the handler layer's scope,
     // so server shutdown still reaps every bridge and its PTY client.
@@ -47,6 +49,15 @@ export const V1Handlers = HttpApiBuilder.group(
         terminals.update(params.terminalId, payload),
       )
       .handle("deleteTerminal", ({ params }) => terminals.delete(params.terminalId))
+      .handle("listThreads", ({ query }) =>
+        threads.list({ projectId: query.projectId, archived: query.archived === "true" }),
+      )
+      .handle("createThread", ({ payload }) => threads.create(payload))
+      .handle("getThread", ({ params }) => threads.get(params.threadId))
+      .handle("updateThread", ({ params, payload }) => threads.update(params.threadId, payload))
+      .handle("archiveThread", ({ params }) => threads.archive(params.threadId))
+      .handle("unarchiveThread", ({ params }) => threads.unarchive(params.threadId))
+      .handle("deleteThread", ({ params }) => threads.delete(params.threadId))
       .handleRaw("attachTerminal", attachTerminal({ terminals, bridgeScope }))
   }),
 )

--- a/app-server/src/cli/threads.ts
+++ b/app-server/src/cli/threads.ts
@@ -1,0 +1,108 @@
+import { Effect, Option } from "effect"
+import { Argument, Command, Flag } from "effect/unstable/cli"
+import * as path from "node:path"
+import { AGENT_IDS } from "../api/contract.ts"
+import * as Cli from "./cli.ts"
+
+// The `atc thread` command group: thin client commands over the contract.
+// Threads are the primary unit of work, so they get the full named set
+// (ATC-124); `thread open` (open-terminal + attach) arrives with the
+// openTerminal workflow.
+
+const threadIdArgument = Argument.string("thread-id")
+
+const projectFlag = Flag.string("project").pipe(Flag.withDescription("Project id"))
+
+const threadList = Cli.clientCommand(
+  "thread list",
+  "List threads (archived threads only with --archived)",
+  {
+    project: Flag.optional(projectFlag),
+    archived: Flag.boolean("archived").pipe(
+      Flag.withDescription("List archived threads instead of active ones"),
+    ),
+  },
+  (client, { project, archived }) =>
+    client.v1.listThreads({
+      query: {
+        ...(Option.isSome(project) ? { projectId: project.value } : {}),
+        ...(archived ? { archived: "true" as const } : {}),
+      },
+    }),
+)
+
+const threadGet = Cli.clientCommand(
+  "thread get",
+  "Fetch one thread by id",
+  { threadId: threadIdArgument },
+  (client, { threadId }) => client.v1.getThread({ params: { threadId } }),
+)
+
+const threadCreate = Cli.clientCommand(
+  "thread create",
+  "Create a thread (local record only; the agent session starts on first use)",
+  {
+    project: projectFlag,
+    agent: Flag.choice("agent", AGENT_IDS).pipe(
+      Flag.withDescription("Agent to converse with (codex or claude-code)"),
+    ),
+    name: Flag.optional(Cli.nameFlag("Display label")),
+    directory: Flag.optional(
+      Cli.directoryFlag("Working directory (may be relative; defaults to the project's default)"),
+    ),
+  },
+  (client, { project, agent, name, directory }) =>
+    client.v1.createThread({
+      payload: {
+        projectId: project,
+        agentId: agent,
+        ...(Option.isSome(name) ? { name: name.value } : {}),
+        ...(Option.isSome(directory) ? { workingDirectory: path.resolve(directory.value) } : {}),
+      },
+    }),
+)
+
+const threadUpdate = Cli.clientCommand(
+  "thread update",
+  "Update a thread's display label (the only mutable field)",
+  { threadId: threadIdArgument, name: Cli.nameFlag("New display label") },
+  (client, { threadId, name }) =>
+    client.v1.updateThread({ params: { threadId }, payload: { name } }),
+)
+
+const threadArchive = Cli.clientCommand(
+  "thread archive",
+  "Archive a thread (refused while its agent session is working)",
+  { threadId: threadIdArgument },
+  (client, { threadId }) => client.v1.archiveThread({ params: { threadId } }),
+)
+
+const threadUnarchive = Cli.clientCommand(
+  "thread unarchive",
+  "Restore an archived thread",
+  { threadId: threadIdArgument },
+  (client, { threadId }) => client.v1.unarchiveThread({ params: { threadId } }),
+)
+
+const threadDelete = Cli.clientCommand(
+  "thread delete",
+  "Delete a thread: kill its live linked terminal, remove the record (provider history is untouched)",
+  { threadId: threadIdArgument, yes: Cli.yesFlag },
+  (client, { threadId, yes }) =>
+    yes
+      ? client.v1.deleteThread({ params: { threadId } })
+      : Effect.fail(new Error("refusing to delete without --yes (kills the thread's terminal)")),
+)
+
+export const thread = Command.make("thread").pipe(
+  Command.withDescription("Manage durable agent threads (the primary unit of work)"),
+  Command.withSubcommands([
+    threadList,
+    threadGet,
+    threadCreate,
+    threadUpdate,
+    threadArchive,
+    threadUnarchive,
+    threadDelete,
+  ]),
+)

--- a/app-server/src/main.ts
+++ b/app-server/src/main.ts
@@ -7,6 +7,7 @@ import { api, capabilities, context } from "./cli/gateway.ts"
 import { project } from "./cli/projects.ts"
 import { serve } from "./cli/serve.ts"
 import { terminal } from "./cli/terminals.ts"
+import { thread } from "./cli/threads.ts"
 import { smoke } from "./agents/smoke.ts"
 import * as Subprocess from "./platform/subprocess.ts"
 
@@ -23,6 +24,7 @@ const atc = Command.make("atc").pipe(
     health,
     version,
     project,
+    thread,
     terminal,
     fs,
     smoke,

--- a/app-server/src/platform/migrations.ts
+++ b/app-server/src/platform/migrations.ts
@@ -45,4 +45,36 @@ export const migrations: Record<string, Effect.Effect<void, unknown, SqlClient.S
     `
     yield* sql`CREATE INDEX terminals_project_id ON terminals(project_id)`
   }),
+  // Threads (ATC-124): durable ATC identity separate from provider identity.
+  // `provider_session_id` stays NULL until the provider session materializes
+  // on first interaction; `confirmed_at` marks a completed first turn;
+  // `provider_metadata` is an opaque adapter-owned blob the domain never
+  // reads. `agent_id` is validated against the registry in code, not here —
+  // adding an agent must never need a migration. `terminals.thread_id` is
+  // the authoritative side of the Thread↔Terminal link; SET NULL keeps ended
+  // linked terminals as unlinked tombstones when their thread is deleted
+  // (the domain kills the live one first).
+  "0003_threads": Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+    yield* sql`
+      CREATE TABLE threads (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE RESTRICT,
+        agent_id TEXT NOT NULL,
+        name TEXT,
+        working_directory TEXT NOT NULL,
+        provider_session_id TEXT,
+        confirmed_at TEXT,
+        provider_metadata TEXT,
+        archived_at TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      ) STRICT
+    `
+    yield* sql`CREATE INDEX threads_project_id ON threads(project_id)`
+    yield* sql`
+      ALTER TABLE terminals
+      ADD COLUMN thread_id TEXT REFERENCES threads(id) ON DELETE SET NULL
+    `
+  }),
 }

--- a/app-server/src/projects/projects.ts
+++ b/app-server/src/projects/projects.ts
@@ -1,5 +1,5 @@
 import { Context, Effect, Layer, Option } from "effect"
-import { ProjectHasTerminals, ProjectNotFound } from "../api/contract.ts"
+import { ProjectHasTerminals, ProjectHasThreads, ProjectNotFound } from "../api/contract.ts"
 import type {
   CreateProjectRequest,
   DirectoryCheckTimedOut,
@@ -10,6 +10,7 @@ import { Directories } from "../platform/directories.ts"
 import { ProjectRepository } from "./projectRepository.ts"
 import type { Project } from "./projectRepository.ts"
 import { TerminalRepository } from "../terminals/terminalRepository.ts"
+import { ThreadRepository } from "../threads/threadRepository.ts"
 
 // The Projects domain service: the rules above the repository —
 // canonicalize-on-create/update (identity is the symlink-resolved canonical
@@ -31,8 +32,10 @@ export class Projects extends Context.Service<
       id: string,
       patch: typeof UpdateProjectRequest.Type,
     ) => Effect.Effect<Project, ProjectNotFound | DirectoryUnavailable | DirectoryCheckTimedOut>
-    /** Delete the record; restricted while the project owns terminals. */
-    readonly delete: (id: string) => Effect.Effect<void, ProjectNotFound | ProjectHasTerminals>
+    /** Delete the record; restricted while the project owns terminals or threads. */
+    readonly delete: (
+      id: string,
+    ) => Effect.Effect<void, ProjectNotFound | ProjectHasTerminals | ProjectHasThreads>
   }
 >()("app-server/Projects") {}
 
@@ -41,6 +44,7 @@ export const layer = Layer.effect(Projects)(
     const repository = yield* ProjectRepository
     const directories = yield* Directories
     const terminalRepository = yield* TerminalRepository
+    const threadRepository = yield* ThreadRepository
 
     return {
       list: () => repository.list(),
@@ -77,6 +81,10 @@ export const layer = Layer.effect(Projects)(
           const terminalCount = yield* terminalRepository.countForProject(id)
           if (terminalCount > 0) {
             return yield* Effect.fail(new ProjectHasTerminals({ projectId: id, terminalCount }))
+          }
+          const threadCount = yield* threadRepository.countForProject(id)
+          if (threadCount > 0) {
+            return yield* Effect.fail(new ProjectHasThreads({ projectId: id, threadCount }))
           }
           const deleted = yield* repository.delete(id)
           if (!deleted) {

--- a/app-server/src/server.ts
+++ b/app-server/src/server.ts
@@ -14,6 +14,8 @@ import * as ProjectRepository from "./projects/projectRepository.ts"
 import * as Projects from "./projects/projects.ts"
 import * as TerminalRepository from "./terminals/terminalRepository.ts"
 import * as Terminals from "./terminals/terminals.ts"
+import * as ThreadRepository from "./threads/threadRepository.ts"
+import * as Threads from "./threads/threads.ts"
 import * as Zmx from "./terminals/zmxAdapter.ts"
 
 // OpenAPI discovery (ATC-131): the contract-derived document at a stable
@@ -30,8 +32,8 @@ const openApiRoute = HttpRouter.add(
 /**
  * All HTTP routes with the local-trust guard applied, independent of any
  * listener. Requires the handler services (BuildInfo, Projects, Directories,
- * Terminals, ClaudeHooks). The Claude hook webhook is an internal route
- * (claudeHooks.ts), deliberately outside the contract.
+ * Terminals, Threads, ClaudeHooks). The Claude hook webhook is an internal
+ * route (claudeHooks.ts), deliberately outside the contract.
  */
 export const routes = Layer.mergeAll(
   HttpApiBuilder.layer(Api).pipe(Layer.provide(V1Handlers)),
@@ -68,10 +70,12 @@ export const layer = (options: { readonly port: number }) =>
  */
 export const production = (options: { readonly port: number }) =>
   layer(options).pipe(
-    Layer.provide([Projects.layer, Terminals.layer]),
+    Layer.provide([Projects.layer, Threads.layer]),
+    Layer.provide(Terminals.layer),
     Layer.provide([
       ProjectRepository.layer,
       TerminalRepository.layer,
+      ThreadRepository.layer,
       Directories.layer,
       Zmx.layer,
       ClaudeHooks.layer,

--- a/app-server/src/terminals/terminalRepository.ts
+++ b/app-server/src/terminals/terminalRepository.ts
@@ -12,6 +12,7 @@ export type TerminalStatus = "starting" | "live" | "ended"
 export interface TerminalRecord {
   readonly id: string
   readonly projectId: string
+  readonly threadId?: string
   readonly name?: string
   readonly command?: ReadonlyArray<string>
   readonly initialWorkingDirectory: string
@@ -25,6 +26,7 @@ export interface TerminalRecord {
 const TerminalRow = Schema.Struct({
   id: Schema.String,
   project_id: Schema.String,
+  thread_id: Schema.NullOr(Schema.String),
   name: Schema.NullOr(Schema.String),
   command: Schema.NullOr(Schema.String),
   initial_working_directory: Schema.String,
@@ -37,6 +39,7 @@ const TerminalRow = Schema.Struct({
 const toRecord = (row: typeof TerminalRow.Type): TerminalRecord => ({
   id: row.id,
   projectId: row.project_id,
+  ...(row.thread_id !== null ? { threadId: row.thread_id } : {}),
   ...(row.name !== null ? { name: row.name } : {}),
   ...(row.command !== null ? { command: JSON.parse(row.command) as Array<string> } : {}),
   initialWorkingDirectory: row.initial_working_directory,
@@ -52,6 +55,7 @@ export class TerminalRepository extends Context.Service<
     /** Insert a new `starting` record and return it (id is generated). */
     readonly create: (input: {
       readonly projectId: string
+      readonly threadId?: string | undefined
       readonly name?: string | undefined
       readonly command?: ReadonlyArray<string> | undefined
       readonly initialWorkingDirectory: string
@@ -171,6 +175,7 @@ export const layer = Layer.effect(TerminalRepository)(
           const row: typeof TerminalRow.Type = {
             id: Bun.randomUUIDv7(),
             project_id: input.projectId,
+            thread_id: input.threadId ?? null,
             name: input.name ?? null,
             command: input.command !== undefined ? JSON.stringify(input.command) : null,
             initial_working_directory: input.initialWorkingDirectory,

--- a/app-server/src/threads/threadRepository.ts
+++ b/app-server/src/threads/threadRepository.ts
@@ -1,0 +1,214 @@
+import { Context, Effect, Layer, Option, Schema } from "effect"
+import { SqlClient, SqlSchema } from "effect/unstable/sql"
+import { ThreadNotFound } from "../api/contract.ts"
+import type { AgentId } from "../api/contract.ts"
+
+// The Threads repository (ATC-124): the only module that speaks SQL for
+// threads. Row types stay here — the service and handlers see camelCase
+// records. Provider identity (providerSessionId, confirmedAt) and the
+// opaque adapter-owned providerMetadata live on the record but never reach
+// public contract schemas.
+//
+// agent_id is validated at the write boundary (the contract's AgentId) but
+// decoded permissively as a plain string: a row holding a slug this build
+// does not know (written by a newer build) must never brick reads — above
+// all delete, the recovery path.
+
+export interface ThreadRecord {
+  readonly id: string
+  readonly projectId: string
+  readonly agentId: string
+  readonly name?: string
+  readonly workingDirectory: string
+  readonly providerSessionId?: string
+  /** Set when the session's first turn completed (the confirmed marker). */
+  readonly confirmedAt?: string
+  /** Opaque adapter-owned blob; the domain never reads inside it. */
+  readonly providerMetadata?: string
+  readonly archivedAt?: string
+  readonly createdAt: string
+  readonly updatedAt: string
+}
+
+/** Internal row shape (snake_case columns, as stored). */
+const ThreadRow = Schema.Struct({
+  id: Schema.String,
+  project_id: Schema.String,
+  agent_id: Schema.String,
+  name: Schema.NullOr(Schema.String),
+  working_directory: Schema.String,
+  provider_session_id: Schema.NullOr(Schema.String),
+  confirmed_at: Schema.NullOr(Schema.String),
+  provider_metadata: Schema.NullOr(Schema.String),
+  archived_at: Schema.NullOr(Schema.String),
+  created_at: Schema.String,
+  updated_at: Schema.String,
+})
+
+const toRecord = (row: typeof ThreadRow.Type): ThreadRecord => ({
+  id: row.id,
+  projectId: row.project_id,
+  agentId: row.agent_id,
+  ...(row.name !== null ? { name: row.name } : {}),
+  workingDirectory: row.working_directory,
+  ...(row.provider_session_id !== null ? { providerSessionId: row.provider_session_id } : {}),
+  ...(row.confirmed_at !== null ? { confirmedAt: row.confirmed_at } : {}),
+  ...(row.provider_metadata !== null ? { providerMetadata: row.provider_metadata } : {}),
+  ...(row.archived_at !== null ? { archivedAt: row.archived_at } : {}),
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+})
+
+export class ThreadRepository extends Context.Service<
+  ThreadRepository,
+  {
+    /** Insert a new record and return it (id is generated). */
+    readonly create: (input: {
+      readonly projectId: string
+      readonly agentId: typeof AgentId.Type
+      readonly name?: string | undefined
+      readonly workingDirectory: string
+    }) => Effect.Effect<ThreadRecord>
+    /** All records (archived included), newest first; optionally one project's. */
+    readonly list: (projectId?: string) => Effect.Effect<ReadonlyArray<ThreadRecord>>
+    readonly get: (id: string) => Effect.Effect<Option.Option<ThreadRecord>>
+    readonly require: (id: string) => Effect.Effect<ThreadRecord, ThreadNotFound>
+    /** Update the display label; callers hold the record — a vanished row is a bug. */
+    readonly rename: (id: string, name: string) => Effect.Effect<ThreadRecord>
+    /** Set or clear the archive marker; callers hold the record (see rename). */
+    readonly setArchived: (id: string, archived: boolean) => Effect.Effect<ThreadRecord>
+    readonly delete: (id: string) => Effect.Effect<void>
+    /** Every record (archived included) — the project-deletion guard. */
+    readonly countForProject: (projectId: string) => Effect.Effect<number>
+  }
+>()("app-server/ThreadRepository") {}
+
+// Database failures are defects, not domain errors: the API surfaces them as
+// 500s and the one-line CLI contract reports them; nothing can handle them.
+export const layer = Layer.effect(ThreadRepository)(
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+
+    const insertRow = SqlSchema.void({
+      Request: ThreadRow,
+      execute: (row) => sql`INSERT INTO threads ${sql.insert(row)}`,
+    })
+
+    const listRows = SqlSchema.findAll({
+      Request: Schema.NullOr(Schema.String),
+      Result: ThreadRow,
+      execute: (projectId) =>
+        projectId === null
+          ? sql`SELECT * FROM threads ORDER BY id DESC`
+          : sql`SELECT * FROM threads WHERE project_id = ${projectId} ORDER BY id DESC`,
+    })
+
+    const getRows = SqlSchema.findAll({
+      Request: Schema.String,
+      Result: ThreadRow,
+      execute: (id) => sql`SELECT * FROM threads WHERE id = ${id}`,
+    })
+
+    const renameRows = SqlSchema.findAll({
+      Request: Schema.Struct({ id: Schema.String, name: Schema.String, updated_at: Schema.String }),
+      Result: ThreadRow,
+      execute: (patch) => sql`
+        UPDATE threads SET name = ${patch.name}, updated_at = ${patch.updated_at}
+        WHERE id = ${patch.id}
+        RETURNING *
+      `,
+    })
+
+    const setArchivedRows = SqlSchema.findAll({
+      Request: Schema.Struct({
+        id: Schema.String,
+        archived_at: Schema.NullOr(Schema.String),
+        updated_at: Schema.String,
+      }),
+      Result: ThreadRow,
+      execute: (patch) => sql`
+        UPDATE threads SET archived_at = ${patch.archived_at}, updated_at = ${patch.updated_at}
+        WHERE id = ${patch.id}
+        RETURNING *
+      `,
+    })
+
+    const deleteRows = SqlSchema.void({
+      Request: Schema.String,
+      execute: (id) => sql`DELETE FROM threads WHERE id = ${id}`,
+    })
+
+    const countRows = SqlSchema.findAll({
+      Request: Schema.String,
+      Result: Schema.Struct({ n: Schema.Int }),
+      execute: (projectId) =>
+        sql`SELECT COUNT(*) AS n FROM threads WHERE project_id = ${projectId}`,
+    })
+
+    const firstRecord = (rows: ReadonlyArray<typeof ThreadRow.Type>) =>
+      Option.fromNullishOr(rows[0]).pipe(Option.map(toRecord))
+
+    /** For updates whose caller holds the record: a vanished row is a bug. */
+    const requireFirst = (what: string) => (rows: ReadonlyArray<typeof ThreadRow.Type>) =>
+      rows[0] !== undefined
+        ? Effect.succeed(toRecord(rows[0]))
+        : Effect.die(new Error(`${what}: thread row vanished mid-update`))
+
+    const get = (id: string) => getRows(id).pipe(Effect.map(firstRecord), Effect.orDie)
+
+    // Timestamps (and the generated id) are captured inside Effect.suspend so
+    // an effect built early and run later stamps the run time, not the build
+    // time.
+    return {
+      create: (input) =>
+        Effect.suspend(() => {
+          const now = new Date().toISOString()
+          const row: typeof ThreadRow.Type = {
+            id: Bun.randomUUIDv7(),
+            project_id: input.projectId,
+            agent_id: input.agentId,
+            name: input.name ?? null,
+            working_directory: input.workingDirectory,
+            provider_session_id: null,
+            confirmed_at: null,
+            provider_metadata: null,
+            archived_at: null,
+            created_at: now,
+            updated_at: now,
+          }
+          return insertRow(row).pipe(Effect.as(toRecord(row)))
+        }).pipe(Effect.orDie),
+      list: (projectId) =>
+        listRows(projectId ?? null).pipe(
+          Effect.map((rows) => rows.map(toRecord)),
+          Effect.orDie,
+        ),
+      get,
+      require: (id) =>
+        get(id).pipe(
+          Effect.flatMap(
+            Option.match({
+              onNone: () => Effect.fail(new ThreadNotFound({ threadId: id })),
+              onSome: Effect.succeed,
+            }),
+          ),
+        ),
+      rename: (id, name) =>
+        Effect.suspend(() => renameRows({ id, name, updated_at: new Date().toISOString() })).pipe(
+          Effect.orDie,
+          Effect.flatMap(requireFirst("rename")),
+        ),
+      setArchived: (id, archived) =>
+        Effect.suspend(() => {
+          const now = new Date().toISOString()
+          return setArchivedRows({ id, archived_at: archived ? now : null, updated_at: now })
+        }).pipe(Effect.orDie, Effect.flatMap(requireFirst("setArchived"))),
+      delete: (id) => deleteRows(id).pipe(Effect.orDie),
+      countForProject: (projectId) =>
+        countRows(projectId).pipe(
+          Effect.map((rows) => rows[0]?.n ?? 0),
+          Effect.orDie,
+        ),
+    }
+  }),
+)

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -1,0 +1,189 @@
+import { Context, Effect, Layer } from "effect"
+import type { AgentActivity } from "../agents/agentAdapter.ts"
+import { Thread as ThreadSchema, ThreadBusy } from "../api/contract.ts"
+import type {
+  CreateThreadRequest,
+  DirectoryCheckTimedOut,
+  DirectoryUnavailable,
+  ProjectNotFound,
+  ThreadNotFound,
+  ZmxUnavailable,
+} from "../api/contract.ts"
+import { Directories } from "../platform/directories.ts"
+import { ProjectRepository } from "../projects/projectRepository.ts"
+import { Terminals } from "../terminals/terminals.ts"
+import { ThreadRepository } from "./threadRepository.ts"
+import type { ThreadRecord } from "./threadRepository.ts"
+
+export type Thread = typeof ThreadSchema.Type
+
+// The Threads domain service (ATC-124): Threads are the primary unit of
+// work — durable ATC identity separate from provider identity. Invariants:
+//
+//   - The boundary rule: this module contains zero provider branching and
+//     imports nothing provider-specific — only the AgentAdapter seam's
+//     vocabulary. Every provider difference is translated inside adapters.
+//   - `create` is local-only: the durable row, no provider call. The
+//     provider session materializes on the thread's first interaction
+//     (ATC-141 wires the first caller); until then providerSessionId is
+//     absent and stays out of every public schema.
+//   - workingDirectory is validated, canonicalized, and immutable.
+//   - activityState is in-memory evidence, never persisted: a thread with
+//     no provider session is idle by construction; with one, the live
+//     feed's last word, `unknown` when there is no evidence.
+//   - delete kills the live linked TUI terminal first (the terminals
+//     confirmed-kill rules), then removes the row; ended linked terminals
+//     stay as unlinked tombstones (FK SET NULL), and provider-owned
+//     conversation history is never touched. Known gap: a linked terminal
+//     still `starting` is invisible here (it belongs to its in-flight
+//     create), so ATC-141's openTerminal re-checks the thread still exists
+//     before marking its terminal live.
+
+export class Threads extends Context.Service<
+  Threads,
+  {
+    /** Listing, newest first; archived threads only on request. */
+    readonly list: (options?: {
+      readonly projectId?: string | undefined
+      readonly archived?: boolean | undefined
+    }) => Effect.Effect<ReadonlyArray<Thread>>
+    readonly get: (id: string) => Effect.Effect<Thread, ThreadNotFound>
+    /** Write the durable record; no provider call (see the header). */
+    readonly create: (
+      input: typeof CreateThreadRequest.Type,
+    ) => Effect.Effect<Thread, ProjectNotFound | DirectoryUnavailable | DirectoryCheckTimedOut>
+    /** Patch mutable fields; an empty patch changes nothing, updatedAt included. */
+    readonly update: (
+      id: string,
+      patch: { readonly name?: string | undefined },
+    ) => Effect.Effect<Thread, ThreadNotFound>
+    /** Idempotent; refused while the agent session is actively working. */
+    readonly archive: (id: string) => Effect.Effect<Thread, ThreadNotFound | ThreadBusy>
+    /** Idempotent. */
+    readonly unarchive: (id: string) => Effect.Effect<Thread, ThreadNotFound>
+    /** Kill the live linked terminal if present, then remove the record. */
+    readonly delete: (id: string) => Effect.Effect<void, ThreadNotFound | ZmxUnavailable>
+  }
+>()("app-server/Threads") {}
+
+export const layer = Layer.effect(Threads)(
+  Effect.gen(function* () {
+    const repository = yield* ThreadRepository
+    const projects = yield* ProjectRepository
+    const directories = yield* Directories
+    const terminals = yield* Terminals
+
+    // No provider session ⇒ nothing can be running; with one, this PR has
+    // no evidence source yet — ATC-141 wires the live feed in.
+    const activityFor = (record: ThreadRecord): AgentActivity =>
+      record.providerSessionId === undefined ? "idle" : "unknown"
+
+    const toThread = (record: ThreadRecord, linkedTerminalId: string | undefined): Thread => ({
+      id: record.id,
+      projectId: record.projectId,
+      // Permissive read (see the repository header); a foreign slug fails
+      // response encoding for that row, never the domain logic.
+      agentId: record.agentId as Thread["agentId"],
+      ...(record.name !== undefined ? { name: record.name } : {}),
+      workingDirectory: record.workingDirectory,
+      activityState: activityFor(record),
+      ...(linkedTerminalId !== undefined ? { linkedTerminalId } : {}),
+      ...(record.archivedAt !== undefined ? { archivedAt: record.archivedAt } : {}),
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+    })
+
+    /**
+     * The thread's live linked terminal, if any, from the reconciled
+     * terminals listing — a terminal that just died stops being "linked"
+     * the moment the inventory says so, not at its next explicit read.
+     */
+    const linkedFor = (record: ThreadRecord): Effect.Effect<string | undefined> =>
+      terminals
+        .list(record.projectId)
+        .pipe(
+          Effect.map(
+            (list) => list.find((t) => t.threadId === record.id && t.status === "live")?.id,
+          ),
+        )
+
+    const withLinked = (record: ThreadRecord): Effect.Effect<Thread> =>
+      linkedFor(record).pipe(Effect.map((linked) => toThread(record, linked)))
+
+    return {
+      list: (options) =>
+        Effect.gen(function* () {
+          const records = yield* repository.list(options?.projectId)
+          const wanted = records.filter((record) =>
+            options?.archived === true
+              ? record.archivedAt !== undefined
+              : record.archivedAt === undefined,
+          )
+          if (wanted.length === 0) return []
+          const linked = new Map<string, string>()
+          for (const terminal of yield* terminals.list(options?.projectId)) {
+            // Newest first, first write wins — the same pick linkedFor makes.
+            if (
+              terminal.threadId !== undefined &&
+              terminal.status === "live" &&
+              !linked.has(terminal.threadId)
+            ) {
+              linked.set(terminal.threadId, terminal.id)
+            }
+          }
+          return wanted.map((record) => toThread(record, linked.get(record.id)))
+        }),
+      get: (id) => repository.require(id).pipe(Effect.flatMap(withLinked)),
+      create: (input) =>
+        Effect.gen(function* () {
+          const project = yield* projects.require(input.projectId)
+          const canonical = yield* directories.canonicalize(
+            input.workingDirectory ?? project.defaultWorkingDirectory,
+          )
+          const record = yield* repository.create({
+            projectId: input.projectId,
+            agentId: input.agentId,
+            name: input.name,
+            workingDirectory: canonical,
+          })
+          return toThread(record, undefined)
+        }),
+      update: (id, patch) =>
+        // An empty patch changes nothing — including updatedAt (the same
+        // rule the other repositories apply).
+        patch.name === undefined
+          ? repository.require(id).pipe(Effect.flatMap(withLinked))
+          : repository
+              .require(id)
+              .pipe(Effect.andThen(repository.rename(id, patch.name)), Effect.flatMap(withLinked)),
+      archive: (id) =>
+        Effect.gen(function* () {
+          const record = yield* repository.require(id)
+          if (activityFor(record) === "working") {
+            return yield* Effect.fail(new ThreadBusy({ threadId: id }))
+          }
+          if (record.archivedAt !== undefined) return yield* withLinked(record)
+          return yield* repository.setArchived(id, true).pipe(Effect.flatMap(withLinked))
+        }),
+      unarchive: (id) =>
+        Effect.gen(function* () {
+          const record = yield* repository.require(id)
+          if (record.archivedAt === undefined) return yield* withLinked(record)
+          return yield* repository.setArchived(id, false).pipe(Effect.flatMap(withLinked))
+        }),
+      delete: (id) =>
+        Effect.gen(function* () {
+          const record = yield* repository.require(id)
+          const linked = yield* linkedFor(record)
+          if (linked !== undefined) {
+            // Confirmed-kill rules live in Terminals.delete; a terminal that
+            // vanished since the lookup is already the goal state.
+            yield* terminals
+              .delete(linked)
+              .pipe(Effect.catchTag("TerminalNotFound", () => Effect.void))
+          }
+          yield* repository.delete(id)
+        }),
+    }
+  }),
+)

--- a/app-server/test/api/openapi.test.ts
+++ b/app-server/test/api/openapi.test.ts
@@ -146,6 +146,10 @@ describe("openapi document vs runtime", () => {
       "/api/v1/projects/{projectId}",
       "/api/v1/terminals",
       "/api/v1/terminals/{terminalId}",
+      "/api/v1/threads",
+      "/api/v1/threads/{threadId}",
+      "/api/v1/threads/{threadId}/archive",
+      "/api/v1/threads/{threadId}/unarchive",
       "/api/v1/fs/check",
     ])
     // The WebSocket attach endpoint is contract-declared but excluded from
@@ -277,6 +281,96 @@ describe("openapi document vs runtime", () => {
         operation("/api/v1/terminals/{terminalId}").responses["404"]!.content["application/json"]!
           .schema,
         { $ref: "#/components/schemas/TerminalNotFoundJsonEncoding" },
+      )
+    }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
+  )
+
+  it.effect("/api/v1/threads: created and listed payloads match the documented schemas", () =>
+    Effect.gen(function* () {
+      const client = yield* rawClient
+      const project = yield* client.post("http://127.0.0.1/api/v1/projects", {
+        body: HttpBody.jsonUnsafe({ name: "Thread Docs", defaultWorkingDirectory: "/tmp" }),
+      })
+      const projectBody = (yield* project.json) as { id: string }
+
+      const created = yield* client.post("http://127.0.0.1/api/v1/threads", {
+        body: HttpBody.jsonUnsafe({ projectId: projectBody.id, agentId: "codex" }),
+      })
+      assert.strictEqual(created.status, 200)
+      const createdBody = (yield* created.json) as Record<string, unknown>
+      const schema = componentSchema("Thread")
+      // A fresh unnamed thread carries exactly the required keys;
+      // name/linkedTerminalId/archivedAt are absent optional keys, never null.
+      assert.sameMembers([...schema.required], Object.keys(createdBody))
+      assert.includeMembers(Object.keys(schema.properties), Object.keys(createdBody))
+      assert.deepStrictEqual(
+        operation("/api/v1/threads", "post").responses["200"]!.content["application/json"]!.schema,
+        { $ref: "#/components/schemas/Thread" },
+      )
+
+      const listed = yield* client.get(
+        `http://127.0.0.1/api/v1/threads?projectId=${projectBody.id}`,
+      )
+      assert.strictEqual(listed.status, 200)
+      assert.deepStrictEqual(yield* listed.json, [createdBody] as unknown)
+      assert.deepStrictEqual(
+        operation("/api/v1/threads").responses["200"]!.content["application/json"]!.schema,
+        { $ref: "#/components/schemas/ThreadList" },
+      )
+    }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
+  )
+
+  it.effect("GET /api/v1/threads/{threadId} documents and returns the 404 error payload", () =>
+    Effect.gen(function* () {
+      const response = yield* (yield* rawClient).get("http://127.0.0.1/api/v1/threads/nope")
+      assert.strictEqual(response.status, 404)
+      assert.deepStrictEqual(yield* response.json, { _tag: "ThreadNotFound", threadId: "nope" })
+      assert.deepStrictEqual(
+        operation("/api/v1/threads/{threadId}").responses["404"]!.content["application/json"]!
+          .schema,
+        { $ref: "#/components/schemas/ThreadNotFoundJsonEncoding" },
+      )
+    }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
+  )
+
+  it.effect("/api/v1/threads/{threadId}/archive and /unarchive round-trip the Thread schema", () =>
+    Effect.gen(function* () {
+      const client = yield* rawClient
+      const project = yield* client.post("http://127.0.0.1/api/v1/projects", {
+        body: HttpBody.jsonUnsafe({ name: "Archive Docs", defaultWorkingDirectory: "/tmp" }),
+      })
+      const projectBody = (yield* project.json) as { id: string }
+      const created = yield* client.post("http://127.0.0.1/api/v1/threads", {
+        body: HttpBody.jsonUnsafe({ projectId: projectBody.id, agentId: "claude-code" }),
+      })
+      const createdBody = (yield* created.json) as { id: string }
+
+      const archived = yield* client.post(
+        `http://127.0.0.1/api/v1/threads/${createdBody.id}/archive`,
+        { body: HttpBody.empty },
+      )
+      assert.strictEqual(archived.status, 200)
+      const archivedBody = (yield* archived.json) as Record<string, unknown>
+      assert.isString(archivedBody["archivedAt"])
+      assert.deepStrictEqual(
+        operation(`/api/v1/threads/{threadId}/archive`, "post").responses["200"]!.content[
+          "application/json"
+        ]!.schema,
+        { $ref: "#/components/schemas/Thread" },
+      )
+
+      const restored = yield* client.post(
+        `http://127.0.0.1/api/v1/threads/${createdBody.id}/unarchive`,
+        { body: HttpBody.empty },
+      )
+      assert.strictEqual(restored.status, 200)
+      const restoredBody = (yield* restored.json) as Record<string, unknown>
+      assert.notProperty(restoredBody, "archivedAt")
+      assert.deepStrictEqual(
+        operation(`/api/v1/threads/{threadId}/unarchive`, "post").responses["200"]!.content[
+          "application/json"
+        ]!.schema,
+        { $ref: "#/components/schemas/Thread" },
       )
     }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
   )

--- a/app-server/test/cli/cli.blackbox.test.ts
+++ b/app-server/test/cli/cli.blackbox.test.ts
@@ -278,6 +278,90 @@ describe("atc project / atc fs (black box)", () => {
   }, 30_000)
 })
 
+describe("atc thread (black box)", () => {
+  test("thread lifecycle: create, list, get, update, archive, unarchive, delete", async () => {
+    const projectResult = await cli([
+      "project",
+      "create",
+      "--name",
+      "ThreadBox",
+      "--directory",
+      scratch,
+    ])
+    const project = JSON.parse(projectResult.stdout) as { id: string }
+
+    const created = await cli([
+      "thread",
+      "create",
+      "--project",
+      project.id,
+      "--agent",
+      "codex",
+      "--name",
+      "First",
+    ])
+    expect(created.stderr).toBe("")
+    expect(created.exitCode).toBe(0)
+    const thread = JSON.parse(created.stdout) as {
+      id: string
+      agentId: string
+      name: string
+      activityState: string
+    }
+    expect(thread.agentId).toBe("codex")
+    expect(thread.name).toBe("First")
+    expect(thread.activityState).toBe("idle")
+
+    // An unknown agent slug is invalid usage, rejected client-side.
+    const badAgent = await cli([
+      "thread",
+      "create",
+      "--project",
+      project.id,
+      "--agent",
+      "gpt-marketing",
+    ])
+    expect(badAgent.exitCode).toBe(1)
+
+    const listed = await cli(["thread", "list"])
+    expect(JSON.parse(listed.stdout)).toEqual([thread])
+
+    const fetched = await cli(["thread", "get", thread.id])
+    expect(JSON.parse(fetched.stdout)).toEqual(thread)
+
+    const updated = await cli(["thread", "update", thread.id, "--name", "Renamed"])
+    expect((JSON.parse(updated.stdout) as { name: string }).name).toBe("Renamed")
+
+    // Archive hides the thread from the default list and shows it under
+    // --archived; unarchive restores it.
+    const archived = await cli(["thread", "archive", thread.id])
+    expect((JSON.parse(archived.stdout) as { archivedAt?: string }).archivedAt).toBeTruthy()
+    expect(JSON.parse((await cli(["thread", "list"])).stdout)).toEqual([])
+    const archivedList = await cli(["thread", "list", "--archived"])
+    expect((JSON.parse(archivedList.stdout) as Array<{ id: string }>).map((t) => t.id)).toEqual([
+      thread.id,
+    ])
+    const restored = await cli(["thread", "unarchive", thread.id])
+    expect((JSON.parse(restored.stdout) as { archivedAt?: string }).archivedAt).toBeUndefined()
+
+    // Deletion requires explicit confirmation; the CLI never prompts.
+    const refused = await cli(["thread", "delete", thread.id])
+    expect(refused.stderr).toContain("--yes")
+    expect(refused.exitCode).toBe(1)
+
+    const deleted = await cli(["thread", "delete", thread.id, "--yes"])
+    expect(deleted.stdout).toBe("")
+    expect(deleted.stderr).toBe("")
+    expect(deleted.exitCode).toBe(0)
+
+    const gone = await cli(["thread", "get", thread.id])
+    expect(gone.stderr.trim()).toBe(`atc thread get: no thread with id ${thread.id}`)
+    expect(gone.exitCode).toBe(1)
+
+    await cli(["project", "delete", project.id, "--yes"])
+  }, 30_000)
+})
+
 // The five stable context variables, all explicitly unset (empty means
 // unset), so gateway tests never depend on the developer's environment.
 const noContext = {

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -15,6 +15,8 @@ import * as Subprocess from "../src/platform/subprocess.ts"
 import type { TerminalAdapter } from "../src/terminals/terminalAdapter.ts"
 import * as TerminalRepository from "../src/terminals/terminalRepository.ts"
 import * as Terminals from "../src/terminals/terminals.ts"
+import * as ThreadRepository from "../src/threads/threadRepository.ts"
+import * as Threads from "../src/threads/threads.ts"
 import * as Zmx from "../src/terminals/zmxAdapter.ts"
 import {
   appServerRoot,
@@ -30,6 +32,7 @@ import type { FakeTerminalAdapter } from "./terminals/fakeTerminalAdapter.ts"
 type ServiceLayer = Layer.Layer<
   | ProjectRepository.ProjectRepository
   | TerminalRepository.TerminalRepository
+  | ThreadRepository.ThreadRepository
   | Directories.Directories
   | TerminalAdapter
   | ClaudeHooks.ClaudeHooks,
@@ -49,21 +52,25 @@ export const makeTestServiceLayers = (
   readonly fake: FakeTerminalAdapter
   readonly services: ServiceLayer
   readonly layer: Layer.Layer<
-    Layer.Success<ServiceLayer> | Terminals.Terminals | Projects.Projects,
+    Layer.Success<ServiceLayer> | Terminals.Terminals | Threads.Threads | Projects.Projects,
     unknown
   >
 } => {
   const fake = makeFakeAdapter()
-  const base = Layer.mergeAll(ProjectRepository.layer, TerminalRepository.layer).pipe(
-    Layer.provide(Persistence.layerFile(dbFile)),
-  )
+  const base = Layer.mergeAll(
+    ProjectRepository.layer,
+    TerminalRepository.layer,
+    ThreadRepository.layer,
+  ).pipe(Layer.provide(Persistence.layerFile(dbFile)))
   const services = Layer.mergeAll(base, Directories.layer, fake.layer, ClaudeHooks.layer)
+  const terminals = Terminals.layer.pipe(Layer.provide(services))
   return {
     fake,
     services,
     layer: Layer.mergeAll(
       services,
-      Terminals.layer.pipe(Layer.provide(services)),
+      terminals,
+      Threads.layer.pipe(Layer.provide([services, terminals])),
       Projects.layer.pipe(Layer.provide(services)),
     ),
   }

--- a/app-server/test/threads/threads.test.ts
+++ b/app-server/test/threads/threads.test.ts
@@ -1,0 +1,276 @@
+import { assert, describe, it } from "@effect/vitest"
+import { BunHttpServer } from "@effect/platform-bun"
+import { Effect, Layer } from "effect"
+import { HttpApiTest } from "effect/unstable/httpapi"
+import { mkdtempSync, realpathSync, rmSync, symlinkSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll } from "vitest"
+import { Api } from "../../src/api/contract.ts"
+import { V1Handlers } from "../../src/api/handlers.ts"
+import { sessionNameForTerminalId } from "../../src/terminals/terminalAdapter.ts"
+import { TerminalRepository } from "../../src/terminals/terminalRepository.ts"
+import { TestBuildInfoLayer } from "../testBuildInfo.ts"
+import { makeTestServiceLayers } from "../testLayers.ts"
+
+// Threads foundation coverage (ATC-124 / ATC-139): the durable local-only
+// record, its lifecycle rules, and the derived Thread↔Terminal link — all
+// through the public contract. Provider materialization is ATC-141 work; the
+// proof here is that none of these paths need an agent adapter at all.
+
+const kit = makeTestServiceLayers()
+// The kit layer is shared by reference between the handlers and the test
+// bodies, so repository seeding below hits the same database the API serves.
+const TestLayer = Layer.mergeAll(
+  V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, kit.layer])),
+  kit.layer,
+  BunHttpServer.layerHttpServices,
+)
+
+const scratch = mkdtempSync(join(tmpdir(), "atc-threads-test-"))
+afterAll(() => rmSync(scratch, { recursive: true, force: true }))
+const realDir = realpathSync(scratch)
+const linkedDir = join(scratch, "linked")
+symlinkSync(realDir, linkedDir)
+
+const testClient = Effect.gen(function* () {
+  const client = yield* HttpApiTest.groups(Api, ["v1"])
+  const makeProject = client.v1.createProject({
+    payload: { name: "Threads", defaultWorkingDirectory: realDir },
+  })
+  return { client, makeProject }
+})
+
+describe("/api/v1/threads", () => {
+  it.effect("creates, lists, gets, updates, archives, and deletes a thread", () =>
+    Effect.gen(function* () {
+      const { client, makeProject } = yield* testClient
+      const project = yield* makeProject
+
+      // Create is local-only, defaults to the project directory, and starts
+      // idle: no provider session exists, so nothing can be running.
+      const created = yield* client.v1.createThread({
+        payload: { projectId: project.id, agentId: "codex" },
+      })
+      assert.match(
+        created.id,
+        /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+        "UUIDv7 id",
+      )
+      assert.strictEqual(created.agentId, "codex")
+      assert.strictEqual(created.workingDirectory, realDir)
+      assert.strictEqual(created.activityState, "idle")
+      assert.isUndefined(created.name)
+      assert.isUndefined(created.linkedTerminalId)
+      assert.isUndefined(created.archivedAt)
+      assert.strictEqual(created.createdAt, created.updatedAt)
+
+      // An explicit symlinked directory is stored canonicalized.
+      const canonical = yield* client.v1.createThread({
+        payload: {
+          projectId: project.id,
+          agentId: "claude-code",
+          name: "Canonical",
+          workingDirectory: linkedDir,
+        },
+      })
+      assert.strictEqual(canonical.workingDirectory, realDir)
+      assert.strictEqual(canonical.name, "Canonical")
+
+      // Newest first, both active. Listings are asserted project-scoped so
+      // tests stay order-independent on the shared module database.
+      assert.deepStrictEqual(yield* client.v1.listThreads({ query: { projectId: project.id } }), [
+        canonical,
+        created,
+      ])
+      assert.deepStrictEqual(
+        yield* client.v1.getThread({ params: { threadId: created.id } }),
+        created,
+      )
+
+      // Rename; an empty patch changes nothing, updatedAt included.
+      const renamed = yield* client.v1.updateThread({
+        params: { threadId: created.id },
+        payload: { name: "Renamed" },
+      })
+      assert.strictEqual(renamed.name, "Renamed")
+      const unchanged = yield* client.v1.updateThread({
+        params: { threadId: created.id },
+        payload: {},
+      })
+      assert.deepStrictEqual(unchanged, renamed)
+
+      // Archive: idempotent, excluded from the default list, in the
+      // archived list; unarchive restores.
+      const archived = yield* client.v1.archiveThread({ params: { threadId: created.id } })
+      assert.isString(archived.archivedAt)
+      const again = yield* client.v1.archiveThread({ params: { threadId: created.id } })
+      assert.deepStrictEqual(again, archived)
+      assert.deepStrictEqual(yield* client.v1.listThreads({ query: { projectId: project.id } }), [
+        canonical,
+      ])
+      assert.deepStrictEqual(
+        yield* client.v1.listThreads({ query: { projectId: project.id, archived: "true" } }),
+        [archived],
+      )
+      const restored = yield* client.v1.unarchiveThread({ params: { threadId: created.id } })
+      assert.isUndefined(restored.archivedAt)
+
+      // Project-scoped listing.
+      assert.deepStrictEqual(
+        yield* client.v1.listThreads({ query: { projectId: "someone-else" } }),
+        [],
+      )
+
+      yield* client.v1.deleteThread({ params: { threadId: created.id } })
+      yield* client.v1.deleteThread({ params: { threadId: canonical.id } })
+      assert.deepStrictEqual(yield* client.v1.listThreads({ query: { projectId: project.id } }), [])
+      yield* client.v1.deleteProject({ params: { projectId: project.id } })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("unknown ids are ThreadNotFound on every id-taking operation", () =>
+    Effect.gen(function* () {
+      const client = yield* HttpApiTest.groups(Api, ["v1"])
+      const attempts: ReadonlyArray<Effect.Effect<unknown, unknown>> = [
+        client.v1.getThread({ params: { threadId: "missing" } }),
+        client.v1.updateThread({ params: { threadId: "missing" }, payload: { name: "x" } }),
+        client.v1.archiveThread({ params: { threadId: "missing" } }),
+        client.v1.unarchiveThread({ params: { threadId: "missing" } }),
+        client.v1.deleteThread({ params: { threadId: "missing" } }),
+      ]
+      for (const attempt of attempts) {
+        const error = (yield* Effect.flip(attempt)) as { _tag: string; threadId?: string }
+        assert.strictEqual(error._tag, "ThreadNotFound")
+        assert.strictEqual(error.threadId, "missing")
+      }
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("create validates the project and the directory, storing nothing on failure", () =>
+    Effect.gen(function* () {
+      const { client, makeProject } = yield* testClient
+      const unknownProject = yield* Effect.flip(
+        client.v1.createThread({ payload: { projectId: "missing", agentId: "codex" } }),
+      )
+      assert.strictEqual(unknownProject._tag, "ProjectNotFound")
+
+      const project = yield* makeProject
+      const missingDir = yield* Effect.flip(
+        client.v1.createThread({
+          payload: {
+            projectId: project.id,
+            agentId: "codex",
+            workingDirectory: join(realDir, "nope"),
+          },
+        }),
+      )
+      assert.strictEqual(missingDir._tag, "DirectoryUnavailable")
+      assert.deepStrictEqual(yield* client.v1.listThreads({ query: { projectId: project.id } }), [])
+      yield* client.v1.deleteProject({ params: { projectId: project.id } })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("project deletion is restricted while threads exist, archived included", () =>
+    Effect.gen(function* () {
+      const { client, makeProject } = yield* testClient
+      const project = yield* makeProject
+      const thread = yield* client.v1.createThread({
+        payload: { projectId: project.id, agentId: "codex" },
+      })
+      yield* client.v1.archiveThread({ params: { threadId: thread.id } })
+      const restricted = yield* Effect.flip(
+        client.v1.deleteProject({ params: { projectId: project.id } }),
+      )
+      assert.strictEqual(restricted._tag, "ProjectHasThreads")
+      if (restricted._tag === "ProjectHasThreads") {
+        assert.strictEqual(restricted.threadCount, 1)
+      }
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+      yield* client.v1.deleteProject({ params: { projectId: project.id } })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("delete kills the live linked terminal and unlinks ended tombstones", () =>
+    Effect.gen(function* () {
+      const { client, makeProject } = yield* testClient
+      const repository = yield* TerminalRepository
+      const project = yield* makeProject
+      const thread = yield* client.v1.createThread({
+        payload: { projectId: project.id, agentId: "codex" },
+      })
+
+      // Seed a live linked TUI terminal the way ATC-141's openTerminal will:
+      // a terminals row carrying thread_id plus its adapter session.
+      const record = yield* repository.create({
+        projectId: project.id,
+        threadId: thread.id,
+        initialWorkingDirectory: realDir,
+      })
+      kit.fake.seed(sessionNameForTerminalId(record.id))
+      yield* repository.markLive(record.id)
+
+      // The link is derived onto the thread, and onto the terminal itself.
+      const linked = yield* client.v1.getThread({ params: { threadId: thread.id } })
+      assert.strictEqual(linked.linkedTerminalId, record.id)
+      const terminal = yield* client.v1.getTerminal({ params: { terminalId: record.id } })
+      assert.strictEqual(terminal.threadId, thread.id)
+
+      // An ended linked terminal (a previous TUI run) must survive the
+      // thread's deletion as an unlinked tombstone.
+      const ended = yield* repository.create({
+        projectId: project.id,
+        threadId: thread.id,
+        initialWorkingDirectory: realDir,
+      })
+      yield* repository.markLive(ended.id)
+      yield* repository.markEnded([ended.id])
+
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+      // The live terminal's record and session are gone…
+      assert.isFalse(kit.fake.sessions.has(sessionNameForTerminalId(record.id)))
+      const gone = yield* Effect.flip(client.v1.getTerminal({ params: { terminalId: record.id } }))
+      assert.strictEqual(gone._tag, "TerminalNotFound")
+      // …while the tombstone remains, now unlinked (FK SET NULL).
+      const tombstone = yield* client.v1.getTerminal({ params: { terminalId: ended.id } })
+      assert.strictEqual(tombstone.status, "ended")
+      assert.isUndefined(tombstone.threadId)
+
+      yield* client.v1.deleteTerminal({ params: { terminalId: ended.id } })
+      yield* client.v1.deleteProject({ params: { projectId: project.id } })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("a linked terminal that died shows as unlinked once reconciled", () =>
+    Effect.gen(function* () {
+      const { client, makeProject } = yield* testClient
+      const repository = yield* TerminalRepository
+      const project = yield* makeProject
+      const thread = yield* client.v1.createThread({
+        payload: { projectId: project.id, agentId: "claude-code" },
+      })
+      const record = yield* repository.create({
+        projectId: project.id,
+        threadId: thread.id,
+        initialWorkingDirectory: realDir,
+      })
+      kit.fake.seed(sessionNameForTerminalId(record.id))
+      yield* repository.markLive(record.id)
+      assert.strictEqual(
+        (yield* client.v1.getThread({ params: { threadId: thread.id } })).linkedTerminalId,
+        record.id,
+      )
+
+      // The session dies out from under ATC: the reconciled terminals
+      // listing tombstones it, so the thread's derived link disappears.
+      kit.fake.sessions.delete(sessionNameForTerminalId(record.id))
+      assert.isUndefined(
+        (yield* client.v1.getThread({ params: { threadId: thread.id } })).linkedTerminalId,
+      )
+
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+      yield* client.v1.deleteTerminal({ params: { terminalId: record.id } })
+      yield* client.v1.deleteProject({ params: { projectId: project.id } })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+})


### PR DESCRIPTION
PR 1 of 3 for [ATC-124](https://linear.app/elevenideas/issue/ATC-124) (Durable Threads and the terminal-first agent workflow). Implements [ATC-139](https://linear.app/elevenideas/issue/ATC-139).

## What this adds

- **Migration `0003_threads`**: the `threads` table (UUIDv7 id, immutable canonical `working_directory`, nullable `provider_session_id` + `confirmed_at` + opaque adapter-owned `provider_metadata`, `archived_at`) plus a nullable `thread_id` column on `terminals` — the authoritative side of the Thread↔Terminal link, `ON DELETE SET NULL` so ended linked terminals survive a thread's deletion as unlinked tombstones.
- **`ThreadRepository`** — the only module speaking SQL for threads. `agent_id` is validated at the write boundary but decoded permissively, so a row written by a newer build can never brick reads (above all delete, the recovery path).
- **`Threads` domain service** — `create` is local-only (durable row, no provider call; provider sessions materialize on first interaction, per the probe-settled decision record). Archive/unarchive are idempotent; archive is refused while the agent session is working; delete kills the live linked terminal first (terminals' confirmed-kill rules) and never touches provider history. `activityState` is in-memory evidence only: no provider session ⇒ `idle`; the live feed lands in ATC-141.
- **Contract group**: `listThreads` (archived excluded by default, `?archived=` filter), `createThread`, `getThread`, `updateThread`, `archiveThread`, `unarchiveThread`, `deleteThread`; errors `ThreadNotFound` (404), `ThreadBusy` (409), `ProjectHasThreads` (409). Provider identity stays out of every public schema. `Terminal` gains a derived `threadId`.
- **Projects delete guard** extended: deletion is restricted while the project owns threads (mirrors the terminals guard — the FK would otherwise surface as a 500).
- **CLI**: `atc thread create|list|get|update|archive|unarchive|delete` (`open` arrives with ATC-141). `--agent` is a typed choice bound to the contract's `AgentId`.
- **`PROVIDER_FOR_AGENT`** in the adapter seam: a compile-checked mapping from public registry slugs (`codex`, `claude-code`) to seam providers (`codex`, `claude`), so the two vocabularies cannot drift silently.

## Tests

- `test/threads/threads.test.ts`: lifecycle through the public contract, canonicalization, archived filtering, `ThreadNotFound` on every id-taking operation, the project-deletion guard, delete-kills-linked-terminal (live killed, ended tombstone unlinked), and derived-link reconciliation when a session dies out from under ATC.
- OpenAPI document/runtime cases for every new path; CLI blackbox lifecycle including the typed `--agent` rejection.
- `mise run check` and `mise run contract:check` green (205 tests; Swift client builds).

Stacked: ATC-140 (agents registry + seam extensions) and ATC-141 (openTerminal workflow) follow on top of this branch.

https://claude.ai/code/session_01336PDxLnsF6jXJ8w8uJiQc