### PR TITLE
ATC-128: client event streaming for live resource updates

### DIFF
--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -1014,6 +1014,129 @@
         "description": "Fetch one built-in agent by its registry slug."
       }
     },
+    "/api/v1/events": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "subscribeEvents",
+        "parameters": [],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "event": {
+                      "type": "string"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/ResourceChangedEventJsonEncoding"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "event",
+                    "data"
+                  ],
+                  "additionalProperties": false
+                },
+                "x-effect-stream": {
+                  "encoding": "sse",
+                  "causeSchema": {
+                    "type": "array",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "_tag": {
+                              "type": "string",
+                              "enum": [
+                                "Fail"
+                              ]
+                            },
+                            "error": {
+                              "not": {}
+                            }
+                          },
+                          "required": [
+                            "_tag",
+                            "error"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "_tag": {
+                              "type": "string",
+                              "enum": [
+                                "Die"
+                              ]
+                            },
+                            "defect": {}
+                          },
+                          "required": [
+                            "_tag",
+                            "defect"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "_tag": {
+                              "type": "string",
+                              "enum": [
+                                "Interrupt"
+                              ]
+                            },
+                            "fiberId": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "_tag",
+                            "fiberId"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  },
+                  "errorSchema": {
+                    "not": {}
+                  },
+                  "failureEvent": "effect/httpapi/stream/failure"
+                }
+              }
+            }
+          }
+        },
+        "description": "Subscribe to live resource-change events (SSE). The stream is ephemeral — no replay: on every (re)connect, refetch lists first, then trust the stream. The server ends the stream of a subscriber that falls too far behind; reconnect and resync."
+      }
+    },
     "/api/v1/fs/check": {
       "get": {
         "tags": [
@@ -1748,6 +1871,10 @@
         ],
         "additionalProperties": false
       },
+      "ResourceChangedEventJsonEncoding": {
+        "type": "string",
+        "contentMediaType": "application/json"
+      },
       "DirectoryState": {
         "type": "string",
         "enum": [
@@ -1785,6 +1912,40 @@
         ],
         "additionalProperties": false,
         "description": "Result of a directory health check. Never persisted."
+      },
+      "ResourceChangedEvent": {
+        "type": "object",
+        "properties": {
+          "resource": {
+            "type": "string",
+            "enum": [
+              "project",
+              "thread",
+              "terminal"
+            ],
+            "description": "Which resource collection changed."
+          },
+          "id": {
+            "type": "string",
+            "description": "Id of the changed resource."
+          },
+          "change": {
+            "type": "string",
+            "enum": [
+              "created",
+              "updated",
+              "deleted"
+            ],
+            "description": "What happened. Every field-level transition (status, archive state, activity) is \"updated\"."
+          }
+        },
+        "required": [
+          "resource",
+          "id",
+          "change"
+        ],
+        "additionalProperties": false,
+        "description": "Thin invalidation event: names what changed, never carries resource state. Clients coalesce events and refetch through the corresponding GETs, which stay the single source of truth."
       }
     },
     "securitySchemes": {}

--- a/app-server/src/api/contract.ts
+++ b/app-server/src/api/contract.ts
@@ -1,5 +1,11 @@
 import { Schema } from "effect"
-import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+import {
+  HttpApi,
+  HttpApiEndpoint,
+  HttpApiGroup,
+  HttpApiSchema,
+  OpenApi,
+} from "effect/unstable/httpapi"
 
 // The public HTTP contract. The server implementation (handlers.ts), the
 // checked-in OpenAPI document (openapi.ts), and typed clients all derive from
@@ -292,6 +298,21 @@ export const UpdateThreadRequest = Schema.Struct({
 }).annotate({
   identifier: "UpdateThreadRequest",
   description: "Partial update; only the display label is mutable.",
+})
+
+export const ResourceChangedEvent = Schema.Struct({
+  resource: Schema.Literals(["project", "thread", "terminal"]).annotate({
+    description: "Which resource collection changed.",
+  }),
+  id: Schema.String.annotate({ description: "Id of the changed resource." }),
+  change: Schema.Literals(["created", "updated", "deleted"]).annotate({
+    description:
+      'What happened. Every field-level transition (status, archive state, activity) is "updated".',
+  }),
+}).annotate({
+  identifier: "ResourceChangedEvent",
+  description:
+    "Thin invalidation event: names what changed, never carries resource state. Clients coalesce events and refetch through the corresponding GETs, which stay the single source of truth.",
 })
 
 // The error classes carry human `message`s so every consumer (the CLI above
@@ -764,6 +785,14 @@ export class V1 extends HttpApiGroup.make("v1")
     })
       .annotate(OpenApi.Identifier, "getAgent")
       .annotate(OpenApi.Description, "Fetch one built-in agent by its registry slug."),
