### PR TITLE
ATC-141: the openTerminal workflow — identity establishment, status wiring, thread open, recovery

### DIFF
--- a/app-server/README.md
+++ b/app-server/README.md
@@ -75,9 +75,9 @@ responses print nothing; `atc context` and `atc capabilities` print text by
 default and JSON with `--json`). Failures exit `1`: config/request failures
 print one `atc <command>: …` diagnostic line on stderr (`atc api` also
 relays the server's JSON error body there); invalid usage prints an `ERROR`
-block on stderr (help goes to stdout). `atc terminal attach` is the one
-exception — it bridges the local TTY onto the WebSocket attach endpoint in
-raw mode (detach with `Ctrl-]`).
+block on stderr (help goes to stdout). `atc terminal attach` and
+`atc thread open` are the exceptions — they bridge the local TTY onto the
+WebSocket attach endpoint in raw mode (detach with `Ctrl-]`).
 
 ## API
 

--- a/app-server/mise.toml
+++ b/app-server/mise.toml
@@ -71,7 +71,7 @@ run = "ATC_COMPILED_TEST=1 bun --bun vitest run test/compiled.blackbox.test.ts"
 [tasks."test:smoke"]
 description = "Opt-in live provider smoke tests (requires Codex CLI and Claude Code credentials)"
 depends = ["build"]
-run = "ATC_SMOKE=1 bun --bun vitest run test/agents/provider.smoke.test.ts test/agents/codexAdapter.smoke.test.ts test/agents/claudeAdapter.smoke.test.ts"
+run = "ATC_SMOKE=1 bun --bun vitest run test/agents/provider.smoke.test.ts test/agents/codexAdapter.smoke.test.ts test/agents/claudeAdapter.smoke.test.ts test/agents/claudeTui.smoke.test.ts"
 
 [tasks."test:zmx"]
 description = "Opt-in tests against the real installed zmx: adapter smoke and compiled restart recovery"

--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -853,6 +853,102 @@
         "description": "Restore an archived thread (idempotent)."
       }
     },
+    "/api/v1/threads/{threadId}/terminal": {
+      "post": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "openThreadTerminal",
+        "parameters": [
+          {
+            "name": "threadId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "A durable, project-scoped terminal backed by a zmx session.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Terminal"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No thread exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadNotFoundJsonEncoding"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The thread is archived; unarchive it first. | The thread's provider session cannot be driven as requested (resume failed, identity mismatch, or a concurrent writer). Fail-closed: no changed identity was adopted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ThreadArchivedJsonEncoding"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ProviderSessionConflictJsonEncoding"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The directory does not exist, is not a directory, or cannot be read/traversed. | The directory check did not complete within its bounded timeout. Retryable — a timeout is not proof the path is missing. | The terminal's zmx session failed to launch (bad command, immediate exit, or settle failure). The failed launch leaves no terminal record.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/DirectoryUnavailableJsonEncoding"
+                    },
+                    {
+                      "$ref": "#/components/schemas/DirectoryCheckTimedOutJsonEncoding"
+                    },
+                    {
+                      "$ref": "#/components/schemas/TerminalLaunchFailedJsonEncoding"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The thread's agent provider cannot be used right now (not installed, not ready, or unreachable). Retryable once the cause is fixed. | The zmx multiplexer cannot be consulted right now. Retryable; stored terminal state is untouched.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ProviderUnavailableJsonEncoding"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ZmxUnavailableJsonEncoding"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Open the thread's TUI terminal. Idempotent: a live linked terminal is returned as-is. Otherwise the provider TUI is launched in a new terminal — a confirmed session is relaunched against its exact persisted identity (ATC never adopts a different one), an unconfirmed one materializes a fresh provider session whose identity is established and persisted before this call returns."
+      }
+    },
     "/api/v1/agents": {
       "get": {
         "tags": [
@@ -1518,6 +1614,71 @@
         "required": [
           "_tag",
           "threadId"
+        ],
+        "additionalProperties": false
+      },
+      "ThreadArchivedJsonEncoding": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": [
+              "ThreadArchived"
+            ]
+          },
+          "threadId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "_tag",
+          "threadId"
+        ],
+        "additionalProperties": false
+      },
+      "ProviderSessionConflictJsonEncoding": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": [
+              "ProviderSessionConflict"
+            ]
+          },
+          "threadId": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "_tag",
+          "threadId",
+          "reason"
+        ],
+        "additionalProperties": false
+      },
+      "ProviderUnavailableJsonEncoding": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": [
+              "ProviderUnavailable"
+            ]
+          },
+          "agentId": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "_tag",
+          "agentId",
+          "reason"
         ],
         "additionalProperties": false
       },

--- a/app-server/src/agents/agentAdapter.ts
+++ b/app-server/src/agents/agentAdapter.ts
@@ -19,8 +19,8 @@ import { resolveExecutable } from "../platform/subprocess.ts"
 //     writers; observation never opens a second writer.
 //   - Status is derived from structured provider events only — never from
 //     transcript or terminal-output parsing.
-//   - Responding to provider requests (approvals, questions) is deferred to
-//     ATC-124: adapters surface `requestOpened` and answer the provider
+//   - Responding to provider requests (approvals, questions) is native-mode
+//     work: adapters surface `requestOpened` and answer the provider
 //     conservatively (reject) so a turn can never hang on ATC.
 //
 // The fake adapter for tests lives in test/agents/fakeAgentAdapter.ts; per-provider
@@ -39,6 +39,23 @@ export const PROVIDER_FOR_AGENT: Record<typeof AgentId.Type, AgentProvider> = {
   codex: "codex",
   "claude-code": "claude",
 }
+
+/**
+ * Nested-session environment markers, scrubbed wherever ATC launches an
+ * agent process or TUI (uniformly — not per provider): inherited from a
+ * dev-mode ATC running inside a session, they silently change provider
+ * behavior (e.g. disable Claude transcript persistence, which breaks
+ * resume).
+ */
+export const NESTED_SESSION_ENV_VARIABLES = [
+  "CLAUDE_CODE_CHILD_SESSION",
+  "CLAUDECODE",
+  "CLAUDE_CODE_ENTRYPOINT",
+  "CLAUDE_CODE_SSE_PORT",
+  "CLAUDE_CODE_SESSION_ID",
+  "CLAUDE_CODE_BRIDGE_SESSION_ID",
+  "CLAUDE_PID",
+] as const
 
 /**
  * Normalized activity for one provider session. `unknown` means no evidence
@@ -301,8 +318,8 @@ export interface AgentAdapter {
 }
 
 // Internal-only failures (ATC-123): not part of the HTTP contract, so no
-// httpApiStatus annotations. ATC-124 maps them to public errors when agent
-// sessions become an API surface.
+// httpApiStatus annotations. The Threads domain maps them to the public
+// tagged errors (threads.ts mapAgentError).
 
 /** Provider missing, not ready, or gone — retryable once the cause is fixed. */
 export class AgentUnavailable extends Schema.TaggedErrorClass<AgentUnavailable>()(

--- a/app-server/src/agents/claudeAdapter.ts
+++ b/app-server/src/agents/claudeAdapter.ts
@@ -26,6 +26,7 @@ import {
   AgentResumeFailed,
   AgentUnavailable,
   makeVersionGate,
+  NESTED_SESSION_ENV_VARIABLES,
   resolveProviderExecutable,
   samePath,
 } from "./agentAdapter.ts"
@@ -87,27 +88,16 @@ const conflict = (reason: string) => new AgentConflict({ provider: "claude", rea
 
 /**
  * Environment for the SDK child: the user's environment (credentials) plus
- * the state-events opt-in, minus the nested-session markers a dev-mode ATC
- * would otherwise pass down (they silently disable transcript persistence,
- * which breaks resume).
+ * the state-events opt-in, minus the shared nested-session markers
+ * (agentAdapter.ts) a dev-mode ATC would otherwise pass down.
  */
-const NESTED_SESSION_VARIABLES = [
-  "CLAUDE_CODE_CHILD_SESSION",
-  "CLAUDECODE",
-  "CLAUDE_CODE_ENTRYPOINT",
-  "CLAUDE_CODE_SSE_PORT",
-  "CLAUDE_CODE_SESSION_ID",
-  "CLAUDE_CODE_BRIDGE_SESSION_ID",
-  "CLAUDE_PID",
-]
-
 const claudeEnvironment = (): Record<string, string> => {
   const env: Record<string, string> = {}
   for (const [key, value] of Object.entries(process.env)) {
     if (value !== undefined) env[key] = value
   }
   env["CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS"] = "1"
-  for (const name of NESTED_SESSION_VARIABLES) delete env[name]
+  for (const name of NESTED_SESSION_ENV_VARIABLES) delete env[name]
   return env
 }
 
@@ -378,7 +368,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
           }
           return Promise.resolve({
             behavior: "deny",
-            message: "atc does not answer provider requests yet (ATC-124)",
+            message: "atc does not answer provider requests yet (native-mode work)",
           })
         }
 

--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -223,7 +223,10 @@ export const layer = Layer.effect(CodexAdapter)(
       state.socket.send(
         JSON.stringify({
           id: message.id,
-          error: { code: -32601, message: "atc does not answer provider requests yet (ATC-124)" },
+          error: {
+            code: -32601,
+            message: "atc does not answer provider requests yet (native-mode work)",
+          },
         }),
       )
     }

--- a/app-server/src/api/contract.ts
+++ b/app-server/src/api/contract.ts
@@ -465,6 +465,53 @@ export class ThreadNotFound extends Schema.TaggedErrorClass<ThreadNotFound>()(
   }
 }
 
