### PR TITLE
ATC-144: ATCKit transport layer — attach WebSocket client and SSE reader (ATC-125 PR ①)

### DIFF
--- a/packages/ATCKit/Package.swift
+++ b/packages/ATCKit/Package.swift
@@ -13,6 +13,9 @@ let package = Package(
         // (app-server/openapi.json). Coexists with ATCAPI until the app
         // migrates to the App Server.
         .library(name: "ATCAppServerAPI", targets: ["ATCAppServerAPI"]),
+        // Hand-written App Server transports the OpenAPI document cannot
+        // express: the terminal-attach WebSocket and the SSE event stream.
+        .library(name: "ATCAppServerTransport", targets: ["ATCAppServerTransport"]),
     ],
     dependencies: [
         // Exact pins: generated code and the contract artifact are coupled,
@@ -34,6 +37,14 @@ let package = Package(
             plugins: [
                 .plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator"),
             ]
+        ),
+        .target(
+            name: "ATCAppServerTransport",
+            dependencies: ["ATCAppServerAPI"]
+        ),
+        .testTarget(
+            name: "ATCAppServerTransportTests",
+            dependencies: ["ATCAppServerTransport"]
         ),
         // The test's stub transport works with OpenAPIRuntime/HTTPTypes
         // values directly, so those imports are declared, not left to

--- a/packages/ATCKit/Sources/ATCAppServerTransport/AttachProtocol.swift
+++ b/packages/ATCKit/Sources/ATCAppServerTransport/AttachProtocol.swift
@@ -1,0 +1,124 @@
+// AttachProtocol: the pure, transport-free rules of the App Server's
+// terminal-attach WebSocket — URL construction, dimension clamping, control
+// frames, and close classification.
+//
+// The wire contract is owned by `packages/attach-protocol/README.md` and the
+// server module `app-server/src/terminals/attachProtocol.ts`; the shared JSON
+// vectors in `packages/attach-protocol/fixtures/` pin this implementation in
+// tests so drift between clients fails a test, not a terminal window.
+
+import Foundation
+
+public enum AttachProtocol {
+    /// Server defaults when no size accompanies an attach.
+    public static let fallbackCols = 80
+    public static let fallbackRows = 24
+
+    /// `ws(s)://<host>/api/v1/terminals/{terminalId}/attach?cols=&rows=` —
+    /// scheme derived from the HTTP base URL.
+    public static func attachURL(
+        base: URL,
+        terminalID: String,
+        size: (cols: Int, rows: Int)? = nil
+    ) -> URL {
+        var components = URLComponents(url: base, resolvingAgainstBaseURL: false) ?? URLComponents()
+        components.scheme = components.scheme == "https" ? "wss" : "ws"
+        // Absolute path, like the server authority's `new URL(path, base)`:
+        // a trailing slash on a user-entered base URL must not double up.
+        components.path = "/api/v1/terminals/\(terminalID)/attach"
+        if let size {
+            components.queryItems = [
+                URLQueryItem(name: "cols", value: String(size.cols)),
+                URLQueryItem(name: "rows", value: String(size.rows)),
+            ]
+        }
+        // The contract's URLs (loopback origin + path segments) always
+        // compose into a valid URL.
+        return components.url!
+    }
+
+    /// The one dimension rule for cols/rows everywhere they occur: floored
+    /// and clamped into [1, 1000]; anything non-finite takes the fallback
+    /// (matching the server's `Number.isFinite` guard).
+    public static func clampDimension(_ value: Double?, fallback: Int) -> Int {
+        guard let value, value.isFinite else { return fallback }
+        return Int(max(1, min(1000, value.rounded(.down))))
+    }
+
+    /// String variant for query parameters: malformed unless the entire
+    /// string is numeric (a numeric prefix does not count).
+    public static func clampDimension(_ raw: String?, fallback: Int) -> Int {
+        clampDimension(raw.flatMap(Double.init), fallback: fallback)
+    }
+
+    /// Text-frame control vocabulary. Binary frames are raw terminal bytes
+    /// and never appear here.
+    public enum ControlFrame: Sendable, Equatable {
+        case resize(cols: Int, rows: Int)
+        case ping
+        case pong
+
+        public var wire: String {
+            switch self {
+            case .resize(let cols, let rows):
+                return #"{"type":"resize","cols":\#(cols),"rows":\#(rows)}"#
+            case .ping:
+                return #"{"type":"ping"}"#
+            case .pong:
+                return #"{"type":"pong"}"#
+            }
+        }
+
+        /// Returns nil for unknown or malformed frames — the protocol says
+        /// they are ignored, never fatal. JSONDecoder gives strict number
+        /// typing (booleans and numeric strings are malformed, as on the
+        /// server), and `clampDimension` makes the Int conversion total, so
+        /// no wire value can trap.
+        public static func decode(_ text: String) -> ControlFrame? {
+            guard let wire = try? JSONDecoder().decode(WireFrame.self, from: Data(text.utf8))
+            else { return nil }
+            switch wire.type {
+            case "resize":
+                guard let cols = wire.cols, let rows = wire.rows else { return nil }
+                return .resize(
+                    cols: clampDimension(cols, fallback: fallbackCols),
+                    rows: clampDimension(rows, fallback: fallbackRows)
+                )
+            case "ping":
+                return .ping
+            case "pong":
+                return .pong
+            default:
+                return nil
+            }
+        }
+
+        private struct WireFrame: Decodable {
+            let type: String
+            let cols: Double?
+            let rows: Double?
+        }
+    }
+
+    /// Reason string the client sends on deliberate detach (close code 1000).
+    public static let detachReason = "detach"
+
+    /// What a close tells the client about the terminal.
+    public enum CloseDisposition: Sendable, Equatable {
+        /// `1000 terminal_ended` — authoritative: a complete multiplexer
+        /// inventory proved the session gone; the tombstone is written.
+        case terminalEnded
+        /// `1000 detach` — deliberate client detach; the session runs on.
+        case detach
+        /// Everything else (`1011 attach_failed|zmx_unavailable|ping_timeout`,
+        /// `1006`, unknown codes): says nothing about the terminal — refetch
+        /// it and reattach if still live.
+        case retryable
+    }
+
+    public static func classifyClose(code: Int, reason: String?) -> CloseDisposition {
+        if code == 1000 && reason == "terminal_ended" { return .terminalEnded }
+        if code == 1000 && reason == detachReason { return .detach }
+        return .retryable
+    }
+}

--- a/packages/ATCKit/Sources/ATCAppServerTransport/AttachSocket.swift
+++ b/packages/ATCKit/Sources/ATCAppServerTransport/AttachSocket.swift
@@ -1,0 +1,346 @@
+// AttachSocket: one WebSocket attach to the App Server's
+// `GET /api/v1/terminals/{terminalId}/attach`.
+//
+// Framing per AttachProtocol: binary frames are raw terminal bytes both
+// directions; text frames are JSON control messages (the server pings every
+// 30 s and closes clients silent for 120 s, so the pong reply here is
+// load-bearing). Unknown or malformed text frames are ignored, never fatal
+// and never written to the terminal. One instance per connection attempt —
+// reconnect makes a new one. Only `terminalEnded` proves the terminal is
+// gone; every retryable end must be followed by a reconciled
+// `GET /terminals/{id}` before reattaching.
+
+import Foundation
+
+/// Why the attach stream stopped.
+public enum AttachEndReason: Sendable, Equatable {
+    /// Authoritative: `1000 terminal_ended`, or pre-upgrade 410 (tombstone).
+    /// The terminal is gone; do not reattach.
+    case terminalEnded
+    /// Pre-upgrade HTTP rejection other than 410 (404 unknown terminal,
+    /// 426 upgrade misuse). Refetch state; do not blindly retry.
+    case rejected(statusCode: Int)
+    /// Says nothing about the terminal: retryable server closes (1011),
+    /// abnormal closure (1006), or transport failure. Refetch the terminal
+    /// and reattach if it is still live.
+    case retryable(String)
+    /// We hung up (detach / app teardown).
+    case closedByClient
+}
+
+public enum AttachEvent: Sendable {
+    case connected
+    case output(Data)
+    case ended(AttachEndReason)
+}
+
+/// Seam over one WebSocket connection so the socket's protocol behavior —
+/// the pong reply, binary passthrough, close mapping, teardown — is testable
+/// without a live server. The live implementation wraps URLSession.
+protocol AttachWebSocketTask: Sendable {
+    func receive() async throws -> URLSessionWebSocketTask.Message
+    func send(_ message: URLSessionWebSocketTask.Message) async throws
+    /// Best-effort protocol-level keepalive; failures are not a disconnect
+    /// signal (the receive loop owns failure detection).
+    func sendKeepalivePing()
+    func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?)
+    /// Releases the connection's owning resources once the task is done.
+    func invalidate()
+    var closeCode: URLSessionWebSocketTask.CloseCode { get }
+    var closeReason: Data? { get }
+    /// Pre-upgrade HTTP status when the server rejected the handshake
+    /// (a failed handshake is a plain HTTP response, never a close frame).
+    var httpStatusCode: Int? { get }
+}
+
+/// Opens one connection; `onOpen` fires when the handshake completes.
+typealias AttachTransport = @Sendable (
+    _ request: URLRequest,
+    _ onOpen: @escaping @Sendable () -> Void
+) -> any AttachWebSocketTask
+
+public actor AttachSocket {
+    /// Protocol-level pings are a liveness backstop for sleeping Macs and
+    /// idle tunnel forwards. They are independent of the server's app-level
+    /// text-frame pings, which Bun neither sends nor surfaces.
+    private static let pingInterval: Duration = .seconds(10)
+
+    private let request: URLRequest
+    private let transport: AttachTransport
+    private var socket: (any AttachWebSocketTask)?
+    private var pingTask: Task<Void, Never>?
+    private var pumpTask: Task<Void, Never>?
+    private var closedByClient = false
+    private var finished = false
+
+    private let outbound = OutboundQueue()
+    /// Wake-up for the pump; the data itself lives in `outbound`, so one
+    /// buffered signal is always enough.
+    private let outboundSignal: AsyncStream<Void>
+    private let outboundSignalContinuation: AsyncStream<Void>.Continuation
+
+    public init(url: URL, headers: [String: String] = [:]) {
+        self.init(url: url, headers: headers, transport: LiveWebSocketTask.transport)
+    }
+
+    init(url: URL, headers: [String: String], transport: @escaping AttachTransport) {
+        var request = URLRequest(url: url)
+        for (header, value) in headers {
+            request.setValue(value, forHTTPHeaderField: header)
+        }
+        self.request = request
+        self.transport = transport
+        (outboundSignal, outboundSignalContinuation) = AsyncStream.makeStream(
+            of: Void.self, bufferingPolicy: .bufferingNewest(1)
+        )
+    }
+
+    // MARK: - Producer side (called synchronously from the terminal's
+    // background callbacks; the lock-guarded queue keeps keystroke ordering)
+
+    /// May block the calling thread for backpressure when the outbound
+    /// buffer is full — call from the terminal's background write callback,
+    /// never from the main actor or a cooperative-pool task.
+    public nonisolated func enqueue(_ data: Data) {
+        outbound.enqueue(data) {
+            // Large writes may block for backpressure and enter the queue in
+            // several chunks. Wake the pump after every chunk so it can make
+            // room for the remainder of the same synchronous callback.
+            outboundSignalContinuation.yield(())
+        }
+    }
+
+    public nonisolated func enqueueResize(cols: Int, rows: Int) {
+        outbound.setResize(
+            cols: AttachProtocol.clampDimension(Double(cols), fallback: AttachProtocol.fallbackCols),
+            rows: AttachProtocol.clampDimension(Double(rows), fallback: AttachProtocol.fallbackRows)
+        )
+        outboundSignalContinuation.yield(())
+    }
+
+    // MARK: - Lifecycle
+
+    /// Opens the socket and returns the event stream. Call once. Dropping
+    /// the stream (consumer cancellation) closes the socket: an abandoned
+    /// attach would otherwise keep answering server pings indefinitely.
+    public func start() -> AsyncStream<AttachEvent> {
+        AsyncStream { continuation in
+            let socket = transport(request) {
+                continuation.yield(.connected)
+            }
+            self.socket = socket
+
+            continuation.onTermination = { [weak self] termination in
+                // finish() ends the stream itself; only consumer
+                // cancellation needs the teardown driven from here.
+                guard case .cancelled = termination else { return }
+                Task { await self?.close() }
+            }
+
+            startOutboundPump(socket)
+            startPingLoop(socket)
+
+            Task { await self.receiveLoop(socket, continuation: continuation) }
+        }
+    }
+
+    /// Deliberate detach: the session keeps running server-side.
+    public func close() {
+        closedByClient = true
+        socket?.cancel(with: .normalClosure, reason: Data(AttachProtocol.detachReason.utf8))
+        tearDown()
+    }
+
+    private func tearDown() {
+        pingTask?.cancel()
+        pumpTask?.cancel()
+        // Cancelled pumps cannot make more queue space. Finish the queue to
+        // wake any producer currently waiting on backpressure.
+        outbound.finish()
+        outboundSignalContinuation.finish()
+        socket?.invalidate()
+        socket = nil
+    }
+
+    // MARK: - Loops
+
+    private func receiveLoop(
+        _ socket: any AttachWebSocketTask,
+        continuation: AsyncStream<AttachEvent>.Continuation
+    ) async {
+        while true {
+            do {
+                let message = try await socket.receive()
+                switch message {
+                case .data(let data):
+                    continuation.yield(.output(data))
+                case .string(let string):
+                    handleControlFrame(string)
+                @unknown default:
+                    break
+                }
+            } catch {
+                finish(continuation, reason: endReason(for: socket, error: error))
+                return
+            }
+        }
+    }
+
+    private func handleControlFrame(_ text: String) {
+        // Text frames are control messages, never terminal output. The only
+        // one the server sends today is the keepalive ping.
+        guard case .ping = AttachProtocol.ControlFrame.decode(text) else { return }
+        outbound.setPong()
+        outboundSignalContinuation.yield(())
+    }
+
+    private func finish(_ continuation: AsyncStream<AttachEvent>.Continuation, reason: AttachEndReason) {
+        guard !finished else { return }
+        finished = true
+        continuation.yield(.ended(reason))
+        continuation.finish()
+        tearDown()
+    }
+
+    private func endReason(for socket: any AttachWebSocketTask, error: any Error) -> AttachEndReason {
+        Self.endReason(
+            closedByClient: closedByClient,
+            statusCode: socket.httpStatusCode,
+            closeCode: socket.closeCode,
+            closeReason: socket.closeReason,
+            errorDescription: error.localizedDescription
+        )
+    }
+
+    static func endReason(
+        closedByClient: Bool = false,
+        statusCode: Int? = nil,
+        closeCode: URLSessionWebSocketTask.CloseCode,
+        closeReason: Data?,
+        errorDescription: String
+    ) -> AttachEndReason {
+        if closedByClient {
+            return .closedByClient
+        }
+        if let statusCode, statusCode != 101 {
+            return statusCode == 410 ? .terminalEnded : .rejected(statusCode: statusCode)
+        }
+        let reason = closeReason.flatMap { String(data: $0, encoding: .utf8) }
+        switch AttachProtocol.classifyClose(code: closeCode.rawValue, reason: reason) {
+        case .terminalEnded:
+            return .terminalEnded
+        case .detach:
+            // Only this client sends detach; receiving it back means we
+            // initiated the close but the flag lost the race.
+            return .closedByClient
+        case .retryable:
+            return .retryable(reason ?? errorDescription)
+        }
+    }
+
+    private func startOutboundPump(_ socket: any AttachWebSocketTask) {
+        pumpTask = Task {
+            for await _ in outboundSignal {
+                while let item = outbound.dequeue() {
+                    do {
+                        switch item {
+                        case .data(let data):
+                            try await socket.send(.data(data))
+                        case .resize(let cols, let rows):
+                            try await socket.send(
+                                .string(AttachProtocol.ControlFrame.resize(cols: cols, rows: rows).wire)
+                            )
+                        case .pong:
+                            try await socket.send(.string(AttachProtocol.ControlFrame.pong.wire))
+                        }
+                    } catch {
+                        // The receive loop surfaces the transport failure.
+                        // Stop accepting input immediately so a producer
+                        // cannot remain blocked behind this dead pump.
+                        outbound.finish()
+                        return
+                    }
+                }
+            }
+        }
+    }
+
+    /// URLSessionWebSocketTask does not auto-ping. Without this, dead peers
+    /// linger and idle SSH-tunnel forwards get reaped.
+    private func startPingLoop(_ socket: any AttachWebSocketTask) {
+        pingTask = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: Self.pingInterval)
+                guard !Task.isCancelled else { return }
+                socket.sendKeepalivePing()
+            }
+        }
+    }
+}
+
+/// The live transport: one URLSession per connection, torn down with it.
+private final class LiveWebSocketTask: AttachWebSocketTask, @unchecked Sendable {
+    static let transport: AttachTransport = { request, onOpen in
+        LiveWebSocketTask(request: request, onOpen: onOpen)
+    }
+
+    private let session: URLSession
+    private let task: URLSessionWebSocketTask
+
+    init(request: URLRequest, onOpen: @escaping @Sendable () -> Void) {
+        session = URLSession(
+            configuration: .default,
+            delegate: SocketDelegate(onOpen: onOpen),
+            delegateQueue: nil
+        )
+        task = session.webSocketTask(with: request)
+        task.maximumMessageSize = 1 << 20
+        task.resume()
+    }
+
+    func receive() async throws -> URLSessionWebSocketTask.Message {
+        try await task.receive()
+    }
+
+    func send(_ message: URLSessionWebSocketTask.Message) async throws {
+        try await task.send(message)
+    }
+
+    func sendKeepalivePing() {
+        task.sendPing { _ in
+            // Best effort: pings keep tunnels and NATs from reaping an idle
+            // connection and give the OS traffic with which to notice a
+            // dead peer.
+        }
+    }
+
+    func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        task.cancel(with: closeCode, reason: reason)
+    }
+
+    func invalidate() {
+        session.finishTasksAndInvalidate()
+    }
+
+    var closeCode: URLSessionWebSocketTask.CloseCode { task.closeCode }
+    var closeReason: Data? { task.closeReason }
+    var httpStatusCode: Int? { (task.response as? HTTPURLResponse)?.statusCode }
+}
+
+/// Delegate that surfaces the WebSocket handshake completing. Receive-path
+/// errors and close codes are still read off the task itself.
+private final class SocketDelegate: NSObject, URLSessionWebSocketDelegate {
+    private let onOpen: @Sendable () -> Void
+
+    init(onOpen: @escaping @Sendable () -> Void) {
+        self.onOpen = onOpen
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        webSocketTask: URLSessionWebSocketTask,
+        didOpenWithProtocol protocol: String?
+    ) {
+        onOpen()
+    }
+}

