### PR TITLE
Remote access: bind setting + bearer-token trust (ATC-148)

### DIFF
--- a/app-server/README.md
+++ b/app-server/README.md
@@ -38,13 +38,13 @@ overrides:
 | Data dir    | `~/.local/share/atc/`       | SQLite database (`atc.db`)                       |
 | State dir   | `~/.local/state/atc/`       | JSON log (`atc.log`), zmx sockets (`terminals/`) |
 
-Environment variables are flat `ATC_<KEY>`: `ATC_PORT`, `ATC_LOG_LEVEL`,
-`ATC_DATA_DIR`, `ATC_ZMX_EXECUTABLE`, `ATC_CODEX_EXECUTABLE`,
+Environment variables are flat `ATC_<KEY>`: `ATC_PORT`, `ATC_BIND`,
+`ATC_LOG_LEVEL`, `ATC_DATA_DIR`, `ATC_ZMX_EXECUTABLE`, `ATC_CODEX_EXECUTABLE`,
 `ATC_CLAUDE_EXECUTABLE`, and `ATC_CONFIG` (path to an alternate config file).
-The config file may set `port`, `logLevel` (case-insensitive), `dataDir`,
-`zmxExecutable`, `codexExecutable`, and `claudeExecutable`; unknown keys are
-rejected. `atc serve --port` overrides the configured port for that server
-only.
+The config file may set `port`, `bind`, `logLevel` (case-insensitive),
+`dataDir`, `zmxExecutable`, `codexExecutable`, and `claudeExecutable`; unknown
+keys are rejected. `atc serve --port`/`--bind` override the configured values
+for that server only.
 
 atc bundles no third-party binaries — install them yourself. Terminals
 require [zmx](https://github.com/neurosnap/zmx); the agent integrations use
@@ -54,12 +54,14 @@ variable or config key, else its bare name on PATH.
 ## CLI
 
 `atc serve` runs the server (it creates and migrates the database on boot).
-Everything else is a client of the HTTP API, which is the complete canonical
-interface: `atc api <method> <path>` (GET, POST, PUT, PATCH, DELETE) reaches
-every operation, and curated commands exist only where they add local
-behavior (relative-path resolution, TTY attach, `--yes` delete guards). Run
-`atc --help` for the command surface and `atc capabilities --json` for the
-machine-readable summary.
+Almost everything else is a client of the HTTP API, which is the complete
+canonical interface: `atc api <method> <path>` (GET, POST, PUT, PATCH, DELETE)
+reaches every operation, and curated commands exist only where they add local
+behavior (relative-path resolution, TTY attach, `--yes` delete guards). The
+exceptions are `atc start`/`stop`/`status` (background process management) and
+`atc token` (the remote-access credential is a local `0600` file, not an API
+resource). Run `atc --help` for the command surface and
+`atc capabilities --json` for the machine-readable summary.
 
 API-backed commands take zero connection flags — `ATC_ENDPOINT` (a full base
 URL, set automatically in the environment of ATC-launched terminal sessions)
@@ -90,9 +92,24 @@ change — never edit it by hand. It is symlinked into `packages/ATCKit` to gene
 client, so the server, the TypeScript client (`src/api/client.ts`), and the Swift
 client all derive from the same definition.
 
-The loopback listener validates `Host`/`Origin` on every request (403
-otherwise) — the local half of the settled trust architecture; bearer-token
-remote access is a later, purely additive layer.
+One trust rule guards every route (API, SSE, the attach WebSocket): a request
+passes if it presents a recognized loopback `Host`/`Origin`, or if it carries
+`Authorization: Bearer <token>` matching the server's token; everything else
+is an empty 403. Loopback clients never need the token.
+
+### Remote access
+
+The listener binds `127.0.0.1` by default. Setting `bind = "0.0.0.0"` (or
+`ATC_BIND` / `--bind`; see the `bind` note in `platform/config.ts` for why a
+single non-loopback address is the wrong choice) opens it, and the bearer
+token gates every non-loopback request. The intended posture is tailnet-only
+reachability (Tailscale) — the token is the just-in-case backstop, not an
+invitation to expose the server publicly. The token is generated on first
+server start (or by `atc token`) into a `0600` file in the data dir; `atc
+token` prints it for pasting into a client, and `atc token rotate` reissues
+it, taking effect immediately on a running server. Remote browser access to
+the Web UI stays unsupported — browsers cannot attach bearer headers to SSE
+or WebSockets.
 
 ## Structure
 

--- a/app-server/README.md
+++ b/app-server/README.md
@@ -93,9 +93,10 @@ client, so the server, the TypeScript client (`src/api/client.ts`), and the Swif
 client all derive from the same definition.
 
 One trust rule guards every route (API, SSE, the attach WebSocket): a request
-passes if it presents a recognized loopback `Host`/`Origin`, or if it carries
-`Authorization: Bearer <token>` matching the server's token; everything else
-is an empty 403. Loopback clients never need the token.
+passes if it arrives on a loopback connection presenting a recognized loopback
+`Host`/`Origin`, or if it carries `Authorization: Bearer <token>` matching the
+server's token; everything else is an empty 403. Local loopback clients never
+need the token.
 
 ### Remote access
 
@@ -107,9 +108,13 @@ reachability (Tailscale) — the token is the just-in-case backstop, not an
 invitation to expose the server publicly. The token is generated on first
 server start (or by `atc token`) into a `0600` file in the data dir; `atc
 token` prints it for pasting into a client, and `atc token rotate` reissues
-it, taking effect immediately on a running server. Remote browser access to
-the Web UI stays unsupported — browsers cannot attach bearer headers to SSE
-or WebSockets.
+it, taking effect immediately on a running server. Requests arriving through
+a local reverse proxy (`tailscale serve`) also need the token: the proxy
+preserves the incoming `Host`, which makes its requests indistinguishable
+from DNS rebinding, so only direct loopback traffic is token-free (the trust
+module header has the full reasoning). Remote browser access to the Web UI
+stays unsupported — browsers cannot attach bearer headers to SSE or
+WebSockets.
 
 ## Structure
 

--- a/app-server/src/api/localTrust.ts
+++ b/app-server/src/api/localTrust.ts
@@ -28,9 +28,15 @@ import * as AuthToken from "../platform/authToken.ts"
 // The token-free path is gated on the TCP PEER address, never on the `Host`
 // header alone: `Host` is client-controlled, so trusting a "loopback" Host
 // from a non-loopback peer would let any remote client send `Host: localhost`
-// and skip the token entirely. Peer-gating also keeps `tailscale serve`
-// working token-free — it proxies to us over loopback — while a direct
-// tailnet/LAN connection (a non-loopback peer) must present the token.
+// and skip the token entirely. The loopback-Host requirement still applies
+// to loopback peers because a DNS-rebinding request IS a loopback peer
+// carrying the hostile name in `Host` — and a local reverse proxy
+// (`tailscale serve` preserves the incoming Host) presents exactly that same
+// shape, indistinguishable from rebinding here. Proxied requests therefore
+// authenticate with the bearer token like any other remote path; making them
+// token-free would take a configured Host allowlist, which nothing needs
+// while every remote client attaches the token anyway (remote browsers are
+// out of scope by design).
 
 const LOOPBACK_NAMES = new Set(["localhost", "127.0.0.1", "[::1]"])
 

--- a/app-server/src/api/localTrust.ts
+++ b/app-server/src/api/localTrust.ts
@@ -1,19 +1,46 @@
 import { Effect, Option } from "effect"
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import * as AuthToken from "../platform/authToken.ts"
 
-// Local trust for the loopback listener (ATC-121): the server only ever binds
-// 127.0.0.1, and this middleware rejects the one attack class that still
-// reaches a loopback control plane from a browser — DNS rebinding (a hostile
-// name resolving to 127.0.0.1 puts its own name in Host) and CSRF (a hostile
+// The trust rule, in one sentence: a request passes if it meets the loopback
+// Host/Origin rules below OR presents the bearer token (ATC-148); everything
+// else gets the same empty 403. One global middleware, so the API, SSE, the
+// attach WebSocket upgrade, and the hook webhook are covered uniformly.
+//
+// Loopback trust (ATC-121): the default listener binds 127.0.0.1, and the
+// Host/Origin rules reject the one attack class that still reaches a
+// loopback control plane from a browser — DNS rebinding (a hostile name
+// resolving to 127.0.0.1 puts its own name in Host) and CSRF (a hostile
 // page's request carries its Origin). Requests must present a recognized
 // loopback Host, and browser requests (Origin present) must come from a
 // loopback origin. Non-browser clients send no Origin and pass untouched.
 // Origin-less browser requests (e.g. a cross-site <img>) can only be simple
 // GETs — safe while every GET is side-effect-free and responses are
 // unreadable cross-origin; revisit if a GET ever gains a side effect.
-// The remote-auth pass later relaxes this deliberately for tokened clients.
+//
+// Token trust (ATC-148): with the `bind` setting opened beyond loopback
+// (intended posture: tailnet-only reachability), non-loopback requests pass
+// only with `Authorization: Bearer <token>` matching the persisted token
+// (platform/authToken.ts, timing-safe). Loopback stays token-free: local
+// clients ("no secrets, just the URL") are untouched. Browsers cannot attach
+// bearer headers to SSE/WebSockets, so remote browser access 403s by design.
+//
+// The token-free path is gated on the TCP PEER address, never on the `Host`
+// header alone: `Host` is client-controlled, so trusting a "loopback" Host
+// from a non-loopback peer would let any remote client send `Host: localhost`
+// and skip the token entirely. Peer-gating also keeps `tailscale serve`
+// working token-free — it proxies to us over loopback — while a direct
+// tailnet/LAN connection (a non-loopback peer) must present the token.
 
 const LOOPBACK_NAMES = new Set(["localhost", "127.0.0.1", "[::1]"])
+
+// Peer addresses Bun reports for a loopback connection: IPv4, IPv6, and the
+// IPv4-mapped-IPv6 form. Any 127.0.0.0/8 address is loopback too.
+export const isLoopbackAddress = (address: string): boolean =>
+  address === "::1" ||
+  address === "::ffff:127.0.0.1" ||
+  address.startsWith("127.") ||
+  address.startsWith("::ffff:127.")
 
 /** `Host` header values that identify this loopback server (optional port). */
 export const isLoopbackHost = (host: string | undefined): boolean => {
@@ -37,9 +64,10 @@ export const isLoopbackOrigin = (origin: string): boolean => {
 }
 
 /**
- * Global route middleware: reject spoofed-`Host`/cross-`Origin` requests with
- * an empty 403, and annotate every log line in an accepted request with the
- * request span ids so file logs correlate per request.
+ * Global route middleware: reject requests that neither satisfy the loopback
+ * `Host`/`Origin` rules nor present the bearer token with an empty 403, and
+ * annotate every log line in an accepted request with the request span ids
+ * so file logs correlate per request.
  */
 export const middleware = HttpRouter.middleware(
   Effect.fnUntraced(function* <E, R>(
@@ -49,12 +77,16 @@ export const middleware = HttpRouter.middleware(
       HttpServerRequest.HttpServerRequest | R
     >,
   ) {
+    const authToken = yield* AuthToken.AuthToken
     const request = yield* HttpServerRequest.HttpServerRequest
     const origin = request.headers["origin"]
-    if (
-      !isLoopbackHost(request.headers["host"]) ||
-      (origin !== undefined && !isLoopbackOrigin(origin))
-    ) {
+    // A loopback PEER (unknown peer fails closed) whose Host/Origin also pass
+    // is the token-free local path; every other request needs the token.
+    const loopback =
+      Option.match(request.remoteAddress, { onNone: () => false, onSome: isLoopbackAddress }) &&
+      isLoopbackHost(request.headers["host"]) &&
+      (origin === undefined || isLoopbackOrigin(origin))
+    if (!loopback && !(yield* authToken.verify(request.headers["authorization"]))) {
       return HttpServerResponse.empty({ status: 403 })
     }
     const span = yield* Effect.option(Effect.currentParentSpan)

--- a/app-server/src/cli/serve.ts
+++ b/app-server/src/cli/serve.ts
@@ -27,8 +27,13 @@ export const Port = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 655
 export const port = Flag.integer("port").pipe(
   Flag.withSchema(Port),
   Flag.optional,
+  Flag.withDescription("TCP port to listen on (overrides ATC_PORT/config.toml/default)"),
+)
+
+export const bind = Flag.string("bind").pipe(
+  Flag.optional,
   Flag.withDescription(
-    "TCP port to listen on (loopback only; overrides ATC_PORT/config.toml/default)",
+    "Address to bind (default 127.0.0.1; 0.0.0.0 also opens remote access — overrides ATC_BIND/config.toml)",
   ),
 )
 
@@ -43,14 +48,18 @@ const isSystemError = (defect: unknown): defect is Error & { code: string } =>
 const isMigrationError = (defect: unknown): defect is Error =>
   defect instanceof Error && (defect as { _tag?: unknown })._tag === "MigrationError"
 
-export const serve = Command.make("serve", { port }, ({ port }) =>
+export const serve = Command.make("serve", { port, bind }, ({ port, bind }) =>
   Effect.gen(function* () {
     const config = yield* AppConfig
     // The flag level of the precedence rule: flags > env > file > defaults.
     // The override is folded back into the AppConfig the server stack sees,
     // so consumers of the settled port (e.g. the zmx adapter's ATC_ENDPOINT
     // injection) always read the port actually being served.
-    const effective = { ...config, port: Option.getOrElse(port, () => config.port) }
+    const effective = {
+      ...config,
+      port: Option.getOrElse(port, () => config.port),
+      bind: Option.getOrElse(bind, () => config.bind),
+    }
     // Compiled builds keep structured logs file-only (see logging.ts), which
     // would make a successful foreground start indistinguishable from a
     // hang. One human-facing stderr line announces the server; dev runs
@@ -60,11 +69,11 @@ export const serve = Command.make("serve", { port }, ({ port }) =>
     if (build.commit !== "dev") {
       yield* Effect.sync(() => {
         process.stderr.write(
-          `atc app server starting on http://127.0.0.1:${effective.port} (logs: ${effective.logFile})\n`,
+          `atc app server starting on http://${effective.bind}:${effective.port} (logs: ${effective.logFile})\n`,
         )
       })
     }
-    yield* Layer.launch(Server.production({ port: effective.port })).pipe(
+    yield* Layer.launch(Server.production({ port: effective.port, hostname: effective.bind })).pipe(
       Effect.provideService(AppConfig, effective),
     )
   }).pipe(
@@ -80,8 +89,8 @@ export const serve = Command.make("serve", { port }, ({ port }) =>
 
 // --- Background management ---
 
-/** Pidfile contents: which process, and which port it was started on. */
-const PidRecord = Schema.Struct({ pid: Schema.Int, port: Schema.Int })
+/** Pidfile contents: which process, and where it was told to listen. */
+const PidRecord = Schema.Struct({ pid: Schema.Int, port: Schema.Int, bind: Schema.String })
 const decodePidRecord = Schema.decodeEffect(Schema.fromJsonString(PidRecord))
 const encodePidRecord = Schema.encodeEffect(Schema.fromJsonString(PidRecord))
 
@@ -92,10 +101,17 @@ const readPidRecord = (fs: FileSystem.FileSystem, file: string) =>
     Effect.catch(() => Effect.succeed(undefined)),
   )
 
-/** One bounded health probe; false on any failure. */
-const probeHealth = (port: number, timeoutMillis: number) =>
+// The wildcard binds are not connectable addresses; probe and report loopback
+// for them. A specific address (loopback or a real interface) is reachable at
+// itself from the same host. IPv6 literals need brackets in a URL.
+const reachableHost = (bind: string): string =>
+  bind === "0.0.0.0" || bind === "::" || bind === "" ? "127.0.0.1" : bind
+const hostForUrl = (host: string): string => (host.includes(":") ? `[${host}]` : host)
+
+/** One bounded health probe against `host`; false on any failure. */
+const probeHealth = (host: string, port: number, timeoutMillis: number) =>
   Effect.tryPromise(() =>
-    fetch(`http://127.0.0.1:${port}/api/v1/health`, {
+    fetch(`http://${hostForUrl(host)}:${port}/api/v1/health`, {
       signal: AbortSignal.timeout(timeoutMillis),
     }),
   ).pipe(
@@ -133,23 +149,27 @@ const serviceCommand = (name: string) => {
   ) => effect.pipe(Effect.provide(appConfigLayer), Effect.catch(Cli.reportOnce(`atc ${name}`)))
 }
 
-export const start = Command.make("start", { port }, ({ port }) =>
+export const start = Command.make("start", { port, bind }, ({ port, bind }) =>
   Effect.gen(function* () {
     const config = yield* AppConfig
-    const effective = { ...config, port: Option.getOrElse(port, () => config.port) }
+    const effective = {
+      ...config,
+      port: Option.getOrElse(port, () => config.port),
+      bind: Option.getOrElse(bind, () => config.bind),
+    }
     const fs = yield* FileSystem.FileSystem
     const subprocess = yield* Subprocess
     const existing = yield* readPidRecord(fs, effective.pidFile)
     if (existing !== undefined && isProcessAlive(existing.pid)) {
       yield* Console.log(
-        `atc app server already running (pid ${existing.pid}) on http://127.0.0.1:${existing.port}`,
+        `atc app server already running (pid ${existing.pid}) on http://${hostForUrl(existing.bind)}:${existing.port}`,
       )
       return
     }
     // A healthy responder without a live pidfile is a foreground serve or
     // someone else's instance; a second server would only fail its bind
     // after the fact and this start would then claim the wrong process.
-    if (yield* probeHealth(effective.port, 1_000)) {
+    if (yield* probeHealth(reachableHost(effective.bind), effective.port, 1_000)) {
       return yield* Cli.failReported(
         `atc start: something is already serving on port ${effective.port} (a foreground \`atc serve\`?); stop it or pass --port`,
       )
@@ -158,17 +178,21 @@ export const start = Command.make("start", { port }, ({ port }) =>
     // source run is the bun runtime plus the entry script (argv[1]),
     // resolved against this same working directory.
     const build = yield* BuildInfo
-    const serveArgs = ["serve", "--port", String(effective.port)]
+    const serveArgs = ["serve", "--port", String(effective.port), "--bind", effective.bind]
     const pid = yield* subprocess.spawnDetached(
       build.commit === "dev"
         ? { executable: process.execPath, args: [process.argv[1] ?? "src/main.ts", ...serveArgs] }
         : { executable: process.execPath, args: serveArgs },
     )
     yield* fs.makeDirectory(config.stateDir, { recursive: true })
-    yield* encodePidRecord({ pid, port: effective.port }).pipe(
+    yield* encodePidRecord({ pid, port: effective.port, bind: effective.bind }).pipe(
       Effect.flatMap((json) => fs.writeFileString(effective.pidFile, json)),
     )
-    const healthy = yield* pollUntil(15_000, 150, probeHealth(effective.port, 1_000))
+    const healthy = yield* pollUntil(
+      15_000,
+      150,
+      probeHealth(reachableHost(effective.bind), effective.port, 1_000),
+    )
     if (!healthy) {
       // Success is only ever reported for a healthy server, so the spawned
       // child is stopped rather than left as an orphan no `stop` can reach.
@@ -186,7 +210,7 @@ export const start = Command.make("start", { port }, ({ port }) =>
       )
     }
     yield* Console.log(
-      `started atc app server (pid ${pid}) on http://127.0.0.1:${effective.port} (logs: ${effective.logFile})`,
+      `started atc app server (pid ${pid}) on http://${hostForUrl(effective.bind)}:${effective.port} (logs: ${effective.logFile})`,
     )
   }).pipe(serviceCommand("start")),
 ).pipe(Command.withDescription("Start the App Server in the background"))
@@ -248,12 +272,13 @@ export const status = Command.make("status", {}, () =>
     if (record === undefined || !isProcessAlive(record.pid)) {
       return yield* Cli.failReported("atc status: not running")
     }
-    const healthy = yield* probeHealth(record.port, 2_000)
+    const healthy = yield* probeHealth(reachableHost(record.bind), record.port, 2_000)
+    const url = `http://${hostForUrl(record.bind)}:${record.port}`
     if (!healthy) {
       return yield* Cli.failReported(
-        `atc status: running (pid ${record.pid}) but not answering on http://127.0.0.1:${record.port}; logs: ${config.logFile}`,
+        `atc status: running (pid ${record.pid}) but not answering on ${url}; logs: ${config.logFile}`,
       )
     }
-    yield* Console.log(`running (pid ${record.pid}) on http://127.0.0.1:${record.port}`)
+    yield* Console.log(`running (pid ${record.pid}) on ${url}`)
   }).pipe(serviceCommand("status")),
 ).pipe(Command.withDescription("Report background App Server status"))

--- a/app-server/src/cli/serve.ts
+++ b/app-server/src/cli/serve.ts
@@ -1,5 +1,7 @@
 import { Console, Effect, FileSystem, Layer, Option, Schema } from "effect"
 import { Command, Flag } from "effect/unstable/cli"
+import * as LocalTrust from "../api/localTrust.ts"
+import * as AuthToken from "../platform/authToken.ts"
 import { BuildInfo } from "../platform/buildInfo.ts"
 import { AppConfig, layer as appConfigLayer } from "../platform/config.ts"
 import {
@@ -69,7 +71,7 @@ export const serve = Command.make("serve", { port, bind }, ({ port, bind }) =>
     if (build.commit !== "dev") {
       yield* Effect.sync(() => {
         process.stderr.write(
-          `atc app server starting on http://${effective.bind}:${effective.port} (logs: ${effective.logFile})\n`,
+          `atc app server starting on http://${Server.hostForUrl(effective.bind)}:${effective.port} (logs: ${effective.logFile})\n`,
         )
       })
     }
@@ -89,8 +91,15 @@ export const serve = Command.make("serve", { port, bind }, ({ port, bind }) =>
 
 // --- Background management ---
 
-/** Pidfile contents: which process, and where it was told to listen. */
-const PidRecord = Schema.Struct({ pid: Schema.Int, port: Schema.Int, bind: Schema.String })
+/** Pidfile contents: which process, and where it was told to listen. `bind`
+ * is optional because the release before ATC-148 wrote `{ pid, port }`; those
+ * servers listened on the then-hardcoded loopback address, so a missing bind
+ * decodes as `127.0.0.1` and upgrades keep managing the old process. */
+const PidRecord = Schema.Struct({
+  pid: Schema.Int,
+  port: Schema.Int,
+  bind: Schema.optionalKey(Schema.String),
+})
 const decodePidRecord = Schema.decodeEffect(Schema.fromJsonString(PidRecord))
 const encodePidRecord = Schema.encodeEffect(Schema.fromJsonString(PidRecord))
 
@@ -98,21 +107,27 @@ const encodePidRecord = Schema.encodeEffect(Schema.fromJsonString(PidRecord))
 const readPidRecord = (fs: FileSystem.FileSystem, file: string) =>
   fs.readFileString(file).pipe(
     Effect.flatMap(decodePidRecord),
+    Effect.map((record) => ({ ...record, bind: record.bind ?? "127.0.0.1" })),
     Effect.catch(() => Effect.succeed(undefined)),
   )
 
 // The wildcard binds are not connectable addresses; probe and report loopback
 // for them. A specific address (loopback or a real interface) is reachable at
-// itself from the same host. IPv6 literals need brackets in a URL.
+// itself from the same host.
 const reachableHost = (bind: string): string =>
   bind === "0.0.0.0" || bind === "::" || bind === "" ? "127.0.0.1" : bind
-const hostForUrl = (host: string): string => (host.includes(":") ? `[${host}]` : host)
+
+// A probe at a host the trust rule does not recognize as loopback is itself
+// a remote request (api/localTrust.ts) and only passes with the bearer token.
+const probeNeedsToken = (host: string): boolean =>
+  !LocalTrust.isLoopbackHost(Server.hostForUrl(host))
 
 /** One bounded health probe against `host`; false on any failure. */
-const probeHealth = (host: string, port: number, timeoutMillis: number) =>
+const probeHealth = (host: string, port: number, timeoutMillis: number, token?: string) =>
   Effect.tryPromise(() =>
-    fetch(`http://${hostForUrl(host)}:${port}/api/v1/health`, {
+    fetch(`http://${Server.hostForUrl(host)}:${port}/api/v1/health`, {
       signal: AbortSignal.timeout(timeoutMillis),
+      headers: token === undefined ? {} : { authorization: `Bearer ${token}` },
     }),
   ).pipe(
     Effect.map((response) => response.ok),
@@ -162,14 +177,22 @@ export const start = Command.make("start", { port, bind }, ({ port, bind }) =>
     const existing = yield* readPidRecord(fs, effective.pidFile)
     if (existing !== undefined && isProcessAlive(existing.pid)) {
       yield* Console.log(
-        `atc app server already running (pid ${existing.pid}) on http://${hostForUrl(existing.bind)}:${existing.port}`,
+        `atc app server already running (pid ${existing.pid}) on http://${Server.hostForUrl(existing.bind)}:${existing.port}`,
       )
       return
     }
+    // A non-loopback probe host needs the bearer token; prepare it up front
+    // (the spawned server adopts the same file — `ensure` resolves the
+    // create race), and let token-file trouble fail with its own actionable
+    // diagnostic rather than 15 s of 403s and a generic unhealthy report.
+    // Loopback starts never touch the token, so a broken token file cannot
+    // block them (mirroring the server's own boot rule).
+    const probeHost = reachableHost(effective.bind)
+    const token = probeNeedsToken(probeHost) ? yield* AuthToken.ensure : undefined
     // A healthy responder without a live pidfile is a foreground serve or
     // someone else's instance; a second server would only fail its bind
     // after the fact and this start would then claim the wrong process.
-    if (yield* probeHealth(reachableHost(effective.bind), effective.port, 1_000)) {
+    if (yield* probeHealth(probeHost, effective.port, 1_000, token)) {
       return yield* Cli.failReported(
         `atc start: something is already serving on port ${effective.port} (a foreground \`atc serve\`?); stop it or pass --port`,
       )
@@ -191,7 +214,7 @@ export const start = Command.make("start", { port, bind }, ({ port, bind }) =>
     const healthy = yield* pollUntil(
       15_000,
       150,
-      probeHealth(reachableHost(effective.bind), effective.port, 1_000),
+      probeHealth(probeHost, effective.port, 1_000, token),
     )
     if (!healthy) {
       // Success is only ever reported for a healthy server, so the spawned
@@ -210,7 +233,7 @@ export const start = Command.make("start", { port, bind }, ({ port, bind }) =>
       )
     }
     yield* Console.log(
-      `started atc app server (pid ${pid}) on http://${hostForUrl(effective.bind)}:${effective.port} (logs: ${effective.logFile})`,
+      `started atc app server (pid ${pid}) on http://${Server.hostForUrl(effective.bind)}:${effective.port} (logs: ${effective.logFile})`,
     )
   }).pipe(serviceCommand("start")),
 ).pipe(Command.withDescription("Start the App Server in the background"))
@@ -272,8 +295,15 @@ export const status = Command.make("status", {}, () =>
     if (record === undefined || !isProcessAlive(record.pid)) {
       return yield* Cli.failReported("atc status: not running")
     }
-    const healthy = yield* probeHealth(reachableHost(record.bind), record.port, 2_000)
-    const url = `http://${hostForUrl(record.bind)}:${record.port}`
+    // Status never creates or repairs the token file; a missing or invalid
+    // one simply leaves the probe unauthenticated (and the server it cannot
+    // reach was not serving remote clients anyway — verify fails closed).
+    const probeHost = reachableHost(record.bind)
+    const token = probeNeedsToken(probeHost)
+      ? yield* AuthToken.read.pipe(Effect.catch(() => Effect.succeed(undefined)))
+      : undefined
+    const healthy = yield* probeHealth(probeHost, record.port, 2_000, token)
+    const url = `http://${Server.hostForUrl(record.bind)}:${record.port}`
     if (!healthy) {
       return yield* Cli.failReported(
         `atc status: running (pid ${record.pid}) but not answering on ${url}; logs: ${config.logFile}`,

--- a/app-server/src/cli/token.ts
+++ b/app-server/src/cli/token.ts
@@ -1,0 +1,31 @@
+import { Console, Effect, FileSystem } from "effect"
+import { Command } from "effect/unstable/cli"
+import * as AuthToken from "../platform/authToken.ts"
+import { AppConfig, layer as appConfigLayer } from "../platform/config.ts"
+import * as Cli from "./cli.ts"
+
+// `atc token` (ATC-148): the remote-access credential, managed locally.
+// These are filesystem commands over the data dir's token file — not API
+// operations — so they work with no server running and take no connection
+// flags. Rotation takes effect immediately on a running server (the trust
+// middleware re-reads the file per check); distributing the new token to
+// remote clients means re-pasting it.
+
+const printToken = <E>(
+  diagnosticName: string,
+  read: Effect.Effect<string, E, AppConfig | FileSystem.FileSystem>,
+) =>
+  read.pipe(
+    Effect.flatMap((value) => Console.log(value)),
+    Effect.provide(appConfigLayer),
+    Effect.catch(Cli.reportOnce(`atc ${diagnosticName}`)),
+  )
+
+const rotate = Command.make("rotate", {}, () => printToken("token rotate", AuthToken.rotate)).pipe(
+  Command.withDescription("Reissue the token and print it (the old token stops working)"),
+)
+
+export const token = Command.make("token", {}, () => printToken("token", AuthToken.ensure)).pipe(
+  Command.withDescription("Print the remote-access bearer token, generating it if absent"),
+  Command.withSubcommands([rotate]),
+)

--- a/app-server/src/main.ts
+++ b/app-server/src/main.ts
@@ -7,6 +7,7 @@ import { api, capabilities, context } from "./cli/gateway.ts"
 import { project } from "./cli/projects.ts"
 import { serve, start, status, stop } from "./cli/serve.ts"
 import { terminal } from "./cli/terminals.ts"
+import { token } from "./cli/token.ts"
 import { thread } from "./cli/threads.ts"
 import { smoke } from "./agents/smoke.ts"
 import * as Subprocess from "./platform/subprocess.ts"
@@ -29,6 +30,7 @@ const atc = Command.make("atc").pipe(
     project,
     thread,
     terminal,
+    token,
     fs,
     smoke,
   ]),

--- a/app-server/src/platform/authToken.ts
+++ b/app-server/src/platform/authToken.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, FileSystem, Layer } from "effect"
+import { Context, Effect, FileSystem, Layer, Schema } from "effect"
 import { timingSafeEqual } from "node:crypto"
 import * as path from "node:path"
 import { AppConfig } from "./config.ts"
@@ -12,7 +12,8 @@ import { AppConfig } from "./config.ts"
 // at startup, so `atc token rotate` takes effect immediately — the old token
 // stops working without a server restart, and there is no cache-invalidation
 // machinery to get wrong. The read cost is paid only by non-loopback
-// requests presenting a token. A missing or unreadable file fails closed.
+// requests presenting a token. A missing, unreadable, or malformed file
+// fails closed.
 
 /** Prefixed 256-bit random token; the prefix makes leaks greppable. */
 const generate = (): string => {
@@ -20,6 +21,23 @@ const generate = (): string => {
   crypto.getRandomValues(bytes)
   return `atc_${Buffer.from(bytes).toString("base64url")}`
 }
+
+// Exactly the shape `generate` produces (32 base64url bytes = 43 chars). A
+// file holding anything else — a restored fragment, a hand-typed value — is
+// never adopted as a credential: `ensure` refuses it with a remedy and
+// `verify` fails closed, so weak or corrupt contents cannot become a
+// remotely accepted secret.
+const TOKEN_FORMAT = /^atc_[A-Za-z0-9_-]{43}$/
+
+/** The token file exists but does not hold a token we could have issued. */
+export class TokenFileError extends Schema.TaggedErrorClass<TokenFileError>()("TokenFileError", {
+  message: Schema.String,
+}) {}
+
+const malformed = (file: string) =>
+  new TokenFileError({
+    message: `token file ${file} does not hold a valid token; delete it or run \`atc token rotate\``,
+  })
 
 // Byte-wise timing-safe comparison. Length is not secret (the format is
 // public), so a length mismatch may return early.
@@ -29,13 +47,10 @@ const tokenEquals = (presented: string, actual: string): boolean => {
   return a.length === b.length && timingSafeEqual(a, b)
 }
 
-/** The stored token, or undefined when the file does not exist yet. */
+/** The trimmed file contents, or undefined when the file does not exist. */
 const readToken = (fs: FileSystem.FileSystem, file: string) =>
   fs.readFileString(file).pipe(
-    Effect.map((text) => {
-      const token = text.trim()
-      return token === "" ? undefined : token
-    }),
+    Effect.map((text) => text.trim()),
     Effect.catchTag("PlatformError", (error) =>
       error.reason._tag === "NotFound" ? Effect.succeed(undefined) : Effect.fail(error),
     ),
@@ -55,25 +70,47 @@ const replaceToken = (fs: FileSystem.FileSystem, file: string, token: string) =>
     return token
   })
 
+/** The persisted token when present and valid; never generates one. */
+export const read = Effect.gen(function* () {
+  const config = yield* AppConfig
+  const fs = yield* FileSystem.FileSystem
+  const token = yield* readToken(fs, config.tokenFile)
+  return token !== undefined && TOKEN_FORMAT.test(token) ? token : undefined
+})
+
 /** Read the persisted token, generating and persisting one if absent. */
 export const ensure = Effect.gen(function* () {
   const config = yield* AppConfig
   const fs = yield* FileSystem.FileSystem
   const existing = yield* readToken(fs, config.tokenFile)
-  if (existing !== undefined) return existing
+  if (existing !== undefined) {
+    if (!TOKEN_FORMAT.test(existing)) return yield* Effect.fail(malformed(config.tokenFile))
+    // Re-assert 0600: a copy or restore may have widened the mode, and a
+    // world-readable bearer credential defeats the point of one.
+    yield* fs.chmod(config.tokenFile, 0o600)
+    return existing
+  }
   yield* fs.makeDirectory(path.dirname(config.tokenFile), { recursive: true })
   const token = generate()
   // Exclusive create ("wx"): if a concurrent ensure (server boot racing
   // `atc token` on a fresh install) already created the file, adopt the
   // winner's token instead of overwriting it — otherwise each caller could
-  // mint and hand out a different token.
+  // mint and hand out a different token. When the winner's contents cannot
+  // be read back as a valid token, fail: returning our own value here would
+  // hand out a credential that is not on disk and will never verify.
   return yield* fs
     .writeFileString(config.tokenFile, `${token}\n`, { flag: "wx", mode: 0o600 })
     .pipe(
       Effect.as(token),
       Effect.catchTag("PlatformError", (error) =>
         error.reason._tag === "AlreadyExists"
-          ? readToken(fs, config.tokenFile).pipe(Effect.map((winner) => winner ?? token))
+          ? readToken(fs, config.tokenFile).pipe(
+              Effect.flatMap((winner) =>
+                winner !== undefined && TOKEN_FORMAT.test(winner)
+                  ? Effect.succeed(winner)
+                  : Effect.fail(malformed(config.tokenFile)),
+              ),
+            )
           : Effect.fail(error),
       ),
     )
@@ -111,7 +148,7 @@ export const layer = Layer.effect(AuthToken)(
     // file (bad permissions, wrong type) leaves remote access unavailable
     // (verify fails closed below), never blocks the server from starting.
     yield* ensure.pipe(
-      Effect.catchTag("PlatformError", (error) =>
+      Effect.catch((error) =>
         Effect.logWarning(`remote-access token unavailable: ${error.message}`),
       ),
     )
@@ -119,8 +156,13 @@ export const layer = Layer.effect(AuthToken)(
       verify: (authorization) => {
         const presented = authorization?.match(/^Bearer\s+(.+)$/i)?.[1]
         if (presented === undefined) return Effect.succeed(false)
+        // A stored value `generate` could not have produced never matches:
+        // a corrupt or hand-written file must not become a live credential.
         return readToken(fs, config.tokenFile).pipe(
-          Effect.map((token) => token !== undefined && tokenEquals(presented, token)),
+          Effect.map(
+            (token) =>
+              token !== undefined && TOKEN_FORMAT.test(token) && tokenEquals(presented, token),
+          ),
           Effect.catch(() => Effect.succeed(false)),
         )
       },

--- a/app-server/src/platform/authToken.ts
+++ b/app-server/src/platform/authToken.ts
@@ -1,0 +1,129 @@
+import { Context, Effect, FileSystem, Layer } from "effect"
+import { timingSafeEqual } from "node:crypto"
+import * as path from "node:path"
+import { AppConfig } from "./config.ts"
+
+// The remote-access credential (ATC-148): one static bearer token,
+// auto-generated on first server start and persisted as a 0600 file in the
+// data dir (SSH-host-key style). Loopback requests never consult it — it only
+// gates non-loopback requests in the trust middleware (api/localTrust.ts).
+//
+// Rotation rule: `verify` re-reads the file on every check instead of caching
+// at startup, so `atc token rotate` takes effect immediately — the old token
+// stops working without a server restart, and there is no cache-invalidation
+// machinery to get wrong. The read cost is paid only by non-loopback
+// requests presenting a token. A missing or unreadable file fails closed.
+
+/** Prefixed 256-bit random token; the prefix makes leaks greppable. */
+const generate = (): string => {
+  const bytes = new Uint8Array(32)
+  crypto.getRandomValues(bytes)
+  return `atc_${Buffer.from(bytes).toString("base64url")}`
+}
+
+// Byte-wise timing-safe comparison. Length is not secret (the format is
+// public), so a length mismatch may return early.
+const tokenEquals = (presented: string, actual: string): boolean => {
+  const a = Buffer.from(presented)
+  const b = Buffer.from(actual)
+  return a.length === b.length && timingSafeEqual(a, b)
+}
+
+/** The stored token, or undefined when the file does not exist yet. */
+const readToken = (fs: FileSystem.FileSystem, file: string) =>
+  fs.readFileString(file).pipe(
+    Effect.map((text) => {
+      const token = text.trim()
+      return token === "" ? undefined : token
+    }),
+    Effect.catchTag("PlatformError", (error) =>
+      error.reason._tag === "NotFound" ? Effect.succeed(undefined) : Effect.fail(error),
+    ),
+  )
+
+// Atomic replace: write a fresh 0600 temp file, then rename it over the
+// target. The mode is honored unconditionally (it applies at creation of the
+// temp, which rename preserves — plain `writeFileString`'s mode option is a
+// no-op over an existing file), and a concurrent `verify` never observes a
+// truncated or half-written token. Used by rotation.
+const replaceToken = (fs: FileSystem.FileSystem, file: string, token: string) =>
+  Effect.gen(function* () {
+    yield* fs.makeDirectory(path.dirname(file), { recursive: true })
+    const temp = `${file}.${crypto.randomUUID()}.tmp`
+    yield* fs.writeFileString(temp, `${token}\n`, { flag: "wx", mode: 0o600 })
+    yield* fs.rename(temp, file)
+    return token
+  })
+
+/** Read the persisted token, generating and persisting one if absent. */
+export const ensure = Effect.gen(function* () {
+  const config = yield* AppConfig
+  const fs = yield* FileSystem.FileSystem
+  const existing = yield* readToken(fs, config.tokenFile)
+  if (existing !== undefined) return existing
+  yield* fs.makeDirectory(path.dirname(config.tokenFile), { recursive: true })
+  const token = generate()
+  // Exclusive create ("wx"): if a concurrent ensure (server boot racing
+  // `atc token` on a fresh install) already created the file, adopt the
+  // winner's token instead of overwriting it — otherwise each caller could
+  // mint and hand out a different token.
+  return yield* fs
+    .writeFileString(config.tokenFile, `${token}\n`, { flag: "wx", mode: 0o600 })
+    .pipe(
+      Effect.as(token),
+      Effect.catchTag("PlatformError", (error) =>
+        error.reason._tag === "AlreadyExists"
+          ? readToken(fs, config.tokenFile).pipe(Effect.map((winner) => winner ?? token))
+          : Effect.fail(error),
+      ),
+    )
+})
+
+/** Unconditionally reissue the token; the old one stops working at once. */
+export const rotate = Effect.gen(function* () {
+  const config = yield* AppConfig
+  const fs = yield* FileSystem.FileSystem
+  return yield* replaceToken(fs, config.tokenFile, generate())
+})
+
+/**
+ * Bearer-credential check for the trust middleware: does this
+ * `Authorization` header value present the current token?
+ */
+export class AuthToken extends Context.Service<
+  AuthToken,
+  {
+    /** True only for a well-formed `Bearer` header matching the stored token. */
+    readonly verify: (authorization: string | undefined) => Effect.Effect<boolean>
+  }
+>()("app-server/AuthToken") {}
+
+/**
+ * Production layer: ensures the token exists at startup (so `atc token` on a
+ * fresh install prints the same credential the server enforces) and verifies
+ * by re-reading the file, failing closed on any read error.
+ */
+export const layer = Layer.effect(AuthToken)(
+  Effect.gen(function* () {
+    const config = yield* AppConfig
+    const fs = yield* FileSystem.FileSystem
+    // Preparing the token must not sink a loopback-only boot: a broken token
+    // file (bad permissions, wrong type) leaves remote access unavailable
+    // (verify fails closed below), never blocks the server from starting.
+    yield* ensure.pipe(
+      Effect.catchTag("PlatformError", (error) =>
+        Effect.logWarning(`remote-access token unavailable: ${error.message}`),
+      ),
+    )
+    return {
+      verify: (authorization) => {
+        const presented = authorization?.match(/^Bearer\s+(.+)$/i)?.[1]
+        if (presented === undefined) return Effect.succeed(false)
+        return readToken(fs, config.tokenFile).pipe(
+          Effect.map((token) => token !== undefined && tokenEquals(presented, token)),
+          Effect.catch(() => Effect.succeed(false)),
+        )
+      },
+    }
+  }),
+)

--- a/app-server/src/platform/config.ts
+++ b/app-server/src/platform/config.ts
@@ -57,6 +57,14 @@ export class AppConfig extends Context.Service<
     /** TCP port the server listens on / the CLI connects to. */
     readonly port: number
     /**
+     * Address the server binds. Default 127.0.0.1 (loopback only). The
+     * practical non-loopback value is 0.0.0.0: binding a single non-loopback
+     * address drops the loopback listener and breaks local clients (zmx
+     * children, the `atc start` health probe, the Web UI). Documented, not
+     * policed — any address is accepted.
+     */
+    readonly bind: string
+    /**
      * App Server base URL from ATC_ENDPOINT (set for processes ATC
      * launches); undefined means "derive from the local port". Environment
      * only — never a config-file key, because it describes the launching
@@ -75,6 +83,8 @@ export class AppConfig extends Context.Service<
     readonly stateDir: string
     /** SQLite database file path. */
     readonly dbFile: string
+    /** Bearer token file path (remote-access credential; 0600 in dataDir). */
+    readonly tokenFile: string
     /** Structured JSON log file path. */
     readonly logFile: string
     /** Background-service pidfile path (written by `atc start`). */
@@ -116,6 +126,7 @@ const configFilePath = (env: Env) =>
 // falling back to a default would be a partial boot).
 const FILE_KEYS = [
   "port",
+  "bind",
   "logLevel",
   "dataDir",
   "zmxExecutable",
@@ -226,6 +237,7 @@ export const load = (
 
     const settings = yield* Config.all({
       port: Config.port("port").pipe(Config.withDefault(DEFAULT_PORT)),
+      bind: Config.string("bind").pipe(Config.withDefault("127.0.0.1")),
       logLevel: logLevelConfig,
       dataDir: Config.string("dataDir").pipe(
         Config.withDefault(xdgDir(env, "XDG_DATA_HOME", [".local", "share"])),
@@ -296,6 +308,7 @@ export const load = (
     )
     return {
       port: settings.port,
+      bind: settings.bind,
       endpoint,
       context,
       logLevel: settings.logLevel,
@@ -303,6 +316,7 @@ export const load = (
       dataDir,
       stateDir,
       dbFile: path.join(dataDir, "atc.db"),
+      tokenFile: path.join(dataDir, "auth-token"),
       logFile: path.join(stateDir, "atc.log"),
       pidFile: path.join(stateDir, "atc.pid"),
       zmxExecutable: settings.zmxExecutable,

--- a/app-server/src/server.ts
+++ b/app-server/src/server.ts
@@ -67,6 +67,9 @@ const drainEventsBeforeStop = Layer.effectDiscard(
   }),
 )
 
+/** IPv6 literals need brackets to form a valid URL host (`[::1]:7332`). */
+export const hostForUrl = (host: string): string => (host.includes(":") ? `[${host}]` : host)
+
 // The resolved listen address, logged once the listener is up: with `bind`
 // configurable, the file log must record what the server actually bound.
 const logListenAddress = Layer.effectDiscard(
@@ -74,7 +77,7 @@ const logListenAddress = Layer.effectDiscard(
     const server = yield* HttpServer.HttpServer
     const address = server.address
     if (address._tag === "TcpAddress") {
-      yield* Effect.logInfo(`listening on http://${address.hostname}:${address.port}`)
+      yield* Effect.logInfo(`listening on http://${hostForUrl(address.hostname)}:${address.port}`)
     }
   }),
 )

--- a/app-server/src/server.ts
+++ b/app-server/src/server.ts
@@ -1,9 +1,10 @@
 import { BunHttpServer } from "@effect/platform-bun"
 import { Effect, Layer } from "effect"
-import { HttpMiddleware, HttpRouter, HttpServerResponse } from "effect/unstable/http"
+import { HttpMiddleware, HttpRouter, HttpServer, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { Api } from "./api/contract.ts"
 import * as AgentRegistry from "./agents/agentRegistry.ts"
+import * as AuthToken from "./platform/authToken.ts"
 import * as ClaudeAdapter from "./agents/claudeAdapter.ts"
 import * as ClaudeHooks from "./agents/claudeHooks.ts"
 import * as CodexAdapter from "./agents/codexAdapter.ts"
@@ -35,10 +36,11 @@ const openApiRoute = HttpRouter.add(
 )
 
 /**
- * All HTTP routes with the local-trust guard applied, independent of any
- * listener. Requires the handler services (BuildInfo, Projects, Directories,
- * Terminals, Threads, ClaudeHooks). The Claude hook webhook is an internal
- * route (claudeHooks.ts), deliberately outside the contract.
+ * All HTTP routes with the trust guard applied, independent of any listener.
+ * Requires the handler services (BuildInfo, Projects, Directories, Terminals,
+ * Threads, ClaudeHooks) plus AuthToken for the guard's bearer check. The
+ * Claude hook webhook is an internal route (claudeHooks.ts), deliberately
+ * outside the contract.
  */
 export const routes = Layer.mergeAll(
   HttpApiBuilder.layer(Api).pipe(Layer.provide(V1Handlers)),
@@ -65,19 +67,33 @@ const drainEventsBeforeStop = Layer.effectDiscard(
   }),
 )
 
+// The resolved listen address, logged once the listener is up: with `bind`
+// configurable, the file log must record what the server actually bound.
+const logListenAddress = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const server = yield* HttpServer.HttpServer
+    const address = server.address
+    if (address._tag === "TcpAddress") {
+      yield* Effect.logInfo(`listening on http://${address.hostname}:${address.port}`)
+    }
+  }),
+)
+
 /**
- * The full server: guarded routes on a loopback TCP listener, each request
- * wrapped in a tracer span (the correlation id source for logs). The layer's
- * scope owns the listener, so closing the scope (e.g. on SIGINT/SIGTERM
- * interruption) stops the server and releases the port.
+ * The full server: guarded routes on a TCP listener bound to `hostname`
+ * (loopback by default; the `bind` setting opens it — see localTrust.ts for
+ * the trust rule), each request wrapped in a tracer span (the correlation id
+ * source for logs). The layer's scope owns the listener, so closing the
+ * scope (e.g. on SIGINT/SIGTERM interruption) stops the server and releases
+ * the port.
  */
-export const layer = (options: { readonly port: number }) =>
-  drainEventsBeforeStop.pipe(
+export const layer = (options: { readonly port: number; readonly hostname?: string }) =>
+  Layer.mergeAll(drainEventsBeforeStop, logListenAddress).pipe(
     Layer.provideMerge(HttpRouter.serve(routes, { middleware: HttpMiddleware.tracer })),
     Layer.provideMerge(
       BunHttpServer.layer({
         port: options.port,
-        hostname: "127.0.0.1",
+        hostname: options.hostname ?? "127.0.0.1",
         // Bun never finishes a graceful stop once the server has initiated
         // a WebSocket close (the connection stays in its bookkeeping), so a
         // long grace period turns every shutdown after a terminal attach
@@ -98,8 +114,9 @@ export const layer = (options: { readonly port: number }) =>
  * layers. What remains open are the process-level services — AppConfig,
  * Subprocess, and the Bun runtime — supplied by the entrypoint.
  */
-export const production = (options: { readonly port: number }) =>
+export const production = (options: { readonly port: number; readonly hostname?: string }) =>
   layer(options).pipe(
+    Layer.provide(AuthToken.layer),
     Layer.provide([Projects.layer, Threads.layer]),
     Layer.provide([Terminals.layer, AgentRegistry.layer]),
     // Below Terminals (the deepest publisher) so one memoized Events instance

--- a/app-server/test/agents/claudeHooks.test.ts
+++ b/app-server/test/agents/claudeHooks.test.ts
@@ -1,6 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
 import { BunHttpServer } from "@effect/platform-bun"
-import { Effect, Layer } from "effect"
+import { Effect, Layer, Option } from "effect"
 import { HttpBody, HttpClientRequest, HttpRouter, HttpServerRequest } from "effect/unstable/http"
 import * as fs from "node:fs"
 import { fileURLToPath } from "node:url"
@@ -8,7 +8,7 @@ import type { AgentActivity } from "../../src/agents/agentAdapter.ts"
 import * as ClaudeHooks from "../../src/agents/claudeHooks.ts"
 import * as Server from "../../src/server.ts"
 import { TestBuildInfoLayer } from "../testBuildInfo.ts"
-import { TestRepositoryLayers } from "../testLayers.ts"
+import { TestAuthTokenLayer, TestRepositoryLayers } from "../testLayers.ts"
 
 // The Claude hook receiver, exercised with payloads RECORDED from a real
 // Claude Code 2.1.221 run (fixtures/claude-hook-payloads.json): secret
@@ -117,7 +117,7 @@ describe("claude hook webhook delivery", () => {
                   HttpClientRequest.setHeader(ClaudeHooks.SECRET_HEADER, headerSecret),
                   HttpClientRequest.setBody(HttpBody.jsonUnsafe(recorded[3])),
                 ),
-              ),
+              ).modify({ remoteAddress: Option.some("127.0.0.1") }),
             ),
             Effect.provideService(ClaudeHooks.ClaudeHooks, hooks),
             Effect.orDie,
@@ -126,6 +126,8 @@ describe("claude hook webhook delivery", () => {
         assert.deepStrictEqual(seen, ["idle"])
         assert.strictEqual((yield* post("bogus")).status, 404)
       }),
-    ).pipe(Effect.provide([ClaudeHooks.layer, BunHttpServer.layerHttpServices])),
+    ).pipe(
+      Effect.provide([ClaudeHooks.layer, TestAuthTokenLayer, BunHttpServer.layerHttpServices]),
+    ),
   )
 })

--- a/app-server/test/api/localTrust.test.ts
+++ b/app-server/test/api/localTrust.test.ts
@@ -120,6 +120,10 @@ describe("hardened listener", () => {
 })
 
 describe("bearer token trust (remote access)", () => {
+  // A loopback connection carrying a non-loopback Host: the shape of both a
+  // request proxied by `tailscale serve` (which preserves the incoming Host)
+  // and a DNS-rebinding attempt — indistinguishable server-side, so the
+  // token is required for it either way (see localTrust.ts).
   const remoteHost = "Host: workstation.tailnet:7332"
   const bearer = `Authorization: Bearer ${TEST_AUTH_TOKEN}`
 

--- a/app-server/test/api/localTrust.test.ts
+++ b/app-server/test/api/localTrust.test.ts
@@ -1,15 +1,16 @@
 import { assert, describe, it } from "@effect/vitest"
 import { BunServices } from "@effect/platform-bun"
 import { Effect, Layer } from "effect"
-import { isLoopbackHost, isLoopbackOrigin } from "../../src/api/localTrust.ts"
+import { isLoopbackAddress, isLoopbackHost, isLoopbackOrigin } from "../../src/api/localTrust.ts"
 import { openApiJson } from "../../src/api/openapi.ts"
 import * as Server from "../../src/server.ts"
-import { freePort } from "../blackbox.ts"
+import { freePort, rawStatus } from "../blackbox.ts"
 import { TestBuildInfoLayer } from "../testBuildInfo.ts"
-import { TestRepositoryLayers } from "../testLayers.ts"
+import { TEST_AUTH_TOKEN, TestRepositoryLayers } from "../testLayers.ts"
 
-// Listener hardening: spoofed-Host / cross-Origin requests are rejected with
-// 403 while ordinary local requests pass. Runs against a real loopback
+// Listener trust: spoofed-Host / cross-Origin requests are rejected with 403
+// while ordinary local requests pass, and non-loopback requests pass exactly
+// when they present the bearer token (ATC-148). Runs against a real loopback
 // listener because the guard sits on the HTTP layer, not in the handlers.
 
 const withServer = <A, E, R>(run: (port: number) => Effect.Effect<A, E, R>) =>
@@ -20,38 +21,6 @@ const withServer = <A, E, R>(run: (port: number) => Effect.Effect<A, E, R>) =>
     )
     return yield* run(port)
   }).pipe(Effect.scoped, Effect.provide(BunServices.layer))
-
-/** Raw HTTP exchange so tests can send arbitrary Host headers (fetch can't). */
-const rawStatus = (
-  port: number,
-  headers: ReadonlyArray<string>,
-  path = "/api/v1/health",
-): Promise<number> =>
-  new Promise((resolve, reject) => {
-    let data = ""
-    Bun.connect({
-      hostname: "127.0.0.1",
-      port,
-      socket: {
-        open(socket) {
-          socket.write(
-            [`GET ${path} HTTP/1.1`, ...headers, "Connection: close", "", ""].join("\r\n"),
-          )
-        },
-        data(socket, chunk) {
-          data += chunk.toString()
-          const match = data.match(/^HTTP\/1\.1 (\d{3})/)
-          if (match) {
-            socket.end()
-            resolve(Number(match[1]))
-          }
-        },
-        error(_socket, error) {
-          reject(error)
-        },
-      },
-    }).catch(reject)
-  })
 
 describe("host validation", () => {
   it("accepts loopback hosts and rejects everything else", () => {
@@ -66,6 +35,18 @@ describe("host validation", () => {
     assert.isFalse(isLoopbackHost("127.0.0.1.evil.example"))
     assert.isFalse(isLoopbackHost("localhost.evil.example"))
     assert.isFalse(isLoopbackHost("192.168.1.10:7332"))
+  })
+
+  it("recognizes loopback peer addresses and rejects routable ones", () => {
+    assert.isTrue(isLoopbackAddress("127.0.0.1"))
+    assert.isTrue(isLoopbackAddress("127.1.2.3"))
+    assert.isTrue(isLoopbackAddress("::1"))
+    assert.isTrue(isLoopbackAddress("::ffff:127.0.0.1"))
+    // The gate that stops a remote client spoofing `Host: localhost`.
+    assert.isFalse(isLoopbackAddress("192.168.1.10"))
+    assert.isFalse(isLoopbackAddress("10.0.0.5"))
+    assert.isFalse(isLoopbackAddress("100.64.0.7"))
+    assert.isFalse(isLoopbackAddress("::ffff:192.168.1.10"))
   })
 
   it("accepts loopback origins and rejects everything else", () => {
@@ -133,6 +114,48 @@ describe("hardened listener", () => {
           headers: { Origin: "null" },
         })
         assert.strictEqual(nullOrigin.status, 403)
+      }),
+    ),
+  )
+})
+
+describe("bearer token trust (remote access)", () => {
+  const remoteHost = "Host: workstation.tailnet:7332"
+  const bearer = `Authorization: Bearer ${TEST_AUTH_TOKEN}`
+
+  it.effect("a non-loopback request passes exactly when it presents the token", () =>
+    withServer((port) =>
+      Effect.promise(async () => {
+        assert.strictEqual(await rawStatus(port, [remoteHost, bearer]), 200)
+        assert.strictEqual(await rawStatus(port, [remoteHost]), 403)
+        assert.strictEqual(
+          await rawStatus(port, [remoteHost, "Authorization: Bearer atc_wrong"]),
+          403,
+        )
+        assert.strictEqual(
+          await rawStatus(port, [remoteHost, `Authorization: Basic ${TEST_AUTH_TOKEN}`]),
+          403,
+        )
+      }),
+    ),
+  )
+
+  it.effect("the attach WebSocket path sits under the same guard", () =>
+    withServer((port) =>
+      Effect.promise(async () => {
+        const attach = "/api/v1/terminals/nonexistent/attach"
+        assert.strictEqual(await rawStatus(port, [remoteHost], attach), 403)
+        // With the token the guard passes and the handler answers (404: no
+        // such terminal) — proof the token opens the pre-upgrade path too.
+        assert.strictEqual(await rawStatus(port, [remoteHost, bearer], attach), 404)
+      }),
+    ),
+  )
+
+  it.effect("loopback requests never need the token", () =>
+    withServer((port) =>
+      Effect.promise(async () => {
+        assert.strictEqual(await rawStatus(port, [`Host: 127.0.0.1:${port}`]), 200)
       }),
     ),
   )

--- a/app-server/test/api/openapi.test.ts
+++ b/app-server/test/api/openapi.test.ts
@@ -1,6 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
 import { BunHttpServer } from "@effect/platform-bun"
-import { Context, Effect, Layer } from "effect"
+import { Context, Effect, Layer, Option } from "effect"
 import {
   HttpBody,
   HttpClient,
@@ -16,7 +16,7 @@ import { openApiDocument, openApiJson } from "../../src/api/openapi.ts"
 import * as Server from "../../src/server.ts"
 import { appServerRoot } from "../blackbox.ts"
 import { TestBuildInfoLayer, testBuildInfo } from "../testBuildInfo.ts"
-import { TestRepositoryLayers } from "../testLayers.ts"
+import { TestAuthTokenLayer, TestRepositoryLayers } from "../testLayers.ts"
 
 // Contract-generation tests: the document must be deterministic, match the
 // checked-in artifact, cover every contract operation, and agree with what
@@ -117,15 +117,17 @@ const rawClient = Effect.gen(function* () {
   )
   return HttpClient.make(
     Effect.fnUntraced(function* (request) {
-      // fromClientRequest synthesizes no Host header; the local-trust guard in
-      // Server.routes requires a loopback one just like a real client sends.
+      // fromClientRequest synthesizes no Host header or peer address; the
+      // trust guard in Server.routes requires both a loopback Host and a
+      // loopback peer, just as Bun reports for a real local client.
       const serverRequest = HttpServerRequest.fromClientRequest(
         HttpClientRequest.setHeader(request, "host", "127.0.0.1"),
-      )
+      ).modify({ remoteAddress: Option.some("127.0.0.1") })
       const response = yield* handler.pipe(
         Effect.provideService(HttpServerRequest.HttpServerRequest, serverRequest),
-        // The internal Claude hook route resolves its service per request.
-        Effect.provide(ClaudeHooks.layer),
+        // The internal Claude hook route resolves its service per request;
+        // the trust middleware resolves AuthToken the same way.
+        Effect.provide([ClaudeHooks.layer, TestAuthTokenLayer]),
         Effect.orDie,
       )
       return HttpServerResponse.toClientResponse(response)

--- a/app-server/test/blackbox.ts
+++ b/app-server/test/blackbox.ts
@@ -102,6 +102,38 @@ export const freePort = async (): Promise<number> => {
   return port
 }
 
+/** Raw HTTP exchange so tests can send arbitrary Host headers (fetch can't). */
+export const rawStatus = (
+  port: number,
+  headers: ReadonlyArray<string>,
+  path = "/api/v1/health",
+): Promise<number> =>
+  new Promise((resolve, reject) => {
+    let data = ""
+    Bun.connect({
+      hostname: "127.0.0.1",
+      port,
+      socket: {
+        open(socket) {
+          socket.write(
+            [`GET ${path} HTTP/1.1`, ...headers, "Connection: close", "", ""].join("\r\n"),
+          )
+        },
+        data(socket, chunk) {
+          data += chunk.toString()
+          const match = data.match(/^HTTP\/1\.1 (\d{3})/)
+          if (match) {
+            socket.end()
+            resolve(Number(match[1]))
+          }
+        },
+        error(_socket, error) {
+          reject(error)
+        },
+      },
+    }).catch(reject)
+  })
+
 export const waitForHealth = async (base: string, proc: Bun.Subprocess): Promise<Response> => {
   for (let attempt = 0; attempt < 100; attempt++) {
     try {

--- a/app-server/test/cli/cli.blackbox.test.ts
+++ b/app-server/test/cli/cli.blackbox.test.ts
@@ -118,6 +118,27 @@ describe("atc health/version (black box)", () => {
   })
 })
 
+// Local filesystem commands over the data dir — they need no server, and the
+// shared suite server ignores them (loopback requests never read the token).
+describe("atc token (black box)", () => {
+  test("prints the persisted token, stable across calls", async () => {
+    const first = await cli(["token"])
+    expect(first.stdout).toMatch(/^atc_[A-Za-z0-9_-]{43}\n$/)
+    expect(first.stderr).toBe("")
+    expect(first.exitCode).toBe(0)
+    expect((await cli(["token"])).stdout).toBe(first.stdout)
+  })
+
+  test("rotate reissues the token and the file follows", async () => {
+    const before = (await cli(["token"])).stdout
+    const rotated = await cli(["token", "rotate"])
+    expect(rotated.stdout).toMatch(/^atc_[A-Za-z0-9_-]{43}\n$/)
+    expect(rotated.stdout).not.toBe(before)
+    expect(rotated.exitCode).toBe(0)
+    expect((await cli(["token"])).stdout).toBe(rotated.stdout)
+  })
+})
+
 describe("atc project / atc fs (black box)", () => {
   test("the server created and migrated the database in the configured data directory", () => {
     expect(existsSync(join(dataRoot, "data", "atc", "atc.db"))).toBe(true)

--- a/app-server/test/cli/serve.blackbox.test.ts
+++ b/app-server/test/cli/serve.blackbox.test.ts
@@ -86,10 +86,11 @@ describe("atc serve (black box)", () => {
   )
 
   // The remote-access trust rule (ATC-148) end to end: the real server
-  // generates the credential at startup, enforces it for non-loopback
-  // requests, and honors a CLI rotation immediately — no restart. Trust is
-  // header+token based, so a loopback connection with a non-loopback Host
-  // exercises exactly what a tailnet request presents.
+  // generates the credential at startup, enforces it for any non-loopback
+  // Host, and honors a CLI rotation immediately — no restart. A loopback
+  // connection with a non-loopback Host is the shape both a proxied request
+  // (`tailscale serve` preserves the incoming Host) and a DNS-rebinding
+  // attempt present, so the token is required for it by design.
   test("generates the auth token on start and enforces rotation live", async () => {
     const port = await freePort()
     const env = serveEnv()

--- a/app-server/test/cli/serve.blackbox.test.ts
+++ b/app-server/test/cli/serve.blackbox.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs"
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterAll, describe, expect, test } from "vitest"
@@ -7,6 +7,8 @@ import {
   cleanupTempDirs,
   freePort,
   isolatedEnv,
+  rawStatus,
+  runCli,
   spawnServe,
   waitForHealth,
 } from "../blackbox.ts"
@@ -82,6 +84,64 @@ describe("atc serve (black box)", () => {
     },
     30_000,
   )
+
+  // The remote-access trust rule (ATC-148) end to end: the real server
+  // generates the credential at startup, enforces it for non-loopback
+  // requests, and honors a CLI rotation immediately — no restart. Trust is
+  // header+token based, so a loopback connection with a non-loopback Host
+  // exercises exactly what a tailnet request presents.
+  test("generates the auth token on start and enforces rotation live", async () => {
+    const port = await freePort()
+    const env = serveEnv()
+    const proc = spawnFromSource(port, env)
+    try {
+      await waitForHealth(`http://127.0.0.1:${port}`, proc)
+
+      const tokenFile = `${env.XDG_DATA_HOME}/atc/auth-token`
+      expect(statSync(tokenFile).mode & 0o777).toBe(0o600)
+      const token = readFileSync(tokenFile, "utf8").trim()
+      expect(token).toMatch(/^atc_/)
+
+      const remoteHost = "Host: workstation.tailnet:7332"
+      expect(await rawStatus(port, [remoteHost])).toBe(403)
+      expect(await rawStatus(port, [remoteHost, `Authorization: Bearer ${token}`])).toBe(200)
+
+      const rotated = await runCli(
+        [process.execPath, "src/main.ts"],
+        ["token", "rotate"],
+        appServerRoot,
+        env,
+      )
+      expect(rotated.exitCode).toBe(0)
+      const newToken = rotated.stdout.trim()
+      expect(newToken).not.toBe(token)
+      expect(await rawStatus(port, [remoteHost, `Authorization: Bearer ${token}`])).toBe(403)
+      expect(await rawStatus(port, [remoteHost, `Authorization: Bearer ${newToken}`])).toBe(200)
+    } finally {
+      proc.kill()
+      await proc.exited
+    }
+  }, 30_000)
+
+  // `--bind 0.0.0.0` opens the listener beyond loopback while loopback still
+  // answers (0.0.0.0 includes it), so local clients keep working. Exercises
+  // the serve.ts flag-resolution path end to end.
+  test("serves over loopback when bound to 0.0.0.0 via --bind", async () => {
+    const port = await freePort()
+    const base = `http://127.0.0.1:${port}`
+    const proc = Bun.spawn(
+      [process.execPath, "src/main.ts", "serve", "--port", String(port), "--bind", "0.0.0.0"],
+      { cwd: appServerRoot, env: serveEnv(), stdout: "pipe", stderr: "pipe" },
+    )
+    try {
+      const health = await waitForHealth(base, proc)
+      expect(health.status).toBe(200)
+      expect(await health.json()).toEqual({ status: "ok" })
+    } finally {
+      proc.kill()
+      await proc.exited
+    }
+  }, 30_000)
 
   test("fails with one friendly stderr line when the port is taken", async () => {
     const occupant = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response("") })

--- a/app-server/test/cli/service.blackbox.test.ts
+++ b/app-server/test/cli/service.blackbox.test.ts
@@ -97,6 +97,41 @@ describe("atc start / stop / status (black box)", () => {
     expect(stopAgain.stdout).toContain("not running")
   }, 60_000)
 
+  // The release before ATC-148 wrote `{ pid, port }` pidfiles (no bind).
+  // `stop` proving it decodes the old shape — dead pid, so it removes the
+  // stale file rather than reporting "not running" from a failed decode —
+  // is what keeps upgrades able to manage a server the old binary started.
+  test("a pre-bind pidfile ({ pid, port }) still decodes", async () => {
+    const shortLived = Bun.spawn(["sh", "-c", "exit 0"])
+    await shortLived.exited
+    mkdirSync(join(env.XDG_STATE_HOME, "atc"), { recursive: true })
+    writeFileSync(pidFile, JSON.stringify({ pid: shortLived.pid, port: 1 }))
+
+    const stopped = await cli("stop")
+    expect(stopped.exitCode).toBe(0)
+    expect(stopped.stdout).toContain("removed a stale pidfile")
+    expect(existsSync(pidFile)).toBe(false)
+  }, 60_000)
+
+  // A specific (non-wildcard) bind: probes and reported URLs target the bind
+  // itself, and IPv6 literals come out bracketed.
+  test("start/status/stop manage a server bound to a specific address (::1)", async () => {
+    const port = await freePort()
+    const started = await cli("start", "--port", String(port), "--bind", "::1")
+    expect(started.stderr).toBe("")
+    expect(started.exitCode).toBe(0)
+    expect(started.stdout).toContain(`http://[::1]:${port}`)
+    const record = JSON.parse(readFileSync(pidFile, "utf8")) as { pid: number }
+    startedPids.push(record.pid)
+
+    const status = await cli("status")
+    expect(status.exitCode).toBe(0)
+    expect(status.stdout).toContain(`http://[::1]:${port}`)
+
+    const stopped = await cli("stop")
+    expect(stopped.exitCode).toBe(0)
+  }, 60_000)
+
   test("a stale pidfile is replaced by start and reported by status", async () => {
     // A pid that existed and is certainly gone now. The pidfile's parent
     // exists regardless of test order.

--- a/app-server/test/platform/authToken.test.ts
+++ b/app-server/test/platform/authToken.test.ts
@@ -60,6 +60,42 @@ describe("auth token", () => {
     }).pipe(Effect.provide(AuthToken.layer.pipe(Layer.provideMerge([config, BunServices.layer]))))
   })
 
+  it.effect("ensure refuses foreign token-file contents and repairs permissions", () => {
+    const { tokenFile, config } = withTokenDir()
+    return Effect.gen(function* () {
+      // Contents `generate` could not have produced are never adopted — a
+      // restored or hand-written value must not become a live credential.
+      fs.mkdirSync(path.dirname(tokenFile), { recursive: true })
+      fs.writeFileSync(tokenFile, "hunter2\n")
+      const malformed = yield* Effect.flip(AuthToken.ensure)
+      assert.strictEqual(malformed._tag, "TokenFileError")
+      assert.include(String(malformed.message), "atc token rotate")
+
+      // An empty file fails the same way rather than handing out a token
+      // that was never persisted.
+      fs.writeFileSync(tokenFile, "")
+      assert.strictEqual((yield* Effect.flip(AuthToken.ensure))._tag, "TokenFileError")
+
+      // A valid file whose mode was widened (copy, restore) is re-secured.
+      fs.rmSync(tokenFile)
+      const token = yield* AuthToken.ensure
+      fs.chmodSync(tokenFile, 0o644)
+      assert.strictEqual(yield* AuthToken.ensure, token)
+      assert.strictEqual(fs.statSync(tokenFile).mode & 0o777, 0o600)
+    }).pipe(Effect.provide([config, BunServices.layer]))
+  })
+
+  it.effect("a malformed token file fails closed in verify without blocking the layer", () => {
+    const { tokenFile, config } = withTokenDir()
+    fs.mkdirSync(path.dirname(tokenFile), { recursive: true })
+    fs.writeFileSync(tokenFile, "hunter2\n")
+    return Effect.gen(function* () {
+      const auth = yield* AuthToken.AuthToken
+      // The weak stored value is not accepted even when presented exactly.
+      assert.isFalse(yield* auth.verify("Bearer hunter2"))
+    }).pipe(Effect.provide(AuthToken.layer.pipe(Layer.provideMerge([config, BunServices.layer]))))
+  })
+
   it.effect("the service layer ensures the token exists at startup", () => {
     const { tokenFile, config } = withTokenDir()
     return Effect.gen(function* () {

--- a/app-server/test/platform/authToken.test.ts
+++ b/app-server/test/platform/authToken.test.ts
@@ -1,0 +1,71 @@
+import { assert, describe, it } from "@effect/vitest"
+import { BunServices } from "@effect/platform-bun"
+import { Effect, Layer } from "effect"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import * as AuthToken from "../../src/platform/authToken.ts"
+import { trackTempDir } from "../blackbox.ts"
+import { testAppConfig } from "../testLayers.ts"
+
+// The remote-access credential (ATC-148): generation is one-shot and 0600,
+// and `verify` follows the file — rotation applies immediately, a missing
+// file fails closed. Real filesystem because permissions and re-reads are
+// exactly what is under test.
+
+const withTokenDir = () => {
+  const dir = trackTempDir(fs.mkdtempSync(path.join(os.tmpdir(), "atc-token-")))
+  const tokenFile = path.join(dir, "data", "auth-token")
+  const config = testAppConfig({ tokenFile })
+  return { tokenFile, config }
+}
+
+describe("auth token", () => {
+  it.effect("ensure generates once, persists 0600, and stays stable", () => {
+    const { tokenFile, config } = withTokenDir()
+    return Effect.gen(function* () {
+      const first = yield* AuthToken.ensure
+      assert.match(first, /^atc_[A-Za-z0-9_-]{43}$/)
+      assert.strictEqual(fs.statSync(tokenFile).mode & 0o777, 0o600)
+      assert.strictEqual(fs.readFileSync(tokenFile, "utf8"), `${first}\n`)
+      assert.strictEqual(yield* AuthToken.ensure, first)
+    }).pipe(Effect.provide([config, BunServices.layer]))
+  })
+
+  it.effect("verify follows the file: rotation applies immediately, missing fails closed", () => {
+    const { tokenFile, config } = withTokenDir()
+    return Effect.gen(function* () {
+      const auth = yield* AuthToken.AuthToken
+      const token = yield* AuthToken.ensure
+
+      assert.isTrue(yield* auth.verify(`Bearer ${token}`))
+      // The scheme is case-insensitive; the token is not.
+      assert.isTrue(yield* auth.verify(`bearer ${token}`))
+      assert.isFalse(yield* auth.verify(token))
+      assert.isFalse(yield* auth.verify(`Bearer ${token}x`))
+      assert.isFalse(yield* auth.verify(`Bearer ${token.slice(0, -1)}`))
+      assert.isFalse(yield* auth.verify(undefined))
+      assert.isFalse(yield* auth.verify(""))
+
+      // Rotation is picked up without rebuilding anything — the old token
+      // stops working at once, the new one starts.
+      const rotated = yield* AuthToken.rotate
+      assert.notStrictEqual(rotated, token)
+      assert.isFalse(yield* auth.verify(`Bearer ${token}`))
+      assert.isTrue(yield* auth.verify(`Bearer ${rotated}`))
+
+      // No token on disk: fail closed rather than accept anything.
+      fs.rmSync(tokenFile)
+      assert.isFalse(yield* auth.verify(`Bearer ${rotated}`))
+    }).pipe(Effect.provide(AuthToken.layer.pipe(Layer.provideMerge([config, BunServices.layer]))))
+  })
+
+  it.effect("the service layer ensures the token exists at startup", () => {
+    const { tokenFile, config } = withTokenDir()
+    return Effect.gen(function* () {
+      yield* AuthToken.AuthToken
+      assert.isTrue(fs.existsSync(tokenFile))
+      assert.strictEqual(fs.statSync(tokenFile).mode & 0o777, 0o600)
+    }).pipe(Effect.provide(AuthToken.layer.pipe(Layer.provideMerge([config, BunServices.layer]))))
+  })
+})

--- a/app-server/test/platform/config.test.ts
+++ b/app-server/test/platform/config.test.ts
@@ -36,11 +36,13 @@ describe("configuration", () => {
     Effect.gen(function* () {
       const config = yield* load({})
       assert.strictEqual(config.port, DEFAULT_PORT)
+      assert.strictEqual(config.bind, "127.0.0.1")
       assert.strictEqual(config.logLevel, "Info")
       assert.strictEqual(config.configFile, join(home, ".config", "atc", "config.toml"))
       assert.strictEqual(config.dataDir, join(home, ".local", "share", "atc"))
       assert.strictEqual(config.stateDir, join(home, ".local", "state", "atc"))
       assert.strictEqual(config.dbFile, join(home, ".local", "share", "atc", "atc.db"))
+      assert.strictEqual(config.tokenFile, join(home, ".local", "share", "atc", "auth-token"))
       assert.strictEqual(config.logFile, join(home, ".local", "state", "atc", "atc.log"))
       assert.strictEqual(config.zmxExecutable, "zmx")
       assert.strictEqual(config.codexExecutable, "codex")
@@ -112,25 +114,31 @@ describe("configuration", () => {
 
   it.effect("config file values apply when the environment is silent", () =>
     Effect.gen(function* () {
-      const file = writeConfig(`port = 9100\nlogLevel = "debug"\ndataDir = "${scratch}/d"\n`)
+      const file = writeConfig(
+        `port = 9100\nbind = "0.0.0.0"\nlogLevel = "debug"\ndataDir = "${scratch}/d"\n`,
+      )
       const config = yield* load({ ATC_CONFIG: file })
       assert.strictEqual(config.port, 9100)
+      assert.strictEqual(config.bind, "0.0.0.0")
       assert.strictEqual(config.logLevel, "Debug")
       assert.strictEqual(config.dataDir, `${scratch}/d`)
       assert.strictEqual(config.dbFile, `${scratch}/d/atc.db`)
+      assert.strictEqual(config.tokenFile, `${scratch}/d/auth-token`)
     }),
   )
 
   it.effect("environment beats the config file", () =>
     Effect.gen(function* () {
-      const file = writeConfig(`port = 9100\nlogLevel = "debug"\n`)
+      const file = writeConfig(`port = 9100\nbind = "0.0.0.0"\nlogLevel = "debug"\n`)
       const config = yield* load({
         ATC_CONFIG: file,
         ATC_PORT: "9200",
+        ATC_BIND: "100.64.0.7",
         ATC_LOG_LEVEL: "warn",
         ATC_DATA_DIR: join(scratch, "env-data"),
       })
       assert.strictEqual(config.port, 9200)
+      assert.strictEqual(config.bind, "100.64.0.7")
       assert.strictEqual(config.logLevel, "Warn")
       assert.strictEqual(config.dataDir, join(scratch, "env-data"))
     }),

--- a/app-server/test/server.test.ts
+++ b/app-server/test/server.test.ts
@@ -20,8 +20,12 @@ const startServer = <R, E>(layer: Layer.Layer<R | HttpServer.HttpServer, E>) =>
     if (address._tag !== "TcpAddress") {
       return yield* Effect.die(`expected a TCP address, got ${address._tag}`)
     }
-    assert.strictEqual(address.hostname, "127.0.0.1")
-    return { scope, context, base: `http://127.0.0.1:${address.port}` }
+    return {
+      scope,
+      context,
+      hostname: address.hostname,
+      base: `http://127.0.0.1:${address.port}`,
+    }
   })
 
 describe("server layer", () => {
@@ -29,9 +33,10 @@ describe("server layer", () => {
   // timeout must run on the real clock, not it.effect's TestClock.
   it.live("binds loopback, serves the API, and releases the port when closed", () =>
     Effect.gen(function* () {
-      const { scope, base } = yield* startServer(
+      const { scope, base, hostname } = yield* startServer(
         Server.layer({ port: 0 }).pipe(Layer.provide([TestBuildInfoLayer, TestRepositoryLayers])),
       )
+      assert.strictEqual(hostname, "127.0.0.1")
 
       // Connection: close keeps fetch from pooling an idle socket, so the
       // release check below is forced onto a fresh connection.
@@ -50,6 +55,24 @@ describe("server layer", () => {
         ),
       )
       assert.strictEqual(released, true)
+    }),
+  )
+
+  // The `bind` setting (ATC-148) reaches the listener: a non-loopback bind
+  // still answers on loopback (0.0.0.0 includes it), keeping local clients
+  // working while remote interfaces open.
+  it.live("binds the configured address", () =>
+    Effect.gen(function* () {
+      const { base, hostname } = yield* startServer(
+        Server.layer({ port: 0, hostname: "0.0.0.0" }).pipe(
+          Layer.provide([TestBuildInfoLayer, TestRepositoryLayers]),
+        ),
+      )
+      assert.strictEqual(hostname, "0.0.0.0")
+      const health = yield* Effect.promise(() =>
+        fetch(`${base}/api/v1/health`, { headers: { connection: "close" } }),
+      )
+      assert.strictEqual(health.status, 200)
     }),
   )
 

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -6,6 +6,7 @@ import * as os from "node:os"
 import * as path from "node:path"
 import { fileURLToPath } from "node:url"
 import * as AgentRegistry from "../src/agents/agentRegistry.ts"
+import * as AuthToken from "../src/platform/authToken.ts"
 import * as ClaudeAdapter from "../src/agents/claudeAdapter.ts"
 import * as ClaudeHooks from "../src/agents/claudeHooks.ts"
 import * as CodexAdapter from "../src/agents/codexAdapter.ts"
@@ -47,10 +48,19 @@ type ServiceLayer = Layer.Layer<
   unknown
 >
 
+/** The fixed bearer token the test AuthToken layer accepts. */
+export const TEST_AUTH_TOKEN = "atc_test-token"
+
+/** AuthToken over a fixed credential — no filesystem, deterministic. */
+export const TestAuthTokenLayer = Layer.succeed(AuthToken.AuthToken)({
+  verify: (authorization) => Effect.succeed(authorization === `Bearer ${TEST_AUTH_TOKEN}`),
+})
+
 /** A settled AppConfig for tests that only need a few fields overridden. */
 export const testAppConfig = (overrides: Partial<AppConfig["Service"]>): Layer.Layer<AppConfig> =>
   Layer.succeed(AppConfig)({
     port: 0,
+    bind: "127.0.0.1",
     endpoint: undefined,
     context: {},
     logLevel: "Info",
@@ -58,6 +68,7 @@ export const testAppConfig = (overrides: Partial<AppConfig["Service"]>): Layer.L
     dataDir: "/tmp",
     stateDir: "/tmp",
     dbFile: "/tmp/atc.db",
+    tokenFile: "/tmp/atc-auth-token",
     logFile: "/tmp/atc.log",
     pidFile: "/tmp/atc.pid",
     zmxExecutable: "zmx",
@@ -90,7 +101,8 @@ export const makeTestServiceLayers = (
     | Threads.Threads
     | Projects.Projects
     | AgentRegistry.AgentRegistry
-    | Events.Events,
+    | Events.Events
+    | AuthToken.AuthToken,
     unknown
   >
 } => {
@@ -128,6 +140,7 @@ export const makeTestServiceLayers = (
       terminals,
       registry,
       eventsLayer,
+      TestAuthTokenLayer,
       Threads.layerWith(threadsOptions).pipe(
         Layer.provide([services, terminals, registry, eventsLayer]),
       ),

--- a/macos/ATC/Settings/ConnectionsSettingsView.swift
+++ b/macos/ATC/Settings/ConnectionsSettingsView.swift
@@ -313,7 +313,7 @@ private struct ConnectionEditorView: View {
         case .emptyName:
             return "Enter a name for this connection."
         case .invalidURL:
-            return "Enter a valid URL, including scheme — e.g. http://127.0.0.1:7331"
+            return "Enter a valid URL, including scheme — e.g. http://127.0.0.1:7332"
         case .duplicate:
             return "Another connection already uses this host and port."
         case .notFound:


### PR DESCRIPTION
Implements [ATC-148](https://linear.app/elevenideas/issue/ATC-148/remote-access): the server half of secure remote access. A `bind` setting opens the listener beyond loopback, and a server-generated bearer token gates every non-loopback request. Intended posture is tailnet-only reachability (Tailscale); the token is the just-in-case backstop.

## What's here

- **`bind` config setting** — precedence flags (`--bind`) > `ATC_BIND` > `config.toml` > default `127.0.0.1`. Replaces the hardcoded loopback hostname in `server.ts`. Any address is accepted, not validated; `0.0.0.0` is the documented non-loopback value (a single non-loopback address drops the loopback listener and breaks local clients). Startup/`status` lines show the resolved address, and the pidfile now records the bind.
- **Bearer token** (`platform/authToken.ts`) — one static token, generated on first server start into a `0600` file in the data dir (SSH-host-key style). Atomic temp+rename write guarantees the mode and never exposes a partial token; `ensure` uses exclusive-create so a first-start race (`atc token` vs boot) can't mint two tokens. `verify` re-reads the file per check, so rotation is immediate with no cache to invalidate.
- **One trust rule** (`api/localTrust.ts`, global middleware over API + SSE + attach WebSocket + hook webhook): a request passes if it's a **loopback TCP peer** whose `Host`/`Origin` are loopback, **or** presents `Authorization: Bearer <token>` (timing-safe); else the same empty 403 as before. Gating the token-free path on the peer address — not the client-controlled `Host` header — is what stops a remote client sending `Host: localhost` to skip the token. Requests proxied by `tailscale serve` keep the incoming (non-loopback) `Host`, making them indistinguishable from DNS rebinding, so they present the token like a direct tailnet/LAN peer — only direct loopback traffic is token-free.
- **`atc token` / `atc token rotate`** — local filesystem commands over the data dir (no server needed, no connection flags), print and reissue the credential.
- **No contract/OpenAPI change** — auth is a property of how you reach the server, not of any endpoint.
- **macOS** — fixed the stale `127.0.0.1:7331` placeholder in `ConnectionsSettingsView` (default port is 7332). No new client machinery (ATC-125 already shipped the Keychain token + `BearerAuthMiddleware` seams).

## Key decisions

- **Peer-address gating over Host-only trust.** The original loopback guard keyed trust off the `Host` header, which was safe only because the listener bound `127.0.0.1`. Opening `bind` made that a token-bypass (`Host: localhost` from any remote peer). The fix gates the token-free path on the real TCP peer (`request.remoteAddress`). `tailscale serve` still works — its proxied requests carry the bearer header remote clients attach anyway (the proxy preserves the incoming `Host`, so token-free proxying would need a Host allowlist nothing requires). Verified live: a remote peer with `Host: localhost` and no token now 403s.
- **Broken token file never blocks boot.** A loopback-only user who never wants remote access shouldn't be stopped by a bad `auth-token`; the layer logs a warning and continues, and `verify` fails closed.
- **Rotation is lazy re-read, not restart-required** — the simplest reliable rule; the per-request file read is paid only by non-loopback tokened requests.

## Testing

- Unit: token generate/ensure/rotate/verify (0600, rotation-follows-file, fail-closed), `isLoopbackAddress` spoof-defense table, `bind` config precedence.
- In-process listener: non-loopback `Host` + valid token passes, missing/wrong/mis-schemed token 403s, loopback free, attach WebSocket path under the same guard.
- Blackbox: token file creation + `0600`, `atc token`/`rotate` stdout, live rotation enforcement against a real `atc serve`, `serve --bind 0.0.0.0` serving over loopback.
- `mise run -C app-server check` green (266 passed). Manual macOS end-to-end over the tailnet remains the acceptance step per the issue.

## Review

Two adversarial sub-agent reviews (correctness + simplicity). The correctness pass caught the Host-spoof token bypass (now fixed with peer-gating) plus non-atomic token writes, the first-start race, fail-closed boot, and the `atc start` probe hardcoding loopback — all addressed. Simplicity pass drove the pidfile/message fixes, README de-duplication, and the `--bind` blackbox test.

https://claude.ai/code/session_013BegU75begedQiErViRJAn


## Review follow-up

Commit 0b25ce6a addresses all six findings from the inline review: token-file format/permission enforcement (fail-closed verify, actionable `ensure` diagnostics, 0600 repair), no unpersisted tokens on create races, pre-ATC-148 pidfile compatibility, bearer-authenticated management probes (verified live with `--bind 192.168.1.26`), bracketed IPv6 URLs, and corrected `tailscale serve` docs per the above.
