### PR TITLE
ATC-146: exceptional states, accessibility, end-to-end hardening (ATC-125 PR ③)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Tasks run with [mise](https://mise.jdx.dev), which also installs the pinned
 toolchains. `mise tasks` lists everything; from the repo root:
 
 ```sh
+mise run dev            # run the App Server in the foreground (http://127.0.0.1:7332)
+mise run install        # build the App Server and install it as ~/.local/bin/atc
 mise run check          # every gate: Go server, web, App Server, ATCKit, macOS app
 mise run test           # every test suite
 mise run refs           # fetch read-only reference source into repos/ (gitignored)

--- a/app-server/src/cli/serve.ts
+++ b/app-server/src/cli/serve.ts
@@ -1,5 +1,6 @@
 import { Effect, Layer, Option, Schema } from "effect"
 import { Command, Flag } from "effect/unstable/cli"
+import { BuildInfo } from "../platform/buildInfo.ts"
 import { AppConfig, layer as appConfigLayer } from "../platform/config.ts"
 import * as Server from "../server.ts"
 import * as Cli from "./cli.ts"
@@ -37,6 +38,19 @@ export const serve = Command.make("serve", { port }, ({ port }) =>
     // so consumers of the settled port (e.g. the zmx adapter's ATC_ENDPOINT
     // injection) always read the port actually being served.
     const effective = { ...config, port: Option.getOrElse(port, () => config.port) }
+    // Compiled builds keep structured logs file-only (see logging.ts), which
+    // would make a successful foreground start indistinguishable from a
+    // hang. One human-facing stderr line announces the server; dev runs
+    // already announce through the pretty logger. A port conflict still
+    // fails with its own diagnostic right after.
+    const build = yield* BuildInfo
+    if (build.commit !== "dev") {
+      yield* Effect.sync(() => {
+        process.stderr.write(
+          `atc app server starting on http://127.0.0.1:${effective.port} (logs: ${effective.logFile})\n`,
+        )
+      })
+    }
     yield* Layer.launch(Server.production({ port: effective.port })).pipe(
       Effect.provideService(AppConfig, effective),
     )

--- a/app-server/src/server.ts
+++ b/app-server/src/server.ts
@@ -83,6 +83,12 @@ export const layer = (options: { readonly port: number }) =>
         // long grace period turns every shutdown after a terminal attach
         // into a hang. Requests are local and short; two seconds is plenty.
         gracefulShutdownTimeout: "2 seconds",
+        // Bun's default idleTimeout (10 s) counts a request that has not yet
+        // written response bytes as idle, which severs openThreadTerminal
+        // mid-materialization — a cold provider launch legitimately runs up
+        // to the 30 s identity timeout. Sixty seconds clears that with
+        // margin; SSE heartbeats and attach pings keep long streams under it.
+        idleTimeout: 60,
       }),
     ),
   )

