### PR TITLE
ATC-140: Agents registry and the AgentAdapter seam extensions

### DIFF
--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -853,6 +853,71 @@
         "description": "Restore an archived thread (idempotent)."
       }
     },
+    "/api/v1/agents": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "listAgents",
+        "parameters": [],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "The built-in agent registry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentList"
+                }
+              }
+            }
+          }
+        },
+        "description": "List the built-in agents with availability and capabilities, detected on demand."
+      }
+    },
+    "/api/v1/agents/{agentId}": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "getAgent",
+        "parameters": [
+          {
+            "name": "agentId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "A built-in agent provider: availability and capability report, detected on demand and never persisted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Agent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No built-in agent exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentNotFoundJsonEncoding"
+                }
+              }
+            }
+          }
+        },
+        "description": "Fetch one built-in agent by its registry slug."
+      }
+    },
     "/api/v1/fs/check": {
       "get": {
         "tags": [
@@ -1453,6 +1518,72 @@
         "required": [
           "_tag",
           "threadId"
+        ],
+        "additionalProperties": false
+      },
+      "Agent": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/AgentId"
+          },
+          "available": {
+            "type": "boolean",
+            "description": "Whether the agent's CLI is installed and resolvable right now."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Actionable install-or-configure hint; absent when available."
+          },
+          "detectedVersion": {
+            "type": "string",
+            "description": "Installed CLI version, when it could be determined."
+          },
+          "testedVersion": {
+            "type": "string",
+            "description": "Version the adapter was validated against (drift warns, never blocks)."
+          },
+          "tuiObservation": {
+            "type": "string",
+            "enum": [
+              "shared-server",
+              "hooks"
+            ],
+            "description": "How live activity is observed while a TUI drives a session: full event fan-out from the shared provider server, or coarser provider hook callbacks."
+          }
+        },
+        "required": [
+          "id",
+          "available",
+          "testedVersion",
+          "tuiObservation"
+        ],
+        "additionalProperties": false,
+        "description": "A built-in agent provider: availability and capability report, detected on demand and never persisted."
+      },
+      "AgentList": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Agent"
+        },
+        "description": "The built-in agent registry."
+      },
+      "AgentNotFoundJsonEncoding": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": [
+              "AgentNotFound"
+            ]
+          },
+          "agentId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "_tag",
+          "agentId"
         ],
         "additionalProperties": false
       },

--- a/app-server/src/agents/agentAdapter.ts
+++ b/app-server/src/agents/agentAdapter.ts
@@ -101,6 +101,14 @@ export interface TuiLaunchSpec {
   readonly env: Readonly<Record<string, string>>
 }
 
+/** A resume launch, plus any adapter metadata the launch minted or rotated
+ * — the caller must persist it, or state minted here (e.g. a hook secret)
+ * dies with the process while the TUI keeps using it. */
+export interface TuiLaunch {
+  readonly launchSpec: TuiLaunchSpec
+  readonly providerMetadata?: string
+}
+
 /**
  * A live writer connection to one provider session. Lives in a Scope:
  * closing the scope stops the driver (releasing the writer role) and never
@@ -168,6 +176,35 @@ export interface AgentSessionStart {
 }
 
 /**
+ * Verified identity of a freshly launched TUI session (ATC-124). The
+ * optional metadata is an opaque adapter-owned blob the caller persists on
+ * the thread and hands back on later seam calls (e.g. the Claude hook
+ * secret); the domain never reads inside it.
+ */
+export interface EstablishedIdentity {
+  readonly providerSessionId: string
+  /** The verified canonical working directory the caller asked for. */
+  readonly cwd: string
+  readonly providerMetadata?: string
+}
+
+/**
+ * What `prepareTuiSession` hands back: how to launch the fresh provider
+ * TUI, and one awaitable resolving to the session's verified identity.
+ * How identity is established is adapter-internal: Claude pre-assigns an
+ * id and resolves immediately; Codex resolves when the launched TUI's
+ * `thread/started` is captured (cwd-checked fail closed). Awaiting is the
+ * caller's job and must be bounded by the caller.
+ */
+export interface PreparedTuiSession {
+  readonly launchSpec: TuiLaunchSpec
+  readonly identity: Effect.Effect<
+    EstablishedIdentity,
+    AgentUnavailable | AgentIdentityMismatch | AgentProtocolError
+  >
+}
+
+/**
  * The shared adapter interface. Create requires initial input because both
  * providers establish durable identity while starting a turn (and a Codex
  * thread with zero completed turns is not restart-resumable), so a created
@@ -210,11 +247,57 @@ export interface AgentAdapter {
     | AgentProtocolError,
     Scope.Scope
   >
-  /** How to launch the provider TUI attached to an existing session. */
+  /**
+   * How to launch the provider TUI attached to an existing session.
+   * `providerMetadata` is deliberately required (pass undefined when the
+   * thread has none): forgetting to thread it through would silently
+   * rotate adapter state out from under a running TUI.
+   */
   readonly tuiLaunch: (options: {
     readonly providerSessionId: string
     readonly cwd: string
-  }) => Effect.Effect<TuiLaunchSpec, AgentUnavailable>
+    readonly providerMetadata: string | undefined
+  }) => Effect.Effect<TuiLaunch, AgentUnavailable>
+  /**
+   * Prepare a FRESH provider TUI session in `cwd`: the uniform contract
+   * behind "provider sessions materialize on first interaction". The Scope
+   * owns the adapter's capture/serialization resources (Codex holds the
+   * per-provider launch lock until the scope closes, so concurrent
+   * launches cannot mis-adopt each other's identity); close it once
+   * `identity` has resolved, or to abandon the launch.
+   */
+  readonly prepareTuiSession: (options: {
+    readonly cwd: string
+  }) => Effect.Effect<PreparedTuiSession, AgentUnavailable, Scope.Scope>
+  /**
+   * The one normalized per-session activity subscription for TUI-driven
+   * sessions. Whether it is fed by hook webhooks (Claude) or the shared
+   * server's status fan-out (Codex) is adapter-internal. Metadata is
+   * handed back so adapters can restore per-session state (hook secrets)
+   * across ATC restarts. Scoped: closing unsubscribes. The stream goes
+   * silent — never lies — when the adapter loses its evidence source.
+   */
+  readonly observeSession: (options: {
+    readonly providerSessionId: string
+    readonly providerMetadata: string | undefined
+  }) => Effect.Effect<Stream.Stream<AgentActivity>, AgentUnavailable, Scope.Scope>
+  /**
+   * Demand-driven reconciliation: the provider's current word on the
+   * session's activity, `unknown` when it offers no evidence. Never
+   * guesses; failures are the retryable AgentUnavailable.
+   */
+  readonly checkSession: (options: {
+    readonly providerSessionId: string
+  }) => Effect.Effect<AgentActivity, AgentUnavailable>
+  /**
+   * Release adapter-owned per-session resources (launch files, secret
+   * registrations) when the owning thread is deleted. Best-effort and
+   * idempotent — cleanup problems are logged, never surfaced.
+   */
+  readonly releaseSession: (options: {
+    readonly providerSessionId: string
+    readonly providerMetadata: string | undefined
+  }) => Effect.Effect<void>
 }
 
 // Internal-only failures (ATC-123): not part of the HTTP contract, so no
@@ -328,6 +411,39 @@ export const samePath = (left: string, right: string): boolean => {
 }
 
 /**
+ * Read `<executable> --version` and extract an x.y.z version string;
+ * null when the version cannot be determined (any spawn or parse failure).
+ */
+export const readInstalledVersion = (
+  subprocess: Subprocess["Service"],
+  executable: string,
+): Effect.Effect<string | null> =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const child = yield* subprocess.spawn({
+        executable,
+        args: ["--version"],
+        env: {},
+        extendEnv: true,
+      })
+      const lines = yield* Stream.runCollect(child.stdoutLines)
+      yield* child.exitCode
+      return lines.join(" ")
+    }),
+  ).pipe(
+    // Bounded: a wedged binary must not hang a demand-driven registry read.
+    Effect.timeoutOrElse({ duration: "5 seconds", orElse: () => Effect.succeed("") }),
+    Effect.orElseSucceed(() => ""),
+    Effect.map(
+      (output) =>
+        output
+          .match(/(\d+)\.(\d+)\.(\d+)/)
+          ?.slice(1, 4)
+          .join(".") ?? null,
+    ),
+  )
+
+/**
  * The shared version-drift rule (record + warn, never block), memoized to
  * one check per adapter: resolve the configured executable, read the
  * installed version via `--version`, and log one actionable warning when
@@ -345,32 +461,21 @@ export const makeVersionGate = (
     if (checked) return
     checked = true
     const executable = yield* resolveProviderExecutable(provider, configured)
-    const output = yield* Effect.scoped(
-      Effect.gen(function* () {
-        const child = yield* subprocess.spawn({
-          executable,
-          args: ["--version"],
-          env: {},
-          extendEnv: true,
-        })
-        const lines = yield* Stream.runCollect(child.stdoutLines)
-        yield* child.exitCode
-        return lines.join(" ")
-      }),
-    ).pipe(Effect.orElseSucceed(() => ""))
-    const match = output.match(/(\d+)\.(\d+)\.(\d+)/)
-    if (match === null) {
+    const installed = yield* readInstalledVersion(subprocess, executable)
+    if (installed === null) {
       return yield* Effect.logWarning(
         `could not determine the installed ${provider} version (tested against ${testedVersion})`,
       )
     }
     // Components are small; packing keeps the comparison one expression.
-    const pack = (parts: ReadonlyArray<number>) =>
-      (parts[0] ?? 0) * 1_000_000 + (parts[1] ?? 0) * 1_000 + (parts[2] ?? 0)
-    const installed = [Number(match[1]), Number(match[2]), Number(match[3])]
-    if (pack(installed) < pack(testedVersion.split(".").map(Number))) {
+    const pack = (version: string) =>
+      version
+        .split(".")
+        .map(Number)
+        .reduce((total, part) => total * 1_000 + part, 0)
+    if (pack(installed) < pack(testedVersion)) {
       yield* Effect.logWarning(
-        `installed ${provider} ${installed.join(".")} is older than the tested ${testedVersion}; proceeding, but upgrade it if provider behavior misbehaves`,
+        `installed ${provider} ${installed} is older than the tested ${testedVersion}; proceeding, but upgrade it if provider behavior misbehaves`,
       )
     }
   })

--- a/app-server/src/agents/agentRegistry.ts
+++ b/app-server/src/agents/agentRegistry.ts
@@ -1,0 +1,83 @@
+import { Context, Effect, Layer } from "effect"
+import { AGENT_IDS, AgentNotFound } from "../api/contract.ts"
+import type { Agent as AgentSchema, AgentId } from "../api/contract.ts"
+import { AppConfig } from "../platform/config.ts"
+import * as Subprocess from "../platform/subprocess.ts"
+import type { AgentAdapter } from "./agentAdapter.ts"
+import {
+  PROVIDER_FOR_AGENT,
+  readInstalledVersion,
+  resolveProviderExecutable,
+} from "./agentAdapter.ts"
+import { ClaudeAdapter } from "./claudeAdapter.ts"
+import { CodexAdapter } from "./codexAdapter.ts"
+
+export type Agent = typeof AgentSchema.Type
+
+// The read-only built-in agent registry (ATC-124): the one place the public
+// agent slugs meet the provider adapters. Availability and versions are
+// detected on demand — nothing persisted, no migration. Adding an agent is
+// one new adapter layer (wired in server.ts) plus registry entries: the
+// contract's AgentId literal, PROVIDER_FOR_AGENT in agentAdapter.ts, and
+// the table here — the Record types make a missed entry a compile error,
+// and threads/ never changes.
+
+export class AgentRegistry extends Context.Service<
+  AgentRegistry,
+  {
+    readonly list: () => Effect.Effect<ReadonlyArray<Agent>>
+    readonly get: (id: string) => Effect.Effect<Agent, AgentNotFound>
+    /** The adapter behind a public slug — the domain's only door to providers. */
+    readonly adapterFor: (id: typeof AgentId.Type) => AgentAdapter
+  }
+>()("app-server/AgentRegistry") {}
+
+export const layer = Layer.effect(AgentRegistry)(
+  Effect.gen(function* () {
+    const config = yield* AppConfig
+    const subprocess = yield* Subprocess.Subprocess
+    const codex = yield* CodexAdapter
+    const claude = yield* ClaudeAdapter
+
+    // The one registry table: adding an agent adds one entry here.
+    const entries: Record<
+      typeof AgentId.Type,
+      { readonly adapter: AgentAdapter; readonly executable: string }
+    > = {
+      codex: { adapter: codex, executable: config.codexExecutable },
+      "claude-code": { adapter: claude, executable: config.claudeExecutable },
+    }
+
+    const describe = (id: typeof AgentId.Type): Effect.Effect<Agent> => {
+      const { adapter, executable } = entries[id]
+      const base = {
+        id,
+        testedVersion: adapter.capabilities.testedVersion,
+        tuiObservation: adapter.capabilities.tuiObservation,
+      }
+      return resolveProviderExecutable(PROVIDER_FOR_AGENT[id], executable).pipe(
+        Effect.flatMap((executable) =>
+          readInstalledVersion(subprocess, executable).pipe(
+            Effect.map((detected) => ({
+              ...base,
+              available: true,
+              ...(detected !== null ? { detectedVersion: detected } : {}),
+            })),
+          ),
+        ),
+        Effect.catchTag("AgentUnavailable", (error) =>
+          Effect.succeed({ ...base, available: false, reason: error.reason }),
+        ),
+      )
+    }
+
+    const isAgentId = (id: string): id is typeof AgentId.Type =>
+      (AGENT_IDS as ReadonlyArray<string>).includes(id)
+
+    return {
+      list: () => Effect.forEach(AGENT_IDS, describe),
+      get: (id) => (isAgentId(id) ? describe(id) : Effect.fail(new AgentNotFound({ agentId: id }))),
+      adapterFor: (id) => entries[id].adapter,
+    }
+  }),
+)

