### PR TITLE
macOS sidebar: align navigation with approved design

### DIFF
--- a/macos/ATC/AppServer/ServerModels.swift
+++ b/macos/ATC/AppServer/ServerModels.swift
@@ -5,6 +5,7 @@
 
 import ATCAppServerAPI
 import Foundation
+import SwiftUI
 
 typealias ATCThread = Components.Schemas.Thread
 typealias Project = Components.Schemas.Project
@@ -40,6 +41,28 @@ extension ATCThread {
 
     var isArchived: Bool { archivedAt != nil }
     var isPinned: Bool { pinnedAt != nil }
+}
+
+extension ThreadActivityState {
+    /// Card status text per the design comps; `unknown` is deliberately
+    /// unlabeled. The wording differs per state so color is never the only
+    /// signal.
+    var statusLabel: String? {
+        switch self {
+        case .working: "Running"
+        case .needsInput: "Needs you"
+        case .idle: "Idle"
+        case .unknown: nil
+        }
+    }
+
+    var statusColor: Color {
+        switch self {
+        case .working: .green
+        case .needsInput: .orange
+        case .idle, .unknown: .secondary
+        }
+    }
 }
 
 extension Terminal {

--- a/macos/ATC/Features/Threads/ThreadListModel.swift
+++ b/macos/ATC/Features/Threads/ThreadListModel.swift
@@ -24,7 +24,21 @@ struct ThreadListItem: Identifiable, Equatable {
     /// default — an identical path is noise on every card.
     let distinctWorkingDirectory: String?
 
-    var id: ThreadRef { ref }
+    /// Row identity is section-scoped, not the bare `ThreadRef`. The pinned,
+    /// recent, and archived sections are sibling `ForEach`es inside one
+    /// `LazyVStack`, whose item cache is keyed by id across the whole stack:
+    /// with a ref-only id, pin/unpin/archive reads as a *move* of one row
+    /// between sections and the lazy layout keeps serving the stale cached
+    /// view — a card that neither updates nor responds until relaunch.
+    /// Folding the section-determining flags into the id turns those
+    /// transitions into remove-plus-insert of distinct rows.
+    struct ID: Hashable {
+        let ref: ThreadRef
+        let isPinned: Bool
+        let isArchived: Bool
+    }
+
+    var id: ID { ID(ref: ref, isPinned: thread.isPinned, isArchived: thread.isArchived) }
 }
 
 /// One project as the filter menu and the New Thread picker present it.

--- a/macos/ATC/Features/Threads/ThreadListModel.swift
+++ b/macos/ATC/Features/Threads/ThreadListModel.swift
@@ -18,6 +18,8 @@ struct ThreadListItem: Identifiable, Equatable {
     let thread: ATCThread
     /// Project name, suffixed with the Connection name when ambiguous.
     let projectLabel: String
+    /// The Connection's display name, shown on every card per the design.
+    let connectionName: String
     /// Working directory, present only when it differs from the Project's
     /// default — an identical path is noise on every card.
     let distinctWorkingDirectory: String?
@@ -82,13 +84,14 @@ struct ThreadListModel {
         }
         projects = options
 
-        func item(_ thread: ATCThread, connectionID: UUID) -> ThreadListItem {
-            let projectRef = ProjectRef(connectionID: connectionID, projectID: thread.projectId)
+        func item(_ thread: ATCThread, input: ConnectionInput) -> ThreadListItem {
+            let projectRef = ProjectRef(connectionID: input.connectionID, projectID: thread.projectId)
             let project = projectsByRef[projectRef]
             return ThreadListItem(
-                ref: ThreadRef(connectionID: connectionID, threadID: thread.id),
+                ref: ThreadRef(connectionID: input.connectionID, threadID: thread.id),
                 thread: thread,
                 projectLabel: labelsByRef[projectRef] ?? "Unknown Project",
+                connectionName: input.connectionName,
                 distinctWorkingDirectory: thread.workingDirectory == project?.defaultWorkingDirectory
                     ? nil
                     : thread.workingDirectory
@@ -101,16 +104,16 @@ struct ThreadListModel {
         for input in inputs {
             for thread in input.threads where !thread.isArchived {
                 if thread.isPinned {
-                    pinnedItems.append(item(thread, connectionID: input.connectionID))
+                    pinnedItems.append(item(thread, input: input))
                     continue
                 }
                 guard Self.matches(thread, connectionID: input.connectionID, filter: filter) else {
                     continue
                 }
-                recentItems.append(item(thread, connectionID: input.connectionID))
+                recentItems.append(item(thread, input: input))
             }
             for thread in input.archivedThreads {
-                archivedItems.append(item(thread, connectionID: input.connectionID))
+                archivedItems.append(item(thread, input: input))
             }
         }
 

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -119,7 +119,6 @@ struct NavigatorSidebar: View {
             ) {
                 windowState.presentNewThread(in: appModel)
             }
-            .padding(.trailing, NavigatorMetrics.contentHorizontalPadding)
         }
         .navigatorListRow(top: Spacing.sm, bottom: Spacing.sm)
     }
@@ -148,9 +147,9 @@ struct NavigatorSidebar: View {
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                 }
-                .padding(.horizontal, Spacing.sm)
+                .padding(.horizontal, Spacing.md)
                 .frame(maxWidth: .infinity, minHeight: NavigatorMetrics.chipSize)
-                .contentShape(RoundedRectangle(cornerRadius: Radius.control, style: .continuous))
+                .contentShape(RoundedRectangle(cornerRadius: Radius.chip, style: .continuous))
             }
             .menuStyle(.borderlessButton)
             .menuIndicator(.hidden)
@@ -166,7 +165,7 @@ struct NavigatorSidebar: View {
                 windowState.isCreateProjectPresented = true
             }
         }
-        .padding(.horizontal, NavigatorMetrics.contentHorizontalPadding)
+        // Flush with the card edges — the chips share the cards' gutter.
         .navigatorListRow(top: Spacing.sm, bottom: Spacing.sm)
     }
 
@@ -196,6 +195,7 @@ struct NavigatorSidebar: View {
         ForEach(limited(items, expanded: isExpanded.wrappedValue)) { item in
             ThreadCard(
                 item: item,
+                reachability: appModel.runtime(id: item.ref.connectionID)?.reachability ?? .unknown,
                 isSelected: windowState.isThreadHighlighted(item.ref),
                 isBusy: inFlightThreads.contains(item.ref),
                 canMutate: appModel.canMutate(connectionID: item.ref.connectionID),
@@ -435,6 +435,7 @@ struct NavigatorSidebar: View {
 /// independently clickable and tabbable when shown.
 private struct ThreadCard: View {
     let item: ThreadListItem
+    let reachability: Reachability
     let isSelected: Bool
     let isBusy: Bool
     let canMutate: Bool
@@ -451,8 +452,8 @@ private struct ThreadCard: View {
     var body: some View {
         let thread = item.thread
         VStack(alignment: .leading, spacing: Spacing.xs) {
-            // Top row: Project name as compact context, actions on the
-            // upper-trailing area per the design.
+            // Top row: Project name as compact context; the trailing area
+            // shows the Connection at rest and the actions on hover/focus.
             HStack(alignment: .center, spacing: Spacing.sm) {
                 Text(item.projectLabel)
                     .font(.caption.weight(.semibold))
@@ -478,28 +479,27 @@ private struct ThreadCard: View {
                         )
                     }
                 } else {
-                    // Reserve the action row's height so the card does not
+                    HStack(spacing: Spacing.xs) {
+                        Text(item.connectionName)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                        StatusDot(reachability: reachability, size: .inline)
+                    }
+                    // Match the action chips' height so the card does not
                     // resize under the pointer.
-                    Color.clear.frame(width: 1, height: NavigatorMetrics.actionSize)
+                    .frame(height: NavigatorMetrics.actionSize)
                 }
             }
 
             // The dominant element.
-            HStack(alignment: .firstTextBaseline, spacing: Spacing.xs) {
-                Text(thread.displayName)
-                    .font(.callout.weight(.medium))
-                    .lineLimit(2)
-                    .multilineTextAlignment(.leading)
-                if thread.activityState == .working {
-                    ProgressView()
-                        .progressViewStyle(.circular)
-                        .controlSize(.mini)
-                        .accessibilityLabel("Working")
-                }
-            }
+            Text(thread.displayName)
+                .font(.body.weight(.medium))
+                .lineLimit(2)
+                .multilineTextAlignment(.leading)
 
             // Bottom metadata row: working directory when it differs from
-            // the Project default; exceptional state and Agent trailing.
+            // the Project default; activity state and Agent trailing.
             HStack(alignment: .center, spacing: Spacing.sm) {
                 if let directory = item.distinctWorkingDirectory {
                     Text(directory)
@@ -509,8 +509,10 @@ private struct ThreadCard: View {
                         .truncationMode(.head)
                 }
                 Spacer(minLength: Spacing.sm)
-                if thread.activityState == .needsInput {
-                    needsInputBadge
+                if let status = thread.activityState.statusLabel {
+                    Text(status)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(thread.activityState.statusColor)
                 }
                 agentBadge
             }
@@ -592,16 +594,6 @@ private struct ThreadCard: View {
         .disabled(!isEnabled)
         .help(help)
         .accessibilityLabel(help)
-    }
-
-    /// Symbol plus text, never color alone — the badge has to read for
-    /// color-blind users and in monochrome accessibility modes. Amber like
-    /// the app's other warnings, per the design.
-    private var needsInputBadge: some View {
-        Label("Needs input", systemImage: "exclamationmark.bubble.fill")
-            .font(.caption.weight(.medium))
-            .labelStyle(.titleAndIcon)
-            .foregroundStyle(.orange)
     }
 
     /// Cards read as bordered containers at rest; selection is the accent

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -125,37 +125,45 @@ struct NavigatorSidebar: View {
 
     private func filterRow(_ model: ThreadListModel) -> some View {
         HStack(spacing: Spacing.sm) {
-            Menu {
-                Button("All Projects") { select(.all) }
-                if !model.projects.isEmpty {
-                    Divider()
-                    ForEach(model.projects) { option in
-                        Button(option.label) { select(.project(option.ref)) }
-                    }
-                }
-                Divider()
-                Button("Archived") { select(.archived) }
-            } label: {
-                HStack(spacing: Spacing.sm) {
-                    Image(systemName: "folder")
-                        .foregroundStyle(.secondary)
-                    Text(filterTitle(model))
-                        .font(.callout.weight(.medium))
-                        .lineLimit(1)
-                    Spacer(minLength: Spacing.xs)
-                    Image(systemName: "chevron.down")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                }
-                .padding(.horizontal, Spacing.md)
-                .frame(maxWidth: .infinity, minHeight: NavigatorMetrics.chipSize)
-                .contentShape(RoundedRectangle(cornerRadius: Radius.chip, style: .continuous))
+            // The bordered dropdown is drawn directly so the box always
+            // spans the available width with the chevron pinned trailing —
+            // a borderless Menu sizes to its label, so the Menu instead
+            // rides on top as a clear, full-size click target.
+            HStack(spacing: Spacing.sm) {
+                Image(systemName: "folder")
+                    .foregroundStyle(.secondary)
+                Text(filterTitle(model))
+                    .font(.callout.weight(.medium))
+                    .lineLimit(1)
+                Spacer(minLength: Spacing.xs)
+                Image(systemName: "chevron.down")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
             }
-            .menuStyle(.borderlessButton)
-            .menuIndicator(.hidden)
+            .padding(.horizontal, Spacing.md)
+            .frame(maxWidth: .infinity, minHeight: NavigatorMetrics.chipSize)
             .navigatorChipSurface()
-            .help("Filter threads")
-            .accessibilityLabel("Thread filter: \(filterTitle(model))")
+            .accessibilityHidden(true)
+            .overlay {
+                Menu {
+                    Button("All Projects") { select(.all) }
+                    if !model.projects.isEmpty {
+                        Divider()
+                        ForEach(model.projects) { option in
+                            Button(option.label) { select(.project(option.ref)) }
+                        }
+                    }
+                    Divider()
+                    Button("Archived") { select(.archived) }
+                } label: {
+                    Color.clear
+                        .contentShape(RoundedRectangle(cornerRadius: Radius.chip, style: .continuous))
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .help("Filter threads")
+                .accessibilityLabel("Thread filter: \(filterTitle(model))")
+            }
 
             NavigatorChipButton(
                 systemImage: "plus",

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -125,45 +125,23 @@ struct NavigatorSidebar: View {
 
     private func filterRow(_ model: ThreadListModel) -> some View {
         HStack(spacing: Spacing.sm) {
-            // A borderless Menu adopts its label's ideal width — maxWidth
-            // expansion collapses to a text-hugging pill, and a clear
-            // overlay label never gets a clickable size. GeometryReader
-            // hands the label the concrete leftover width, so the menu is
-            // full-width and natively clickable at once.
-            GeometryReader { geometry in
-                Menu {
-                    Button("All Projects") { select(.all) }
-                    if !model.projects.isEmpty {
-                        Divider()
-                        ForEach(model.projects) { option in
-                            Button(option.label) { select(.project(option.ref)) }
-                        }
-                    }
-                    Divider()
-                    Button("Archived") { select(.archived) }
-                } label: {
-                    HStack(spacing: Spacing.sm) {
-                        Image(systemName: "folder")
-                            .foregroundStyle(.secondary)
-                        Text(filterTitle(model))
-                            .font(.callout.weight(.medium))
-                            .lineLimit(1)
-                        Spacer(minLength: Spacing.xs)
-                        Image(systemName: "chevron.down")
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                    }
-                    .padding(.horizontal, Spacing.md)
-                    .frame(width: geometry.size.width, height: NavigatorMetrics.chipSize)
-                    .contentShape(RoundedRectangle(cornerRadius: Radius.chip, style: .continuous))
+            NavigatorDropdown(entries: filterEntries(model)) {
+                HStack(spacing: Spacing.sm) {
+                    Image(systemName: "folder")
+                        .foregroundStyle(.secondary)
+                    Text(filterTitle(model))
+                        .font(.callout.weight(.medium))
+                        .lineLimit(1)
+                    Spacer(minLength: Spacing.xs)
+                    Image(systemName: "chevron.down")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
                 }
-                .menuStyle(.borderlessButton)
-                .menuIndicator(.hidden)
-                .navigatorChipSurface()
-                .help("Filter threads")
-                .accessibilityLabel("Thread filter: \(filterTitle(model))")
+                .padding(.horizontal, Spacing.md)
+                .frame(maxWidth: .infinity, minHeight: NavigatorMetrics.chipSize)
             }
-            .frame(height: NavigatorMetrics.chipSize)
+            .help("Filter threads")
+            .accessibilityLabel("Thread filter: \(filterTitle(model))")
 
             NavigatorChipButton(
                 systemImage: "plus",
@@ -431,6 +409,33 @@ struct NavigatorSidebar: View {
         case .project(let ref):
             model.projects.first { $0.ref == ref }?.label ?? "Project"
         }
+    }
+
+    private func filterEntries(_ model: ThreadListModel) -> [NavigatorDropdownEntry] {
+        var entries: [NavigatorDropdownEntry] = [
+            .item(
+                title: "All Projects",
+                isSelected: windowState.threadFilter == .all,
+                action: { select(.all) }
+            ),
+        ]
+        if !model.projects.isEmpty {
+            entries.append(.separator)
+            for option in model.projects {
+                entries.append(.item(
+                    title: option.label,
+                    isSelected: windowState.threadFilter == .project(option.ref),
+                    action: { select(.project(option.ref)) }
+                ))
+            }
+        }
+        entries.append(.separator)
+        entries.append(.item(
+            title: "Archived",
+            isSelected: windowState.threadFilter == .archived,
+            action: { select(.archived) }
+        ))
+        return entries
     }
 
     private func limited<T>(_ items: [T], expanded: Bool) -> [T] {

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -125,26 +125,12 @@ struct NavigatorSidebar: View {
 
     private func filterRow(_ model: ThreadListModel) -> some View {
         HStack(spacing: Spacing.sm) {
-            // The bordered dropdown is drawn directly so the box always
-            // spans the available width with the chevron pinned trailing —
-            // a borderless Menu sizes to its label, so the Menu instead
-            // rides on top as a clear, full-size click target.
-            HStack(spacing: Spacing.sm) {
-                Image(systemName: "folder")
-                    .foregroundStyle(.secondary)
-                Text(filterTitle(model))
-                    .font(.callout.weight(.medium))
-                    .lineLimit(1)
-                Spacer(minLength: Spacing.xs)
-                Image(systemName: "chevron.down")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-            }
-            .padding(.horizontal, Spacing.md)
-            .frame(maxWidth: .infinity, minHeight: NavigatorMetrics.chipSize)
-            .navigatorChipSurface()
-            .accessibilityHidden(true)
-            .overlay {
+            // A borderless Menu adopts its label's ideal width — maxWidth
+            // expansion collapses to a text-hugging pill, and a clear
+            // overlay label never gets a clickable size. GeometryReader
+            // hands the label the concrete leftover width, so the menu is
+            // full-width and natively clickable at once.
+            GeometryReader { geometry in
                 Menu {
                     Button("All Projects") { select(.all) }
                     if !model.projects.isEmpty {
@@ -156,14 +142,28 @@ struct NavigatorSidebar: View {
                     Divider()
                     Button("Archived") { select(.archived) }
                 } label: {
-                    Color.clear
-                        .contentShape(RoundedRectangle(cornerRadius: Radius.chip, style: .continuous))
+                    HStack(spacing: Spacing.sm) {
+                        Image(systemName: "folder")
+                            .foregroundStyle(.secondary)
+                        Text(filterTitle(model))
+                            .font(.callout.weight(.medium))
+                            .lineLimit(1)
+                        Spacer(minLength: Spacing.xs)
+                        Image(systemName: "chevron.down")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.horizontal, Spacing.md)
+                    .frame(width: geometry.size.width, height: NavigatorMetrics.chipSize)
+                    .contentShape(RoundedRectangle(cornerRadius: Radius.chip, style: .continuous))
                 }
                 .menuStyle(.borderlessButton)
                 .menuIndicator(.hidden)
+                .navigatorChipSurface()
                 .help("Filter threads")
                 .accessibilityLabel("Thread filter: \(filterTitle(model))")
             }
+            .frame(height: NavigatorMetrics.chipSize)
 
             NavigatorChipButton(
                 systemImage: "plus",

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -38,18 +38,18 @@ struct NavigatorSidebar: View {
             filter: windowState.threadFilter
         )
         NavigatorList {
-            dashboardRow
-            newThreadRow
+            headerRow
 
             if !model.pinned.isEmpty {
-                sectionLabel("Pinned")
                 threadCards(model.pinned, isExpanded: $windowState.isPinnedExpanded)
+                sectionDivider
             }
 
             filterRow(model)
             threadListSection(model)
 
             if let project = windowState.activeProject {
+                sectionDivider
                 terminalsSection(project)
             }
         }
@@ -99,30 +99,33 @@ struct NavigatorSidebar: View {
 
     // MARK: - Fixed rows
 
-    private var dashboardRow: some View {
-        NavigatorRow(
-            isSelected: windowState.selectedContent == .dashboard,
-            action: { windowState.showDashboard() }
-        ) { _ in
-            NavigatorIconLabel(title: "Dashboard", systemImage: "rectangle.3.group")
-        } actions: {
-            EmptyView()
-        }
-    }
+    /// Dashboard plus the compose (New Thread) chip in one header row, per
+    /// the design: the chip is the dedicated New Thread action.
+    private var headerRow: some View {
+        HStack(spacing: Spacing.sm) {
+            NavigatorRow(
+                isSelected: windowState.selectedContent == .dashboard,
+                action: { windowState.showDashboard() }
+            ) { _ in
+                NavigatorIconLabel(title: "Dashboard", systemImage: "square.grid.2x2")
+            } actions: {
+                EmptyView()
+            }
 
-    private var newThreadRow: some View {
-        NavigatorRow(
-            isEnabled: canCreateAnywhere,
-            action: { windowState.presentNewThread(in: appModel) }
-        ) { _ in
-            NavigatorIconLabel(title: "New Thread", systemImage: "plus.bubble")
-        } actions: {
-            EmptyView()
+            NavigatorChipButton(
+                systemImage: "square.and.pencil",
+                help: "New Thread",
+                isEnabled: canCreateAnywhere
+            ) {
+                windowState.presentNewThread(in: appModel)
+            }
+            .padding(.trailing, NavigatorMetrics.contentHorizontalPadding)
         }
+        .navigatorListRow(top: Spacing.sm, bottom: Spacing.sm)
     }
 
     private func filterRow(_ model: ThreadListModel) -> some View {
-        HStack(spacing: Spacing.xs) {
+        HStack(spacing: Spacing.sm) {
             Menu {
                 Button("All Projects") { select(.all) }
                 if !model.projects.isEmpty {
@@ -134,24 +137,29 @@ struct NavigatorSidebar: View {
                 Divider()
                 Button("Archived") { select(.archived) }
             } label: {
-                HStack(spacing: Spacing.xs) {
+                HStack(spacing: Spacing.sm) {
+                    Image(systemName: "folder")
+                        .foregroundStyle(.secondary)
                     Text(filterTitle(model))
-                        .font(.headline)
+                        .font(.callout.weight(.medium))
                         .lineLimit(1)
-                    Image(systemName: "chevron.up.chevron.down")
+                    Spacer(minLength: Spacing.xs)
+                    Image(systemName: "chevron.down")
                         .font(.caption2)
+                        .foregroundStyle(.secondary)
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .contentShape(Rectangle())
+                .padding(.horizontal, Spacing.sm)
+                .frame(maxWidth: .infinity, minHeight: NavigatorMetrics.chipSize)
+                .contentShape(RoundedRectangle(cornerRadius: Radius.control, style: .continuous))
             }
             .menuStyle(.borderlessButton)
             .menuIndicator(.hidden)
-            .foregroundStyle(.secondary)
+            .navigatorChipSurface()
             .help("Filter threads")
             .accessibilityLabel("Thread filter: \(filterTitle(model))")
 
-            NavigatorActionButton(
-                systemImage: "folder.badge.plus",
+            NavigatorChipButton(
+                systemImage: "plus",
                 help: "New project",
                 isEnabled: canCreateAnywhere
             ) {
@@ -159,8 +167,7 @@ struct NavigatorSidebar: View {
             }
         }
         .padding(.horizontal, NavigatorMetrics.contentHorizontalPadding)
-        .frame(minHeight: NavigatorMetrics.rowHeight)
-        .navigatorListRow(top: Spacing.md)
+        .navigatorListRow(top: Spacing.sm, bottom: Spacing.sm)
     }
 
     // MARK: - Thread list
@@ -316,13 +323,10 @@ struct NavigatorSidebar: View {
 
     // MARK: - Shared row chrome
 
-    private func sectionLabel(_ title: String) -> some View {
-        Text(title)
-            .font(.headline)
-            .foregroundStyle(.secondary)
+    private var sectionDivider: some View {
+        Divider()
             .padding(.horizontal, NavigatorMetrics.contentHorizontalPadding)
-            .frame(minHeight: NavigatorMetrics.rowHeight, alignment: .leading)
-            .navigatorListRow(top: Spacing.md)
+            .navigatorListRow(top: Spacing.sm, bottom: Spacing.sm)
     }
 
     private func emptyLabel(_ title: String) -> some View {
@@ -340,17 +344,21 @@ struct NavigatorSidebar: View {
             Button {
                 isExpanded.wrappedValue.toggle()
             } label: {
-                Text(isExpanded.wrappedValue
-                    ? "Hide"
-                    : "More (\(total - Self.initialRowLimit))")
-                    .font(.caption.weight(.medium))
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .contentShape(Rectangle())
+                HStack(spacing: Spacing.xs) {
+                    Text(isExpanded.wrappedValue
+                        ? "Hide"
+                        : "\(total - Self.initialRowLimit) more")
+                    Image(systemName: isExpanded.wrappedValue ? "chevron.up" : "chevron.down")
+                        .font(.caption2)
+                }
+                .font(.caption.weight(.medium))
+                .frame(maxWidth: .infinity)
+                .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .foregroundStyle(.secondary)
             .padding(.horizontal, NavigatorMetrics.contentHorizontalPadding)
-            .frame(minHeight: NavigatorMetrics.rowHeight, alignment: .leading)
+            .frame(minHeight: NavigatorMetrics.rowHeight)
             .navigatorListRow()
         }
     }
@@ -442,52 +450,80 @@ private struct ThreadCard: View {
 
     var body: some View {
         let thread = item.thread
-        HStack(alignment: .top, spacing: Spacing.sm) {
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: Spacing.xs) {
-                    Text(thread.displayName)
-                        .font(.callout.weight(.medium))
-                        .lineLimit(1)
-                    if thread.activityState == .working {
-                        ProgressView()
-                            .progressViewStyle(.circular)
-                            .controlSize(.mini)
-                            .accessibilityLabel("Working")
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            // Top row: Project name as compact context, actions on the
+            // upper-trailing area per the design.
+            HStack(alignment: .center, spacing: Spacing.sm) {
+                Text(item.projectLabel)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+                Spacer(minLength: Spacing.sm)
+                if isHovering || isFocused {
+                    HStack(spacing: Spacing.xs) {
+                        cardAction(
+                            systemImage: thread.isPinned ? "pin.slash" : "pin",
+                            help: thread.isPinned ? "Unpin" : "Pin",
+                            isEnabled: canMutate && !isBusy,
+                            action: onTogglePin
+                        )
+                        cardAction(
+                            systemImage: "archivebox",
+                            help: "Archive",
+                            // The server refuses archiving a working thread;
+                            // the control is disabled rather than surfacing
+                            // that as an error the user did not ask for.
+                            isEnabled: canMutate && !isBusy
+                                && thread.activityState != .working,
+                            action: onArchive
+                        )
                     }
+                } else {
+                    // Reserve the action row's height so the card does not
+                    // resize under the pointer.
+                    Color.clear.frame(width: 1, height: NavigatorMetrics.actionSize)
                 }
-                HStack(spacing: Spacing.xs) {
-                    Text(item.projectLabel)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                    if thread.activityState == .needsInput {
-                        needsInputBadge
-                    }
+            }
+
+            // The dominant element.
+            HStack(alignment: .firstTextBaseline, spacing: Spacing.xs) {
+                Text(thread.displayName)
+                    .font(.callout.weight(.medium))
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+                if thread.activityState == .working {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                        .controlSize(.mini)
+                        .accessibilityLabel("Working")
                 }
+            }
+
+            // Bottom metadata row: working directory when it differs from
+            // the Project default; exceptional state and Agent trailing.
+            HStack(alignment: .center, spacing: Spacing.sm) {
                 if let directory = item.distinctWorkingDirectory {
                     Text(directory)
-                        .font(.caption2.monospaced())
+                        .font(.caption.monospaced())
                         .foregroundStyle(.tertiary)
                         .lineLimit(1)
                         .truncationMode(.head)
                 }
+                Spacer(minLength: Spacing.sm)
+                if thread.activityState == .needsInput {
+                    needsInputBadge
+                }
+                agentBadge
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            trailingColumn
         }
-        .padding(.horizontal, NavigatorMetrics.contentHorizontalPadding)
-        .padding(.vertical, Spacing.sm)
+        .padding(Spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background {
-            RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+            RoundedRectangle(cornerRadius: Radius.card, style: .continuous)
                 .fill(backgroundStyle)
         }
         .overlay {
-            if isFocused {
-                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
-                    .stroke(Color.accentColor, lineWidth: 1)
-            }
+            RoundedRectangle(cornerRadius: Radius.card, style: .continuous)
+                .strokeBorder(borderColor, lineWidth: 1)
         }
         .opacity(isBusy ? Dimming.unavailable : 1)
         .contentShape(Rectangle())
@@ -518,42 +554,21 @@ private struct ThreadCard: View {
         .accessibilityElement(children: .contain)
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
         .accessibilityAction(named: "Open", onOpen)
-        .navigatorListRow()
+        .navigatorListRow(top: Spacing.xs, bottom: Spacing.xs)
     }
 
-    private var trailingColumn: some View {
-        VStack(alignment: .trailing, spacing: Spacing.xs) {
-            if isHovering || isFocused {
-                HStack(spacing: 0) {
-                    cardAction(
-                        systemImage: item.thread.isPinned ? "pin.slash" : "pin",
-                        help: item.thread.isPinned ? "Unpin" : "Pin",
-                        isEnabled: canMutate && !isBusy,
-                        action: onTogglePin
-                    )
-                    cardAction(
-                        systemImage: "archivebox",
-                        help: "Archive",
-                        // The server refuses archiving a working thread; the
-                        // control is disabled rather than surfacing that as an
-                        // error the user did not ask for.
-                        isEnabled: canMutate && !isBusy
-                            && item.thread.activityState != .working,
-                        action: onArchive
-                    )
-                }
-            } else {
-                // Reserve the action row's height so the card does not
-                // resize under the pointer.
-                Color.clear.frame(height: NavigatorMetrics.actionSize)
-            }
-            Spacer(minLength: 0)
-            Image(systemName: item.thread.agentId.systemImage)
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-                .accessibilityLabel(item.thread.agentId.displayName)
-        }
-        .frame(width: NavigatorMetrics.actionSize * 2)
+    /// The Agent icon in a small rounded-square badge, lower-trailing per
+    /// the design.
+    private var agentBadge: some View {
+        Image(systemName: item.thread.agentId.systemImage)
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+            .frame(width: NavigatorMetrics.actionSize, height: NavigatorMetrics.actionSize)
+            .background(
+                Color.white.opacity(0.07),
+                in: RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+            )
+            .accessibilityLabel(item.thread.agentId.displayName)
     }
 
     private func cardAction(
@@ -566,7 +581,11 @@ private struct ThreadCard: View {
             Image(systemName: systemImage)
                 .font(.caption)
                 .frame(width: NavigatorMetrics.actionSize, height: NavigatorMetrics.actionSize)
-                .contentShape(Rectangle())
+                .background(
+                    Color.white.opacity(0.07),
+                    in: RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                )
+                .contentShape(RoundedRectangle(cornerRadius: Radius.control, style: .continuous))
         }
         .buttonStyle(.plain)
         .foregroundStyle(.secondary)
@@ -576,20 +595,25 @@ private struct ThreadCard: View {
     }
 
     /// Symbol plus text, never color alone — the badge has to read for
-    /// color-blind users and in monochrome accessibility modes.
+    /// color-blind users and in monochrome accessibility modes. Amber like
+    /// the app's other warnings, per the design.
     private var needsInputBadge: some View {
         Label("Needs input", systemImage: "exclamationmark.bubble.fill")
-            .font(.caption2.weight(.semibold))
+            .font(.caption.weight(.medium))
             .labelStyle(.titleAndIcon)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(Color.accentColor.opacity(0.22), in: Capsule())
-            .foregroundStyle(Color.accentColor)
+            .foregroundStyle(.orange)
     }
 
+    /// Cards read as bordered containers at rest; selection is the accent
+    /// border plus tint, hover a brighter neutral fill.
     private var backgroundStyle: AnyShapeStyle {
-        if isSelected { return AnyShapeStyle(Color.accentColor.opacity(0.28)) }
-        if isHovering { return AnyShapeStyle(.quaternary) }
-        return AnyShapeStyle(Color.clear)
+        if isSelected { return AnyShapeStyle(Color.accentColor.opacity(0.13)) }
+        if isHovering { return AnyShapeStyle(Color.white.opacity(0.07)) }
+        return AnyShapeStyle(Color.white.opacity(0.035))
+    }
+
+    private var borderColor: Color {
+        if isSelected || isFocused { return Color.accentColor }
+        return Color.white.opacity(0.08)
     }
 }

--- a/macos/ATC/Shared/DesignTokens.swift
+++ b/macos/ATC/Shared/DesignTokens.swift
@@ -34,9 +34,11 @@ enum Spacing {
     static let xxl: CGFloat = 32
 }
 
-/// Corner radii: small controls and cards. Text pills use `Capsule`.
+/// Corner radii: small controls, chip controls, and cards. Text pills use
+/// `Capsule`.
 enum Radius {
     static let control: CGFloat = 6
+    static let chip: CGFloat = 8
     static let card: CGFloat = 12
 }
 

--- a/macos/ATC/Shared/NavigatorComponents.swift
+++ b/macos/ATC/Shared/NavigatorComponents.swift
@@ -6,6 +6,9 @@ enum NavigatorMetrics {
     static let rowHeight: CGFloat = 28
     static let iconWidth: CGFloat = 18
     static let actionSize: CGFloat = 22
+    /// Bordered chip controls: the New Thread compose button, the thread
+    /// filter, and New Project.
+    static let chipSize: CGFloat = 28
     static let horizontalPadding = Spacing.sm
     static let contentHorizontalPadding = Spacing.sm
     static let rowVerticalInset: CGFloat = 1
@@ -122,6 +125,30 @@ struct NavigatorActionButton: View {
     }
 }
 
+/// A bordered rounded-square icon button, per the design's chip controls
+/// (compose, New Project). The chip surface stays visible at rest.
+struct NavigatorChipButton: View {
+    let systemImage: String
+    let help: String
+    var isEnabled = true
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .frame(width: NavigatorMetrics.chipSize, height: NavigatorMetrics.chipSize)
+                .contentShape(RoundedRectangle(cornerRadius: Radius.control, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.secondary)
+        .navigatorChipSurface()
+        .opacity(isEnabled ? 1 : Dimming.unavailable)
+        .disabled(!isEnabled)
+        .help(help)
+        .accessibilityLabel(help)
+    }
+}
+
 struct NavigatorDisclosureHeader: View {
     let title: String
     @Binding var isExpanded: Bool
@@ -149,14 +176,14 @@ struct NavigatorDisclosureHeader: View {
             }
             .buttonStyle(.plain)
 
-            if isHovering {
-                NavigatorActionButton(
-                    systemImage: "plus",
-                    help: addHelp,
-                    isEnabled: isAddEnabled,
-                    action: onAdd
-                )
-            }
+            // Persistent per the design: the add affordance is part of the
+            // section header, not a hover reveal.
+            NavigatorActionButton(
+                systemImage: "plus",
+                help: addHelp,
+                isEnabled: isAddEnabled,
+                action: onAdd
+            )
         }
         .frame(minHeight: NavigatorMetrics.rowHeight)
         .foregroundStyle(.secondary)
@@ -186,5 +213,18 @@ extension View {
                         .fill(.quaternary)
                 }
             }
+    }
+
+    /// The bordered chip surface shared by the filter dropdown and chip
+    /// buttons: a faint fill with a hairline stroke, visible at rest.
+    func navigatorChipSurface() -> some View {
+        background {
+            RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                .fill(Color.white.opacity(0.05))
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.08))
+        }
     }
 }

--- a/macos/ATC/Shared/NavigatorComponents.swift
+++ b/macos/ATC/Shared/NavigatorComponents.swift
@@ -8,9 +8,11 @@ enum NavigatorMetrics {
     static let actionSize: CGFloat = 22
     /// Bordered chip controls: the New Thread compose button, the thread
     /// filter, and New Project.
-    static let chipSize: CGFloat = 28
-    static let horizontalPadding = Spacing.sm
-    static let contentHorizontalPadding = Spacing.sm
+    static let chipSize: CGFloat = 32
+    static let horizontalPadding = Spacing.md
+    /// Keeps plain-row text aligned with card interiors: outer padding plus
+    /// this equals the outer padding plus a card's internal padding.
+    static let contentHorizontalPadding = Spacing.md
     static let rowVerticalInset: CGFloat = 1
 }
 
@@ -137,7 +139,7 @@ struct NavigatorChipButton: View {
         Button(action: action) {
             Image(systemName: systemImage)
                 .frame(width: NavigatorMetrics.chipSize, height: NavigatorMetrics.chipSize)
-                .contentShape(RoundedRectangle(cornerRadius: Radius.control, style: .continuous))
+                .contentShape(RoundedRectangle(cornerRadius: Radius.chip, style: .continuous))
         }
         .buttonStyle(.plain)
         .foregroundStyle(.secondary)
@@ -216,15 +218,15 @@ extension View {
     }
 
     /// The bordered chip surface shared by the filter dropdown and chip
-    /// buttons: a faint fill with a hairline stroke, visible at rest.
+    /// buttons: a faint fill with a clearly visible stroke, present at rest.
     func navigatorChipSurface() -> some View {
         background {
-            RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
-                .fill(Color.white.opacity(0.05))
+            RoundedRectangle(cornerRadius: Radius.chip, style: .continuous)
+                .fill(Color.white.opacity(0.06))
         }
         .overlay {
-            RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
-                .strokeBorder(Color.white.opacity(0.08))
+            RoundedRectangle(cornerRadius: Radius.chip, style: .continuous)
+                .strokeBorder(Color.white.opacity(0.12))
         }
     }
 }

--- a/macos/ATC/Shared/NavigatorComponents.swift
+++ b/macos/ATC/Shared/NavigatorComponents.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// Shared geometry for every Navigator. Sidebar-specific values live here so
@@ -124,6 +125,95 @@ struct NavigatorActionButton: View {
         .foregroundStyle(.secondary)
         .disabled(!isEnabled)
         .help(help)
+    }
+}
+
+/// One entry in a `NavigatorDropdown` menu.
+enum NavigatorDropdownEntry {
+    case item(title: String, isSelected: Bool, action: () -> Void)
+    case separator
+}
+
+/// A full-width dropdown with a caller-drawn label that pops a native
+/// NSMenu. SwiftUI's borderless `Menu` sizes to its label's compressed
+/// ideal width — every frame-based expansion collapses back to a text
+/// pill — so the label is an ordinary Button (layout we fully control)
+/// and AppKit owns the popup.
+struct NavigatorDropdown<Label: View>: View {
+    let entries: [NavigatorDropdownEntry]
+    @ViewBuilder let label: () -> Label
+
+    @State private var anchor = AnchorHolder()
+
+    var body: some View {
+        Button {
+            popUp()
+        } label: {
+            label()
+                .contentShape(RoundedRectangle(cornerRadius: Radius.chip, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .navigatorChipSurface()
+        .background {
+            AnchorView(holder: anchor)
+        }
+    }
+
+    private func popUp() {
+        guard let view = anchor.view else { return }
+        let menu = NSMenu()
+        for entry in entries {
+            switch entry {
+            case .separator:
+                menu.addItem(.separator())
+            case .item(let title, let isSelected, let action):
+                let item = ClosureMenuItem(title: title, handler: action)
+                item.state = isSelected ? .on : .off
+                menu.addItem(item)
+            }
+        }
+        menu.popUp(positioning: nil, at: NSPoint(x: 0, y: view.bounds.maxY + 4), in: view)
+    }
+
+    /// Bridges the SwiftUI position to AppKit: the invisible background
+    /// view is the menu's positioning anchor.
+    private final class AnchorHolder {
+        weak var view: NSView?
+    }
+
+    private struct AnchorView: NSViewRepresentable {
+        let holder: AnchorHolder
+
+        func makeNSView(context: Context) -> NSView {
+            let view = NSView()
+            holder.view = view
+            return view
+        }
+
+        func updateNSView(_ nsView: NSView, context: Context) {
+            holder.view = nsView
+        }
+    }
+
+    /// NSMenuItem needs a target/selector pair; this carries the closure
+    /// and targets itself.
+    private final class ClosureMenuItem: NSMenuItem {
+        private let handler: () -> Void
+
+        init(title: String, handler: @escaping () -> Void) {
+            self.handler = handler
+            super.init(title: title, action: #selector(invoke), keyEquivalent: "")
+            target = self
+        }
+
+        @available(*, unavailable)
+        required init(coder: NSCoder) {
+            fatalError("not used")
+        }
+
+        @objc private func invoke() {
+            handler()
+        }
     }
 }
 

--- a/mise.toml
+++ b/mise.toml
@@ -98,10 +98,18 @@ description = "macOS app tests (signing disabled so any machine/CI can run them)
 # Swift OpenAPI Generator build plugin, which xcodebuild refuses to run until
 # trusted; the plugin is version-pinned in ATCKit's Package.swift.
 run = """
+#!/usr/bin/env bash
+set -euo pipefail
+
+derived_data_path="$(mktemp -d "${TMPDIR:-/tmp}/atc-macos-test.XXXXXX")"
+trap 'rm -rf "$derived_data_path"' EXIT
+
+scripts/prepare-xcode-openapi.sh "$derived_data_path"
 xcodebuild test \
   -project macos/atc.xcodeproj \
   -scheme atc \
   -destination platform=macOS \
+  -derivedDataPath "$derived_data_path" \
   -skipPackagePluginValidation \
   CODE_SIGNING_ALLOWED=NO
 """

--- a/scripts/prepare-xcode-openapi.sh
+++ b/scripts/prepare-xcode-openapi.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Xcode 26 discovers the Swift OpenAPI Generator command for ATCKit but can
+# omit it from the build graph while still compiling its declared outputs.
+# Generate into the plugin's DerivedData directory first so clean Xcode builds
+# remain deterministic. The build plugin then treats these files as current.
+
+if [[ $# -ne 1 || -z "$1" ]]; then
+  printf 'usage: %s <derived-data-path>\n' "$0" >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+DERIVED_DATA_PATH="$1"
+GENERATED_SOURCES_PATH="$DERIVED_DATA_PATH/Build/Intermediates.noindex/BuildToolPluginIntermediates/atckit.output/ATCAppServerAPI/OpenAPIGenerator/GeneratedSources"
+
+mkdir -p "$GENERATED_SOURCES_PATH"
+
+swift run \
+  --package-path "$REPO_ROOT/packages/ATCKit" \
+  swift-openapi-generator generate \
+  "$REPO_ROOT/packages/ATCKit/Sources/ATCAppServerAPI/openapi.json" \
+  --config "$REPO_ROOT/packages/ATCKit/Sources/ATCAppServerAPI/openapi-generator-config.yaml" \
+  --output-directory "$GENERATED_SOURCES_PATH" \
+  --plugin-source build

--- a/scripts/release-dev.sh
+++ b/scripts/release-dev.sh
@@ -135,6 +135,9 @@ validate_github_auth
 
 mkdir -p "$RUN_DIR" "$EXPORT_PATH" "$DERIVED_DATA_PATH" "$SOURCE_PACKAGES_PATH" "$DMG_ROOT"
 
+log "Generating App Server API sources for Xcode"
+"$SCRIPT_DIR/prepare-xcode-openapi.sh" "$DERIVED_DATA_PATH"
+
 XCODE_OVERRIDES=(
   "ARCHS=arm64"
   "ONLY_ACTIVE_ARCH=NO"


### PR DESCRIPTION
## Summary

- align the macOS navigator sidebar with the approved client design mockups
- add richer thread-card status and connection presentation
- make the full-width project filter use a native `NSMenu`
- scope thread-row identity by section so pinned and recent cards update reliably

## Why

The sidebar had drifted from the approved visual design, and its project filter did not provide the expected full-width native interaction. Thread rows also reused identity across sidebar sections, which could leave pinned cards visually frozen after a thread moved between sections.

## Impact

The sidebar now matches the intended hierarchy and interaction model, exposes clearer thread and connection state, and updates cards consistently as threads are pinned or moved.

## Validation

- `TMPDIR=/tmp mise run macos:test` (208 tests passed)

## Notes

An initial XcodeBuildMCP test attempt discovered all 208 tests but failed during generated OpenAPI plugin output setup. The repository's canonical macOS test gate completed successfully.