--- a/packages/ATCKit/Sources/ATCAppServerTransport/OutboundQueue.swift
+++ b/packages/ATCKit/Sources/ATCAppServerTransport/OutboundQueue.swift
@@ -1,0 +1,157 @@
+// OutboundQueue: lock-guarded outbound buffer for one attach socket.
+//
+// Keystroke chunks keep their order under a byte bound. A full queue applies
+// synchronous backpressure to the terminal's background write callback
+// instead of discarding paste data. Control frames collapse: only the most
+// recent resize and a single pending pong are kept, sent ahead of data so the
+// server sizes the PTY (and observes liveness) before applying input.
+
+import Foundation
+
+final class OutboundQueue: @unchecked Sendable {
+    /// The server's 1 MiB limit applies to individual WebSocket frames, not
+    /// the aggregate backlog. Eight MiB accommodates paste-heavy workflows
+    /// while still bounding a stalled connection's retained input.
+    private static let defaultMaxBufferedBytes = 8 << 20
+    /// Stay comfortably below the server's per-frame read limit.
+    private static let defaultMaxChunkBytes = 256 << 10
+
+    /// Serializes whole producer calls. Without this, two write callbacks
+    /// could interleave when the first one waits for queue space.
+    private let producerLock = NSLock()
+    private let condition = NSCondition()
+    private let maxBufferedBytes: Int
+    private let maxChunkBytes: Int
+    private var chunks: [Data] = []
+    private var firstChunkIndex = 0
+    private var bufferedBytes = 0
+    private var pendingResize: (cols: Int, rows: Int)?
+    private var pendingPong = false
+    private var isFinished = false
+
+    enum Item: Equatable {
+        case data(Data)
+        case resize(cols: Int, rows: Int)
+        case pong
+    }
+
+    init(
+        maxBufferedBytes: Int = OutboundQueue.defaultMaxBufferedBytes,
+        maxChunkBytes: Int = OutboundQueue.defaultMaxChunkBytes
+    ) {
+        precondition(maxBufferedBytes > 0)
+        precondition(maxChunkBytes > 0)
+        self.maxBufferedBytes = maxBufferedBytes
+        self.maxChunkBytes = min(maxChunkBytes, maxBufferedBytes)
+    }
+
+    /// Returns false only when shutdown interrupts or precedes the write.
+    /// `didEnqueue` must wake the consumer after each accepted chunk: a write
+    /// larger than the byte bound cannot finish until the consumer drains it.
+    @discardableResult
+    func enqueue(_ data: Data, didEnqueue: @Sendable () -> Void = {}) -> Bool {
+        producerLock.lock()
+        defer { producerLock.unlock() }
+
+        // Nothing to buffer — don't park an empty write behind a full queue.
+        if data.isEmpty {
+            condition.lock()
+            defer { condition.unlock() }
+            return !isFinished
+        }
+
+        var offset = data.startIndex
+        repeat {
+            condition.lock()
+            while !isFinished && bufferedBytes == maxBufferedBytes {
+                condition.wait()
+            }
+            guard !isFinished else {
+                condition.unlock()
+                return false
+            }
+            guard offset < data.endIndex else {
+                condition.unlock()
+                return true
+            }
+
+            let availableBytes = maxBufferedBytes - bufferedBytes
+            let chunkCount = min(maxChunkBytes, availableBytes, data.distance(from: offset, to: data.endIndex))
+            let end = data.index(offset, offsetBy: chunkCount)
+            let chunk = data.subdata(in: offset..<end)
+            chunks.append(chunk)
+            bufferedBytes += chunk.count
+            offset = end
+            condition.unlock()
+
+            didEnqueue()
+        } while offset < data.endIndex
+
+        return true
+    }
+
+    func setResize(cols: Int, rows: Int) {
+        condition.lock()
+        if !isFinished {
+            pendingResize = (cols, rows)
+        }
+        condition.unlock()
+    }
+
+    func setPong() {
+        condition.lock()
+        if !isFinished {
+            pendingPong = true
+        }
+        condition.unlock()
+    }
+
+    func dequeue() -> Item? {
+        condition.lock()
+        defer { condition.unlock() }
+
+        if let resize = pendingResize {
+            pendingResize = nil
+            return .resize(cols: resize.cols, rows: resize.rows)
+        }
+        if pendingPong {
+            pendingPong = false
+            return .pong
+        }
+        guard firstChunkIndex < chunks.count else { return nil }
+
+        let data = chunks[firstChunkIndex]
+        // Release the queue's reference immediately without paying the
+        // removeFirst() copy on every keystroke.
+        chunks[firstChunkIndex] = Data()
+        firstChunkIndex += 1
+        bufferedBytes -= data.count
+        if firstChunkIndex == chunks.count {
+            chunks.removeAll(keepingCapacity: true)
+            firstChunkIndex = 0
+        } else if firstChunkIndex >= 64, firstChunkIndex * 2 >= chunks.count {
+            chunks.removeFirst(firstChunkIndex)
+            firstChunkIndex = 0
+        }
+        condition.signal()
+        return .data(data)
+    }
+
+    /// Discards input only as part of explicit connection teardown and wakes
+    /// every producer that may be blocked waiting for the cancelled pump.
+    func finish() {
+        condition.lock()
+        guard !isFinished else {
+            condition.unlock()
+            return
+        }
+        isFinished = true
+        chunks.removeAll()
+        firstChunkIndex = 0
+        bufferedBytes = 0
+        pendingResize = nil
+        pendingPong = false
+        condition.broadcast()
+        condition.unlock()
+    }
+}