+    HttpApiEndpoint.get("subscribeEvents", "/events", {
+      success: HttpApiSchema.StreamSse({ data: ResourceChangedEvent }),
+    })
+      .annotate(OpenApi.Identifier, "subscribeEvents")
+      .annotate(
+        OpenApi.Description,
+        "Subscribe to live resource-change events (SSE). The stream is ephemeral — no replay: on every (re)connect, refetch lists first, then trust the stream. The server ends the stream of a subscriber that falls too far behind; reconnect and resync.",
+      ),
     HttpApiEndpoint.get("checkDirectory", "/fs/check", {
       query: { path: AbsolutePath },
       success: FsCheckResponse,

--- a/app-server/src/api/handlers.ts
+++ b/app-server/src/api/handlers.ts
@@ -1,13 +1,18 @@
-import { Effect } from "effect"
+import { Effect, Schema, Stream } from "effect"
+import { HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
-import { Api } from "./contract.ts"
+import { Api, ResourceChangedEvent } from "./contract.ts"
 import { AgentRegistry } from "../agents/agentRegistry.ts"
+import { Events } from "../events/events.ts"
 import { BuildInfo } from "../platform/buildInfo.ts"
 import { Directories } from "../platform/directories.ts"
 import { Projects } from "../projects/projects.ts"
 import { attachTerminal } from "../terminals/terminalAttach.ts"
 import { Terminals } from "../terminals/terminals.ts"
 import { Threads } from "../threads/threads.ts"
+
+/** One SSE frame per contract event: the exact wire shape StreamSse encodes. */
+const encodeEventJson = Schema.encodeEffect(Schema.fromJsonString(ResourceChangedEvent))
 
 /**
  * Implements the /api/v1 contract. App construction only — no listener, and
@@ -23,46 +28,81 @@ export const V1Handlers = HttpApiBuilder.group(
     const terminals = yield* Terminals
     const threads = yield* Threads
     const agents = yield* AgentRegistry
+    const events = yield* Events
     // Attach bridges outlive their originating requests (Bun aborts the
     // request on protocol switch); they live in the handler layer's scope,
     // so server shutdown still reaps every bridge and its PTY client.
     const bridgeScope = yield* Effect.scope
 
-    return handlers
-      .handle("health", () => Effect.succeed({ status: "ok" } as const))
-      .handle("version", () =>
-        Effect.succeed({
-          version: build.version,
-          apiVersion: "v1",
-          commit: build.commit,
-          builtAt: build.builtAt,
-        } as const),
-      )
-      .handle("listProjects", () => projects.list())
-      .handle("createProject", ({ payload }) => projects.create(payload))
-      .handle("getProject", ({ params }) => projects.get(params.projectId))
-      .handle("updateProject", ({ params, payload }) => projects.update(params.projectId, payload))
-      .handle("deleteProject", ({ params }) => projects.delete(params.projectId))
-      .handle("checkDirectory", ({ query }) => directories.check(query.path))
-      .handle("listTerminals", ({ query }) => terminals.list(query.projectId))
-      .handle("createTerminal", ({ payload }) => terminals.create(payload))
-      .handle("getTerminal", ({ params }) => terminals.get(params.terminalId))
-      .handle("updateTerminal", ({ params, payload }) =>
-        terminals.update(params.terminalId, payload),
-      )
-      .handle("deleteTerminal", ({ params }) => terminals.delete(params.terminalId))
-      .handle("listThreads", ({ query }) =>
-        threads.list({ projectId: query.projectId, archived: query.archived === "true" }),
-      )
-      .handle("createThread", ({ payload }) => threads.create(payload))
-      .handle("getThread", ({ params }) => threads.get(params.threadId))
-      .handle("updateThread", ({ params, payload }) => threads.update(params.threadId, payload))
-      .handle("archiveThread", ({ params }) => threads.archive(params.threadId))
-      .handle("unarchiveThread", ({ params }) => threads.unarchive(params.threadId))
-      .handle("deleteThread", ({ params }) => threads.delete(params.threadId))
-      .handle("openThreadTerminal", ({ params }) => threads.openTerminal(params.threadId))
-      .handle("listAgents", () => agents.list())
-      .handle("getAgent", ({ params }) => agents.get(params.agentId))
-      .handleRaw("attachTerminal", attachTerminal({ terminals, bridgeScope }))
+    return (
+      handlers
+        .handle("health", () => Effect.succeed({ status: "ok" } as const))
+        .handle("version", () =>
+          Effect.succeed({
+            version: build.version,
+            apiVersion: "v1",
+            commit: build.commit,
+            builtAt: build.builtAt,
+          } as const),
+        )
+        .handle("listProjects", () => projects.list())
+        .handle("createProject", ({ payload }) => projects.create(payload))
+        .handle("getProject", ({ params }) => projects.get(params.projectId))
+        .handle("updateProject", ({ params, payload }) =>
+          projects.update(params.projectId, payload),
+        )
+        .handle("deleteProject", ({ params }) => projects.delete(params.projectId))
+        .handle("checkDirectory", ({ query }) => directories.check(query.path))
+        .handle("listTerminals", ({ query }) => terminals.list(query.projectId))
+        .handle("createTerminal", ({ payload }) => terminals.create(payload))
+        .handle("getTerminal", ({ params }) => terminals.get(params.terminalId))
+        .handle("updateTerminal", ({ params, payload }) =>
+          terminals.update(params.terminalId, payload),
+        )
+        .handle("deleteTerminal", ({ params }) => terminals.delete(params.terminalId))
+        .handle("listThreads", ({ query }) =>
+          threads.list({ projectId: query.projectId, archived: query.archived === "true" }),
+        )
+        .handle("createThread", ({ payload }) => threads.create(payload))
+        .handle("getThread", ({ params }) => threads.get(params.threadId))
+        .handle("updateThread", ({ params, payload }) => threads.update(params.threadId, payload))
+        .handle("archiveThread", ({ params }) => threads.archive(params.threadId))
+        .handle("unarchiveThread", ({ params }) => threads.unarchive(params.threadId))
+        .handle("deleteThread", ({ params }) => threads.delete(params.threadId))
+        .handle("openThreadTerminal", ({ params }) => threads.openTerminal(params.threadId))
+        .handle("listAgents", () => agents.list())
+        .handle("getAgent", ({ params }) => agents.get(params.agentId))
+        // handleRaw instead of the typed handler for one reason: this stream
+        // emits nothing until the first change, and Bun's fetch (every Bun
+        // client, the contract TS client included) does not resolve a
+        // chunked response until its first body byte — so the opening SSE
+        // comment is what lets subscribers observe "stream open" and start
+        // their resync. Conforming SSE parsers ignore comment lines, and
+        // events are encoded through the contract schema, so the wire shape
+        // is exactly what the typed StreamSse pipeline produces.
+        .handleRaw("subscribeEvents", () =>
+          Effect.gen(function* () {
+            // Registration first: a client may resync the moment it sees
+            // the comment, so the subscription must already be live. The
+            // reconcile pass then lands its tombstone transitions IN this
+            // subscriber's stream — the "a client showed up" refresh.
+            const feed = yield* events.subscribe()
+            yield* terminals.list()
+            const encoded = feed.pipe(
+              Stream.mapEffect((event) =>
+                Effect.map(encodeEventJson(event), (json) => `data: ${json}\n\n`),
+              ),
+            )
+            return HttpServerResponse.stream(
+              Stream.concat(Stream.succeed(": connected\n\n"), encoded).pipe(
+                Stream.encodeText,
+                Stream.orDie,
+              ),
+              { contentType: "text/event-stream" },
+            )
+          }),
+        )
+        .handleRaw("attachTerminal", attachTerminal({ terminals, bridgeScope }))
+    )
   }),
 )

--- a/app-server/src/api/handlers.ts
+++ b/app-server/src/api/handlers.ts
@@ -82,12 +82,15 @@ export const V1Handlers = HttpApiBuilder.group(
         // is exactly what the typed StreamSse pipeline produces.
         .handleRaw("subscribeEvents", () =>
           Effect.gen(function* () {
-            // Registration first: a client may resync the moment it sees
-            // the comment, so the subscription must already be live. The
-            // reconcile pass then lands its tombstone transitions IN this
-            // subscriber's stream — the "a client showed up" refresh.
-            const feed = yield* events.subscribe()
+            // Reconcile (the "a client showed up" refresh) BEFORE
+            // registering: a queue registered first would sit in the
+            // subscriber set until overflow if the fallible reconcile
+            // failed — or the request died during it — before the stream's
+            // cleanup was armed. Registration still precedes the first
+            // response byte, so a client that resyncs the moment it sees
+            // the comment observes the reconciled state and misses nothing.
             yield* terminals.list()
+            const feed = yield* events.subscribe()
             const encoded = feed.pipe(
               Stream.mapEffect((event) =>
                 Effect.map(encodeEventJson(event), (json) => `data: ${json}\n\n`),

--- a/app-server/src/api/openapi.ts
+++ b/app-server/src/api/openapi.ts
@@ -1,5 +1,6 @@
+import { Schema } from "effect"
 import { OpenApi } from "effect/unstable/httpapi"
-import { Api } from "./contract.ts"
+import { Api, ResourceChangedEvent } from "./contract.ts"
 
 // The OpenAPI document derived from the contract. This module is pure — no
 // server, no side effects — so generation works anywhere the contract compiles.
@@ -36,9 +37,45 @@ const hoistSingleAllOf = (node: unknown): unknown => {
   return schema
 }
 
-export const openApiDocument = hoistSingleAllOf(OpenApi.fromApi(Api)) as ReturnType<
-  typeof OpenApi.fromApi
->
+/**
+ * Emit the SSE payload schema as an ordinary component. Data-mode `StreamSse`
+ * documents its payload as the JSON-encoded string that crosses the wire
+ * inside each `data:` line (`ResourceChangedEventJsonEncoding`), which the
+ * pinned Swift generator can only render as a `String` typealias — leaving
+ * Swift clients no generated type to decode that JSON into. The added plain
+ * component fills that gap. Both guards below fail generation loudly rather
+ * than emit a silently broken document: a nested named schema would carry a
+ * dangling `#/$defs/` ref, and a same-named component from the contract
+ * would be clobbered.
+ */
+const withSsePayloadComponents = (document: ReturnType<typeof OpenApi.fromApi>) => {
+  const { definitions } = Schema.toJsonSchemaDocument(ResourceChangedEvent)
+  const names = Object.keys(definitions)
+  if (names.length !== 1) {
+    throw new Error(
+      `the SSE payload schema must stay flat (no nested named schemas); got components ${names.join(", ")}`,
+    )
+  }
+  if ("ResourceChangedEvent" in document.components.schemas) {
+    throw new Error(
+      "the document already has a ResourceChangedEvent component; refusing to overwrite it",
+    )
+  }
+  return {
+    ...document,
+    components: {
+      ...document.components,
+      schemas: {
+        ...document.components.schemas,
+        ResourceChangedEvent: definitions["ResourceChangedEvent"],
+      },
+    },
+  } as ReturnType<typeof OpenApi.fromApi>
+}
+
+export const openApiDocument = hoistSingleAllOf(
+  withSsePayloadComponents(OpenApi.fromApi(Api)),
+) as ReturnType<typeof OpenApi.fromApi>
 
 /**
  * The canonical serialized form of the document: 2-space indentation and a

--- a/app-server/src/events/events.ts
+++ b/app-server/src/events/events.ts
@@ -1,0 +1,101 @@
+import { Context, Effect, Layer, Queue, Stream } from "effect"
+import type { Cause } from "effect"
+import type { ResourceChangedEvent as ResourceChangedEventSchema } from "../api/contract.ts"
+
+export type ResourceChangedEvent = typeof ResourceChangedEventSchema.Type
+
+// The Events service (ATC-128): the in-process fan-out for resource-change
+// events. Domain services publish next to each successful mutation; the
+// subscribe endpoint streams to clients. Invariants:
+//
+//   - Delivery is ephemeral, best-effort: no log, no replay, and publishes
+//     sit after their durable write outside any uninterruptible region, so
+//     a crash or abort in between can drop an event. Clients resync on
+//     every (re)connect, which heals every drop the service can detect by
+//     ending the stream — the design contract is "close the stream on any
+//     doubt".
+//   - publish never blocks or fails: each subscriber has its own bounded
+//     queue, and a full queue ends that subscriber's stream (the client's
+//     reconnect resync heals it) rather than back-pressuring mutations.
+//   - subscribe() registers eagerly, in the effect: by the time it returns,
+//     the subscriber receives every subsequent publish. The subscribe
+//     endpoint relies on this to guarantee "registered before the client
+//     sees any byte". A registered stream that never runs self-heals: its
+//     queue fills and publish drops it.
+//   - close() (also the layer finalizer) ends every subscriber stream
+//     cleanly. server.ts sequences it to release BEFORE the HTTP listener's
+//     bounded graceful stop — an open SSE response would otherwise hold the
+//     stop for the full timeout and die on the noisy forced-interrupt path.
+
+export class Events extends Context.Service<
+  Events,
+  {
+    /** Deliver one event to every current subscriber; never blocks. */
+    readonly publish: (event: ResourceChangedEvent) => Effect.Effect<void>
+    /**
+     * Register a subscriber (eagerly — see the header) and return its live
+     * stream, which ends on lag or on close().
+     */
+    readonly subscribe: () => Effect.Effect<Stream.Stream<ResourceChangedEvent>>
+    /** Currently registered subscribers. Exists for tests and diagnostics. */
+    readonly subscriberCount: () => Effect.Effect<number>
+    /** End every subscriber stream, current and future. Idempotent. */
+    readonly close: () => Effect.Effect<void>
+  }
+>()("app-server/Events") {}
+
+export interface EventsOptions {
+  /** Per-subscriber queue capacity; overflow ends that subscriber's stream. */
+  readonly subscriberCapacity?: number
+}
+
+export const layerWith = (options: EventsOptions) =>
+  Layer.effect(Events)(
+    Effect.gen(function* () {
+      const capacity = options.subscriberCapacity ?? 128
+      const subscribers = new Set<Queue.Queue<ResourceChangedEvent, Cause.Done>>()
+      let closed = false
+
+      const close = () =>
+        Effect.sync(() => {
+          closed = true
+          for (const queue of subscribers) Queue.endUnsafe(queue)
+          subscribers.clear()
+        })
+
+      // Belt and braces: the server drains explicitly before the listener
+      // stops (server.ts); this covers every other lifecycle (tests, crashes
+      // of sibling layers) so no subscriber stream outlives the service.
+      yield* Effect.addFinalizer(close)
+
+      return {
+        publish: (event) =>
+          Effect.sync(() => {
+            for (const queue of subscribers) {
+              if (Queue.offerUnsafe(queue, event)) continue
+              // Ended queues buffered events the subscriber still drains;
+              // this one lost `event`, so resync-on-reconnect is the only
+              // honest recovery.
+              Queue.endUnsafe(queue)
+              subscribers.delete(queue)
+            }
+          }),
+        subscribe: () =>
+          Effect.gen(function* () {
+            const queue = yield* Queue.make<ResourceChangedEvent, Cause.Done>({ capacity })
+            if (closed) {
+              yield* Queue.end(queue)
+            } else {
+              subscribers.add(queue)
+            }
+            return Stream.fromQueue(queue).pipe(
+              Stream.ensuring(Effect.sync(() => subscribers.delete(queue))),
+            )
+          }),
+        subscriberCount: () => Effect.sync(() => subscribers.size),
+        close,
+      }
+    }),
+  )
+
+export const layer = layerWith({})

--- a/app-server/src/projects/projects.ts
+++ b/app-server/src/projects/projects.ts
@@ -6,6 +6,7 @@ import type {
   DirectoryUnavailable,
   UpdateProjectRequest,
 } from "../api/contract.ts"
+import { Events } from "../events/events.ts"
 import { Directories } from "../platform/directories.ts"
 import { ProjectRepository } from "./projectRepository.ts"
 import type { Project } from "./projectRepository.ts"
@@ -45,16 +46,19 @@ export const layer = Layer.effect(Projects)(
     const directories = yield* Directories
     const terminalRepository = yield* TerminalRepository
     const threadRepository = yield* ThreadRepository
+    const events = yield* Events
 
     return {
       list: () => repository.list(),
       create: (input) =>
         Effect.gen(function* () {
           const canonical = yield* directories.canonicalize(input.defaultWorkingDirectory)
-          return yield* repository.create({
+          const created = yield* repository.create({
             name: input.name,
             defaultWorkingDirectory: canonical,
           })
+          yield* events.publish({ resource: "project", id: created.id, change: "created" })
+          return created
         }),
       get: (id) => repository.require(id),
       update: (id, patch) =>
@@ -69,7 +73,14 @@ export const layer = Layer.effect(Projects)(
           })
           return yield* Option.match(updated, {
             onNone: () => Effect.fail(new ProjectNotFound({ projectId: id })),
-            onSome: Effect.succeed,
+            onSome: (project) =>
+              // An empty patch changed nothing (the repository short-circuits
+              // it), so it publishes nothing.
+              patch.name === undefined && canonical === undefined
+                ? Effect.succeed(project)
+                : events
+                    .publish({ resource: "project", id, change: "updated" })
+                    .pipe(Effect.as(project)),
           })
         }),
       delete: (id) =>
@@ -90,6 +101,7 @@ export const layer = Layer.effect(Projects)(
           if (!deleted) {
             return yield* Effect.fail(new ProjectNotFound({ projectId: id }))
           }
+          yield* events.publish({ resource: "project", id, change: "deleted" })
         }),
     }
   }),