+/** The thread is archived; unarchive it before opening or driving it. */
+export class ThreadArchived extends Schema.TaggedErrorClass<ThreadArchived>()(
+  "ThreadArchived",
+  { threadId: Schema.String },
+  {
+    identifier: "ThreadArchived",
+    description: "The thread is archived; unarchive it first.",
+    httpApiStatus: 409,
+  },
+) {
+  override get message(): string {
+    return `thread ${this.threadId} is archived; unarchive it first`
+  }
+}
+
+/** The thread's agent provider cannot be used right now. Retryable. */
+export class ProviderUnavailable extends Schema.TaggedErrorClass<ProviderUnavailable>()(
+  "ProviderUnavailable",
+  { agentId: Schema.String, reason: Schema.String },
+  {
+    identifier: "ProviderUnavailable",
+    description:
+      "The thread's agent provider cannot be used right now (not installed, not ready, or unreachable). Retryable once the cause is fixed.",
+    httpApiStatus: 503,
+  },
+) {
+  override get message(): string {
+    return this.reason
+  }
+}
+
+/** The provider session cannot be driven as asked; nothing was adopted. */
+export class ProviderSessionConflict extends Schema.TaggedErrorClass<ProviderSessionConflict>()(
+  "ProviderSessionConflict",
+  { threadId: Schema.String, reason: Schema.String },
+  {
+    identifier: "ProviderSessionConflict",
+    description:
+      "The thread's provider session cannot be driven as requested (resume failed, identity mismatch, or a concurrent writer). Fail-closed: no changed identity was adopted.",
+    httpApiStatus: 409,
+  },
+) {
+  override get message(): string {
+    return this.reason
+  }
+}
+
 /** The thread's agent session is actively working; retry once the turn ends. */
 export class ThreadBusy extends Schema.TaggedErrorClass<ThreadBusy>()(
   "ThreadBusy",
@@ -684,6 +731,25 @@ export class V1 extends HttpApiGroup.make("v1")
       .annotate(
         OpenApi.Description,
         "Delete the thread: kill its live linked terminal if one is open, then remove the record. Provider-owned conversation history is never touched.",
+      ),
+    HttpApiEndpoint.post("openThreadTerminal", "/threads/:threadId/terminal", {
+      params: threadIdParam,
+      success: Terminal,
+      error: [
+        ThreadNotFound,
+        ThreadArchived,
+        ProviderUnavailable,
+        ProviderSessionConflict,
+        DirectoryUnavailable,
+        DirectoryCheckTimedOut,
+        ZmxUnavailable,
+        TerminalLaunchFailed,
+      ],
+    })
+      .annotate(OpenApi.Identifier, "openThreadTerminal")
+      .annotate(
+        OpenApi.Description,
+        "Open the thread's TUI terminal. Idempotent: a live linked terminal is returned as-is. Otherwise the provider TUI is launched in a new terminal — a confirmed session is relaunched against its exact persisted identity (ATC never adopts a different one), an unconfirmed one materializes a fresh provider session whose identity is established and persisted before this call returns.",
       ),
     HttpApiEndpoint.get("listAgents", "/agents", { success: AgentList })
       .annotate(OpenApi.Identifier, "listAgents")

--- a/app-server/src/api/handlers.ts
+++ b/app-server/src/api/handlers.ts
@@ -60,6 +60,7 @@ export const V1Handlers = HttpApiBuilder.group(
       .handle("archiveThread", ({ params }) => threads.archive(params.threadId))
       .handle("unarchiveThread", ({ params }) => threads.unarchive(params.threadId))
       .handle("deleteThread", ({ params }) => threads.delete(params.threadId))
+      .handle("openThreadTerminal", ({ params }) => threads.openTerminal(params.threadId))
       .handle("listAgents", () => agents.list())
       .handle("getAgent", ({ params }) => agents.get(params.agentId))
       .handleRaw("attachTerminal", attachTerminal({ terminals, bridgeScope }))

--- a/app-server/src/cli/terminals.ts
+++ b/app-server/src/cli/terminals.ts
@@ -1,6 +1,7 @@
 import { Console, Effect, Option } from "effect"
 import { Argument, Command, Flag } from "effect/unstable/cli"
 import * as path from "node:path"
+import type * as Client from "../api/client.ts"
 import * as AttachClient from "../terminals/attachClient.ts"
 import { attachUrl, CLOSE_DETACH } from "../terminals/attachProtocol.ts"
 import * as Cli from "./cli.ts"
@@ -72,35 +73,40 @@ const terminalDelete = Cli.clientCommand(
       : Effect.fail(new Error("refusing to delete without --yes (kills the running session)")),
 )
 
+/**
+ * The raw-mode attach loop shared by `terminal attach` and `thread open`:
+ * pre-flight over the typed API (the WebSocket handshake cannot carry the
+ * contract's diagnostics — a browser-style client only sees "connection
+ * failed"), then bridge the TTY until detach or terminal end.
+ */
+export const attachAndReport = (client: Client.AppServerClient, baseUrl: URL, terminalId: string) =>
+  Effect.gen(function* () {
+    const terminal = yield* client.v1.getTerminal({ params: { terminalId } })
+    if (terminal.status === "ended") {
+      return yield* Effect.fail(new Error(`terminal ${terminalId} has ended`))
+    }
+    const size =
+      process.stdout.isTTY === true
+        ? { cols: process.stdout.columns, rows: process.stdout.rows }
+        : undefined
+    const result = yield* AttachClient.runAttach(attachUrl(baseUrl, terminalId, size))
+    if (result.code === 1000 && result.reason === CLOSE_DETACH) {
+      yield* Console.error("detached (session keeps running)")
+    } else if (result.code === 1000) {
+      yield* Console.error("terminal ended")
+    } else {
+      return yield* Effect.fail(
+        new Error(`connection closed (${result.code} ${result.reason || "no reason"})`),
+      )
+    }
+  })
+
 const terminalAttach = Command.make(
   "attach",
   { terminalId: terminalIdArgument },
   ({ terminalId }) =>
     Cli.withClient("terminal attach", (client, baseUrl) =>
-      Effect.gen(function* () {
-        // Pre-flight over the typed API: the WebSocket handshake cannot carry
-        // the contract's diagnostics (a browser-style client only sees
-        // "connection failed"), so unknown or ended terminals are reported
-        // here, with the real error, before any socket opens.
-        const terminal = yield* client.v1.getTerminal({ params: { terminalId } })
-        if (terminal.status === "ended") {
-          return yield* Effect.fail(new Error(`terminal ${terminalId} has ended`))
-        }
-        const size =
-          process.stdout.isTTY === true
-            ? { cols: process.stdout.columns, rows: process.stdout.rows }
-            : undefined
-        const result = yield* AttachClient.runAttach(attachUrl(baseUrl, terminalId, size))
-        if (result.code === 1000 && result.reason === CLOSE_DETACH) {
-          yield* Console.error("detached (session keeps running)")
-        } else if (result.code === 1000) {
-          yield* Console.error("terminal ended")
-        } else {
-          return yield* Effect.fail(
-            new Error(`connection closed (${result.code} ${result.reason || "no reason"})`),
-          )
-        }
-      }),
+      attachAndReport(client, baseUrl, terminalId),
     ),
 ).pipe(
   Command.withDescription(

--- a/app-server/src/cli/threads.ts
+++ b/app-server/src/cli/threads.ts
@@ -3,11 +3,12 @@ import { Argument, Command, Flag } from "effect/unstable/cli"
 import * as path from "node:path"
 import { AGENT_IDS } from "../api/contract.ts"
 import * as Cli from "./cli.ts"
+import { attachAndReport } from "./terminals.ts"
 
-// The `atc thread` command group: thin client commands over the contract.
-// Threads are the primary unit of work, so they get the full named set
-// (ATC-124); `thread open` (open-terminal + attach) arrives with the
-// openTerminal workflow.
+// The `atc thread` command group: thin client commands over the contract,
+// plus `thread open` — open-terminal + raw attach, the one command here
+// with local TTY behavior. Threads are the primary unit of work, so they
+// get the full named set (ATC-124).
 
 const threadIdArgument = Argument.string("thread-id")
 
@@ -84,6 +85,21 @@ const threadUnarchive = Cli.clientCommand(
   (client, { threadId }) => client.v1.unarchiveThread({ params: { threadId } }),
 )
 
+const threadOpen = Command.make("open", { threadId: threadIdArgument }, ({ threadId }) =>
+  Cli.withClient("thread open", (client, baseUrl) =>
+    Effect.gen(function* () {
+      // Open-terminal + raw-TTY attach in one command: the terminal-first
+      // thread workflow's front door.
+      const terminal = yield* client.v1.openThreadTerminal({ params: { threadId } })
+      yield* attachAndReport(client, baseUrl, terminal.id)
+    }),
+  ),
+).pipe(
+  Command.withDescription(
+    "Open the thread's TUI terminal (launching the agent if needed) and attach in raw mode",
+  ),
+)
+
 const threadDelete = Cli.clientCommand(
   "thread delete",
   "Delete a thread: kill its live linked terminal, remove the record (provider history is untouched)",
@@ -101,6 +117,7 @@ export const thread = Command.make("thread").pipe(
     threadGet,
     threadCreate,
     threadUpdate,
+    threadOpen,
     threadArchive,
     threadUnarchive,
     threadDelete,

--- a/app-server/src/terminals/terminalAdapter.ts
+++ b/app-server/src/terminals/terminalAdapter.ts
@@ -88,11 +88,15 @@ export class TerminalAdapter extends Context.Service<
      * reachable session is confirmed in the inventory; fails when `name`
      * already exists (creating is never silently attaching), and a command
      * that finishes before the session settles is a failed launch.
+     * `env` overlays the adapter's base child environment per key; an
+     * `undefined` value removes the inherited key (how TUI terminals scrub
+     * nested-session markers).
      */
     readonly createSession: (options: {
       readonly name: string
       readonly cwd: string
       readonly command?: ReadonlyArray<string> | undefined
+      readonly env?: Record<string, string | undefined> | undefined
     }) => Effect.Effect<void, ZmxUnavailable | SessionOperationFailed>
     /**
      * A complete inventory of ATC's private session directory. Any failure

--- a/app-server/src/terminals/terminals.ts
+++ b/app-server/src/terminals/terminals.ts
@@ -65,9 +65,16 @@ export class Terminals extends Context.Service<
     readonly list: (projectId?: string) => Effect.Effect<ReadonlyArray<Terminal>>
     /** Reconciled read. */
     readonly get: (id: string) => Effect.Effect<Terminal, TerminalNotFound>
-    /** Create the record and start the zmx session (two-phase). */
+    /**
+     * Create the record and start the zmx session (two-phase). `threadId`
+     * and `env` are internal extensions used by the Threads domain's
+     * openTerminal — never accepted from the public contract.
+     */
     readonly create: (
-      input: typeof CreateTerminalRequest.Type,
+      input: typeof CreateTerminalRequest.Type & {
+        readonly threadId?: string | undefined
+        readonly env?: Record<string, string | undefined> | undefined
+      },
     ) => Effect.Effect<
       Terminal,
       | ProjectNotFound
@@ -241,6 +248,7 @@ export const layer = Layer.effect(Terminals)(
         // mid-create is resolvable either way at the next startup.
         const record = yield* repository.create({
           projectId: input.projectId,
+          threadId: input.threadId,
           name: input.name,
           command: input.command,
           initialWorkingDirectory: canonical,
@@ -253,7 +261,12 @@ export const layer = Layer.effect(Terminals)(
           .killSession(sessionName)
           .pipe(Effect.ignore, Effect.andThen(repository.delete(record.id)))
         const live = yield* adapter
-          .createSession({ name: sessionName, cwd: canonical, command: input.command })
+          .createSession({
+            name: sessionName,
+            cwd: canonical,
+            command: input.command,
+            env: input.env,
+          })
           .pipe(
             Effect.catchTag("SessionOperationFailed", (error) =>
               Effect.fail(new TerminalLaunchFailed({ reason: error.reason })),

--- a/app-server/src/terminals/zmxAdapter.ts
+++ b/app-server/src/terminals/zmxAdapter.ts
@@ -262,13 +262,20 @@ export const layerWith = (options: ZmxOptions) =>
           // session is in the inventory the scope closes, detaching the
           // client; the session daemon persists. Exec-style commands come
           // from a Schema-typed argv — never a shell string.
+          // Per-session overlay on the base child env; undefined removes a
+          // key (TUI terminals scrub nested-session markers this way).
+          const sessionEnv = { ...childEnv }
+          for (const [key, value] of Object.entries(options.env ?? {})) {
+            if (value === undefined) delete sessionEnv[key]
+            else sessionEnv[key] = value
+          }
           const client = yield* Effect.gen(function* () {
             const child = yield* subprocess
               .spawnPty({
                 executable,
                 args: ["attach", options.name, ...(options.command ?? [])],
                 cwd: options.cwd,
-                env: childEnv,
+                env: sessionEnv,
                 // The tail is the launch-failure diagnostic below.
                 captureOutputTail: true,
               })

--- a/app-server/src/threads/threadRepository.ts
+++ b/app-server/src/threads/threadRepository.ts
@@ -75,6 +75,27 @@ export class ThreadRepository extends Context.Service<
     readonly require: (id: string) => Effect.Effect<ThreadRecord, ThreadNotFound>
     /** Update the display label; callers hold the record — a vanished row is a bug. */
     readonly rename: (id: string, name: string) => Effect.Effect<ThreadRecord>
+    /**
+     * Adopt a freshly established provider identity: session id and opaque
+     * metadata together, clearing the confirmed marker (a fresh session has
+     * no completed turn yet). Callers hold the record (see rename).
+     */
+    readonly setProviderSession: (
+      id: string,
+      providerSessionId: string,
+      providerMetadata: string | null,
+    ) => Effect.Effect<ThreadRecord>
+    /** Update only the opaque adapter metadata; callers hold the record. */
+    readonly setProviderMetadata: (
+      id: string,
+      providerMetadata: string,
+    ) => Effect.Effect<ThreadRecord>
+    /**
+     * Set the confirmed marker (first completed turn observed). Idempotent
+     * and tolerant: fed by the live status feed, which can race a delete —
+     * a vanished row is a no-op, and an existing marker is never rewritten.
+     */
+    readonly confirm: (id: string) => Effect.Effect<void>
     /** Set or clear the archive marker; callers hold the record (see rename). */
     readonly setArchived: (id: string, archived: boolean) => Effect.Effect<ThreadRecord>
     readonly delete: (id: string) => Effect.Effect<void>
@@ -116,6 +137,53 @@ export const layer = Layer.effect(ThreadRepository)(
         UPDATE threads SET name = ${patch.name}, updated_at = ${patch.updated_at}
         WHERE id = ${patch.id}
         RETURNING *
+      `,
+    })
+
+    const setProviderSessionRows = SqlSchema.findAll({
+      Request: Schema.Struct({
+        id: Schema.String,
+        provider_session_id: Schema.String,
+        provider_metadata: Schema.NullOr(Schema.String),
+        updated_at: Schema.String,
+      }),
+      Result: ThreadRow,
+      execute: (patch) => sql`
+        UPDATE threads SET
+          provider_session_id = ${patch.provider_session_id},
+          provider_metadata = ${patch.provider_metadata},
+          confirmed_at = NULL,
+          updated_at = ${patch.updated_at}
+        WHERE id = ${patch.id}
+        RETURNING *
+      `,
+    })
+
+    const setProviderMetadataRows = SqlSchema.findAll({
+      Request: Schema.Struct({
+        id: Schema.String,
+        provider_metadata: Schema.String,
+        updated_at: Schema.String,
+      }),
+      Result: ThreadRow,
+      execute: (patch) => sql`
+        UPDATE threads SET
+          provider_metadata = ${patch.provider_metadata},
+          updated_at = ${patch.updated_at}
+        WHERE id = ${patch.id}
+        RETURNING *
+      `,
+    })
+
+    // Idempotent confirmation: the first observation wins, and a row that
+    // vanished (deleted mid-feed) is a no-op.
+    const confirmRows = SqlSchema.void({
+      Request: Schema.Struct({ id: Schema.String, confirmed_at: Schema.String }),
+      execute: (patch) => sql`
+        UPDATE threads SET
+          confirmed_at = COALESCE(confirmed_at, ${patch.confirmed_at}),
+          updated_at = CASE WHEN confirmed_at IS NULL THEN ${patch.confirmed_at} ELSE updated_at END
+        WHERE id = ${patch.id}
       `,
     })
 
@@ -197,6 +265,27 @@ export const layer = Layer.effect(ThreadRepository)(
         Effect.suspend(() => renameRows({ id, name, updated_at: new Date().toISOString() })).pipe(
           Effect.orDie,
           Effect.flatMap(requireFirst("rename")),
+        ),
+      setProviderSession: (id, providerSessionId, providerMetadata) =>
+        Effect.suspend(() =>
+          setProviderSessionRows({
+            id,
+            provider_session_id: providerSessionId,
+            provider_metadata: providerMetadata,
+            updated_at: new Date().toISOString(),
+          }),
+        ).pipe(Effect.orDie, Effect.flatMap(requireFirst("setProviderSession"))),
+      setProviderMetadata: (id, providerMetadata) =>
+        Effect.suspend(() =>
+          setProviderMetadataRows({
+            id,
+            provider_metadata: providerMetadata,
+            updated_at: new Date().toISOString(),
+          }),
+        ).pipe(Effect.orDie, Effect.flatMap(requireFirst("setProviderMetadata"))),
+      confirm: (id) =>
+        Effect.suspend(() => confirmRows({ id, confirmed_at: new Date().toISOString() })).pipe(
+          Effect.orDie,
         ),
       setArchived: (id, archived) =>
         Effect.suspend(() => {

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -1,17 +1,38 @@
-import { Context, Effect, Layer } from "effect"
-import type { AgentActivity } from "../agents/agentAdapter.ts"
-import { Thread as ThreadSchema, ThreadBusy } from "../api/contract.ts"
+import { Context, Duration, Effect, Exit, Layer, Option, Scope, Stream } from "effect"
+import { AgentRegistry } from "../agents/agentRegistry.ts"
 import type {
+  AgentActivity,
+  AgentAdapter,
+  AgentConflict,
+  AgentIdentityMismatch,
+  AgentProtocolError,
+  AgentResumeFailed,
+  AgentUnavailable,
+  TuiLaunchSpec,
+} from "../agents/agentAdapter.ts"
+import { NESTED_SESSION_ENV_VARIABLES } from "../agents/agentAdapter.ts"
+import {
+  AGENT_IDS,
+  ProviderSessionConflict,
+  ProviderUnavailable,
+  Thread as ThreadSchema,
+  ThreadArchived,
+  ThreadBusy,
+  ThreadNotFound,
+} from "../api/contract.ts"
+import type {
+  AgentId,
   CreateThreadRequest,
   DirectoryCheckTimedOut,
   DirectoryUnavailable,
   ProjectNotFound,
-  ThreadNotFound,
+  TerminalLaunchFailed,
   ZmxUnavailable,
 } from "../api/contract.ts"
 import { Directories } from "../platform/directories.ts"
 import { ProjectRepository } from "../projects/projectRepository.ts"
 import { Terminals } from "../terminals/terminals.ts"
+import type { Terminal } from "../terminals/terminals.ts"
 import { ThreadRepository } from "./threadRepository.ts"
 import type { ThreadRecord } from "./threadRepository.ts"
 
@@ -21,23 +42,48 @@ export type Thread = typeof ThreadSchema.Type
 // work — durable ATC identity separate from provider identity. Invariants:
 //
 //   - The boundary rule: this module contains zero provider branching and
-//     imports nothing provider-specific — only the AgentAdapter seam's
-//     vocabulary. Every provider difference is translated inside adapters.
-//   - `create` is local-only: the durable row, no provider call. The
-//     provider session materializes on the thread's first interaction
-//     (ATC-141 wires the first caller); until then providerSessionId is
-//     absent and stays out of every public schema.
+//     reaches providers only through the AgentAdapter seam (via the
+//     registry's adapterFor). Every provider difference is translated
+//     inside adapters; the same columns are persisted at the same points
+//     in the same flow for every agent.
+//   - `create` is local-only: the durable row, no provider call. Identity
+//     establishment is one internal transition (`materialize`, below) with
+//     openTerminal as its first caller — a future native first-prompt is
+//     the second caller, with identical persistence.
+//   - openTerminal is idempotent (a live linked terminal is returned
+//     as-is) and enforces at most one live linked TUI terminal per thread
+//     (concurrent opens conflict). Confirmed sessions reopen their exact
+//     id; unconfirmed ones re-materialize with fresh identity — there is
+//     no history to protect yet.
+//   - The writer rule is a WRITE SEAT, not a terminal check (ATC-124
+//     surface-agnostic follow-up): the live-linked-terminal check above IS
+//     the V1 seat check, because a TUI terminal is the only holder that
+//     can exist yet. Native mode adds the second holder type — the
+//     adapter connection — here, so "open a TUI while native drives" and
+//     "prompt natively while a TUI is live" become the same conflict;
+//     nothing ever binds a Thread to one surface (sequential cross-surface
+//     alternation stays supported).
 //   - workingDirectory is validated, canonicalized, and immutable.
-//   - activityState is in-memory evidence, never persisted: a thread with
-//     no provider session is idle by construction; with one, the live
-//     feed's last word, `unknown` when there is no evidence.
+//   - activityState is in-memory evidence from the one normalized status
+//     feed, never persisted; `unknown` when there is no evidence, and a
+//     busy state whose driver (the seat holder: the linked terminal in
+//     V1, the adapter connection in native mode) is gone re-derives
+//     demand-driven from the adapter's reconciliation check on read. The
+//     confirmed marker is persisted at the FIRST busy signal observed on
+//     the feed — a submitted prompt is already durable provider history
+//     worth protecting, and writing at onset (not busy→idle) keeps the
+//     marker across a restart or observer gap mid-first-turn — the same
+//     signal for every provider.
 //   - delete kills the live linked TUI terminal first (the terminals
-//     confirmed-kill rules), then removes the row; ended linked terminals
-//     stay as unlinked tombstones (FK SET NULL), and provider-owned
-//     conversation history is never touched. Known gap: a linked terminal
-//     still `starting` is invisible here (it belongs to its in-flight
-//     create), so ATC-141's openTerminal re-checks the thread still exists
-//     before marking its terminal live.
+//     confirmed-kill rules), releases adapter-owned session resources,
+//     then removes the row; ended linked terminals stay as unlinked
+//     tombstones (FK SET NULL), and provider-owned conversation history
+//     is never touched.
+
+export interface ThreadsOptions {
+  /** How long openTerminal waits for a fresh session's identity. */
+  readonly identityTimeout?: Duration.Input
+}
 
 export class Threads extends Context.Service<
   Threads,
@@ -61,117 +107,398 @@ export class Threads extends Context.Service<
     readonly archive: (id: string) => Effect.Effect<Thread, ThreadNotFound | ThreadBusy>
     /** Idempotent. */
     readonly unarchive: (id: string) => Effect.Effect<Thread, ThreadNotFound>
-    /** Kill the live linked terminal if present, then remove the record. */
+    /** Kill the live linked terminal and release adapter resources, then
+     * remove the record. */
     readonly delete: (id: string) => Effect.Effect<void, ThreadNotFound | ZmxUnavailable>
+    /** Open (or return) the thread's TUI terminal — the header's workflow. */
+    readonly openTerminal: (
+      id: string,
+    ) => Effect.Effect<
+      Terminal,
+      | ThreadNotFound
+      | ThreadArchived
+      | ProviderUnavailable
+      | ProviderSessionConflict
+      | DirectoryUnavailable
+      | DirectoryCheckTimedOut
+      | ZmxUnavailable
+      | TerminalLaunchFailed
+    >
   }
 >()("app-server/Threads") {}
 
-export const layer = Layer.effect(Threads)(
-  Effect.gen(function* () {
-    const repository = yield* ThreadRepository
-    const projects = yield* ProjectRepository
-    const directories = yield* Directories
-    const terminals = yield* Terminals
+const isAgentId = (id: string): id is typeof AgentId.Type =>
+  (AGENT_IDS as ReadonlyArray<string>).includes(id)
 
-    // No provider session ⇒ nothing can be running; with one, this PR has
-    // no evidence source yet — ATC-141 wires the live feed in.
-    const activityFor = (record: ThreadRecord): AgentActivity =>
-      record.providerSessionId === undefined ? "idle" : "unknown"
+export const layerWith = (options: ThreadsOptions) =>
+  Layer.effect(Threads)(
+    Effect.gen(function* () {
+      const repository = yield* ThreadRepository
+      const projects = yield* ProjectRepository
+      const directories = yield* Directories
+      const terminals = yield* Terminals
+      const registry = yield* AgentRegistry
+      // Observation fibers outlive their originating requests; they live in
+      // the service's own scope so shutdown reaps every subscription.
+      const serviceScope = yield* Effect.scope
+      const identityTimeout = options.identityTimeout ?? "30 seconds"
 
-    const toThread = (record: ThreadRecord, linkedTerminalId: string | undefined): Thread => ({
-      id: record.id,
-      projectId: record.projectId,
-      // Permissive read (see the repository header); a foreign slug fails
-      // response encoding for that row, never the domain logic.
-      agentId: record.agentId as Thread["agentId"],
-      ...(record.name !== undefined ? { name: record.name } : {}),
-      workingDirectory: record.workingDirectory,
-      activityState: activityFor(record),
-      ...(linkedTerminalId !== undefined ? { linkedTerminalId } : {}),
-      ...(record.archivedAt !== undefined ? { archivedAt: record.archivedAt } : {}),
-      createdAt: record.createdAt,
-      updatedAt: record.updatedAt,
-    })
+      // Live activity evidence by thread id, fed by the per-session
+      // subscriptions below. In-memory only — restart resets to no
+      // evidence, and reads re-derive on demand.
+      const liveActivity = new Map<string, AgentActivity>()
+      /** The observed session per thread; the child scope closes it. */
+      interface Observation {
+        readonly providerSessionId: string
+        readonly scope: Scope.Closeable
+      }
+      const observed = new Map<string, Observation>()
+      /** Threads with an openTerminal in flight — the one-open guard. */
+      const opening = new Set<string>()
 
-    /**
-     * The thread's live linked terminal, if any, from the reconciled
-     * terminals listing — a terminal that just died stops being "linked"
-     * the moment the inventory says so, not at its next explicit read.
-     */
-    const linkedFor = (record: ThreadRecord): Effect.Effect<string | undefined> =>
-      terminals
-        .list(record.projectId)
-        .pipe(
-          Effect.map(
-            (list) => list.find((t) => t.threadId === record.id && t.status === "live")?.id,
-          ),
+      const adapterFor = (record: ThreadRecord): AgentAdapter | undefined =>
+        isAgentId(record.agentId) ? registry.adapterFor(record.agentId) : undefined
+
+      const isBusy = (activity: AgentActivity): boolean =>
+        activity === "working" || activity === "needs_input"
+
+      /**
+       * Start (once) the thread's normalized activity subscription. The
+       * consumer keeps the in-memory snapshot current and persists the
+       * confirmed marker at the first busy evidence it sees (the header's
+       * confirmation invariant).
+       */
+      const ensureObserved = (record: ThreadRecord): Effect.Effect<void> =>
+        Effect.gen(function* () {
+          const adapter = adapterFor(record)
+          const providerSessionId = record.providerSessionId
+          if (adapter === undefined || providerSessionId === undefined) return
+          const existing = observed.get(record.id)
+          if (existing?.providerSessionId === providerSessionId) return
+          // A superseded session's subscription must never keep driving
+          // the thread (its feed would confirm a session it never saw).
+          if (existing !== undefined) yield* unobserve(record.id)
+          const child = yield* Scope.fork(serviceScope)
+          const observation: Observation = { providerSessionId, scope: child }
+          observed.set(record.id, observation)
+          // The subscription is established HERE, before the caller
+          // proceeds — only the drain loop is forked. An unavailable
+          // evidence source yields an empty feed: `unknown` on reads,
+          // never a guess or a crash.
+          const stream = yield* adapter
+            .observeSession({
+              providerSessionId,
+              providerMetadata: record.providerMetadata,
+            })
+            .pipe(
+              Effect.catchTag("AgentUnavailable", () =>
+                Effect.succeed(Stream.empty as Stream.Stream<AgentActivity>),
+              ),
+              Scope.provide(child),
+            )
+          let confirmed = record.confirmedAt !== undefined
+          yield* stream.pipe(
+            Stream.runForEach((activity) =>
+              Effect.gen(function* () {
+                liveActivity.set(record.id, activity)
+                if (!confirmed && isBusy(activity)) {
+                  confirmed = true
+                  yield* repository.confirm(record.id)
+                }
+              }),
+            ),
+            // A feed that ends on its own must not pin the entry (the
+            // next read re-subscribes instead of trusting a dead stream)
+            // nor leak its child scope into the service scope.
+            Effect.ensuring(
+              Effect.gen(function* () {
+                if (observed.get(record.id) !== observation) return
+                observed.delete(record.id)
+                yield* Scope.close(child, Exit.void)
+              }),
+            ),
+            Effect.forkIn(child),
+          )
+        })
+
+      const unobserve = (threadId: string): Effect.Effect<void> =>
+        Effect.gen(function* () {
+          liveActivity.delete(threadId)
+          const observation = observed.get(threadId)
+          if (observation === undefined) return
+          observed.delete(threadId)
+          yield* Scope.close(observation.scope, Exit.void)
+        })
+
+      /**
+       * The activity snapshot for one read. A busy state whose driver (the
+       * live linked terminal) is gone is stale: re-derive it from the
+       * adapter's reconciliation check instead of reporting a dead turn.
+       */
+      const resolveActivity = (
+        record: ThreadRecord,
+        linked: string | undefined,
+      ): Effect.Effect<AgentActivity> =>
+        Effect.gen(function* () {
+          if (record.providerSessionId === undefined) return "idle"
+          const live = liveActivity.get(record.id) ?? "unknown"
+          if (!isBusy(live) || linked !== undefined) return live
+          const adapter = adapterFor(record)
+          const providerSessionId = record.providerSessionId
+          const checked =
+            adapter === undefined
+              ? ("unknown" as const)
+              : yield* adapter
+                  .checkSession({ providerSessionId })
+                  .pipe(Effect.orElseSucceed(() => "unknown" as const))
+          liveActivity.set(record.id, checked)
+          return checked
+        })
+
+      const toThread = (
+        record: ThreadRecord,
+        linkedTerminalId: string | undefined,
+        activityState: AgentActivity,
+      ): Thread => ({
+        id: record.id,
+        projectId: record.projectId,
+        // Permissive read (see the repository header); a foreign slug fails
+        // response encoding for that row, never the domain logic.
+        agentId: record.agentId as Thread["agentId"],
+        ...(record.name !== undefined ? { name: record.name } : {}),
+        workingDirectory: record.workingDirectory,
+        activityState,
+        ...(linkedTerminalId !== undefined ? { linkedTerminalId } : {}),
+        ...(record.archivedAt !== undefined ? { archivedAt: record.archivedAt } : {}),
+        createdAt: record.createdAt,
+        updatedAt: record.updatedAt,
+      })
+
+      /**
+       * The thread's live linked terminal, if any, from the reconciled
+       * terminals listing — a terminal that just died stops being "linked"
+       * the moment the inventory says so, not at its next explicit read.
+       */
+      const linkedFor = (record: ThreadRecord): Effect.Effect<Terminal | undefined> =>
+        terminals
+          .list(record.projectId)
+          .pipe(
+            Effect.map((list) => list.find((t) => t.threadId === record.id && t.status === "live")),
+          )
+
+      /**
+       * Assemble one Thread from an already-looked-up linked terminal —
+       * listing callers batch one reconciled inventory pass for the whole
+       * page instead of one per record.
+       */
+      const assemble = (
+        record: ThreadRecord,
+        linked: Terminal | undefined,
+      ): Effect.Effect<Thread> =>
+        Effect.gen(function* () {
+          // Demand-driven recovery: a restart under a live TUI re-observes
+          // on the first read, so status flows again with no poller.
+          if (linked !== undefined) yield* ensureObserved(record)
+          const activity = yield* resolveActivity(record, linked?.id)
+          return toThread(record, linked?.id, activity)
+        })
+
+      /** `assemble` for single-record callers (one listing pass of its own). */
+      const assembleAlone = (record: ThreadRecord): Effect.Effect<Thread> =>
+        linkedFor(record).pipe(Effect.flatMap((linked) => assemble(record, linked)))
+
+      const mapAgentError =
+        (record: ThreadRecord) =>
+        (
+          error:
+            | AgentUnavailable
+            | AgentProtocolError
+            | AgentIdentityMismatch
+            | AgentResumeFailed
+            | AgentConflict,
+        ) =>
+          error._tag === "AgentUnavailable" || error._tag === "AgentProtocolError"
+            ? new ProviderUnavailable({ agentId: record.agentId, reason: error.message })
+            : new ProviderSessionConflict({ threadId: record.id, reason: error.message })
+
+      /** Launch a TUI terminal for the thread from an adapter launch spec,
+       * with the nested-session markers scrubbed uniformly. */
+      const createTuiTerminal = (record: ThreadRecord, spec: TuiLaunchSpec) =>
+        terminals
+          .create({
+            projectId: record.projectId,
+            threadId: record.id,
+            ...(record.name !== undefined ? { name: record.name } : {}),
+            command: spec.command,
+            workingDirectory: record.workingDirectory,
+            env: {
+              ...spec.env,
+              ...Object.fromEntries(NESTED_SESSION_ENV_VARIABLES.map((name) => [name, undefined])),
+            },
+          })
+          // The owning project cannot vanish under a live thread (FK).
+          .pipe(Effect.catchTag("ProjectNotFound", (error) => Effect.die(error)))
+
+      /**
+       * The single identity-establishment transition: launch fresh via the
+       * uniform prepareTuiSession contract, await verified identity
+       * (bounded), persist it. openTerminal is its first caller; a native
+       * first-prompt is the future second one.
+       */
+      const materialize = (record: ThreadRecord, adapter: AgentAdapter) =>
+        Effect.scoped(
+          Effect.gen(function* () {
+            // A superseded unconfirmed session is dead to ATC: stop its
+            // feed (it must never confirm the successor) and release its
+            // adapter resources before minting the replacement.
+            if (record.providerSessionId !== undefined) {
+              yield* unobserve(record.id)
+              yield* adapter.releaseSession({
+                providerSessionId: record.providerSessionId,
+                providerMetadata: record.providerMetadata,
+              })
+            }
+            const prepared = yield* adapter
+              .prepareTuiSession({ cwd: record.workingDirectory })
+              .pipe(Effect.mapError(mapAgentError(record)))
+            const terminal = yield* createTuiTerminal(record, prepared.launchSpec)
+            const cleanupTerminal = terminals
+              .delete(terminal.id)
+              .pipe(Effect.catch(() => Effect.void))
+            yield* Effect.uninterruptibleMask((restore) =>
+              Effect.gen(function* () {
+                // The identity await stays interruptible (openTerminal's
+                // bound must be able to cancel it), but the mask leaves no
+                // window where interruption can land between resolution and
+                // the release bracket below.
+                const identity = yield* restore(
+                  prepared.identity.pipe(Effect.mapError(mapAgentError(record))),
+                )
+                // From resolution until a thread row owns the identity, the
+                // fresh session is OURS: every non-success — the row deleted
+                // mid-open (the ATC-139 delete-vs-starting-terminal window),
+                // a persistence defect, or interruption — must release the
+                // adapter's session resources; nothing else will.
+                let adopted = false
+                yield* restore(
+                  Effect.gen(function* () {
+                    const still = yield* repository.get(record.id)
+                    if (Option.isNone(still)) {
+                      return yield* Effect.fail(new ThreadNotFound({ threadId: record.id }))
+                    }
+                    const updated = yield* repository.setProviderSession(
+                      record.id,
+                      identity.providerSessionId,
+                      identity.providerMetadata ?? null,
+                    )
+                    adopted = true
+                    yield* ensureObserved(updated)
+                  }),
+                ).pipe(
+                  Effect.onExit((exit) =>
+                    exit._tag === "Failure" && !adopted
+                      ? adapter.releaseSession({
+                          providerSessionId: identity.providerSessionId,
+                          providerMetadata: identity.providerMetadata,
+                        })
+                      : Effect.void,
+                  ),
+                )
+              }),
+            ).pipe(
+              // On ANY non-success — failure, defect, or interruption (a
+              // dropped client cancels the request fiber) — the terminal
+              // must not survive as a live TUI the thread adopted nothing
+              // from.
+              Effect.onExit((exit) => (exit._tag === "Failure" ? cleanupTerminal : Effect.void)),
+            )
+            return terminal
+          }),
         )
 
-    const withLinked = (record: ThreadRecord): Effect.Effect<Thread> =>
-      linkedFor(record).pipe(Effect.map((linked) => toThread(record, linked)))
+      /** Reopen a confirmed session: exact identity, mismatches fail closed. */
+      const reopen = (record: ThreadRecord, adapter: AgentAdapter) =>
+        Effect.gen(function* () {
+          const providerSessionId = record.providerSessionId ?? ""
+          const launch = yield* adapter
+            .tuiLaunch({
+              providerSessionId,
+              cwd: record.workingDirectory,
+              providerMetadata: record.providerMetadata,
+            })
+            .pipe(Effect.mapError(mapAgentError(record)))
+          // Deleted mid-open: adopt nothing (the metadata write would die
+          // on the vanished row, the terminal would violate the FK).
+          const still = yield* repository.get(record.id)
+          if (Option.isNone(still)) {
+            return yield* Effect.fail(new ThreadNotFound({ threadId: record.id }))
+          }
+          const current =
+            launch.providerMetadata !== undefined &&
+            launch.providerMetadata !== record.providerMetadata
+              ? yield* repository.setProviderMetadata(record.id, launch.providerMetadata)
+              : record
+          const terminal = yield* createTuiTerminal(current, launch.launchSpec)
+          yield* ensureObserved(current)
+          return terminal
+        })
 
-    return {
-      list: (options) =>
-        Effect.gen(function* () {
-          const records = yield* repository.list(options?.projectId)
-          const wanted = records.filter((record) =>
-            options?.archived === true
-              ? record.archivedAt !== undefined
-              : record.archivedAt === undefined,
-          )
-          if (wanted.length === 0) return []
-          const linked = new Map<string, string>()
-          for (const terminal of yield* terminals.list(options?.projectId)) {
-            // Newest first, first write wins — the same pick linkedFor makes.
-            if (
-              terminal.threadId !== undefined &&
-              terminal.status === "live" &&
-              !linked.has(terminal.threadId)
-            ) {
-              linked.set(terminal.threadId, terminal.id)
-            }
-          }
-          return wanted.map((record) => toThread(record, linked.get(record.id)))
-        }),
-      get: (id) => repository.require(id).pipe(Effect.flatMap(withLinked)),
-      create: (input) =>
-        Effect.gen(function* () {
-          const project = yield* projects.require(input.projectId)
-          const canonical = yield* directories.canonicalize(
-            input.workingDirectory ?? project.defaultWorkingDirectory,
-          )
-          const record = yield* repository.create({
-            projectId: input.projectId,
-            agentId: input.agentId,
-            name: input.name,
-            workingDirectory: canonical,
-          })
-          return toThread(record, undefined)
-        }),
-      update: (id, patch) =>
-        // An empty patch changes nothing — including updatedAt (the same
-        // rule the other repositories apply).
-        patch.name === undefined
-          ? repository.require(id).pipe(Effect.flatMap(withLinked))
-          : repository
-              .require(id)
-              .pipe(Effect.andThen(repository.rename(id, patch.name)), Effect.flatMap(withLinked)),
-      archive: (id) =>
+      const openTerminal: Threads["Service"]["openTerminal"] = (id) =>
         Effect.gen(function* () {
           const record = yield* repository.require(id)
-          if (activityFor(record) === "working") {
-            return yield* Effect.fail(new ThreadBusy({ threadId: id }))
+          if (record.archivedAt !== undefined) {
+            return yield* Effect.fail(new ThreadArchived({ threadId: id }))
           }
-          if (record.archivedAt !== undefined) return yield* withLinked(record)
-          return yield* repository.setArchived(id, true).pipe(Effect.flatMap(withLinked))
-        }),
-      unarchive: (id) =>
-        Effect.gen(function* () {
-          const record = yield* repository.require(id)
-          if (record.archivedAt === undefined) return yield* withLinked(record)
-          return yield* repository.setArchived(id, false).pipe(Effect.flatMap(withLinked))
-        }),
-      delete: (id) =>
+          const adapter = adapterFor(record)
+          if (adapter === undefined) {
+            return yield* Effect.fail(
+              new ProviderUnavailable({
+                agentId: record.agentId,
+                reason: `this build knows no agent "${record.agentId}"`,
+              }),
+            )
+          }
+          // Idempotent: one live linked TUI terminal per thread, returned
+          // as-is (two TUIs into one conversation is the documented
+          // concurrency hazard).
+          const linked = yield* linkedFor(record)
+          if (linked !== undefined) {
+            yield* ensureObserved(record)
+            return linked
+          }
+          if (opening.has(id)) {
+            return yield* Effect.fail(
+              new ProviderSessionConflict({
+                threadId: id,
+                reason: "an open of this thread's terminal is already in progress",
+              }),
+            )
+          }
+          opening.add(id)
+          return yield* (
+            record.providerSessionId !== undefined && record.confirmedAt !== undefined
+              ? reopen(record, adapter)
+              : // Unconfirmed (none, or zero completed turns): re-materialize
+                // with fresh identity — there is no history to protect. The
+                // bound covers the WHOLE flow (launch-lock queueing and
+                // terminal creation included), so a slow provider can never
+                // hang the caller past the window.
+                materialize(record, adapter).pipe(
+                  Effect.timeoutOrElse({
+                    duration: identityTimeout,
+                    orElse: () =>
+                      Effect.fail(
+                        new ProviderUnavailable({
+                          agentId: record.agentId,
+                          reason: `the provider session was not established within ${Duration.format(Duration.fromInputUnsafe(identityTimeout))}; retry`,
+                        }),
+                      ),
+                  }),
+                )
+          ).pipe(Effect.ensuring(Effect.sync(() => opening.delete(id))))
+        })
+
+      const del: Threads["Service"]["delete"] = (id) =>
         Effect.gen(function* () {
           const record = yield* repository.require(id)
           const linked = yield* linkedFor(record)
@@ -179,11 +506,96 @@ export const layer = Layer.effect(Threads)(
             // Confirmed-kill rules live in Terminals.delete; a terminal that
             // vanished since the lookup is already the goal state.
             yield* terminals
-              .delete(linked)
+              .delete(linked.id)
               .pipe(Effect.catchTag("TerminalNotFound", () => Effect.void))
           }
+          const adapter = adapterFor(record)
+          if (adapter !== undefined && record.providerSessionId !== undefined) {
+            yield* adapter.releaseSession({
+              providerSessionId: record.providerSessionId,
+              providerMetadata: record.providerMetadata,
+            })
+          }
+          yield* unobserve(id)
           yield* repository.delete(id)
-        }),
-    }
-  }),
-)
+        })
+
+      return {
+        list: (listOptions) =>
+          Effect.gen(function* () {
+            const records = yield* repository.list(listOptions?.projectId)
+            const wanted = records.filter((record) =>
+              listOptions?.archived === true
+                ? record.archivedAt !== undefined
+                : record.archivedAt === undefined,
+            )
+            if (wanted.length === 0) return []
+            // One reconciled inventory pass for the whole page.
+            const linked = new Map<string, Terminal>()
+            for (const terminal of yield* terminals.list(listOptions?.projectId)) {
+              // Newest first, first write wins — the same pick linkedFor makes.
+              if (
+                terminal.threadId !== undefined &&
+                terminal.status === "live" &&
+                !linked.has(terminal.threadId)
+              ) {
+                linked.set(terminal.threadId, terminal)
+              }
+            }
+            return yield* Effect.forEach(wanted, (record) =>
+              assemble(record, linked.get(record.id)),
+            )
+          }),
+        get: (id) => repository.require(id).pipe(Effect.flatMap(assembleAlone)),
+        create: (input) =>
+          Effect.gen(function* () {
+            const project = yield* projects.require(input.projectId)
+            const canonical = yield* directories.canonicalize(
+              input.workingDirectory ?? project.defaultWorkingDirectory,
+            )
+            const record = yield* repository.create({
+              projectId: input.projectId,
+              agentId: input.agentId,
+              name: input.name,
+              workingDirectory: canonical,
+            })
+            return toThread(record, undefined, "idle")
+          }),
+        update: (id, patch) =>
+          // An empty patch changes nothing — including updatedAt (the same
+          // rule the other repositories apply).
+          patch.name === undefined
+            ? repository.require(id).pipe(Effect.flatMap(assembleAlone))
+            : repository
+                .require(id)
+                .pipe(
+                  Effect.andThen(repository.rename(id, patch.name)),
+                  Effect.flatMap(assembleAlone),
+                ),
+        archive: (id) =>
+          Effect.gen(function* () {
+            const record = yield* repository.require(id)
+            const linked = yield* linkedFor(record)
+            // Busy covers needs_input too: a turn parked on an approval is
+            // still mid-turn.
+            if (isBusy(yield* resolveActivity(record, linked?.id))) {
+              return yield* Effect.fail(new ThreadBusy({ threadId: id }))
+            }
+            if (record.archivedAt !== undefined) return yield* assemble(record, linked)
+            const updated = yield* repository.setArchived(id, true)
+            return yield* assemble(updated, linked)
+          }),
+        unarchive: (id) =>
+          Effect.gen(function* () {
+            const record = yield* repository.require(id)
+            if (record.archivedAt === undefined) return yield* assembleAlone(record)
+            const updated = yield* repository.setArchived(id, false)
+            return yield* assembleAlone(updated)
+          }),
+        delete: del,
+        openTerminal,
+      }
+    }),
+  )
+
+export const layer = layerWith({})

--- a/app-server/test/agents/claudeTui.smoke.test.ts
+++ b/app-server/test/agents/claudeTui.smoke.test.ts
@@ -1,0 +1,94 @@
+import { assert, describe, it } from "@effect/vitest"
+import { BunServices } from "@effect/platform-bun"
+import { Effect, Layer } from "effect"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import { NESTED_SESSION_ENV_VARIABLES } from "../../src/agents/agentAdapter.ts"
+import * as Subprocess from "../../src/platform/subprocess.ts"
+import { trackTempDir } from "../blackbox.ts"
+
+// Live interactive-TUI smoke (opt-in: mise run test:smoke): the one
+// implementation-time check the ATC-124 decision record left open —
+// `--session-id` pre-assignment on an INTERACTIVE Claude launch (the -p
+// engine-shared evidence was probed; this proves the TUI path). A real
+// `claude --session-id <minted> --settings <hooks>` is spawned in a PTY and
+// must report the exact minted id through its own hook delivery, before any
+// prompt is typed. A possible first-run trust dialog is answered with Enter.
+
+const enabled = process.env["ATC_SMOKE"] === "1"
+
+describe.skipIf(!enabled)("live claude TUI pre-assignment smoke (opt-in)", () => {
+  it.live(
+    "an interactive launch adopts the minted --session-id and confirms via hooks",
+    () =>
+      Effect.gen(function* () {
+        const base = trackTempDir(fs.mkdtempSync(path.join(os.tmpdir(), "atc-claude-tui-")))
+        const cwd = path.join(base, "work")
+        fs.mkdirSync(cwd)
+
+        // Capture server: every hook delivery lands here as JSON.
+        const captured: Array<{ session_id?: string; hook_event_name?: string }> = []
+        const server = Bun.serve({
+          hostname: "127.0.0.1",
+          port: 0,
+          fetch: async (request) => {
+            captured.push((await request.json()) as (typeof captured)[number])
+            return new Response(null, { status: 204 })
+          },
+        })
+        yield* Effect.addFinalizer(() => Effect.promise(() => server.stop(true)))
+
+        const command = `curl -fsS -m 5 -X POST -H 'Content-Type: application/json' --data-binary @- 'http://127.0.0.1:${server.port}/hook'`
+        const hookConfig = Object.fromEntries(
+          ["SessionStart", "UserPromptSubmit", "Stop"].map((event) => [
+            event,
+            [{ hooks: [{ type: "command", command }] }],
+          ]),
+        )
+        const settingsFile = path.join(base, "settings.json")
+        fs.writeFileSync(settingsFile, JSON.stringify({ hooks: hookConfig }))
+
+        const sessionId = crypto.randomUUID()
+        // The user's env (credentials) minus the nested-session markers this
+        // test process may itself carry.
+        const env: Record<string, string> = {}
+        for (const [key, value] of Object.entries(process.env)) {
+          if (value !== undefined) env[key] = value
+        }
+        for (const name of NESTED_SESSION_ENV_VARIABLES) delete env[name]
+
+        const subprocess = yield* Subprocess.Subprocess
+        const child = yield* subprocess.spawnPty({
+          executable: Subprocess.resolveExecutable("claude") ?? "claude",
+          args: ["--session-id", sessionId, "--settings", settingsFile],
+          cwd,
+          env,
+          captureOutputTail: true,
+        })
+        yield* child.resize({ cols: 120, rows: 40 })
+
+        // Wait for the hook confirmation; nudge Enter through occasionally
+        // in case the TUI is sitting on a first-run trust dialog.
+        const confirmed = yield* Effect.gen(function* () {
+          for (let attempt = 0; attempt < 240; attempt++) {
+            const hit = captured.find((payload) => payload.session_id === sessionId)
+            if (hit !== undefined) return true
+            if (attempt > 0 && attempt % 20 === 0) yield* child.write("\r")
+            yield* Effect.sleep("250 millis")
+          }
+          return false
+        })
+        const tail = yield* child.outputTail
+        assert.isTrue(
+          confirmed,
+          `no hook delivery carried the minted id; captured=${JSON.stringify(captured)} tail=${tail.slice(-500)}`,
+        )
+        assert.notInclude(tail, "already in use")
+      }).pipe(
+        Effect.scoped,
+        Effect.provide(Subprocess.layer.pipe(Layer.provideMerge(BunServices.layer))),
+      ),
+    120_000,
+  )
+})

--- a/app-server/test/agents/fakeAgentAdapter.ts
+++ b/app-server/test/agents/fakeAgentAdapter.ts
@@ -1,4 +1,4 @@
-import { Cause, Effect, Queue, Stream } from "effect"
+import { Cause, Deferred, Effect, Queue, Stream } from "effect"
 import type {
   AgentActivity,
   AgentAdapter,
@@ -48,6 +48,17 @@ export interface FakeAgentAdapter {
   readonly openRequest: (providerSessionId: string, kind: AgentRequestKind) => string
   /** Close a previously opened request; activity → working. */
   readonly closeRequest: (providerSessionId: string, requestId: string) => void
+  /** While set, prepared identities wait on a gate; unsetting releases any
+   * waiter (so a hung identity can resolve late, after the test acted). */
+  readonly setIdentityHangs: (hangs: boolean) => void
+  /** Push one activity value to every observer of `providerSessionId`. */
+  readonly emitActivity: (providerSessionId: string, activity: AgentActivity) => void
+  /** Script what checkSession reports for `providerSessionId`. */
+  readonly setCheckActivity: (providerSessionId: string, activity: AgentActivity | null) => void
+  /** prepareTuiSession identities handed out, in order. */
+  readonly prepared: Array<{ providerSessionId: string; cwd: string }>
+  /** releaseSession calls, in order. */
+  readonly released: Array<{ providerSessionId: string; providerMetadata: string | undefined }>
 }
 
 export interface FakeAgentAdapterOptions {
@@ -68,6 +79,10 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
   // One live connection per session — the single-writer rule.
   const connections = new Map<string, LiveConnection>()
   const observers = new Map<string, Set<Queue.Queue<AgentActivity, Cause.Done>>>()
+  const checkActivity = new Map<string, AgentActivity>()
+  const prepared: FakeAgentAdapter["prepared"] = []
+  const released: FakeAgentAdapter["released"] = []
+  let identityGate: Deferred.Deferred<void> | null = null
   let unavailableReason: string | null = null
   let nextSessionId = 1
   let nextTurnId = 1
@@ -256,15 +271,20 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
       Effect.gen(function* () {
         yield* requireAvailable
         const providerSessionId = `fake-session-${nextSessionId++}`
+        prepared.push({ providerSessionId, cwd: options.cwd })
         // The prepared session becomes resumable once identity resolves —
         // mirroring "a completed first interaction materializes it".
-        const identity = Effect.suspend(() => {
+        const resolve = Effect.sync(() => {
           sessions.set(providerSessionId, { providerSessionId, cwd: options.cwd, inputs: [] })
-          return Effect.succeed({
+          return {
             providerSessionId,
             cwd: options.cwd,
             providerMetadata: JSON.stringify({ fake: providerSessionId }),
-          })
+          }
+        })
+        const identity = Effect.suspend(() => {
+          const gate = identityGate
+          return gate === null ? resolve : Deferred.await(gate).pipe(Effect.andThen(resolve))
         })
         return {
           launchSpec: {
@@ -290,8 +310,17 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
         )
         return Stream.fromQueue(queue)
       }),
-    checkSession: () => requireAvailable.pipe(Effect.as("unknown" as const)),
-    releaseSession: () => Effect.void,
+    checkSession: (options) =>
+      requireAvailable.pipe(
+        Effect.map(() => checkActivity.get(options.providerSessionId) ?? "unknown"),
+      ),
+    releaseSession: (options) =>
+      Effect.sync(() => {
+        released.push({
+          providerSessionId: options.providerSessionId,
+          providerMetadata: options.providerMetadata,
+        })
+      }),
   }
 
   return {
@@ -322,5 +351,24 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
       emit(live, { type: "requestClosed", requestId })
       setActivity(live, "working")
     },
+    setIdentityHangs: (hangs) => {
+      if (hangs) {
+        identityGate = Deferred.makeUnsafe<void>()
+        return
+      }
+      if (identityGate !== null) Deferred.doneUnsafe(identityGate, Effect.void)
+      identityGate = null
+    },
+    emitActivity: (providerSessionId, activity) => {
+      for (const queue of observers.get(providerSessionId) ?? []) {
+        Queue.offerUnsafe(queue, activity)
+      }
+    },
+    setCheckActivity: (providerSessionId, activity) => {
+      if (activity === null) checkActivity.delete(providerSessionId)
+      else checkActivity.set(providerSessionId, activity)
+    },
+    prepared,
+    released,
   }
 }

--- a/app-server/test/api/openapi.test.ts
+++ b/app-server/test/api/openapi.test.ts
@@ -150,6 +150,7 @@ describe("openapi document vs runtime", () => {
       "/api/v1/threads/{threadId}",
       "/api/v1/threads/{threadId}/archive",
       "/api/v1/threads/{threadId}/unarchive",
+      "/api/v1/threads/{threadId}/terminal",
       "/api/v1/agents",
       "/api/v1/agents/{agentId}",
       "/api/v1/fs/check",
@@ -373,6 +374,35 @@ describe("openapi document vs runtime", () => {
           "application/json"
         ]!.schema,
         { $ref: "#/components/schemas/Thread" },
+      )
+    }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
+  )
+
+  it.effect("POST /api/v1/threads/{threadId}/terminal opens a linked Terminal", () =>
+    Effect.gen(function* () {
+      const client = yield* rawClient
+      const project = yield* client.post("http://127.0.0.1/api/v1/projects", {
+        body: HttpBody.jsonUnsafe({ name: "Open Docs", defaultWorkingDirectory: "/tmp" }),
+      })
+      const projectBody = (yield* project.json) as { id: string }
+      const thread = yield* client.post("http://127.0.0.1/api/v1/threads", {
+        body: HttpBody.jsonUnsafe({ projectId: projectBody.id, agentId: "codex" }),
+      })
+      const threadBody = (yield* thread.json) as { id: string }
+
+      const opened = yield* client.post(
+        `http://127.0.0.1/api/v1/threads/${threadBody.id}/terminal`,
+        { body: HttpBody.empty },
+      )
+      assert.strictEqual(opened.status, 200)
+      const terminal = (yield* opened.json) as { threadId?: string; status?: string }
+      assert.strictEqual(terminal.threadId, threadBody.id)
+      assert.strictEqual(terminal.status, "live")
+      assert.deepStrictEqual(
+        operation("/api/v1/threads/{threadId}/terminal", "post").responses["200"]!.content[
+          "application/json"
+        ]!.schema,
+        { $ref: "#/components/schemas/Terminal" },
       )
     }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
   )

--- a/app-server/test/cli/cli.blackbox.test.ts
+++ b/app-server/test/cli/cli.blackbox.test.ts
@@ -360,6 +360,29 @@ describe("atc thread (black box)", () => {
 
     await cli(["project", "delete", project.id, "--yes"])
   }, 30_000)
+
+  test("thread open reports one actionable line when the provider is missing", async () => {
+    // A dedicated server whose codex executable cannot resolve: the open
+    // must fail as the contract's 503 diagnostic, not a hang or a crash.
+    await withFakeZmxServer(
+      async (srv) => {
+        const run = (args: ReadonlyArray<string>) =>
+          runCli([process.execPath, "src/main.ts"], args, appServerRoot, srv.env)
+        const project = JSON.parse(
+          (await run(["project", "create", "--name", "NoAgent", "--directory", scratch])).stdout,
+        ) as { id: string }
+        const thread = JSON.parse(
+          (await run(["thread", "create", "--project", project.id, "--agent", "codex"])).stdout,
+        ) as { id: string }
+        const opened = await run(["thread", "open", thread.id])
+        expect(opened.stdout).toBe("")
+        expect(opened.stderr).toMatch(/^atc thread open: .*codexExecutable/)
+        expect(opened.stderr.trim().split("\n")).toHaveLength(1)
+        expect(opened.exitCode).toBe(1)
+      },
+      { ATC_CODEX_EXECUTABLE: "/definitely/not/codex" },
+    )
+  }, 30_000)
 })
 
 // The five stable context variables, all explicitly unset (empty means

--- a/app-server/test/terminals/fakeTerminalAdapter.ts
+++ b/app-server/test/terminals/fakeTerminalAdapter.ts
@@ -22,6 +22,8 @@ export interface FakeSession {
   readonly name: string
   readonly cwd: string
   readonly command: ReadonlyArray<string> | undefined
+  /** The per-session env overlay the session was created with. */
+  readonly env: Record<string, string | undefined> | undefined
   /** Everything written to an attached connection, for assertions. */
   readonly written: Array<Uint8Array | string>
   lastResize: SessionSize | undefined
@@ -82,6 +84,7 @@ export const makeFakeAdapter = (): FakeTerminalAdapter => {
           name: options.name,
           cwd: options.cwd,
           command: options.command,
+          env: options.env,
           written: [],
           lastResize: undefined,
           reachable: true,
@@ -175,6 +178,7 @@ export const makeFakeAdapter = (): FakeTerminalAdapter => {
         name,
         cwd: "/",
         command: undefined,
+        env: undefined,
         written: [],
         lastResize: undefined,
         reachable: true,

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -74,6 +74,7 @@ export const testAppConfig = (overrides: Partial<AppConfig["Service"]>): Layer.L
  */
 export const makeTestServiceLayers = (
   dbFile = ":memory:",
+  threadsOptions: Threads.ThreadsOptions = {},
 ): {
   readonly fake: FakeTerminalAdapter
   readonly fakeAgents: { readonly codex: FakeAgentAdapter; readonly claude: FakeAgentAdapter }
@@ -119,7 +120,7 @@ export const makeTestServiceLayers = (
       services,
       terminals,
       registry,
-      Threads.layer.pipe(Layer.provide([services, terminals])),
+      Threads.layerWith(threadsOptions).pipe(Layer.provide([services, terminals, registry])),
       Projects.layer.pipe(Layer.provide(services)),
     ),
   }

--- a/app-server/test/threads/threadOpen.test.ts
+++ b/app-server/test/threads/threadOpen.test.ts
@@ -1,0 +1,442 @@
+import { assert, describe, it } from "@effect/vitest"
+import { BunHttpServer } from "@effect/platform-bun"
+import { Effect, Fiber, Layer, Option } from "effect"
+import { HttpApiTest } from "effect/unstable/httpapi"
+import { mkdtempSync, realpathSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll } from "vitest"
+import { Api } from "../../src/api/contract.ts"
+import { V1Handlers } from "../../src/api/handlers.ts"
+import { sessionNameForTerminalId } from "../../src/terminals/terminalAdapter.ts"
+import { ThreadRepository } from "../../src/threads/threadRepository.ts"
+import { TestBuildInfoLayer } from "../testBuildInfo.ts"
+import { makeTestServiceLayers } from "../testLayers.ts"
+
+// The terminal-first workflow (ATC-124 / ATC-141) against the uniform seam
+// contract only — these tests are the proof that threads/ needs no provider
+// knowledge: identity materialization, idempotent reopen, confirmation from
+// the normalized feed, provisional re-materialization, fail-closed cleanup,
+// release-on-delete, and demand-driven staleness re-derivation, all through
+// the fake adapters.
+
+const kit = makeTestServiceLayers()
+const TestLayer = Layer.mergeAll(
+  V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, kit.layer])),
+  kit.layer,
+  BunHttpServer.layerHttpServices,
+)
+
+// A dedicated kit whose identity await is tight, for the timeout path.
+const hangKit = makeTestServiceLayers(":memory:", { identityTimeout: "250 millis" })
+const HangLayer = Layer.mergeAll(
+  V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, hangKit.layer])),
+  hangKit.layer,
+  BunHttpServer.layerHttpServices,
+)
+
+// A kit with the default (generous) bound whose identity simply never
+// resolves — for externally-interrupted and concurrent-open paths, where
+// the open must still be in flight when the test acts.
+const holdKit = makeTestServiceLayers()
+const HoldLayer = Layer.mergeAll(
+  V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, holdKit.layer])),
+  holdKit.layer,
+  BunHttpServer.layerHttpServices,
+)
+
+const scratch = mkdtempSync(join(tmpdir(), "atc-thread-open-"))
+afterAll(() => rmSync(scratch, { recursive: true, force: true }))
+const realDir = realpathSync(scratch)
+
+/** Poll (real clock) until `predicate` accepts the effect's value; bounded. */
+const eventually = <A, E>(effect: Effect.Effect<A, E>, predicate: (value: A) => boolean) =>
+  Effect.gen(function* () {
+    for (let attempt = 0; ; attempt++) {
+      const value = yield* effect
+      if (predicate(value)) return value
+      assert.isBelow(attempt, 300, `condition never held; last: ${JSON.stringify(value)}`)
+      yield* Effect.sleep("10 millis")
+    }
+  })
+
+const setup = Effect.gen(function* () {
+  const client = yield* HttpApiTest.groups(Api, ["v1"])
+  const project = yield* client.v1.createProject({
+    payload: { name: "Open", defaultWorkingDirectory: realDir },
+  })
+  const thread = yield* client.v1.createThread({
+    payload: { projectId: project.id, agentId: "codex" },
+  })
+  return { client, project, thread }
+})
+
+describe("threads.openTerminal", () => {
+  it.live("materializes a fresh session: launch, identity, persistence, idempotency", () =>
+    Effect.gen(function* () {
+      const { client, thread } = yield* setup
+      const repository = yield* ThreadRepository
+      const preparedBefore = kit.fakeAgents.codex.prepared.length
+
+      const terminal = yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+      assert.strictEqual(terminal.threadId, thread.id)
+      assert.strictEqual(terminal.status, "live")
+
+      // The terminal runs the adapter's launch spec with the launch env
+      // applied and the nested-session markers scrubbed.
+      const session = kit.fake.sessions.get(sessionNameForTerminalId(terminal.id))
+      assert.deepStrictEqual(session?.command?.slice(0, 2), ["fake-agent", "--fresh"])
+      assert.strictEqual(session?.env?.["FAKE_AGENT"], "1")
+      assert.isTrue(session?.env !== undefined && "CLAUDECODE" in session.env)
+      assert.isUndefined(session?.env?.["CLAUDECODE"])
+
+      // Identity and opaque metadata are persisted, unconfirmed.
+      const record = Option.getOrThrow(yield* repository.get(thread.id))
+      assert.strictEqual(record.providerSessionId, session?.command?.[2])
+      assert.include(record.providerMetadata ?? "", "fake")
+      assert.isUndefined(record.confirmedAt)
+
+      // Honest status: a session exists but no evidence has arrived.
+      const read = yield* client.v1.getThread({ params: { threadId: thread.id } })
+      assert.strictEqual(read.linkedTerminalId, terminal.id)
+      assert.strictEqual(read.activityState, "unknown")
+
+      // Idempotent: a second open returns the live linked terminal as-is.
+      const again = yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+      assert.strictEqual(again.id, terminal.id)
+      assert.strictEqual(kit.fakeAgents.codex.prepared.length, preparedBefore + 1)
+
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.live("confirms at the feed's first busy signal and reopens the exact session", () =>
+    Effect.gen(function* () {
+      const { client, thread } = yield* setup
+      const repository = yield* ThreadRepository
+      const terminal = yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+      const record = Option.getOrThrow(yield* repository.get(thread.id))
+      const sessionId = record.providerSessionId ?? ""
+      const preparedAfterOpen = kit.fakeAgents.codex.prepared.length
+
+      // The one normalized feed: busy = a submitted first prompt — the
+      // confirmed marker persists at onset, activity tracks truthfully.
+      kit.fakeAgents.codex.emitActivity(sessionId, "working")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId: thread.id } }),
+        (t) => t.activityState === "working",
+      )
+      yield* eventually(
+        repository.get(thread.id),
+        (r) => Option.isSome(r) && r.value.confirmedAt !== undefined,
+      )
+      // Archive is refused mid-turn.
+      const busy = yield* Effect.flip(client.v1.archiveThread({ params: { threadId: thread.id } }))
+      assert.strictEqual(busy._tag, "ThreadBusy")
+      kit.fakeAgents.codex.emitActivity(sessionId, "idle")
+
+      // The TUI ends; the confirmed session reopens with its exact id.
+      kit.fake.sessions.delete(sessionNameForTerminalId(terminal.id))
+      const reopened = yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+      assert.notStrictEqual(reopened.id, terminal.id)
+      const relaunch = kit.fake.sessions.get(sessionNameForTerminalId(reopened.id))
+      assert.deepStrictEqual(relaunch?.command, ["fake-agent", "resume", sessionId])
+      // Reopen is exact resume — no fresh session was prepared.
+      assert.strictEqual(kit.fakeAgents.codex.prepared.length, preparedAfterOpen)
+
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.live("an unconfirmed session re-materializes with fresh identity on the next open", () =>
+    Effect.gen(function* () {
+      const { client, thread } = yield* setup
+      const repository = yield* ThreadRepository
+      const terminal = yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+      const first = Option.getOrThrow(yield* repository.get(thread.id)).providerSessionId ?? ""
+
+      // Zero completed turns: the TUI ends before any prompt. The next
+      // open must not resume — there is no history to protect, and the
+      // superseded session's adapter resources are released.
+      kit.fake.sessions.delete(sessionNameForTerminalId(terminal.id))
+      yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+      const second = Option.getOrThrow(yield* repository.get(thread.id)).providerSessionId ?? ""
+      assert.isAbove(second.length, 0)
+      assert.notStrictEqual(second, first)
+      assert.isTrue(
+        kit.fakeAgents.codex.released.some((r) => r.providerSessionId === first),
+        "the superseded session was released",
+      )
+
+      // The NEW session's feed drives the thread — the old subscription is
+      // gone, and the old feed can no longer confirm anything.
+      kit.fakeAgents.codex.emitActivity(first, "working")
+      const record = Option.getOrThrow(yield* repository.get(thread.id))
+      assert.isUndefined(record.confirmedAt)
+
+      kit.fakeAgents.codex.emitActivity(second, "working")
+      yield* eventually(
+        repository.get(thread.id),
+        (r) => Option.isSome(r) && r.value.confirmedAt !== undefined,
+      )
+
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.live("an interrupted open leaves no live terminal behind", () =>
+    Effect.gen(function* () {
+      const { client, thread, project } = yield* setup
+      holdKit.fakeAgents.codex.setIdentityHangs(true)
+      const fiber = yield* client.v1
+        .openThreadTerminal({ params: { threadId: thread.id } })
+        .pipe(Effect.forkChild)
+      // The terminal is live and identity is still pending…
+      yield* eventually(
+        Effect.sync(() => holdKit.fake.sessions.size),
+        (size) => size === 1,
+      )
+
+      // …and a concurrent second open never double-launches: the in-flight
+      // terminal is already live and linked, so the idempotent path returns
+      // it as-is.
+      const second = yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+      assert.strictEqual(second.threadId, thread.id)
+      assert.strictEqual(holdKit.fake.sessions.size, 1)
+
+      // The caller goes away (Ctrl-C / dropped connection): the launched
+      // terminal must not survive as an orphan the thread adopted nothing
+      // from.
+      yield* Fiber.interrupt(fiber)
+      yield* eventually(
+        Effect.sync(() => holdKit.fake.sessions.size),
+        (size) => size === 0,
+      )
+      assert.deepStrictEqual(
+        yield* client.v1.listTerminals({ query: { projectId: project.id } }),
+        [],
+      )
+      holdKit.fakeAgents.codex.setIdentityHangs(false)
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+    }).pipe(Effect.provide(HoldLayer)),
+  )
+
+  it.live("identity resolving after a mid-open delete releases the fresh session", () =>
+    Effect.gen(function* () {
+      const { client, thread } = yield* setup
+      holdKit.fakeAgents.codex.setIdentityHangs(true)
+      const fiber = yield* client.v1
+        .openThreadTerminal({ params: { threadId: thread.id } })
+        .pipe(Effect.forkChild)
+      yield* eventually(
+        Effect.sync(() => holdKit.fake.sessions.size),
+        (size) => size === 1,
+      )
+      const fresh = holdKit.fakeAgents.codex.prepared.at(-1)?.providerSessionId ?? ""
+
+      // The thread is deleted while identity is still pending; when the
+      // identity then resolves, adoption finds no row — the ownership
+      // bracket must release the fresh session's adapter resources, because
+      // no thread row will ever own (or release) them.
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+      holdKit.fakeAgents.codex.setIdentityHangs(false)
+      const exit = yield* Fiber.await(fiber)
+      assert.strictEqual(exit._tag, "Failure")
+      yield* eventually(
+        Effect.sync(() => holdKit.fakeAgents.codex.released),
+        (released) => released.some((r) => r.providerSessionId === fresh),
+      )
+      assert.strictEqual(holdKit.fake.sessions.size, 0)
+    }).pipe(Effect.provide(HoldLayer)),
+  )
+
+  it.live("identity establishment failing in time cleans up the launched terminal", () =>
+    Effect.gen(function* () {
+      const { client, thread, project } = yield* setup
+      hangKit.fakeAgents.codex.setIdentityHangs(true)
+      const failure = yield* Effect.flip(
+        client.v1.openThreadTerminal({ params: { threadId: thread.id } }),
+      )
+      assert.strictEqual(failure._tag, "ProviderUnavailable")
+      // Fail-closed: no terminal survives, nothing was adopted.
+      assert.deepStrictEqual(
+        yield* client.v1.listTerminals({ query: { projectId: project.id } }),
+        [],
+      )
+      assert.strictEqual(hangKit.fake.sessions.size, 0)
+      const read = yield* client.v1.getThread({ params: { threadId: thread.id } })
+      assert.strictEqual(read.activityState, "idle")
+      hangKit.fakeAgents.codex.setIdentityHangs(false)
+    }).pipe(Effect.provide(HangLayer)),
+  )
+
+  it.live("archived threads are blocked from opening", () =>
+    Effect.gen(function* () {
+      const { client, thread } = yield* setup
+      yield* client.v1.archiveThread({ params: { threadId: thread.id } })
+      const failure = yield* Effect.flip(
+        client.v1.openThreadTerminal({ params: { threadId: thread.id } }),
+      )
+      assert.strictEqual(failure._tag, "ThreadArchived")
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.live("delete releases the adapter's session resources with the persisted metadata", () =>
+    Effect.gen(function* () {
+      const { client, thread } = yield* setup
+      const repository = yield* ThreadRepository
+      yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+      const record = Option.getOrThrow(yield* repository.get(thread.id))
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+      const release = kit.fakeAgents.codex.released.at(-1)
+      assert.strictEqual(release?.providerSessionId, record.providerSessionId)
+      assert.strictEqual(release?.providerMetadata, record.providerMetadata)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.live("restart recovery: a read under a live TUI re-establishes observation", () =>
+    Effect.gen(function* () {
+      const dbFile = join(scratch, "restart.db")
+      // "Before the restart": open a thread's terminal and persist identity.
+      const before = makeTestServiceLayers(dbFile)
+      const state = yield* Effect.gen(function* () {
+        const client = yield* HttpApiTest.groups(Api, ["v1"])
+        const repository = yield* ThreadRepository
+        const project = yield* client.v1.createProject({
+          payload: { name: "Restart", defaultWorkingDirectory: realDir },
+        })
+        const thread = yield* client.v1.createThread({
+          payload: { projectId: project.id, agentId: "codex" },
+        })
+        const terminal = yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+        const record = Option.getOrThrow(yield* repository.get(thread.id))
+        return {
+          threadId: thread.id,
+          terminalId: terminal.id,
+          sessionId: record.providerSessionId ?? "",
+        }
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, before.layer])),
+            before.layer,
+            BunHttpServer.layerHttpServices,
+          ),
+        ),
+      )
+
+      // "After the restart": a fresh process (fresh in-memory adapters) over
+      // the same database, with the zmx session still alive (seeded — real
+      // zmx sessions survive an ATC restart). No poller runs: the first
+      // READ re-links, re-observes, and status flows again.
+      const after = makeTestServiceLayers(dbFile)
+      after.fake.seed(sessionNameForTerminalId(state.terminalId))
+      yield* Effect.gen(function* () {
+        const client = yield* HttpApiTest.groups(Api, ["v1"])
+        const read = yield* client.v1.getThread({ params: { threadId: state.threadId } })
+        assert.strictEqual(read.linkedTerminalId, state.terminalId)
+        assert.strictEqual(read.activityState, "unknown")
+        after.fakeAgents.codex.emitActivity(state.sessionId, "working")
+        yield* eventually(
+          client.v1.getThread({ params: { threadId: state.threadId } }),
+          (t) => t.activityState === "working",
+        )
+        yield* client.v1.deleteThread({ params: { threadId: state.threadId } })
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, after.layer])),
+            after.layer,
+            BunHttpServer.layerHttpServices,
+          ),
+        ),
+      )
+    }),
+  )
+
+  it.live("restart mid-first-turn: an observed busy confirms durably, the next open resumes", () =>
+    Effect.gen(function* () {
+      const dbFile = join(scratch, "restart-mid-turn.db")
+      // "Before the restart": the first turn starts; ATC goes down before
+      // its idle ever arrives on the feed.
+      const before = makeTestServiceLayers(dbFile)
+      const state = yield* Effect.gen(function* () {
+        const client = yield* HttpApiTest.groups(Api, ["v1"])
+        const repository = yield* ThreadRepository
+        const project = yield* client.v1.createProject({
+          payload: { name: "RestartMidTurn", defaultWorkingDirectory: realDir },
+        })
+        const thread = yield* client.v1.createThread({
+          payload: { projectId: project.id, agentId: "codex" },
+        })
+        yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+        const record = Option.getOrThrow(yield* repository.get(thread.id))
+        const sessionId = record.providerSessionId ?? ""
+        before.fakeAgents.codex.emitActivity(sessionId, "working")
+        yield* eventually(
+          repository.get(thread.id),
+          (r) => Option.isSome(r) && r.value.confirmedAt !== undefined,
+        )
+        return { threadId: thread.id, sessionId }
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, before.layer])),
+            before.layer,
+            BunHttpServer.layerHttpServices,
+          ),
+        ),
+      )
+
+      // "After the restart": the TUI ended during the downtime, and the
+      // completed turn's idle was never observed by any process. The session
+      // has history (a submitted prompt), so the next open must resume the
+      // exact id, never re-materialize.
+      const after = makeTestServiceLayers(dbFile)
+      yield* Effect.gen(function* () {
+        const client = yield* HttpApiTest.groups(Api, ["v1"])
+        const reopened = yield* client.v1.openThreadTerminal({
+          params: { threadId: state.threadId },
+        })
+        const relaunch = after.fake.sessions.get(sessionNameForTerminalId(reopened.id))
+        assert.deepStrictEqual(relaunch?.command, ["fake-agent", "resume", state.sessionId])
+        assert.strictEqual(after.fakeAgents.codex.prepared.length, 0)
+        yield* client.v1.deleteThread({ params: { threadId: state.threadId } })
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, after.layer])),
+            after.layer,
+            BunHttpServer.layerHttpServices,
+          ),
+        ),
+      )
+    }),
+  )
+
+  it.live("a busy state with no live driver re-derives from the adapter on read", () =>
+    Effect.gen(function* () {
+      const { client, thread } = yield* setup
+      const repository = yield* ThreadRepository
+      const terminal = yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+      const sessionId = Option.getOrThrow(yield* repository.get(thread.id)).providerSessionId ?? ""
+      kit.fakeAgents.codex.emitActivity(sessionId, "working")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId: thread.id } }),
+        (t) => t.activityState === "working",
+      )
+
+      // The driver dies out from under ATC: stale `working` must re-derive
+      // from the adapter's reconciliation check, not persist as a lie.
+      kit.fake.sessions.delete(sessionNameForTerminalId(terminal.id))
+      kit.fakeAgents.codex.setCheckActivity(sessionId, "idle")
+      const read = yield* client.v1.getThread({ params: { threadId: thread.id } })
+      assert.isUndefined(read.linkedTerminalId)
+      assert.strictEqual(read.activityState, "idle")
+
+      kit.fakeAgents.codex.setCheckActivity(sessionId, null)
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+})


