### PR TITLE
ATC-142: final app-server hardening before the macOS migration

### DIFF
--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -1239,12 +1239,12 @@
           },
           "createdAt": {
             "type": "string",
-            "description": "Creation time (ISO 8601 UTC).",
+            "description": "Creation time.",
             "format": "date-time"
           },
           "updatedAt": {
             "type": "string",
-            "description": "Last update time (ISO 8601 UTC).",
+            "description": "Last update time.",
             "format": "date-time"
           }
         },
@@ -1484,17 +1484,17 @@
           },
           "createdAt": {
             "type": "string",
-            "description": "Creation time (ISO 8601 UTC).",
+            "description": "Creation time.",
             "format": "date-time"
           },
           "updatedAt": {
             "type": "string",
-            "description": "Last update time (ISO 8601 UTC).",
+            "description": "Last update time.",
             "format": "date-time"
           },
           "endedAt": {
             "type": "string",
-            "description": "When the terminal was observed ended (ISO 8601 UTC); absent while live.",
+            "description": "When the terminal was observed ended; absent while live.",
             "format": "date-time"
           }
         },
@@ -1679,17 +1679,17 @@
           },
           "archivedAt": {
             "type": "string",
-            "description": "When the thread was archived (ISO 8601 UTC); absent while active.",
+            "description": "When the thread was archived; absent while active.",
             "format": "date-time"
           },
           "createdAt": {
             "type": "string",
-            "description": "Creation time (ISO 8601 UTC).",
+            "description": "Creation time.",
             "format": "date-time"
           },
           "updatedAt": {
             "type": "string",
-            "description": "Last update time (ISO 8601 UTC).",
+            "description": "Last update time.",
             "format": "date-time"
           }
         },
@@ -1976,7 +1976,7 @@
           },
           "checkedAt": {
             "type": "string",
-            "description": "Check time (ISO 8601 UTC).",
+            "description": "Check time.",
             "format": "date-time"
           },
           "reason": {

--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -946,7 +946,7 @@
             }
           }
         },
-        "description": "Open the thread's TUI terminal. Idempotent: a live linked terminal is returned as-is. Otherwise the provider TUI is launched in a new terminal — a confirmed session is relaunched against its exact persisted identity (ATC never adopts a different one), an unconfirmed one materializes a fresh provider session whose identity is established and persisted before this call returns."
+        "description": "Open the thread's TUI terminal. Idempotent: a live linked terminal is returned as-is. Otherwise the provider TUI is launched in a new terminal — a confirmed session is relaunched against its exact persisted identity (ATC never adopts a different one), an unconfirmed one materializes a fresh provider session whose identity is established and persisted before this call returns. A provider that can be probed (Codex) fails fast when the persisted session no longer exists; one that cannot (Claude) launches blind — a successful open whose terminal dies within seconds is a state clients must expect and surface."
       }
     },
     "/api/v1/agents": {
@@ -1134,7 +1134,7 @@
             }
           }
         },
-        "description": "Subscribe to live resource-change events (SSE). The stream is ephemeral — no replay: on every (re)connect, refetch lists first, then trust the stream. The server ends the stream of a subscriber that falls too far behind; reconnect and resync."
+        "description": "Subscribe to live resource-change events (SSE). The stream is ephemeral — no replay. Resync race-free on every (re)connect: open the stream, wait for the opening `: connected` comment, THEN refetch lists — fetching before the stream is open leaves a missed-event window. Events are thin invalidations and arrive in bursts: coalesce (~100ms) and refetch once per named collection, not per event (terminal-bearing refetches consult the multiplexer and are priced accordingly). The server emits a comment heartbeat roughly every 25 seconds; treat a stream silent for much longer as dead — reconnect and resync. The server ends the stream of a subscriber that falls too far behind; reconnect and resync."
       }
     },
     "/api/v1/fs/check": {
@@ -1239,11 +1239,13 @@
           },
           "createdAt": {
             "type": "string",
-            "description": "Creation time (ISO 8601 UTC)."
+            "description": "Creation time (ISO 8601 UTC).",
+            "format": "date-time"
           },
           "updatedAt": {
             "type": "string",
-            "description": "Last update time (ISO 8601 UTC)."
+            "description": "Last update time (ISO 8601 UTC).",
+            "format": "date-time"
           }
         },
         "required": [
@@ -1303,12 +1305,17 @@
               "inaccessible",
               "not_directory"
             ]
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic derived from the structured fields."
           }
         },
         "required": [
           "_tag",
           "path",
-          "state"
+          "state",
+          "message"
         ],
         "additionalProperties": false
       },
@@ -1323,11 +1330,16 @@
           },
           "path": {
             "type": "string"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic derived from the structured fields."
           }
         },
         "required": [
           "_tag",
-          "path"
+          "path",
+          "message"
         ],
         "additionalProperties": false
       },
@@ -1342,11 +1354,16 @@
           },
           "projectId": {
             "type": "string"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic derived from the structured fields."
           }
         },
         "required": [
           "_tag",
-          "projectId"
+          "projectId",
+          "message"
         ],
         "additionalProperties": false
       },
@@ -1381,12 +1398,17 @@
           },
           "terminalCount": {
             "type": "integer"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic derived from the structured fields."
           }
         },
         "required": [
           "_tag",
           "projectId",
-          "terminalCount"
+          "terminalCount",
+          "message"
         ],
         "additionalProperties": false
       },
@@ -1404,12 +1426,17 @@
           },
           "threadCount": {
             "type": "integer"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic derived from the structured fields."
           }
         },
         "required": [
           "_tag",
           "projectId",
-          "threadCount"
+          "threadCount",
+          "message"
         ],
         "additionalProperties": false
       },
@@ -1457,15 +1484,18 @@
           },
           "createdAt": {
             "type": "string",
-            "description": "Creation time (ISO 8601 UTC)."
+            "description": "Creation time (ISO 8601 UTC).",
+            "format": "date-time"
           },
           "updatedAt": {
             "type": "string",
-            "description": "Last update time (ISO 8601 UTC)."
+            "description": "Last update time (ISO 8601 UTC).",
+            "format": "date-time"
           },
           "endedAt": {
             "type": "string",
-            "description": "When the terminal was observed ended (ISO 8601 UTC); absent while live."
+            "description": "When the terminal was observed ended (ISO 8601 UTC); absent while live.",
+            "format": "date-time"
           }
         },
         "required": [
@@ -1528,11 +1558,16 @@
           },
           "reason": {
             "type": "string"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic derived from the structured fields."
           }
         },
         "required": [
           "_tag",
-          "reason"
+          "reason",
+          "message"
         ],
         "additionalProperties": false
       },
@@ -1547,11 +1582,16 @@
           },
           "reason": {
             "type": "string"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic derived from the structured fields."
           }
         },
         "required": [
           "_tag",
-          "reason"
+          "reason",
+          "message"
         ],
         "additionalProperties": false
       },
@@ -1566,11 +1606,16 @@
           },
           "terminalId": {
             "type": "string"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic derived from the structured fields."
           }
         },
         "required": [
           "_tag",
-          "terminalId"
+          "terminalId",
+          "message"
         ],
         "additionalProperties": false
       },
@@ -1634,15 +1679,18 @@
           },
           "archivedAt": {
             "type": "string",
-            "description": "When the thread was archived (ISO 8601 UTC); absent while active."
+            "description": "When the thread was archived (ISO 8601 UTC); absent while active.",
+            "format": "date-time"
           },
           "createdAt": {
             "type": "string",
-            "description": "Creation time (ISO 8601 UTC)."
+            "description": "Creation time (ISO 8601 UTC).",
+            "format": "date-time"
           },
           "updatedAt": {
             "type": "string",
-            "description": "Last update time (ISO 8601 UTC)."
+            "description": "Last update time (ISO 8601 UTC).",
+            "format": "date-time"
           }
         },
         "required": [
@@ -1702,11 +1750,16 @@
           },
           "threadId": {
             "type": "string"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic derived from the structured fields."
           }
         },
         "required": [
           "_tag",
-          "threadId"
+          "threadId",
+          "message"
         ],
         "additionalProperties": false
       },
@@ -1732,11 +1785,16 @@
           },
           "threadId": {
             "type": "string"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic derived from the structured fields."
           }
         },
         "required": [
           "_tag",
-          "threadId"
+          "threadId",
+          "message"
         ],
         "additionalProperties": false
       },
@@ -1751,11 +1809,16 @@
           },
           "threadId": {
             "type": "string"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic derived from the structured fields."
           }
         },
         "required": [
           "_tag",
-          "threadId"
+          "threadId",
+          "message"
         ],
         "additionalProperties": false
       },
@@ -1773,12 +1836,17 @@
           },
           "reason": {
             "type": "string"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic derived from the structured fields."
           }
         },
         "required": [
           "_tag",
           "threadId",
-          "reason"
+          "reason",
+          "message"
         ],
         "additionalProperties": false
       },
@@ -1796,12 +1864,17 @@
           },
           "reason": {
             "type": "string"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic derived from the structured fields."
           }
         },
         "required": [
           "_tag",
           "agentId",
-          "reason"
+          "reason",
+          "message"
         ],
         "additionalProperties": false
       },
@@ -1863,11 +1936,16 @@
           },
           "agentId": {
             "type": "string"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic derived from the structured fields."
           }
         },
         "required": [
           "_tag",
-          "agentId"
+          "agentId",
+          "message"
         ],
         "additionalProperties": false
       },
@@ -1898,7 +1976,8 @@
           },
           "checkedAt": {
             "type": "string",
-            "description": "Check time (ISO 8601 UTC)."
+            "description": "Check time (ISO 8601 UTC).",
+            "format": "date-time"
           },
           "reason": {
             "type": "string",

--- a/app-server/src/agents/agentAdapter.ts
+++ b/app-server/src/agents/agentAdapter.ts
@@ -269,12 +269,19 @@ export interface AgentAdapter {
    * `providerMetadata` is deliberately required (pass undefined when the
    * thread has none): forgetting to thread it through would silently
    * rotate adapter state out from under a running TUI.
+   *
+   * A provider that can probe session existence (Codex, via thread/list)
+   * does so here and fails `AgentResumeFailed` when the session is gone —
+   * launching blind would die inside the pty with no typed error. A
+   * provider that cannot probe (Claude: checkSession is hardwired
+   * `unknown`) launches blind, so "the open succeeded but the terminal
+   * died within seconds" remains a state clients must expect.
    */
   readonly tuiLaunch: (options: {
     readonly providerSessionId: string
     readonly cwd: string
     readonly providerMetadata: string | undefined
-  }) => Effect.Effect<TuiLaunch, AgentUnavailable>
+  }) => Effect.Effect<TuiLaunch, AgentUnavailable | AgentResumeFailed>
   /**
    * Prepare a FRESH provider TUI session in `cwd`: the uniform contract
    * behind "provider sessions materialize on first interaction". The Scope

--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -544,21 +544,22 @@ export const layer = Layer.effect(CodexAdapter)(
       })
 
     /**
-     * Walk the paginated thread/list for one thread: the found entry,
-     * `"absent"` when a complete walk (nextCursor exhausted) omits the id,
-     * or `"unknown"` when the walk could not be completed — a repeated
-     * cursor or the page cap, either a provider that cannot make
-     * pagination progress or a pathologically long list. Callers must not
-     * treat `"unknown"` as absence.
+     * Walk one paginated thread/list population (thread/list returns only
+     * non-archived threads unless `archived: true` — the populations are
+     * disjoint): the found entry, `"absent"` when a complete walk
+     * (nextCursor exhausted) omits the id, or `"unknown"` when the walk
+     * could not be completed — a repeated cursor or the page cap, either a
+     * provider that cannot make pagination progress or a pathologically
+     * long list.
      */