--- a/app-server/src/server.ts
+++ b/app-server/src/server.ts
@@ -1,5 +1,5 @@
 import { BunHttpServer } from "@effect/platform-bun"
-import { Layer } from "effect"
+import { Effect, Layer } from "effect"
 import { HttpMiddleware, HttpRouter, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { Api } from "./api/contract.ts"
@@ -9,6 +9,7 @@ import * as ClaudeHooks from "./agents/claudeHooks.ts"
 import * as CodexAdapter from "./agents/codexAdapter.ts"
 import * as CodexServer from "./agents/codexServer.ts"
 import * as Directories from "./platform/directories.ts"
+import * as Events from "./events/events.ts"
 import { V1Handlers } from "./api/handlers.ts"
 import * as LocalTrust from "./api/localTrust.ts"
 import * as Logging from "./platform/logging.ts"
@@ -46,6 +47,19 @@ export const routes = Layer.mergeAll(
   LocalTrust.middleware,
 )
 
+// Layer finalizers run dependents-first, so this must sit ABOVE the serve
+// layer: on shutdown it ends every event subscriber stream before the
+// listener's bounded graceful stop starts waiting on open responses. Left to
+// the Events layer's own finalizer (a dependency, released after the stop),
+// an open SSE response would hold the stop for the full timeout and die on
+// the noisy forced-interrupt path instead.
+const drainEventsBeforeStop = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const events = yield* Events.Events
+    yield* Effect.addFinalizer(events.close)
+  }),
+)
+
 /**
  * The full server: guarded routes on a loopback TCP listener, each request
  * wrapped in a tracer span (the correlation id source for logs). The layer's
@@ -53,7 +67,8 @@ export const routes = Layer.mergeAll(
  * interruption) stops the server and releases the port.
  */
 export const layer = (options: { readonly port: number }) =>
