### PR TITLE
ATC-147: background service management — atc start / stop / status (ATC-125 PR ④)

### DIFF
--- a/app-server/src/agents/codexServer.ts
+++ b/app-server/src/agents/codexServer.ts
@@ -166,28 +166,10 @@ export const layerWith = (options: CodexServerOptions) =>
 
       /**
        * Whether `pid` still looks like the app-server we recorded. Guards
-       * every adoption and every signal against pid recycling. The check is
-       * for an exact `app-server` argv token (a substring would match any
-       * command whose path merely contains "app-server"). `ps` exits
-       * non-zero for a missing pid, which lands in the not-ours branch.
+       * every adoption and every signal against pid recycling.
        */
       const isOurServer = (pid: number) =>
-        Effect.scoped(
-          Effect.gen(function* () {
-            const ps = yield* subprocess.spawn({
-              executable: "ps",
-              args: ["-p", String(pid), "-o", "command="],
-              env: {},
-              extendEnv: true,
-            })
-            const lines = yield* Stream.runCollect(ps.stdoutLines)
-            yield* ps.exitCode
-            return lines
-              .join(" ")
-              .split(/\s+/)
-              .some((token) => token === "app-server")
-          }),
-        ).pipe(Effect.orElseSucceed(() => false))
+        Subprocess.processHasArgvToken(subprocess, pid, "app-server")
 
       /** Terminate `pid` only if it is provably still our server. */
       const terminateOurs = (pid: number) =>

--- a/app-server/src/cli/cli.ts
+++ b/app-server/src/cli/cli.ts
@@ -28,6 +28,15 @@ export const failReported = (message: string) => {
   return Console.error(line).pipe(Effect.andThen(Effect.fail(new ReportedError({ message: line }))))
 }
 
+/** The catch tail for wrappers: an already-reported failure passes through
+ * unchanged; anything else becomes the one-line diagnostic. */
+export const reportOnce =
+  (prefix: string) =>
+  (error: unknown): Effect.Effect<never, ReportedError> =>
+    error instanceof ReportedError
+      ? Effect.fail(error)
+      : failReported(`${prefix}: ${describeError(error)}`)
+
 // Contract error classes carry human messages (contract.ts); the String fallback
 // covers any Error subclass whose message is empty.
 export const describeError = (error: unknown): string =>
@@ -61,7 +70,7 @@ export const withCliContext = <E>(
 ): Effect.Effect<void, ReportedError, FileSystem.FileSystem> =>
   effect.pipe(
     Effect.provide([BunHttpClient.layer, appConfigLayer]),
-    Effect.catch((error) => failReported(`atc ${diagnosticName}: ${describeError(error)}`)),
+    Effect.catch(reportOnce(`atc ${diagnosticName}`)),
   )
 
 /**

--- a/app-server/src/cli/serve.ts
+++ b/app-server/src/cli/serve.ts
@@ -1,12 +1,25 @@
-import { Effect, Layer, Option, Schema } from "effect"
+import { Console, Effect, FileSystem, Layer, Option, Schema } from "effect"
 import { Command, Flag } from "effect/unstable/cli"
 import { BuildInfo } from "../platform/buildInfo.ts"
 import { AppConfig, layer as appConfigLayer } from "../platform/config.ts"
+import {
+  isProcessAlive,
+  processHasArgvToken,
+  Subprocess,
+  waitForProcessExit,
+} from "../platform/subprocess.ts"
 import * as Server from "../server.ts"
 import * as Cli from "./cli.ts"
 
-// The serve command: settle configuration, then launch the closed production
-// assembly (server.ts). The CLI carries zero domain-layer imports.
+// Running the service: `serve` is the foreground primitive (what a
+// supervisor owns, and what `start` spawns); `start`/`stop`/`status` are the
+// background management porcelain over one pidfile in the state directory.
+// The CLI carries zero domain-layer imports.
+//
+// Liveness discipline: the pidfile records intent, never truth. Every
+// consumer re-verifies against the live process table (and, before
+// signaling, that the pid still looks like our server — pids get recycled),
+// and stale files are removed on sight rather than trusted.
 
 /** The one reusable port contract for CLI (and config/API) inputs. */
 export const Port = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 65535 }))