--- a/app-server/src/agents/claudeAdapter.ts
+++ b/app-server/src/agents/claudeAdapter.ts
@@ -59,8 +59,9 @@ import * as Subprocess from "../platform/subprocess.ts"
 //     NOT bridged into these feeds: a TUI-driven session has no adapter
 //     connection by definition, and while ATC drives, the same vocabulary
 //     already arrives as in-process SDK callbacks — a webhook delivery for
-//     a live connection could only be stale or spoofed. TUI-side consumers
-//     subscribe to claudeHooks directly (ATC-124).
+//     a live connection could only be stale or spoofed. TUI-driven activity
+//     flows through observeSession below, which is the claudeHooks
+//     subscriber; consumers stay above the seam.
 
 /** The Claude Code version this adapter was validated against. */
 export const CLAUDE_TESTED_VERSION = "2.1.221"
@@ -411,6 +412,77 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
         CLAUDE_TESTED_VERSION,
       )
 
+      const hookFilePaths = (providerSessionId: string) => ({
+        headerFile: path.join(config.stateDir, `claude-hooks-${providerSessionId}.header`),
+        settingsFile: path.join(config.stateDir, `claude-hooks-${providerSessionId}.json`),
+      })
+
+      const removeHookFiles = (providerSessionId: string) =>
+        Effect.gen(function* () {
+          const { headerFile, settingsFile } = hookFilePaths(providerSessionId)
+          yield* fs.remove(headerFile).pipe(Effect.ignore)
+          yield* fs.remove(settingsFile).pipe(Effect.ignore)
+        })
+
+      /** The persisted hook secret, if the thread's opaque metadata has one. */
+      const metadataSecret = (metadata: string | undefined): string | null => {
+        if (metadata === undefined) return null
+        try {
+          const parsed = JSON.parse(metadata) as { hookSecret?: unknown }
+          return typeof parsed.hookSecret === "string" ? parsed.hookSecret : null
+        } catch {
+          return null
+        }
+      }
+
+      /**
+       * Register the session's webhook secret (reusing the persisted one so
+       * it stays stable for the thread's life, minting on first use) and
+       * write the per-session hook plumbing. The secret only ever lives in
+       * 0600 files: the settings file and a curl header file (`-H @file`) —
+       * never in any argv (ps would show it, including curl's) and never in
+       * the URL (request paths land in tracer span names). Files are
+       * overwritten per launch and removed by releaseSession.
+       */
+      const ensureHookPlumbing = (providerSessionId: string, metadata: string | undefined) =>
+        Effect.gen(function* () {
+          const known = metadataSecret(metadata)
+          const secret = known ?? (yield* hooks.registerSecret(providerSessionId))
+          if (known !== null) yield* hooks.adoptSecret(providerSessionId, known)
+          const url = `http://127.0.0.1:${config.port}/internal/claude/hooks`
+          const { headerFile, settingsFile } = hookFilePaths(providerSessionId)
+          const command =
+            `curl -fsS -m 5 -X POST -H 'Content-Type: application/json' ` +
+            `-H @'${headerFile}' --data-binary @- '${url}'`
+          const hookConfig = Object.fromEntries(
+            HOOK_EVENTS.map((event) => [event, [{ hooks: [{ type: "command", command }] }]]),
+          )
+          const write = (file: string, content: string) =>
+            fs.writeFileString(file, content).pipe(Effect.andThen(fs.chmod(file, 0o600)))
+          yield* fs.makeDirectory(config.stateDir, { recursive: true }).pipe(
+            Effect.andThen(write(headerFile, `${ClaudeHooks.SECRET_HEADER}: ${secret}`)),
+            Effect.andThen(write(settingsFile, JSON.stringify({ hooks: hookConfig }))),
+            Effect.mapError(
+              (error) =>
+                new AgentUnavailable({
+                  provider: "claude",
+                  reason: `could not write the hook settings files: ${error.message}`,
+                }),
+            ),
+            // A failed (or interrupted) write sequence must not strand the
+            // allocation it sits inside: drop any partial file, and revoke
+            // the secret iff this call minted it — a metadata-carried secret
+            // may still be validating a running TUI's hooks.
+            Effect.onError(() =>
+              Effect.gen(function* () {
+                if (known === null) yield* hooks.revokeSecret(providerSessionId)
+                yield* removeHookFiles(providerSessionId)
+              }),
+            ),
+          )
+          return { secret, settingsFile }
+        })
+
       const openSession = (options: { readonly cwd: string; readonly resume?: string }) =>
         Effect.gen(function* () {
           const executable = yield* resolveProviderExecutable("claude", config.claudeExecutable)
@@ -583,51 +655,98 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
         tuiLaunch: (options) =>
           Effect.gen(function* () {
             const executable = yield* resolveProviderExecutable("claude", config.claudeExecutable)
-            const secret = yield* hooks.registerSecret(options.providerSessionId)
-            // The secret only ever lives in 0600 files: the settings file
-            // and a curl header file (`-H @file`) — never in any argv (ps
-            // would show it, including curl's) and never in the URL
-            // (request paths land in tracer span names). Both files are
-            // overwritten per launch; tying their lifetime to the TUI
-            // terminal session is ATC-124 work.
-            const url = `http://127.0.0.1:${config.port}/internal/claude/hooks`
-            const headerFile = path.join(
-              config.stateDir,
-              `claude-hooks-${options.providerSessionId}.header`,
-            )
-            const command =
-              `curl -fsS -m 5 -X POST -H 'Content-Type: application/json' ` +
-              `-H @'${headerFile}' --data-binary @- '${url}'`
-            const hookConfig = Object.fromEntries(
-              HOOK_EVENTS.map((event) => [event, [{ hooks: [{ type: "command", command }] }]]),
-            )
-            const settingsFile = path.join(
-              config.stateDir,
-              `claude-hooks-${options.providerSessionId}.json`,
-            )
-            const write = (file: string, content: string) =>
-              fs.writeFileString(file, content).pipe(Effect.andThen(fs.chmod(file, 0o600)))
-            yield* fs.makeDirectory(config.stateDir, { recursive: true }).pipe(
-              Effect.andThen(write(headerFile, `${ClaudeHooks.SECRET_HEADER}: ${secret}`)),
-              Effect.andThen(write(settingsFile, JSON.stringify({ hooks: hookConfig }))),
-              Effect.mapError(
-                (error) =>
-                  new AgentUnavailable({
-                    provider: "claude",
-                    reason: `could not write the hook settings files: ${error.message}`,
-                  }),
-              ),
+            const { secret, settingsFile } = yield* ensureHookPlumbing(
+              options.providerSessionId,
+              options.providerMetadata,
             )
             return {
-              command: [
-                executable,
-                "--resume",
-                options.providerSessionId,
-                "--settings",
-                settingsFile,
-              ],
-              env: {},
+              launchSpec: {
+                command: [
+                  executable,
+                  "--resume",
+                  options.providerSessionId,
+                  "--settings",
+                  settingsFile,
+                ],
+                env: {},
+              },
+              // Always handed back: when the caller had no metadata this
+              // launch minted the secret, and only persistence keeps the
+              // running TUI's hooks valid across an ATC restart.
+              providerMetadata: JSON.stringify({ hookSecret: secret }),
             }
+          }),
+        prepareTuiSession: (options) =>
+          Effect.gen(function* () {
+            const executable = yield* resolveProviderExecutable("claude", config.claudeExecutable)
+            yield* versionCheck
+            // Pre-assignment (probed 2026-08-05): `--session-id` creates
+            // exactly the minted id, and a duplicate launch fails closed —
+            // so identity resolves immediately and the first hook payload
+            // is confirmation, not discovery. The secret is minted once
+            // here and rides the thread's metadata from then on.
+            const providerSessionId = crypto.randomUUID()
+            // An abandoned prepare (the caller never awaited identity —
+            // e.g. its terminal launch failed) must not leak the secret
+            // registration or the 0600 files. acquireRelease pairs the
+            // plumbing with its cleanup atomically, so interruption cannot
+            // land between the allocation and its finalizer.
+            let claimed = false
+            const { secret, settingsFile } = yield* Effect.acquireRelease(
+              ensureHookPlumbing(providerSessionId, undefined),
+              () =>
+                claimed
+                  ? Effect.void
+                  : Effect.gen(function* () {
+                      yield* hooks.revokeSecret(providerSessionId)
+                      yield* removeHookFiles(providerSessionId)
+                    }),
+            )
+            return {
+              launchSpec: {
+                command: [
+                  executable,
+                  "--session-id",
+                  providerSessionId,
+                  "--settings",
+                  settingsFile,
+                ],
+                env: {},
+              },
+              identity: Effect.sync(() => {
+                claimed = true
+                return {
+                  providerSessionId,
+                  cwd: options.cwd,
+                  providerMetadata: JSON.stringify({ hookSecret: secret }),
+                }
+              }),
+            }
+          }),
+        observeSession: (options) =>
+          Effect.gen(function* () {
+            // Restore the persisted secret first: the registry is
+            // in-memory, so a TUI launched before an ATC restart keeps
+            // validating only because the thread's metadata carries it.
+            const known = metadataSecret(options.providerMetadata)
+            if (known !== null) yield* hooks.adoptSecret(options.providerSessionId, known)
+            const queue = yield* Queue.make<AgentActivity, Cause.Done>()
+            // Registered before the subscription so it runs after it on
+            // scope close: unsubscribe first, then end the queue.
+            yield* Effect.addFinalizer(() => Effect.sync(() => Queue.endUnsafe(queue)))
+            yield* hooks.subscribe((sessionId, activity) => {
+              if (sessionId === options.providerSessionId) Queue.offerUnsafe(queue, activity)
+            })
+            return Stream.fromQueue(queue)
+          }),
+        // Claude offers no cheap truthful liveness query for a session it
+        // is not driving; the domain's linked-terminal liveness carries
+        // staleness re-derivation for TUI-driven Claude sessions.
+        checkSession: () => Effect.succeed("unknown" as const),
+        releaseSession: (options) =>
+          Effect.gen(function* () {
+            yield* hooks.revokeSecret(options.providerSessionId)
+            yield* removeHookFiles(options.providerSessionId)
           }),
       }
       return adapter

--- a/app-server/src/agents/claudeHooks.ts
+++ b/app-server/src/agents/claudeHooks.ts
@@ -6,16 +6,18 @@ import type { AgentActivity } from "./agentAdapter.ts"
 // vocabulary into activity signals, fed from two transports — in-process
 // SDK callbacks while ATC drives a session (claudeAdapter.ts), and the
 // internal webhook below while a TUI drives one. TUI-driven sessions have
-// no adapter connection (one-writer rule), so webhook activity is consumed
-// via `subscribe` by whatever owns TUI session state — ATC-124's job; in
-// ATC-123 deliveries are validated and then dropped. The webhook is
-// machine-to-machine plumbing whose payload shape Claude Code owns, so it
-// is deliberately NOT in the public contract or openapi.json. Spoofing is
-// guarded by a per-session secret carried in the x-atc-hook-secret header
-// (minted at TUI launch; a re-mint invalidates the session's prior secret);
-// a payload whose session_id disagrees with the secret's registration is
-// dropped. Hooks carry no turn or request correlation ids, so they
-// normalize to activity only — never to turn or request events.
+// no adapter connection (one-writer rule), so webhook activity reaches
+// consumers via `subscribe` — the Claude adapter's observeSession is the
+// subscriber, filtering per session for the seam's activity stream. The
+// webhook is machine-to-machine plumbing whose payload shape Claude Code
+// owns, so it is deliberately NOT in the public contract or openapi.json.
+// Spoofing is guarded by a per-session secret carried in the
+// x-atc-hook-secret header (stable per thread: persisted in the thread's
+// opaque provider metadata and adopted back after restarts; registering a
+// different secret invalidates the prior one); a payload whose session_id
+// disagrees with the secret's registration is dropped. Hooks carry no turn
+// or request correlation ids, so they normalize to activity only — never
+// to turn or request events.
 
 /** What one hook event says about the session's activity, if anything. */
 export const hookActivity = (
@@ -64,11 +66,18 @@ export class ClaudeHooks extends Context.Service<
   {
     /**
      * Mint and register the webhook secret for one provider session,
-     * replacing (and invalidating) any prior secret for that session. The
-     * registration lives until replaced; scoping secrets to the TUI
-     * terminal session's lifetime is ATC-124 work.
+     * replacing (and invalidating) any prior secret for that session.
+     * The registration lives until replaced, adopted over, or revoked.
      */
     readonly registerSecret: (providerSessionId: string) => Effect.Effect<string>
+    /**
+     * Register a known secret for one provider session (the persisted
+     * per-thread secret being restored after a restart or reused across
+     * launches), replacing any prior registration. Idempotent.
+     */
+    readonly adoptSecret: (providerSessionId: string, secret: string) => Effect.Effect<void>
+    /** Drop the session's registration (thread deletion). Idempotent. */
+    readonly revokeSecret: (providerSessionId: string) => Effect.Effect<void>
     /**
      * Subscribe to normalized webhook activity for TUI-driven sessions
      * (nothing subscribes in ATC-123). Scoped: closing unsubscribes.
@@ -90,16 +99,27 @@ export const layer = Layer.effect(ClaudeHooks)(
     const secrets = new Map<string, string>()
     const secretForSession = new Map<string, string>()
     const listeners = new Set<HookListener>()
+    const adopt = (providerSessionId: string, secret: string): void => {
+      const previous = secretForSession.get(providerSessionId)
+      if (previous !== undefined) secrets.delete(previous)
+      secrets.set(secret, providerSessionId)
+      secretForSession.set(providerSessionId, secret)
+    }
     return {
       registerSecret: (providerSessionId: string) =>
         Effect.sync(() => {
-          const previous = secretForSession.get(providerSessionId)
-          if (previous !== undefined) secrets.delete(previous)
           const secret =
             crypto.randomUUID().replaceAll("-", "") + crypto.randomUUID().replaceAll("-", "")
-          secrets.set(secret, providerSessionId)
-          secretForSession.set(providerSessionId, secret)
+          adopt(providerSessionId, secret)
           return secret
+        }),
+      adoptSecret: (providerSessionId: string, secret: string) =>
+        Effect.sync(() => adopt(providerSessionId, secret)),
+      revokeSecret: (providerSessionId: string) =>
+        Effect.sync(() => {
+          const previous = secretForSession.get(providerSessionId)
+          if (previous !== undefined) secrets.delete(previous)
+          secretForSession.delete(providerSessionId)
         }),
       subscribe: (listener: HookListener) =>
         Effect.gen(function* () {

--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -1,5 +1,11 @@
-import { Cause, Context, Effect, Layer, Queue, Schema, Semaphore, Stream } from "effect"
-import type { AgentActivity, AgentAdapter, AgentConnection, AgentEvent } from "./agentAdapter.ts"
+import { Cause, Context, Deferred, Effect, Layer, Queue, Schema, Semaphore, Stream } from "effect"
+import type {
+  AgentActivity,
+  AgentAdapter,
+  AgentConnection,
+  AgentEvent,
+  EstablishedIdentity,
+} from "./agentAdapter.ts"
 import {
   AgentConflict,
   AgentIdentityMismatch,
@@ -60,6 +66,14 @@ const ThreadReply = Schema.Struct({
 
 const TurnReply = Schema.Struct({ turn: Schema.Struct({ id: Schema.String }) })
 
+// The real thread/list reply is paginated: { data, nextCursor } (probe
+// evidence in experiments/provider-identity-resume, pinned generated schema
+// V2ThreadListResponse). nextCursor is absent or null on the last page.
+const ThreadListReply = Schema.Struct({
+  data: Schema.Array(Schema.Struct({ id: Schema.String, status: Schema.optional(Schema.Unknown) })),
+  nextCursor: Schema.optional(Schema.NullOr(Schema.String)),
+})
+
 const statusToActivity = (status: unknown): AgentActivity => {
   if (typeof status !== "object" || status === null) return "unknown"
   const record = status as { type?: unknown; activeFlags?: unknown }
@@ -115,9 +129,43 @@ export const layer = Layer.effect(CodexAdapter)(
     // All live writer sessions, keyed by thread id. They always belong to
     // `current`; a connection teardown fails and clears every one of them.
     const sessions = new Map<string, LiveSession>()
+    // Passive per-thread activity observers (TUI-driven sessions). Unlike
+    // sessions they survive reconnects: the map is adapter-level, and a new
+    // connection's broadcasts route to the same queues.
+    const observers = new Map<string, Set<Queue.Queue<AgentActivity, Cause.Done>>>()
     const connectLock = yield* Semaphore.make(1)
     const resumeLock = yield* Semaphore.make(1)
+    // Serializes TUI launch → thread/started capture (prepareTuiSession).
+    const launchLock = yield* Semaphore.make(1)
+    interface PendingCapture {
+      readonly cwd: string
+      readonly gate: Deferred.Deferred<
+        EstablishedIdentity,
+        AgentUnavailable | AgentIdentityMismatch | AgentProtocolError
+      >
+    }
+    let pendingCapture: PendingCapture | null = null
     let current: ClientState | null = null
+
+    /**
+     * A broadcast `thread/started` while a capture is armed: adopt the new
+     * thread iff its cwd matches the launch we serialized. A different cwd
+     * is another client's thread — leave the capture armed. (A manual
+     * `codex --remote` in the same cwd inside this window is the accepted,
+     * recorded residual risk.)
+     */
+    const captureStarted = (params: Record<string, unknown>): void => {
+      if (pendingCapture === null) return
+      const thread = params["thread"] as { id?: unknown; cwd?: unknown } | undefined
+      if (typeof thread?.id !== "string" || typeof thread.cwd !== "string") return
+      if (!samePath(thread.cwd, pendingCapture.cwd)) return
+      const capture = pendingCapture
+      pendingCapture = null
+      Deferred.doneUnsafe(
+        capture.gate,
+        Effect.succeed({ providerSessionId: thread.id, cwd: capture.cwd }),
+      )
+    }
 
     const emit = (session: LiveSession, event: AgentEvent): void => {
       Queue.offerUnsafe(session.queue, event)
@@ -138,6 +186,13 @@ export const layer = Layer.effect(CodexAdapter)(
           Queue.failCauseUnsafe(session.queue, Cause.fail(error))
         }
         sessions.clear()
+        // An armed capture fails closed with the connection: the caller
+        // abandons the launch and retries rather than adopting anything
+        // observed through a fresh, unserialized window.
+        if (pendingCapture !== null) {
+          Deferred.doneUnsafe(pendingCapture.gate, Effect.fail(error))
+          pendingCapture = null
+        }
       }
       state.socket.close()
     }
@@ -178,8 +233,17 @@ export const layer = Layer.effect(CodexAdapter)(
       params: Record<string, unknown> | undefined
     }): void => {
       const params = message.params ?? {}
+      if (message.method === "thread/started") return captureStarted(params)
       const threadId = params["threadId"]
       if (typeof threadId !== "string") return
+      // Coarse status fans out to every thread on the shared server without
+      // subscription (probed) — observers get it even with no writer session.
+      if (message.method === "thread/status/changed") {
+        const activity = statusToActivity(params["status"])
+        for (const queue of observers.get(threadId) ?? []) {
+          Queue.offerUnsafe(queue, activity)
+        }
+      }
       const session = sessions.get(threadId)
       if (session === undefined) return
       switch (message.method) {
@@ -361,6 +425,12 @@ export const layer = Layer.effect(CodexAdapter)(
       }),
     )
 
+    // The passive seam methods promise only AgentUnavailable: a broken
+    // handshake is "cannot consult the provider right now" to them.
+    const getClientRetryable = getClient.pipe(
+      Effect.catchTag("AgentProtocolError", (error) => Effect.fail(unavailable(error.reason))),
+    )
+
     // Close the socket with the layer; the detached server itself lives on.
     yield* Effect.addFinalizer(() =>
       Effect.sync(() => {
@@ -475,28 +545,36 @@ export const layer = Layer.effect(CodexAdapter)(
       capabilities: { testedVersion: CODEX_TESTED_VERSION, tuiObservation: "shared-server" },
       createSession: (options) =>
         Effect.gen(function* () {
-          const state = yield* getClient
-          const reply = yield* request(state, "thread/start", {
-            cwd: options.cwd,
-            approvalPolicy: "never",
-            sandbox: "workspace-write",
-          }).pipe(Effect.mapError(rpcToProtocol))
-          const decoded = yield* decodeReply(ThreadReply, reply)
-          if (!samePath(decoded.thread.cwd, options.cwd)) {
-            return yield* Effect.fail(
-              new AgentIdentityMismatch({
-                provider: "codex",
-                field: "cwd",
-                expected: options.cwd,
-                actual: decoded.thread.cwd,
-              }),
-            )
-          }
-          const { connection, unregister } = yield* registerSession(
-            state,
-            decoded.thread.id,
-            options.cwd,
-            decoded.thread.status,
+          // thread/start broadcasts thread/started to every socket — ours
+          // included — so it must never run while a TUI capture is armed:
+          // an ATC-driven create in the same cwd would be mis-adopted as
+          // the TUI's identity. The launch lock serializes both paths.
+          const { connection, unregister } = yield* launchLock.withPermits(1)(
+            Effect.gen(function* () {
+              const state = yield* getClient
+              const reply = yield* request(state, "thread/start", {
+                cwd: options.cwd,
+                approvalPolicy: "never",
+                sandbox: "workspace-write",
+              }).pipe(Effect.mapError(rpcToProtocol))
+              const decoded = yield* decodeReply(ThreadReply, reply)
+              if (!samePath(decoded.thread.cwd, options.cwd)) {
+                return yield* Effect.fail(
+                  new AgentIdentityMismatch({
+                    provider: "codex",
+                    field: "cwd",
+                    expected: options.cwd,
+                    actual: decoded.thread.cwd,
+                  }),
+                )
+              }
+              return yield* registerSession(
+                state,
+                decoded.thread.id,
+                options.cwd,
+                decoded.thread.status,
+              )
+            }),
           )
           // The seam widens startTurn's errors for deferred-verification
           // providers; codex verified above, so those tags are impossible.
@@ -568,10 +646,99 @@ export const layer = Layer.effect(CodexAdapter)(
           const executable = yield* resolveProviderExecutable("codex", config.codexExecutable)
           const info = yield* codexServer.ensure()
           return {
-            command: [executable, "resume", "--remote", info.url, options.providerSessionId],
-            env: {},
+            launchSpec: {
+              command: [executable, "resume", "--remote", info.url, options.providerSessionId],
+              env: {},
+            },
           }
         }),
+      prepareTuiSession: (options) =>
+        Effect.gen(function* () {
+          const executable = yield* resolveProviderExecutable("codex", config.codexExecutable)
+          // The held observer connection is the capture channel: it must
+          // exist before the TUI can be launched.
+          yield* getClientRetryable
+          const info = yield* codexServer.ensure()
+          // Codex has no pre-assignment flag, so identity is captured from
+          // the fresh TUI's thread/started broadcast. The launch lock is
+          // held for the caller's whole scope: launch → capture is
+          // serialized (against other prepares AND createSession's own
+          // thread/start), making the correlation deterministic. Interruptible:
+          // a queued caller must stay cancellable while a slow capture holds
+          // the permit.
+          yield* Effect.acquireRelease(launchLock.take(1), () => launchLock.release(1), {
+            interruptible: true,
+          })
+          const gate = yield* Deferred.make<
+            EstablishedIdentity,
+            AgentUnavailable | AgentIdentityMismatch | AgentProtocolError
+          >()
+          pendingCapture = { cwd: options.cwd, gate }
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              if (pendingCapture?.gate !== gate) return
+              pendingCapture = null
+              // Anyone still awaiting identity outside the scope must not
+              // hang forever on an abandoned launch.
+              Deferred.doneUnsafe(gate, Effect.fail(unavailable("the launch was abandoned")))
+            }),
+          )
+          return {
+            launchSpec: { command: [executable, "--remote", info.url], env: {} },
+            identity: Deferred.await(gate),
+          }
+        }),
+      observeSession: (options) =>
+        Effect.gen(function* () {
+          // Ensure the shared connection exists — it is the evidence source.
+          yield* getClientRetryable
+          const queue = yield* Queue.make<AgentActivity, Cause.Done>()
+          const set = observers.get(options.providerSessionId) ?? new Set()
+          set.add(queue)
+          observers.set(options.providerSessionId, set)
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              set.delete(queue)
+              if (set.size === 0) observers.delete(options.providerSessionId)
+              Queue.endUnsafe(queue)
+            }),
+          )
+          return Stream.fromQueue(queue)
+        }),
+      checkSession: (options) =>
+        Effect.gen(function* () {
+          const state = yield* getClientRetryable
+          // thread/list (probed) is the reconciliation aid: absent thread or
+          // undeterminable status is honestly `unknown`, never a guess. The
+          // reply is paginated; walk pages until the target thread appears
+          // or the cursor runs out.
+          let cursor: string | undefined
+          while (true) {
+            const reply = yield* request(
+              state,
+              "thread/list",
+              cursor === undefined ? {} : { cursor },
+            ).pipe(
+              Effect.mapError((error) =>
+                unavailable(error._tag === "RpcError" ? error.text : error.reason),
+              ),
+            )
+            const decoded = yield* Schema.decodeUnknownEffect(ThreadListReply)(reply).pipe(
+              Effect.mapError((error) =>
+                unavailable(`unexpected thread/list reply: ${error.message}`),
+              ),
+            )
+            const thread = decoded.data.find((t) => t.id === options.providerSessionId)
+            if (thread !== undefined) return statusToActivity(thread.status)
+            const next = decoded.nextCursor
+            // A repeated cursor cannot make progress; treat it as the end.
+            if (typeof next !== "string" || next === cursor) return "unknown"
+            cursor = next
+          }
+        }),
+      // Codex holds no per-session launch files or secrets; provider-owned
+      // rollouts are never ATC's to touch.
+      releaseSession: () => Effect.void,
     }
     return adapter
   }),