-  HttpRouter.serve(routes, { middleware: HttpMiddleware.tracer }).pipe(
+  drainEventsBeforeStop.pipe(
+    Layer.provideMerge(HttpRouter.serve(routes, { middleware: HttpMiddleware.tracer })),
     Layer.provideMerge(
       BunHttpServer.layer({
         port: options.port,
@@ -76,6 +91,9 @@ export const production = (options: { readonly port: number }) =>
   layer(options).pipe(
     Layer.provide([Projects.layer, Threads.layer]),
     Layer.provide([Terminals.layer, AgentRegistry.layer]),
+    // Below Terminals (the deepest publisher) so one memoized Events instance
+    // serves every domain service, the handlers, and the shutdown drain.
+    Layer.provide(Events.layer),
     Layer.provide([CodexAdapter.layer, ClaudeAdapter.layer]),
     Layer.provide(CodexServer.layer),
     Layer.provide([

--- a/app-server/src/terminals/terminals.ts
+++ b/app-server/src/terminals/terminals.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer } from "effect"
+import { Context, Effect, Layer, Option } from "effect"
 import type { Scope } from "effect"
 import {
   ProjectNotFound,
@@ -12,6 +12,7 @@ import type {
   DirectoryCheckTimedOut,
   DirectoryUnavailable,
 } from "../api/contract.ts"
+import { Events } from "../events/events.ts"
 import { Directories } from "../platform/directories.ts"
 import { ProjectRepository } from "../projects/projectRepository.ts"
 import { sessionNameForTerminalId, TerminalAdapter } from "./terminalAdapter.ts"
@@ -114,6 +115,7 @@ export const layer = Layer.effect(Terminals)(
     const adapter = yield* TerminalAdapter
     const projects = yield* ProjectRepository
     const directories = yield* Directories
+    const events = yield* Events
 
     const presentSessionNames = adapter
       .listSessions()
@@ -129,13 +131,21 @@ export const layer = Layer.effect(Terminals)(
       present: ReadonlySet<string>,
     ): Effect.Effect<ReadonlyArray<TerminalRecord>> =>
       Effect.gen(function* () {
-        const dead = new Set(
-          records
-            .filter((r) => r.status === "live" && !present.has(sessionNameForTerminalId(r.id)))
-            .map((r) => r.id),
+        const deadRecords = records.filter(
+          (r) => r.status === "live" && !present.has(sessionNameForTerminalId(r.id)),
         )
-        if (dead.size === 0) return records
+        if (deadRecords.length === 0) return records
+        const dead = new Set(deadRecords.map((r) => r.id))
         const endedAt = yield* repository.markEnded([...dead])
+        yield* Effect.forEach(deadRecords, (record) =>
+          events.publish({ resource: "terminal", id: record.id, change: "updated" }),
+        )
+        // A dead TUI terminal also changes its thread's derived fields
+        // (linkedTerminalId, activity re-derivation), so the thread
+        // publishes alongside — the event names no thread otherwise.
+        yield* Effect.forEach(new Set(deadRecords.flatMap((r) => r.threadId ?? [])), (id) =>
+          events.publish({ resource: "thread", id, change: "updated" }),
+        )
         return records.map((record) =>
           dead.has(record.id)
             ? { ...record, status: "ended" as const, endedAt, updatedAt: endedAt }
@@ -186,6 +196,7 @@ export const layer = Layer.effect(Terminals)(
             // failed launch leaves no record.
             if (reachable.has(sessionName)) {
               yield* repository.markLive(record.id)
+              yield* events.publish({ resource: "terminal", id: record.id, change: "created" })
               claimed.add(sessionName)
             } else if (present.has(sessionName)) {
               claimed.add(sessionName)
@@ -274,6 +285,7 @@ export const layer = Layer.effect(Terminals)(
             Effect.andThen(repository.markLive(record.id)),
             Effect.onExit((exit) => (exit._tag === "Failure" ? cleanup : Effect.void)),
           )
+        yield* events.publish({ resource: "terminal", id: live.id, change: "created" })
         return toTerminal(live)
       })
 
@@ -291,6 +303,12 @@ export const layer = Layer.effect(Terminals)(
             ),
           )
         yield* repository.delete(id)
+        yield* events.publish({ resource: "terminal", id, change: "deleted" })
+        // Deleting a thread's TUI terminal changes that thread's derived
+        // linkedTerminalId (see tombstoneAbsent).
+        if (record.threadId !== undefined) {
+          yield* events.publish({ resource: "thread", id: record.threadId, change: "updated" })
+        }
       })
 
     return {
@@ -323,6 +341,7 @@ export const layer = Layer.effect(Terminals)(
           ? requireRecord(id).pipe(Effect.map(toTerminal))
           : requireRecord(id).pipe(
               Effect.andThen(repository.rename(id, patch.name)),
+              Effect.tap(() => events.publish({ resource: "terminal", id, change: "updated" })),
               Effect.map(toTerminal),
             ),
       delete: del,
@@ -331,7 +350,20 @@ export const layer = Layer.effect(Terminals)(
         Effect.gen(function* () {
           const present = yield* presentSessionNames
           if (present.has(sessionNameForTerminalId(id))) return false
+          // Publish only the actual live→ended transition: a repeat confirm
+          // of an already-ended (or since-deleted) terminal changes nothing.
+          const record = yield* repository.get(id)
           yield* repository.markEnded([id])
+          if (Option.isSome(record) && record.value.status === "live") {
+            yield* events.publish({ resource: "terminal", id, change: "updated" })
+            if (record.value.threadId !== undefined) {
+              yield* events.publish({
+                resource: "thread",
+                id: record.value.threadId,
+                change: "updated",
+              })
+            }
+          }
           return true
         }),
     }

--- a/app-server/src/terminals/terminals.ts
+++ b/app-server/src/terminals/terminals.ts
@@ -286,6 +286,12 @@ export const layer = Layer.effect(Terminals)(
             Effect.onExit((exit) => (exit._tag === "Failure" ? cleanup : Effect.void)),
           )
         yield* events.publish({ resource: "terminal", id: live.id, change: "created" })
+        // A live terminal created into a thread immediately changes that
+        // thread's derived linkedTerminalId; openTerminal's own event lands
+        // only after the identity wait, far too late for this transition.
+        if (input.threadId !== undefined) {
+          yield* events.publish({ resource: "thread", id: input.threadId, change: "updated" })
+        }
         return toTerminal(live)
       })
 

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -29,6 +29,7 @@ import type {
   TerminalLaunchFailed,
   ZmxUnavailable,
 } from "../api/contract.ts"
+import { Events } from "../events/events.ts"
 import { Directories } from "../platform/directories.ts"
 import { ProjectRepository } from "../projects/projectRepository.ts"
 import { Terminals } from "../terminals/terminals.ts"
@@ -138,6 +139,7 @@ export const layerWith = (options: ThreadsOptions) =>
       const directories = yield* Directories
       const terminals = yield* Terminals
       const registry = yield* AgentRegistry
+      const events = yield* Events
       // Observation fibers outlive their originating requests; they live in
       // the service's own scope so shutdown reaps every subscription.
       const serviceScope = yield* Effect.scope
@@ -200,10 +202,16 @@ export const layerWith = (options: ThreadsOptions) =>
           yield* stream.pipe(
             Stream.runForEach((activity) =>
               Effect.gen(function* () {
+                const previous = liveActivity.get(record.id)
                 liveActivity.set(record.id, activity)
                 if (!confirmed && isBusy(activity)) {
                   confirmed = true
                   yield* repository.confirm(record.id)
+                }
+                // One publish covers both the activity transition and the
+                // confirm write above (which only happens on a transition).
+                if (previous !== activity) {
+                  yield* events.publish({ resource: "thread", id: record.id, change: "updated" })
                 }
               }),
             ),
@@ -252,6 +260,13 @@ export const layerWith = (options: ThreadsOptions) =>
                   .checkSession({ providerSessionId })
                   .pipe(Effect.orElseSucceed(() => "unknown" as const))
           liveActivity.set(record.id, checked)
+          // Other subscribers must hear about the re-derived state too, not
+          // just the client whose read triggered it. Loop-safe: the busy
+          // snapshot is gone, so the next event-triggered read returns at
+          // the short-circuit above without publishing.
+          if (checked !== live) {
+            yield* events.publish({ resource: "thread", id: record.id, change: "updated" })
+          }
           return checked
         })
 
@@ -495,7 +510,12 @@ export const layerWith = (options: ThreadsOptions) =>
                       ),
                   }),
                 )
-          ).pipe(Effect.ensuring(Effect.sync(() => opening.delete(id))))
+          ).pipe(
+            // The open changed the thread (linked terminal, and possibly
+            // provider identity); the idempotent return above changed nothing.
+            Effect.tap(() => events.publish({ resource: "thread", id, change: "updated" })),
+            Effect.ensuring(Effect.sync(() => opening.delete(id))),
+          )
         })
 
       const del: Threads["Service"]["delete"] = (id) =>
@@ -517,7 +537,17 @@ export const layerWith = (options: ThreadsOptions) =>
             })
           }
           yield* unobserve(id)