@@ -56,7 +69,7 @@ export const serve = Command.make("serve", { port }, ({ port }) =>
     )
   }).pipe(
     Effect.provide(appConfigLayer),
-    Effect.catch((error) => Cli.failReported(`atc serve: ${Cli.describeError(error)}`)),
+    Effect.catch(Cli.reportOnce("atc serve")),
     Effect.catchDefect((defect) =>
       isSystemError(defect) || isMigrationError(defect)
         ? Cli.failReported(`atc serve: ${defect.message}`)
@@ -64,3 +77,183 @@ export const serve = Command.make("serve", { port }, ({ port }) =>
     ),
   ),
 ).pipe(Command.withDescription("Run the App Server in the foreground until interrupted"))
+
+// --- Background management ---
+
+/** Pidfile contents: which process, and which port it was started on. */
+const PidRecord = Schema.Struct({ pid: Schema.Int, port: Schema.Int })
+const decodePidRecord = Schema.decodeEffect(Schema.fromJsonString(PidRecord))
+const encodePidRecord = Schema.encodeEffect(Schema.fromJsonString(PidRecord))
+
+/** A missing or unreadable pidfile is "not running", never an error. */
+const readPidRecord = (fs: FileSystem.FileSystem, file: string) =>
+  fs.readFileString(file).pipe(
+    Effect.flatMap(decodePidRecord),
+    Effect.catch(() => Effect.succeed(undefined)),
+  )
+
+/** One bounded health probe; false on any failure. */
+const probeHealth = (port: number, timeoutMillis: number) =>
+  Effect.tryPromise(() =>
+    fetch(`http://127.0.0.1:${port}/api/v1/health`, {
+      signal: AbortSignal.timeout(timeoutMillis),
+    }),
+  ).pipe(
+    Effect.map((response) => response.ok),
+    Effect.catch(() => Effect.succeed(false)),
+  )
+
+/** Polls `check` until true or the deadline lapses. */
+const pollUntil = (deadlineMillis: number, intervalMillis: number, check: Effect.Effect<boolean>) =>
+  Effect.gen(function* () {
+    const attempts = Math.ceil(deadlineMillis / intervalMillis)
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      if (yield* check) return true
+      yield* Effect.sleep(intervalMillis)
+    }
+    return yield* check
+  })
+
+const signal = (pid: number, name: "SIGTERM" | "SIGKILL") =>
+  Effect.sync(() => {
+    // A process that exits between the liveness check and the signal is
+    // simply already stopped.
+    try {
+      process.kill(pid, name)
+    } catch {
+      // ignored
+    }
+  })
+
+/** Shared command tail: settled config plus the one-line diagnostic.
+ * Failures the body already reported pass through unchanged. */
+const serviceCommand = (name: string) => {
+  return <E>(
+    effect: Effect.Effect<void, E, AppConfig | FileSystem.FileSystem | Subprocess | BuildInfo>,
+  ) => effect.pipe(Effect.provide(appConfigLayer), Effect.catch(Cli.reportOnce(`atc ${name}`)))
+}
+
+export const start = Command.make("start", { port }, ({ port }) =>
+  Effect.gen(function* () {
+    const config = yield* AppConfig
+    const effective = { ...config, port: Option.getOrElse(port, () => config.port) }
+    const fs = yield* FileSystem.FileSystem
+    const subprocess = yield* Subprocess
+    const existing = yield* readPidRecord(fs, effective.pidFile)
+    if (existing !== undefined && isProcessAlive(existing.pid)) {
+      yield* Console.log(
+        `atc app server already running (pid ${existing.pid}) on http://127.0.0.1:${existing.port}`,
+      )
+      return
+    }
+    // A healthy responder without a live pidfile is a foreground serve or
+    // someone else's instance; a second server would only fail its bind
+    // after the fact and this start would then claim the wrong process.
+    if (yield* probeHealth(effective.port, 1_000)) {
+      return yield* Cli.failReported(
+        `atc start: something is already serving on port ${effective.port} (a foreground \`atc serve\`?); stop it or pass --port`,
+      )
+    }
+    // Spawn ourselves: the compiled binary is process.execPath alone; a
+    // source run is the bun runtime plus the entry script (argv[1]),
+    // resolved against this same working directory.
+    const build = yield* BuildInfo
+    const serveArgs = ["serve", "--port", String(effective.port)]
+    const pid = yield* subprocess.spawnDetached(
+      build.commit === "dev"
+        ? { executable: process.execPath, args: [process.argv[1] ?? "src/main.ts", ...serveArgs] }
+        : { executable: process.execPath, args: serveArgs },
+    )
+    yield* fs.makeDirectory(config.stateDir, { recursive: true })
+    yield* encodePidRecord({ pid, port: effective.port }).pipe(
+      Effect.flatMap((json) => fs.writeFileString(effective.pidFile, json)),
+    )
+    const healthy = yield* pollUntil(15_000, 150, probeHealth(effective.port, 1_000))
+    if (!healthy) {
+      // Success is only ever reported for a healthy server, so the spawned
+      // child is stopped rather than left as an orphan no `stop` can reach.
+      yield* signal(pid, "SIGTERM")
+      yield* waitForProcessExit(pid, { attempts: 50, interval: "100 millis" })
+      // Concurrent starts are not serialized; remove the pidfile only while
+      // it still records OUR child, so a racing start's healthy server is
+      // never made invisible by this cleanup.
+      const current = yield* readPidRecord(fs, effective.pidFile)
+      if (current?.pid === pid) {
+        yield* fs.remove(effective.pidFile).pipe(Effect.ignore)
+      }
+      return yield* Cli.failReported(
+        `atc start: the server did not become healthy within 15s (stopped pid ${pid}); logs: ${effective.logFile}`,
+      )
+    }
+    yield* Console.log(
+      `started atc app server (pid ${pid}) on http://127.0.0.1:${effective.port} (logs: ${effective.logFile})`,
+    )
+  }).pipe(serviceCommand("start")),
+).pipe(Command.withDescription("Start the App Server in the background"))
+
+export const stop = Command.make("stop", {}, () =>
+  Effect.gen(function* () {
+    const config = yield* AppConfig
+    const fs = yield* FileSystem.FileSystem
+    const record = yield* readPidRecord(fs, config.pidFile)
+    if (record === undefined) {
+      yield* Console.log("atc app server is not running")
+      return
+    }
+    if (!isProcessAlive(record.pid)) {
+      yield* fs.remove(config.pidFile).pipe(Effect.ignore)
+      yield* Console.log("atc app server is not running (removed a stale pidfile)")
+      return
+    }
+    // Pids get recycled: never signal a process that no longer looks like
+    // our server (`serve` is an exact argv token in both the compiled and
+    // source forms; an unverifiable pid is never signaled).
+    const subprocess = yield* Subprocess
+    const looksLikeOurs = yield* processHasArgvToken(subprocess, record.pid, "serve")
+    if (!looksLikeOurs) {
+      yield* fs.remove(config.pidFile).pipe(Effect.ignore)
+      return yield* Cli.failReported(
+        `atc stop: pid ${record.pid} no longer looks like the atc server; removed the stale pidfile without signaling it`,
+      )
+    }
+    yield* signal(record.pid, "SIGTERM")
+    const exited = yield* waitForProcessExit(record.pid, {
+      attempts: 100,
+      interval: "100 millis",
+    })
+    if (!exited) {
+      yield* signal(record.pid, "SIGKILL")
+      const killed = yield* waitForProcessExit(record.pid, {
+        attempts: 20,
+        interval: "100 millis",
+      })
+      if (!killed) {
+        // Still alive even after SIGKILL (unkillable state): the pidfile
+        // still tells the truth, so it stays.
+        return yield* Cli.failReported(
+          `atc stop: pid ${record.pid} did not exit even after SIGKILL`,
+        )
+      }
+    }
+    yield* fs.remove(config.pidFile).pipe(Effect.ignore)
+    yield* Console.log(`stopped atc app server (pid ${record.pid})`)
+  }).pipe(serviceCommand("stop")),
+).pipe(Command.withDescription("Stop the background App Server"))
+
+export const status = Command.make("status", {}, () =>
+  Effect.gen(function* () {
+    const config = yield* AppConfig
+    const fs = yield* FileSystem.FileSystem
+    const record = yield* readPidRecord(fs, config.pidFile)
+    if (record === undefined || !isProcessAlive(record.pid)) {
+      return yield* Cli.failReported("atc status: not running")
+    }
+    const healthy = yield* probeHealth(record.port, 2_000)
+    if (!healthy) {
+      return yield* Cli.failReported(
+        `atc status: running (pid ${record.pid}) but not answering on http://127.0.0.1:${record.port}; logs: ${config.logFile}`,
+      )
+    }
+    yield* Console.log(`running (pid ${record.pid}) on http://127.0.0.1:${record.port}`)
+  }).pipe(serviceCommand("status")),
+).pipe(Command.withDescription("Report background App Server status"))