--- a/app-server/src/api/contract.ts
+++ b/app-server/src/api/contract.ts
@@ -193,6 +193,40 @@ export const AgentId = Schema.Literals(AGENT_IDS).annotate({
   description: "Built-in agent registry slug.",
 })
 
+export const Agent = Schema.Struct({
+  id: AgentId,
+  available: Schema.Boolean.annotate({
+    description: "Whether the agent's CLI is installed and resolvable right now.",
+  }),
+  // Absent keys (not null) for optional fields — see UpdateProjectRequest.
+  reason: Schema.optionalKey(
+    Schema.String.annotate({
+      description: "Actionable install-or-configure hint; absent when available.",
+    }),
+  ),
+  detectedVersion: Schema.optionalKey(
+    Schema.String.annotate({
+      description: "Installed CLI version, when it could be determined.",
+    }),
+  ),
+  testedVersion: Schema.String.annotate({
+    description: "Version the adapter was validated against (drift warns, never blocks).",
+  }),
+  tuiObservation: Schema.Literals(["shared-server", "hooks"]).annotate({
+    description:
+      "How live activity is observed while a TUI drives a session: full event fan-out from the shared provider server, or coarser provider hook callbacks.",
+  }),
+}).annotate({
+  identifier: "Agent",
+  description:
+    "A built-in agent provider: availability and capability report, detected on demand and never persisted.",
+})
+
+export const AgentList = Schema.Array(Agent).annotate({
+  identifier: "AgentList",
+  description: "The built-in agent registry.",
+})
+
 export const ThreadActivityState = Schema.Literals([
   "idle",
   "working",
@@ -398,6 +432,21 @@ export class ProjectHasThreads extends Schema.TaggedErrorClass<ProjectHasThreads
 ) {
   override get message(): string {
     return `project ${this.projectId} still owns ${this.threadCount} thread(s); delete them first`
+  }
+}
+
+/** Unknown agent registry slug. */
+export class AgentNotFound extends Schema.TaggedErrorClass<AgentNotFound>()(
+  "AgentNotFound",
+  { agentId: Schema.String },
+  {
+    identifier: "AgentNotFound",
+    description: "No built-in agent exists with the given id.",
+    httpApiStatus: 404,
+  },
+) {
+  override get message(): string {
+    return `no agent with id ${this.agentId}`
   }
 }
 
@@ -636,6 +685,19 @@ export class V1 extends HttpApiGroup.make("v1")
         OpenApi.Description,
         "Delete the thread: kill its live linked terminal if one is open, then remove the record. Provider-owned conversation history is never touched.",
       ),