### PR DESCRIPTION
PR 3 of 3 for [ATC-124](https://linear.app/elevenideas/issue/ATC-124). Implements [ATC-141](https://linear.app/elevenideas/issue/ATC-141). **Stacked on #136** (which is stacked on #135) — merge in order 135 → 136 → 137.

## What this adds

- **`threads.openTerminal`** (`POST /threads/:threadId/terminal` → Terminal, plus `atc thread open` = open + raw-TTY attach):
  - **Idempotent**: a live linked terminal is returned as-is — including one whose identity is still being established; at most one live linked TUI terminal per thread.
  - **Unconfirmed threads materialize fresh** through the uniform seam flow: `prepareTuiSession` → Terminal from `launchSpec` (nested-session env markers scrubbed uniformly via a new per-session env overlay on the terminal seam) → bounded identity await → persist session id + opaque metadata. The bound covers the whole flow (launch-lock queueing included), so a slow provider can't hang callers. On failure, defect, **or interruption** (a dropped client), the launched terminal is torn down — nothing survives that the thread adopted nothing from. Superseded unconfirmed sessions are unobserved + released before a successor is minted.
  - **Confirmed threads reopen their exact session** via `tuiLaunch`; mismatches fail closed; a delete racing the open adopts nothing.
  - `materialize` is the single identity-establishment transition, with openTerminal as its first caller (a native first-prompt is the future second caller — same persistence, no schema change).
- **Status wiring**: per-session activity subscriptions (keyed by thread **and** session, so a superseded session's feed can never drive — or falsely confirm — its successor) feed the in-memory `activityState`; the confirmed marker is set on the feed's busy→idle transition (a completed first turn — the same signal for every provider). Stale busy states with no live driver re-derive demand-driven via `checkSession`; a read after an ATC restart re-links and re-observes with no poller. Archive is refused while busy (`needs_input` counts — an approval prompt is still mid-turn).
- **Error mapping** per the decision record: `ProviderUnavailable` 503 (retryable), `ProviderSessionConflict` 409 (fail-closed), `ThreadArchived` 409.
- **Gated live smoke** (`test:smoke`): a real interactive `claude --session-id <minted> --settings <hooks>` launch confirms the pre-assigned id through its own hook delivery — the one implementation-time check the decision record left open, now verified passing on a real install.

## Review hardening folded in

Two adversarial reviews (correctness with reproduction probes, simplicity). Fixed from them: the superseded-session observation leak (old feed could confirm the new session and permanently wedge the thread), interruption-safe terminal cleanup (`onExit`, not `tapError`), release of superseded sessions' adapter resources, thread listing restored to one reconciled inventory pass per page (was N+1 zmx spawns), the idempotent open path no longer double-lists, reopen re-checks the row before inserting, and the open bound now covers launch-lock queueing. Regression tests cover each.

## Tests

`threadOpen.test.ts`: materialization/persistence/idempotency (env scrubbing included), confirmation + exact reopen, provisional re-materialization with feed-isolation and release assertions, timeout and interruption cleanup, archived blocking, release-on-delete, staleness re-derivation, and an in-process restart-recovery case (fresh process over the same DB re-observes on first read). CLI blackbox: `thread open` produces the one-line actionable 503 diagnostic when the provider is missing. `mise run check` (228 tests) and `mise run contract:check` green; `ATC_SMOKE=1` TUI smoke verified live.

https://claude.ai/code/session_01336PDxLnsF6jXJ8w8uJiQc