--- a/app-server/src/main.ts
+++ b/app-server/src/main.ts
@@ -5,7 +5,7 @@ import * as BuildInfo from "./platform/buildInfo.ts"
 import { fs, health, version } from "./cli/cli.ts"
 import { api, capabilities, context } from "./cli/gateway.ts"
 import { project } from "./cli/projects.ts"
-import { serve } from "./cli/serve.ts"
+import { serve, start, status, stop } from "./cli/serve.ts"
 import { terminal } from "./cli/terminals.ts"
 import { thread } from "./cli/threads.ts"
 import { smoke } from "./agents/smoke.ts"
@@ -18,6 +18,9 @@ const atc = Command.make("atc").pipe(
   Command.withDescription("ATC App Server"),
   Command.withSubcommands([
     serve,
+    start,
+    stop,
+    status,
     api,
     context,
     capabilities,

--- a/app-server/src/platform/config.ts
+++ b/app-server/src/platform/config.ts
@@ -77,6 +77,8 @@ export class AppConfig extends Context.Service<
     readonly dbFile: string
     /** Structured JSON log file path. */
     readonly logFile: string
+    /** Background-service pidfile path (written by `atc start`). */
+    readonly pidFile: string
     /** zmx executable: an absolute path, or a name resolved on PATH. */
     readonly zmxExecutable: string
     /** Codex CLI executable: an absolute path, or a name resolved on PATH. */
@@ -302,6 +304,7 @@ export const load = (
       stateDir,
       dbFile: path.join(dataDir, "atc.db"),
       logFile: path.join(stateDir, "atc.log"),
+      pidFile: path.join(stateDir, "atc.pid"),
       zmxExecutable: settings.zmxExecutable,
       codexExecutable: settings.codexExecutable,
       claudeExecutable: settings.claudeExecutable,

--- a/app-server/src/platform/subprocess.ts
+++ b/app-server/src/platform/subprocess.ts
@@ -11,6 +11,7 @@ import {
   Stream,
 } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+import { spawn as nodeSpawn } from "node:child_process"
 
 // The generic subprocess seam: how the App Server launches and supervises
 // child processes. Children are acquired in Scopes, so closing the scope —
@@ -116,6 +117,16 @@ export class Subprocess extends Context.Service<
      * escalating to SIGKILL) and releases the PTY.
      */
     readonly spawnPty: (spec: PtySpawnSpec) => Effect.Effect<PtyChild, SubprocessError, Scope.Scope>
+    /**
+     * The one deliberate exception to scope ownership: spawn a child meant
+     * to OUTLIVE this process (`atc start`'s background server). Detached
+     * session, stdio ignored, environment inherited; returns the pid. The
+     * caller owns liveness from here — nothing supervises the child.
+     */
+    readonly spawnDetached: (spec: {
+      readonly executable: string
+      readonly args?: ReadonlyArray<string>
+    }) => Effect.Effect<number, SubprocessError>
   }
 >()("app-server/Subprocess") {}
 
@@ -138,6 +149,36 @@ export const isProcessAlive = (pid: number): boolean => {
     return false
   }
 }
+
+/**
+ * Whether `pid`'s argv contains `token` as an exact whitespace-delimited
+ * word — the one pid-recycling guard used before signaling any process we
+ * only know by number. A substring would match any command whose path
+ * merely contains the token. `ps` exits non-zero for a missing pid, and any
+ * failure lands in the false branch: an unverifiable pid is never signaled.
+ */
+export const processHasArgvToken = (
+  subprocess: Subprocess["Service"],
+  pid: number,
+  token: string,
+): Effect.Effect<boolean> =>
+  Effect.gen(function* () {
+    const ps = yield* subprocess.spawn({
+      executable: "ps",
+      args: ["-p", String(pid), "-o", "command="],
+      env: {},
+      extendEnv: true,
+    })
+    const lines = yield* Stream.runCollect(ps.stdoutLines)
+    yield* ps.exitCode
+    return lines
+      .join(" ")
+      .split(/\s+/)
+      .some((word) => word === token)
+  }).pipe(
+    Effect.scoped,
+    Effect.orElseSucceed(() => false),
+  )
 
 /**
  * Poll until `pid` is gone; resolves to whether it exited within the window.
@@ -380,9 +421,42 @@ const spawnPty = Effect.fnUntraced(function* (spec: PtySpawnSpec) {
   return child
 })
 
+// node:child_process rather than Bun.spawn: only it offers `detached`
+// (its own session, immune to the parent's terminal lifetime). Spawn
+// failures for a bad executable surface on the child's async error event,
+// not as a throw — the caller's bounded health wait is what detects a
+// child that died immediately.
+const spawnDetached = (spec: {
+  readonly executable: string
+  readonly args?: ReadonlyArray<string>
+}) =>
+  Effect.try({
+    try: () => {
+      const child = nodeSpawn(spec.executable, [...(spec.args ?? [])], {
+        detached: true,
+        stdio: "ignore",
+      })
+      // An EventEmitter with no error listener re-throws asynchronously and
+      // would crash this process; the missing-pid check below is the actual
+      // fast-fail, and anything later is the caller's bounded-wait problem.
+      child.on("error", () => {})
+      if (child.pid === undefined) {
+        throw new Error("the child reported no pid")
+      }
+      child.unref()
+      return child.pid
+    },
+    catch: (error) =>
+      new SubprocessError({
+        executable: spec.executable,
+        operation: "spawn",
+        message: error instanceof Error ? error.message : String(error),
+      }),
+  })
+
 export const layer = Layer.effect(Subprocess)(
   Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
-    return { spawn: (spec) => spawn(spawner, spec), spawnPty }
+    return { spawn: (spec) => spawn(spawner, spec), spawnPty, spawnDetached }
   }),
 )

--- a/app-server/test/cli/service.blackbox.test.ts
+++ b/app-server/test/cli/service.blackbox.test.ts
@@ -1,0 +1,122 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll, describe, expect, test } from "vitest"
+import {
+  appServerRoot,
+  cleanupTempDirs,
+  freePort,
+  isolatedEnv,
+  runCli,
+  waitUntil,
+} from "../blackbox.ts"
+import { makeFakeZmxSandbox } from "../testLayers.ts"
+
+// Black-box lifecycle of the background service commands: `atc start` spawns
+// a detached `atc serve` and owns the pidfile; `status` and `stop` re-verify
+// liveness rather than trusting it. Spawned from source, so the detached
+// child is `bun src/main.ts serve` resolved against the repo cwd.
+
+const scratch = mkdtempSync(join(tmpdir(), "atc-service-blackbox-"))
+const startedPids: Array<number> = []
+
+afterAll(() => {
+  // A failed assertion must not leak a detached server; these pids came from
+  // pidfiles inside this suite's isolated state dir, so they are ours.
+  for (const pid of startedPids) {
+    try {
+      process.kill(pid, "SIGKILL")
+    } catch {
+      // already gone
+    }
+  }
+  rmSync(scratch, { recursive: true, force: true })
+  cleanupTempDirs()
+})
+
+const sandbox = makeFakeZmxSandbox()
+const env = isolatedEnv(scratch, { ATC_ZMX_EXECUTABLE: sandbox.wrapper })
+const pidFile = join(env.XDG_STATE_HOME, "atc", "atc.pid")
+const cli = (...args: Array<string>) =>
+  runCli([process.execPath, "src/main.ts"], args, appServerRoot, env)
+
+const isAlive = (pid: number) => {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+describe("atc start / stop / status (black box)", () => {
+  test("the full lifecycle: start, verify, idempotent start, stop, verify", async () => {
+    const port = await freePort()
+
+    // Nothing running yet.
+    const idle = await cli("status")
+    expect(idle.exitCode).not.toBe(0)
+    expect(idle.stderr).toContain("not running")
+
+    const started = await cli("start", "--port", String(port))
+    expect(started.stderr).toBe("")
+    expect(started.exitCode).toBe(0)
+    expect(started.stdout).toContain(`started atc app server`)
+    expect(started.stdout).toContain(`http://127.0.0.1:${port}`)
+
+    const record = JSON.parse(readFileSync(pidFile, "utf8")) as { pid: number; port: number }
+    startedPids.push(record.pid)
+    expect(record.port).toBe(port)
+    expect(isAlive(record.pid)).toBe(true)
+
+    // start already waited for health; the endpoint answers immediately.
+    const health = await fetch(`http://127.0.0.1:${port}/api/v1/health`)
+    expect(health.status).toBe(200)
+
+    const again = await cli("start", "--port", String(port))
+    expect(again.exitCode).toBe(0)
+    expect(again.stdout).toContain(`already running (pid ${record.pid})`)
+
+    const running = await cli("status")
+    expect(running.exitCode).toBe(0)
+    expect(running.stdout).toContain(`running (pid ${record.pid})`)
+
+    const stopped = await cli("stop")
+    expect(stopped.exitCode).toBe(0)
+    expect(stopped.stdout).toContain(`stopped atc app server (pid ${record.pid})`)
+    await waitUntil(() => !isAlive(record.pid), "the stopped server to exit")
+    expect(existsSync(pidFile)).toBe(false)
+
+    const gone = await cli("status")
+    expect(gone.exitCode).not.toBe(0)
+    expect(gone.stderr).toContain("not running")
+
+    // stop is idempotent.
+    const stopAgain = await cli("stop")
+    expect(stopAgain.exitCode).toBe(0)
+    expect(stopAgain.stdout).toContain("not running")
+  }, 60_000)
+
+  test("a stale pidfile is replaced by start and reported by status", async () => {
+    // A pid that existed and is certainly gone now. The pidfile's parent
+    // exists regardless of test order.
+    const shortLived = Bun.spawn(["sh", "-c", "exit 0"])
+    await shortLived.exited
+    mkdirSync(join(env.XDG_STATE_HOME, "atc"), { recursive: true })
+    writeFileSync(pidFile, JSON.stringify({ pid: shortLived.pid, port: 1 }))
+
+    const stale = await cli("status")
+    expect(stale.exitCode).not.toBe(0)
+    expect(stale.stderr).toContain("not running")
+
+    const port = await freePort()
+    const started = await cli("start", "--port", String(port))
+    expect(started.exitCode).toBe(0)
+    const record = JSON.parse(readFileSync(pidFile, "utf8")) as { pid: number; port: number }
+    startedPids.push(record.pid)
+    expect(record.pid).not.toBe(shortLived.pid)
+
+    const stopped = await cli("stop")
+    expect(stopped.exitCode).toBe(0)
+  }, 60_000)
+})

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -59,6 +59,7 @@ export const testAppConfig = (overrides: Partial<AppConfig["Service"]>): Layer.L
     stateDir: "/tmp",
     dbFile: "/tmp/atc.db",
     logFile: "/tmp/atc.log",
+    pidFile: "/tmp/atc.pid",
     zmxExecutable: "zmx",
     codexExecutable: "codex",
     claudeExecutable: "claude",


### PR DESCRIPTION
Fourth PR of the [ATC-125](https://linear.app/elevenideas/issue/ATC-125/migration-of-the-macos-application) stack ([ATC-147](https://linear.app/elevenideas/issue/ATC-147)), stacked on #143. Decided during acceptance: `atc serve` stays the foreground primitive (what launchd/supervisors need, and what `start` spawns); the day-to-day background porcelain returns as first-class commands, the shape the legacy Go CLI had.

## What

- **`atc start`** — settles config (same `--port` flag as serve), refuses when a live pidfile or a healthy responder already owns the port, spawns `atc serve` detached via the new `Subprocess.spawnDetached` (the one documented exception to the service's scope-owned children), writes a pidfile in the state directory, and reports success only after the health endpoint answers. A start that times out stops its own child instead of orphaning it, and its cleanup removes the pidfile only while it still records that child, so racing starts can't blind each other.
- **`atc stop`** — re-verifies liveness against the process table and, before signaling, that the pid still carries an exact `serve` argv token (`Subprocess.processHasArgvToken`, now also used by the codex server manager instead of its own copy — an unverifiable pid is never signaled). SIGTERM with a bounded wait, SIGKILL escalation whose outcome is verified before success is claimed.
- **`atc status`** — pidfile + liveness + health probe on the recorded port; exit 0 only for running-and-healthy.
- All three idempotent; `pidFile` is settled `AppConfig`; the CLI's already-reported failures now pass through wrapper catches once (`reportOnce`), fixing doubled diagnostic prefixes.

## Verification

Blackbox lifecycle suite (source-run): start → health → idempotent start → status → stop → gone, plus stale-pidfile replacement. Compiled-binary lifecycle verified by hand, including the correct refusal when a foreground server owns the port. Full `mise run check` green (254 app-server tests; macOS + kit suites unaffected).

Adversarial reviews (correctness + simplicity) ran; all confirmed findings fixed: the substring pid-identity regression (now shared exact-token helper), doubled diagnostics, unverified SIGKILL success, the missing `error` listener on detached spawns (async ENOENT would have crashed the CLI), the orphaned-child timeout path, and guarded pidfile cleanup under concurrent starts.

https://claude.ai/code/session_01336PDxLnsF6jXJ8w8uJiQc