+    HttpApiEndpoint.get("listAgents", "/agents", { success: AgentList })
+      .annotate(OpenApi.Identifier, "listAgents")
+      .annotate(
+        OpenApi.Description,
+        "List the built-in agents with availability and capabilities, detected on demand.",
+      ),
+    HttpApiEndpoint.get("getAgent", "/agents/:agentId", {
+      params: { agentId: Schema.String },
+      success: Agent,
+      error: AgentNotFound,
+    })
+      .annotate(OpenApi.Identifier, "getAgent")
+      .annotate(OpenApi.Description, "Fetch one built-in agent by its registry slug."),
     HttpApiEndpoint.get("checkDirectory", "/fs/check", {
       query: { path: AbsolutePath },
       success: FsCheckResponse,

--- a/app-server/src/api/handlers.ts
+++ b/app-server/src/api/handlers.ts
@@ -1,6 +1,7 @@
 import { Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { Api } from "./contract.ts"
+import { AgentRegistry } from "../agents/agentRegistry.ts"
 import { BuildInfo } from "../platform/buildInfo.ts"
 import { Directories } from "../platform/directories.ts"
 import { Projects } from "../projects/projects.ts"
@@ -21,6 +22,7 @@ export const V1Handlers = HttpApiBuilder.group(
     const directories = yield* Directories
     const terminals = yield* Terminals
     const threads = yield* Threads
+    const agents = yield* AgentRegistry
     // Attach bridges outlive their originating requests (Bun aborts the
     // request on protocol switch); they live in the handler layer's scope,
     // so server shutdown still reaps every bridge and its PTY client.
@@ -58,6 +60,8 @@ export const V1Handlers = HttpApiBuilder.group(
       .handle("archiveThread", ({ params }) => threads.archive(params.threadId))
       .handle("unarchiveThread", ({ params }) => threads.unarchive(params.threadId))
       .handle("deleteThread", ({ params }) => threads.delete(params.threadId))
+      .handle("listAgents", () => agents.list())
+      .handle("getAgent", ({ params }) => agents.get(params.agentId))
       .handleRaw("attachTerminal", attachTerminal({ terminals, bridgeScope }))
   }),
 )

--- a/app-server/src/server.ts
+++ b/app-server/src/server.ts
@@ -3,7 +3,11 @@ import { Layer } from "effect"
 import { HttpMiddleware, HttpRouter, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { Api } from "./api/contract.ts"
+import * as AgentRegistry from "./agents/agentRegistry.ts"
+import * as ClaudeAdapter from "./agents/claudeAdapter.ts"
 import * as ClaudeHooks from "./agents/claudeHooks.ts"
+import * as CodexAdapter from "./agents/codexAdapter.ts"
+import * as CodexServer from "./agents/codexServer.ts"
 import * as Directories from "./platform/directories.ts"
 import { V1Handlers } from "./api/handlers.ts"
 import * as LocalTrust from "./api/localTrust.ts"
@@ -71,7 +75,9 @@ export const layer = (options: { readonly port: number }) =>
 export const production = (options: { readonly port: number }) =>
   layer(options).pipe(
     Layer.provide([Projects.layer, Threads.layer]),
-    Layer.provide(Terminals.layer),
+    Layer.provide([Terminals.layer, AgentRegistry.layer]),
+    Layer.provide([CodexAdapter.layer, ClaudeAdapter.layer]),
+    Layer.provide(CodexServer.layer),
     Layer.provide([
       ProjectRepository.layer,
       TerminalRepository.layer,

--- a/app-server/test/agents/agentRegistry.test.ts
+++ b/app-server/test/agents/agentRegistry.test.ts
@@ -1,0 +1,95 @@
+import { assert, describe, it } from "@effect/vitest"
+import { BunHttpServer, BunServices } from "@effect/platform-bun"
+import { Effect, Layer } from "effect"
+import { HttpApiTest } from "effect/unstable/httpapi"
+import * as AgentRegistry from "../../src/agents/agentRegistry.ts"
+import * as ClaudeAdapter from "../../src/agents/claudeAdapter.ts"
+import * as CodexAdapter from "../../src/agents/codexAdapter.ts"
+import * as Subprocess from "../../src/platform/subprocess.ts"
+import { Api } from "../../src/api/contract.ts"
+import { V1Handlers } from "../../src/api/handlers.ts"
+import { TestBuildInfoLayer } from "../testBuildInfo.ts"
+import { makeTestServiceLayers, testAppConfig } from "../testLayers.ts"
+import { makeFakeAgentAdapter } from "./fakeAgentAdapter.ts"
+
+// The read-only agents registry through the public contract (ATC-140):
+// demand-driven detection over the fake adapters, capability report from
+// the seam, unknown slugs 404. Nothing is persisted anywhere.
+
+const kit = makeTestServiceLayers()
+const TestLayer = Layer.mergeAll(
+  V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, kit.layer])),
+  kit.layer,
+  BunHttpServer.layerHttpServices,
+)
+
+describe("/api/v1/agents", () => {
+  it.effect("lists both built-in agents with each adapter's own capability report", () =>
+    Effect.gen(function* () {
+      const client = yield* HttpApiTest.groups(Api, ["v1"])
+      const agents = yield* client.v1.listAgents()
+      // Per-slug capabilities: a swapped slug→adapter mapping fails here.
+      assert.deepStrictEqual(
+        agents.map(({ id, testedVersion, tuiObservation }) => ({
+          id,
+          testedVersion,
+          tuiObservation,
+        })),
+        [
+          { id: "codex", testedVersion: "0.0.0-fake", tuiObservation: "shared-server" },
+          { id: "claude-code", testedVersion: "0.0.0-fake-claude", tuiObservation: "hooks" },
+        ],
+      )
+      // /bin/echo resolves, so both are available.
+      for (const agent of agents) {
+        assert.isTrue(agent.available)
+        assert.isUndefined(agent.reason)
+      }
+      assert.deepStrictEqual(
+        yield* client.v1.getAgent({ params: { agentId: "claude-code" } }),
+        agents[1],
+      )
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("adapterFor hands back the adapter behind the slug", () =>
+    Effect.gen(function* () {
+      const registry = yield* AgentRegistry.AgentRegistry
+      assert.strictEqual(registry.adapterFor("codex"), kit.fakeAgents.codex.adapter)
+      assert.strictEqual(registry.adapterFor("claude-code"), kit.fakeAgents.claude.adapter)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("an unknown slug is AgentNotFound", () =>
+    Effect.gen(function* () {
+      const client = yield* HttpApiTest.groups(Api, ["v1"])
+      const error = yield* Effect.flip(client.v1.getAgent({ params: { agentId: "gpt" } }))
+      assert.strictEqual(error._tag, "AgentNotFound")
+      if (error._tag === "AgentNotFound") assert.strictEqual(error.agentId, "gpt")
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("a missing executable reports unavailable with the actionable hint", () =>
+    Effect.gen(function* () {
+      const registry = yield* AgentRegistry.AgentRegistry
+      const agent = yield* registry.get("codex")
+      assert.isFalse(agent.available)
+      assert.include(agent.reason ?? "", "codexExecutable")
+      assert.isUndefined(agent.detectedVersion)
+    }).pipe(
+      Effect.provide(
+        AgentRegistry.layer.pipe(
+          Layer.provide([
+            Layer.succeed(CodexAdapter.CodexAdapter)(makeFakeAgentAdapter().adapter),
+            Layer.succeed(ClaudeAdapter.ClaudeAdapter)(makeFakeAgentAdapter().adapter),
+            testAppConfig({
+              codexExecutable: "/definitely/not/codex",
+              claudeExecutable: "/definitely/not/claude",
+            }),
+            Subprocess.layer.pipe(Layer.provide(BunServices.layer)),
+          ]),
+        ),
+      ),
+    ),
+  )
+})

--- a/app-server/test/agents/agentTestKit.ts
+++ b/app-server/test/agents/agentTestKit.ts
@@ -90,10 +90,12 @@ export const codexAdapterLayer = (sandbox: {
 export const claudeAdapterLayer = (
   options: ClaudeAdapter.ClaudeAdapterOptions = {},
   executable = "/bin/echo",
+  configOverrides: Partial<Parameters<typeof testAppConfig>[0]> = {},
+  hooksLayer: Layer.Layer<ClaudeHooks.ClaudeHooks> = ClaudeHooks.layer,
 ): Layer.Layer<ClaudeAdapter.ClaudeAdapter | ClaudeHooks.ClaudeHooks, unknown> =>
   ClaudeAdapter.layerWith(options).pipe(
-    Layer.provideMerge(ClaudeHooks.layer),
-    Layer.provide(testAppConfig({ claudeExecutable: executable })),
+    Layer.provideMerge(hooksLayer),
+    Layer.provide(testAppConfig({ claudeExecutable: executable, ...configOverrides })),
     Layer.provide(Subprocess.layer),
     Layer.provideMerge(BunServices.layer),
   )

--- a/app-server/test/agents/claudeAdapter.test.ts
+++ b/app-server/test/agents/claudeAdapter.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect } from "effect"
+import { Effect, Layer, Stream } from "effect"
 import * as fs from "node:fs"
 import * as os from "node:os"
 import * as path from "node:path"
@@ -320,7 +320,15 @@ describe("ClaudeAdapter", () => {
       yield* Effect.gen(function* () {
         const adapter = yield* ClaudeAdapter.ClaudeAdapter
         const hooks = yield* ClaudeHooks.ClaudeHooks
-        const spec = yield* adapter.tuiLaunch({ providerSessionId: "session-t", cwd: "/w" })
+        const launch = yield* adapter.tuiLaunch({
+          providerSessionId: "session-t",
+          cwd: "/w",
+          providerMetadata: undefined,
+        })
+        const spec = launch.launchSpec
+        // A launch that minted the secret hands the metadata back so the
+        // caller can persist it.
+        assert.isString(launch.providerMetadata)
         assert.strictEqual(spec.command[0], "/bin/echo")
         assert.deepStrictEqual(spec.command.slice(1, 3), ["--resume", "session-t"])
         assert.strictEqual(spec.command[3], "--settings")
@@ -342,13 +350,242 @@ describe("ClaudeAdapter", () => {
           new RegExp(`${ClaudeHooks.SECRET_HEADER}: ([a-f0-9]+)`).exec(header)?.[1] ?? ""
         assert.isAbove(secret.length, 30)
         assert.notInclude(command, secret)
+        // The returned metadata carries exactly the registered secret.
+        assert.strictEqual(
+          (JSON.parse(launch.providerMetadata ?? "{}") as { hookSecret?: string }).hookSecret,
+          secret,
+        )
         // The secret is live: a delivery for the registered session lands.
         const status = yield* hooks.deliver(secret, {
           session_id: "session-t",
           hook_event_name: "Stop",
         })
         assert.strictEqual(status, 204)
+        // A relaunch that hands the metadata back keeps the same secret —
+        // the running TUI's hooks stay valid.
+        const relaunch = yield* adapter.tuiLaunch({
+          providerSessionId: "session-t",
+          cwd: "/w",
+          providerMetadata: launch.providerMetadata,
+        })
+        assert.strictEqual(relaunch.providerMetadata, launch.providerMetadata)
       }).pipe(Effect.provide(layer))
+    }),
+  )
+})
+
+// ATC-140: the TUI-session plumbing — pre-assigned identity, hook-secret
+// metadata, webhook-fed observation, and release cleanup. No query() seam
+// involved: nothing here spawns or scripts the SDK.
+describe("ClaudeAdapter TUI session plumbing", () => {
+  const stateDir = () => trackTempDir(fs.mkdtempSync(path.join(os.tmpdir(), "atc-claude-state-")))
+
+  /** The real hooks service, with minted secrets recorded for assertions. */
+  const spyHooksLayer = (minted: Array<string>) =>
+    Layer.effect(ClaudeHooks.ClaudeHooks)(
+      Effect.gen(function* () {
+        const real = yield* ClaudeHooks.ClaudeHooks
+        return {
+          ...real,
+          registerSecret: (providerSessionId: string) =>
+            real
+              .registerSecret(providerSessionId)
+              .pipe(Effect.tap((secret) => Effect.sync(() => minted.push(secret)))),
+        }
+      }),
+    ).pipe(Layer.provide(ClaudeHooks.layer))
+
+  /** Collect an activity stream into a sink in the background (scoped). */
+  const collectActivity = (stream: Stream.Stream<string>) =>
+    Effect.gen(function* () {
+      const sink: Array<string> = []
+      yield* stream.pipe(
+        Stream.runForEach((activity) => Effect.sync(() => sink.push(activity))),
+        Effect.ignore,
+        Effect.forkScoped,
+      )
+      return sink
+    })
+
+  const waitForActivity = (sink: Array<string>, wanted: string) =>
+    Effect.gen(function* () {
+      for (let attempt = 0; !sink.includes(wanted); attempt++) {
+        assert.isBelow(attempt, 200, `never saw ${wanted} in ${JSON.stringify(sink)}`)
+        yield* Effect.sleep("10 millis")
+      }
+    })
+
+  it.live("prepareTuiSession pre-assigns identity and writes the hook plumbing", () =>
+    Effect.gen(function* () {
+      const cwd = workDir()
+      const dir = stateDir()
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        const hooks = yield* ClaudeHooks.ClaudeHooks
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const prepared = yield* adapter.prepareTuiSession({ cwd })
+            // Identity resolves immediately: pre-assignment, not capture.
+            const identity = yield* prepared.identity
+            assert.match(
+              identity.providerSessionId,
+              /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+            )
+            assert.strictEqual(identity.cwd, cwd)
+            assert.deepStrictEqual(prepared.launchSpec.command.slice(1, 3), [
+              "--session-id",
+              identity.providerSessionId,
+            ])
+            const settingsFile = prepared.launchSpec.command[4]!
+            assert.isTrue(fs.existsSync(settingsFile))
+            // The metadata carries the secret; the registration accepts it.
+            const metadata = JSON.parse(identity.providerMetadata ?? "{}") as {
+              hookSecret?: string
+            }
+            assert.isString(metadata.hookSecret)
+            const status = yield* hooks.deliver(metadata.hookSecret ?? "", {
+              session_id: identity.providerSessionId,
+              hook_event_name: "Stop",
+            })
+            assert.strictEqual(status, 204)
+          }),
+        )
+      }).pipe(Effect.provide(claudeAdapterLayer({}, "/bin/echo", { stateDir: dir })))
+    }),
+  )
+
+  it.live("observeSession restores the persisted secret and streams webhook activity", () =>
+    Effect.gen(function* () {
+      const dir = stateDir()
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        const hooks = yield* ClaudeHooks.ClaudeHooks
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            // The secret arrives only via persisted metadata — the register
+            // path never ran in this "restarted" process.
+            const secret = "a".repeat(64)
+            const metadata = JSON.stringify({ hookSecret: secret })
+            const stream = yield* adapter.observeSession({
+              providerSessionId: "restored-session",
+              providerMetadata: metadata,
+            })
+            const sink = yield* collectActivity(stream)
+            const status = yield* hooks.deliver(secret, {
+              session_id: "restored-session",
+              hook_event_name: "UserPromptSubmit",
+            })
+            assert.strictEqual(status, 204)
+            yield* waitForActivity(sink, "working")
+            // Another session's activity never leaks into this stream.
+            const otherSecret = "b".repeat(64)
+            yield* hooks.adoptSecret("other-session", otherSecret)
+            yield* hooks.deliver(otherSecret, {
+              session_id: "other-session",
+              hook_event_name: "Stop",
+            })
+            yield* hooks.deliver(secret, {
+              session_id: "restored-session",
+              hook_event_name: "Stop",
+            })
+            yield* waitForActivity(sink, "idle")
+            assert.deepStrictEqual(sink, ["working", "idle"])
+          }),
+        )
+      }).pipe(Effect.provide(claudeAdapterLayer({}, "/bin/echo", { stateDir: dir })))
+    }),
+  )
+
+  it.live("releaseSession removes the hook files and revokes the secret", () =>
+    Effect.gen(function* () {
+      const cwd = workDir()
+      const dir = stateDir()
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        const hooks = yield* ClaudeHooks.ClaudeHooks
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const prepared = yield* adapter.prepareTuiSession({ cwd })
+            const identity = yield* prepared.identity
+            const settingsFile = prepared.launchSpec.command[4]!
+            const metadata = JSON.parse(identity.providerMetadata ?? "{}") as {
+              hookSecret?: string
+            }
+            yield* adapter.releaseSession({
+              providerSessionId: identity.providerSessionId,
+              providerMetadata: identity.providerMetadata,
+            })
+            assert.isFalse(fs.existsSync(settingsFile))
+            assert.isFalse(fs.existsSync(settingsFile.replace(/\.json$/, ".header")))
+            const status = yield* hooks.deliver(metadata.hookSecret ?? "", {
+              session_id: identity.providerSessionId,
+              hook_event_name: "Stop",
+            })
+            assert.strictEqual(status, 404)
+          }),
+        )
+      }).pipe(Effect.provide(claudeAdapterLayer({}, "/bin/echo", { stateDir: dir })))
+    }),
+  )
+
+  it.live("a failed prepare revokes the freshly minted secret", () =>
+    Effect.gen(function* () {
+      const cwd = workDir()
+      // stateDir is occupied by a regular file, so the hook plumbing fails
+      // after the secret was minted and registered.
+      const base = trackTempDir(fs.mkdtempSync(path.join(os.tmpdir(), "atc-claude-state-")))
+      const blocked = path.join(base, "not-a-dir")
+      fs.writeFileSync(blocked, "")
+      const minted: Array<string> = []
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        const hooks = yield* ClaudeHooks.ClaudeHooks
+        const failure = yield* Effect.scoped(Effect.flip(adapter.prepareTuiSession({ cwd })))
+        assert.strictEqual(failure._tag, "AgentUnavailable")
+        assert.lengthOf(minted, 1)
+        const status = yield* hooks.deliver(minted[0] ?? "", {
+          session_id: "any",
+          hook_event_name: "Stop",
+        })
+        assert.strictEqual(status, 404)
+      }).pipe(
+        Effect.provide(
+          claudeAdapterLayer({}, "/bin/echo", { stateDir: blocked }, spyHooksLayer(minted)),
+        ),
+      )
+    }),
+  )
+
+  it.live("a failed settings write cleans the partial header file and secret", () =>
+    Effect.gen(function* () {
+      const dir = stateDir()
+      // The settings path is occupied by a directory, so the SECOND write
+      // fails after the header file was written and the secret registered.
+      fs.mkdirSync(path.join(dir, "claude-hooks-session-w.json"))
+      const minted: Array<string> = []
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        const hooks = yield* ClaudeHooks.ClaudeHooks
+        const failure = yield* Effect.flip(
+          adapter.tuiLaunch({
+            providerSessionId: "session-w",
+            cwd: "/w",
+            providerMetadata: undefined,
+          }),
+        )
+        assert.strictEqual(failure._tag, "AgentUnavailable")
+        assert.isFalse(fs.existsSync(path.join(dir, "claude-hooks-session-w.header")))
+        assert.lengthOf(minted, 1)
+        const status = yield* hooks.deliver(minted[0] ?? "", {
+          session_id: "session-w",
+          hook_event_name: "Stop",
+        })
+        assert.strictEqual(status, 404)
+      }).pipe(
+        Effect.provide(
+          claudeAdapterLayer({}, "/bin/echo", { stateDir: dir }, spyHooksLayer(minted)),
+        ),
+      )
     }),
   )
 })