+          // Ended linked terminals survive as unlinked tombstones (FK SET
+          // NULL) — their client-visible threadId changes with the delete,
+          // so each publishes alongside the thread's own event.
+          const orphaned = (yield* terminals.list(record.projectId)).filter(
+            (terminal) => terminal.threadId === id,
+          )
           yield* repository.delete(id)
+          yield* events.publish({ resource: "thread", id, change: "deleted" })
+          yield* Effect.forEach(orphaned, (terminal) =>
+            events.publish({ resource: "terminal", id: terminal.id, change: "updated" }),
+          )
         })
 
       return {
@@ -559,6 +589,7 @@ export const layerWith = (options: ThreadsOptions) =>
               name: input.name,
               workingDirectory: canonical,
             })
+            yield* events.publish({ resource: "thread", id: record.id, change: "created" })
             return toThread(record, undefined, "idle")
           }),
         update: (id, patch) =>
@@ -566,12 +597,11 @@ export const layerWith = (options: ThreadsOptions) =>
           // rule the other repositories apply).
           patch.name === undefined
             ? repository.require(id).pipe(Effect.flatMap(assembleAlone))
-            : repository
-                .require(id)
-                .pipe(
-                  Effect.andThen(repository.rename(id, patch.name)),
-                  Effect.flatMap(assembleAlone),
-                ),
+            : repository.require(id).pipe(
+                Effect.andThen(repository.rename(id, patch.name)),
+                Effect.tap(() => events.publish({ resource: "thread", id, change: "updated" })),
+                Effect.flatMap(assembleAlone),
+              ),
         archive: (id) =>
           Effect.gen(function* () {
             const record = yield* repository.require(id)
@@ -583,6 +613,7 @@ export const layerWith = (options: ThreadsOptions) =>
             }
             if (record.archivedAt !== undefined) return yield* assemble(record, linked)
             const updated = yield* repository.setArchived(id, true)
+            yield* events.publish({ resource: "thread", id, change: "updated" })
             return yield* assemble(updated, linked)
           }),
         unarchive: (id) =>
@@ -590,6 +621,7 @@ export const layerWith = (options: ThreadsOptions) =>
             const record = yield* repository.require(id)
             if (record.archivedAt === undefined) return yield* assembleAlone(record)
             const updated = yield* repository.setArchived(id, false)
+            yield* events.publish({ resource: "thread", id, change: "updated" })
             return yield* assembleAlone(updated)
           }),
         delete: del,

--- a/app-server/test/api/api.test.ts
+++ b/app-server/test/api/api.test.ts
@@ -1,6 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
 import { BunHttpServer } from "@effect/platform-bun"
-import { Effect, Layer } from "effect"
+import { Effect, Fiber, Layer, Stream } from "effect"
 import { HttpApiTest } from "effect/unstable/httpapi"
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
@@ -9,13 +9,17 @@ import { realpathSync } from "node:fs"
 import { afterAll } from "vitest"
 import { Api } from "../../src/api/contract.ts"
 import { V1Handlers } from "../../src/api/handlers.ts"
+import * as Events from "../../src/events/events.ts"
 import { TestBuildInfoLayer, testBuildInfo } from "../testBuildInfo.ts"
 import { TestRepositoryLayers } from "../testLayers.ts"
 
 // In-process contract tests: the same encode/route/decode pipeline as the real
-// server, but no listener.
+// server, but no listener. TestRepositoryLayers is merged in as well (one
+// memoized instance) so tests can reach the same domain services the handlers
+// use — the events test drives the Events service directly.
 const TestLayer = Layer.mergeAll(
   V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, TestRepositoryLayers])),
+  TestRepositoryLayers,
   BunHttpServer.layerHttpServices,
 )
 
@@ -187,6 +191,48 @@ describe("/api/v1/projects", () => {
       // Encoding fails client-side before any request: the contract's
       // AbsolutePath check applies to the typed client too.
       assert.strictEqual(error._tag, "SchemaError")
+    }).pipe(Effect.provide(TestLayer)),
+  )
+})
+
+describe("/api/v1/events", () => {
+  // it.live: subscription registration and SSE delivery cross the in-process
+  // HTTP pipeline's promise boundaries, so the polls below need the real
+  // clock, not it.effect's TestClock.
+  it.live("streams typed mutation events and completes when the service closes", () =>
+    Effect.gen(function* () {
+      const client = yield* HttpApiTest.groups(Api, ["v1"])
+      const events = yield* Events.Events
+      const received: Array<Events.ResourceChangedEvent> = []
+      const subscriber = yield* Effect.forkChild(
+        client.v1
+          .subscribeEvents()
+          .pipe(
+            Effect.flatMap(Stream.runForEach((event) => Effect.sync(() => received.push(event)))),
+          ),
+      )
+      // The subscriber registers when its stream starts running; events
+      // published before that are (by design) missed, so wait for it.
+      for (let attempt = 0; (yield* events.subscriberCount()) === 0; attempt++) {
+        assert.isBelow(attempt, 100, "the subscriber never registered")
+        yield* Effect.sleep("10 millis")
+      }
+
+      const project = yield* client.v1.createProject({
+        payload: { name: "Evented", defaultWorkingDirectory: realDir },
+      })
+      for (let attempt = 0; received.length === 0; attempt++) {
+        assert.isBelow(attempt, 100, "the mutation event never arrived")
+        yield* Effect.sleep("10 millis")
+      }
+      assert.deepStrictEqual(received, [{ resource: "project", id: project.id, change: "created" }])
+
+      // Service shutdown ends the stream cleanly: the subscriber returns
+      // instead of hanging or failing — the guarantee graceful server
+      // shutdown relies on.
+      yield* events.close()
+      yield* Fiber.join(subscriber)
+      yield* client.v1.deleteProject({ params: { projectId: project.id } })
     }).pipe(Effect.provide(TestLayer)),
   )
 })

--- a/app-server/test/api/api.test.ts
+++ b/app-server/test/api/api.test.ts
@@ -1,6 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
 import { BunHttpServer } from "@effect/platform-bun"