--- a/packages/ATCKit/Sources/ATCAppServerTransport/ResourceEventStream.swift
+++ b/packages/ATCKit/Sources/ATCAppServerTransport/ResourceEventStream.swift
@@ -1,0 +1,239 @@
+// ResourceEventStream: the App Server's SSE resource-change stream
+// (`GET /api/v1/events`) as a long-lived AsyncStream.
+//
+// The contract's invariants, all owned here so consumers can't get them
+// wrong:
+// - `.connected` is emitted only after the stream's opening `: connected`
+//   comment — the server guarantees a subscriber registered before that byte,
+//   so refetching lists on `.connected` is race-free. Fetching earlier leaves
+//   a missed-event window.
+// - Delivery is ephemeral with no replay: every reconnect emits `.connected`
+//   again and the consumer must resync by refetching, never resume.
+// - Heartbeat comments arrive every ~25 s; a stream silent well past that is
+//   dead. The watchdog tears it down and reconnects with backoff. Backoff
+//   only resets once a connection has proven stable — a server that greets
+//   and immediately drops must not induce a hot reconnect loop, because
+//   every subscribe runs a terminal reconciliation server-side.
+// - Events are thin invalidations; payloads that fail to decode are dropped
+//   (a decode failure means contract drift, which regeneration catches).
+//
+// The stream retries forever; it ends only when the consuming task is
+// cancelled. `.disconnected` marks each loss so consumers can surface
+// reachability, but reachability policy lives above this seam.
+
+import ATCAppServerAPI
+import Foundation
+
+public enum ResourceEventStream {
+    public typealias Change = Components.Schemas.ResourceChangedEvent
+
+    public enum Event: Sendable, Equatable {
+        /// Stream is open and reconciled server-side: refetch everything now.
+        case connected
+        /// A named resource changed: coalesce and refetch what it names.
+        case change(Change)
+        /// Stream lost; a reconnect attempt follows automatically.
+        case disconnected
+    }
+
+    public struct Configuration: Sendable {
+        /// Heartbeats arrive every ~25 s; 60 s of silence means dead.
+        public var silenceTimeout: Duration = .seconds(60)
+        public var reconnectBaseDelay: Duration = .milliseconds(500)
+        public var reconnectMaxDelay: Duration = .seconds(8)
+
+        public init() {}
+    }
+
+    /// A single connection attempt: HTTP status plus the raw byte chunks.
+    /// Injected in tests; live path wraps URLSession.bytes.
+    typealias Connector = @Sendable (URL, [String: String]) async throws
+        -> (statusCode: Int, chunks: AsyncThrowingStream<[UInt8], any Error>)
+
+    public static func live(
+        baseURL: URL,
+        headers: [String: String] = [:],
+        configuration: Configuration = Configuration()
+    ) -> AsyncStream<Event> {
+        stream(
+            url: baseURL.appending(path: "api/v1/events"),
+            headers: headers,
+            configuration: configuration,
+            connector: liveConnector(configuration: configuration)
+        )
+    }
+
+    static func stream(
+        url: URL,
+        headers: [String: String] = [:],
+        configuration: Configuration = Configuration(),
+        connector: @escaping Connector
+    ) -> AsyncStream<Event> {
+        AsyncStream { continuation in
+            let task = Task {
+                var delay = configuration.reconnectBaseDelay
+                while !Task.isCancelled {
+                    let clock = ContinuousClock()
+                    let opened = clock.now
+                    let sawConnected = await runConnection(
+                        url: url,
+                        headers: headers,
+                        configuration: configuration,
+                        connector: connector,
+                        continuation: continuation
+                    )
+                    if Task.isCancelled { break }
+                    if sawConnected {
+                        continuation.yield(.disconnected)
+                    }
+                    // Only a connection that lived a while proves the server
+                    // healthy; a greet-then-drop cycle keeps escalating.
+                    if sawConnected && clock.now - opened >= configuration.reconnectMaxDelay {
+                        delay = configuration.reconnectBaseDelay
+                    } else {
+                        delay = min(delay * 2, configuration.reconnectMaxDelay)
+                    }
+                    try? await Task.sleep(for: delay)
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    /// Runs one connection to completion. Returns whether the server's
+    /// opening comment was observed (controls the `.disconnected` signal —
+    /// a connect that never opened stays silent so consumers don't see
+    /// phantom connect/disconnect cycles).
+    private static func runConnection(
+        url: URL,
+        headers: [String: String],
+        configuration: Configuration,
+        connector: @escaping Connector,
+        continuation: AsyncStream<Event>.Continuation
+    ) async -> Bool {
+        let watchdog = Watchdog()
+        // The reader and the watchdog race: whichever finishes first — byte
+        // stream ending / silence expiring — cancels the other.
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask {
+                do {
+                    let (statusCode, chunks) = try await connector(url, headers)
+                    guard statusCode == 200 else { return }
+                    var parser = SSEParser()
+                    for try await chunk in chunks {
+                        await watchdog.touch()
+                        for item in parser.consume(chunk) {
+                            await handle(item, watchdog: watchdog, continuation: continuation)
+                        }
+                    }
+                } catch {
+                    // Connect failures and mid-stream errors land in the
+                    // shared reconnect path; there is nothing to distinguish.
+                }
+            }
+            group.addTask {
+                await watchdog.touch()
+                while await watchdog.sleepUntilDeadline(configuration.silenceTimeout) {}
+            }
+            // First side to finish decides; tear the other down.
+            await group.next()
+            group.cancelAll()
+        }
+        return await watchdog.sawConnected
+    }
+
+    private static func handle(
+        _ item: SSEParser.Item,
+        watchdog: Watchdog,
+        continuation: AsyncStream<Event>.Continuation
+    ) async {
+        switch item {
+        case .comment("connected"):
+            await watchdog.markConnected()
+            continuation.yield(.connected)
+        case .comment:
+            // Heartbeats (and any future comments) only feed the watchdog.
+            break
+        case .data(let payload):
+            guard let change = try? JSONDecoder().decode(Change.self, from: Data(payload.utf8)) else {
+                return
+            }
+            continuation.yield(.change(change))
+        }
+    }
+
+    private static func liveConnector(configuration: Configuration) -> Connector {
+        { url, headers in
+            // A dedicated ephemeral session whose request timeout sits above
+            // the watchdog: URLSession's idle timeout must never win the
+            // race, or reconnects would look like silent server deaths.
+            let sessionConfiguration = URLSessionConfiguration.ephemeral
+            sessionConfiguration.timeoutIntervalForRequest =
+                Double(configuration.silenceTimeout.components.seconds) + 30
+            let session = URLSession(configuration: sessionConfiguration)
+            let bytes: URLSession.AsyncBytes
+            let response: URLResponse
+            var request = URLRequest(url: url)
+            request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+            for (header, value) in headers {
+                request.setValue(value, forHTTPHeaderField: header)
+            }
+            do {
+                (bytes, response) = try await session.bytes(for: request)
+            } catch {
+                // Sessions leak unless invalidated; every exit owns its own.
+                session.invalidateAndCancel()
+                throw error
+            }
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+            guard statusCode == 200 else {
+                // Don't hand back a stream nobody will read — an error body
+                // could otherwise buffer unbounded on a still-live session.
+                session.invalidateAndCancel()
+                return (statusCode, AsyncThrowingStream { $0.finish() })
+            }
+            let chunks = AsyncThrowingStream<[UInt8], any Error> { continuation in
+                let reader = Task {
+                    do {
+                        // Byte-at-a-time is fine here: events are tiny and
+                        // rare, and AsyncBytes buffers internally.
+                        for try await byte in bytes {
+                            continuation.yield([byte])
+                        }
+                        continuation.finish()
+                    } catch {
+                        continuation.finish(throwing: error)
+                    }
+                    session.invalidateAndCancel()
+                }
+                continuation.onTermination = { _ in reader.cancel() }
+            }
+            return (statusCode, chunks)
+        }
+    }
+}
+
+/// Shared per-connection state: the silence deadline (`touch` on every
+/// chunk; `sleepUntilDeadline` returns false once a full quiet interval has
+/// elapsed) and whether the server's opening comment was seen.
+private actor Watchdog {
+    private var last = ContinuousClock.now
+    private(set) var sawConnected = false
+
+    func touch() {
+        last = ContinuousClock.now
+    }
+
+    func markConnected() {
+        sawConnected = true
+    }
+
+    func sleepUntilDeadline(_ timeout: Duration) async -> Bool {
+        let deadline = last + timeout
+        let now = ContinuousClock.now
+        if now >= deadline { return false }
+        try? await Task.sleep(until: deadline)
+        return !Task.isCancelled
+    }
+}

--- a/packages/ATCKit/Sources/ATCAppServerTransport/SSEParser.swift
+++ b/packages/ATCKit/Sources/ATCAppServerTransport/SSEParser.swift
@@ -1,0 +1,78 @@
+// SSEParser: incremental parser for the App Server's text/event-stream
+// framing.
+//
+// The server emits two things: comment lines (`: connected` on open,
+// `: heartbeat` every 25 s) and single-`data:`-line events. The parser still
+// implements the general SSE rules that matter for correctness — bytes are
+// buffered until a complete line, `\r\n` is tolerated, multiple `data:`
+// lines join with `\n`, events dispatch on a blank line, and unknown fields
+// are ignored — so chunk boundaries and framing variations can never corrupt
+// an event.
+
+import Foundation
+
+struct SSEParser {
+    enum Item: Equatable, Sendable {
+        /// A comment line, leading colon stripped (`: connected` → "connected").
+        case comment(String)
+        /// A dispatched event's joined data payload.
+        case data(String)
+    }
+
+    private var lineBuffer: [UInt8] = []
+    private var pendingData: [String] = []
+
+    /// Feed a chunk; returns every item completed by it. Comments surface as
+    /// soon as their line completes — the connected/heartbeat signals must
+    /// not wait for an event boundary.
+    mutating func consume(_ bytes: some Sequence<UInt8>) -> [Item] {
+        var items: [Item] = []
+        for byte in bytes {
+            guard byte == 0x0A else {
+                lineBuffer.append(byte)
+                continue
+            }
+            if lineBuffer.last == 0x0D {
+                lineBuffer.removeLast()
+            }
+            let line = String(decoding: lineBuffer, as: UTF8.self)
+            lineBuffer.removeAll(keepingCapacity: true)
+            if let item = consumeLine(line) {
+                items.append(item)
+            }
+        }
+        return items
+    }
+
+    private mutating func consumeLine(_ line: String) -> Item? {
+        if line.isEmpty {
+            guard !pendingData.isEmpty else { return nil }
+            let data = pendingData.joined(separator: "\n")
+            pendingData.removeAll()
+            return .data(data)
+        }
+        if line.hasPrefix(":") {
+            return .comment(stripFieldSpace(line.dropFirst()))
+        }
+        let field: Substring
+        let value: Substring
+        if let colon = line.firstIndex(of: ":") {
+            field = line[..<colon]
+            value = line[line.index(after: colon)...]
+        } else {
+            field = line[...]
+            value = ""
+        }
+        if field == "data" {
+            pendingData.append(stripFieldSpace(value))
+        }
+        // id/event/retry and unknown fields are ignored: the contract's
+        // stream is data-only with no replay.
+        return nil
+    }
+
+    /// The SSE spec strips a single leading space after the colon.
+    private func stripFieldSpace(_ value: Substring) -> String {
+        String(value.hasPrefix(" ") ? value.dropFirst() : value)
+    }
+}

--- a/packages/ATCKit/Tests/ATCAppServerTransportTests/AttachProtocolFixtureTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerTransportTests/AttachProtocolFixtureTests.swift
@@ -1,0 +1,244 @@
+// Consumes the shared cross-language vectors in
+// packages/attach-protocol/fixtures/ so protocol drift between this client
+// and the server fails a test instead of a terminal window (the TypeScript
+// side consumes the same files in attachProtocolFixtures.test.ts).
+
+import Foundation
+import Testing
+@testable import ATCAppServerTransport
+
+private func fixture<T: Decodable>(_ name: String, as type: T.Type) throws -> T {
+    // Tests run from the repo checkout, so the shared fixtures resolve
+    // relative to this source file; there is no bundle-resource copy to
+    // drift from the canonical files.
+    let url = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .appending(path: "attach-protocol/fixtures/\(name).json")
+    return try JSONDecoder().decode(T.self, from: Data(contentsOf: url))
+}
+
+@Suite("Attach protocol fixtures")
+struct AttachProtocolFixtureTests {
+    struct URLFixture: Decodable {
+        struct Case: Decodable {
+            let name: String
+            let base: String
+            let terminalId: String
+            let cols: Int?
+            let rows: Int?
+            let expect: String
+        }
+
+        let cases: [Case]
+    }
+
+    @Test("attach URLs match the shared construction vectors")
+    func attachURLs() throws {
+        let fixture = try fixture("attach-urls", as: URLFixture.self)
+        for testCase in fixture.cases {
+            let size: (cols: Int, rows: Int)? =
+                if let cols = testCase.cols, let rows = testCase.rows {
+                    (cols, rows)
+                } else {
+                    nil
+                }
+            let url = AttachProtocol.attachURL(
+                base: URL(string: testCase.base)!,
+                terminalID: testCase.terminalId,
+                size: size
+            )
+            #expect(url.absoluteString == testCase.expect, "\(testCase.name)")
+        }
+    }
+
+    struct ControlFrameFixture: Decodable {
+        struct Valid: Decodable {
+            struct Frame: Decodable {
+                let type: String
+                let cols: Int?
+                let rows: Int?
+            }
+
+            let name: String
+            let wire: String
+            let frame: Frame
+        }
+
+        struct Ignored: Decodable {
+            let name: String
+            let wire: String
+        }
+
+        let valid: [Valid]
+        let ignored: [Ignored]
+    }
+
+    @Test("control frames decode, and their encodings round-trip")
+    func controlFrames() throws {
+        let fixture = try fixture("control-frames", as: ControlFrameFixture.self)
+        for entry in fixture.valid {
+            let expected: AttachProtocol.ControlFrame? =
+                switch entry.frame.type {
+                case "resize": .resize(cols: entry.frame.cols!, rows: entry.frame.rows!)
+                case "ping": .ping
+                case "pong": .pong
+                default: nil
+                }
+            let frame = try #require(expected, "unknown fixture frame type: \(entry.frame.type)")
+            #expect(AttachProtocol.ControlFrame.decode(entry.wire) == frame, "\(entry.name)")
+            #expect(AttachProtocol.ControlFrame.decode(frame.wire) == frame, "\(entry.name) round-trip")
+        }
+        for entry in fixture.ignored {
+            #expect(AttachProtocol.ControlFrame.decode(entry.wire) == nil, "\(entry.name)")
+        }
+    }
+
+    struct ClampFixture: Decodable {
+        enum Raw: Decodable {
+            case string(String)
+            case number(Double)
+            case absent
+
+            init(from decoder: any Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                if container.decodeNil() {
+                    self = .absent
+                } else if let number = try? container.decode(Double.self) {
+                    self = .number(number)
+                } else {
+                    self = .string(try container.decode(String.self))
+                }
+            }
+        }
+
+        struct Case: Decodable {
+            let name: String
+            let raw: Raw
+            let expect: Int
+        }
+
+        let fallback: Int
+        let cases: [Case]
+    }
+
+    @Test("dimension clamping matches the shared vectors")
+    func dimensionClamp() throws {
+        let fixture = try fixture("dimension-clamp", as: ClampFixture.self)
+        for testCase in fixture.cases {
+            let clamped =
+                switch testCase.raw {
+                case .string(let raw):
+                    AttachProtocol.clampDimension(raw, fallback: fixture.fallback)
+                case .number(let raw):
+                    AttachProtocol.clampDimension(raw, fallback: fixture.fallback)
+                case .absent:
+                    AttachProtocol.clampDimension(nil as Double?, fallback: fixture.fallback)
+                }
+            #expect(clamped == testCase.expect, "\(testCase.name)")
+        }
+    }
+
+    struct CloseFixture: Decodable {
+        struct Close: Decodable {
+            let code: Int
+            let reason: String?
+            let sender: String
+            let retryable: Bool?
+        }
+
+        let closes: [Close]
+    }
+
+    @Test("close classification matches the shared vocabulary")
+    func closeCodes() throws {
+        let fixture = try fixture("close-codes", as: CloseFixture.self)
+        for close in fixture.closes {
+            let disposition = AttachProtocol.classifyClose(code: close.code, reason: close.reason)
+            // The fixture encodes the meaning through `retryable`: false is
+            // the one authoritative death, null is the client's own detach,
+            // true must land in the reattach path.
+            switch close.retryable {
+            case false:
+                #expect(disposition == .terminalEnded, "\(close.reason ?? "\(close.code)")")
+            case nil:
+                #expect(disposition == .detach, "\(close.reason ?? "\(close.code)")")
+            case true:
+                #expect(disposition == .retryable, "\(close.reason ?? "\(close.code)")")
+            }
+        }
+    }
+}
+
+@Suite("Attach end-reason mapping")
+struct AttachEndReasonTests {
+    @Test("pre-upgrade rejections map by status")
+    func preUpgradeStatuses() {
+        #expect(
+            AttachSocket.endReason(
+                statusCode: 410, closeCode: .invalid, closeReason: nil, errorDescription: "gone"
+            ) == .terminalEnded
+        )
+        #expect(
+            AttachSocket.endReason(
+                statusCode: 404, closeCode: .invalid, closeReason: nil, errorDescription: "missing"
+            ) == .rejected(statusCode: 404)
+        )
+        #expect(
+            AttachSocket.endReason(
+                statusCode: 426, closeCode: .invalid, closeReason: nil, errorDescription: "upgrade"
+            ) == .rejected(statusCode: 426)
+        )
+    }
+
+    @Test("server closes map through the shared vocabulary")
+    func serverCloses() {
+        #expect(
+            AttachSocket.endReason(
+                closeCode: .normalClosure,
+                closeReason: Data("terminal_ended".utf8),
+                errorDescription: "closed"
+            ) == .terminalEnded
+        )
+        #expect(
+            AttachSocket.endReason(
+                closeCode: .internalServerError,
+                closeReason: Data("ping_timeout".utf8),
+                errorDescription: "closed"
+            ) == .retryable("ping_timeout")
+        )
+        #expect(
+            AttachSocket.endReason(
+                closeCode: .abnormalClosure,
+                closeReason: nil,
+                errorDescription: "socket closed"
+            ) == .retryable("socket closed")
+        )
+    }
+
+    @Test("a client-initiated close wins over any other signal")
+    func clientClose() {
+        #expect(
+            AttachSocket.endReason(
+                closedByClient: true,
+                closeCode: .normalClosure,
+                closeReason: Data("terminal_ended".utf8),
+                errorDescription: "closed"
+            ) == .closedByClient
+        )
+    }
+
+    @Test("a successful upgrade's 101 does not shadow the close reason")
+    func upgradeStatusIgnored() {
+        #expect(
+            AttachSocket.endReason(
+                statusCode: 101,
+                closeCode: .internalServerError,
+                closeReason: Data("attach_failed".utf8),
+                errorDescription: "closed"
+            ) == .retryable("attach_failed")
+        )
+    }
+}