--- a/app-server/test/agents/codexAdapter.test.ts
+++ b/app-server/test/agents/codexAdapter.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect } from "effect"
+import { Effect, Stream } from "effect"
 import * as fs from "node:fs"
 import * as path from "node:path"
 import * as CodexAdapter from "../../src/agents/codexAdapter.ts"
@@ -318,14 +318,15 @@ describe("CodexAdapter", () => {
         const sandbox = makeCodexSandbox()
         yield* withAdapter(sandbox, (adapter) =>
           Effect.gen(function* () {
-            const spec = yield* adapter.tuiLaunch({
+            const { launchSpec } = yield* adapter.tuiLaunch({
               providerSessionId: "some-thread",
               cwd: sandbox.cwd,
+              providerMetadata: undefined,
             })
-            assert.strictEqual(spec.command[0], sandbox.wrapper)
-            assert.deepStrictEqual(spec.command.slice(1, 3), ["resume", "--remote"])
-            assert.match(spec.command[3] ?? "", /^ws:\/\/127\.0\.0\.1:\d+$/)
-            assert.strictEqual(spec.command[4], "some-thread")
+            assert.strictEqual(launchSpec.command[0], sandbox.wrapper)
+            assert.deepStrictEqual(launchSpec.command.slice(1, 3), ["resume", "--remote"])
+            assert.match(launchSpec.command[3] ?? "", /^ws:\/\/127\.0\.0\.1:\d+$/)
+            assert.strictEqual(launchSpec.command[4], "some-thread")
           }),
         )
       }),
@@ -351,6 +352,178 @@ describe("CodexAdapter", () => {
               )
             }),
           ),