-import { Effect, Fiber, Layer, Stream } from "effect"
+import { Effect, Fiber, Layer, Queue, Stream } from "effect"
 import { HttpApiTest } from "effect/unstable/httpapi"
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
@@ -196,36 +196,30 @@ describe("/api/v1/projects", () => {
 })
 
 describe("/api/v1/events", () => {
-  // it.live: subscription registration and SSE delivery cross the in-process
-  // HTTP pipeline's promise boundaries, so the polls below need the real
-  // clock, not it.effect's TestClock.
+  // it.live: SSE delivery crosses the in-process HTTP pipeline's promise
+  // boundaries, so the queue take below needs the real clock, not
+  // it.effect's TestClock.
   it.live("streams typed mutation events and completes when the service closes", () =>
     Effect.gen(function* () {
       const client = yield* HttpApiTest.groups(Api, ["v1"])
       const events = yield* Events.Events
-      const received: Array<Events.ResourceChangedEvent> = []
+      // The handler registers the subscriber before producing the response,
+      // so once subscribeEvents resolves the feed is live — no mutation
+      // published after this point can be missed.
+      const feed = yield* client.v1.subscribeEvents()
+      assert.strictEqual(yield* events.subscriberCount(), 1)
+      const received = yield* Queue.make<Events.ResourceChangedEvent>()
       const subscriber = yield* Effect.forkChild(
-        client.v1
-          .subscribeEvents()
-          .pipe(
-            Effect.flatMap(Stream.runForEach((event) => Effect.sync(() => received.push(event)))),
-          ),
+        Stream.runForEach(feed, (event) => Queue.offer(received, event)),
       )
-      // The subscriber registers when its stream starts running; events
-      // published before that are (by design) missed, so wait for it.
-      for (let attempt = 0; (yield* events.subscriberCount()) === 0; attempt++) {
-        assert.isBelow(attempt, 100, "the subscriber never registered")
-        yield* Effect.sleep("10 millis")
-      }
 
       const project = yield* client.v1.createProject({
         payload: { name: "Evented", defaultWorkingDirectory: realDir },
       })
-      for (let attempt = 0; received.length === 0; attempt++) {
-        assert.isBelow(attempt, 100, "the mutation event never arrived")
-        yield* Effect.sleep("10 millis")
-      }
-      assert.deepStrictEqual(received, [{ resource: "project", id: project.id, change: "created" }])
+      // Condition-driven: take blocks until delivery, bounded only by the
+      // test timeout.
+      const event = yield* Queue.take(received)
+      assert.deepStrictEqual(event, { resource: "project", id: project.id, change: "created" })
 
       // Service shutdown ends the stream cleanly: the subscriber returns
       // instead of hanging or failing — the guarantee graceful server

--- a/app-server/test/api/openapi.test.ts
+++ b/app-server/test/api/openapi.test.ts
@@ -153,6 +153,7 @@ describe("openapi document vs runtime", () => {
       "/api/v1/threads/{threadId}/terminal",
       "/api/v1/agents",
       "/api/v1/agents/{agentId}",
+      "/api/v1/events",
       "/api/v1/fs/check",
     ])
     // The WebSocket attach endpoint is contract-declared but excluded from
@@ -440,6 +441,35 @@ describe("openapi document vs runtime", () => {
       const missing = yield* client.get("http://127.0.0.1/api/v1/agents/nope")
       assert.strictEqual(missing.status, 404)
       assert.deepStrictEqual(yield* missing.json, { _tag: "AgentNotFound", agentId: "nope" })
+    }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
+  )
+
+  it.effect("GET /api/v1/events serves the documented SSE stream", () =>
+    Effect.gen(function* () {
+      const response = yield* (yield* rawClient).get("http://127.0.0.1/api/v1/events")
+      assert.strictEqual(response.status, 200)
+      assert.match(response.headers["content-type"] ?? "", /^text\/event-stream/)
+
+      // The documented payload is the SSE envelope whose data line carries a
+      // JSON-encoded ResourceChangedEvent...
+      const content = operation("/api/v1/events").responses["200"]!.content["text/event-stream"]!
+      const envelope = content.schema as unknown as {
+        properties: { data: { $ref?: string } }
+      }
+      assert.deepStrictEqual(envelope.properties.data, {
+        $ref: "#/components/schemas/ResourceChangedEventJsonEncoding",
+      })
+      assert.deepStrictEqual(componentSchema("ResourceChangedEventJsonEncoding") as unknown, {
+        type: "string",
+        contentMediaType: "application/json",
+      })
+
+      // ...and the plain payload schema is emitted as an ordinary component
+      // (openapi.ts), so generated clients get a real model type to decode
+      // that JSON into. Delivery itself is covered in api.test.ts.
+      const payload = componentSchema("ResourceChangedEvent")
+      assert.sameMembers(Object.keys(payload.properties), ["resource", "id", "change"])
+      assert.sameMembers([...payload.required], ["resource", "id", "change"])
     }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
   )
 

--- a/app-server/test/events/events.test.ts
+++ b/app-server/test/events/events.test.ts
@@ -1,0 +1,144 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Deferred, Effect, Fiber, Stream } from "effect"
+import * as Events from "../../src/events/events.ts"
+import type { ResourceChangedEvent } from "../../src/events/events.ts"
+
+// Events service semantics: fan-out delivery, the overflow-closes-the-lagging-
+// subscriber rule, and the clean-completion guarantees subscribers rely on
+// for reconnect-and-resync.
+
+const capacity = 2
+const layer = Events.layerWith({ subscriberCapacity: capacity })
+
+const event = (id: string): ResourceChangedEvent => ({
+  resource: "project",
+  id,
+  change: "updated",
+})
+
+/** Poll (assertion-bounded) until `condition` holds; no timers involved. */
+const waitFor = (condition: Effect.Effect<boolean>, label: string) =>
+  Effect.gen(function* () {
+    for (let attempt = 0; !(yield* condition); attempt++) {
+      assert.isBelow(attempt, 1000, `never observed: ${label}`)
+      yield* Effect.yieldNow
+    }
+  })
+
+const collectInto = (events: Events.Events["Service"], sink: Array<ResourceChangedEvent>) =>
+  events
+    .subscribe()
+    .pipe(Effect.flatMap(Stream.runForEach((received) => Effect.sync(() => sink.push(received)))))
+
+describe("Events", () => {
+  it.effect("delivers published events to every subscriber, in order", () =>
+    Effect.gen(function* () {
+      const events = yield* Events.Events
+      const first: Array<ResourceChangedEvent> = []
+      const second: Array<ResourceChangedEvent> = []
+      const firstFiber = yield* Effect.forkChild(collectInto(events, first))
+      const secondFiber = yield* Effect.forkChild(collectInto(events, second))
+      yield* waitFor(
+        Effect.map(events.subscriberCount(), (count) => count === 2),
+        "both subscribers registered",
+      )
+
+      yield* events.publish(event("a"))
+      yield* events.publish(event("b"))
+      yield* waitFor(
+        Effect.sync(() => first.length === 2 && second.length === 2),
+        "both received both events",
+      )
+      assert.deepStrictEqual(first, [event("a"), event("b")])
+      assert.deepStrictEqual(second, [event("a"), event("b")])
+
+      // close() completes every stream cleanly — the collectors return.
+      yield* events.close()
+      yield* Fiber.join(firstFiber)
+      yield* Fiber.join(secondFiber)
+    }).pipe(Effect.provide(layer)),
+  )
+
+  it.effect("overflow ends only the lagging subscriber's stream", () =>
+    Effect.gen(function* () {
+      const events = yield* Events.Events
+      const gate = yield* Deferred.make<void>()
+      const lagging: Array<ResourceChangedEvent> = []
+      const healthy: Array<ResourceChangedEvent> = []
+      // The lagging consumer records each event, then parks until the gate
+      // opens — events pile up in its bounded queue behind the parked pull.
+      const laggingFiber = yield* Effect.forkChild(
+        events
+          .subscribe()
+          .pipe(
+            Effect.flatMap(
+              Stream.runForEach((received) =>
+                Effect.sync(() => lagging.push(received)).pipe(
+                  Effect.andThen(Deferred.await(gate)),
+                ),
+              ),
+            ),
+          ),
+      )
+      const healthyFiber = yield* Effect.forkChild(collectInto(events, healthy))
+      yield* waitFor(
+        Effect.map(events.subscriberCount(), (count) => count === 2),
+        "both subscribers registered",
+      )
+
+      // Park the lagging consumer on its first event, then keep publishing
+      // until its bounded queue overflows and the service drops it. How many
+      // events fit before that (queue capacity plus the stream's pull-ahead)
+      // is an implementation detail; the contract is that a bounded number
+      // suffices and only the lagging subscriber is dropped.
+      yield* events.publish(event("fill-0"))
+      yield* waitFor(
+        Effect.sync(() => lagging.length === 1),
+        "the lagging consumer pulled the first event",
+      )
+      let published = 1
+      while ((yield* events.subscriberCount()) === 2) {
+        assert.isBelow(published, capacity + 5, "overflow never dropped the lagging subscriber")
+        yield* events.publish(event(`fill-${published}`))
+        published++
+        // Let the healthy consumer drain between publishes — only the
+        // parked subscriber may fall behind.
+        yield* Effect.yieldNow
+      }
+      assert.strictEqual(yield* events.subscriberCount(), 1)
+
+      // The lagging stream ends cleanly after draining what its queue still
+      // held — a strict prefix of the feed, missing at least the overflowed
+      // tail — so its consumer can reconnect and resync.
+      yield* Deferred.succeed(gate, undefined)
+      yield* Fiber.join(laggingFiber)
+      assert.isBelow(lagging.length, published)
+      assert.deepStrictEqual(
+        lagging.map((received) => received.id),
+        Array.from({ length: lagging.length }, (_, sequence) => `fill-${sequence}`),
+      )
+
+      // The healthy subscriber saw everything and keeps receiving.
+      yield* events.publish(event("after"))
+      yield* waitFor(
+        Effect.sync(() => healthy.length === published + 1),
+        "the healthy subscriber kept the feed",
+      )
+      assert.deepStrictEqual(
+        healthy.map((received) => received.id),
+        [...Array.from({ length: published }, (_, sequence) => `fill-${sequence}`), "after"],
+      )
+      yield* events.close()
+      yield* Fiber.join(healthyFiber)
+    }).pipe(Effect.provide(layer)),
+  )
+
+  it.effect("subscribing after close yields an immediately ended stream", () =>
+    Effect.gen(function* () {
+      const events = yield* Events.Events
+      yield* events.close()
+      const received = yield* Effect.flatMap(events.subscribe(), Stream.runCollect)
+      assert.deepStrictEqual(received, [])
+    }).pipe(Effect.provide(layer)),
+  )
+})

--- a/app-server/test/server.test.ts
+++ b/app-server/test/server.test.ts
@@ -1,6 +1,7 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Context, Effect, Exit, Layer, Scope } from "effect"
 import { HttpServer } from "effect/unstable/http"
+import * as Events from "../src/events/events.ts"
 import * as Server from "../src/server.ts"
 import { TestBuildInfoLayer } from "./testBuildInfo.ts"
 import { TestRepositoryLayers } from "./testLayers.ts"
@@ -41,6 +42,105 @@ describe("server layer", () => {
         ),
       )
       assert.strictEqual(released, true)
+    }),
+  )
+
+  // The ATC-128 shutdown requirement: an open SSE subscriber must not hold
+  // the listener's bounded graceful stop (2s) and die on the forced-interrupt
+  // path — the drain layer in server.ts ends subscriber streams first.
+  it.live("graceful shutdown with an open event subscriber is quick and clean", () =>
+    Effect.gen(function* () {
+      const scope = yield* Scope.make()
+      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
+      // TestRepositoryLayers is merged alongside the server (one memoized
+      // instance) so the test can watch the same Events service the
+      // handlers publish through.
+      const context = yield* Layer.build(
+        Layer.mergeAll(Server.layer({ port: 0 }), TestRepositoryLayers).pipe(
+          Layer.provide([TestBuildInfoLayer, TestRepositoryLayers]),
+        ),
+      ).pipe(Effect.provideService(Scope.Scope, scope))
+      const events = Context.get(context, Events.Events)
+      const address = Context.get(context, HttpServer.HttpServer).address
+      assert.strictEqual(address._tag, "TcpAddress")
+      if (address._tag !== "TcpAddress") return
+      const base = `http://127.0.0.1:${address.port}`
+
+      const response = yield* Effect.promise(() =>
+        fetch(`${base}/api/v1/events`, { headers: { accept: "text/event-stream" } }),
+      )
+      assert.strictEqual(response.status, 200)
+      // The subscription registers before the response exists, so by the
+      // time fetch resolved the feed is already live.
+      assert.strictEqual(yield* events.subscriberCount(), 1)
+      const reader = response.body!.getReader()
+      // The opening SSE comment is load-bearing: it is the first body byte
+      // that lets fetch-based clients observe "stream open" at all.
+      const opening = yield* Effect.promise(() => reader.read())
+      assert.strictEqual(new TextDecoder().decode(opening.value), ": connected\n\n")
+
+      // A mutation event traverses the real wire before shutdown begins.
+      const created = yield* Effect.promise(() =>
+        fetch(`${base}/api/v1/projects`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ name: "Shutdown", defaultWorkingDirectory: "/tmp" }),
+        }).then((r) => r.json() as Promise<{ id: string }>),
+      )
+      const decoder = new TextDecoder()
+      let payload = ""
+      for (let attempt = 0; !payload.includes(`"id":"${created.id}"`); attempt++) {
+        assert.isBelow(attempt, 10, `event never arrived; saw: ${JSON.stringify(payload)}`)
+        const chunk = yield* Effect.promise(() => reader.read())
+        assert.isFalse(chunk.done, "the stream ended before delivering the event")
+        payload += decoder.decode(chunk.value, { stream: true })
+      }
+      assert.include(payload, '"change":"created"')
+
+      // Shutdown must complete well inside the 2s graceful-stop bound, and
+      // the subscriber's stream must end rather than error.
+      const started = Date.now()
+      yield* Scope.close(scope, Exit.void)
+      assert.isBelow(Date.now() - started, 1500, "shutdown rode the graceful-stop timeout")
+      const end = yield* Effect.promise(() =>
+        reader.read().then(
+          (result) => ({ done: result.done, errored: false }),
+          () => ({ done: false, errored: true }),
+        ),
+      )
+      assert.isFalse(end.errored, "the subscriber stream errored instead of ending")
+      assert.isTrue(end.done)
+    }),
+  )
+
+  // Subscriber cleanup on client disconnect rides Bun's ReadableStream
+  // cancel → fiber interrupt → Stream.ensuring — third-party behavior an
+  // Effect or Bun upgrade could silently change, hence a real-wire test.
+  it.live("a dropped subscriber is unregistered", () =>
+    Effect.gen(function* () {
+      const scope = yield* Scope.make()
+      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
+      const context = yield* Layer.build(
+        Layer.mergeAll(Server.layer({ port: 0 }), TestRepositoryLayers).pipe(
+          Layer.provide([TestBuildInfoLayer, TestRepositoryLayers]),
+        ),
+      ).pipe(Effect.provideService(Scope.Scope, scope))
+      const events = Context.get(context, Events.Events)
+      const address = Context.get(context, HttpServer.HttpServer).address
+      if (address._tag !== "TcpAddress") return assert.fail("expected a TCP address")
+
+      const abort = new AbortController()
+      const response = yield* Effect.promise(() =>
+        fetch(`http://127.0.0.1:${address.port}/api/v1/events`, { signal: abort.signal }),
+      )
+      assert.strictEqual(response.status, 200)
+      assert.strictEqual(yield* events.subscriberCount(), 1)
+
+      abort.abort()
+      for (let attempt = 0; (yield* events.subscriberCount()) > 0; attempt++) {
+        assert.isBelow(attempt, 100, "the dropped subscriber was never unregistered")
+        yield* Effect.sleep("10 millis")
+      }
     }),
   )
 })