--- a/packages/ATCKit/Tests/ATCAppServerTransportTests/AttachSocketTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerTransportTests/AttachSocketTests.swift
@@ -1,0 +1,260 @@
+import Foundation
+import Testing
+@testable import ATCAppServerTransport
+
+/// Scripted stand-in for one WebSocket connection: the test delivers server
+/// frames and observes what the socket sends, cancels, and tears down.
+private final class FakeWebSocket: AttachWebSocketTask, @unchecked Sendable {
+    enum Sent: Equatable {
+        case data(Data)
+        case text(String)
+    }
+
+    private let lock = NSLock()
+    private var incomingIterator: AsyncStream<URLSessionWebSocketTask.Message>.Iterator
+    private let incoming: AsyncStream<URLSessionWebSocketTask.Message>.Continuation
+    private var recordedSent: [Sent] = []
+    private var recordedCancel: (code: URLSessionWebSocketTask.CloseCode, reason: String?)?
+    private var recordedInvalidated = false
+    private var openHandler: (@Sendable () -> Void)?
+    private var storedCloseCode: URLSessionWebSocketTask.CloseCode = .invalid
+    private var storedCloseReason: Data?
+    private var storedStatusCode: Int?
+
+    init() {
+        var continuation: AsyncStream<URLSessionWebSocketTask.Message>.Continuation!
+        let stream = AsyncStream<URLSessionWebSocketTask.Message> { continuation = $0 }
+        incoming = continuation
+        incomingIterator = stream.makeAsyncIterator()
+    }
+
+    // MARK: - Test controls
+
+    func transport() -> AttachTransport {
+        { _, onOpen in
+            self.lock.withLock { self.openHandler = onOpen }
+            return self
+        }
+    }
+
+    func open() {
+        lock.withLock { openHandler }?()
+    }
+
+    func deliver(_ message: URLSessionWebSocketTask.Message) {
+        incoming.yield(message)
+    }
+
+    /// Server-side close: sets the close vocabulary, then ends receive().
+    func closeFromServer(code: URLSessionWebSocketTask.CloseCode, reason: String?) {
+        lock.withLock {
+            storedCloseCode = code
+            storedCloseReason = reason.map { Data($0.utf8) }
+        }
+        incoming.finish()
+    }
+
+    var sent: [Sent] { lock.withLock { recordedSent } }
+    var cancelled: (code: URLSessionWebSocketTask.CloseCode, reason: String?)? {
+        lock.withLock { recordedCancel }
+    }
+    var invalidated: Bool { lock.withLock { recordedInvalidated } }
+
+    // MARK: - AttachWebSocketTask
+
+    func receive() async throws -> URLSessionWebSocketTask.Message {
+        if let message = await incomingIterator.next() {
+            return message
+        }
+        throw URLError(.networkConnectionLost)
+    }
+
+    func send(_ message: URLSessionWebSocketTask.Message) async throws {
+        lock.withLock {
+            switch message {
+            case .data(let data): recordedSent.append(.data(data))
+            case .string(let text): recordedSent.append(.text(text))
+            @unknown default: break
+            }
+        }
+    }
+
+    func sendKeepalivePing() {}
+
+    func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        lock.withLock {
+            recordedCancel = (closeCode, reason.flatMap { String(data: $0, encoding: .utf8) })
+        }
+        incoming.finish()
+    }
+
+    func invalidate() {
+        lock.withLock { recordedInvalidated = true }
+    }
+
+    var closeCode: URLSessionWebSocketTask.CloseCode { lock.withLock { storedCloseCode } }
+    var closeReason: Data? { lock.withLock { storedCloseReason } }
+    var httpStatusCode: Int? { lock.withLock { storedStatusCode } }
+}
+
+private let attachURL = URL(string: "ws://127.0.0.1:7332/api/v1/terminals/t1/attach")!
+
+/// Collects socket events on a background task so tests wait on real
+/// conditions (`waitUntil` over the captured list), never on fixed sleeps.
+private final class EventLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recorded: [AttachEvent] = []
+    private var task: Task<Void, Never>?
+
+    func observe(_ stream: AsyncStream<AttachEvent>) {
+        task = Task {
+            for await event in stream {
+                lock.withLock { recorded.append(event) }
+            }
+        }
+    }
+
+    var events: [AttachEvent] { lock.withLock { recorded } }
+
+    var lastEnd: AttachEndReason? {
+        for event in events.reversed() {
+            if case .ended(let reason) = event { return reason }
+        }
+        return nil
+    }
+
+    func cancel() {
+        task?.cancel()
+    }
+}
+
+private func waitUntil(
+    attempts: Int = 2_000,
+    _ condition: () -> Bool
+) async -> Bool {
+    for _ in 0..<attempts {
+        if condition() { return true }
+        try? await Task.sleep(for: .milliseconds(1))
+    }
+    return condition()
+}
+
+@Suite("Attach socket")
+struct AttachSocketTests {
+    @Test("server pings are answered with pongs, never echoed as output")
+    func pingPong() async {
+        let fake = FakeWebSocket()
+        let socket = AttachSocket(url: attachURL, headers: [:], transport: fake.transport())
+        let log = EventLog()
+        log.observe(await socket.start())
+
+        fake.open()
+        fake.deliver(.string(#"{"type":"ping"}"#))
+
+        let ponged = await waitUntil { fake.sent.contains(.text(#"{"type":"pong"}"#)) }
+        #expect(ponged, "the pong reply is load-bearing: silent clients are closed after 120s")
+        // The ping text frame must not surface as terminal output.
+        #expect(
+            !log.events.contains { event in
+                if case .output = event { return true }
+                return false
+            }
+        )
+        await socket.close()
+        log.cancel()
+    }
+
+    @Test("binary frames pass through both directions")
+    func binaryPassthrough() async {
+        let fake = FakeWebSocket()
+        let socket = AttachSocket(url: attachURL, headers: [:], transport: fake.transport())
+        let log = EventLog()
+        log.observe(await socket.start())
+
+        fake.open()
+        fake.deliver(.data(Data("output".utf8)))
+        socket.enqueue(Data("keys".utf8))
+
+        let delivered = await waitUntil {
+            log.events.contains { event in
+                if case .output(let data) = event { return data == Data("output".utf8) }
+                return false
+            }
+        }
+        let forwarded = await waitUntil { fake.sent.contains(.data(Data("keys".utf8))) }
+        #expect(delivered)
+        #expect(forwarded)
+        await socket.close()
+        log.cancel()
+    }
+
+    @Test("resize is clamped and sent as a control frame")
+    func resizeClamped() async {
+        let fake = FakeWebSocket()
+        let socket = AttachSocket(url: attachURL, headers: [:], transport: fake.transport())
+        let log = EventLog()
+        log.observe(await socket.start())
+
+        fake.open()
+        socket.enqueueResize(cols: 5000, rows: 0)
+
+        let resized = await waitUntil {
+            fake.sent.contains(.text(#"{"type":"resize","cols":1000,"rows":1}"#))
+        }
+        #expect(resized)
+        await socket.close()
+        log.cancel()
+    }
+
+    @Test("a server terminal_ended close is authoritative and tears down")
+    func terminalEndedClose() async {
+        let fake = FakeWebSocket()
+        let socket = AttachSocket(url: attachURL, headers: [:], transport: fake.transport())
+        let log = EventLog()
+        log.observe(await socket.start())
+
+        fake.open()
+        fake.closeFromServer(code: .normalClosure, reason: "terminal_ended")
+
+        let ended = await waitUntil { log.lastEnd == .terminalEnded }
+        #expect(ended)
+        #expect(await waitUntil { fake.invalidated })
+        log.cancel()
+    }
+
+    @Test("dropping the event stream detaches instead of leaking the socket")
+    func consumerCancellationCloses() async {
+        let fake = FakeWebSocket()
+        let socket = AttachSocket(url: attachURL, headers: [:], transport: fake.transport())
+        let log = EventLog()
+        log.observe(await socket.start())
+
+        fake.open()
+        // The consumer walks away without calling close() — an abandoned
+        // socket would keep answering pings and never be reaped serverside.
+        log.cancel()
+
+        let detached = await waitUntil {
+            fake.cancelled?.code == .normalClosure && fake.cancelled?.reason == "detach"
+        }
+        #expect(detached)
+        #expect(await waitUntil { fake.invalidated })
+    }
+
+    @Test("close() sends the protocol's detach close")
+    func explicitDetach() async {
+        let fake = FakeWebSocket()
+        let socket = AttachSocket(url: attachURL, headers: [:], transport: fake.transport())
+        let log = EventLog()
+        log.observe(await socket.start())
+
+        fake.open()
+        await socket.close()
+
+        #expect(fake.cancelled?.code == .normalClosure)
+        #expect(fake.cancelled?.reason == "detach")
+        let ended = await waitUntil { log.lastEnd == .closedByClient }
+        #expect(ended)
+        log.cancel()
+    }
+}

--- a/packages/ATCKit/Tests/ATCAppServerTransportTests/OutboundQueueTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerTransportTests/OutboundQueueTests.swift
@@ -1,0 +1,181 @@
+import Foundation
+import Testing
+@testable import ATCAppServerTransport
+
+@Suite("Attach outbound queue")
+struct OutboundQueueTests {
+    @Test("a paste larger than one MiB is queued intact")
+    func largePasteIsLossless() {
+        let queue = OutboundQueue()
+        let paste = patternedData(count: (1 << 20) + 1_337)
+
+        #expect(queue.enqueue(paste))
+
+        var received = Data()
+        while let item = queue.dequeue() {
+            switch item {
+            case .data(let data):
+                // Each WebSocket message stays below the server's frame cap.
+                #expect(data.count <= 256 << 10)
+                received.append(data)
+            case .resize, .pong:
+                Issue.record("unexpected control item")
+            }
+        }
+
+        #expect(received == paste)
+    }
+
+    @Test("control frames jump ahead of buffered data and collapse")
+    func controlFramesLeapfrogData() {
+        let queue = OutboundQueue()
+        #expect(queue.enqueue(Data("keystrokes".utf8)))
+        queue.setResize(cols: 80, rows: 24)
+        queue.setResize(cols: 120, rows: 40)
+        queue.setPong()
+        queue.setPong()
+
+        // Only the latest resize and a single pong survive, both ahead of
+        // the data so the server sizes the PTY before applying input.
+        #expect(queue.dequeue() == .resize(cols: 120, rows: 40))
+        #expect(queue.dequeue() == .pong)
+        #expect(queue.dequeue() == .data(Data("keystrokes".utf8)))
+        #expect(queue.dequeue() == nil)
+    }
+
+    @Test("backpressure preserves whole-write ordering across producers")
+    func backpressurePreservesProducerOrdering() async {
+        let queue = OutboundQueue(maxBufferedBytes: 4, maxChunkBytes: 2)
+        let firstProbe = ProducerProbe()
+        let firstData = Data("AAAAAA".utf8)
+        let secondData = Data("BBBB".utf8)
+
+        let first = Task.detached {
+            queue.enqueue(firstData) { firstProbe.recordEnqueuedChunk() }
+        }
+
+        // Two chunks fill the four-byte queue, leaving the first producer
+        // blocked with two bytes still to write.
+        let firstFilledQueue = await waitUntil { firstProbe.enqueuedChunks == 2 }
+        guard firstFilledQueue else {
+            queue.finish()
+            _ = await first.value
+            Issue.record("first producer never filled the queue")
+            return
+        }
+
+        let second = Task.detached { queue.enqueue(secondData) }
+        var received = Data()
+        let receivedEverything = await waitUntil {
+            while let item = queue.dequeue() {
+                if case .data(let data) = item {
+                    received.append(data)
+                }
+            }
+            return received.count == firstData.count + secondData.count
+        }
+
+        if !receivedEverything {
+            queue.finish()
+        }
+        let firstAccepted = await first.value
+        let secondAccepted = await second.value
+
+        #expect(receivedEverything)
+        #expect(firstAccepted)
+        #expect(secondAccepted)
+        #expect(received == firstData + secondData)
+    }
+
+    @Test("an empty write returns immediately even when the queue is full")
+    func emptyWriteNeverBlocks() async {
+        let queue = OutboundQueue(maxBufferedBytes: 4, maxChunkBytes: 4)
+        let probe = ProducerProbe()
+        #expect(queue.enqueue(Data("full".utf8)))
+
+        // Run detached so a regression shows up as a failed expectation
+        // instead of hanging the suite on the blocked producer.
+        let empty = Task.detached {
+            let accepted = queue.enqueue(Data())
+            probe.recordFinished(accepted: accepted)
+            return accepted
+        }
+        let finished = await waitUntil { probe.accepted != nil }
+        if !finished {
+            queue.finish()
+        }
+        let accepted = await empty.value
+        #expect(finished, "empty write blocked behind a full queue")
+        #expect(accepted)
+
+        // After shutdown even an empty write reports the queue as unusable.
+        queue.finish()
+        #expect(!queue.enqueue(Data()))
+    }
+
+    @Test("finish wakes a backpressured producer and rejects later writes")
+    func finishWakesBlockedProducer() async {
+        let queue = OutboundQueue(maxBufferedBytes: 4, maxChunkBytes: 4)
+        let probe = ProducerProbe()
+        #expect(queue.enqueue(Data("full".utf8)))
+
+        let blocked = Task.detached {
+            probe.recordStarted()
+            let accepted = queue.enqueue(Data("x".utf8))
+            probe.recordFinished(accepted: accepted)
+            return accepted
+        }
+
+        // Wait on the producer actually running, then release it via finish.
+        // Whether finish lands before or after the producer reaches its
+        // condition wait, the write must be rejected and nothing may hang —
+        // a lost wake-up would deadlock `blocked.value` and fail the suite.
+        let producerStarted = await waitUntil { probe.started }
+        #expect(producerStarted)
+
+        queue.finish()
+        let accepted = await blocked.value
+        #expect(!accepted)
+        #expect(probe.accepted == false)
+        #expect(queue.dequeue() == nil)
+        #expect(!queue.enqueue(Data("later".utf8)))
+    }
+}
+
+private func patternedData(count: Int) -> Data {
+    Data((0..<count).map { UInt8(truncatingIfNeeded: $0) })
+}
+
+private func waitUntil(
+    attempts: Int = 2_000,
+    _ condition: () -> Bool
+) async -> Bool {
+    for _ in 0..<attempts {
+        if condition() { return true }
+        try? await Task.sleep(for: .milliseconds(1))
+    }
+    return condition()
+}
+
+nonisolated private final class ProducerProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedStarted = false
+    private var storedEnqueuedChunks = 0
+    private var storedAccepted: Bool?
+
+    var started: Bool { lock.withLock { storedStarted } }
+    var enqueuedChunks: Int { lock.withLock { storedEnqueuedChunks } }
+    var accepted: Bool? { lock.withLock { storedAccepted } }
+
+    func recordStarted() {
+        lock.withLock { storedStarted = true }
+    }
+
+    func recordEnqueuedChunk() {
+        lock.withLock { storedEnqueuedChunks += 1 }
+    }
+
+    func recordFinished(accepted: Bool) {
+        lock.withLock { storedAccepted = accepted }
+    }
+}

--- a/packages/ATCKit/Tests/ATCAppServerTransportTests/ResourceEventStreamTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerTransportTests/ResourceEventStreamTests.swift
@@ -1,0 +1,210 @@
+import Foundation
+import Testing
+@testable import ATCAppServerTransport
+
+/// Scripted stand-in for the live URLSession connector: each connection
+/// attempt pops the next script; an exhausted script hangs (a quiet, open
+/// stream) so a test never spins through unplanned reconnects.
+private final class ScriptedConnector: @unchecked Sendable {
+    enum Connection {
+        /// The connect call itself throws.
+        case failure
+        /// Connects with a non-200 status.
+        case rejected(Int)
+        /// Serves the chunks, then either ends the stream or holds it open.
+        case stream([String], thenHang: Bool)
+    }
+
+    private let lock = NSLock()
+    private var script: [Connection]
+    private var recordedAttempts = 0
+
+    var attempts: Int { lock.withLock { recordedAttempts } }
+
+    init(_ script: [Connection]) {
+        self.script = script
+    }
+
+    private func next() -> Connection {
+        lock.lock()
+        defer { lock.unlock() }
+        recordedAttempts += 1
+        return script.isEmpty ? .stream([], thenHang: true) : script.removeFirst()
+    }
+
+    func connect() -> ResourceEventStream.Connector {
+        { _, _ in
+            switch self.next() {
+            case .failure:
+                throw URLError(.cannotConnectToHost)
+            case .rejected(let status):
+                return (status, AsyncThrowingStream { $0.finish() })
+            case .stream(let chunks, let thenHang):
+                return (
+                    200,
+                    AsyncThrowingStream { continuation in
+                        for chunk in chunks {
+                            continuation.yield(Array(chunk.utf8))
+                        }
+                        if !thenHang {
+                            continuation.finish()
+                        }
+                    }
+                )
+            }
+        }
+    }
+}
+
+private func fastConfiguration(silenceTimeout: Duration = .seconds(5)) -> ResourceEventStream.Configuration {
+    var configuration = ResourceEventStream.Configuration()
+    configuration.silenceTimeout = silenceTimeout
+    configuration.reconnectBaseDelay = .milliseconds(1)
+    configuration.reconnectMaxDelay = .milliseconds(5)
+    return configuration
+}
+
+private let eventsURL = URL(string: "http://127.0.0.1:7332/api/v1/events")!
+
+/// Consumes until `count` events arrive; a deadline turns a hung stream into
+/// a visible assertion failure instead of a stuck suite.
+private func collect(
+    _ stream: AsyncStream<ResourceEventStream.Event>,
+    count: Int
+) async -> [ResourceEventStream.Event] {
+    let collector = Task {
+        var events: [ResourceEventStream.Event] = []
+        for await event in stream {
+            events.append(event)
+            if events.count == count { break }
+        }
+        return events
+    }
+    let deadline = Task {
+        try? await Task.sleep(for: .seconds(10))
+        collector.cancel()
+    }
+    let events = await collector.value
+    deadline.cancel()
+    return events
+}
+
+@Suite("Resource event stream")
+struct ResourceEventStreamTests {
+    @Test("connected precedes changes, and reconnects resignal connected")
+    func connectAndResync() async {
+        let connector = ScriptedConnector([
+            .stream(
+                [": connected\n\n", "data: {\"resource\":\"thread\",\"id\":\"t1\",\"change\":\"updated\"}\n\n"],
+                thenHang: false
+            ),
+            .stream([": connected\n\n"], thenHang: true),
+        ])
+        let stream = ResourceEventStream.stream(
+            url: eventsURL, configuration: fastConfiguration(), connector: connector.connect()
+        )
+
+        let events = await collect(stream, count: 4)
+
+        #expect(events.count == 4)
+        #expect(events.first == .connected)
+        guard case .change(let change) = events[1] else {
+            Issue.record("expected a change event, got \(events[1])")
+            return
+        }
+        #expect(change.id == "t1")
+        #expect(events[2] == .disconnected)
+        // The reconnect emitted connected again: the consumer's cue to
+        // refetch, since delivery is ephemeral with no replay.
+        #expect(events[3] == .connected)
+    }
+
+    @Test("a silent stream is torn down and reconnected")
+    func silenceTimeout() async {
+        let connector = ScriptedConnector([
+            .stream([": connected\n\n"], thenHang: true),
+            .stream([": connected\n\n"], thenHang: true),
+        ])
+        let stream = ResourceEventStream.stream(
+            url: eventsURL,
+            configuration: fastConfiguration(silenceTimeout: .milliseconds(50)),
+            connector: connector.connect()
+        )
+
+        let events = await collect(stream, count: 3)
+
+        #expect(events == [.connected, .disconnected, .connected])
+    }
+
+    @Test("failed connects retry silently until one opens")
+    func failedConnectsStaySilent() async {
+        let connector = ScriptedConnector([
+            .rejected(404),
+            .failure,
+            .stream([": connected\n\n"], thenHang: true),
+        ])
+        let stream = ResourceEventStream.stream(
+            url: eventsURL, configuration: fastConfiguration(), connector: connector.connect()
+        )
+
+        let events = await collect(stream, count: 1)
+
+        // No phantom connect/disconnect cycles from attempts that never
+        // reached the opening comment.
+        #expect(events == [.connected])
+        #expect(connector.attempts == 3)
+    }
+
+    @Test("heartbeats keep the stream alive without surfacing events")
+    func heartbeatsAreInvisible() async {
+        let connector = ScriptedConnector([
+            .stream(
+                [
+                    ": connected\n\n",
+                    ": heartbeat\n\n",
+                    ": heartbeat\n\n",
+                    "data: {\"resource\":\"project\",\"id\":\"p1\",\"change\":\"created\"}\n\n",
+                ],
+                thenHang: true
+            ),
+        ])
+        let stream = ResourceEventStream.stream(
+            url: eventsURL, configuration: fastConfiguration(), connector: connector.connect()
+        )
+
+        let events = await collect(stream, count: 2)
+
+        #expect(events.first == .connected)
+        guard case .change(let change) = events[1] else {
+            Issue.record("expected a change event, got \(events[1])")
+            return
+        }
+        #expect(change.id == "p1")
+    }
+
+    @Test("undecodable payloads are dropped, not fatal")
+    func undecodablePayloadDropped() async {
+        let connector = ScriptedConnector([
+            .stream(
+                [
+                    ": connected\n\n",
+                    "data: {\"resource\":\"galaxy\",\"id\":\"g1\",\"change\":\"updated\"}\n\n",
+                    "data: {\"resource\":\"terminal\",\"id\":\"term1\",\"change\":\"deleted\"}\n\n",
+                ],
+                thenHang: true
+            ),
+        ])
+        let stream = ResourceEventStream.stream(
+            url: eventsURL, configuration: fastConfiguration(), connector: connector.connect()
+        )
+
+        let events = await collect(stream, count: 2)
+
+        #expect(events.first == .connected)
+        guard case .change(let change) = events[1] else {
+            Issue.record("expected a change event, got \(events[1])")
+            return
+        }
+        #expect(change.id == "term1")
+    }
+}

--- a/packages/ATCKit/Tests/ATCAppServerTransportTests/SSEParserTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerTransportTests/SSEParserTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+@testable import ATCAppServerTransport
+
+@Suite("SSE parser")
+struct SSEParserTests {
+    private func consume(_ text: String, chunkSize: Int = .max) -> [SSEParser.Item] {
+        var parser = SSEParser()
+        var items: [SSEParser.Item] = []
+        let bytes = Array(text.utf8)
+        var index = 0
+        while index < bytes.count {
+            let end = min(index + chunkSize, bytes.count)
+            items.append(contentsOf: parser.consume(bytes[index..<end]))
+            index = end
+        }
+        return items
+    }
+
+    @Test("the server's opening bytes parse as the connected comment")
+    func openingComment() {
+        #expect(consume(": connected\n\n") == [.comment("connected")])
+    }
+
+    @Test("data events dispatch on the blank line")
+    func dataEvent() {
+        let wire = ": connected\n\ndata: {\"resource\":\"thread\"}\n\n"
+        #expect(
+            consume(wire) == [
+                .comment("connected"),
+                .data("{\"resource\":\"thread\"}"),
+            ]
+        )
+    }
+
+    @Test("byte-at-a-time chunking changes nothing")
+    func chunkSplits() {
+        let wire = ": connected\n\ndata: {\"id\":\"x\"}\n\n: heartbeat\n\n"
+        let whole = consume(wire)
+        #expect(whole == consume(wire, chunkSize: 1))
+        #expect(whole == consume(wire, chunkSize: 3))
+        #expect(whole == [.comment("connected"), .data("{\"id\":\"x\"}"), .comment("heartbeat")])
+    }
+
+    @Test("CRLF line endings are tolerated")
+    func crlf() {
+        #expect(
+            consume(": connected\r\n\r\ndata: 1\r\n\r\n")
+                == [.comment("connected"), .data("1")]
+        )
+    }
+
+    @Test("multiple data lines join with a newline")
+    func multiLineData() {
+        #expect(consume("data: a\ndata: b\n\n") == [.data("a\nb")])
+    }
+
+    @Test("only the first space after the colon is stripped")
+    func fieldSpaceStripping() {
+        #expect(consume("data:  padded\n\n") == [.data(" padded")])
+        #expect(consume("data:tight\n\n") == [.data("tight")])
+        #expect(consume(":comment-no-space\n\n") == [.comment("comment-no-space")])
+    }
+
+    @Test("unknown fields and fieldless lines are ignored")
+    func unknownFields() {
+        #expect(consume("id: 7\nevent: change\nretry: 100\nnonsense\ndata: x\n\n") == [.data("x")])
+    }
+
+    @Test("blank lines without pending data dispatch nothing")
+    func emptyDispatch() {
+        #expect(consume("\n\n\n") == [])
+    }
+
+    @Test("an incomplete line stays buffered until its newline arrives")
+    func incompleteLine() {
+        var parser = SSEParser()
+        #expect(parser.consume(Array("data: par".utf8)) == [])
+        #expect(parser.consume(Array("tial\n".utf8)) == [])
+        #expect(parser.consume(Array("\n".utf8)) == [.data("partial")])
+    }
+}

--- a/packages/attach-protocol/fixtures/attach-urls.json
+++ b/packages/attach-protocol/fixtures/attach-urls.json
@@ -16,6 +16,12 @@
       "expect": "ws://127.0.0.1:7332/api/v1/terminals/abc/attach"
     },
     {
+      "name": "trailing slash on the base does not double the path",
+      "base": "http://127.0.0.1:7332/",
+      "terminalId": "abc",
+      "expect": "ws://127.0.0.1:7332/api/v1/terminals/abc/attach"
+    },
+    {
       "name": "https base becomes wss",
       "base": "https://example.test:8443",
       "terminalId": "abc",

--- a/packages/attach-protocol/fixtures/control-frames.json
+++ b/packages/attach-protocol/fixtures/control-frames.json
@@ -21,6 +21,7 @@
     { "name": "unknown type", "wire": "{\"type\":\"scroll\",\"lines\":3}" },
     { "name": "resize missing rows", "wire": "{\"type\":\"resize\",\"cols\":120}" },
     { "name": "resize with string dimensions", "wire": "{\"type\":\"resize\",\"cols\":\"120\",\"rows\":\"40\"}" },
+    { "name": "resize with boolean dimensions", "wire": "{\"type\":\"resize\",\"cols\":true,\"rows\":false}" },
     { "name": "not json", "wire": "resize 120 40" },
     { "name": "json but not an object", "wire": "42" },
     { "name": "empty string", "wire": "" }


### PR DESCRIPTION
First PR of the [ATC-125](https://linear.app/elevenideas/issue/ATC-125/migration-of-the-macos-application) stack ([ATC-144](https://linear.app/elevenideas/issue/ATC-144)). ATCKit-only — no app changes; the app still builds and tests green on the legacy path.

## What

New hand-written `ATCAppServerTransport` target holding the two App Server transports the OpenAPI document cannot express:

- **`AttachProtocol`** — pure rules of the terminal-attach WebSocket: URL construction (absolute path, ws/wss scheme), the one dimension rule (floor + clamp to [1, 1000], non-finite → fallback, matching the server's `Number.isFinite` guard), control-frame encode/decode (strict number typing; malformed frames ignored, never fatal, never trapping), and close classification (`1000 terminal_ended` is the only authoritative death; `1011` reasons and `1006` are retryable).
- **`AttachSocket`** — actor over one WebSocket connection behind a small transport seam: binary frames pass through raw, the server's app-level `ping` gets a `pong` ahead of buffered data (server reaps clients silent 120 s), the ordered outbound queue applies byte-bounded backpressure, and dropping the event stream closes the socket instead of leaking a ping-answering zombie attach.
- **`ResourceEventStream`** — the SSE `/api/v1/events` stream as a long-lived AsyncStream: `.connected` fires only after the server's opening `: connected` comment (the race-free refetch signal), heartbeats feed a silence watchdog, reconnects back off and only reset after a connection proves stable (a greet-then-drop server can't induce a hot reconnect loop against the priced subscribe path).

## Protocol parity

Swift tests consume the shared vectors in `packages/attach-protocol/fixtures/` — the same files the TypeScript suite pins — so drift between clients fails a test. Two vectors added here: trailing-slash base URL construction and boolean resize dimensions (both verified against the TS implementation).

## Verification

- `mise run kit:test` — 94 tests green, including scripted attach-socket behavior (pong keepalive, passthrough, close vocabulary, teardown on consumer cancellation) and SSE parser/stream suites
- `mise run contract:check` — green (TS fixture suite accepts the new vectors)
- `mise run macos:test` — green (app untouched)

Two adversarial sub-agent reviews (correctness, simplicity) ran on the initial commit; all confirmed findings are fixed in this squashed commit: consumer-cancellation socket leak, trailing-slash URL bug, trap on out-of-range resize decode, per-attempt URLSession leak, hot-reconnect backoff reset, unsynchronized delegate state, sleep-based test synchronization.

https://claude.ai/code/session_01336PDxLnsF6jXJ8w8uJiQc