+        )
+      }),
+    30_000,
+  )
+})
+
+// ATC-140: fresh-launch identity capture, passive observation, and the
+// thread/list reconciliation check — the TUI stand-in is a second WebSocket
+// client of the same shared fake app-server.
+describe("CodexAdapter TUI session plumbing", () => {
+  const openExternal = (url: string) =>
+    Effect.acquireRelease(
+      Effect.callback<WebSocket>((resume) => {
+        const socket = new WebSocket(url)
+        socket.onopen = () => resume(Effect.succeed(socket))
+      }),
+      (socket) => Effect.sync(() => socket.close()),
+    )
+
+  const externalRequest = (socket: WebSocket, id: number, method: string, params: unknown) =>
+    Effect.callback<Record<string, unknown>>((resume) => {
+      const listener = (event: MessageEvent) => {
+        const message = JSON.parse(String(event.data)) as { id?: number; result?: unknown }
+        if (message.id === id) {
+          socket.removeEventListener("message", listener)
+          resume(Effect.succeed((message.result ?? {}) as Record<string, unknown>))
+        }
+      }
+      socket.addEventListener("message", listener)
+      socket.send(JSON.stringify({ id, method, params }))
+    })
+
+  const startExternalThread = (socket: WebSocket, id: number, cwd: string) =>
+    externalRequest(socket, id, "thread/start", { cwd }).pipe(
+      Effect.map((result) => (result["thread"] as { id: string }).id),
+    )
+
+  const waitForActivity = (sink: Array<string>, wanted: string) =>
+    Effect.gen(function* () {
+      for (let attempt = 0; !sink.includes(wanted); attempt++) {
+        assert.isBelow(attempt, 200, `never saw ${wanted} in ${JSON.stringify(sink)}`)
+        yield* Effect.sleep("25 millis")
+      }
+    })
+
+  it.live(
+    "prepareTuiSession captures the fresh TUI's thread/started identity",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.scoped(
+            Effect.gen(function* () {
+              const prepared = yield* adapter.prepareTuiSession({ cwd: sandbox.cwd })
+              assert.strictEqual(prepared.launchSpec.command[0], sandbox.wrapper)
+              assert.strictEqual(prepared.launchSpec.command[1], "--remote")
+              const url = prepared.launchSpec.command[2] ?? ""
+              assert.match(url, /^ws:\/\/127\.0\.0\.1:\d+$/)
+
+              // The launched TUI stand-in bootstraps a thread in the cwd.
+              const external = yield* openExternal(url)
+              const threadId = yield* startExternalThread(external, 1, sandbox.cwd)
+              const identity = yield* prepared.identity
+              assert.strictEqual(identity.providerSessionId, threadId)
+              assert.strictEqual(identity.cwd, sandbox.cwd)
+            }),
+          ),
+        )
+      }),
+    30_000,
+  )
+
+  it.live(
+    "capture ignores foreign-cwd threads and adopts the matching one",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        const otherCwd = path.join(sandbox.base, "other")
+        fs.mkdirSync(otherCwd, { recursive: true })
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.scoped(
+            Effect.gen(function* () {
+              const prepared = yield* adapter.prepareTuiSession({ cwd: sandbox.cwd })
+              const url = prepared.launchSpec.command[2] ?? ""
+              const external = yield* openExternal(url)
+              // Another client's thread in a different cwd is not ours.
+              const foreignId = yield* startExternalThread(external, 1, otherCwd)
+              const matchingId = yield* startExternalThread(external, 2, sandbox.cwd)
+              const identity = yield* prepared.identity
+              assert.notStrictEqual(identity.providerSessionId, foreignId)
+              assert.strictEqual(identity.providerSessionId, matchingId)
+            }),
+          ),
+        )
+      }),
+    30_000,
+  )
+
+  it.live(
+    "observeSession streams coarse status for a thread it never joined",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.scoped(
+            Effect.gen(function* () {
+              // Arm the shared connection, then drive a thread externally.
+              const activity = yield* adapter.checkSession({ providerSessionId: "none" })
+              assert.strictEqual(activity, "unknown")
+              const identity = JSON.parse(
+                fs.readFileSync(path.join(sandbox.stateDir, "codex-app-server.json"), "utf8"),
+              ) as { port: number }
+              const external = yield* openExternal(`ws://127.0.0.1:${identity.port}`)
+              const threadId = yield* startExternalThread(external, 1, sandbox.cwd)
+
+              const stream = yield* adapter.observeSession({
+                providerSessionId: threadId,
+                providerMetadata: undefined,
+              })
+              const sink: Array<string> = []
+              yield* stream.pipe(
+                Stream.runForEach((value) => Effect.sync(() => sink.push(value))),
+                Effect.ignore,
+                Effect.forkScoped,
+              )
+              yield* externalRequest(external, 2, "turn/start", {
+                threadId,
+                input: [{ type: "text", text: "external turn" }],
+              })
+              yield* waitForActivity(sink, "working")
+              yield* waitForActivity(sink, "idle")
+            }),
+          ),
+        )
+      }),
+    30_000,
+  )
+
+  it.live(
+    "checkSession walks the provider's paginated thread list",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.gen(function* () {
+            // Force the connection + server up before the external client.
+            assert.strictEqual(
+              yield* adapter.checkSession({ providerSessionId: "missing" }),
+              "unknown",
+            )
+            const identity = JSON.parse(
+              fs.readFileSync(path.join(sandbox.stateDir, "codex-app-server.json"), "utf8"),
+            ) as { port: number }
+            // The fake serves one thread per page, so the second thread only
+            // appears after following nextCursor.
+            const laterPage = yield* Effect.scoped(
+              Effect.gen(function* () {
+                const socket = yield* openExternal(`ws://127.0.0.1:${identity.port}`)
+                yield* startExternalThread(socket, 1, sandbox.cwd)
+                return yield* startExternalThread(socket, 2, sandbox.cwd)
+              }),
+            )
+            assert.strictEqual(
+              yield* adapter.checkSession({ providerSessionId: laterPage }),
+              "idle",
+            )
+            // A miss walks every page before answering `unknown`.
+            assert.strictEqual(
+              yield* adapter.checkSession({ providerSessionId: "missing" }),
+              "unknown",
+            )
+          }),
         )
       }),
     30_000,