--- a/app-server/test/server.test.ts
+++ b/app-server/test/server.test.ts
@@ -137,8 +137,10 @@ describe("server layer", () => {
       assert.strictEqual(yield* events.subscriberCount(), 1)
 
       abort.abort()
-      for (let attempt = 0; (yield* events.subscriberCount()) > 0; attempt++) {
-        assert.isBelow(attempt, 100, "the dropped subscriber was never unregistered")
+      // Unregistration has no awaitable signal — it rides Bun's cancel →
+      // fiber interrupt → ensuring — so poll the condition bounded only by
+      // the test timeout, never a fixed wall-clock budget of our own.
+      while ((yield* events.subscriberCount()) > 0) {
         yield* Effect.sleep("10 millis")
       }
     }),

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -11,6 +11,7 @@ import * as ClaudeHooks from "../src/agents/claudeHooks.ts"
 import * as CodexAdapter from "../src/agents/codexAdapter.ts"
 import { AppConfig } from "../src/platform/config.ts"
 import * as Directories from "../src/platform/directories.ts"
+import * as Events from "../src/events/events.ts"
 import * as Persistence from "../src/platform/persistence.ts"
 import * as ProjectRepository from "../src/projects/projectRepository.ts"
 import * as Projects from "../src/projects/projects.ts"
@@ -84,7 +85,8 @@ export const makeTestServiceLayers = (
     | Terminals.Terminals
     | Threads.Threads
     | Projects.Projects
-    | AgentRegistry.AgentRegistry,
+    | AgentRegistry.AgentRegistry
+    | Events.Events,
     unknown
   >
 } => {
@@ -103,7 +105,7 @@ export const makeTestServiceLayers = (
     ThreadRepository.layer,
   ).pipe(Layer.provide(Persistence.layerFile(dbFile)))
   const services = Layer.mergeAll(base, Directories.layer, fake.layer, ClaudeHooks.layer)
-  const terminals = Terminals.layer.pipe(Layer.provide(services))
+  const terminals = Terminals.layer.pipe(Layer.provide([services, Events.layer]))
   const registry = AgentRegistry.layer.pipe(
     Layer.provide([
       Layer.succeed(CodexAdapter.CodexAdapter)(fakeAgents.codex.adapter),
@@ -120,8 +122,11 @@ export const makeTestServiceLayers = (
       services,
       terminals,
       registry,
-      Threads.layerWith(threadsOptions).pipe(Layer.provide([services, terminals, registry])),
-      Projects.layer.pipe(Layer.provide(services)),
+      Events.layer,
+      Threads.layerWith(threadsOptions).pipe(
+        Layer.provide([services, terminals, registry, Events.layer]),
+      ),
+      Projects.layer.pipe(Layer.provide([services, Events.layer])),
     ),
   }
 }


### PR DESCRIPTION
# ATC-128: Client event streaming for live resource updates

Implements [ATC-128](https://linear.app/elevenideas/issue/ATC-128/client-event-streaming-for-live-resource-updates): a contract-defined SSE stream at `GET /api/v1/events` carrying thin `ResourceChangedEvent { resource, id, change }` invalidations for Projects, Threads, and Terminals, so clients stay current without polling. Payloads are Schema-typed and derive from the contract like every other surface.

## What's here

- **Contract** — `ResourceChangedEvent` schema + `subscribeEvents` endpoint (`HttpApiSchema.StreamSse`, data mode). Thin invalidation only: clients coalesce and refetch through existing GETs, which stay the single source of truth.
- **Events service** (`src/events/events.ts`) — in-process fan-out. Each subscriber gets its own bounded queue; `publish` never blocks or fails; overflow ends only the lagging subscriber's stream (its reconnect resync heals it); `close()` ends every stream cleanly.
- **Emission points** — service-layer publishes next to each successful mutation in Projects (create/update/delete), Terminals (create incl. startup-recovery markLive, rename, delete, every markEnded path: reconcile tombstoning and `confirmEnded`), and Threads (create, rename, archive/unarchive transitions, delete, openTerminal, observed activity-state changes). Repositories stay SQL-only.
- **Subscribe handler** — runs one terminals reconcile pass per new subscriber, then streams. Implemented with `handleRaw` (see decisions below).
- **Shutdown** — a `drainEventsBeforeStop` layer sequenced above `HttpRouter.serve` ends all subscriber streams before Bun's 2s bounded graceful stop, so shutdown with open subscribers completes quickly and quietly instead of riding the forced-interrupt path.
- **OpenAPI/Swift** — `openapi.ts` additionally emits the plain `ResourceChangedEvent` object schema as an ordinary component; the pinned Swift generator now produces a real `ResourceChangedEvent` struct for decoding SSE `data` (data-mode `StreamSse` alone yields only a `String` typealias).

## Key decisions made during implementation

1. **Per-subscriber bounded `Queue`s instead of a raw Effect `PubSub`.** v4 `PubSub.shutdown` *interrupts* takers (the noisy path the issue requires avoiding), and none of its overflow strategies close just the lagging subscriber. A `Set` of bounded queues (`offerUnsafe` false ⇒ `Queue.end` that subscriber) implements the issue's exact semantics with clean `Done` completion via `Stream.fromQueue`.
2. **`handleRaw` + an opening `": connected"` SSE comment.** Discovered during testing: Bun's `fetch` does not resolve a chunked response until its first body byte arrives, and this stream emits nothing until the first change — so every fetch-based client (the contract TS client included) would block in subscribe until an unrelated mutation happened, breaking subscribe-then-resync. A spec-standard SSE comment as the first bytes fixes it; conforming parsers (Effect's SSE decoder, Swift's) ignore comment lines. The typed `.handle` pipeline has no seam for it, so the handler is `handleRaw` with events encoded through the contract schema — wire shape identical to the typed pipeline (the typed test client decodes it in the tests).
3. **Drain layer above the listener, not just a service finalizer.** Layer finalizers run dependents-first; Events (a dependency of the handlers) would release *after* the serve layer's bounded graceful stop already waited out its 2s timeout on the open SSE response. The drain layer is composed as a dependent of the serve stack, so its finalizer runs first.
4. **Companion thread events for terminal transitions.** A terminal transition with a `threadId` changes the thread's derived contract fields (`linkedTerminalId`, activity re-derivation), and thread deletion nulls surviving tombstones' `threadId` via the FK — the event names no other resource, so those cross-resource changes each publish their own event (found in adversarial review).
5. **Subscribers register eagerly, before the first response byte.** `Events.subscribe` is an effect that registers the queue before returning its stream, and the handler subscribes before emitting the comment — otherwise a client that resyncs on first byte could miss events in the registration gap (found in adversarial review; it also makes the pre-stream terminals reconcile land *in* the new subscriber's feed).
6. **Publish-on-change-only for activity, including the read path.** The activity consumer publishes `thread updated` only when the observed activity changes, and `resolveActivity`'s re-derivation publishes on change too (loop-safe: the busy snapshot is gone afterward, so event-triggered rereads short-circuit).

## Verification

- New: Events service unit tests (fan-out order, overflow-drops-only-the-laggard, clean close, subscribe-after-close), typed end-to-end API test (subscribe → mutate → receive → clean end), OpenAPI doc/runtime case for `/events`, and a live shutdown test (open subscriber, event over the real wire, `Scope.close` under 1.5s, stream ends without error).
- `mise run -C app-server check` and `mise run contract:check` (incl. Swift client build) pass.

## Review

Two adversarial sub-agent reviews (correctness, simplicity) ran before this PR; their accepted findings are folded in (companion thread events, eager registration, read-path activity publish, empty-patch and repeat-confirm publish guards, fail-fast openapi.ts guards, disconnect/first-byte test coverage).

https://claude.ai/code/session_01336PDxLnsF6jXJ8w8uJiQc
