### PR TITLE
codex TUI launch: pass --cd so identity capture can match

### DIFF
--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -758,7 +758,14 @@ export const layer = Layer.effect(CodexAdapter)(
             }),
           )
           return {
-            launchSpec: { command: [executable, "--remote", info.url], env: {} },
+            // --cd is load-bearing: in --remote mode the TUI does not forward
+            // its own working directory, so without it the app-server stamps
+            // the new thread with ITS process cwd and the capture's cwd match
+            // below can never adopt the thread (observed on codex 0.146.0).
+            launchSpec: {
+              command: [executable, "--cd", options.cwd, "--remote", info.url],
+              env: {},
+            },
             identity: Deferred.await(gate),
           }
         }),

--- a/app-server/src/agents/codexServer.ts
+++ b/app-server/src/agents/codexServer.ts
@@ -266,6 +266,11 @@ export const layerWith = (options: CodexServerOptions) =>
               env: {},
               // The server needs the user's full environment (auth state).
               extendEnv: true,
+              // A fixed, neutral cwd: the detached server outlives ATC, and
+              // codex uses the server's cwd as the default for threads whose
+              // client did not send one — an inherited launch cwd would leak
+              // into those threads (and pin a project directory open).
+              cwd: config.stateDir,
             })
             const lines = yield* Stream.runCollect(child.stdoutLines)
             yield* child.exitCode

--- a/app-server/test/agents/codexAdapter.test.ts
+++ b/app-server/test/agents/codexAdapter.test.ts
@@ -426,8 +426,11 @@ describe("CodexAdapter TUI session plumbing", () => {
             Effect.gen(function* () {
               const prepared = yield* adapter.prepareTuiSession({ cwd: sandbox.cwd })
               assert.strictEqual(prepared.launchSpec.command[0], sandbox.wrapper)
-              assert.strictEqual(prepared.launchSpec.command[1], "--remote")
-              const url = prepared.launchSpec.command[2] ?? ""
+              // --cd pins the thread's cwd server-side: the remote TUI does
+              // not forward its own working directory (codex 0.146.0).
+              assert.deepStrictEqual(prepared.launchSpec.command.slice(1, 3), ["--cd", sandbox.cwd])
+              assert.strictEqual(prepared.launchSpec.command[3], "--remote")
+              const url = prepared.launchSpec.command[4] ?? ""
               assert.match(url, /^ws:\/\/127\.0\.0\.1:\d+$/)
 
               // The launched TUI stand-in bootstraps a thread in the cwd.
@@ -454,7 +457,7 @@ describe("CodexAdapter TUI session plumbing", () => {
           Effect.scoped(
             Effect.gen(function* () {
               const prepared = yield* adapter.prepareTuiSession({ cwd: sandbox.cwd })
-              const url = prepared.launchSpec.command[2] ?? ""
+              const url = prepared.launchSpec.command[4] ?? ""
               const external = yield* openExternal(url)
               // Another client's thread in a different cwd is not ours.
               const foreignId = yield* startExternalThread(external, 1, otherCwd)


### PR DESCRIPTION
In --remote mode the codex TUI (0.146.0) does not forward its working directory, so the shared app-server stamped every fresh TUI thread with its own process cwd. `prepareTuiSession`'s cwd-matched thread/started capture could then never adopt the thread: every codex `openTerminal` timed out at 30s and 503'd.

Pass `--cd` explicitly, and spawn the detached app-server with a fixed neutral cwd (`stateDir`) so an inherited launch directory can't leak into threads whose client sends no cwd.

https://claude.ai/code/session_01336PDxLnsF6jXJ8w8uJiQc