--- a/app-server/test/agents/fakeAgentAdapter.ts
+++ b/app-server/test/agents/fakeAgentAdapter.ts
@@ -50,6 +50,11 @@ export interface FakeAgentAdapter {
   readonly closeRequest: (providerSessionId: string, requestId: string) => void
 }
 
+export interface FakeAgentAdapterOptions {
+  /** Capability report overrides, so registry tests can tell fakes apart. */
+  readonly capabilities?: Partial<AgentAdapter["capabilities"]>
+}
+
 interface LiveConnection {
   readonly events: Queue.Queue<AgentEvent, Cause.Done>
   activity: AgentActivity
@@ -58,10 +63,11 @@ interface LiveConnection {
   readonly openRequests: Set<string>
 }
 
-export const makeFakeAgentAdapter = (): FakeAgentAdapter => {
+export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): FakeAgentAdapter => {
   const sessions = new Map<string, FakeAgentSession>()
   // One live connection per session — the single-writer rule.
   const connections = new Map<string, LiveConnection>()
+  const observers = new Map<string, Set<Queue.Queue<AgentActivity, Cause.Done>>>()
   let unavailableReason: string | null = null
   let nextSessionId = 1
   let nextTurnId = 1
@@ -190,7 +196,11 @@ export const makeFakeAgentAdapter = (): FakeAgentAdapter => {
 
   const adapter: AgentAdapter = {
     provider: "codex",
-    capabilities: { testedVersion: "0.0.0-fake", tuiObservation: "shared-server" },
+    capabilities: {
+      testedVersion: "0.0.0-fake",
+      tuiObservation: "shared-server",
+      ...options.capabilities,
+    },
     createSession: (options) =>
       Effect.gen(function* () {
         yield* requireAvailable
@@ -236,10 +246,52 @@ export const makeFakeAgentAdapter = (): FakeAgentAdapter => {
     tuiLaunch: (options) =>
       requireAvailable.pipe(
         Effect.as({
-          command: ["fake-agent", "resume", options.providerSessionId],
-          env: {},
+          launchSpec: {
+            command: ["fake-agent", "resume", options.providerSessionId],
+            env: {},
+          },
         }),
       ),
+    prepareTuiSession: (options) =>
+      Effect.gen(function* () {
+        yield* requireAvailable
+        const providerSessionId = `fake-session-${nextSessionId++}`
+        // The prepared session becomes resumable once identity resolves —
+        // mirroring "a completed first interaction materializes it".
+        const identity = Effect.suspend(() => {
+          sessions.set(providerSessionId, { providerSessionId, cwd: options.cwd, inputs: [] })
+          return Effect.succeed({
+            providerSessionId,
+            cwd: options.cwd,
+            providerMetadata: JSON.stringify({ fake: providerSessionId }),
+          })
+        })
+        return {
+          launchSpec: {
+            command: ["fake-agent", "--fresh", providerSessionId],
+            env: { FAKE_AGENT: "1" },
+          },
+          identity,
+        }
+      }),
+    observeSession: (options) =>
+      Effect.gen(function* () {
+        yield* requireAvailable
+        const queue = yield* Queue.make<AgentActivity, Cause.Done>()
+        const set = observers.get(options.providerSessionId) ?? new Set()
+        set.add(queue)
+        observers.set(options.providerSessionId, set)
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            set.delete(queue)
+            if (set.size === 0) observers.delete(options.providerSessionId)
+            Queue.endUnsafe(queue)
+          }),
+        )
+        return Stream.fromQueue(queue)
+      }),
+    checkSession: () => requireAvailable.pipe(Effect.as("unknown" as const)),
+    releaseSession: () => Effect.void,
   }
 
   return {

--- a/app-server/test/api/openapi.test.ts
+++ b/app-server/test/api/openapi.test.ts
@@ -150,6 +150,8 @@ describe("openapi document vs runtime", () => {
       "/api/v1/threads/{threadId}",
       "/api/v1/threads/{threadId}/archive",
       "/api/v1/threads/{threadId}/unarchive",
+      "/api/v1/agents",
+      "/api/v1/agents/{agentId}",
       "/api/v1/fs/check",
     ])
     // The WebSocket attach endpoint is contract-declared but excluded from
@@ -372,6 +374,42 @@ describe("openapi document vs runtime", () => {
         ]!.schema,
         { $ref: "#/components/schemas/Thread" },
       )
+    }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
+  )
+
+  it.effect("/api/v1/agents: listed and fetched payloads match the documented schemas", () =>
+    Effect.gen(function* () {
+      const client = yield* rawClient
+      const listed = yield* client.get("http://127.0.0.1/api/v1/agents")
+      assert.strictEqual(listed.status, 200)
+      const agents = (yield* listed.json) as Array<Record<string, unknown>>
+      assert.deepStrictEqual(
+        agents.map((agent) => agent["id"]),
+        ["codex", "claude-code"],
+      )
+      const schema = componentSchema("Agent")
+      for (const agent of agents) {
+        assert.includeMembers(Object.keys(schema.properties), Object.keys(agent))
+        assert.sameMembers(
+          [...schema.required].filter((key) => !(key in agent)),
+          [],
+        )
+      }
+      assert.deepStrictEqual(
+        operation("/api/v1/agents").responses["200"]!.content["application/json"]!.schema,
+        { $ref: "#/components/schemas/AgentList" },
+      )
+
+      const fetched = yield* client.get("http://127.0.0.1/api/v1/agents/codex")
+      assert.strictEqual(fetched.status, 200)
+      assert.deepStrictEqual(
+        operation("/api/v1/agents/{agentId}").responses["200"]!.content["application/json"]!.schema,
+        { $ref: "#/components/schemas/Agent" },
+      )
+
+      const missing = yield* client.get("http://127.0.0.1/api/v1/agents/nope")
+      assert.strictEqual(missing.status, 404)
+      assert.deepStrictEqual(yield* missing.json, { _tag: "AgentNotFound", agentId: "nope" })
     }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
   )
 

--- a/app-server/test/fixtures/fake-codex-listener.ts
+++ b/app-server/test/fixtures/fake-codex-listener.ts
@@ -120,6 +120,23 @@ const handle = (
     }
     case "thread/unsubscribe":
       return respond({ status: "unsubscribed" })
+    case "thread/list": {
+      // Real reply shape is paginated: { data, nextCursor } with nextCursor
+      // null on the last page. One thread per page forces clients to walk.
+      const all = [...threads.values()]
+      const offset = Number.parseInt(String(params["cursor"] ?? "0"), 10) || 0
+      return respond({
+        data: all.slice(offset, offset + 1).map((thread) => ({
+          id: thread.id,
+          cwd: thread.cwd,
+          status: hangingTurns.has(thread.id)
+            ? { type: "active", activeFlags: [] }
+            : { type: "idle" },
+          turns: thread.turns,
+        })),
+        nextCursor: offset + 1 < all.length ? String(offset + 1) : null,
+      })
+    }
     case "turn/start": {
       const threadId = String(params["threadId"] ?? "")
       const thread = threads.get(threadId)

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -5,7 +5,10 @@ import * as fs from "node:fs"
 import * as os from "node:os"
 import * as path from "node:path"
 import { fileURLToPath } from "node:url"
+import * as AgentRegistry from "../src/agents/agentRegistry.ts"
+import * as ClaudeAdapter from "../src/agents/claudeAdapter.ts"
 import * as ClaudeHooks from "../src/agents/claudeHooks.ts"
+import * as CodexAdapter from "../src/agents/codexAdapter.ts"
 import { AppConfig } from "../src/platform/config.ts"
 import * as Directories from "../src/platform/directories.ts"
 import * as Persistence from "../src/platform/persistence.ts"
@@ -28,6 +31,8 @@ import {
 } from "./blackbox.ts"
 import { makeFakeAdapter } from "./terminals/fakeTerminalAdapter.ts"
 import type { FakeTerminalAdapter } from "./terminals/fakeTerminalAdapter.ts"
+import { makeFakeAgentAdapter } from "./agents/fakeAgentAdapter.ts"
+import type { FakeAgentAdapter } from "./agents/fakeAgentAdapter.ts"
 
 type ServiceLayer = Layer.Layer<
   | ProjectRepository.ProjectRepository
@@ -38,45 +43,6 @@ type ServiceLayer = Layer.Layer<
   | ClaudeHooks.ClaudeHooks,
   unknown
 >
-
-/**
- * Handler dependencies for in-process and ephemeral-listener tests: real
- * repositories over one fresh database (in-memory unless a file is given),
- * real directory checks, and the fake in-memory terminal adapter (returned
- * for failure injection and assertions). `services` omits Terminals so
- * startup-reconciliation tests can seed rows before its layer builds.
- */
-export const makeTestServiceLayers = (
-  dbFile = ":memory:",
-): {
-  readonly fake: FakeTerminalAdapter
-  readonly services: ServiceLayer
-  readonly layer: Layer.Layer<
-    Layer.Success<ServiceLayer> | Terminals.Terminals | Threads.Threads | Projects.Projects,
-    unknown
-  >
-} => {
-  const fake = makeFakeAdapter()
-  const base = Layer.mergeAll(
-    ProjectRepository.layer,
-    TerminalRepository.layer,
-    ThreadRepository.layer,
-  ).pipe(Layer.provide(Persistence.layerFile(dbFile)))
-  const services = Layer.mergeAll(base, Directories.layer, fake.layer, ClaudeHooks.layer)
-  const terminals = Terminals.layer.pipe(Layer.provide(services))
-  return {
-    fake,
-    services,
-    layer: Layer.mergeAll(
-      services,
-      terminals,
-      Threads.layer.pipe(Layer.provide([services, terminals])),
-      Projects.layer.pipe(Layer.provide(services)),
-    ),
-  }
-}
-
-export const TestRepositoryLayers = makeTestServiceLayers().layer
 
 /** A settled AppConfig for tests that only need a few fields overridden. */
 export const testAppConfig = (overrides: Partial<AppConfig["Service"]>): Layer.Layer<AppConfig> =>
@@ -96,6 +62,70 @@ export const testAppConfig = (overrides: Partial<AppConfig["Service"]>): Layer.L
     terminalSocketDir: "/tmp/atc-sockets",
     ...overrides,
   })
+
+/**
+ * Handler dependencies for in-process and ephemeral-listener tests: real
+ * repositories over one fresh database (in-memory unless a file is given),
+ * real directory checks, and the fake in-memory adapters (returned for
+ * failure injection and assertions). Both agent slugs resolve to fake
+ * adapters; the registry detects availability against /bin/echo so no
+ * provider install is ever consulted. `services` omits Terminals so
+ * startup-reconciliation tests can seed rows before its layer builds.
+ */
+export const makeTestServiceLayers = (
+  dbFile = ":memory:",
+): {
+  readonly fake: FakeTerminalAdapter
+  readonly fakeAgents: { readonly codex: FakeAgentAdapter; readonly claude: FakeAgentAdapter }
+  readonly services: ServiceLayer
+  readonly layer: Layer.Layer<
+    | Layer.Success<ServiceLayer>
+    | Terminals.Terminals
+    | Threads.Threads
+    | Projects.Projects
+    | AgentRegistry.AgentRegistry,
+    unknown
+  >
+} => {
+  const fake = makeFakeAdapter()
+  // Distinct capability reports so a swapped slug→adapter mapping cannot
+  // pass the registry tests.
+  const fakeAgents = {
+    codex: makeFakeAgentAdapter(),
+    claude: makeFakeAgentAdapter({
+      capabilities: { testedVersion: "0.0.0-fake-claude", tuiObservation: "hooks" },
+    }),
+  }
+  const base = Layer.mergeAll(
+    ProjectRepository.layer,
+    TerminalRepository.layer,
+    ThreadRepository.layer,
+  ).pipe(Layer.provide(Persistence.layerFile(dbFile)))
+  const services = Layer.mergeAll(base, Directories.layer, fake.layer, ClaudeHooks.layer)
+  const terminals = Terminals.layer.pipe(Layer.provide(services))
+  const registry = AgentRegistry.layer.pipe(
+    Layer.provide([
+      Layer.succeed(CodexAdapter.CodexAdapter)(fakeAgents.codex.adapter),
+      Layer.succeed(ClaudeAdapter.ClaudeAdapter)(fakeAgents.claude.adapter),
+      testAppConfig({ codexExecutable: "/bin/echo", claudeExecutable: "/bin/echo" }),
+      Subprocess.layer.pipe(Layer.provide(BunServices.layer)),
+    ]),
+  )
+  return {
+    fake,
+    fakeAgents,
+    services,
+    layer: Layer.mergeAll(
+      services,
+      terminals,
+      registry,
+      Threads.layer.pipe(Layer.provide([services, terminals])),
+      Projects.layer.pipe(Layer.provide(services)),
+    ),
+  }
+}
+
+export const TestRepositoryLayers = makeTestServiceLayers().layer
 
 /** The full zmx-adapter layer stack shared by every in-process adapter test. */
 export const zmxAdapterLayer = (options: {


### PR DESCRIPTION
PR 2 of 3 for [ATC-124](https://linear.app/elevenideas/issue/ATC-124). Implements [ATC-140](https://linear.app/elevenideas/issue/ATC-140). **Stacked on #135** (base branch is the ATC-139 branch; merge #135 first, then retarget or merge this).

## What this adds

- **Seam extensions on `AgentAdapter`** — the uniform contracts behind "provider sessions materialize on first interaction":
  - `prepareTuiSession({ cwd }) → { launchSpec, identity }`: one fresh-launch shape for every provider. Claude pre-assigns a minted UUID (`--session-id`, probe-verified) so `identity` resolves immediately; Codex captures the launched TUI's `thread/started` broadcast on the held observer connection, cwd-checked fail-closed, with a per-provider launch lock held for the caller's scope so the correlation is deterministic. **The lock also serializes Codex `createSession`'s own `thread/start`** — the provider echoes `thread/started` for every thread, so an ATC-driven create in the same cwd could otherwise be mis-adopted as the TUI's identity (adversarial-review catch, reproduced live before fixing).
  - `observeSession` — the one normalized per-session activity subscription for TUI-driven sessions (Claude: webhook-fed; Codex: shared-server status fan-out that survives reconnects).
  - `checkSession` — demand-driven reconciliation (Codex: `thread/list`; Claude: honestly `unknown` — no cheap truthful provider query exists, so linked-terminal liveness carries staleness re-derivation in V1).
  - `releaseSession` — launch-file/secret cleanup for thread deletion.
  - `tuiLaunch` now takes the thread's opaque `providerMetadata` and returns `{ launchSpec, providerMetadata? }` so adapter state minted at launch (the Claude hook secret) can always be persisted.
- **The opaque `provider_metadata` path**: the Claude hook secret is minted once, rides the thread's metadata, and is adopted back after ATC restarts (`ClaudeHooks.adoptSecret`/`revokeSecret`), keeping a running TUI's hooks valid across restarts. Abandoned prepares clean up their secret registration and 0600 hook files.
- **Read-only Agents registry**: `GET /agents`, `GET /agents/:agentId` (`AgentNotFound` 404) with availability + detected version (demand-driven, bounded, never persisted) and the seam's capability report; `AgentRegistry.adapterFor` is the domain's only door to providers. No CLI commands — `atc api` covers it.
- **Production wiring**: the provider adapters join the server assembly (previously smoke-only). Verified: boot spawns no provider process; detection runs only on `/agents` reads.

## Review hardening folded in

Two adversarial reviews (correctness with live probes, simplicity). Beyond the mis-capture fix above: the launch-lock acquisition is interruptible (a queued open stays cancellable), an abandoned capture completes its identity gate instead of hanging awaiters, `readInstalledVersion` is bounded (a wedged binary can't hang the request), the fakes got per-slug capability reports so a swapped registry mapping can't pass tests, and speculative test-harness surface was cut.

## Tests

Per-adapter mechanics: Claude pre-assignment + hook plumbing + secret restore/revoke against hook fixtures; Codex capture (incl. foreign-cwd rejection), passive observation, and `thread/list` reconciliation against the fake app-server listener. Registry behavior + OpenAPI document/runtime cases. `mise run check` (217 tests) and `mise run contract:check` green.

https://claude.ai/code/session_01336PDxLnsF6jXJ8w8uJiQc