--- a/macos/ATC/ConnectionRuntime.swift
+++ b/macos/ATC/ConnectionRuntime.swift
@@ -102,6 +102,10 @@ final class ConnectionRuntime: Identifiable {
 
     func start() {
         guard eventTask == nil else { return }
+        // First-contact probe: a server that is down at launch must go red,
+        // not sit gray forever — the stream alone stays silent for attempts
+        // that never open, so it can't report that failure.
+        Task { [weak self] in await self?.refresh() }
         let stream = eventStreamFactory(baseURL, transportHeaders)
         eventTask = Task { [weak self] in
             for await event in stream {
@@ -175,8 +179,16 @@ final class ConnectionRuntime: Identifiable {
         }
     }
 
+    /// Failed refreshes are red regardless of the stream; clean refreshes
+    /// are green only once the stream is open (no invalidations flowing =
+    /// not current) and stay gray before that, so launch never flashes a
+    /// warning for a healthy server that simply hasn't connected yet.
     private func settleReachability() {
-        reachability = streamOpen && allRefreshesClean() ? .connected : .unreachable
+        guard allRefreshesClean() else {
+            reachability = .unreachable
+            return
+        }
+        reachability = streamOpen ? .connected : .unknown
     }
 
     /// Agent availability has no invalidation event (it is detected, not

--- a/macos/ATC/Features/Dashboard/DashboardView.swift
+++ b/macos/ATC/Features/Dashboard/DashboardView.swift
@@ -69,7 +69,7 @@ struct DashboardView: View {
         let reachability = appModel.reachability(of: section.connectionID)
         return VStack(alignment: .leading, spacing: Spacing.md) {
             HStack(spacing: Spacing.sm) {
-                StatusDot(color: reachability.color)
+                StatusDot(reachability: reachability)
                 Text(section.connectionName)
                     .font(.title3.weight(.semibold))
                 Text(section.contextLabel)
@@ -212,8 +212,10 @@ struct DashboardView: View {
 
     // MARK: - Helpers
 
+    /// "No projects yet" is an affirmative statement; an unreachable server
+    /// must never make it (its section shows red + the toolbar warns).
     private var allProjectsLoaded: Bool {
-        appModel.runtimes.allSatisfy(\.projects.hasLoadedOnce)
+        appModel.runtimes.allSatisfy(\.projects.isResolved)
     }
 
     private var cardShape: RoundedRectangle {

--- a/macos/ATC/Features/Projects/ProjectsStore.swift
+++ b/macos/ATC/Features/Projects/ProjectsStore.swift
@@ -57,6 +57,7 @@ final class ProjectsStore {
     /// Server-refused while the project still owns threads or terminals.
     func delete(id: String) async throws {
         _ = try await client.deleteProject(path: .init(projectId: id)).noContent
+        refreshState.invalidateInFlight()
         projects.removeAll { $0.id == id }
     }
 

--- a/macos/ATC/Features/Terminal/TerminalPane.swift
+++ b/macos/ATC/Features/Terminal/TerminalPane.swift
@@ -66,6 +66,9 @@ struct TerminalStatusBanner: View {
                 Button("Reconnect") { controller.reconnect() }
             }
         case .ended(.closedByClient):
+            // No production path renders this today (disconnects also drop
+            // the controller); the branch exists for a future user-facing
+            // detach and to keep the switch exhaustive.
             banner {
                 Image(systemName: "cable.connector.slash")
                 Text("Disconnected")

--- a/macos/ATC/Features/Terminal/TerminalSessionController.swift
+++ b/macos/ATC/Features/Terminal/TerminalSessionController.swift
@@ -107,9 +107,9 @@ final class TerminalSessionController: Identifiable {
     let terminalID: String
     let viewState: TerminalViewState
     private(set) var phase: Phase = .connecting
-    /// Fired once when the server proves the terminal gone (authoritative
-    /// close or reconciled read) — the owner refreshes stores so the
-    /// tombstone and dropped thread link land.
+    /// Fired when the terminal may be gone — an authoritative close, a
+    /// reconciled read, or a pre-upgrade rejection — so the owner refetches
+    /// and the tombstone (or corrected state) lands.
     @ObservationIgnored var onTerminalEnded: (() -> Void)?
 
     var id: String { terminalID }

--- a/macos/ATC/Features/Terminals/TerminalsStore.swift
+++ b/macos/ATC/Features/Terminals/TerminalsStore.swift
@@ -79,6 +79,7 @@ final class TerminalsStore {
 
     func delete(id: String) async throws {
         _ = try await client.deleteTerminal(path: .init(terminalId: id)).noContent
+        refreshState.invalidateInFlight()
         terminals.removeAll { $0.id == id }
     }
 

--- a/macos/ATC/Features/Threads/ThreadsStore.swift
+++ b/macos/ATC/Features/Threads/ThreadsStore.swift
@@ -112,6 +112,7 @@ final class ThreadsStore {
 
     func delete(id: String) async throws {
         _ = try await client.deleteThread(path: .init(threadId: id)).noContent
+        refreshState.invalidateInFlight()
         threads.removeAll { $0.id == id }
         archivedThreads.removeAll { $0.id == id }
     }

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -148,6 +148,7 @@ struct NavigatorSidebar: View {
             .menuIndicator(.hidden)
             .foregroundStyle(.secondary)
             .help("Filter threads")
+            .accessibilityLabel("Thread filter: \(filterTitle(model))")
 
             NavigatorActionButton(
                 systemImage: "folder.badge.plus",

--- a/macos/ATC/RootView.swift
+++ b/macos/ATC/RootView.swift
@@ -45,6 +45,11 @@ struct RootView: View {
             ToolbarItem(placement: .principal) {
                 contextTitle
             }
+            // The design's exceptional-state surface: needs-input and
+            // Connection-unreachable live here; healthy states show nothing.
+            ToolbarItem(placement: .status) {
+                exceptionalStatus
+            }
             ToolbarItem(placement: .primaryAction) {
                 Toggle(isOn: $windowState.isInspectorPresented) {
                     Label("Inspector", systemImage: "sidebar.trailing")
@@ -110,6 +115,36 @@ struct RootView: View {
                     .lineLimit(1)
             }
         }
+    }
+
+    @ViewBuilder
+    private var exceptionalStatus: some View {
+        HStack(spacing: Spacing.md) {
+            if let ref = selectedThread,
+               appModel.thread(for: ref)?.activityState == .needsInput {
+                Label("Needs input", systemImage: "exclamationmark.bubble.fill")
+                    .font(.callout.weight(.medium))
+                    .foregroundStyle(Color.accentColor)
+                    .help("The agent is waiting for your input")
+            }
+            if let name = unreachableConnectionName {
+                Label("\(name) unreachable", systemImage: "wifi.exclamationmark")
+                    .font(.callout.weight(.medium))
+                    // Orange like the app's other warning banners: this is a
+                    // persistent surface, softer than the red state dot.
+                    .foregroundStyle(.orange)
+                    // The attach WebSocket is deliberately independent of
+                    // this state — an open terminal keeps working — so the
+                    // copy only claims what canMutate actually gates.
+                    .help("Showing cached content; creating and organizing are disabled until the connection returns")
+            }
+        }
+    }
+
+    /// The first unreachable Connection's display name; nil while all are
+    /// healthy or still unknown (launch must not flash a warning).
+    private var unreachableConnectionName: String? {
+        appModel.runtimes.first { $0.reachability == .unreachable }?.record.name
     }
 
     @ViewBuilder

--- a/macos/ATC/Settings/ConnectionsSettingsView.swift
+++ b/macos/ATC/Settings/ConnectionsSettingsView.swift
@@ -58,7 +58,7 @@ struct ConnectionsSettingsView: View {
             List(selection: $target) {
                 ForEach(store.connections) { record in
                     HStack(spacing: Spacing.sm) {
-                        StatusDot(color: appModel.reachability(of: record.id).color)
+                        StatusDot(reachability: appModel.reachability(of: record.id))
                         VStack(alignment: .leading, spacing: 2) {
                             Text(record.name)
                                 .font(.headline)

--- a/macos/ATC/Settings/Reachability.swift
+++ b/macos/ATC/Settings/Reachability.swift
@@ -1,8 +1,7 @@
 import SwiftUI
 
-/// The most recent reachability outcome for a Connection. Phase 3 derives this
-/// from each per-Connection refresh completion; until then everything is
-/// `.unknown`.
+/// The most recent reachability outcome for a Connection: gray until the
+/// event stream and first refresh settle, then green/red from there.
 enum Reachability {
     case unknown
     case connected
@@ -14,6 +13,15 @@ enum Reachability {
         case .unknown: return .secondary
         case .connected: return .green
         case .unreachable: return .red
+        }
+    }
+
+    /// The dot is color-only; assistive tech gets the state in words.
+    var accessibilityDescription: String {
+        switch self {
+        case .unknown: "status unknown"
+        case .connected: "reachable"
+        case .unreachable: "unreachable"
         }
     }
 }

--- a/macos/ATC/Shared/StatusDot.swift
+++ b/macos/ATC/Shared/StatusDot.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
-/// The one reachability/liveness dot used across the app.
+/// The one reachability dot used across the app. Takes the state, not a
+/// color, so the color and its spoken description cannot drift apart.
 struct StatusDot: View {
     enum Size {
         /// 6pt — inside captions and chips.
@@ -16,19 +17,13 @@ struct StatusDot: View {
         }
     }
 
-    let color: Color
+    let reachability: Reachability
     var size: Size = .standard
-    /// Hollow ring for "present but inactive" (e.g. no active sessions).
-    var hollow = false
 
     var body: some View {
         Circle()
-            .fill(hollow ? Color.clear : color)
-            .overlay {
-                if hollow {
-                    Circle().stroke(.tertiary, lineWidth: 2)
-                }
-            }
+            .fill(reachability.color)
             .frame(width: size.diameter, height: size.diameter)
+            .accessibilityLabel("Connection \(reachability.accessibilityDescription)")
     }
 }

--- a/macos/ATCTests/AppModelRuntimeTests.swift
+++ b/macos/ATCTests/AppModelRuntimeTests.swift
@@ -81,14 +81,16 @@ struct AppModelRuntimeTests {
     func navigationSnapshot() async throws {
         let client = ScriptableAppServerClient()
         Fixtures.seed(client)
-        let test = try makeModel(client: client)
-        // Before any refresh nothing is current, so the window treats every
-        // reference as unresolved rather than deleted.
+        // A failed first-contact probe leaves nothing current, so the window
+        // treats every reference as unresolved rather than deleted.
+        client.shouldFail = true
+        let test = try await makeModel(client: client)
         let cold = test.model.windowNavigationSnapshot()
         #expect(cold.connections.map(\.id) == [test.connectionID])
         #expect(!cold.connections[0].threadsCurrent)
         #expect(!cold.connections[0].terminalsCurrent)
 
+        client.shouldFail = false
         await test.runtime.refresh()
         await test.runtime.threads.loadArchivedIfNeeded()
         let warm = test.model.windowNavigationSnapshot()
@@ -109,7 +111,7 @@ struct AppModelRuntimeTests {
     func staleRefreshHarmless() async throws {
         let client = ScriptableAppServerClient()
         Fixtures.seed(client)
-        let test = try makeModel(client: client)
+        let test = try await makeModel(client: client)
         client.delay = .milliseconds(200)
         let oldRuntime = test.runtime
         let slowRefresh = Task { await oldRuntime.refresh() }
@@ -123,9 +125,11 @@ struct AppModelRuntimeTests {
         #expect(newRuntime !== oldRuntime)
 
         await slowRefresh.value
-        // The late result mutated only the discarded runtime's stores.
+        // The late result mutated only the discarded runtime's stores; the
+        // rebuilt runtime's own first-contact probe loads current data.
         #expect(test.runtime === newRuntime)
-        #expect(test.runtime.threads.threads.isEmpty)
+        await settle(until: { newRuntime.threads.hasLoadedOnce })
+        #expect(newRuntime.threads.threads.count == 3)
         #expect(test.model.runtimes.count == 1)
     }
 
@@ -135,7 +139,7 @@ struct AppModelRuntimeTests {
     func openThreadAttaches() async throws {
         let client = ScriptableAppServerClient()
         Fixtures.seed(client)
-        let test = try makeModel(client: client)
+        let test = try await makeModel(client: client)
         await test.runtime.refresh()
 
         let ref = try await test.model.openThread(test.threadRef("thr1"))
@@ -164,7 +168,7 @@ struct AppModelRuntimeTests {
     func openThreadFailure() async throws {
         let client = ScriptableAppServerClient()
         Fixtures.seed(client)
-        let test = try makeModel(client: client)
+        let test = try await makeModel(client: client)
         await test.runtime.refresh()
 
         client.shouldFail = true
@@ -180,7 +184,7 @@ struct AppModelRuntimeTests {
     func reconcileDisconnectsEndedTerminal() async throws {
         let client = ScriptableAppServerClient()
         Fixtures.seed(client)
-        let test = try makeModel(client: client)
+        let test = try await makeModel(client: client)
         await test.runtime.refresh()
 
         let terminal = try #require(test.runtime.terminals.terminal(id: "trm_live"))
@@ -207,7 +211,7 @@ struct AppModelRuntimeTests {
     func reconcileIgnoresFailedRefresh() async throws {
         let client = ScriptableAppServerClient()
         Fixtures.seed(client)
-        let test = try makeModel(client: client)
+        let test = try await makeModel(client: client)
         await test.runtime.refresh()
 
         let terminal = try #require(test.runtime.terminals.terminal(id: "trm_live"))
@@ -227,7 +231,7 @@ struct AppModelRuntimeTests {
     func attachRequiresLiveness() async throws {
         let client = ScriptableAppServerClient()
         Fixtures.seed(client)
-        let test = try makeModel(client: client)
+        let test = try await makeModel(client: client)
         await test.runtime.refresh()
 
         let ended = try #require(test.runtime.terminals.terminal(id: "trm_ended"))
@@ -243,7 +247,7 @@ struct AppModelRuntimeTests {
     func removingConnectionTearsDownTerminals() async throws {
         let client = ScriptableAppServerClient()
         Fixtures.seed(client)
-        let test = try makeModel(client: client)
+        let test = try await makeModel(client: client)
         await test.runtime.refresh()
 
         let terminal = try #require(test.runtime.terminals.terminal(id: "trm_live"))
@@ -260,7 +264,7 @@ struct AppModelRuntimeTests {
     func livenessFollowsPhase() async throws {
         let client = ScriptableAppServerClient()
         Fixtures.seed(client)
-        let test = try makeModel(client: client)
+        let test = try await makeModel(client: client)
         await test.runtime.refresh()
 
         let terminal = try #require(test.runtime.terminals.terminal(id: "trm_live"))

--- a/macos/ATCTests/AttachmentBudgetTests.swift
+++ b/macos/ATCTests/AttachmentBudgetTests.swift
@@ -14,8 +14,8 @@ struct AttachmentBudgetTests {
     }
 
     @Test("attaching past the budget evicts the least-recently-used terminal")
-    func evictsLRU() throws {
-        let test = try makeModel(attachmentBudget: 2)
+    func evictsLRU() async throws {
+        let test = try await makeModel(attachmentBudget: 2)
         for index in 1...3 {
             test.model.attachIfNeeded(to: liveTerminal("t\(index)"), connectionID: test.connectionID)
         }
@@ -26,8 +26,8 @@ struct AttachmentBudgetTests {
     }
 
     @Test("touching a terminal refreshes its LRU position")
-    func touchRefreshesLRU() throws {
-        let test = try makeModel(attachmentBudget: 2)
+    func touchRefreshesLRU() async throws {
+        let test = try await makeModel(attachmentBudget: 2)
         test.model.attachIfNeeded(to: liveTerminal("t1"), connectionID: test.connectionID)
         test.model.attachIfNeeded(to: liveTerminal("t2"), connectionID: test.connectionID)
 
@@ -38,8 +38,8 @@ struct AttachmentBudgetTests {
     }
 
     @Test("the visible terminal is never evicted")
-    func visibleTerminalIsPinned() throws {
-        let test = try makeModel(attachmentBudget: 2)
+    func visibleTerminalIsPinned() async throws {
+        let test = try await makeModel(attachmentBudget: 2)
         let visible = test.terminalRef("t1")
         test.model.attachIfNeeded(to: liveTerminal("t1"), connectionID: test.connectionID)
         test.model.attachIfNeeded(to: liveTerminal("t2"), connectionID: test.connectionID)
@@ -55,8 +55,8 @@ struct AttachmentBudgetTests {
     }
 
     @Test("the visible terminal and the newest attach may together exceed the budget")
-    func pinnedRefsExceedBudget() throws {
-        let test = try makeModel(attachmentBudget: 1)
+    func pinnedRefsExceedBudget() async throws {
+        let test = try await makeModel(attachmentBudget: 1)
         let visible = test.terminalRef("t1")
         test.model.attachIfNeeded(to: liveTerminal("t1"), connectionID: test.connectionID)
         test.model.attachIfNeeded(
@@ -73,8 +73,8 @@ struct AttachmentBudgetTests {
     }
 
     @Test("eviction goes through the standard disconnect path")
-    func evictionDisconnects() throws {
-        let test = try makeModel(attachmentBudget: 1)
+    func evictionDisconnects() async throws {
+        let test = try await makeModel(attachmentBudget: 1)
         test.model.attachIfNeeded(to: liveTerminal("t1"), connectionID: test.connectionID)
         let ref = test.terminalRef("t1")
         let controller = try #require(test.model.terminals[ref])
@@ -87,8 +87,8 @@ struct AttachmentBudgetTests {
     }
 
     @Test("reselecting an evicted terminal reattaches through attachIfNeeded")
-    func evictedTerminalReattaches() throws {
-        let test = try makeModel(attachmentBudget: 1)
+    func evictedTerminalReattaches() async throws {
+        let test = try await makeModel(attachmentBudget: 1)
         test.model.attachIfNeeded(to: liveTerminal("t1"), connectionID: test.connectionID)
         test.model.attachIfNeeded(to: liveTerminal("t2"), connectionID: test.connectionID)
         let ref = test.terminalRef("t1")
@@ -100,8 +100,8 @@ struct AttachmentBudgetTests {
     }
 
     @Test("a disconnect releases the controller, and a later attach recreates it")
-    func disconnectReleasesController() throws {
-        let test = try makeModel()
+    func disconnectReleasesController() async throws {
+        let test = try await makeModel()
         test.model.attachIfNeeded(to: liveTerminal("t1"), connectionID: test.connectionID)
         let ref = test.terminalRef("t1")
 

--- a/macos/ATCTests/CommandPaletteContentTests.swift
+++ b/macos/ATCTests/CommandPaletteContentTests.swift
@@ -19,7 +19,7 @@ struct CommandPaletteContentTests {
         let client = ScriptableAppServerClient()
         Fixtures.seed(client)
         let events = ScriptedEventStream()
-        let test = try makeModel(client: client, events: events)
+        let test = try await makeModel(client: client, events: events)
         events.connect()
         await settle(until: { test.model.canMutate(connectionID: test.connectionID) })
         await test.runtime.threads.loadArchivedIfNeeded()
@@ -131,7 +131,7 @@ struct CommandPaletteContentTests {
             return named
         }
         let events = ScriptedEventStream()
-        let test = try makeModel(client: client, events: events)
+        let test = try await makeModel(client: client, events: events)
         events.connect()
         await settle(until: { test.model.canMutate(connectionID: test.connectionID) })
         let context = CommandContext(

--- a/macos/ATCTests/CommandRegistryTests.swift
+++ b/macos/ATCTests/CommandRegistryTests.swift
@@ -34,7 +34,7 @@ struct CommandRegistryTests {
         let client = ScriptableAppServerClient()
         Fixtures.seed(client)
         let events = ScriptedEventStream()
-        let test = try makeModel(client: client, events: events)
+        let test = try await makeModel(client: client, events: events)
         events.connect()
         await settle(until: { test.model.canMutate(connectionID: test.connectionID) })
 
@@ -90,7 +90,7 @@ struct CommandRegistryTests {
         let client = ScriptableAppServerClient()
         Fixtures.seed(client)
         let events = ScriptedEventStream()
-        let test = try makeModel(client: client, events: events)
+        let test = try await makeModel(client: client, events: events)
         events.connect()
         await settle(until: { test.model.canMutate(connectionID: test.connectionID) })
 

--- a/macos/ATCTests/ConnectionRuntimeTests.swift
+++ b/macos/ATCTests/ConnectionRuntimeTests.swift
@@ -120,10 +120,11 @@ struct ConnectionRuntimeTests {
         let runtime = makeRuntime(client: client, events: events)
         defer { runtime.stop() }
 
-        // Green requires the event stream: without it no invalidations flow,
-        // so successful HTTP alone must never claim .connected.
+        // Green requires the event stream: a clean refresh before the stream
+        // opens stays gray — successful HTTP alone must never claim
+        // .connected, and a healthy launch must not flash a warning.
         await runtime.refresh()
-        #expect(runtime.reachability == .unreachable)
+        #expect(runtime.reachability == .unknown)
 
         runtime.start()
         events.connect()

--- a/macos/ATCTests/TerminalLivenessTests.swift
+++ b/macos/ATCTests/TerminalLivenessTests.swift
@@ -38,7 +38,7 @@ struct TerminalLivenessTests {
     func endedControllerRetainedNotLive() async throws {
         let client = ScriptableAppServerClient()
         Fixtures.seed(client)
-        let test = try makeModel(client: client)
+        let test = try await makeModel(client: client)
         await test.runtime.refresh()
 
         let terminal = try #require(test.runtime.terminals.terminal(id: "trm_live"))
@@ -62,7 +62,7 @@ struct TerminalLivenessTests {
     func endedTerminalRefetchesStores() async throws {
         let client = ScriptableAppServerClient()
         Fixtures.seed(client)
-        let test = try makeModel(client: client)
+        let test = try await makeModel(client: client)
         await test.runtime.refresh()
 
         let terminal = try #require(test.runtime.terminals.terminal(id: "trm_live"))
@@ -86,7 +86,7 @@ struct TerminalLivenessTests {
     func explicitDisconnectRemoves() async throws {
         let client = ScriptableAppServerClient()
         Fixtures.seed(client)
-        let test = try makeModel(client: client)
+        let test = try await makeModel(client: client)
         await test.runtime.refresh()
 
         let terminal = try #require(test.runtime.terminals.terminal(id: "trm_live"))

--- a/macos/ATCTests/TestSupport.swift
+++ b/macos/ATCTests/TestSupport.swift
@@ -212,7 +212,7 @@ func makeModel(
     attachmentBudget: Int = 12,
     name: String = "A",
     urlString: String = "http://a:1"
-) throws -> TestModel {
+) async throws -> TestModel {
     let store = makeConnectionsStore()
     let record = try store.add(name: name, urlString: urlString, token: "")
     let model = makeAppModel(
@@ -222,6 +222,15 @@ func makeModel(
         attach: attach,
         attachmentBudget: attachmentBudget
     )
+    // A started runtime probes immediately (first-contact reachability).
+    // Settle that probe here so tests never race it: whatever the client
+    // held at construction is loaded, and every later mutation is the
+    // test's own doing.
+    let runtime = model.runtime(id: record.id)!
+    await settle(until: {
+        runtime.projects.hasLoadedOnce && runtime.threads.hasLoadedOnce
+            && runtime.terminals.hasLoadedOnce && runtime.agents.hasLoadedOnce
+    })
     return TestModel(
         model: model,
         client: client,

--- a/macos/ATCTests/WindowStateTests.swift
+++ b/macos/ATCTests/WindowStateTests.swift
@@ -14,7 +14,7 @@ struct WindowStateTests {
         _ client: ScriptableAppServerClient = ScriptableAppServerClient()
     ) async throws -> TestModel {
         Fixtures.seed(client)
-        let test = try makeModel(client: client)
+        let test = try await makeModel(client: client)
         await test.runtime.refresh()
         await test.runtime.threads.loadArchivedIfNeeded()
         return test

--- a/macos/atc.xcodeproj/project.pbxproj
+++ b/macos/atc.xcodeproj/project.pbxproj
@@ -7,11 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		AC00000000000000000000B1 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		AC00000000000000000000B2 /* GhosttyKit in Frameworks */ = {isa = PBXBuildFile; productRef = AC00000000000000000000A2 /* GhosttyKit */; };
 		AC00000000000000000000B3 /* GhosttyTerminal in Frameworks */ = {isa = PBXBuildFile; productRef = AC00000000000000000000A3 /* GhosttyTerminal */; };
 		AC00000000000000000000B4 /* GhosttyTheme in Frameworks */ = {isa = PBXBuildFile; productRef = AC00000000000000000000A4 /* GhosttyTheme */; };
-		AC00000000000000000000B5 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		AC00000000000000000000B6 /* TOMLDecoder in Frameworks */ = {isa = PBXBuildFile; productRef = AC00000000000000000000A6 /* TOMLDecoder */; };
 		AC00000000000000000000B7 /* ATCAppServerAPI in Frameworks */ = {isa = PBXBuildFile; productRef = AC00000000000000000000A7 /* ATCAppServerAPI */; };
 		DEC8867630264F5C006D3531 /* ATCAppServerTransport in Frameworks */ = {isa = PBXBuildFile; productRef = AC00000000000000000000A8 /* ATCAppServerTransport */; };
@@ -54,7 +52,6 @@
 			files = (
 				DEC8867830264F5C006D3531 /* ATCAppServerTransport in Frameworks */,
 				DEC8867730264F5C006D3531 /* ATCAppServerAPI in Frameworks */,
-				AC00000000000000000000B5 /* (null) in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -63,7 +60,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				DEC8867630264F5C006D3531 /* ATCAppServerTransport in Frameworks */,
-				AC00000000000000000000B1 /* (null) in Frameworks */,
 				AC00000000000000000000B7 /* ATCAppServerAPI in Frameworks */,
 				AC00000000000000000000B2 /* GhosttyKit in Frameworks */,
 				AC00000000000000000000B3 /* GhosttyTerminal in Frameworks */,

--- a/mise.toml
+++ b/mise.toml
@@ -2,6 +2,33 @@
 # independently buildable; these tasks fan out so one command answers
 # "is the repo healthy?" the same way locally and in CI.
 
+# --- Primary entrypoints (the App Server is the atc service; the Go
+# server/ tree is legacy awaiting removal and must never win a task name) ---
+
+[tasks.dev]
+description = "Run the App Server in the foreground (http://127.0.0.1:7332)"
+run = "mise run -C app-server dev"
+
+[tasks.install]
+description = "Build the App Server and install it as the local atc binary (default: ~/.local/bin/atc)"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+mise run -C app-server build
+case "$(uname -m)" in
+  arm64|aarch64) arch=arm64 ;;
+  x86_64) arch=x64 ;;
+  *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+dir="${ATC_INSTALL_DIR:-$HOME/.local/bin}"
+mkdir -p "$dir"
+install -m 0755 "app-server/dist/atc-$os-$arch" "$dir/atc"
+# --version is the binary's own build stamp; `atc version` would ask a
+# running server and fail when none is up.
+echo "installed $dir/atc ($("$dir/atc" --version))"
+"""
+
 [tasks.check]
 description = "All gates: server fmt/vet/tests + web check, App Server check, Kit tests, macOS app tests"
 depends = ["server:check", "app-server:check", "kit:test", "macos:test"]

--- a/packages/ATCKit/Tests/ATCAppServerAPITests/ClientTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerAPITests/ClientTests.swift
@@ -73,6 +73,24 @@ struct ClientTests {
         #expect(try Servers.Server1.url() == URL(string: "http://127.0.0.1:7332"))
     }
 
+    // The bearer-auth seam remote servers will rely on: the middleware must
+    // actually stamp the header (deleting it would otherwise pass silently).
+    @Test("BearerAuthMiddleware stamps the Authorization header")
+    func bearerMiddleware() async throws {
+        let middleware = BearerAuthMiddleware(token: "token-1")
+        var forwarded: HTTPRequest?
+        _ = try await middleware.intercept(
+            HTTPRequest(method: .get, scheme: nil, authority: nil, path: "/api/v1/health"),
+            body: nil,
+            baseURL: URL(string: "http://127.0.0.1:7332")!,
+            operationID: "getHealth"
+        ) { request, body, _ in
+            forwarded = request
+            return (HTTPResponse(status: .ok), body)
+        }
+        #expect(forwarded?.headerFields[.authorization] == "Bearer token-1")
+    }
+
     // Regression: optional contract fields must survive generation as plain
     // strings. Earlier schema shapes made the pinned generator either drop
     // the fields entirely (nullable unions) or wrap them in single-value

--- a/packages/ATCKit/Tests/ATCAppServerTransportTests/AttachSocketTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerTransportTests/AttachSocketTests.swift
@@ -17,6 +17,7 @@ private final class FakeWebSocket: AttachWebSocketTask, @unchecked Sendable {
     private var recordedCancel: (code: URLSessionWebSocketTask.CloseCode, reason: String?)?
     private var recordedInvalidated = false
     private var openHandler: (@Sendable () -> Void)?
+    private var recordedRequest: URLRequest?
     private var storedCloseCode: URLSessionWebSocketTask.CloseCode = .invalid
     private var storedCloseReason: Data?
     private var storedStatusCode: Int?
@@ -31,11 +32,16 @@ private final class FakeWebSocket: AttachWebSocketTask, @unchecked Sendable {
     // MARK: - Test controls
 
     func transport() -> AttachTransport {
-        { _, onOpen in
-            self.lock.withLock { self.openHandler = onOpen }
+        { request, onOpen in
+            self.lock.withLock {
+                self.openHandler = onOpen
+                self.recordedRequest = request
+            }
             return self
         }
     }
+
+    var request: URLRequest? { lock.withLock { recordedRequest } }
 
     func open() {
         lock.withLock { openHandler }?()
@@ -239,6 +245,22 @@ struct AttachSocketTests {
         }
         #expect(detached)
         #expect(await waitUntil { fake.invalidated })
+    }
+
+    @Test("headers reach the connection request — the bearer-auth seam")
+    func headersPassThrough() async {
+        let fake = FakeWebSocket()
+        let socket = AttachSocket(
+            url: attachURL,
+            headers: ["Authorization": "Bearer token-1"],
+            transport: fake.transport()
+        )
+        let log = EventLog()
+        log.observe(await socket.start())
+
+        #expect(fake.request?.value(forHTTPHeaderField: "Authorization") == "Bearer token-1")
+        await socket.close()
+        log.cancel()
     }
 
     @Test("close() sends the protocol's detach close")

--- a/packages/ATCKit/Tests/ATCAppServerTransportTests/ResourceEventStreamTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerTransportTests/ResourceEventStreamTests.swift
@@ -18,8 +18,10 @@ private final class ScriptedConnector: @unchecked Sendable {
     private let lock = NSLock()
     private var script: [Connection]
     private var recordedAttempts = 0
+    private var recordedHeaders: [String: String] = [:]
 
     var attempts: Int { lock.withLock { recordedAttempts } }
+    var headers: [String: String] { lock.withLock { recordedHeaders } }
 
     init(_ script: [Connection]) {
         self.script = script
@@ -33,7 +35,8 @@ private final class ScriptedConnector: @unchecked Sendable {
     }
 
     func connect() -> ResourceEventStream.Connector {
-        { _, _ in
+        { _, headers in
+            self.lock.withLock { self.recordedHeaders = headers }
             switch self.next() {
             case .failure:
                 throw URLError(.cannotConnectToHost)
@@ -153,6 +156,21 @@ struct ResourceEventStreamTests {
         // reached the opening comment.
         #expect(events == [.connected])
         #expect(connector.attempts == 3)
+    }
+
+    @Test("headers reach the connector — the bearer-auth seam")
+    func headersPassThrough() async {
+        let connector = ScriptedConnector([.stream([": connected\n\n"], thenHang: true)])
+        let stream = ResourceEventStream.stream(
+            url: eventsURL,
+            headers: ["Authorization": "Bearer token-1"],
+            configuration: fastConfiguration(),
+            connector: connector.connect()
+        )
+
+        _ = await collect(stream, count: 1)
+
+        #expect(connector.headers == ["Authorization": "Bearer token-1"])
     }
 
     @Test("heartbeats keep the stream alive without surfacing events")

--- a/server/mise.toml
+++ b/server/mise.toml
@@ -23,10 +23,9 @@ run = [
   "go build -o dist/atc ./cmd/atc",
 ]
 
-[tasks.install]
-description = "Build and install atc locally (default: ~/.local/bin/atc)"
-depends = ["build"]
-run = 'mkdir -p "${ATC_INSTALL_DIR:-$HOME/.local/bin}" && install -m 0755 dist/atc "${ATC_INSTALL_DIR:-$HOME/.local/bin}/atc"'
+# No install task here: `atc` on a developer's PATH is the App Server
+# (root `mise run install`). This legacy tree still builds into dist/ for
+# its own tests but must never be installed over the real binary.
 
 [tasks.test]
 description = "Run Go tests"


### PR DESCRIPTION
Third PR of the [ATC-125](https://linear.app/elevenideas/issue/ATC-125/migration-of-the-macos-application) stack ([ATC-146](https://linear.app/elevenideas/issue/ATC-146)), stacked on #142. Merge order: #141 → #142 → this, retargeting each to `main` as its base merges.

## What

- **Toolbar exceptional-state surface** (the design's third toolbar element): a needs-input label for the displayed thread and a `<connection> unreachable` warning while cached content is shown. Healthy states show nothing; `unknown` at launch never flashes a warning. The warning copy claims only what `canMutate` actually gates — an open terminal's attach socket is deliberately independent and keeps working.
- **Accessibility**: `StatusDot` now takes `Reachability` directly and derives both color and spoken description (color-only state eliminated at every dot); the sidebar's thread filter announces its selection.
- **Server fix found by the e2e pass**: `BunHttpServer` now sets `idleTimeout: 60` — Bun's 10 s default counts a request that hasn't written response bytes as idle, which severed `openThreadTerminal` mid-materialization (a cold provider launch legitimately runs up to the 30 s identity timeout).

## End-to-end verification

Headless transport e2e against a **real** local App Server (real zmx, real Claude Code TUI), exercising the exact ATCKit seams the app runs on — **15/15 PASS**: contract ops (health, lists, server-backed pins, archived collection), SSE connected-signal-then-events discipline with thread invalidation, idempotent `openThreadTerminal`, attach WebSocket with real TUI paint bytes (2.8 KB), resize, deliberate detach (session survives), reattach leader repaint (3.9 KB), archive-clears-pin, unarchive, and thread deletion killing the linked terminal. The failed-open cleanup path was also observed live: a codex open that timed out left no orphaned terminal or zmx session.

**Visual acceptance**: the screenshot-verified UI pass could not run — the machine's screen was locked for the entire implementation window, so no window server access. All 208 app tests + the full `mise run check` gate are green, and Jeremy is final acceptance per the plan; the seeded-server recipe used here (isolated `XDG_STATE_HOME`/`ATC_PORT=7399` server + seeded connection) is reproducible for that pass.

Adversarial reviews (correctness + simplicity) ran; findings folded in: StatusDot/label consolidation, warning-copy accuracy, documented toolbar color choice.

https://claude.ai/code/session_01336PDxLnsF6jXJ8w8uJiQc