-    const findThread = (state: ClientState, threadId: string) =>
+    const walkThreadList = (state: ClientState, threadId: string, archived: boolean) =>
       Effect.gen(function* () {
         let cursor: string | undefined
         for (let page = 0; page < 100; page++) {
           const reply = yield* request(
             state,
             "thread/list",
-            cursor === undefined ? {} : { cursor },
+            cursor === undefined ? { archived } : { archived, cursor },
           ).pipe(
             Effect.mapError((error) =>
               unavailable(error._tag === "RpcError" ? error.text : error.reason),
@@ -577,6 +578,24 @@ export const layer = Layer.effect(CodexAdapter)(
           cursor = next
         }
         return "unknown" as const
+      })
+
+    /**
+     * Find one thread across BOTH thread/list populations — a session
+     * archived through another Codex surface still exists and must not be
+     * reported as deleted. `"absent"` only when complete walks of both the
+     * non-archived and archived lists omit the id; `"unknown"` when either
+     * walk was inconclusive. Callers must not treat `"unknown"` as absence.
+     */
+    const findThread = (state: ClientState, threadId: string) =>
+      Effect.gen(function* () {
+        const live = yield* walkThreadList(state, threadId, false)
+        if (typeof live !== "string") return live
+        const archived = yield* walkThreadList(state, threadId, true)
+        if (typeof archived !== "string") return archived
+        return live === "absent" && archived === "absent"
+          ? ("absent" as const)
+          : ("unknown" as const)
       })
 
     const adapter: AgentAdapter = {

--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -544,16 +544,17 @@ export const layer = Layer.effect(CodexAdapter)(
       })
 
     /**
-     * Walk the paginated thread/list for one thread. `undefined` after a
-     * complete walk means the provider does not have it (used as conclusive
-     * absence by the tuiLaunch probe and as honest `unknown` by
-     * checkSession). A repeated cursor cannot make progress and is treated
-     * as the end of the walk.
+     * Walk the paginated thread/list for one thread: the found entry,
+     * `"absent"` when a complete walk (nextCursor exhausted) omits the id,
+     * or `"unknown"` when the walk could not be completed — a repeated
+     * cursor or the page cap, either a provider that cannot make
+     * pagination progress or a pathologically long list. Callers must not
+     * treat `"unknown"` as absence.
      */
     const findThread = (state: ClientState, threadId: string) =>
       Effect.gen(function* () {
         let cursor: string | undefined
-        while (true) {
+        for (let page = 0; page < 100; page++) {
           const reply = yield* request(
             state,
             "thread/list",
@@ -571,9 +572,11 @@ export const layer = Layer.effect(CodexAdapter)(
           const thread = decoded.data.find((t) => t.id === threadId)
           if (thread !== undefined) return thread
           const next = decoded.nextCursor
-          if (typeof next !== "string" || next === cursor) return undefined
+          if (typeof next !== "string") return "absent" as const
+          if (next === cursor) return "unknown" as const
           cursor = next
         }
+        return "unknown" as const
       })
 
     const adapter: AgentAdapter = {
@@ -682,11 +685,12 @@ export const layer = Layer.effect(CodexAdapter)(
           const executable = yield* resolveProviderExecutable("codex", config.codexExecutable)
           // Probe before launching (ATC-142): `codex resume` of a deleted or
           // pruned thread dies inside the pty with no typed error, and every
-          // reopen repeats it. A full thread/list walk that omits the id is
-          // treated as absence and fails closed with a presentable error.
+          // reopen repeats it. Only a COMPLETE walk that omits the id fails
+          // closed; an incomplete walk ("unknown") launches blind like
+          // before — an inconclusive probe must never fabricate absence.
           const state = yield* getClientRetryable
           const thread = yield* findThread(state, options.providerSessionId)
-          if (thread === undefined) {
+          if (thread === "absent") {
             return yield* Effect.fail(
               new AgentResumeFailed({
                 provider: "codex",
@@ -762,7 +766,7 @@ export const layer = Layer.effect(CodexAdapter)(
           // thread/list (probed) is the reconciliation aid: absent thread or
           // undeterminable status is honestly `unknown`, never a guess.
           const thread = yield* findThread(state, options.providerSessionId)
-          return thread === undefined ? "unknown" : statusToActivity(thread.status)
+          return typeof thread === "string" ? "unknown" : statusToActivity(thread.status)
         }),
       // Codex holds no per-session launch files or secrets; provider-owned
       // rollouts are never ATC's to touch.

--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -543,6 +543,37 @@ export const layer = Layer.effect(CodexAdapter)(
         return { connection, unregister }
       })
 
+    /**
+     * Walk the paginated thread/list for one thread. `undefined` after a
+     * complete walk means the provider does not have it (used as conclusive
+     * absence by the tuiLaunch probe and as honest `unknown` by
+     * checkSession). A repeated cursor cannot make progress and is treated
+     * as the end of the walk.
+     */
+    const findThread = (state: ClientState, threadId: string) =>
+      Effect.gen(function* () {
+        let cursor: string | undefined
+        while (true) {
+          const reply = yield* request(
+            state,
+            "thread/list",
+            cursor === undefined ? {} : { cursor },
+          ).pipe(
+            Effect.mapError((error) =>
+              unavailable(error._tag === "RpcError" ? error.text : error.reason),
+            ),
+          )
+          const decoded = yield* Schema.decodeUnknownEffect(ThreadListReply)(reply).pipe(
+            Effect.mapError((error) => unavailable(`unexpected thread/list reply: ${error.message}`)),
+          )
+          const thread = decoded.data.find((t) => t.id === threadId)
+          if (thread !== undefined) return thread
+          const next = decoded.nextCursor
+          if (typeof next !== "string" || next === cursor) return undefined
+          cursor = next
+        }
+      })
+
     const adapter: AgentAdapter = {
       provider: "codex",
       capabilities: { testedVersion: CODEX_TESTED_VERSION, tuiObservation: "shared-server" },
@@ -647,6 +678,21 @@ export const layer = Layer.effect(CodexAdapter)(
       tuiLaunch: (options) =>
         Effect.gen(function* () {
           const executable = yield* resolveProviderExecutable("codex", config.codexExecutable)
+          // Probe before launching (ATC-142): `codex resume` of a deleted or
+          // pruned thread dies inside the pty with no typed error, and every
+          // reopen repeats it. A full thread/list walk that omits the id is
+          // treated as absence and fails closed with a presentable error.
+          const state = yield* getClientRetryable
+          const thread = yield* findThread(state, options.providerSessionId)
+          if (thread === undefined) {
+            return yield* Effect.fail(
+              new AgentResumeFailed({
+                provider: "codex",
+                providerSessionId: options.providerSessionId,
+                reason: "codex no longer has this session (its history was deleted or pruned)",
+              }),
+            )
+          }
           const info = yield* codexServer.ensure()
           return {
             launchSpec: {
@@ -712,32 +758,9 @@ export const layer = Layer.effect(CodexAdapter)(
         Effect.gen(function* () {
           const state = yield* getClientRetryable
           // thread/list (probed) is the reconciliation aid: absent thread or
-          // undeterminable status is honestly `unknown`, never a guess. The
-          // reply is paginated; walk pages until the target thread appears
-          // or the cursor runs out.
-          let cursor: string | undefined
-          while (true) {
-            const reply = yield* request(
-              state,
-              "thread/list",
-              cursor === undefined ? {} : { cursor },
-            ).pipe(
-              Effect.mapError((error) =>
-                unavailable(error._tag === "RpcError" ? error.text : error.reason),
-              ),
-            )
-            const decoded = yield* Schema.decodeUnknownEffect(ThreadListReply)(reply).pipe(
-              Effect.mapError((error) =>
-                unavailable(`unexpected thread/list reply: ${error.message}`),
-              ),
-            )
-            const thread = decoded.data.find((t) => t.id === options.providerSessionId)
-            if (thread !== undefined) return statusToActivity(thread.status)
-            const next = decoded.nextCursor
-            // A repeated cursor cannot make progress; treat it as the end.
-            if (typeof next !== "string" || next === cursor) return "unknown"
-            cursor = next
-          }
+          // undeterminable status is honestly `unknown`, never a guess.
+          const thread = yield* findThread(state, options.providerSessionId)
+          return thread === undefined ? "unknown" : statusToActivity(thread.status)
         }),
       // Codex holds no per-session launch files or secrets; provider-owned
       // rollouts are never ATC's to touch.

--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -564,7 +564,9 @@ export const layer = Layer.effect(CodexAdapter)(
             ),
           )
           const decoded = yield* Schema.decodeUnknownEffect(ThreadListReply)(reply).pipe(
-            Effect.mapError((error) => unavailable(`unexpected thread/list reply: ${error.message}`)),
+            Effect.mapError((error) =>
+              unavailable(`unexpected thread/list reply: ${error.message}`),
+            ),
           )
           const thread = decoded.data.find((t) => t.id === threadId)
           if (thread !== undefined) return thread

--- a/app-server/src/agents/smoke.ts
+++ b/app-server/src/agents/smoke.ts
@@ -9,11 +9,18 @@ import * as BuildInfo from "../platform/buildInfo.ts"
 import { AppConfig, ConfigLoadError, layer as appConfigLayer } from "../platform/config.ts"
 import * as Subprocess from "../platform/subprocess.ts"
 
-// Unstable provider smoke checks (ATC-88). `atc smoke ...` proves that the
-// compiled executable can launch each provider technology and complete one
-// bounded structured round trip. The command is hidden, is not a stable
-// interface, and will be replaced by the production provider integration.
-// Provider SDK and protocol types stay private to this module.
+// Compiled-artifact provider smoke checks (ATC-88). `atc smoke ...` proves
+// the COMPILED executable can launch each provider technology, complete one
+// bounded structured round trip, and leave no orphaned children. This is
+// deliberately not redundant with the adapters' own live smoke tests, which
+// run from source in-process: the risks here are compiled-binary ones (the
+// bundled Claude Agent SDK spawning its child, executable resolution outside
+// the repo), and `mise run test:smoke` drives this command after Bun, Effect,
+// or Agent SDK upgrades. The command stays hidden and unstable. Caveat: the
+// codex check speaks the stdio transport, not the production detached-server
+// path (codexServer.ts) — it asserts only that the configured executable
+// launches and answers JSON-RPC from the compiled binary. Provider SDK and
+// protocol types stay private to this module.
 
 export class SmokeError extends Schema.TaggedErrorClass<SmokeError>()("SmokeError", {
   provider: Schema.Literals(["codex", "claude"]),
@@ -413,7 +420,8 @@ const claudeCommand = Command.make("claude", {}, () =>
   Command.withDescription("[unstable] Claude Agent SDK round trip via the packaged executable"),
 )
 
-/** Hidden and unstable: a de-risking entrypoint, not part of the CLI surface. */
+/** Hidden and unstable: the compiled-artifact check behind `mise run
+ * test:smoke`, not part of the CLI surface. */
 export const smoke = Command.make("smoke").pipe(
   Command.withDescription("[unstable] Provider smoke checks for the compiled executable (ATC-88)"),
   Command.withSubcommands([codexCommand, claudeCommand]),

--- a/app-server/src/api/contract.ts
+++ b/app-server/src/api/contract.ts
@@ -41,6 +41,10 @@ export const AbsolutePath = Schema.String.check(
   Schema.isStartsWith("/", { description: "a server-host absolute path (starting with /)" }),
 )
 
+/** A wire timestamp: RFC 3339 UTC with millisecond precision (`Date.toISOString()`). */
+const timestamp = (description: string) =>
+  Schema.String.annotate({ format: "date-time", description })
+
 export const ProjectName = Schema.NonEmptyString.annotate({
   description: "Human-readable project name.",
 })
@@ -51,8 +55,8 @@ export const Project = Schema.Struct({
   defaultWorkingDirectory: Schema.String.annotate({
     description: "Canonical (symlink-resolved) absolute path new Threads and Terminals default to.",
   }),
-  createdAt: Schema.String.annotate({ description: "Creation time (ISO 8601 UTC)." }),
-  updatedAt: Schema.String.annotate({ description: "Last update time (ISO 8601 UTC)." }),
+  createdAt: timestamp("Creation time (ISO 8601 UTC)."),
+  updatedAt: timestamp("Last update time (ISO 8601 UTC)."),
 }).annotate({
   identifier: "Project",
   description: "A Project: the user-facing container organizing a body of work.",
@@ -104,7 +108,7 @@ export const FsCheckResponse = Schema.Struct({
     description: "The checked path (canonicalized when the directory is available).",
   }),
   state: DirectoryState,
-  checkedAt: Schema.String.annotate({ description: "Check time (ISO 8601 UTC)." }),
+  checkedAt: timestamp("Check time (ISO 8601 UTC)."),
   // Absent when the state is conclusive (not null — see UpdateProjectRequest).
   reason: Schema.optionalKey(
     Schema.String.annotate({
@@ -148,12 +152,10 @@ export const Terminal = Schema.Struct({
     description: "Canonical directory the terminal was launched in (immutable).",
   }),
   status: TerminalStatus,
-  createdAt: Schema.String.annotate({ description: "Creation time (ISO 8601 UTC)." }),
-  updatedAt: Schema.String.annotate({ description: "Last update time (ISO 8601 UTC)." }),
+  createdAt: timestamp("Creation time (ISO 8601 UTC)."),
+  updatedAt: timestamp("Last update time (ISO 8601 UTC)."),
   endedAt: Schema.optionalKey(
-    Schema.String.annotate({
-      description: "When the terminal was observed ended (ISO 8601 UTC); absent while live.",
-    }),
+    timestamp("When the terminal was observed ended (ISO 8601 UTC); absent while live."),
   ),
 }).annotate({
   identifier: "Terminal",
@@ -260,12 +262,10 @@ export const Thread = Schema.Struct({
     }),
   ),
   archivedAt: Schema.optionalKey(
-    Schema.String.annotate({
-      description: "When the thread was archived (ISO 8601 UTC); absent while active.",
-    }),
+    timestamp("When the thread was archived (ISO 8601 UTC); absent while active."),
   ),
-  createdAt: Schema.String.annotate({ description: "Creation time (ISO 8601 UTC)." }),
-  updatedAt: Schema.String.annotate({ description: "Last update time (ISO 8601 UTC)." }),
+  createdAt: timestamp("Creation time (ISO 8601 UTC)."),
+  updatedAt: timestamp("Last update time (ISO 8601 UTC)."),
 }).annotate({
   identifier: "Thread",
   description:
@@ -315,22 +315,43 @@ export const ResourceChangedEvent = Schema.Struct({
     "Thin invalidation event: names what changed, never carries resource state. Clients coalesce events and refetch through the corresponding GETs, which stay the single source of truth.",
 })
 
-// The error classes carry human `message`s so every consumer (the CLI above
-// all) can print a real diagnostic — a TaggedErrorClass message is otherwise
-// empty.
+// Every error carries a required `message` field ON THE WIRE, computed from
+// the structured fields by the class's own constructor — the one place each
+// message rule lives. Construction sites never pass it, every consumer (the
+// CLI, the Swift client) gets a printable diagnostic without re-deriving it,
+// and decode recomputes it so it can never disagree with the fields.
+
+/** The wire `message` field every tagged error carries. */
+const errorMessage = Schema.String.annotate({
+  description: "Human-readable diagnostic derived from the structured fields.",
+})
 
 /** Unknown project id. */
 export class ProjectNotFound extends Schema.TaggedErrorClass<ProjectNotFound>()(
   "ProjectNotFound",
-  { projectId: Schema.String },
+  { projectId: Schema.String, message: errorMessage },
   {
     identifier: "ProjectNotFound",
     description: "No project exists with the given id.",
     httpApiStatus: 404,
   },
 ) {
-  override get message(): string {
-    return `no project with id ${this.projectId}`
+  constructor(props: { readonly projectId: string }) {
+    super({ ...props, message: `no project with id ${props.projectId}` })
+  }
+}
+
+const directoryUnavailableMessage = (props: {
+  readonly path: string
+  readonly state: "missing" | "inaccessible" | "not_directory"
+}): string => {
+  switch (props.state) {
+    case "missing":
+      return `directory ${props.path} does not exist`
+    case "inaccessible":
+      return `directory ${props.path} cannot be read or traversed`
+    case "not_directory":
+      return `${props.path} is not a directory`
   }
 }
 
@@ -340,6 +361,7 @@ export class DirectoryUnavailable extends Schema.TaggedErrorClass<DirectoryUnava
   {
     path: Schema.String,
     state: Schema.Literals(["missing", "inaccessible", "not_directory"]),
+    message: errorMessage,
   },
   {
     identifier: "DirectoryUnavailable",
@@ -347,22 +369,18 @@ export class DirectoryUnavailable extends Schema.TaggedErrorClass<DirectoryUnava
     httpApiStatus: 422,
   },
 ) {
-  override get message(): string {
-    switch (this.state) {
-      case "missing":
-        return `directory ${this.path} does not exist`
-      case "inaccessible":
-        return `directory ${this.path} cannot be read or traversed`
-      case "not_directory":
-        return `${this.path} is not a directory`
-    }
+  constructor(props: {
+    readonly path: string
+    readonly state: "missing" | "inaccessible" | "not_directory"
+  }) {
+    super({ ...props, message: directoryUnavailableMessage(props) })
   }
 }
 
 /** The bounded directory check did not complete; retryable, fail-closed. */
 export class DirectoryCheckTimedOut extends Schema.TaggedErrorClass<DirectoryCheckTimedOut>()(
   "DirectoryCheckTimedOut",
-  { path: Schema.String },
+  { path: Schema.String, message: errorMessage },
   {
     identifier: "DirectoryCheckTimedOut",
     description:
@@ -370,23 +388,23 @@ export class DirectoryCheckTimedOut extends Schema.TaggedErrorClass<DirectoryChe
     httpApiStatus: 422,
   },
 ) {
-  override get message(): string {
-    return `the check of directory ${this.path} timed out; retry`
+  constructor(props: { readonly path: string }) {
+    super({ ...props, message: `the check of directory ${props.path} timed out; retry` })
   }
 }
 
 /** Unknown terminal id. */
 export class TerminalNotFound extends Schema.TaggedErrorClass<TerminalNotFound>()(
   "TerminalNotFound",
-  { terminalId: Schema.String },
+  { terminalId: Schema.String, message: errorMessage },
   {
     identifier: "TerminalNotFound",
     description: "No terminal exists with the given id.",
     httpApiStatus: 404,
   },
 ) {
-  override get message(): string {
-    return `no terminal with id ${this.terminalId}`
+  constructor(props: { readonly terminalId: string }) {
+    super({ ...props, message: `no terminal with id ${props.terminalId}` })
   }
 }
 
@@ -397,7 +415,7 @@ export class TerminalNotFound extends Schema.TaggedErrorClass<TerminalNotFound>(
  */
 export class ZmxUnavailable extends Schema.TaggedErrorClass<ZmxUnavailable>()(
   "ZmxUnavailable",
-  { reason: Schema.String },
+  { reason: Schema.String, message: errorMessage },
   {
     identifier: "ZmxUnavailable",
     description:
@@ -405,15 +423,15 @@ export class ZmxUnavailable extends Schema.TaggedErrorClass<ZmxUnavailable>()(
     httpApiStatus: 503,
   },
 ) {
-  override get message(): string {
-    return this.reason
+  constructor(props: { readonly reason: string }) {
+    super({ ...props, message: props.reason })
   }
 }
 
 /** The zmx session for a new terminal failed to launch; conclusive. */
 export class TerminalLaunchFailed extends Schema.TaggedErrorClass<TerminalLaunchFailed>()(
   "TerminalLaunchFailed",
-  { reason: Schema.String },
+  { reason: Schema.String, message: errorMessage },
   {
     identifier: "TerminalLaunchFailed",
     description:
@@ -421,90 +439,96 @@ export class TerminalLaunchFailed extends Schema.TaggedErrorClass<TerminalLaunch
     httpApiStatus: 422,
   },
 ) {
-  override get message(): string {
-    return this.reason
+  constructor(props: { readonly reason: string }) {
+    super({ ...props, message: props.reason })
   }
 }
 
 /** Project deletion is restricted while it still owns terminals. */
 export class ProjectHasTerminals extends Schema.TaggedErrorClass<ProjectHasTerminals>()(
   "ProjectHasTerminals",
-  { projectId: Schema.String, terminalCount: Schema.Int },
+  { projectId: Schema.String, terminalCount: Schema.Int, message: errorMessage },
   {
     identifier: "ProjectHasTerminals",
     description: "The project still owns terminals (live or ended); delete them first.",
     httpApiStatus: 409,
   },
 ) {
-  override get message(): string {
-    return `project ${this.projectId} still owns ${this.terminalCount} terminal(s); delete them first`
+  constructor(props: { readonly projectId: string; readonly terminalCount: number }) {
+    super({
+      ...props,
+      message: `project ${props.projectId} still owns ${props.terminalCount} terminal(s); delete them first`,
+    })
   }
 }
 
 /** Project deletion is restricted while it still owns threads. */
 export class ProjectHasThreads extends Schema.TaggedErrorClass<ProjectHasThreads>()(
   "ProjectHasThreads",
-  { projectId: Schema.String, threadCount: Schema.Int },
+  { projectId: Schema.String, threadCount: Schema.Int, message: errorMessage },
   {
     identifier: "ProjectHasThreads",
     description: "The project still owns threads (active or archived); delete them first.",
     httpApiStatus: 409,
   },
 ) {
-  override get message(): string {
-    return `project ${this.projectId} still owns ${this.threadCount} thread(s); delete them first`
+  constructor(props: { readonly projectId: string; readonly threadCount: number }) {
+    super({
+      ...props,
+      message: `project ${props.projectId} still owns ${props.threadCount} thread(s); delete them first`,
+    })
   }
 }
 
 /** Unknown agent registry slug. */
 export class AgentNotFound extends Schema.TaggedErrorClass<AgentNotFound>()(
   "AgentNotFound",
-  { agentId: Schema.String },
+  { agentId: Schema.String, message: errorMessage },
   {
     identifier: "AgentNotFound",
     description: "No built-in agent exists with the given id.",
     httpApiStatus: 404,
   },
 ) {
-  override get message(): string {
-    return `no agent with id ${this.agentId}`
+  constructor(props: { readonly agentId: string }) {
+    super({ ...props, message: `no agent with id ${props.agentId}` })
   }
 }
 
 /** Unknown thread id. */
 export class ThreadNotFound extends Schema.TaggedErrorClass<ThreadNotFound>()(
   "ThreadNotFound",
-  { threadId: Schema.String },
+  { threadId: Schema.String, message: errorMessage },
   {
     identifier: "ThreadNotFound",
     description: "No thread exists with the given id.",
     httpApiStatus: 404,
   },
 ) {
-  override get message(): string {
-    return `no thread with id ${this.threadId}`
+  constructor(props: { readonly threadId: string }) {
+    super({ ...props, message: `no thread with id ${props.threadId}` })
   }
 }
 
 /** The thread is archived; unarchive it before opening or driving it. */
 export class ThreadArchived extends Schema.TaggedErrorClass<ThreadArchived>()(
   "ThreadArchived",
-  { threadId: Schema.String },
+  { threadId: Schema.String, message: errorMessage },
   {
     identifier: "ThreadArchived",
     description: "The thread is archived; unarchive it first.",
     httpApiStatus: 409,
   },
 ) {
-  override get message(): string {
-    return `thread ${this.threadId} is archived; unarchive it first`
+  constructor(props: { readonly threadId: string }) {
+    super({ ...props, message: `thread ${props.threadId} is archived; unarchive it first` })
   }
 }
 
 /** The thread's agent provider cannot be used right now. Retryable. */
 export class ProviderUnavailable extends Schema.TaggedErrorClass<ProviderUnavailable>()(
   "ProviderUnavailable",
-  { agentId: Schema.String, reason: Schema.String },
+  { agentId: Schema.String, reason: Schema.String, message: errorMessage },
   {
     identifier: "ProviderUnavailable",
     description:
@@ -512,15 +536,15 @@ export class ProviderUnavailable extends Schema.TaggedErrorClass<ProviderUnavail
     httpApiStatus: 503,
   },
 ) {
-  override get message(): string {
-    return this.reason
+  constructor(props: { readonly agentId: string; readonly reason: string }) {
+    super({ ...props, message: props.reason })
   }
 }
 
 /** The provider session cannot be driven as asked; nothing was adopted. */
 export class ProviderSessionConflict extends Schema.TaggedErrorClass<ProviderSessionConflict>()(
   "ProviderSessionConflict",
-  { threadId: Schema.String, reason: Schema.String },
+  { threadId: Schema.String, reason: Schema.String, message: errorMessage },
   {
     identifier: "ProviderSessionConflict",
     description:
@@ -528,23 +552,26 @@ export class ProviderSessionConflict extends Schema.TaggedErrorClass<ProviderSes
     httpApiStatus: 409,
   },
 ) {
-  override get message(): string {
-    return this.reason
+  constructor(props: { readonly threadId: string; readonly reason: string }) {
+    super({ ...props, message: props.reason })
   }
 }
 
 /** The thread's agent session is actively working; retry once the turn ends. */
 export class ThreadBusy extends Schema.TaggedErrorClass<ThreadBusy>()(
   "ThreadBusy",
-  { threadId: Schema.String },
+  { threadId: Schema.String, message: errorMessage },
   {
     identifier: "ThreadBusy",
     description: "The thread's agent session is actively working; retry once the turn completes.",
     httpApiStatus: 409,
   },
 ) {
-  override get message(): string {
-    return `thread ${this.threadId} is working; retry once the turn completes`
+  constructor(props: { readonly threadId: string }) {
+    super({
+      ...props,
+      message: `thread ${props.threadId} is working; retry once the turn completes`,
+    })
   }
 }
 
@@ -658,11 +685,13 @@ export class V1 extends HttpApiGroup.make("v1")
       ),
     // WebSocket upgrade endpoint: declared in the contract for the typed
     // route tree and params, excluded from the OpenAPI document (REST
-    // clients and the Swift generator cannot represent an upgrade). Wire
-    // protocol: binary frames are terminal bytes both ways; text frames are
-    // JSON control messages ({"type":"resize","cols","rows"} from the
-    // client; {"type":"ping"}/{"type":"pong"} keepalives). Close
-    // vocabulary — the single statement of it, mirrored by the bridge: 1000
+    // clients and the Swift generator cannot represent an upgrade). The
+    // client-facing protocol spec is packages/attach-protocol/README.md
+    // (shared test vectors in packages/attach-protocol/fixtures/); the code
+    // authority both sides import is terminals/attachProtocol.ts. Summary:
+    // binary frames are terminal bytes both ways; text frames are JSON
+    // control messages ({"type":"resize","cols","rows"} from the client;
+    // {"type":"ping"}/{"type":"pong"} keepalives). Close vocabulary: 1000
     // terminal_ended is authoritative (confirmed absent, tombstone
     // written); 1011 attach_failed / zmx_unavailable / ping_timeout are
     // retryable and say nothing about the terminal's existence. Clients
@@ -770,7 +799,8 @@ export class V1 extends HttpApiGroup.make("v1")
       .annotate(OpenApi.Identifier, "openThreadTerminal")
       .annotate(
         OpenApi.Description,
-        "Open the thread's TUI terminal. Idempotent: a live linked terminal is returned as-is. Otherwise the provider TUI is launched in a new terminal — a confirmed session is relaunched against its exact persisted identity (ATC never adopts a different one), an unconfirmed one materializes a fresh provider session whose identity is established and persisted before this call returns.",
+        "Open the thread's TUI terminal. Idempotent: a live linked terminal is returned as-is. Otherwise the provider TUI is launched in a new terminal — a confirmed session is relaunched against its exact persisted identity (ATC never adopts a different one), an unconfirmed one materializes a fresh provider session whose identity is established and persisted before this call returns. " +
+          "A provider that can be probed (Codex) fails fast when the persisted session no longer exists; one that cannot (Claude) launches blind — a successful open whose terminal dies within seconds is a state clients must expect and surface.",
       ),
     HttpApiEndpoint.get("listAgents", "/agents", { success: AgentList })
       .annotate(OpenApi.Identifier, "listAgents")
@@ -791,7 +821,13 @@ export class V1 extends HttpApiGroup.make("v1")
       .annotate(OpenApi.Identifier, "subscribeEvents")
       .annotate(
         OpenApi.Description,
-        "Subscribe to live resource-change events (SSE). The stream is ephemeral — no replay: on every (re)connect, refetch lists first, then trust the stream. The server ends the stream of a subscriber that falls too far behind; reconnect and resync.",
+        "Subscribe to live resource-change events (SSE). The stream is ephemeral — no replay. " +
+          "Resync race-free on every (re)connect: open the stream, wait for the opening `: connected` comment, THEN refetch lists — " +
+          "fetching before the stream is open leaves a missed-event window. " +
+          "Events are thin invalidations and arrive in bursts: coalesce (~100ms) and refetch once per named collection, not per event " +
+          "(terminal-bearing refetches consult the multiplexer and are priced accordingly). " +
+          "The server emits a comment heartbeat roughly every 25 seconds; treat a stream silent for much longer as dead — reconnect and resync. " +
+          "The server ends the stream of a subscriber that falls too far behind; reconnect and resync.",
       ),
     HttpApiEndpoint.get("checkDirectory", "/fs/check", {
       query: { path: AbsolutePath },

--- a/app-server/src/api/contract.ts
+++ b/app-server/src/api/contract.ts
@@ -28,6 +28,8 @@ export const VersionResponse = Schema.Struct({
   commit: Schema.String.annotate({
     description: 'Commit the executable was built from ("dev" when running from source).',
   }),
+  // Deliberately NOT a timestamp(): the literal "dev" would break a Date
+  // decode in generated clients.
   builtAt: Schema.String.annotate({
     description: 'Build timestamp of the executable ("dev" when running from source).',
   }),
@@ -55,8 +57,8 @@ export const Project = Schema.Struct({
   defaultWorkingDirectory: Schema.String.annotate({
     description: "Canonical (symlink-resolved) absolute path new Threads and Terminals default to.",
   }),
-  createdAt: timestamp("Creation time (ISO 8601 UTC)."),
-  updatedAt: timestamp("Last update time (ISO 8601 UTC)."),
+  createdAt: timestamp("Creation time."),
+  updatedAt: timestamp("Last update time."),
 }).annotate({
   identifier: "Project",
   description: "A Project: the user-facing container organizing a body of work.",
@@ -108,7 +110,7 @@ export const FsCheckResponse = Schema.Struct({
     description: "The checked path (canonicalized when the directory is available).",
   }),
   state: DirectoryState,
-  checkedAt: timestamp("Check time (ISO 8601 UTC)."),
+  checkedAt: timestamp("Check time."),
   // Absent when the state is conclusive (not null — see UpdateProjectRequest).
   reason: Schema.optionalKey(
     Schema.String.annotate({
@@ -152,10 +154,10 @@ export const Terminal = Schema.Struct({
     description: "Canonical directory the terminal was launched in (immutable).",
   }),
   status: TerminalStatus,
-  createdAt: timestamp("Creation time (ISO 8601 UTC)."),
-  updatedAt: timestamp("Last update time (ISO 8601 UTC)."),
+  createdAt: timestamp("Creation time."),
+  updatedAt: timestamp("Last update time."),
   endedAt: Schema.optionalKey(
-    timestamp("When the terminal was observed ended (ISO 8601 UTC); absent while live."),
+    timestamp("When the terminal was observed ended; absent while live."),
   ),
 }).annotate({
   identifier: "Terminal",
@@ -261,11 +263,9 @@ export const Thread = Schema.Struct({
       description: "The thread's live TUI terminal, when one is open (derived; never required).",
     }),
   ),
-  archivedAt: Schema.optionalKey(
-    timestamp("When the thread was archived (ISO 8601 UTC); absent while active."),
-  ),
-  createdAt: timestamp("Creation time (ISO 8601 UTC)."),
-  updatedAt: timestamp("Last update time (ISO 8601 UTC)."),
+  archivedAt: Schema.optionalKey(timestamp("When the thread was archived; absent while active.")),
+  createdAt: timestamp("Creation time."),
+  updatedAt: timestamp("Last update time."),
 }).annotate({
   identifier: "Thread",
   description:
@@ -341,9 +341,12 @@ export class ProjectNotFound extends Schema.TaggedErrorClass<ProjectNotFound>()(
   }
 }
 
+const UnavailableState = Schema.Literals(["missing", "inaccessible", "not_directory"])
+type UnavailableState = typeof UnavailableState.Type
+
 const directoryUnavailableMessage = (props: {
   readonly path: string
-  readonly state: "missing" | "inaccessible" | "not_directory"
+  readonly state: UnavailableState
 }): string => {
   switch (props.state) {
     case "missing":
@@ -360,7 +363,7 @@ export class DirectoryUnavailable extends Schema.TaggedErrorClass<DirectoryUnava
   "DirectoryUnavailable",
   {
     path: Schema.String,
-    state: Schema.Literals(["missing", "inaccessible", "not_directory"]),
+    state: UnavailableState,
     message: errorMessage,
   },
   {
@@ -369,10 +372,7 @@ export class DirectoryUnavailable extends Schema.TaggedErrorClass<DirectoryUnava
     httpApiStatus: 422,
   },
 ) {
-  constructor(props: {
-    readonly path: string
-    readonly state: "missing" | "inaccessible" | "not_directory"
-  }) {
+  constructor(props: { readonly path: string; readonly state: UnavailableState }) {
     super({ ...props, message: directoryUnavailableMessage(props) })
   }
 }
@@ -686,16 +686,10 @@ export class V1 extends HttpApiGroup.make("v1")
     // WebSocket upgrade endpoint: declared in the contract for the typed
     // route tree and params, excluded from the OpenAPI document (REST
     // clients and the Swift generator cannot represent an upgrade). The
-    // client-facing protocol spec is packages/attach-protocol/README.md
-    // (shared test vectors in packages/attach-protocol/fixtures/); the code
-    // authority both sides import is terminals/attachProtocol.ts. Summary:
-    // binary frames are terminal bytes both ways; text frames are JSON
-    // control messages ({"type":"resize","cols","rows"} from the client;
-    // {"type":"ping"}/{"type":"pong"} keepalives). Close vocabulary: 1000
-    // terminal_ended is authoritative (confirmed absent, tombstone
-    // written); 1011 attach_failed / zmx_unavailable / ping_timeout are
-    // retryable and say nothing about the terminal's existence. Clients
-    // detach by closing 1000 "detach" (the session keeps running).
+    // client-facing protocol spec — framing, control frames, close
+    // vocabulary, sizing — is packages/attach-protocol/README.md with
+    // shared test vectors in its fixtures/; the code authority TypeScript
+    // sides import is terminals/attachProtocol.ts.
     HttpApiEndpoint.get("attachTerminal", "/terminals/:terminalId/attach", {
       params: terminalIdParam,
       query: {

--- a/app-server/src/api/handlers.ts
+++ b/app-server/src/api/handlers.ts
@@ -3,7 +3,7 @@ import { HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { Api, ResourceChangedEvent } from "./contract.ts"
 import { AgentRegistry } from "../agents/agentRegistry.ts"
-import { Events } from "../events/events.ts"
+import { Events, HEARTBEAT } from "../events/events.ts"
 import { BuildInfo } from "../platform/buildInfo.ts"
 import { Directories } from "../platform/directories.ts"
 import { Projects } from "../projects/projects.ts"
@@ -91,9 +91,14 @@ export const V1Handlers = HttpApiBuilder.group(
             // the comment observes the reconciled state and misses nothing.
             yield* terminals.list()
             const feed = yield* events.subscribe()
+            // Heartbeat ticks become SSE comments: ignored by conforming
+            // parsers, but they keep idle-timeout-prone transports alive and
+            // surface dead sockets to the server via the failing write.
             const encoded = feed.pipe(
-              Stream.mapEffect((event) =>
-                Effect.map(encodeEventJson(event), (json) => `data: ${json}\n\n`),
+              Stream.mapEffect((item) =>
+                item === HEARTBEAT
+                  ? Effect.succeed(": heartbeat\n\n")
+                  : Effect.map(encodeEventJson(item), (json) => `data: ${json}\n\n`),
               ),
             )
             return HttpServerResponse.stream(

--- a/app-server/src/events/events.ts
+++ b/app-server/src/events/events.ts
@@ -4,14 +4,6 @@ import type { ResourceChangedEvent as ResourceChangedEventSchema } from "../api/
 
 export type ResourceChangedEvent = typeof ResourceChangedEventSchema.Type
 
-/**
- * The transport-keepalive tick, delivered through the same per-subscriber
- * queues as real events (the SSE handler encodes it as a comment). One value,
- * so consumers narrow with a strict equality check.
- */
-export const HEARTBEAT = "heartbeat" as const
-export type Heartbeat = typeof HEARTBEAT
-
 // The Events service (ATC-128): the in-process fan-out for resource-change
 // events. Domain services publish next to each successful mutation; the
 // subscribe endpoint streams to clients. Invariants:
@@ -41,6 +33,14 @@ export type Heartbeat = typeof HEARTBEAT
 //     bounded graceful stop — an open SSE response would otherwise hold the
 //     stop for the full timeout and die on the noisy forced-interrupt path.
 
+/**
+ * The transport-keepalive tick, delivered through the same per-subscriber
+ * queues as real events (the SSE handler encodes it as a comment). One value,
+ * so consumers narrow with a strict equality check.
+ */
+export const HEARTBEAT = "heartbeat" as const
+export type Heartbeat = typeof HEARTBEAT
+
 export class Events extends Context.Service<
   Events,
   {
@@ -62,7 +62,7 @@ export class Events extends Context.Service<
 export interface EventsOptions {
   /** Per-subscriber queue capacity; overflow ends that subscriber's stream. */
   readonly subscriberCapacity?: number
-  /** Shared heartbeat period. ~25s in production: safely inside URLSession's
+  /** Shared heartbeat period; the default sits safely inside URLSession's
    * 60-second idle teardown. */
   readonly heartbeatInterval?: Duration.Input
 }

--- a/app-server/src/events/events.ts
+++ b/app-server/src/events/events.ts
@@ -1,8 +1,16 @@
-import { Context, Effect, Layer, Queue, Stream } from "effect"
+import { Context, Duration, Effect, Layer, Queue, Stream } from "effect"
 import type { Cause } from "effect"
 import type { ResourceChangedEvent as ResourceChangedEventSchema } from "../api/contract.ts"
 
 export type ResourceChangedEvent = typeof ResourceChangedEventSchema.Type
+
+/**
+ * The transport-keepalive tick, delivered through the same per-subscriber
+ * queues as real events (the SSE handler encodes it as a comment). One value,
+ * so consumers narrow with a strict equality check.
+ */
+export const HEARTBEAT = "heartbeat" as const
+export type Heartbeat = typeof HEARTBEAT
 
 // The Events service (ATC-128): the in-process fan-out for resource-change
 // events. Domain services publish next to each successful mutation; the
@@ -22,6 +30,12 @@ export type ResourceChangedEvent = typeof ResourceChangedEventSchema.Type
 //     endpoint relies on this to guarantee "registered before the client
 //     sees any byte". A registered stream that never runs self-heals: its
 //     queue fills and publish drops it.
+//   - One shared heartbeat timer (ATC-142) ticks HEARTBEAT into every
+//     subscriber queue so quiet streams still write: transports keep
+//     idle-timeout-prone connections alive (URLSession tears quiet streams
+//     down at ~60s), clients get a liveness signal for half-open sockets,
+//     and a dead subscriber is torn down by its failing write instead of
+//     holding a queue until overflow. No per-subscriber timers, no polling.
 //   - close() (also the layer finalizer) ends every subscriber stream
 //     cleanly. server.ts sequences it to release BEFORE the HTTP listener's
 //     bounded graceful stop — an open SSE response would otherwise hold the
@@ -34,9 +48,10 @@ export class Events extends Context.Service<
     readonly publish: (event: ResourceChangedEvent) => Effect.Effect<void>
     /**
      * Register a subscriber (eagerly — see the header) and return its live
-     * stream, which ends on lag or on close().
+     * stream of events interleaved with heartbeat ticks, which ends on lag
+     * or on close().
      */
-    readonly subscribe: () => Effect.Effect<Stream.Stream<ResourceChangedEvent>>
+    readonly subscribe: () => Effect.Effect<Stream.Stream<ResourceChangedEvent | Heartbeat>>
     /** Currently registered subscribers. Exists for tests and diagnostics. */
     readonly subscriberCount: () => Effect.Effect<number>
     /** End every subscriber stream, current and future. Idempotent. */
@@ -47,13 +62,17 @@ export class Events extends Context.Service<
 export interface EventsOptions {
   /** Per-subscriber queue capacity; overflow ends that subscriber's stream. */
   readonly subscriberCapacity?: number
+  /** Shared heartbeat period. ~25s in production: safely inside URLSession's
+   * 60-second idle teardown. */
+  readonly heartbeatInterval?: Duration.Input
 }
 
 export const layerWith = (options: EventsOptions) =>
   Layer.effect(Events)(
     Effect.gen(function* () {
       const capacity = options.subscriberCapacity ?? 128
-      const subscribers = new Set<Queue.Queue<ResourceChangedEvent, Cause.Done>>()
+      const heartbeatInterval = options.heartbeatInterval ?? "25 seconds"
+      const subscribers = new Set<Queue.Queue<ResourceChangedEvent | Heartbeat, Cause.Done>>()
       let closed = false
 
       const close = () =>
@@ -68,21 +87,31 @@ export const layerWith = (options: EventsOptions) =>
       // of sibling layers) so no subscriber stream outlives the service.
       yield* Effect.addFinalizer(close)
 
+      const offer = (item: ResourceChangedEvent | Heartbeat): void => {
+        for (const queue of subscribers) {
+          if (Queue.offerUnsafe(queue, item)) continue
+          // Ended queues buffered events the subscriber still drains; this
+          // one lost `item`, so resync-on-reconnect is the only honest
+          // recovery.
+          Queue.endUnsafe(queue)
+          subscribers.delete(queue)
+        }
+      }
+
+      // The one shared timer; the layer scope reaps it on release.
+      yield* Effect.sync(() => offer(HEARTBEAT)).pipe(
+        Effect.delay(heartbeatInterval),
+        Effect.forever,
+        Effect.forkScoped,
+      )
+
       return {
-        publish: (event) =>
-          Effect.sync(() => {
-            for (const queue of subscribers) {
-              if (Queue.offerUnsafe(queue, event)) continue
-              // Ended queues buffered events the subscriber still drains;
-              // this one lost `event`, so resync-on-reconnect is the only
-              // honest recovery.
-              Queue.endUnsafe(queue)
-              subscribers.delete(queue)
-            }
-          }),
+        publish: (event) => Effect.sync(() => offer(event)),
         subscribe: () =>
           Effect.gen(function* () {
-            const queue = yield* Queue.make<ResourceChangedEvent, Cause.Done>({ capacity })
+            const queue = yield* Queue.make<ResourceChangedEvent | Heartbeat, Cause.Done>({
+              capacity,
+            })
             if (closed) {
               yield* Queue.end(queue)
             } else {

--- a/app-server/src/server.ts
+++ b/app-server/src/server.ts
@@ -53,10 +53,15 @@ export const routes = Layer.mergeAll(
 // the Events layer's own finalizer (a dependency, released after the stop),
 // an open SSE response would hold the stop for the full timeout and die on
 // the noisy forced-interrupt path instead.
+//
+// The "shutting down" line is registered LAST so it runs FIRST (finalizers
+// are LIFO): the file log otherwise just stops on SIGINT/SIGTERM, leaving a
+// supervising app unable to tell a clean exit from a kill.
 const drainEventsBeforeStop = Layer.effectDiscard(
   Effect.gen(function* () {
     const events = yield* Events.Events
     yield* Effect.addFinalizer(events.close)
+    yield* Effect.addFinalizer(() => Effect.logInfo("shutting down"))
   }),
 )
 

--- a/app-server/src/terminals/attachProtocol.ts
+++ b/app-server/src/terminals/attachProtocol.ts
@@ -3,14 +3,17 @@ import type { SessionSize } from "./terminalAdapter.ts"
 
 // The attach wire protocol (ATC-130), stated once for every side of the
 // socket: the server bridge (terminalAttach.ts), the CLI client
-// (attachClient.ts), and any future client. The contract endpoint
-// description (contract.ts `attachTerminal`) documents it in prose; this module
-// is the code authority both sides import.
+// (attachClient.ts), and any future client. This module is the code
+// authority TypeScript sides import; the client-facing spec (and the shared
+// test vectors that pin it for non-TS clients) is
+// packages/attach-protocol/README.md + fixtures/.
 //
 // Binary frames are terminal bytes in both directions. Text frames are the
 // JSON control frames below. Close vocabulary: 1000 `terminal_ended` is
 // authoritative (a complete inventory proved the terminal ended) and 1000
-// `detach` is a deliberate client detach; 1011 reasons are retryable.
+// `detach` is a deliberate client detach; 1011 reasons are retryable —
+// as is a bare 1006/transport loss, which proves nothing about the
+// terminal.
 
 const ControlFrame = Schema.Union([
   Schema.Struct({ type: Schema.Literal("resize"), cols: Schema.Number, rows: Schema.Number }),

--- a/app-server/src/terminals/attachProtocol.ts
+++ b/app-server/src/terminals/attachProtocol.ts
@@ -39,11 +39,17 @@ export const encodeControlFrame = (frame: ControlFrame): string => JSON.stringif
 /**
  * The one dimension rule for resize frames and `cols`/`rows` query params:
  * missing or malformed values take the fallback, everything else is floored
- * and clamped into [1, 1000].
+ * and clamped into [1, 1000]. A string is malformed unless it is numeric in
+ * its entirety — `"80junk"` falls back, it does not parse as 80.
  */
 export const clampDimension = (raw: string | number | undefined, fallback: number): number => {
-  const parsed = typeof raw === "number" ? raw : Number.parseInt(raw ?? "", 10)
-  return Number.isNaN(parsed) ? fallback : Math.max(1, Math.min(1_000, Math.floor(parsed)))
+  const parsed =
+    typeof raw === "number"
+      ? raw
+      : raw === undefined || raw.trim() === ""
+        ? Number.NaN
+        : Number(raw)
+  return Number.isFinite(parsed) ? Math.max(1, Math.min(1_000, Math.floor(parsed))) : fallback
 }
 
 /** Close (1000) reason proving the terminal ended — not retryable. */

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -84,8 +84,8 @@ export type Thread = typeof ThreadSchema.Type
 export interface ThreadsOptions {
   /** How long openTerminal waits for a fresh session's identity. */
   readonly identityTimeout?: Duration.Input
-  /** How often the identity wait re-checks that the launched TUI terminal
-   * is still alive. */
+  /** Initial delay before the identity wait's first TUI-liveness check;
+   * subsequent checks back off from it (see watchForEarlyDeath). */
   readonly launchWatchInterval?: Duration.Input
 }
 
@@ -147,7 +147,7 @@ export const layerWith = (options: ThreadsOptions) =>
       // the service's own scope so shutdown reaps every subscription.
       const serviceScope = yield* Effect.scope
       const identityTimeout = options.identityTimeout ?? "30 seconds"
-      const launchWatchInterval = options.launchWatchInterval ?? "1 second"
+      const launchWatchInterval = options.launchWatchInterval ?? "500 millis"
 
       // Live activity evidence by thread id, fed by the per-session
       // subscriptions below. In-memory only — restart resets to no
@@ -194,49 +194,55 @@ export const layerWith = (options: ThreadsOptions) =>
           const child = Scope.forkUnsafe(serviceScope)
           const observation: Observation = { providerSessionId, scope: child }
           observed.set(record.id, observation)
-          // The subscription is established HERE, before the caller
-          // proceeds — only the drain loop is forked. An unavailable
-          // evidence source yields an empty feed: `unknown` on reads,
-          // never a guess or a crash.
-          const stream = yield* adapter
-            .observeSession({
-              providerSessionId,
-              providerMetadata: record.providerMetadata,
-            })
-            .pipe(
-              Effect.catchTag("AgentUnavailable", () =>
-                Effect.succeed(Stream.empty as Stream.Stream<AgentActivity>),
+          const releaseClaim = Effect.gen(function* () {
+            if (observed.get(record.id) !== observation) return
+            observed.delete(record.id)
+            yield* Scope.close(child, Exit.void)
+          })
+          yield* Effect.gen(function* () {
+            // The subscription is established HERE, before the caller
+            // proceeds — only the drain loop is forked. An unavailable
+            // evidence source yields an empty feed: `unknown` on reads,
+            // never a guess or a crash.
+            const stream = yield* adapter
+              .observeSession({
+                providerSessionId,
+                providerMetadata: record.providerMetadata,
+              })
+              .pipe(
+                Effect.catchTag("AgentUnavailable", () =>
+                  Effect.succeed(Stream.empty as Stream.Stream<AgentActivity>),
+                ),
+                Scope.provide(child),
+              )
+            let confirmed = record.confirmedAt !== undefined
+            yield* stream.pipe(
+              Stream.runForEach((activity) =>
+                Effect.gen(function* () {
+                  const previous = liveActivity.get(record.id)
+                  liveActivity.set(record.id, activity)
+                  if (!confirmed && isBusy(activity)) {
+                    confirmed = true
+                    yield* repository.confirm(record.id)
+                  }
+                  // One publish covers both the activity transition and the
+                  // confirm write above (which only happens on a transition).
+                  if (previous !== activity) {
+                    yield* events.publish({ resource: "thread", id: record.id, change: "updated" })
+                  }
+                }),
               ),
-              Scope.provide(child),
+              // A feed that ends on its own must not pin the entry (the
+              // next read re-subscribes instead of trusting a dead stream)
+              // nor leak its child scope into the service scope.
+              Effect.ensuring(releaseClaim),
+              Effect.forkIn(child),
             )
-          let confirmed = record.confirmedAt !== undefined
-          yield* stream.pipe(
-            Stream.runForEach((activity) =>
-              Effect.gen(function* () {
-                const previous = liveActivity.get(record.id)
-                liveActivity.set(record.id, activity)
-                if (!confirmed && isBusy(activity)) {
-                  confirmed = true
-                  yield* repository.confirm(record.id)
-                }
-                // One publish covers both the activity transition and the
-                // confirm write above (which only happens on a transition).
-                if (previous !== activity) {
-                  yield* events.publish({ resource: "thread", id: record.id, change: "updated" })
-                }
-              }),
-            ),
-            // A feed that ends on its own must not pin the entry (the
-            // next read re-subscribes instead of trusting a dead stream)
-            // nor leak its child scope into the service scope.
-            Effect.ensuring(
-              Effect.gen(function* () {
-                if (observed.get(record.id) !== observation) return
-                observed.delete(record.id)
-                yield* Scope.close(child, Exit.void)
-              }),
-            ),
-            Effect.forkIn(child),
+          }).pipe(
+            // A caller interrupted (a dropped read) or failing before the
+            // drain fiber arms must not leave a claim with no consumer —
+            // that would freeze the thread's activity until shutdown.
+            Effect.onExit((exit) => (exit._tag === "Failure" ? releaseClaim : Effect.void)),
           )
         })
 
@@ -323,8 +329,12 @@ export const layerWith = (options: ThreadsOptions) =>
       ): Effect.Effect<Thread> =>
         Effect.gen(function* () {
           // Demand-driven recovery: a restart under a live TUI re-observes
-          // on the first read, so status flows again with no poller.
-          if (linked !== undefined) yield* ensureObserved(record)
+          // on the first read, so status flows again with no poller. NOT
+          // while an open is in flight: a mid-materialize row still names
+          // the superseded session, and a read subscribing to it could
+          // confirm a session the thread no longer references — the open's
+          // own ensureObserved covers the fresh identity.
+          if (linked !== undefined && !opening.has(record.id)) yield* ensureObserved(record)
           const activity = yield* resolveActivity(record, linked?.id)
           return toThread(record, linked?.id, activity)
         })
@@ -346,6 +356,39 @@ export const layerWith = (options: ThreadsOptions) =>
           error._tag === "AgentUnavailable" || error._tag === "AgentProtocolError"
             ? new ProviderUnavailable({ agentId: record.agentId, reason: error.message })
             : new ProviderSessionConflict({ threadId: record.id, reason: error.message })
+
+      /**
+       * Fail once the reconciled inventory says the launched TUI terminal
+       * died — the classic first-run failure (a missing provider login)
+       * would otherwise park the open for the full identity bound with a
+       * generic timeout. Each check is a multiplexer inventory, so the
+       * poll backs off from `launchWatchInterval` to a 5-second ceiling.
+       * Claude never reaches the race — its identity resolves immediately.
+       */
+      const watchForEarlyDeath = (
+        record: ThreadRecord,
+        terminalId: string,
+      ): Effect.Effect<never, ProviderUnavailable> =>
+        Effect.gen(function* () {
+          let delay = Duration.toMillis(Duration.fromInputUnsafe(launchWatchInterval))
+          for (;;) {
+            yield* Effect.sleep(Duration.millis(delay))
+            delay = Math.min(delay * 2, 5_000)
+            const current = yield* terminals
+              .get(terminalId)
+              .pipe(Effect.catchTag("TerminalNotFound", () => Effect.succeed(undefined)))
+            if (current === undefined || current.status === "ended") {
+              return yield* Effect.fail(
+                new ProviderUnavailable({
+                  agentId: record.agentId,
+                  reason:
+                    `the ${record.agentId} TUI exited before its session was established; ` +
+                    `run it manually in the thread's directory to see why (a missing provider login is the usual cause)`,
+                }),
+              )
+            }
+          }
+        })
 
       /** Launch a TUI terminal for the thread from an adapter launch spec,
        * with the nested-session markers scrubbed uniformly. */
@@ -391,30 +434,6 @@ export const layerWith = (options: ThreadsOptions) =>
             const cleanupTerminal = terminals
               .delete(terminal.id)
               .pipe(Effect.catch(() => Effect.void))
-            // A TUI that dies right after launch (the classic first-run
-            // failure: a missing provider login) would otherwise park the
-            // caller for the full identity bound; the reconciled read
-            // notices the death and fails fast with a diagnostic that names
-            // the real problem. Claude never reaches the race — its
-            // identity resolves immediately.
-            const deathWatch = Effect.gen(function* () {
-              for (;;) {
-                yield* Effect.sleep(launchWatchInterval)
-                const current = yield* terminals
-                  .get(terminal.id)
-                  .pipe(Effect.catchTag("TerminalNotFound", () => Effect.succeed(undefined)))
-                if (current === undefined || current.status === "ended") {
-                  return yield* Effect.fail(
-                    new ProviderUnavailable({
-                      agentId: record.agentId,
-                      reason:
-                        `the ${record.agentId} TUI exited before its session was established; ` +
-                        `run it manually in the thread's directory to see why (a missing provider login is the usual cause)`,
-                    }),
-                  )
-                }
-              }
-            })
             yield* Effect.uninterruptibleMask((restore) =>
               Effect.gen(function* () {
                 // The identity await stays interruptible (openTerminal's
@@ -424,7 +443,7 @@ export const layerWith = (options: ThreadsOptions) =>
                 const identity = yield* restore(
                   Effect.raceFirst(
                     prepared.identity.pipe(Effect.mapError(mapAgentError(record))),
-                    deathWatch,
+                    watchForEarlyDeath(record, terminal.id),
                   ),
                 )
                 // From resolution until a thread row owns the identity, the

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -84,6 +84,9 @@ export type Thread = typeof ThreadSchema.Type
 export interface ThreadsOptions {
   /** How long openTerminal waits for a fresh session's identity. */
   readonly identityTimeout?: Duration.Input
+  /** How often the identity wait re-checks that the launched TUI terminal
+   * is still alive. */
+  readonly launchWatchInterval?: Duration.Input
 }
 
 export class Threads extends Context.Service<
@@ -144,6 +147,7 @@ export const layerWith = (options: ThreadsOptions) =>
       // the service's own scope so shutdown reaps every subscription.
       const serviceScope = yield* Effect.scope
       const identityTimeout = options.identityTimeout ?? "30 seconds"
+      const launchWatchInterval = options.launchWatchInterval ?? "1 second"
 
       // Live activity evidence by thread id, fed by the per-session
       // subscriptions below. In-memory only — restart resets to no
@@ -387,6 +391,30 @@ export const layerWith = (options: ThreadsOptions) =>
             const cleanupTerminal = terminals
               .delete(terminal.id)
               .pipe(Effect.catch(() => Effect.void))
+            // A TUI that dies right after launch (the classic first-run
+            // failure: a missing provider login) would otherwise park the
+            // caller for the full identity bound; the reconciled read
+            // notices the death and fails fast with a diagnostic that names
+            // the real problem. Claude never reaches the race — its
+            // identity resolves immediately.
+            const deathWatch = Effect.gen(function* () {
+              for (;;) {
+                yield* Effect.sleep(launchWatchInterval)
+                const current = yield* terminals
+                  .get(terminal.id)
+                  .pipe(Effect.catchTag("TerminalNotFound", () => Effect.succeed(undefined)))
+                if (current === undefined || current.status === "ended") {
+                  return yield* Effect.fail(
+                    new ProviderUnavailable({
+                      agentId: record.agentId,
+                      reason:
+                        `the ${record.agentId} TUI exited before its session was established; ` +
+                        `run it manually in the thread's directory to see why (a missing provider login is the usual cause)`,
+                    }),
+                  )
+                }
+              }
+            })
             yield* Effect.uninterruptibleMask((restore) =>
               Effect.gen(function* () {
                 // The identity await stays interruptible (openTerminal's
@@ -394,7 +422,10 @@ export const layerWith = (options: ThreadsOptions) =>
                 // window where interruption can land between resolution and
                 // the release bracket below.
                 const identity = yield* restore(
-                  prepared.identity.pipe(Effect.mapError(mapAgentError(record))),
+                  Effect.raceFirst(
+                    prepared.identity.pipe(Effect.mapError(mapAgentError(record))),
+                    deathWatch,
+                  ),
                 )
                 // From resolution until a thread row owns the identity, the
                 // fresh session is OURS: every non-success — the row deleted

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -180,7 +180,14 @@ export const layerWith = (options: ThreadsOptions) =>
           // A superseded session's subscription must never keep driving
           // the thread (its feed would confirm a session it never saw).
           if (existing !== undefined) yield* unobserve(record.id)
-          const child = yield* Scope.fork(serviceScope)
+          // The re-check, unsafe fork, and claim are ONE synchronous step:
+          // concurrent first reads of the same live thread (sidebar list +
+          // detail get at relaunch) race exactly here, and a loser that
+          // proceeded would leak its adapter subscription until shutdown.
+          // Whoever claimed during the unobserve above wins, whatever
+          // session it observes — the next read re-checks and heals.
+          if (observed.get(record.id) !== undefined) return
+          const child = Scope.forkUnsafe(serviceScope)
           const observation: Observation = { providerSessionId, scope: child }
           observed.set(record.id, observation)
           // The subscription is established HERE, before the caller

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -532,10 +532,11 @@ export const layerWith = (options: ThreadsOptions) =>
           }
           // Idempotent: one live linked TUI terminal per thread, returned
           // as-is (two TUIs into one conversation is the documented
-          // concurrency hazard).
+          // concurrency hazard). Mid-open the row may still name the
+          // superseded session — same rule as `assemble`.
           const linked = yield* linkedFor(record)
           if (linked !== undefined) {
-            yield* ensureObserved(record)
+            if (!opening.has(id)) yield* ensureObserved(record)
             return linked
           }
           if (opening.has(id)) {

--- a/app-server/test/agents/codexAdapter.test.ts
+++ b/app-server/test/agents/codexAdapter.test.ts
@@ -312,21 +312,40 @@ describe("CodexAdapter", () => {
   )
 
   it.live(
-    "tuiLaunch hands back the exact remote-resume argv",
+    "tuiLaunch probes session existence, then hands back the exact remote-resume argv",
     () =>
       Effect.gen(function* () {
         const sandbox = makeCodexSandbox()
         yield* withAdapter(sandbox, (adapter) =>
           Effect.gen(function* () {
+            // A session the provider actually has: the probe passes.
+            const sessionId = yield* Effect.scoped(
+              Effect.map(
+                adapter.createSession({ cwd: sandbox.cwd, input: "seed" }),
+                ({ connection }) => connection.providerSessionId,
+              ),
+            )
             const { launchSpec } = yield* adapter.tuiLaunch({
-              providerSessionId: "some-thread",
+              providerSessionId: sessionId,
               cwd: sandbox.cwd,
               providerMetadata: undefined,
             })
             assert.strictEqual(launchSpec.command[0], sandbox.wrapper)
             assert.deepStrictEqual(launchSpec.command.slice(1, 3), ["resume", "--remote"])
             assert.match(launchSpec.command[3] ?? "", /^ws:\/\/127\.0\.0\.1:\d+$/)
-            assert.strictEqual(launchSpec.command[4], "some-thread")
+            assert.strictEqual(launchSpec.command[4], sessionId)
+
+            // A session codex no longer has (pruned/deleted history) fails
+            // the probe closed instead of launching a TUI that dies in the
+            // pty with no typed error.
+            const missing = yield* Effect.flip(
+              adapter.tuiLaunch({
+                providerSessionId: "some-pruned-thread",
+                cwd: sandbox.cwd,
+                providerMetadata: undefined,
+              }),
+            )
+            assert.strictEqual(missing._tag, "AgentResumeFailed")
           }),
         )
       }),

--- a/app-server/test/agents/codexAdapter.test.ts
+++ b/app-server/test/agents/codexAdapter.test.ts
@@ -542,6 +542,25 @@ describe("CodexAdapter TUI session plumbing", () => {
               yield* adapter.checkSession({ providerSessionId: "missing" }),
               "unknown",
             )
+            // A session archived through another Codex surface still exists:
+            // the archived population is walked too, so it is found — and
+            // tuiLaunch must not fail it closed as deleted.
+            yield* Effect.scoped(
+              Effect.gen(function* () {
+                const socket = yield* openExternal(`ws://127.0.0.1:${identity.port}`)
+                yield* externalRequest(socket, 3, "thread/archive", { threadId: laterPage })
+              }),
+            )
+            assert.strictEqual(
+              yield* adapter.checkSession({ providerSessionId: laterPage }),
+              "idle",
+            )
+            const { launchSpec } = yield* adapter.tuiLaunch({
+              providerSessionId: laterPage,
+              cwd: sandbox.cwd,
+              providerMetadata: undefined,
+            })
+            assert.strictEqual(launchSpec.command[4], laterPage)
           }),
         )
       }),

--- a/app-server/test/agents/fakeAgentAdapter.ts
+++ b/app-server/test/agents/fakeAgentAdapter.ts
@@ -53,6 +53,8 @@ export interface FakeAgentAdapter {
   readonly setIdentityHangs: (hangs: boolean) => void
   /** Push one activity value to every observer of `providerSessionId`. */
   readonly emitActivity: (providerSessionId: string, activity: AgentActivity) => void
+  /** Live observeSession subscriptions for `providerSessionId`. */
+  readonly observerCount: (providerSessionId: string) => number
   /** Script what checkSession reports for `providerSessionId`. */
   readonly setCheckActivity: (providerSessionId: string, activity: AgentActivity | null) => void
   /** prepareTuiSession identities handed out, in order. */
@@ -364,6 +366,7 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
         Queue.offerUnsafe(queue, activity)
       }
     },
+    observerCount: (providerSessionId) => observers.get(providerSessionId)?.size ?? 0,
     setCheckActivity: (providerSessionId, activity) => {
       if (activity === null) checkActivity.delete(providerSessionId)
       else checkActivity.set(providerSessionId, activity)

--- a/app-server/test/agents/fakeAgentAdapter.ts
+++ b/app-server/test/agents/fakeAgentAdapter.ts
@@ -57,6 +57,9 @@ export interface FakeAgentAdapter {
   readonly observerCount: (providerSessionId: string) => number
   /** Script what checkSession reports for `providerSessionId`. */
   readonly setCheckActivity: (providerSessionId: string, activity: AgentActivity | null) => void
+  /** Mark a session as pruned provider-side: tuiLaunch's existence probe
+   * fails AgentResumeFailed (the Codex reopen-probe behavior). */
+  readonly setSessionPruned: (providerSessionId: string, pruned: boolean) => void
   /** prepareTuiSession identities handed out, in order. */
   readonly prepared: Array<{ providerSessionId: string; cwd: string }>
   /** releaseSession calls, in order. */
@@ -82,6 +85,7 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
   const connections = new Map<string, LiveConnection>()
   const observers = new Map<string, Set<Queue.Queue<AgentActivity, Cause.Done>>>()
   const checkActivity = new Map<string, AgentActivity>()
+  const prunedSessions = new Set<string>()
   const prepared: FakeAgentAdapter["prepared"] = []
   const released: FakeAgentAdapter["released"] = []
   let identityGate: Deferred.Deferred<void> | null = null
@@ -262,12 +266,24 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
       }),
     tuiLaunch: (options) =>
       requireAvailable.pipe(
-        Effect.as({
-          launchSpec: {
-            command: ["fake-agent", "resume", options.providerSessionId],
-            env: {},
-          },
-        }),
+        Effect.andThen(
+          Effect.suspend(() =>
+            prunedSessions.has(options.providerSessionId)
+              ? Effect.fail(
+                  new AgentResumeFailed({
+                    provider: "codex",
+                    providerSessionId: options.providerSessionId,
+                    reason: "the provider no longer has this session",
+                  }),
+                )
+              : Effect.succeed({
+                  launchSpec: {
+                    command: ["fake-agent", "resume", options.providerSessionId],
+                    env: {},
+                  },
+                }),
+          ),
+        ),
       ),
     prepareTuiSession: (options) =>
       Effect.gen(function* () {
@@ -370,6 +386,10 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
     setCheckActivity: (providerSessionId, activity) => {
       if (activity === null) checkActivity.delete(providerSessionId)
       else checkActivity.set(providerSessionId, activity)
+    },
+    setSessionPruned: (providerSessionId, pruned) => {
+      if (pruned) prunedSessions.add(providerSessionId)
+      else prunedSessions.delete(providerSessionId)
     },
     prepared,
     released,

--- a/app-server/test/agents/fakeAgentAdapter.ts
+++ b/app-server/test/agents/fakeAgentAdapter.ts
@@ -266,23 +266,21 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
       }),
     tuiLaunch: (options) =>
       requireAvailable.pipe(
-        Effect.andThen(
-          Effect.suspend(() =>
-            prunedSessions.has(options.providerSessionId)
-              ? Effect.fail(
-                  new AgentResumeFailed({
-                    provider: "codex",
-                    providerSessionId: options.providerSessionId,
-                    reason: "the provider no longer has this session",
-                  }),
-                )
-              : Effect.succeed({
-                  launchSpec: {
-                    command: ["fake-agent", "resume", options.providerSessionId],
-                    env: {},
-                  },
+        Effect.andThen(() =>
+          prunedSessions.has(options.providerSessionId)
+            ? Effect.fail(
+                new AgentResumeFailed({
+                  provider: "codex",
+                  providerSessionId: options.providerSessionId,
+                  reason: "the provider no longer has this session",
                 }),
-          ),
+              )
+            : Effect.succeed({
+                launchSpec: {
+                  command: ["fake-agent", "resume", options.providerSessionId],
+                  env: {},
+                },
+              }),
         ),
       ),
     prepareTuiSession: (options) =>

--- a/app-server/test/api/openapi.test.ts
+++ b/app-server/test/api/openapi.test.ts
@@ -229,7 +229,12 @@ describe("openapi document vs runtime", () => {
     Effect.gen(function* () {
       const response = yield* (yield* rawClient).get("http://127.0.0.1/api/v1/projects/nope")
       assert.strictEqual(response.status, 404)
-      assert.deepStrictEqual(yield* response.json, { _tag: "ProjectNotFound", projectId: "nope" })
+      // The wire error carries the required, precomputed message field.
+      assert.deepStrictEqual(yield* response.json, {
+        _tag: "ProjectNotFound",
+        projectId: "nope",
+        message: "no project with id nope",
+      })
       assert.deepStrictEqual(
         operation("/api/v1/projects/{projectId}").responses["404"]!.content["application/json"]!
           .schema,
@@ -280,6 +285,7 @@ describe("openapi document vs runtime", () => {
       assert.deepStrictEqual(yield* response.json, {
         _tag: "TerminalNotFound",
         terminalId: "nope",
+        message: "no terminal with id nope",
       })
       assert.deepStrictEqual(
         operation("/api/v1/terminals/{terminalId}").responses["404"]!.content["application/json"]!
@@ -328,7 +334,11 @@ describe("openapi document vs runtime", () => {
     Effect.gen(function* () {
       const response = yield* (yield* rawClient).get("http://127.0.0.1/api/v1/threads/nope")
       assert.strictEqual(response.status, 404)
-      assert.deepStrictEqual(yield* response.json, { _tag: "ThreadNotFound", threadId: "nope" })
+      assert.deepStrictEqual(yield* response.json, {
+        _tag: "ThreadNotFound",
+        threadId: "nope",
+        message: "no thread with id nope",
+      })
       assert.deepStrictEqual(
         operation("/api/v1/threads/{threadId}").responses["404"]!.content["application/json"]!
           .schema,
@@ -440,7 +450,11 @@ describe("openapi document vs runtime", () => {
 
       const missing = yield* client.get("http://127.0.0.1/api/v1/agents/nope")
       assert.strictEqual(missing.status, 404)
-      assert.deepStrictEqual(yield* missing.json, { _tag: "AgentNotFound", agentId: "nope" })
+      assert.deepStrictEqual(yield* missing.json, {
+        _tag: "AgentNotFound",
+        agentId: "nope",
+        message: "no agent with id nope",
+      })
     }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
   )
 

--- a/app-server/test/cli/serve.blackbox.test.ts
+++ b/app-server/test/cli/serve.blackbox.test.ts
@@ -30,13 +30,9 @@ afterAll(() => {
 // deterministic fake so these tests need no zmx install anywhere they run
 // (a missing install would add a startup warning line to stderr).
 const sandbox = makeFakeZmxSandbox()
-const spawnFromSource = (port: number) =>
-  spawnServe(
-    [process.execPath, "src/main.ts"],
-    port,
-    appServerRoot,
-    isolatedEnv(scratch, { ATC_ZMX_EXECUTABLE: sandbox.wrapper }),
-  )
+const serveEnv = () => isolatedEnv(scratch, { ATC_ZMX_EXECUTABLE: sandbox.wrapper })
+const spawnFromSource = (port: number, env = serveEnv()) =>
+  spawnServe([process.execPath, "src/main.ts"], port, appServerRoot, env)
 
 describe("atc serve (black box)", () => {
   test.each(["SIGTERM", "SIGINT"] as const)(
@@ -44,7 +40,8 @@ describe("atc serve (black box)", () => {
     async (signal) => {
       const port = await freePort()
       const base = `http://127.0.0.1:${port}`
-      const proc = spawnFromSource(port)
+      const env = serveEnv()
+      const proc = spawnFromSource(port, env)
       try {
         const health = await waitForHealth(base, proc)
         expect(health.status).toBe(200)
@@ -74,6 +71,11 @@ describe("atc serve (black box)", () => {
 
         // The port is released once the process is gone.
         await expect(fetch(`${base}/api/v1/health`)).rejects.toThrow()
+
+        // The file log records the clean exit — a supervising app can tell
+        // it from a kill, whose log simply stops.
+        const log = await Bun.file(`${env.XDG_STATE_HOME}/atc/atc.log`).text()
+        expect(log).toContain("shutting down")
       } finally {
         proc.kill()
       }

--- a/app-server/test/cli/serve.blackbox.test.ts
+++ b/app-server/test/cli/serve.blackbox.test.ts
@@ -31,7 +31,7 @@ afterAll(() => {
 // (a missing install would add a startup warning line to stderr).
 const sandbox = makeFakeZmxSandbox()
 const serveEnv = () => isolatedEnv(scratch, { ATC_ZMX_EXECUTABLE: sandbox.wrapper })
-const spawnFromSource = (port: number, env = serveEnv()) =>
+const spawnFromSource = (port: number, env: ReturnType<typeof serveEnv>) =>
   spawnServe([process.execPath, "src/main.ts"], port, appServerRoot, env)
 
 describe("atc serve (black box)", () => {
@@ -85,7 +85,7 @@ describe("atc serve (black box)", () => {
 
   test("fails with one friendly stderr line when the port is taken", async () => {
     const occupant = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response("") })
-    const proc = spawnFromSource(occupant.port!)
+    const proc = spawnFromSource(occupant.port!, serveEnv())
     try {
       expect(await proc.exited).toBe(1)
       const stderr = await new Response(proc.stderr as ReadableStream).text()

--- a/app-server/test/events/eventCascades.test.ts
+++ b/app-server/test/events/eventCascades.test.ts
@@ -1,0 +1,147 @@
+import { assert, describe, it } from "@effect/vitest"
+import { BunHttpServer } from "@effect/platform-bun"
+import { Effect, Layer, Option, Stream } from "effect"
+import { HttpApiTest } from "effect/unstable/httpapi"
+import { mkdtempSync, realpathSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll } from "vitest"
+import { Api } from "../../src/api/contract.ts"
+import { V1Handlers } from "../../src/api/handlers.ts"
+import * as Events from "../../src/events/events.ts"
+import type { ResourceChangedEvent } from "../../src/events/events.ts"
+import { sessionNameForTerminalId } from "../../src/terminals/terminalAdapter.ts"
+import { ThreadRepository } from "../../src/threads/threadRepository.ts"
+import { TestBuildInfoLayer } from "../testBuildInfo.ts"
+import { makeTestServiceLayers } from "../testLayers.ts"
+
+// Cascade-publish regression tests (ATC-142): the mutations whose events are
+// EASY to lose silently, because the changed resource is not the one the
+// request named — the silent-sidebar-staleness class the macOS client depends
+// on. Direct publishes (create/update/delete of the named resource) are
+// covered by the api.test.ts events test.
+
+const kit = makeTestServiceLayers()
+const TestLayer = Layer.mergeAll(
+  V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, kit.layer])),
+  kit.layer,
+  BunHttpServer.layerHttpServices,
+)
+
+const scratch = mkdtempSync(join(tmpdir(), "atc-event-cascade-"))
+afterAll(() => rmSync(scratch, { recursive: true, force: true }))
+const realDir = realpathSync(scratch)
+
+/** Subscribe and collect real events (heartbeats dropped) into a sink. */
+const collect = Effect.gen(function* () {
+  const events = yield* Events.Events
+  const feed = yield* events.subscribe()
+  const sink: Array<ResourceChangedEvent> = []
+  yield* feed.pipe(
+    Stream.runForEach((item) =>
+      Effect.sync(() => {
+        if (item !== Events.HEARTBEAT) sink.push(item)
+      }),
+    ),
+    Effect.forkScoped,
+  )
+  return sink
+})
+
+/** Poll (real clock) until `predicate` holds on the sink; bounded. */
+const eventually = (sink: Array<ResourceChangedEvent>, predicate: () => boolean) =>
+  Effect.gen(function* () {
+    for (let attempt = 0; !predicate(); attempt++) {
+      assert.isBelow(attempt, 300, `condition never held; saw ${JSON.stringify(sink)}`)
+      yield* Effect.sleep("10 millis")
+    }
+  })
+
+const has = (
+  sink: Array<ResourceChangedEvent>,
+  expected: ResourceChangedEvent,
+): (() => boolean) => {
+  const matches = (event: ResourceChangedEvent) =>
+    event.resource === expected.resource &&
+    event.id === expected.id &&
+    event.change === expected.change
+  return () => sink.some(matches)
+}
+
+const setup = Effect.gen(function* () {
+  const client = yield* HttpApiTest.groups(Api, ["v1"])
+  const project = yield* client.v1.createProject({
+    payload: { name: "Cascades", defaultWorkingDirectory: realDir },
+  })
+  const thread = yield* client.v1.createThread({
+    payload: { projectId: project.id, agentId: "codex" },
+  })
+  return { client, project, thread }
+})
+
+describe("cascade event publishes", () => {
+  it.live("thread delete publishes the orphaned ended terminal's update", () =>
+    Effect.gen(function* () {
+      const { client, thread } = yield* setup
+      const terminal = yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+      // The TUI dies and a read tombstones it: the ended terminal survives
+      // the thread delete as an unlinked tombstone (FK SET NULL).
+      kit.fake.sessions.delete(sessionNameForTerminalId(terminal.id))
+      yield* client.v1.listTerminals({ query: { projectId: thread.projectId } })
+
+      const sink = yield* collect
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+      yield* eventually(sink, has(sink, { resource: "thread", id: thread.id, change: "deleted" }))
+      // The tombstone's client-visible threadId changed with the delete.
+      yield* eventually(
+        sink,
+        has(sink, { resource: "terminal", id: terminal.id, change: "updated" }),
+      )
+      yield* client.v1.deleteTerminal({ params: { terminalId: terminal.id } })
+    }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+  )
+
+  it.live("reconcile tombstoning a dead TUI terminal publishes terminal AND thread", () =>
+    Effect.gen(function* () {
+      const { client, thread } = yield* setup
+      const terminal = yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+
+      const sink = yield* collect
+      // The session dies out from under ATC; the next reconciled read (the
+      // demand-driven pass) writes the tombstone and must tell subscribers
+      // about both the terminal and its thread's derived fields.
+      kit.fake.sessions.delete(sessionNameForTerminalId(terminal.id))
+      yield* client.v1.listTerminals({ query: { projectId: thread.projectId } })
+      yield* eventually(
+        sink,
+        has(sink, { resource: "terminal", id: terminal.id, change: "updated" }),
+      )
+      yield* eventually(sink, has(sink, { resource: "thread", id: thread.id, change: "updated" }))
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+    }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+  )
+
+  it.live("activity transitions on the observation feed publish thread updates", () =>
+    Effect.gen(function* () {
+      const { client, thread } = yield* setup
+      const repository = yield* ThreadRepository
+      yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+      const sessionId =
+        Option.getOrThrow(yield* repository.get(thread.id)).providerSessionId ?? ""
+
+      const sink = yield* collect
+      kit.fakeAgents.codex.emitActivity(sessionId, "working")
+      yield* eventually(sink, has(sink, { resource: "thread", id: thread.id, change: "updated" }))
+
+      // Each transition publishes once; a repeated identical activity does
+      // not re-publish (the coalescing clients rely on staying quiet).
+      const updates = () =>
+        sink.filter((event) => event.resource === "thread" && event.change === "updated").length
+      const afterFirst = updates()
+      kit.fakeAgents.codex.emitActivity(sessionId, "working")
+      kit.fakeAgents.codex.emitActivity(sessionId, "idle")
+      yield* eventually(sink, () => updates() === afterFirst + 1)
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+    }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+  )
+})

--- a/app-server/test/events/eventCascades.test.ts
+++ b/app-server/test/events/eventCascades.test.ts
@@ -126,8 +126,7 @@ describe("cascade event publishes", () => {
       const { client, thread } = yield* setup
       const repository = yield* ThreadRepository
       yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
-      const sessionId =
-        Option.getOrThrow(yield* repository.get(thread.id)).providerSessionId ?? ""
+      const sessionId = Option.getOrThrow(yield* repository.get(thread.id)).providerSessionId ?? ""
 
       const sink = yield* collect
       kit.fakeAgents.codex.emitActivity(sessionId, "working")

--- a/app-server/test/events/eventCascades.test.ts
+++ b/app-server/test/events/eventCascades.test.ts
@@ -1,19 +1,16 @@
 import { assert, describe, it } from "@effect/vitest"
-import { BunHttpServer } from "@effect/platform-bun"
-import { Effect, Layer, Option, Stream } from "effect"
+import { Effect, Option, Stream } from "effect"
 import { HttpApiTest } from "effect/unstable/httpapi"
 import { mkdtempSync, realpathSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterAll } from "vitest"
 import { Api } from "../../src/api/contract.ts"
-import { V1Handlers } from "../../src/api/handlers.ts"
 import * as Events from "../../src/events/events.ts"
 import type { ResourceChangedEvent } from "../../src/events/events.ts"
 import { sessionNameForTerminalId } from "../../src/terminals/terminalAdapter.ts"
 import { ThreadRepository } from "../../src/threads/threadRepository.ts"
-import { TestBuildInfoLayer } from "../testBuildInfo.ts"
-import { makeTestServiceLayers } from "../testLayers.ts"
+import { apiTestLayer, makeTestServiceLayers } from "../testLayers.ts"
 
 // Cascade-publish regression tests (ATC-142): the mutations whose events are
 // EASY to lose silently, because the changed resource is not the one the
@@ -22,11 +19,7 @@ import { makeTestServiceLayers } from "../testLayers.ts"
 // covered by the api.test.ts events test.
 
 const kit = makeTestServiceLayers()
-const TestLayer = Layer.mergeAll(
-  V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, kit.layer])),
-  kit.layer,
-  BunHttpServer.layerHttpServices,
-)
+const TestLayer = apiTestLayer(kit)
 
 const scratch = mkdtempSync(join(tmpdir(), "atc-event-cascade-"))
 afterAll(() => rmSync(scratch, { recursive: true, force: true }))
@@ -38,17 +31,14 @@ const collect = Effect.gen(function* () {
   const feed = yield* events.subscribe()
   const sink: Array<ResourceChangedEvent> = []
   yield* feed.pipe(
-    Stream.runForEach((item) =>
-      Effect.sync(() => {
-        if (item !== Events.HEARTBEAT) sink.push(item)
-      }),
-    ),
+    Stream.filter((item): item is ResourceChangedEvent => item !== Events.HEARTBEAT),
+    Stream.runForEach((event) => Effect.sync(() => sink.push(event))),
     Effect.forkScoped,
   )
   return sink
 })
 
-/** Poll (real clock) until `predicate` holds on the sink; bounded. */
+/** Poll (real clock, bounded) until `predicate` holds on the sink. */
 const eventually = (sink: Array<ResourceChangedEvent>, predicate: () => boolean) =>
   Effect.gen(function* () {
     for (let attempt = 0; !predicate(); attempt++) {
@@ -57,16 +47,16 @@ const eventually = (sink: Array<ResourceChangedEvent>, predicate: () => boolean)
     }
   })
 
-const has = (
-  sink: Array<ResourceChangedEvent>,
-  expected: ResourceChangedEvent,
-): (() => boolean) => {
-  const matches = (event: ResourceChangedEvent) =>
-    event.resource === expected.resource &&
-    event.id === expected.id &&
-    event.change === expected.change
-  return () => sink.some(matches)
-}
+/** `eventually` for the common case: one expected event in the sink. */
+const waitForEvent = (sink: Array<ResourceChangedEvent>, expected: ResourceChangedEvent) =>
+  eventually(sink, () =>
+    sink.some(
+      (event) =>
+        event.resource === expected.resource &&
+        event.id === expected.id &&
+        event.change === expected.change,
+    ),
+  )
 
 const setup = Effect.gen(function* () {
   const client = yield* HttpApiTest.groups(Api, ["v1"])
@@ -91,12 +81,9 @@ describe("cascade event publishes", () => {
 
       const sink = yield* collect
       yield* client.v1.deleteThread({ params: { threadId: thread.id } })
-      yield* eventually(sink, has(sink, { resource: "thread", id: thread.id, change: "deleted" }))
+      yield* waitForEvent(sink, { resource: "thread", id: thread.id, change: "deleted" })
       // The tombstone's client-visible threadId changed with the delete.
-      yield* eventually(
-        sink,
-        has(sink, { resource: "terminal", id: terminal.id, change: "updated" }),
-      )
+      yield* waitForEvent(sink, { resource: "terminal", id: terminal.id, change: "updated" })
       yield* client.v1.deleteTerminal({ params: { terminalId: terminal.id } })
     }).pipe(Effect.scoped, Effect.provide(TestLayer)),
   )
@@ -112,11 +99,8 @@ describe("cascade event publishes", () => {
       // about both the terminal and its thread's derived fields.
       kit.fake.sessions.delete(sessionNameForTerminalId(terminal.id))
       yield* client.v1.listTerminals({ query: { projectId: thread.projectId } })
-      yield* eventually(
-        sink,
-        has(sink, { resource: "terminal", id: terminal.id, change: "updated" }),
-      )
-      yield* eventually(sink, has(sink, { resource: "thread", id: thread.id, change: "updated" }))
+      yield* waitForEvent(sink, { resource: "terminal", id: terminal.id, change: "updated" })
+      yield* waitForEvent(sink, { resource: "thread", id: thread.id, change: "updated" })
       yield* client.v1.deleteThread({ params: { threadId: thread.id } })
     }).pipe(Effect.scoped, Effect.provide(TestLayer)),
   )
@@ -130,7 +114,7 @@ describe("cascade event publishes", () => {
 
       const sink = yield* collect
       kit.fakeAgents.codex.emitActivity(sessionId, "working")
-      yield* eventually(sink, has(sink, { resource: "thread", id: thread.id, change: "updated" }))
+      yield* waitForEvent(sink, { resource: "thread", id: thread.id, change: "updated" })
 
       // Each transition publishes once; a repeated identical activity does
       // not re-publish (the coalescing clients rely on staying quiet).

--- a/app-server/test/events/events.test.ts
+++ b/app-server/test/events/events.test.ts
@@ -1,5 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Deferred, Effect, Fiber, Stream } from "effect"
+import type { Duration } from "effect"
 import * as Events from "../../src/events/events.ts"
 import type { ResourceChangedEvent } from "../../src/events/events.ts"
 
@@ -16,12 +17,13 @@ const event = (id: string): ResourceChangedEvent => ({
   change: "updated",
 })
 
-/** Poll (assertion-bounded) until `condition` holds; no timers involved. */
-const waitFor = (condition: Effect.Effect<boolean>, label: string) =>
+/** Poll (assertion-bounded) until `condition` holds. The default spins on
+ * yieldNow; pass a delay when the condition needs real time to change. */
+const waitFor = (condition: Effect.Effect<boolean>, label: string, delay?: Duration.Input) =>
   Effect.gen(function* () {
     for (let attempt = 0; !(yield* condition); attempt++) {
       assert.isBelow(attempt, 1000, `never observed: ${label}`)
-      yield* Effect.yieldNow
+      yield* delay === undefined ? Effect.yieldNow : Effect.sleep(delay)
     }
   })
 
@@ -29,11 +31,10 @@ const waitFor = (condition: Effect.Effect<boolean>, label: string) =>
 // event-delivery tests filter them out so slow CI runs cannot interleave one.
 const collectInto = (events: Events.Events["Service"], sink: Array<ResourceChangedEvent>) =>
   events.subscribe().pipe(
-    Effect.flatMap(
-      Stream.runForEach((received) =>
-        Effect.sync(() => {
-          if (received !== Events.HEARTBEAT) sink.push(received)
-        }),
+    Effect.flatMap((feed) =>
+      feed.pipe(
+        Stream.filter((item): item is ResourceChangedEvent => item !== Events.HEARTBEAT),
+        Stream.runForEach((event) => Effect.sync(() => sink.push(event))),
       ),
     ),
   )
@@ -174,10 +175,11 @@ describe("Events", () => {
         Effect.map(events.subscriberCount(), (count) => count === 2),
         "both subscribers registered",
       )
-      for (let attempt = 0; !counts.every((count) => count >= 2); attempt++) {
-        assert.isBelow(attempt, 1000, `heartbeats never arrived; saw ${JSON.stringify(counts)}`)
-        yield* Effect.sleep("10 millis")
-      }
+      yield* waitFor(
+        Effect.sync(() => counts.every((count) => count >= 2)),
+        "each subscriber saw two heartbeats",
+        "10 millis",
+      )
       yield* events.close()
       yield* Effect.forEach(fibers, Fiber.join)
     }).pipe(Effect.provide(Events.layerWith({ heartbeatInterval: "20 millis" }))),

--- a/app-server/test/events/events.test.ts
+++ b/app-server/test/events/events.test.ts
@@ -28,17 +28,15 @@ const waitFor = (condition: Effect.Effect<boolean>, label: string) =>
 // Heartbeat ticks share the subscriber queues (see the module header); the
 // event-delivery tests filter them out so slow CI runs cannot interleave one.
 const collectInto = (events: Events.Events["Service"], sink: Array<ResourceChangedEvent>) =>
-  events
-    .subscribe()
-    .pipe(
-      Effect.flatMap(
-        Stream.runForEach((received) =>
-          Effect.sync(() => {
-            if (received !== Events.HEARTBEAT) sink.push(received)
-          }),
-        ),
+  events.subscribe().pipe(
+    Effect.flatMap(
+      Stream.runForEach((received) =>
+        Effect.sync(() => {
+          if (received !== Events.HEARTBEAT) sink.push(received)
+        }),
       ),
-    )
+    ),
+  )
 
 describe("Events", () => {
   it.effect("delivers published events to every subscriber, in order", () =>
@@ -161,17 +159,15 @@ describe("Events", () => {
       const counts = [0, 0]
       const fibers = yield* Effect.forEach(counts.keys(), (index) =>
         Effect.forkChild(
-          events
-            .subscribe()
-            .pipe(
-              Effect.flatMap(
-                Stream.runForEach((received) =>
-                  Effect.sync(() => {
-                    if (received === Events.HEARTBEAT) counts[index]!++
-                  }),
-                ),
+          events.subscribe().pipe(
+            Effect.flatMap(
+              Stream.runForEach((received) =>
+                Effect.sync(() => {
+                  if (received === Events.HEARTBEAT) counts[index]!++
+                }),
               ),
             ),
+          ),
         ),
       )
       yield* waitFor(

--- a/app-server/test/events/events.test.ts
+++ b/app-server/test/events/events.test.ts
@@ -25,10 +25,20 @@ const waitFor = (condition: Effect.Effect<boolean>, label: string) =>
     }
   })
 
+// Heartbeat ticks share the subscriber queues (see the module header); the
+// event-delivery tests filter them out so slow CI runs cannot interleave one.
 const collectInto = (events: Events.Events["Service"], sink: Array<ResourceChangedEvent>) =>
   events
     .subscribe()
-    .pipe(Effect.flatMap(Stream.runForEach((received) => Effect.sync(() => sink.push(received)))))
+    .pipe(
+      Effect.flatMap(
+        Stream.runForEach((received) =>
+          Effect.sync(() => {
+            if (received !== Events.HEARTBEAT) sink.push(received)
+          }),
+        ),
+      ),
+    )
 
 describe("Events", () => {
   it.effect("delivers published events to every subscriber, in order", () =>
@@ -73,9 +83,11 @@ describe("Events", () => {
           .pipe(
             Effect.flatMap(
               Stream.runForEach((received) =>
-                Effect.sync(() => lagging.push(received)).pipe(
-                  Effect.andThen(Deferred.await(gate)),
-                ),
+                received === Events.HEARTBEAT
+                  ? Effect.void
+                  : Effect.sync(() => lagging.push(received)).pipe(
+                      Effect.andThen(Deferred.await(gate)),
+                    ),
               ),
             ),
           ),
@@ -140,5 +152,38 @@ describe("Events", () => {
       const received = yield* Effect.flatMap(events.subscribe(), Stream.runCollect)
       assert.deepStrictEqual(received, [])
     }).pipe(Effect.provide(layer)),
+  )
+
+  // it.live: the heartbeat timer runs on the real clock.
+  it.live("one shared timer ticks a heartbeat to every subscriber", () =>
+    Effect.gen(function* () {
+      const events = yield* Events.Events
+      const counts = [0, 0]
+      const fibers = yield* Effect.forEach(counts.keys(), (index) =>
+        Effect.forkChild(
+          events
+            .subscribe()
+            .pipe(
+              Effect.flatMap(
+                Stream.runForEach((received) =>
+                  Effect.sync(() => {
+                    if (received === Events.HEARTBEAT) counts[index]!++
+                  }),
+                ),
+              ),
+            ),
+        ),
+      )
+      yield* waitFor(
+        Effect.map(events.subscriberCount(), (count) => count === 2),
+        "both subscribers registered",
+      )
+      for (let attempt = 0; !counts.every((count) => count >= 2); attempt++) {
+        assert.isBelow(attempt, 1000, `heartbeats never arrived; saw ${JSON.stringify(counts)}`)
+        yield* Effect.sleep("10 millis")
+      }
+      yield* events.close()
+      yield* Effect.forEach(fibers, Fiber.join)
+    }).pipe(Effect.provide(Events.layerWith({ heartbeatInterval: "20 millis" }))),
   )
 })

--- a/app-server/test/fixtures/fake-codex-listener.ts
+++ b/app-server/test/fixtures/fake-codex-listener.ts
@@ -39,6 +39,7 @@ interface Thread {
   readonly id: string
   readonly cwd: string
   readonly turns: Array<{ id: string; status: string }>
+  archived: boolean
 }
 
 const threads = new Map<string, Thread>()
@@ -103,7 +104,7 @@ const handle = (
       return
     case "thread/start": {
       const cwd = String(params["cwd"] ?? "/")
-      const thread: Thread = { id: crypto.randomUUID(), cwd, turns: [] }
+      const thread: Thread = { id: crypto.randomUUID(), cwd, turns: [], archived: false }
       threads.set(thread.id, thread)
       const reported = wrongCwd === "start" ? `${cwd}-wrong` : cwd
       respond({ thread: threadShape(thread, reported) })
@@ -120,10 +121,20 @@ const handle = (
     }
     case "thread/unsubscribe":
       return respond({ status: "unsubscribed" })
+    case "thread/archive": {
+      const thread = threads.get(String(params["threadId"] ?? ""))
+      if (thread === undefined) return respondError(-32600, "unknown thread")
+      thread.archived = true
+      return respond({})
+    }
     case "thread/list": {
       // Real reply shape is paginated: { data, nextCursor } with nextCursor
-      // null on the last page. One thread per page forces clients to walk.
-      const all = [...threads.values()]
+      // null on the last page, and the populations are disjoint: archived
+      // threads appear only when `archived: true`. One thread per page
+      // forces clients to walk.
+      const all = [...threads.values()].filter(
+        (thread) => thread.archived === (params["archived"] === true),
+      )
       const offset = Number.parseInt(String(params["cursor"] ?? "0"), 10) || 0
       return respond({
         data: all.slice(offset, offset + 1).map((thread) => ({

--- a/app-server/test/server.test.ts
+++ b/app-server/test/server.test.ts
@@ -4,7 +4,7 @@ import { HttpServer } from "effect/unstable/http"
 import * as Events from "../src/events/events.ts"
 import * as Server from "../src/server.ts"
 import { TestBuildInfoLayer } from "./testBuildInfo.ts"
-import { TestRepositoryLayers } from "./testLayers.ts"
+import { makeTestServiceLayers, TestRepositoryLayers } from "./testLayers.ts"
 
 describe("server layer", () => {
   // it.live: this test does real socket I/O, and the platform's shutdown
@@ -110,6 +110,39 @@ describe("server layer", () => {
       )
       assert.isFalse(end.errored, "the subscriber stream errored instead of ending")
       assert.isTrue(end.done)
+    }),
+  )
+
+  // The shared heartbeat crosses the real wire as an SSE comment — the
+  // keepalive quiet streams need to survive URLSession's idle timeout.
+  it.live("a quiet event stream carries heartbeat comments", () =>
+    Effect.gen(function* () {
+      const scope = yield* Scope.make()
+      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
+      const kit = makeTestServiceLayers(":memory:", {}, { heartbeatInterval: "30 millis" })
+      const context = yield* Layer.build(
+        Server.layer({ port: 0 }).pipe(Layer.provide([TestBuildInfoLayer, kit.layer])),
+      ).pipe(Effect.provideService(Scope.Scope, scope))
+      const address = Context.get(context, HttpServer.HttpServer).address
+      if (address._tag !== "TcpAddress") return assert.fail("expected a TCP address")
+
+      const response = yield* Effect.promise(() =>
+        fetch(`http://127.0.0.1:${address.port}/api/v1/events`, {
+          headers: { accept: "text/event-stream" },
+        }),
+      )
+      const reader = response.body!.getReader()
+      const decoder = new TextDecoder()
+      let payload = ""
+      // No mutation ever happens: everything on the wire is the opening
+      // comment and heartbeats.
+      for (let attempt = 0; !payload.includes(": heartbeat\n\n"); attempt++) {
+        assert.isBelow(attempt, 10, `no heartbeat arrived; saw ${JSON.stringify(payload)}`)
+        const chunk = yield* Effect.promise(() => reader.read())
+        assert.isFalse(chunk.done, "the stream ended before a heartbeat arrived")
+        payload += decoder.decode(chunk.value, { stream: true })
+      }
+      assert.isTrue(payload.startsWith(": connected\n\n"))
     }),
   )
 

--- a/app-server/test/server.test.ts
+++ b/app-server/test/server.test.ts
@@ -6,27 +6,35 @@ import * as Server from "../src/server.ts"
 import { TestBuildInfoLayer } from "./testBuildInfo.ts"
 import { makeTestServiceLayers, TestRepositoryLayers } from "./testLayers.ts"
 
+/**
+ * Build a server layer in its own closable scope — closable mid-test, and
+ * the finalizer guarantees the listener dies even when an assertion fails
+ * first. Returns the built context and the resolved loopback base URL.
+ */
+const startServer = <R, E>(layer: Layer.Layer<R | HttpServer.HttpServer, E>) =>
+  Effect.gen(function* () {
+    const scope = yield* Scope.make()
+    yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
+    const context = yield* Layer.build(layer).pipe(Effect.provideService(Scope.Scope, scope))
+    const address = Context.get(context, HttpServer.HttpServer).address
+    if (address._tag !== "TcpAddress") {
+      return yield* Effect.die(`expected a TCP address, got ${address._tag}`)
+    }
+    assert.strictEqual(address.hostname, "127.0.0.1")
+    return { scope, context, base: `http://127.0.0.1:${address.port}` }
+  })
+
 describe("server layer", () => {
   // it.live: this test does real socket I/O, and the platform's shutdown
   // timeout must run on the real clock, not it.effect's TestClock.
   it.live("binds loopback, serves the API, and releases the port when closed", () =>
     Effect.gen(function* () {
-      // A manual scope so the server can be closed mid-test; the finalizer
-      // guarantees the listener dies even when an assertion fails first.
-      const scope = yield* Scope.make()
-      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
-      const context = yield* Layer.build(
+      const { scope, base } = yield* startServer(
         Server.layer({ port: 0 }).pipe(Layer.provide([TestBuildInfoLayer, TestRepositoryLayers])),
-      ).pipe(Effect.provideService(Scope.Scope, scope))
-
-      const address = Context.get(context, HttpServer.HttpServer).address
-      assert.strictEqual(address._tag, "TcpAddress")
-      if (address._tag !== "TcpAddress") return
-      assert.strictEqual(address.hostname, "127.0.0.1")
+      )
 
       // Connection: close keeps fetch from pooling an idle socket, so the
       // release check below is forced onto a fresh connection.
-      const base = `http://127.0.0.1:${address.port}`
       const health = yield* Effect.promise(() =>
         fetch(`${base}/api/v1/health`, { headers: { connection: "close" } }),
       )
@@ -50,21 +58,15 @@ describe("server layer", () => {
   // path — the drain layer in server.ts ends subscriber streams first.
   it.live("graceful shutdown with an open event subscriber is quick and clean", () =>
     Effect.gen(function* () {
-      const scope = yield* Scope.make()
-      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
       // TestRepositoryLayers is merged alongside the server (one memoized
       // instance) so the test can watch the same Events service the
       // handlers publish through.
-      const context = yield* Layer.build(
+      const { scope, context, base } = yield* startServer(
         Layer.mergeAll(Server.layer({ port: 0 }), TestRepositoryLayers).pipe(
           Layer.provide([TestBuildInfoLayer, TestRepositoryLayers]),
         ),
-      ).pipe(Effect.provideService(Scope.Scope, scope))
+      )
       const events = Context.get(context, Events.Events)
-      const address = Context.get(context, HttpServer.HttpServer).address
-      assert.strictEqual(address._tag, "TcpAddress")
-      if (address._tag !== "TcpAddress") return
-      const base = `http://127.0.0.1:${address.port}`
 
       const response = yield* Effect.promise(() =>
         fetch(`${base}/api/v1/events`, { headers: { accept: "text/event-stream" } }),
@@ -117,19 +119,13 @@ describe("server layer", () => {
   // keepalive quiet streams need to survive URLSession's idle timeout.
   it.live("a quiet event stream carries heartbeat comments", () =>
     Effect.gen(function* () {
-      const scope = yield* Scope.make()
-      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
       const kit = makeTestServiceLayers(":memory:", {}, { heartbeatInterval: "30 millis" })
-      const context = yield* Layer.build(
+      const { base } = yield* startServer(
         Server.layer({ port: 0 }).pipe(Layer.provide([TestBuildInfoLayer, kit.layer])),
-      ).pipe(Effect.provideService(Scope.Scope, scope))
-      const address = Context.get(context, HttpServer.HttpServer).address
-      if (address._tag !== "TcpAddress") return assert.fail("expected a TCP address")
+      )
 
       const response = yield* Effect.promise(() =>
-        fetch(`http://127.0.0.1:${address.port}/api/v1/events`, {
-          headers: { accept: "text/event-stream" },
-        }),
+        fetch(`${base}/api/v1/events`, { headers: { accept: "text/event-stream" } }),
       )
       const reader = response.body!.getReader()
       const decoder = new TextDecoder()
@@ -151,20 +147,16 @@ describe("server layer", () => {
   // Effect or Bun upgrade could silently change, hence a real-wire test.
   it.live("a dropped subscriber is unregistered", () =>
     Effect.gen(function* () {
-      const scope = yield* Scope.make()
-      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
-      const context = yield* Layer.build(
+      const { context, base } = yield* startServer(
         Layer.mergeAll(Server.layer({ port: 0 }), TestRepositoryLayers).pipe(
           Layer.provide([TestBuildInfoLayer, TestRepositoryLayers]),
         ),
-      ).pipe(Effect.provideService(Scope.Scope, scope))
+      )
       const events = Context.get(context, Events.Events)
-      const address = Context.get(context, HttpServer.HttpServer).address
-      if (address._tag !== "TcpAddress") return assert.fail("expected a TCP address")
 
       const abort = new AbortController()
       const response = yield* Effect.promise(() =>
-        fetch(`http://127.0.0.1:${address.port}/api/v1/events`, { signal: abort.signal }),
+        fetch(`${base}/api/v1/events`, { signal: abort.signal }),
       )
       assert.strictEqual(response.status, 200)
       assert.strictEqual(yield* events.subscriberCount(), 1)

--- a/app-server/test/terminals/attachProtocolFixtures.test.ts
+++ b/app-server/test/terminals/attachProtocolFixtures.test.ts
@@ -13,6 +13,7 @@ import {
   encodeControlFrame,
 } from "../../src/terminals/attachProtocol.ts"
 import type { ControlFrame } from "../../src/terminals/attachProtocol.ts"
+import { DEFAULT_PTY_COLS } from "../../src/platform/subprocess.ts"
 
 // The shared attach-protocol vectors (packages/attach-protocol/fixtures/),
 // run against the TypeScript implementation. ATCKit's attach client must
@@ -44,7 +45,7 @@ describe("attach protocol fixtures", () => {
 
   it("the close vocabulary matches the exported constants exactly", () => {
     const { closes } = fixture<{
-      closes: Array<{ code: number; reason: string | null; retryable: boolean }>
+      closes: Array<{ code: number; reason: string | null; retryable: boolean | null }>
     }>("close-codes.json")
     const reasons = closes.flatMap((close) => close.reason ?? [])
     assert.sameMembers(reasons, [
@@ -54,10 +55,13 @@ describe("attach protocol fixtures", () => {
       CLOSE_ZMX_UNAVAILABLE,
       CLOSE_PING_TIMEOUT,
     ])
-    // The semantic pins clients build retry logic on.
+    // The semantic pins clients build retry logic on. detach is the one
+    // row where retryable must be null: it is client-initiated and proves
+    // nothing about the terminal — a false here would make clients show
+    // "ended" after every deliberate detach.
     const byReason = new Map(closes.map((close) => [close.reason, close]))
     assert.deepInclude(byReason.get(CLOSE_TERMINAL_ENDED), { code: 1000, retryable: false })
-    assert.deepInclude(byReason.get(CLOSE_DETACH), { code: 1000 })
+    assert.deepInclude(byReason.get(CLOSE_DETACH), { code: 1000, retryable: null })
     for (const reason of [CLOSE_ATTACH_FAILED, CLOSE_ZMX_UNAVAILABLE, CLOSE_PING_TIMEOUT]) {
       assert.deepInclude(byReason.get(reason), { code: 1011, retryable: true })
     }
@@ -69,6 +73,8 @@ describe("attach protocol fixtures", () => {
       fallback: number
       cases: Array<{ name: string; raw: string | number | null; expect: number }>
     }>("dimension-clamp.json")
+    // The fixture documents the server default; pin it to the real one.
+    assert.strictEqual(clamp.fallback, DEFAULT_PTY_COLS)
     for (const { name, raw, expect } of clamp.cases) {
       assert.strictEqual(clampDimension(raw ?? undefined, clamp.fallback), expect, name)
     }

--- a/app-server/test/terminals/attachProtocolFixtures.test.ts
+++ b/app-server/test/terminals/attachProtocolFixtures.test.ts
@@ -1,0 +1,93 @@
+import { assert, describe, it } from "@effect/vitest"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import {
+  attachUrl,
+  clampDimension,
+  CLOSE_ATTACH_FAILED,
+  CLOSE_DETACH,
+  CLOSE_PING_TIMEOUT,
+  CLOSE_TERMINAL_ENDED,
+  CLOSE_ZMX_UNAVAILABLE,
+  decodeControlFrame,
+  encodeControlFrame,
+} from "../../src/terminals/attachProtocol.ts"
+import type { ControlFrame } from "../../src/terminals/attachProtocol.ts"
+
+// The shared attach-protocol vectors (packages/attach-protocol/fixtures/),
+// run against the TypeScript implementation. ATCKit's attach client must
+// consume the same files, so protocol drift between clients fails a test
+// instead of surfacing in a terminal window.
+
+const fixture = <T>(name: string): T =>
+  JSON.parse(
+    readFileSync(
+      fileURLToPath(new URL(`../../../packages/attach-protocol/fixtures/${name}`, import.meta.url)),
+      "utf8",
+    ),
+  ) as T
+
+describe("attach protocol fixtures", () => {
+  it("round-trips every valid control frame and ignores every malformed one", () => {
+    const frames = fixture<{
+      valid: Array<{ name: string; wire: string; frame: ControlFrame }>
+      ignored: Array<{ name: string; wire: string }>
+    }>("control-frames.json")
+    for (const { name, wire, frame } of frames.valid) {
+      assert.deepStrictEqual(decodeControlFrame(wire), frame, name)
+      assert.deepStrictEqual(decodeControlFrame(encodeControlFrame(frame)), frame, name)
+    }
+    for (const { name, wire } of frames.ignored) {
+      assert.isUndefined(decodeControlFrame(wire), name)
+    }
+  })
+
+  it("the close vocabulary matches the exported constants exactly", () => {
+    const { closes } = fixture<{
+      closes: Array<{ code: number; reason: string | null; retryable: boolean }>
+    }>("close-codes.json")
+    const reasons = closes.flatMap((close) => close.reason ?? [])
+    assert.sameMembers(reasons, [
+      CLOSE_TERMINAL_ENDED,
+      CLOSE_DETACH,
+      CLOSE_ATTACH_FAILED,
+      CLOSE_ZMX_UNAVAILABLE,
+      CLOSE_PING_TIMEOUT,
+    ])
+    // The semantic pins clients build retry logic on.
+    const byReason = new Map(closes.map((close) => [close.reason, close]))
+    assert.deepInclude(byReason.get(CLOSE_TERMINAL_ENDED), { code: 1000, retryable: false })
+    assert.deepInclude(byReason.get(CLOSE_DETACH), { code: 1000 })
+    for (const reason of [CLOSE_ATTACH_FAILED, CLOSE_ZMX_UNAVAILABLE, CLOSE_PING_TIMEOUT]) {
+      assert.deepInclude(byReason.get(reason), { code: 1011, retryable: true })
+    }
+    assert.deepInclude(byReason.get(null), { code: 1006, retryable: true })
+  })
+
+  it("applies the dimension floor/clamp/fallback rule to every case", () => {
+    const clamp = fixture<{
+      fallback: number
+      cases: Array<{ name: string; raw: string | number | null; expect: number }>
+    }>("dimension-clamp.json")
+    for (const { name, raw, expect } of clamp.cases) {
+      assert.strictEqual(clampDimension(raw ?? undefined, clamp.fallback), expect, name)
+    }
+  })
+
+  it("builds every attach URL case", () => {
+    const urls = fixture<{
+      cases: Array<{
+        name: string
+        base: string
+        terminalId: string
+        cols?: number
+        rows?: number
+        expect: string
+      }>
+    }>("attach-urls.json")
+    for (const { name, base, terminalId, cols, rows, expect } of urls.cases) {
+      const size = cols !== undefined && rows !== undefined ? { cols, rows } : undefined
+      assert.strictEqual(attachUrl(new URL(base), terminalId, size).toString(), expect, name)
+    }
+  })
+})

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -76,6 +76,7 @@ export const testAppConfig = (overrides: Partial<AppConfig["Service"]>): Layer.L
 export const makeTestServiceLayers = (
   dbFile = ":memory:",
   threadsOptions: Threads.ThreadsOptions = {},
+  eventsOptions: Events.EventsOptions = {},
 ): {
   readonly fake: FakeTerminalAdapter
   readonly fakeAgents: { readonly codex: FakeAgentAdapter; readonly claude: FakeAgentAdapter }
@@ -105,7 +106,8 @@ export const makeTestServiceLayers = (
     ThreadRepository.layer,
   ).pipe(Layer.provide(Persistence.layerFile(dbFile)))
   const services = Layer.mergeAll(base, Directories.layer, fake.layer, ClaudeHooks.layer)
-  const terminals = Terminals.layer.pipe(Layer.provide([services, Events.layer]))
+  const eventsLayer = Events.layerWith(eventsOptions)
+  const terminals = Terminals.layer.pipe(Layer.provide([services, eventsLayer]))
   const registry = AgentRegistry.layer.pipe(
     Layer.provide([
       Layer.succeed(CodexAdapter.CodexAdapter)(fakeAgents.codex.adapter),
@@ -122,11 +124,11 @@ export const makeTestServiceLayers = (
       services,
       terminals,
       registry,
-      Events.layer,
+      eventsLayer,
       Threads.layerWith(threadsOptions).pipe(
-        Layer.provide([services, terminals, registry, Events.layer]),
+        Layer.provide([services, terminals, registry, eventsLayer]),
       ),
-      Projects.layer.pipe(Layer.provide([services, Events.layer])),
+      Projects.layer.pipe(Layer.provide([services, eventsLayer])),
     ),
   }
 }

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -1,5 +1,5 @@
 import { assert } from "@effect/vitest"
-import { BunServices } from "@effect/platform-bun"
+import { BunHttpServer, BunServices } from "@effect/platform-bun"
 import { Effect, Layer, Stream } from "effect"
 import * as fs from "node:fs"
 import * as os from "node:os"
@@ -22,6 +22,7 @@ import * as Terminals from "../src/terminals/terminals.ts"
 import * as ThreadRepository from "../src/threads/threadRepository.ts"
 import * as Threads from "../src/threads/threads.ts"
 import * as Zmx from "../src/terminals/zmxAdapter.ts"
+import { V1Handlers } from "../src/api/handlers.ts"
 import {
   appServerRoot,
   freePort,
@@ -30,6 +31,7 @@ import {
   trackTempDir,
   waitForHealth,
 } from "./blackbox.ts"
+import { TestBuildInfoLayer } from "./testBuildInfo.ts"
 import { makeFakeAdapter } from "./terminals/fakeTerminalAdapter.ts"
 import type { FakeTerminalAdapter } from "./terminals/fakeTerminalAdapter.ts"
 import { makeFakeAgentAdapter } from "./agents/fakeAgentAdapter.ts"
@@ -134,6 +136,20 @@ export const makeTestServiceLayers = (
 }
 
 export const TestRepositoryLayers = makeTestServiceLayers().layer
+
+type TestKitLayer = ReturnType<typeof makeTestServiceLayers>["layer"]
+
+/**
+ * The one HttpApiTest layer stack for in-process API tests over a kit:
+ * handlers wired to the kit's services, the services themselves (so tests
+ * reach the same instances the handlers use), and the HTTP test services.
+ */
+export const apiTestLayer = (kit: { readonly layer: TestKitLayer }) =>
+  Layer.mergeAll(
+    V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, kit.layer])),
+    kit.layer,
+    BunHttpServer.layerHttpServices,
+  )
 
 /** The full zmx-adapter layer stack shared by every in-process adapter test. */
 export const zmxAdapterLayer = (options: {

--- a/app-server/test/threads/threadOpen.test.ts
+++ b/app-server/test/threads/threadOpen.test.ts
@@ -250,6 +250,49 @@ describe("threads.openTerminal", () => {
     }).pipe(Effect.provide(HoldLayer)),
   )
 
+  it.live("a TUI that dies during the identity wait fails fast with a real diagnostic", () =>
+    Effect.gen(function* () {
+      // Generous identity bound + tight death-watch: the failure below must
+      // come from the watch noticing the dead terminal, not the timeout.
+      const kit = makeTestServiceLayers(":memory:", { launchWatchInterval: "25 millis" })
+      yield* Effect.gen(function* () {
+        const { client, thread, project } = yield* setup
+        kit.fakeAgents.codex.setIdentityHangs(true)
+        const fiber = yield* client.v1
+          .openThreadTerminal({ params: { threadId: thread.id } })
+          .pipe(Effect.forkChild)
+        yield* eventually(
+          Effect.sync(() => kit.fake.sessions.size),
+          (size) => size === 1,
+        )
+
+        // The TUI exits immediately (the first-run auth failure): the open
+        // fails with the specific diagnostic well before the 30s bound, and
+        // nothing survives.
+        kit.fake.sessions.clear()
+        const failure = yield* Effect.flip(Fiber.join(fiber))
+        assert.strictEqual(failure._tag, "ProviderUnavailable")
+        if (failure._tag === "ProviderUnavailable") {
+          assert.include(failure.reason, "TUI exited")
+        }
+        assert.deepStrictEqual(
+          yield* client.v1.listTerminals({ query: { projectId: project.id } }),
+          [],
+        )
+        kit.fakeAgents.codex.setIdentityHangs(false)
+        yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, kit.layer])),
+            kit.layer,
+            BunHttpServer.layerHttpServices,
+          ),
+        ),
+      )
+    }),
+  )
+
   it.live("identity establishment failing in time cleans up the launched terminal", () =>
     Effect.gen(function* () {
       const { client, thread, project } = yield* setup

--- a/app-server/test/threads/threadOpen.test.ts
+++ b/app-server/test/threads/threadOpen.test.ts
@@ -1,17 +1,14 @@
 import { assert, describe, it } from "@effect/vitest"
-import { BunHttpServer } from "@effect/platform-bun"
-import { Effect, Fiber, Layer, Option } from "effect"
+import { Effect, Fiber, Option } from "effect"
 import { HttpApiTest } from "effect/unstable/httpapi"
 import { mkdtempSync, realpathSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterAll } from "vitest"
 import { Api } from "../../src/api/contract.ts"
-import { V1Handlers } from "../../src/api/handlers.ts"
 import { sessionNameForTerminalId } from "../../src/terminals/terminalAdapter.ts"
 import { ThreadRepository } from "../../src/threads/threadRepository.ts"
-import { TestBuildInfoLayer } from "../testBuildInfo.ts"
-import { makeTestServiceLayers } from "../testLayers.ts"
+import { apiTestLayer, makeTestServiceLayers } from "../testLayers.ts"
 
 // The terminal-first workflow (ATC-124 / ATC-141) against the uniform seam
 // contract only — these tests are the proof that threads/ needs no provider
@@ -21,29 +18,23 @@ import { makeTestServiceLayers } from "../testLayers.ts"
 // the fake adapters.
 
 const kit = makeTestServiceLayers()
-const TestLayer = Layer.mergeAll(
-  V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, kit.layer])),
-  kit.layer,
-  BunHttpServer.layerHttpServices,
-)
+const TestLayer = apiTestLayer(kit)
 
 // A dedicated kit whose identity await is tight, for the timeout path.
 const hangKit = makeTestServiceLayers(":memory:", { identityTimeout: "250 millis" })
-const HangLayer = Layer.mergeAll(
-  V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, hangKit.layer])),
-  hangKit.layer,
-  BunHttpServer.layerHttpServices,
-)
+const HangLayer = apiTestLayer(hangKit)
 
 // A kit with the default (generous) bound whose identity simply never
 // resolves — for externally-interrupted and concurrent-open paths, where
 // the open must still be in flight when the test acts.
 const holdKit = makeTestServiceLayers()
-const HoldLayer = Layer.mergeAll(
-  V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, holdKit.layer])),
-  holdKit.layer,
-  BunHttpServer.layerHttpServices,
-)
+const HoldLayer = apiTestLayer(holdKit)
+
+// A kit whose TUI-liveness watch is tight, for the fail-fast death path —
+// the identity bound stays generous so the failure provably comes from the
+// watch, not the timeout.
+const watchKit = makeTestServiceLayers(":memory:", { launchWatchInterval: "25 millis" })
+const WatchLayer = apiTestLayer(watchKit)
 
 const scratch = mkdtempSync(join(tmpdir(), "atc-thread-open-"))
 afterAll(() => rmSync(scratch, { recursive: true, force: true }))
@@ -70,6 +61,31 @@ const setup = Effect.gen(function* () {
   })
   return { client, project, thread }
 })
+
+/**
+ * The "before the restart" seed shared by the persistence tests: one opened
+ * thread with its identity persisted, returning what the post-restart side
+ * needs. Runs inside the caller's provided layer stack, so callers can keep
+ * acting (emitting activity, awaiting confirmation) in the same build.
+ */
+const openedThreadState = (name: string) =>
+  Effect.gen(function* () {
+    const client = yield* HttpApiTest.groups(Api, ["v1"])
+    const repository = yield* ThreadRepository
+    const project = yield* client.v1.createProject({
+      payload: { name, defaultWorkingDirectory: realDir },
+    })
+    const thread = yield* client.v1.createThread({
+      payload: { projectId: project.id, agentId: "codex" },
+    })
+    const terminal = yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+    const record = Option.getOrThrow(yield* repository.get(thread.id))
+    return {
+      threadId: thread.id,
+      terminalId: terminal.id,
+      sessionId: record.providerSessionId ?? "",
+    }
+  })
 
 describe("threads.openTerminal", () => {
   it.live("materializes a fresh session: launch, identity, persistence, idempotency", () =>
@@ -289,45 +305,32 @@ describe("threads.openTerminal", () => {
 
   it.live("a TUI that dies during the identity wait fails fast with a real diagnostic", () =>
     Effect.gen(function* () {
-      // Generous identity bound + tight death-watch: the failure below must
-      // come from the watch noticing the dead terminal, not the timeout.
-      const kit = makeTestServiceLayers(":memory:", { launchWatchInterval: "25 millis" })
-      yield* Effect.gen(function* () {
-        const { client, thread, project } = yield* setup
-        kit.fakeAgents.codex.setIdentityHangs(true)
-        const fiber = yield* client.v1
-          .openThreadTerminal({ params: { threadId: thread.id } })
-          .pipe(Effect.forkChild)
-        yield* eventually(
-          Effect.sync(() => kit.fake.sessions.size),
-          (size) => size === 1,
-        )
-
-        // The TUI exits immediately (the first-run auth failure): the open
-        // fails with the specific diagnostic well before the 30s bound, and
-        // nothing survives.
-        kit.fake.sessions.clear()
-        const failure = yield* Effect.flip(Fiber.join(fiber))
-        assert.strictEqual(failure._tag, "ProviderUnavailable")
-        if (failure._tag === "ProviderUnavailable") {
-          assert.include(failure.reason, "TUI exited")
-        }
-        assert.deepStrictEqual(
-          yield* client.v1.listTerminals({ query: { projectId: project.id } }),
-          [],
-        )
-        kit.fakeAgents.codex.setIdentityHangs(false)
-        yield* client.v1.deleteThread({ params: { threadId: thread.id } })
-      }).pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, kit.layer])),
-            kit.layer,
-            BunHttpServer.layerHttpServices,
-          ),
-        ),
+      const { client, thread, project } = yield* setup
+      watchKit.fakeAgents.codex.setIdentityHangs(true)
+      const fiber = yield* client.v1
+        .openThreadTerminal({ params: { threadId: thread.id } })
+        .pipe(Effect.forkChild)
+      yield* eventually(
+        Effect.sync(() => watchKit.fake.sessions.size),
+        (size) => size === 1,
       )
-    }),
+
+      // The TUI exits immediately (the first-run auth failure): the open
+      // fails with the specific diagnostic well before the 30s bound, and
+      // nothing survives.
+      watchKit.fake.sessions.clear()
+      const failure = yield* Effect.flip(Fiber.join(fiber))
+      assert.strictEqual(failure._tag, "ProviderUnavailable")
+      if (failure._tag === "ProviderUnavailable") {
+        assert.include(failure.reason, "TUI exited")
+      }
+      assert.deepStrictEqual(
+        yield* client.v1.listTerminals({ query: { projectId: project.id } }),
+        [],
+      )
+      watchKit.fakeAgents.codex.setIdentityHangs(false)
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+    }).pipe(Effect.provide(WatchLayer)),
   )
 
   it.live("identity establishment failing in time cleans up the launched terminal", () =>
@@ -379,31 +382,8 @@ describe("threads.openTerminal", () => {
     Effect.gen(function* () {
       const dbFile = join(scratch, "restart.db")
       // "Before the restart": open a thread's terminal and persist identity.
-      const before = makeTestServiceLayers(dbFile)
-      const state = yield* Effect.gen(function* () {
-        const client = yield* HttpApiTest.groups(Api, ["v1"])
-        const repository = yield* ThreadRepository
-        const project = yield* client.v1.createProject({
-          payload: { name: "Restart", defaultWorkingDirectory: realDir },
-        })
-        const thread = yield* client.v1.createThread({
-          payload: { projectId: project.id, agentId: "codex" },
-        })
-        const terminal = yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
-        const record = Option.getOrThrow(yield* repository.get(thread.id))
-        return {
-          threadId: thread.id,
-          terminalId: terminal.id,
-          sessionId: record.providerSessionId ?? "",
-        }
-      }).pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, before.layer])),
-            before.layer,
-            BunHttpServer.layerHttpServices,
-          ),
-        ),
+      const state = yield* openedThreadState("Restart").pipe(
+        Effect.provide(apiTestLayer(makeTestServiceLayers(dbFile))),
       )
 
       // "After the restart": a fresh process (fresh in-memory adapters) over
@@ -423,15 +403,7 @@ describe("threads.openTerminal", () => {
           (t) => t.activityState === "working",
         )
         yield* client.v1.deleteThread({ params: { threadId: state.threadId } })
-      }).pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, after.layer])),
-            after.layer,
-            BunHttpServer.layerHttpServices,
-          ),
-        ),
-      )
+      }).pipe(Effect.provide(apiTestLayer(after)))
     }),
   )
 
@@ -442,32 +414,15 @@ describe("threads.openTerminal", () => {
       // its idle ever arrives on the feed.
       const before = makeTestServiceLayers(dbFile)
       const state = yield* Effect.gen(function* () {
-        const client = yield* HttpApiTest.groups(Api, ["v1"])
         const repository = yield* ThreadRepository
-        const project = yield* client.v1.createProject({
-          payload: { name: "RestartMidTurn", defaultWorkingDirectory: realDir },
-        })
-        const thread = yield* client.v1.createThread({
-          payload: { projectId: project.id, agentId: "codex" },
-        })
-        yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
-        const record = Option.getOrThrow(yield* repository.get(thread.id))
-        const sessionId = record.providerSessionId ?? ""
-        before.fakeAgents.codex.emitActivity(sessionId, "working")
+        const opened = yield* openedThreadState("RestartMidTurn")
+        before.fakeAgents.codex.emitActivity(opened.sessionId, "working")
         yield* eventually(
-          repository.get(thread.id),
+          repository.get(opened.threadId),
           (r) => Option.isSome(r) && r.value.confirmedAt !== undefined,
         )
-        return { threadId: thread.id, sessionId }
-      }).pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, before.layer])),
-            before.layer,
-            BunHttpServer.layerHttpServices,
-          ),
-        ),
-      )
+        return opened
+      }).pipe(Effect.provide(apiTestLayer(before)))
 
       // "After the restart": the TUI ended during the downtime, and the
       // completed turn's idle was never observed by any process. The session
@@ -483,46 +438,15 @@ describe("threads.openTerminal", () => {
         assert.deepStrictEqual(relaunch?.command, ["fake-agent", "resume", state.sessionId])
         assert.strictEqual(after.fakeAgents.codex.prepared.length, 0)
         yield* client.v1.deleteThread({ params: { threadId: state.threadId } })
-      }).pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, after.layer])),
-            after.layer,
-            BunHttpServer.layerHttpServices,
-          ),
-        ),
-      )
+      }).pipe(Effect.provide(apiTestLayer(after)))
     }),
   )
 
   it.live("concurrent first reads establish exactly one observation (no leaked subscription)", () =>
     Effect.gen(function* () {
       const dbFile = join(scratch, "concurrent-reads.db")
-      const before = makeTestServiceLayers(dbFile)
-      const state = yield* Effect.gen(function* () {
-        const client = yield* HttpApiTest.groups(Api, ["v1"])
-        const repository = yield* ThreadRepository
-        const project = yield* client.v1.createProject({
-          payload: { name: "Concurrent", defaultWorkingDirectory: realDir },
-        })
-        const thread = yield* client.v1.createThread({
-          payload: { projectId: project.id, agentId: "codex" },
-        })
-        const terminal = yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
-        const record = Option.getOrThrow(yield* repository.get(thread.id))
-        return {
-          threadId: thread.id,
-          terminalId: terminal.id,
-          sessionId: record.providerSessionId ?? "",
-        }
-      }).pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, before.layer])),
-            before.layer,
-            BunHttpServer.layerHttpServices,
-          ),
-        ),
+      const state = yield* openedThreadState("Concurrent").pipe(
+        Effect.provide(apiTestLayer(makeTestServiceLayers(dbFile))),
       )
 
       // Relaunch: nothing is observed yet, and the sidebar list + detail
@@ -544,15 +468,7 @@ describe("threads.openTerminal", () => {
         )
         assert.strictEqual(after.fakeAgents.codex.observerCount(state.sessionId), 1)
         yield* client.v1.deleteThread({ params: { threadId: state.threadId } })
-      }).pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, after.layer])),
-            after.layer,
-            BunHttpServer.layerHttpServices,
-          ),
-        ),
-      )
+      }).pipe(Effect.provide(apiTestLayer(after)))
     }),
   )
 

--- a/app-server/test/threads/threadOpen.test.ts
+++ b/app-server/test/threads/threadOpen.test.ts
@@ -415,6 +415,67 @@ describe("threads.openTerminal", () => {
     }),
   )
 
+  it.live("concurrent first reads establish exactly one observation (no leaked subscription)", () =>
+    Effect.gen(function* () {
+      const dbFile = join(scratch, "concurrent-reads.db")
+      const before = makeTestServiceLayers(dbFile)
+      const state = yield* Effect.gen(function* () {
+        const client = yield* HttpApiTest.groups(Api, ["v1"])
+        const repository = yield* ThreadRepository
+        const project = yield* client.v1.createProject({
+          payload: { name: "Concurrent", defaultWorkingDirectory: realDir },
+        })
+        const thread = yield* client.v1.createThread({
+          payload: { projectId: project.id, agentId: "codex" },
+        })
+        const terminal = yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+        const record = Option.getOrThrow(yield* repository.get(thread.id))
+        return {
+          threadId: thread.id,
+          terminalId: terminal.id,
+          sessionId: record.providerSessionId ?? "",
+        }
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, before.layer])),
+            before.layer,
+            BunHttpServer.layerHttpServices,
+          ),
+        ),
+      )
+
+      // Relaunch: nothing is observed yet, and the sidebar list + detail
+      // get race their first reads — exactly one adapter subscription may
+      // survive; a second would leak until shutdown and double-drive the
+      // thread's activity.
+      const after = makeTestServiceLayers(dbFile)
+      after.fake.seed(sessionNameForTerminalId(state.terminalId))
+      yield* Effect.gen(function* () {
+        const client = yield* HttpApiTest.groups(Api, ["v1"])
+        yield* Effect.all(
+          [
+            client.v1.listThreads({ query: {} }),
+            client.v1.getThread({ params: { threadId: state.threadId } }),
+            client.v1.getThread({ params: { threadId: state.threadId } }),
+            client.v1.listThreads({ query: {} }),
+          ],
+          { concurrency: "unbounded" },
+        )
+        assert.strictEqual(after.fakeAgents.codex.observerCount(state.sessionId), 1)
+        yield* client.v1.deleteThread({ params: { threadId: state.threadId } })
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, after.layer])),
+            after.layer,
+            BunHttpServer.layerHttpServices,
+          ),
+        ),
+      )
+    }),
+  )
+
   it.live("a busy state with no live driver re-derives from the adapter on read", () =>
     Effect.gen(function* () {
       const { client, thread } = yield* setup

--- a/app-server/test/threads/threadOpen.test.ts
+++ b/app-server/test/threads/threadOpen.test.ts
@@ -148,6 +148,43 @@ describe("threads.openTerminal", () => {
     }).pipe(Effect.provide(TestLayer)),
   )
 
+  it.live("reopening a confirmed session the provider pruned fails typed, launching nothing", () =>
+    Effect.gen(function* () {
+      const { client, thread, project } = yield* setup
+      const repository = yield* ThreadRepository
+      const terminal = yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+      const sessionId = Option.getOrThrow(yield* repository.get(thread.id)).providerSessionId ?? ""
+      kit.fakeAgents.codex.emitActivity(sessionId, "working")
+      yield* eventually(
+        repository.get(thread.id),
+        (r) => Option.isSome(r) && r.value.confirmedAt !== undefined,
+      )
+      kit.fakeAgents.codex.emitActivity(sessionId, "idle")
+
+      // The TUI ends; meanwhile the provider's history for the session is
+      // pruned. The reopen probe fails closed with a presentable error —
+      // no blind `resume` launch that dies in the pty — and repeats
+      // consistently on every retry.
+      kit.fake.sessions.delete(sessionNameForTerminalId(terminal.id))
+      kit.fakeAgents.codex.setSessionPruned(sessionId, true)
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const failure = yield* Effect.flip(
+          client.v1.openThreadTerminal({ params: { threadId: thread.id } }),
+        )
+        assert.strictEqual(failure._tag, "ProviderSessionConflict")
+      }
+      // Only the first TUI's tombstone remains — no new terminal launched.
+      const terminals = yield* client.v1.listTerminals({ query: { projectId: project.id } })
+      assert.deepStrictEqual(
+        terminals.map((t) => ({ id: t.id, status: t.status })),
+        [{ id: terminal.id, status: "ended" }],
+      )
+      kit.fakeAgents.codex.setSessionPruned(sessionId, false)
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+      yield* client.v1.deleteTerminal({ params: { terminalId: terminal.id } })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
   it.live("an unconfirmed session re-materializes with fresh identity on the next open", () =>
     Effect.gen(function* () {
       const { client, thread } = yield* setup

--- a/packages/ATCKit/Sources/ATCAppServerAPI/ATCAppServerAPI.swift
+++ b/packages/ATCKit/Sources/ATCAppServerAPI/ATCAppServerAPI.swift
@@ -36,7 +36,17 @@ public struct ATCDateTranscoder: DateTranscoder {
     public init() {}
 
     public func encode(_ date: Date) throws -> String {
-        fractional.format(date)
+        // The format style TRUNCATES the fractional field, and millisecond
+        // values are rarely exact in binary — formatting through it would
+        // re-encode roughly half of all decoded server timestamps one
+        // millisecond low. Split the rounded epoch milliseconds instead:
+        // the whole seconds are exact, and the millisecond field is printed
+        // as an integer.
+        let epochMillis = (date.timeIntervalSince1970 * 1000).rounded()
+        var millis = epochMillis.truncatingRemainder(dividingBy: 1000)
+        if millis < 0 { millis += 1000 }
+        let seconds = Date(timeIntervalSince1970: (epochMillis - millis) / 1000)
+        return wholeSecond.format(seconds).dropLast() + String(format: ".%03dZ", Int(millis))
     }
 
     public func decode(_ dateString: String) throws -> Date {

--- a/packages/ATCKit/Sources/ATCAppServerAPI/ATCAppServerAPI.swift
+++ b/packages/ATCKit/Sources/ATCAppServerAPI/ATCAppServerAPI.swift
@@ -7,12 +7,47 @@
 // (`mise run app-server:openapi`). Nothing in this target is written by hand
 // except this file.
 //
-// Construct a client with the URLSession transport:
+// Construct a client with the URLSession transport and the ATC date
+// transcoder (the runtime's default `.iso8601` cannot parse the server's
+// fractional-second timestamps):
 //
 //     import OpenAPIURLSession
 //
 //     let client = Client(
 //         serverURL: try Servers.Server1.url(),
+//         configuration: Configuration(dateTranscoder: ATCDateTranscoder()),
 //         transport: URLSessionTransport()
 //     )
 //     let health = try await client.getHealth().ok.body.json
+
+import Foundation
+import OpenAPIRuntime
+
+/// Transcodes the App Server's `format: date-time` fields. The server emits
+/// `Date.toISOString()` output — RFC 3339 UTC with exactly three fractional
+/// digits — which the runtime's strict `.iso8601` transcoder rejects. Decoding
+/// is lenient (fractional seconds optional) so hand-written fixtures and any
+/// future whole-second producer parse too; encoding always writes fractional
+/// seconds, matching the server byte-for-byte.
+public struct ATCDateTranscoder: DateTranscoder {
+    private let fractional = Date.ISO8601FormatStyle(includingFractionalSeconds: true)
+    private let wholeSecond = Date.ISO8601FormatStyle()
+
+    public init() {}
+
+    public func encode(_ date: Date) throws -> String {
+        fractional.format(date)
+    }
+
+    public func decode(_ dateString: String) throws -> Date {
+        if let date = try? fractional.parse(dateString) {
+            return date
+        }
+        if let date = try? wholeSecond.parse(dateString) {
+            return date
+        }
+        throw DecodingError.dataCorrupted(
+            .init(codingPath: [], debugDescription: "Expected an RFC 3339 date-time, got: \(dateString)")
+        )
+    }
+}

--- a/packages/ATCKit/Tests/ATCAppServerAPITests/ClientTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerAPITests/ClientTests.swift
@@ -143,6 +143,19 @@ struct ClientTests {
         #expect(try ATCDateTranscoder().encode(project.createdAt) == "2026-08-06T12:34:56.789Z")
     }
 
+    // Every millisecond value must survive decode → encode byte-identically.
+    // Most milliseconds are not exact in binary, and the ISO8601 format style
+    // truncates — a single sample would pass or fail by luck.
+    @Test("all thousand millisecond values round-trip byte-identically")
+    func exhaustiveMillisecondRoundTrip() throws {
+        let transcoder = ATCDateTranscoder()
+        for millis in 0..<1000 {
+            let wire = String(format: "2026-08-06T12:34:56.%03dZ", millis)
+            let roundTripped = try transcoder.encode(try transcoder.decode(wire))
+            #expect(roundTripped == wire)
+        }
+    }
+
     @Test("the transcoder decodes both fractional and whole-second timestamps")
     func lenientDecoding() throws {
         let transcoder = ATCDateTranscoder()

--- a/packages/ATCKit/Tests/ATCAppServerAPITests/ClientTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerAPITests/ClientTests.swift
@@ -28,10 +28,12 @@ private struct StubTransport: ClientTransport {
 
 private func client(returning json: String) throws -> (Client, StubTransport.Recorder) {
     let recorder = StubTransport.Recorder()
-    // Servers.Server1 is the documented construction path, so building the
-    // client through it keeps the servers entry in the contract under test.
+    // Servers.Server1 and ATCDateTranscoder are the documented construction
+    // path (ATCAppServerAPI.swift), so building the client through them keeps
+    // both the servers entry and the date coding under test.
     let client = Client(
         serverURL: try Servers.Server1.url(),
+        configuration: Configuration(dateTranscoder: ATCDateTranscoder()),
         transport: StubTransport(json: json, recorded: recorder)
     )
     return (client, recorder)
@@ -88,7 +90,14 @@ struct ClientTests {
 
     @Test("fs check decodes payloads with and without a reason")
     func fsCheckReason() throws {
+        // checkedAt is format: date-time, so it decodes as a Date; the
+        // transcoder's lenient side accepts the whole-second fixture strings.
         let decoder = JSONDecoder()
+        let transcoder = ATCDateTranscoder()
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            return try transcoder.decode(try container.decode(String.self))
+        }
         let conclusive = try decoder.decode(
             Components.Schemas.FsCheckResponse.self,
             from: Data(
@@ -98,6 +107,7 @@ struct ClientTests {
         )
         #expect(conclusive.state == .available)
         #expect(conclusive.reason == nil)
+        #expect(conclusive.checkedAt == Date(timeIntervalSince1970: 1_785_672_000))
 
         let timedOut = try decoder.decode(
             Components.Schemas.FsCheckResponse.self,
@@ -108,5 +118,44 @@ struct ClientTests {
         )
         #expect(timedOut.state == .unknown)
         #expect(timedOut.reason == "timeout")
+    }
+
+    // Regression: contract timestamps are `format: date-time`, so generated
+    // models carry `Date` — and the server's actual encoding (JavaScript
+    // `Date.toISOString()`, always three fractional digits) must survive the
+    // configured transcoder both ways. The runtime's default `.iso8601`
+    // rejects fractional seconds, which is exactly why ATCDateTranscoder
+    // exists.
+    @Test("server timestamps round-trip the configured date transcoder")
+    func timestampRoundTrip() async throws {
+        let (client, _) = try client(
+            returning: #"""
+                {"id":"0198a001-0000-7000-8000-000000000000","name":"Atelier",
+                 "defaultWorkingDirectory":"/code/atc",
+                 "createdAt":"2026-08-06T12:34:56.789Z",
+                 "updatedAt":"2026-08-06T12:34:56.789Z"}
+                """#
+        )
+        let project = try await client.getProject(path: .init(projectId: "p1")).ok.body.json
+        #expect(project.createdAt == Date(timeIntervalSince1970: 1_786_019_696.789))
+        // Byte-identical re-encode: what the transcoder writes is what the
+        // server wrote.
+        #expect(try ATCDateTranscoder().encode(project.createdAt) == "2026-08-06T12:34:56.789Z")
+    }
+
+    @Test("the transcoder decodes both fractional and whole-second timestamps")
+    func lenientDecoding() throws {
+        let transcoder = ATCDateTranscoder()
+        #expect(
+            try transcoder.decode("2026-08-06T12:34:56.789Z")
+                == Date(timeIntervalSince1970: 1_786_019_696.789)
+        )
+        #expect(
+            try transcoder.decode("2026-08-06T12:34:56Z")
+                == Date(timeIntervalSince1970: 1_786_019_696)
+        )
+        #expect(throws: DecodingError.self) {
+            _ = try transcoder.decode("yesterday")
+        }
     }
 }

--- a/packages/attach-protocol/README.md
+++ b/packages/attach-protocol/README.md
@@ -95,13 +95,9 @@ the push signal that a terminal you care about changed state.
 
 ## Test vectors
 
-`fixtures/` holds shared JSON vectors; the TypeScript suite
-(`app-server/test/terminals/attachProtocolFixtures.test.ts`) consumes them
-today, and ATCKit's attach implementation must consume the same files.
-
-- `control-frames.json` — wire ↔ frame pairs every implementation must
-  round-trip, plus malformed frames every implementation must ignore.
-- `close-codes.json` — the close vocabulary above, with retryability.
-- `dimension-clamp.json` — the [1, 1000] floor/clamp/fallback rule as
-  input → expected cases (shared by query params and resize frames).
-- `attach-urls.json` — base URL + terminal id + size → expected attach URL.
+`fixtures/` holds shared JSON vectors — control frames, close codes,
+dimension clamping, and URL construction; each file's `description` field
+says what it pins. The TypeScript suite consumes them in
+`app-server/test/terminals/attachProtocolFixtures.test.ts`, and ATCKit's
+attach implementation must consume the same files so drift between clients
+fails a test instead of a terminal window.

--- a/packages/attach-protocol/README.md
+++ b/packages/attach-protocol/README.md
@@ -1,0 +1,107 @@
+# Terminal Attach Protocol
+
+The wire protocol for the App Server's WebSocket terminal attach — everything
+a client implementer needs, stated once. The server-side authority is
+`app-server/src/terminals/attachProtocol.ts` (imported by the server bridge
+and the CLI client); this document and the machine-readable vectors in
+`fixtures/` exist so non-TypeScript clients (ATCKit/macOS) can implement and
+test against the same rules without reading server source. The endpoint is
+deliberately excluded from `openapi.json` — an OpenAPI document cannot
+represent a WebSocket upgrade.
+
+Consume `fixtures/` from tests (see "Test vectors" below) so drift between
+clients is caught mechanically, not in code review.
+
+## URL
+
+```
+ws://<host>/api/v1/terminals/{terminalId}/attach?cols=<n>&rows=<n>
+```
+
+- Scheme: `ws:` for `http:` base URLs, `wss:` for `https:`.
+- `cols`/`rows` set the initial PTY size. Both are optional; a missing or
+  malformed value falls back to the server default (80×24). Values are
+  floored and clamped into **[1, 1000]** — the same rule applied to `resize`
+  frames.
+
+## Pre-upgrade HTTP statuses
+
+The server validates before upgrading; a failed handshake is a plain HTTP
+response, never a WebSocket close:
+
+| Status | Meaning | Client action |
+| ------ | ------- | ------------- |
+| `404` | No terminal with this id. | Refetch terminals; drop the attach. |
+| `410` | The terminal ended (tombstone). | Show ended state; offer delete. |
+| `426` | Missing/invalid `Upgrade: websocket` header. | Client bug; do not retry. |
+
+## Framing
+
+- **Binary frames are terminal bytes, both directions.** Client → server:
+  keystrokes/paste input. Server → client: PTY output. No message framing
+  inside — write bytes straight to the terminal emulator.
+- **Text frames are JSON control messages.** Unknown or malformed control
+  frames are ignored by both sides — never fatal, never echoed.
+
+### Control vocabulary
+
+| Frame | Direction | Semantics |
+| ----- | --------- | --------- |
+| `{"type":"resize","cols":120,"rows":40}` | client → server | Resize the PTY. Values floored and clamped into [1, 1000]. |
+| `{"type":"ping"}` | server → client | App-level keepalive, sent every **30 s**. |
+| `{"type":"pong"}` | client → server | Answer to `ping`. A client silent for **120 s** is closed with `1011 ping_timeout`. |
+
+Answer every `ping` with a `pong` promptly; WebSocket protocol-level pings are
+not used (Bun's server API does not surface them).
+
+## Close vocabulary
+
+| Code | Reason | Retryable | Meaning |
+| ---- | ------ | --------- | ------- |
+| 1000 | `terminal_ended` | no | **Authoritative.** A complete multiplexer inventory proved the session is gone; the tombstone is already written. Refetch the terminal and show ended state. |
+| 1000 | `detach` | — | Deliberate client detach (sent by the client). The session keeps running; reattach at will. |
+| 1011 | `attach_failed` | yes | The bridge could not attach or lost its PTY client. Says nothing about the terminal's existence. |
+| 1011 | `zmx_unavailable` | yes | The multiplexer could not be consulted. Says nothing about the terminal's existence. |
+| 1011 | `ping_timeout` | yes | The server gave up on an unresponsive client. Reconnect when the client is healthy again. |
+| 1006 | — | yes | Abnormal closure (transport loss, server restart, connection refused). Not server-sent — but treat it exactly like a retryable 1011: reconnect with backoff, and refetch the terminal first to learn whether it still exists. |
+
+"Retryable" means: the terminal may well still be live — refetch it
+(`GET /api/v1/terminals/{terminalId}`) and reattach if it is. Only
+`terminal_ended` proves death.
+
+## Sizing and the zmx leader
+
+The multiplexer (zmx) sizes each session to its **leader** client — in
+practice, the most recent attach. Consequences a client must design for:
+
+- A non-leader's `resize` frames are **silently ignored**; no frame ever
+  reports the effective size. Do not assume the PTY matches what you sent.
+- On (re)attach, zmx repaints the full screen plus scrollback to the new
+  client. This repaint is the recovery mechanism: whatever output or sizing
+  you missed while detached or non-leader is healed by reattaching.
+- Multiple simultaneous attaches to one terminal work (bytes fan out), but
+  only the leader controls size.
+
+## Reconnect flow
+
+1. Attach closes (1011 reason, or 1006).
+2. `GET /api/v1/terminals/{terminalId}` — reconciled read; a dead session
+   becomes an `ended` tombstone here.
+3. If `live`, reattach with current `cols`/`rows` (this also makes you the
+   leader and triggers the full repaint). If `ended`, stop.
+
+Pair the attach with the SSE event stream: a `terminal` `updated` event is
+the push signal that a terminal you care about changed state.
+
+## Test vectors
+
+`fixtures/` holds shared JSON vectors; the TypeScript suite
+(`app-server/test/terminals/attachProtocolFixtures.test.ts`) consumes them
+today, and ATCKit's attach implementation must consume the same files.
+
+- `control-frames.json` — wire ↔ frame pairs every implementation must
+  round-trip, plus malformed frames every implementation must ignore.
+- `close-codes.json` — the close vocabulary above, with retryability.
+- `dimension-clamp.json` — the [1, 1000] floor/clamp/fallback rule as
+  input → expected cases (shared by query params and resize frames).
+- `attach-urls.json` — base URL + terminal id + size → expected attach URL.

--- a/packages/attach-protocol/README.md
+++ b/packages/attach-protocol/README.md
@@ -20,9 +20,10 @@ ws://<host>/api/v1/terminals/{terminalId}/attach?cols=<n>&rows=<n>
 
 - Scheme: `ws:` for `http:` base URLs, `wss:` for `https:`.
 - `cols`/`rows` set the initial PTY size. Both are optional; a missing or
-  malformed value falls back to the server default (80×24). Values are
-  floored and clamped into **[1, 1000]** — the same rule applied to `resize`
-  frames.
+  malformed value falls back to the server default (80×24). A value is
+  malformed unless the entire string is numeric — `cols=80junk` falls back,
+  it does not parse as 80. Valid values are floored and clamped into
+  **[1, 1000]** — the same rule applied to `resize` frames.
 
 ## Pre-upgrade HTTP statuses
 

--- a/packages/attach-protocol/fixtures/attach-urls.json
+++ b/packages/attach-protocol/fixtures/attach-urls.json
@@ -1,0 +1,33 @@
+{
+  "description": "Attach URL construction: the contract route with ws/wss scheme derived from the base URL and optional cols/rows.",
+  "cases": [
+    {
+      "name": "http base with size",
+      "base": "http://127.0.0.1:7332",
+      "terminalId": "0198a001-0000-7000-8000-000000000000",
+      "cols": 120,
+      "rows": 40,
+      "expect": "ws://127.0.0.1:7332/api/v1/terminals/0198a001-0000-7000-8000-000000000000/attach?cols=120&rows=40"
+    },
+    {
+      "name": "http base without size",
+      "base": "http://127.0.0.1:7332",
+      "terminalId": "abc",
+      "expect": "ws://127.0.0.1:7332/api/v1/terminals/abc/attach"
+    },
+    {
+      "name": "https base becomes wss",
+      "base": "https://example.test:8443",
+      "terminalId": "abc",
+      "cols": 80,
+      "rows": 24,
+      "expect": "wss://example.test:8443/api/v1/terminals/abc/attach?cols=80&rows=24"
+    },
+    {
+      "name": "terminal id is percent-encoded",
+      "base": "http://127.0.0.1:7332",
+      "terminalId": "with space",
+      "expect": "ws://127.0.0.1:7332/api/v1/terminals/with%20space/attach"
+    }
+  ]
+}

--- a/packages/attach-protocol/fixtures/close-codes.json
+++ b/packages/attach-protocol/fixtures/close-codes.json
@@ -1,0 +1,11 @@
+{
+  "description": "The complete close vocabulary. `retryable: true` means the terminal may still be live — refetch it and reattach if so; only terminal_ended proves death. 1006 is never server-sent but clients must treat it as retryable.",
+  "closes": [
+    { "code": 1000, "reason": "terminal_ended", "sender": "server", "retryable": false },
+    { "code": 1000, "reason": "detach", "sender": "client", "retryable": false },
+    { "code": 1011, "reason": "attach_failed", "sender": "server", "retryable": true },
+    { "code": 1011, "reason": "zmx_unavailable", "sender": "server", "retryable": true },
+    { "code": 1011, "reason": "ping_timeout", "sender": "server", "retryable": true },
+    { "code": 1006, "reason": null, "sender": "transport", "retryable": true }
+  ]
+}

--- a/packages/attach-protocol/fixtures/close-codes.json
+++ b/packages/attach-protocol/fixtures/close-codes.json
@@ -1,8 +1,8 @@
 {
-  "description": "The complete close vocabulary. `retryable: true` means the terminal may still be live — refetch it and reattach if so; only terminal_ended proves death. 1006 is never server-sent but clients must treat it as retryable.",
+  "description": "The complete close vocabulary. `retryable: true` means the terminal may still be live — refetch it and reattach if so; only terminal_ended proves death. `retryable: null` means not applicable: detach is client-initiated (the session keeps running; reattach at will). 1006 is never server-sent but clients must treat it as retryable.",
   "closes": [
     { "code": 1000, "reason": "terminal_ended", "sender": "server", "retryable": false },
-    { "code": 1000, "reason": "detach", "sender": "client", "retryable": false },
+    { "code": 1000, "reason": "detach", "sender": "client", "retryable": null },
     { "code": 1011, "reason": "attach_failed", "sender": "server", "retryable": true },
     { "code": 1011, "reason": "zmx_unavailable", "sender": "server", "retryable": true },
     { "code": 1011, "reason": "ping_timeout", "sender": "server", "retryable": true },

--- a/packages/attach-protocol/fixtures/control-frames.json
+++ b/packages/attach-protocol/fixtures/control-frames.json
@@ -1,0 +1,28 @@
+{
+  "description": "Text-frame control vocabulary. `valid` entries must decode to `frame` and `frame` must encode to a wire string that decodes back to itself. `ignored` entries must decode to nothing (never an error).",
+  "valid": [
+    {
+      "name": "resize",
+      "wire": "{\"type\":\"resize\",\"cols\":120,\"rows\":40}",
+      "frame": { "type": "resize", "cols": 120, "rows": 40 }
+    },
+    {
+      "name": "ping",
+      "wire": "{\"type\":\"ping\"}",
+      "frame": { "type": "ping" }
+    },
+    {
+      "name": "pong",
+      "wire": "{\"type\":\"pong\"}",
+      "frame": { "type": "pong" }
+    }
+  ],
+  "ignored": [
+    { "name": "unknown type", "wire": "{\"type\":\"scroll\",\"lines\":3}" },
+    { "name": "resize missing rows", "wire": "{\"type\":\"resize\",\"cols\":120}" },
+    { "name": "resize with string dimensions", "wire": "{\"type\":\"resize\",\"cols\":\"120\",\"rows\":\"40\"}" },
+    { "name": "not json", "wire": "resize 120 40" },
+    { "name": "json but not an object", "wire": "42" },
+    { "name": "empty string", "wire": "" }
+  ]
+}

--- a/packages/attach-protocol/fixtures/dimension-clamp.json
+++ b/packages/attach-protocol/fixtures/dimension-clamp.json
@@ -1,0 +1,17 @@
+{
+  "description": "The one dimension rule for cols/rows query params and resize frames: missing or malformed values take the fallback, everything else is floored and clamped into [1, 1000]. `raw` is a string (query param), number (resize frame), or null (absent).",
+  "fallback": 80,
+  "cases": [
+    { "name": "in range", "raw": 120, "expect": 120 },
+    { "name": "in-range string", "raw": "120", "expect": 120 },
+    { "name": "floored", "raw": 79.9, "expect": 79 },
+    { "name": "clamped low", "raw": 0, "expect": 1 },
+    { "name": "clamped negative", "raw": -5, "expect": 1 },
+    { "name": "clamped high", "raw": 5000, "expect": 1000 },
+    { "name": "upper bound", "raw": 1000, "expect": 1000 },
+    { "name": "lower bound", "raw": 1, "expect": 1 },
+    { "name": "absent takes fallback", "raw": null, "expect": 80 },
+    { "name": "malformed string takes fallback", "raw": "wide", "expect": 80 },
+    { "name": "empty string takes fallback", "raw": "", "expect": 80 }
+  ]
+}

--- a/packages/attach-protocol/fixtures/dimension-clamp.json
+++ b/packages/attach-protocol/fixtures/dimension-clamp.json
@@ -1,5 +1,5 @@
 {
-  "description": "The one dimension rule for cols/rows query params and resize frames: missing or malformed values take the fallback, everything else is floored and clamped into [1, 1000]. `raw` is a string (query param), number (resize frame), or null (absent).",
+  "description": "The one dimension rule for cols/rows query params and resize frames: missing or malformed values take the fallback, everything else is floored and clamped into [1, 1000]. A string is malformed unless it is numeric in its entirety — a numeric prefix does not count. `raw` is a string (query param), number (resize frame), or null (absent).",
   "fallback": 80,
   "cases": [
     { "name": "in range", "raw": 120, "expect": 120 },
@@ -12,6 +12,9 @@
     { "name": "lower bound", "raw": 1, "expect": 1 },
     { "name": "absent takes fallback", "raw": null, "expect": 80 },
     { "name": "malformed string takes fallback", "raw": "wide", "expect": 80 },
-    { "name": "empty string takes fallback", "raw": "", "expect": 80 }
+    { "name": "numeric-prefix string takes fallback", "raw": "12junk", "expect": 80 },
+    { "name": "whole-string numeric forms parse", "raw": "1e2", "expect": 100 },
+    { "name": "empty string takes fallback", "raw": "", "expect": 80 },
+    { "name": "whitespace-only string takes fallback", "raw": "   ", "expect": 80 }
   ]
 }


### PR DESCRIPTION
Closes the gaps from the 2026-08-06 full-server readiness review so ATC-125 builds its Swift client once against a finished surface. After this lands, the contract, event stream, and attach protocol are considered stable for the macOS migration.

## Contract
- **Required `message` on every tagged-error wire encoding.** Each error class computes its message in its own constructor (the one place the rule lives); call sites are unchanged, decode recomputes it so it can never disagree with the structured fields, and Swift/CLI consumers get a printable diagnostic without duplicating message-building rules.
- **Timestamps are `format: date-time`.** Generated Swift models now carry `Date`. ATCKit gains a hand-written `ATCDateTranscoder` (lenient decode, byte-identical fractional-second encode) with an exhaustive 1000-millisecond round-trip regression test — the naive format-style encode truncated ~half of all values.
- **`subscribeEvents` description pins the race-free resync ordering** (open stream → wait for `: connected` → refetch), coalescing guidance (~100 ms, per collection), and the heartbeat cadence.

## Events stream
- **Shared ~25 s SSE heartbeat**: one timer in the Events layer ticks through the same per-subscriber queues; the handler emits it as an SSE comment. Quiet streams survive URLSession's 60 s idle teardown, clients get a liveness signal, and dead sockets are torn down by their failing write. Covered at the service level and over a real wire.
- **Cascade-publish regression tests** for the silent-sidebar-staleness class: thread delete → orphaned-terminal update, reconcile tombstone → terminal + thread updates, activity transitions (including no re-publish on repeated identical activity).

## Attach protocol
- **`packages/attach-protocol/`**: a client-consumable spec (framing, control vocabulary and ping/pong timing, close codes including 1006-is-retryable, pre-upgrade statuses, URL shape and the [1,1000] clamp, the zmx leader-resize caveat) plus machine-readable fixtures consumed by a new TS test today and by ATCKit later.

## Threads/agents
- **`ensureObserved` double-subscription race closed** (synchronous check + `Scope.forkUnsafe` + claim), plus the interruption-window claim leak, plus a guard so reads during an in-flight open cannot resubscribe to a superseded provider session.
- **openTerminal death-watch**: the identity wait races a backing-off reconciled liveness check, so a TUI that dies at launch fails in ~a second with a diagnostic naming the real cause instead of a 30 s generic timeout.
- **Codex reopen probes session existence** in `tuiLaunch` via the shared `thread/list` walk; a complete walk that omits the id fails `AgentResumeFailed` → 409 with a presentable reason, while an inconclusive walk (page cap / non-advancing cursor) launches blind rather than fabricating absence. Claude cannot be probed; the contract documents that clients must expect "open succeeded, terminal died".

## Diagnostics
- **"shutting down" log line** on SIGINT/SIGTERM, registered to run first among the shutdown finalizers, with a blackbox assertion.

## Verification
- `mise run -C app-server check` (251 tests), `mise run contract:check`, `swift test` in ATCKit (60 tests), `mise run macos:test` — all green.
- Two adversarial review passes (correctness + simplicity) were run; all majors and most minors were applied, including the Swift millisecond-truncation bug and a `detach` retryability contradiction in the close-code fixtures.

https://claude.ai/code/session_01336PDxLnsF6jXJ8w8uJiQc