### PR TITLE
atc service, release automation, and install.sh (ATC-149)

### DIFF
--- a/.github/workflows/app-server-ci.yml
+++ b/.github/workflows/app-server-ci.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "app-server/**"
       - "mise.toml"
+      - "install.sh"
       - ".github/workflows/app-server-ci.yml"
   push:
     branches:
@@ -12,6 +13,7 @@ on:
     paths:
       - "app-server/**"
       - "mise.toml"
+      - "install.sh"
       - ".github/workflows/app-server-ci.yml"
 
 permissions:
@@ -44,6 +46,10 @@ jobs:
       # contract).
       - name: Check
         run: mise run check
+
+      # The root install script has no test suite; at least keep it parseable.
+      - name: Syntax-check install.sh
+        run: sh -n ../install.sh
 
   # Proves all four release targets compile. Cross-compilation alone says
   # nothing about runtime behavior — that is what native-validate is for.

--- a/.github/workflows/app-server-release.yml
+++ b/.github/workflows/app-server-release.yml
@@ -1,0 +1,234 @@
+# Manual-dispatch release pipeline for the App Server executable (ATC-127).
+#
+# channel=test    build + validate + upload a snapshot workflow artifact
+# channel=stable  additionally tag (vX.Y.Z, continuing the existing series)
+#                 and publish a GitHub Release with tarballs + checksums
+#
+# Darwin targets build on macOS so Bun's ad-hoc code signature is applied
+# (and verified) natively; Linux targets cross-compile on ubuntu. Three of
+# the four targets are validated natively with the compiled black-box suite
+# against the release-built binary — darwin-x64 is compile-only best-effort
+# (GitHub's free Intel macOS runners are retired). The tag is only pushed
+# after every build and validation job has passed.
+name: App Server Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: "Build a test artifact or publish a stable GitHub release"
+        type: choice
+        required: true
+        default: test
+        options:
+          - test
+          - stable
+      release_type:
+        description: "Stable release version bump"
+        type: choice
+        required: true
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: read
+
+# One release at a time: two stable dispatches would compute the same tag.
+concurrency:
+  group: app-server-release
+  cancel-in-progress: false
+
+defaults:
+  run:
+    working-directory: app-server
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Compute release version
+        id: version
+        run: |
+          if [ "${{ inputs.channel }}" = "stable" ]; then
+            if [ "${GITHUB_REF_NAME}" != "${{ github.event.repository.default_branch }}" ]; then
+              echo "stable releases must run from ${{ github.event.repository.default_branch }}; use channel=test for branch builds" >&2
+              exit 1
+            fi
+            tag="$(scripts/next-version.sh "${{ inputs.release_type }}")"
+            echo "tag=$tag" >> "$GITHUB_OUTPUT"
+            echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            echo "version=0.0.0-test.$(echo "$GITHUB_SHA" | cut -c1-7)" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-darwin:
+    needs: plan
+    runs-on: macos-14
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: jdx/mise-action@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          working_directory: app-server
+
+      - name: Build darwin targets
+        run: |
+          mise run install
+          bun run scripts/build.ts --version=${{ needs.plan.outputs.version }} darwin-arm64 darwin-x64
+
+      # Bun applies an ad-hoc signature at compile time; verify it, and
+      # re-sign in place if a Bun upgrade ever stops doing so.
+      - name: Verify ad-hoc signatures
+        run: |
+          for target in darwin-arm64 darwin-x64; do
+            codesign --verify --strict "dist/atc-$target" || codesign --force -s - "dist/atc-$target"
+            codesign --verify --strict "dist/atc-$target"
+          done
+
+      - name: Verify version stamp
+        run: test "$(dist/atc-darwin-arm64 --version)" = "atc v${{ needs.plan.outputs.version }}"
+
+      - name: Compiled black-box tests (native arm64)
+        run: ATC_COMPILED_BIN="$PWD/dist/atc-darwin-arm64" bun --bun vitest run test/compiled.blackbox.test.ts
+
+      - name: Package tarballs
+        run: |
+          mkdir -p out
+          for target in darwin-arm64 darwin-x64; do
+            staging="$(mktemp -d)"
+            cp "dist/atc-$target" "$staging/atc"
+            tar -czf "out/atc-$target.tar.gz" -C "$staging" atc
+          done
+          (cd out && shasum -a 256 *.tar.gz > checksums-darwin.txt)
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: atc-darwin
+          path: app-server/out/*
+          if-no-files-found: error
+
+  build-linux:
+    needs: plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: jdx/mise-action@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          working_directory: app-server
+
+      - name: Build linux targets
+        run: |
+          mise run install
+          bun run scripts/build.ts --version=${{ needs.plan.outputs.version }} linux-x64 linux-arm64
+
+      - name: Standing gates (fmt, typecheck, tests, drift)
+        run: mise run check
+
+      - name: Verify version stamp
+        run: test "$(dist/atc-linux-x64 --version)" = "atc v${{ needs.plan.outputs.version }}"
+
+      - name: Compiled black-box tests (native x64)
+        run: ATC_COMPILED_BIN="$PWD/dist/atc-linux-x64" bun --bun vitest run test/compiled.blackbox.test.ts
+
+      - name: Package tarballs
+        run: |
+          mkdir -p out
+          for target in linux-x64 linux-arm64; do
+            staging="$(mktemp -d)"
+            cp "dist/atc-$target" "$staging/atc"
+            tar -czf "out/atc-$target.tar.gz" -C "$staging" atc
+          done
+          (cd out && sha256sum *.tar.gz > checksums-linux.txt)
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: atc-linux
+          path: app-server/out/*
+          if-no-files-found: error
+
+  # Native validation of the cross-compiled arm64 binary, from the packaged
+  # tarball — this also proves the archive layout install.sh relies on.
+  validate-linux-arm:
+    needs: build-linux
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: jdx/mise-action@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          working_directory: app-server
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: atc-linux
+          path: app-server/out
+
+      - name: Compiled black-box tests (native arm64, extracted tarball)
+        run: |
+          mise run install
+          tar -xzf out/atc-linux-arm64.tar.gz -C out
+          ATC_COMPILED_BIN="$PWD/out/atc" bun --bun vitest run test/compiled.blackbox.test.ts
+
+  release:
+    needs: [plan, build-darwin, build-linux, validate-linux-arm]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v7
+        with:
+          path: app-server/release
+          merge-multiple: true
+
+      - name: Merge checksums
+        run: |
+          cd release
+          cat checksums-*.txt | sort -k2 > checksums.txt
+          rm checksums-*.txt
+          ls -l
+
+      - name: Upload test release artifact
+        if: inputs.channel == 'test'
+        uses: actions/upload-artifact@v6
+        with:
+          name: atc-test-release-${{ github.run_id }}
+          path: app-server/release/*
+          if-no-files-found: error
+
+      - name: Publish stable GitHub release
+        if: inputs.channel == 'stable'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ needs.plan.outputs.tag }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$tag" -m "Release $tag"
+          git push origin "$tag"
+          gh release create "$tag" release/*.tar.gz release/checksums.txt \
+            --title "$tag" \
+            --notes "$(printf 'Install or update:\n\n    curl -fsSL https://raw.githubusercontent.com/%s/main/install.sh | sh\n\nThen run `atc service install` to start it as a login service.' "$GITHUB_REPOSITORY")"

--- a/app-server/README.md
+++ b/app-server/README.md
@@ -58,7 +58,9 @@ Almost everything else is a client of the HTTP API, which is the complete
 canonical interface: `atc api <method> <path>` (GET, POST, PUT, PATCH, DELETE)
 reaches every operation, and curated commands exist only where they add local
 behavior (relative-path resolution, TTY attach, `--yes` delete guards). The
-exceptions are `atc start`/`stop`/`status` (background process management) and
+exceptions are `atc start`/`stop`/`status` (self-managed background process),
+`atc service` (user-scope launchd/systemd units for running the server as a
+login service — separate from `start`, which supervises nothing), and
 `atc token` (the remote-access credential is a local `0600` file, not an API
 resource). Run `atc --help` for the command surface and
 `atc capabilities --json` for the machine-readable summary.

--- a/app-server/scripts/build.ts
+++ b/app-server/scripts/build.ts
@@ -1,8 +1,12 @@
 // Compiles src/main.ts into standalone `atc` executables with Bun.
 //
-// Usage: bun run scripts/build.ts [--all]
-//   default  compile for the host platform only
-//   --all    cross-compile every release target
+// Usage: bun run scripts/build.ts [--all] [--version=X.Y.Z] [target ...]
+//   default          compile for the host platform only
+//   --all            cross-compile every release target
+//   --version=X.Y.Z  stamp a release version (default: package.json version)
+//   target ...       compile exactly these targets (release CI builds darwin
+//                    targets on macOS so Bun's ad-hoc code signature is
+//                    applied natively)
 //
 // Output names are deterministic (dist/atc-<os>-<arch>) so CI and release
 // tooling can consume them without discovery logic.
@@ -34,11 +38,29 @@ const dirty = run(["git", "status", "--porcelain"]) === "" ? "" : "-dirty"
 const commit = run(["git", "rev-parse", "HEAD"]) + dirty
 const builtAt = new Date().toISOString()
 
-const targets: ReadonlyArray<Target> = process.argv.includes("--all")
+const args = process.argv.slice(2)
+// A typo'd flag must not silently release with the package.json fallback
+// version, so anything dash-prefixed and unrecognized is fatal.
+const unknownFlags = args.filter(
+  (arg) => arg.startsWith("--") && arg !== "--all" && !arg.startsWith("--version="),
+)
+if (unknownFlags.length > 0) {
+  throw new Error(`unknown flag(s): ${unknownFlags.join(", ")}`)
+}
+const version = args.find((arg) => arg.startsWith("--version="))?.slice("--version=".length)
+const requested = args.filter((arg) => !arg.startsWith("--"))
+const invalid = requested.filter((target) => !(TARGETS as readonly string[]).includes(target))
+if (invalid.length > 0) {
+  throw new Error(`unknown target(s) ${invalid.join(", ")}; expected: ${TARGETS.join(", ")}`)
+}
+
+const targets: ReadonlyArray<Target> = args.includes("--all")
   ? TARGETS
-  : hostTarget !== null
-    ? [hostTarget]
-    : []
+  : requested.length > 0
+    ? (requested as ReadonlyArray<Target>)
+    : hostTarget !== null
+      ? [hostTarget]
+      : []
 if (targets.length === 0) {
   throw new Error(`unsupported host platform ${host}; expected one of: ${TARGETS.join(", ")}`)
 }
@@ -57,8 +79,11 @@ for (const target of targets) {
     // The define value is a JS expression, so a string needs its quotes.
     `--define=ATC_BUILD_COMMIT=${JSON.stringify(commit)}`,
     `--define=ATC_BUILD_BUILT_AT=${JSON.stringify(builtAt)}`,
+    ...(version === undefined ? [] : [`--define=ATC_BUILD_VERSION=${JSON.stringify(version)}`]),
     `--outfile=${outfile}`,
     "src/main.ts",
   ])
-  console.log(`built ${outfile} (commit ${commit.slice(0, 12)}${dirty}, ${builtAt})`)
+  console.log(
+    `built ${outfile} (${version === undefined ? "" : `version ${version}, `}commit ${commit.slice(0, 12)}${dirty}, ${builtAt})`,
+  )
 }

--- a/app-server/scripts/next-version.sh
+++ b/app-server/scripts/next-version.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+set -eu
+
+release_type="${1:-}"
+
+case "$release_type" in
+  patch|minor|major) ;;
+  *)
+    echo "usage: scripts/next-version.sh patch|minor|major" >&2
+    exit 1
+    ;;
+esac
+
+latest="$(
+  git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=v:refname |
+    awk '/^v[0-9]+\.[0-9]+\.[0-9]+$/ { latest=$0 } END { print latest }'
+)"
+
+if [ -z "$latest" ]; then
+  latest="v0.0.0"
+fi
+
+version="${latest#v}"
+major="${version%%.*}"
+rest="${version#*.}"
+minor="${rest%%.*}"
+patch="${rest#*.}"
+
+case "$release_type" in
+  major)
+    major=$((major + 1))
+    minor=0
+    patch=0
+    ;;
+  minor)
+    minor=$((minor + 1))
+    patch=0
+    ;;
+  patch)
+    patch=$((patch + 1))
+    ;;
+esac
+
+next="v${major}.${minor}.${patch}"
+if git rev-parse -q --verify "refs/tags/${next}" >/dev/null; then
+  echo "tag already exists: ${next}" >&2
+  exit 1
+fi
+
+printf '%s\n' "$next"
+

--- a/app-server/src/cli/cli.ts
+++ b/app-server/src/cli/cli.ts
@@ -4,7 +4,9 @@ import { Argument, Command, Flag } from "effect/unstable/cli"
 import { HttpClient } from "effect/unstable/http"
 import * as path from "node:path"
 import * as Client from "../api/client.ts"
+import * as LocalTrust from "../api/localTrust.ts"
 import { AppConfig, ConfigLoadError, layer as appConfigLayer } from "../platform/config.ts"
+import * as Server from "../server.ts"
 
 // Shared CLI plumbing: the one-line stderr diagnostic contract, the base-URL
 // resolution seam, and the clientCommand shape every API-backed command uses.
@@ -45,6 +47,57 @@ export const describeError = (error: unknown): string =>
     : error instanceof Error && error.message !== ""
       ? error.message
       : String(error)
+
+/**
+ * The command tail shared by every settled-config command (serve, the
+ * start/stop/status family, the service group): provide AppConfig and
+ * collapse failures into the one-line diagnostic under `prefix`.
+ */
+export const withSettledConfig = (prefix: string) => {
+  return <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    effect.pipe(Effect.provide(appConfigLayer), Effect.catch(reportOnce(prefix)))
+}
+
+// --- Server liveness probing (shared by serve.ts and service.ts, whose two
+// process families are otherwise deliberately independent) ---
+
+// The wildcard binds are not connectable addresses; probe and report loopback
+// for them. A specific address (loopback or a real interface) is reachable at
+// itself from the same host.
+export const reachableHost = (bind: string): string =>
+  bind === "0.0.0.0" || bind === "::" || bind === "" ? "127.0.0.1" : bind
+
+// A probe at a host the trust rule does not recognize as loopback is itself
+// a remote request (api/localTrust.ts) and only passes with the bearer token.
+export const probeNeedsToken = (host: string): boolean =>
+  !LocalTrust.isLoopbackHost(Server.hostForUrl(host))
+
+/** One bounded health probe against `host`; false on any failure. */
+export const probeHealth = (host: string, port: number, timeoutMillis: number, token?: string) =>
+  Effect.tryPromise(() =>
+    fetch(`http://${Server.hostForUrl(host)}:${port}/api/v1/health`, {
+      signal: AbortSignal.timeout(timeoutMillis),
+      headers: token === undefined ? {} : { authorization: `Bearer ${token}` },
+    }),
+  ).pipe(
+    Effect.map((response) => response.ok),
+    Effect.catch(() => Effect.succeed(false)),
+  )
+
+/** Polls `check` until true or the deadline lapses. */
+export const pollUntil = (
+  deadlineMillis: number,
+  intervalMillis: number,
+  check: Effect.Effect<boolean>,
+) =>
+  Effect.gen(function* () {
+    const attempts = Math.ceil(deadlineMillis / intervalMillis)
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      if (yield* check) return true
+      yield* Effect.sleep(intervalMillis)
+    }
+    return yield* check
+  })
 
 // Base-URL resolution seam for client commands: ATC_ENDPOINT (set in the
 // environment of processes ATC launches) wins; otherwise the URL derives

--- a/app-server/src/cli/serve.ts
+++ b/app-server/src/cli/serve.ts
@@ -1,6 +1,5 @@
 import { Console, Effect, FileSystem, Layer, Option, Schema } from "effect"
 import { Command, Flag } from "effect/unstable/cli"
-import * as LocalTrust from "../api/localTrust.ts"
 import * as AuthToken from "../platform/authToken.ts"
 import { BuildInfo } from "../platform/buildInfo.ts"
 import { AppConfig, layer as appConfigLayer } from "../platform/config.ts"
@@ -111,40 +110,6 @@ const readPidRecord = (fs: FileSystem.FileSystem, file: string) =>
     Effect.catch(() => Effect.succeed(undefined)),
   )
 
-// The wildcard binds are not connectable addresses; probe and report loopback
-// for them. A specific address (loopback or a real interface) is reachable at
-// itself from the same host.
-const reachableHost = (bind: string): string =>
-  bind === "0.0.0.0" || bind === "::" || bind === "" ? "127.0.0.1" : bind
-
-// A probe at a host the trust rule does not recognize as loopback is itself
-// a remote request (api/localTrust.ts) and only passes with the bearer token.
-const probeNeedsToken = (host: string): boolean =>
-  !LocalTrust.isLoopbackHost(Server.hostForUrl(host))
-
-/** One bounded health probe against `host`; false on any failure. */
-const probeHealth = (host: string, port: number, timeoutMillis: number, token?: string) =>
-  Effect.tryPromise(() =>
-    fetch(`http://${Server.hostForUrl(host)}:${port}/api/v1/health`, {
-      signal: AbortSignal.timeout(timeoutMillis),
-      headers: token === undefined ? {} : { authorization: `Bearer ${token}` },
-    }),
-  ).pipe(
-    Effect.map((response) => response.ok),
-    Effect.catch(() => Effect.succeed(false)),
-  )
-
-/** Polls `check` until true or the deadline lapses. */
-const pollUntil = (deadlineMillis: number, intervalMillis: number, check: Effect.Effect<boolean>) =>
-  Effect.gen(function* () {
-    const attempts = Math.ceil(deadlineMillis / intervalMillis)
-    for (let attempt = 0; attempt < attempts; attempt++) {
-      if (yield* check) return true
-      yield* Effect.sleep(intervalMillis)
-    }
-    return yield* check
-  })
-
 const signal = (pid: number, name: "SIGTERM" | "SIGKILL") =>
   Effect.sync(() => {
     // A process that exits between the liveness check and the signal is
@@ -155,14 +120,6 @@ const signal = (pid: number, name: "SIGTERM" | "SIGKILL") =>
       // ignored
     }
   })
-
-/** Shared command tail: settled config plus the one-line diagnostic.
- * Failures the body already reported pass through unchanged. */
-const serviceCommand = (name: string) => {
-  return <E>(
-    effect: Effect.Effect<void, E, AppConfig | FileSystem.FileSystem | Subprocess | BuildInfo>,
-  ) => effect.pipe(Effect.provide(appConfigLayer), Effect.catch(Cli.reportOnce(`atc ${name}`)))
-}
 
 export const start = Command.make("start", { port, bind }, ({ port, bind }) =>
   Effect.gen(function* () {
@@ -187,12 +144,12 @@ export const start = Command.make("start", { port, bind }, ({ port, bind }) =>
     // diagnostic rather than 15 s of 403s and a generic unhealthy report.
     // Loopback starts never touch the token, so a broken token file cannot
     // block them (mirroring the server's own boot rule).
-    const probeHost = reachableHost(effective.bind)
-    const token = probeNeedsToken(probeHost) ? yield* AuthToken.ensure : undefined
+    const probeHost = Cli.reachableHost(effective.bind)
+    const token = Cli.probeNeedsToken(probeHost) ? yield* AuthToken.ensure : undefined
     // A healthy responder without a live pidfile is a foreground serve or
     // someone else's instance; a second server would only fail its bind
     // after the fact and this start would then claim the wrong process.
-    if (yield* probeHealth(probeHost, effective.port, 1_000, token)) {
+    if (yield* Cli.probeHealth(probeHost, effective.port, 1_000, token)) {
       return yield* Cli.failReported(
         `atc start: something is already serving on port ${effective.port} (a foreground \`atc serve\`?); stop it or pass --port`,
       )
@@ -211,10 +168,10 @@ export const start = Command.make("start", { port, bind }, ({ port, bind }) =>
     yield* encodePidRecord({ pid, port: effective.port, bind: effective.bind }).pipe(
       Effect.flatMap((json) => fs.writeFileString(effective.pidFile, json)),
     )
-    const healthy = yield* pollUntil(
+    const healthy = yield* Cli.pollUntil(
       15_000,
       150,
-      probeHealth(probeHost, effective.port, 1_000, token),
+      Cli.probeHealth(probeHost, effective.port, 1_000, token),
     )
     if (!healthy) {
       // Success is only ever reported for a healthy server, so the spawned
@@ -235,7 +192,7 @@ export const start = Command.make("start", { port, bind }, ({ port, bind }) =>
     yield* Console.log(
       `started atc app server (pid ${pid}) on http://${Server.hostForUrl(effective.bind)}:${effective.port} (logs: ${effective.logFile})`,
     )
-  }).pipe(serviceCommand("start")),
+  }).pipe(Cli.withSettledConfig("atc start")),
 ).pipe(Command.withDescription("Start the App Server in the background"))
 
 export const stop = Command.make("stop", {}, () =>
@@ -284,7 +241,7 @@ export const stop = Command.make("stop", {}, () =>
     }
     yield* fs.remove(config.pidFile).pipe(Effect.ignore)
     yield* Console.log(`stopped atc app server (pid ${record.pid})`)
-  }).pipe(serviceCommand("stop")),
+  }).pipe(Cli.withSettledConfig("atc stop")),
 ).pipe(Command.withDescription("Stop the background App Server"))
 
 export const status = Command.make("status", {}, () =>
@@ -298,11 +255,11 @@ export const status = Command.make("status", {}, () =>
     // Status never creates or repairs the token file; a missing or invalid
     // one simply leaves the probe unauthenticated (and the server it cannot
     // reach was not serving remote clients anyway — verify fails closed).
-    const probeHost = reachableHost(record.bind)
-    const token = probeNeedsToken(probeHost)
+    const probeHost = Cli.reachableHost(record.bind)
+    const token = Cli.probeNeedsToken(probeHost)
       ? yield* AuthToken.read.pipe(Effect.catch(() => Effect.succeed(undefined)))
       : undefined
-    const healthy = yield* probeHealth(probeHost, record.port, 2_000, token)
+    const healthy = yield* Cli.probeHealth(probeHost, record.port, 2_000, token)
     const url = `http://${Server.hostForUrl(record.bind)}:${record.port}`
     if (!healthy) {
       return yield* Cli.failReported(
@@ -310,5 +267,5 @@ export const status = Command.make("status", {}, () =>
       )
     }
     yield* Console.log(`running (pid ${record.pid}) on ${url}`)
-  }).pipe(serviceCommand("status")),
+  }).pipe(Cli.withSettledConfig("atc status")),
 ).pipe(Command.withDescription("Report background App Server status"))

--- a/app-server/src/cli/service.ts
+++ b/app-server/src/cli/service.ts
@@ -1,0 +1,432 @@
+import { homedir } from "node:os"
+import { dirname, resolve } from "node:path"
+import { Console, Effect, FileSystem, Stream } from "effect"
+import { Command } from "effect/unstable/cli"
+import * as AuthToken from "../platform/authToken.ts"
+import { BuildInfo } from "../platform/buildInfo.ts"
+import { AppConfig } from "../platform/config.ts"
+import { Subprocess } from "../platform/subprocess.ts"
+import * as Server from "../server.ts"
+import * as Cli from "./cli.ts"
+
+// Supervisor-managed service installation (ATC-127): `atc service` writes a
+// user-scope unit — a launchd LaunchAgent on macOS, a systemd user unit on
+// Linux (systemd >= 240 for append: logging) — that runs `atc serve` in the
+// foreground and restarts it when it dies. This is deliberately separate
+// from `atc start/stop/status` (serve.ts), which self-manages an
+// unsupervised background process via a pidfile: a supervisor-run server
+// never writes a pidfile, so the two families cannot see each other's
+// processes. Invariants:
+//
+// - The unit runs flagless `atc serve`, so the service reads the config-file
+//   and default layers of the settled configuration. Supervisors start
+//   services with a minimal environment — shell exports (ATC_*, PATH) do NOT
+//   reach it — so the installing shell's PATH is stamped into the unit;
+//   without it the service could not resolve zmx or the provider CLIs.
+//   Everything else belongs in config.toml.
+// - Unit rendering is pure and test-covered; launchctl/systemctl calls stay
+//   thin, and their failures surface as one diagnostic carrying the
+//   supervisor's own stderr. install/start only report success after the
+//   server answers its health endpoint.
+// - "stop" means "until next login" on both platforms: launchd bootout /
+//   systemctl stop leave the unit installed (RunAtLoad / enable), matching
+//   supervisor convention. `uninstall` is the way out.
+// - launchd operations try the gui domain first and fall back to the user
+//   domain, so installs over ssh to a Mac without a console session work.
+
+/** The launchd label / systemd unit name; also the unit file basenames. */
+export const serviceName = "atc.server"
+
+const escapeXml = (value: string): string =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+
+// systemd unit files C-unescape inside double quotes and expand % specifiers
+// everywhere, so both need escaping along with the quotes themselves.
+const escapeUnitValue = (value: string): string =>
+  value.replaceAll("\\", "\\\\").replaceAll('"', '\\"').replaceAll("%", "%%")
+
+/**
+ * The command a supervisor should run: the compiled binary itself, or the
+ * bun runtime plus the absolute entry script for a source run (absolute
+ * because unit files execute from the user's home, not this cwd).
+ */
+export const programArguments = (devCommit: boolean): ReadonlyArray<string> =>
+  devCommit
+    ? [process.execPath, resolve(process.argv[1] ?? "src/main.ts"), "serve"]
+    : [process.execPath, "serve"]
+
+/** LaunchAgent plist: KeepAlive relaunches the server whenever it exits. */
+export const launchAgentPlist = (
+  args: ReadonlyArray<string>,
+  logFile: string,
+  path: string,
+): string => `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${serviceName}</string>
+  <key>ProgramArguments</key>
+  <array>
+${args.map((arg) => `    <string>${escapeXml(arg)}</string>`).join("\n")}
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>${escapeXml(path)}</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>${escapeXml(logFile)}</string>
+  <key>StandardErrorPath</key>
+  <string>${escapeXml(logFile)}</string>
+</dict>
+</plist>
+`
+
+/** systemd user unit: Restart=always with backoff; logs append to `logFile`. */
+export const systemdUnit = (
+  args: ReadonlyArray<string>,
+  logFile: string,
+  path: string,
+): string => `[Unit]
+Description=ATC App Server
+
+[Service]
+Type=simple
+ExecStart=${args.map((arg) => `"${escapeUnitValue(arg)}"`).join(" ")}
+Environment="PATH=${escapeUnitValue(path)}"
+Restart=always
+RestartSec=5
+StandardOutput=append:${logFile}
+StandardError=append:${logFile}
+
+[Install]
+WantedBy=default.target
+`
+
+export const launchAgentPath = (home: string): string =>
+  `${home}/Library/LaunchAgents/${serviceName}.plist`
+
+/** systemd's own config-home convention (not an atc path — see header). */
+export const systemdUnitPath = (env: {
+  readonly XDG_CONFIG_HOME?: string | undefined
+  readonly HOME?: string | undefined
+}): string =>
+  `${env.XDG_CONFIG_HOME ?? `${env.HOME ?? homedir()}/.config`}/systemd/user/${serviceName}.service`
+
+type Platform = "darwin" | "linux"
+
+const currentPlatform =
+  process.platform === "darwin" || process.platform === "linux"
+    ? Effect.succeed(process.platform)
+    : Cli.failReported(
+        `atc service: unsupported platform ${process.platform} (launchd on macOS, systemd user units on Linux)`,
+      )
+
+const installerPath = () => process.env["PATH"] ?? "/usr/local/bin:/usr/bin:/bin"
+
+/** One thin supervisor call; failure carries the tool's stderr. Stdout is
+ * drained per the Subprocess contract (and `print` output is discarded). */
+const run = (
+  subprocess: Subprocess["Service"],
+  command: string,
+  executable: string,
+  args: ReadonlyArray<string>,
+) =>
+  Effect.gen(function* () {
+    const child = yield* subprocess.spawn({ executable, args: [...args], env: {}, extendEnv: true })
+    yield* Stream.runDrain(child.stdoutLines).pipe(Effect.ignore)
+    const exitCode = yield* child.exitCode
+    if (exitCode !== 0) {
+      const stderr = (yield* child.stderrTail).join(" ").trim()
+      return yield* Cli.failReported(
+        `atc service ${command}: ${executable} ${args.join(" ")} failed (exit ${exitCode})${stderr === "" ? "" : `: ${stderr}`}`,
+      )
+    }
+  }).pipe(Effect.scoped)
+
+/** Same call, but a non-zero exit is an expected state, not a failure. */
+const runIgnoring = (
+  subprocess: Subprocess["Service"],
+  executable: string,
+  args: ReadonlyArray<string>,
+) =>
+  Effect.gen(function* () {
+    const child = yield* subprocess.spawn({ executable, args: [...args], env: {}, extendEnv: true })
+    yield* Stream.runDrain(child.stdoutLines).pipe(Effect.ignore)
+    return yield* child.exitCode
+  }).pipe(
+    Effect.scoped,
+    Effect.orElseSucceed(() => -1),
+  )
+
+// gui first (normal console login), user as the ssh/headless fallback: the
+// gui domain does not exist without an Aqua session.
+const launchdDomains = (): ReadonlyArray<string> => {
+  const uid = process.getuid!()
+  return [`gui/${uid}`, `user/${uid}`]
+}
+
+/** The domain the agent is currently loaded in, or undefined. */
+const launchdLoadedDomain = (subprocess: Subprocess["Service"]) =>
+  Effect.gen(function* () {
+    for (const domain of launchdDomains()) {
+      if (
+        (yield* runIgnoring(subprocess, "launchctl", ["print", `${domain}/${serviceName}`])) === 0
+      ) {
+        return domain
+      }
+    }
+    return undefined
+  })
+
+const launchdLoaded = (subprocess: Subprocess["Service"]) =>
+  launchdLoadedDomain(subprocess).pipe(Effect.map((domain) => domain !== undefined))
+
+/** Unload from every domain and wait until launchd forgets the label —
+ * bootstrapping again while the old instance is still winding down fails. */
+const launchdUnload = (subprocess: Subprocess["Service"]) =>
+  Effect.gen(function* () {
+    for (const domain of launchdDomains()) {
+      yield* runIgnoring(subprocess, "launchctl", ["bootout", `${domain}/${serviceName}`])
+    }
+    yield* Cli.pollUntil(
+      5_000,
+      100,
+      launchdLoaded(subprocess).pipe(Effect.map((loaded) => !loaded)),
+    )
+  })
+
+/** Bootstrap into the first domain that accepts it; report the last failure. */
+const launchdBootstrap = (subprocess: Subprocess["Service"], command: string, unitFile: string) =>
+  Effect.gen(function* () {
+    const domains = launchdDomains()
+    for (const domain of domains.slice(0, -1)) {
+      if ((yield* runIgnoring(subprocess, "launchctl", ["bootstrap", domain, unitFile])) === 0) {
+        return
+      }
+    }
+    yield* run(subprocess, command, "launchctl", [
+      "bootstrap",
+      domains[domains.length - 1]!,
+      unitFile,
+    ])
+  })
+
+const unitFileFor = (platform: Platform): string =>
+  platform === "darwin"
+    ? launchAgentPath(homedir())
+    : systemdUnitPath({
+        XDG_CONFIG_HOME: process.env["XDG_CONFIG_HOME"],
+        HOME: process.env["HOME"],
+      })
+
+/** Success only when the served address answers health within the deadline. */
+const awaitHealthy = (
+  command: string,
+  config: AppConfig["Service"],
+  token: string | undefined,
+  serviceLog: string,
+) =>
+  Effect.gen(function* () {
+    const probeHost = Cli.reachableHost(config.bind)
+    const healthy = yield* Cli.pollUntil(
+      15_000,
+      150,
+      Cli.probeHealth(probeHost, config.port, 1_000, token),
+    )
+    if (!healthy) {
+      return yield* Cli.failReported(
+        `atc service ${command}: the server did not become healthy within 15s; logs: ${config.logFile} (supervisor: ${serviceLog})`,
+      )
+    }
+  })
+
+const install = Command.make("install", {}, () =>
+  Effect.gen(function* () {
+    const platform = yield* currentPlatform
+    const config = yield* AppConfig
+    const build = yield* BuildInfo
+    const fs = yield* FileSystem.FileSystem
+    const subprocess = yield* Subprocess
+    const args = programArguments(build.commit === "dev")
+    const serviceLog = `${config.stateDir}/service.log`
+    const unitFile = unitFileFor(platform)
+    // Re-running install over our own service is the update path (the unit
+    // points at the stable installed binary, so a reinstall restarts onto
+    // it). Only an UNMANAGED responder is a conflict: it would make the
+    // supervised server crash-loop on its bind while this install claimed a
+    // process it does not manage.
+    const ownService =
+      platform === "darwin"
+        ? yield* launchdLoaded(subprocess)
+        : (yield* runIgnoring(subprocess, "systemctl", [
+            "--user",
+            "is-active",
+            "--quiet",
+            serviceName,
+          ])) === 0
+    const probeHost = Cli.reachableHost(config.bind)
+    const token = Cli.probeNeedsToken(probeHost) ? yield* AuthToken.ensure : undefined
+    if (!ownService && (yield* Cli.probeHealth(probeHost, config.port, 1_000, token))) {
+      return yield* Cli.failReported(
+        `atc service install: something is already serving on port ${config.port} (a foreground \`atc serve\` or \`atc start\`?); stop it first`,
+      )
+    }
+    yield* fs.makeDirectory(config.stateDir, { recursive: true })
+    yield* fs.makeDirectory(dirname(unitFile), { recursive: true })
+    if (platform === "darwin") {
+      yield* fs.writeFileString(unitFile, launchAgentPlist(args, serviceLog, installerPath()))
+      yield* launchdUnload(subprocess)
+      yield* launchdBootstrap(subprocess, "install", unitFile)
+    } else {
+      yield* fs.writeFileString(unitFile, systemdUnit(args, serviceLog, installerPath()))
+      yield* run(subprocess, "install", "systemctl", ["--user", "daemon-reload"])
+      yield* run(subprocess, "install", "systemctl", ["--user", "enable", serviceName])
+      // restart, not `enable --now`: --now is a no-op on an already-active
+      // unit, which would leave a reinstall running the old binary/unit.
+      yield* run(subprocess, "install", "systemctl", ["--user", "restart", serviceName])
+    }
+    yield* awaitHealthy("install", config, token, serviceLog)
+    yield* Console.log(`installed and started ${serviceName} (${unitFile})`)
+    yield* Console.log(`server: http://${Server.hostForUrl(config.bind)}:${config.port}`)
+    yield* Console.log(`logs: ${config.logFile} (supervisor: ${serviceLog})`)
+    if (platform === "linux") {
+      yield* Console.log(
+        "headless machines: run `loginctl enable-linger` once so the service outlives logins",
+      )
+    }
+  }).pipe(Cli.withSettledConfig("atc service install")),
+).pipe(Command.withDescription("Install and start the user-scope service unit (launchd/systemd)"))
+
+const uninstall = Command.make("uninstall", {}, () =>
+  Effect.gen(function* () {
+    const platform = yield* currentPlatform
+    const fs = yield* FileSystem.FileSystem
+    const subprocess = yield* Subprocess
+    const unitFile = unitFileFor(platform)
+    if (platform === "darwin") {
+      yield* launchdUnload(subprocess)
+    } else {
+      yield* runIgnoring(subprocess, "systemctl", ["--user", "disable", "--now", serviceName])
+    }
+    const existed = yield* fs.exists(unitFile).pipe(Effect.orElseSucceed(() => false))
+    yield* fs.remove(unitFile).pipe(Effect.ignore)
+    if (platform === "linux") {
+      yield* runIgnoring(subprocess, "systemctl", ["--user", "daemon-reload"])
+    }
+    yield* Console.log(
+      existed ? `uninstalled ${serviceName}` : `${serviceName} was not installed; nothing removed`,
+    )
+  }).pipe(Cli.withSettledConfig("atc service uninstall")),
+).pipe(Command.withDescription("Stop the service and remove its unit file"))
+
+const start = Command.make("start", {}, () =>
+  Effect.gen(function* () {
+    const platform = yield* currentPlatform
+    const config = yield* AppConfig
+    const fs = yield* FileSystem.FileSystem
+    const subprocess = yield* Subprocess
+    const unitFile = unitFileFor(platform)
+    if (!(yield* fs.exists(unitFile).pipe(Effect.orElseSucceed(() => false)))) {
+      return yield* Cli.failReported(
+        `atc service start: ${unitFile} does not exist; run \`atc service install\` first`,
+      )
+    }
+    if (platform === "darwin") {
+      // Loading starts it (RunAtLoad); when already loaded, kickstart covers
+      // the stopped-but-loaded case in whichever domain holds it.
+      const loadedDomain = yield* launchdLoadedDomain(subprocess)
+      if (loadedDomain === undefined) {
+        yield* launchdBootstrap(subprocess, "start", unitFile)
+      } else {
+        yield* run(subprocess, "start", "launchctl", [
+          "kickstart",
+          `${loadedDomain}/${serviceName}`,
+        ])
+      }
+    } else {
+      yield* run(subprocess, "start", "systemctl", ["--user", "start", serviceName])
+    }
+    const probeHost = Cli.reachableHost(config.bind)
+    const token = Cli.probeNeedsToken(probeHost)
+      ? yield* AuthToken.read.pipe(Effect.orElseSucceed(() => undefined))
+      : undefined
+    yield* awaitHealthy("start", config, token, `${config.stateDir}/service.log`)
+    yield* Console.log(
+      `started ${serviceName} on http://${Server.hostForUrl(config.bind)}:${config.port}`,
+    )
+  }).pipe(Cli.withSettledConfig("atc service start")),
+).pipe(Command.withDescription("Start the installed service"))
+
+const stop = Command.make("stop", {}, () =>
+  Effect.gen(function* () {
+    const platform = yield* currentPlatform
+    const subprocess = yield* Subprocess
+    if (platform === "darwin") {
+      if (!(yield* launchdLoaded(subprocess))) {
+        yield* Console.log(`${serviceName} is not running`)
+        return
+      }
+      yield* launchdUnload(subprocess)
+    } else {
+      // systemctl stop is already a no-op success on an inactive unit.
+      yield* run(subprocess, "stop", "systemctl", ["--user", "stop", serviceName])
+    }
+    yield* Console.log(`stopped ${serviceName} (still installed; returns at next login)`)
+  }).pipe(Cli.withSettledConfig("atc service stop")),
+).pipe(Command.withDescription("Stop the running service (keeps it installed)"))
+
+const status = Command.make("status", {}, () =>
+  Effect.gen(function* () {
+    const platform = yield* currentPlatform
+    const config = yield* AppConfig
+    const fs = yield* FileSystem.FileSystem
+    const subprocess = yield* Subprocess
+    const unitFile = unitFileFor(platform)
+    if (!(yield* fs.exists(unitFile).pipe(Effect.orElseSucceed(() => false)))) {
+      return yield* Cli.failReported(`atc service status: not installed (no ${unitFile})`)
+    }
+    const loaded =
+      platform === "darwin"
+        ? yield* launchdLoaded(subprocess)
+        : (yield* runIgnoring(subprocess, "systemctl", [
+            "--user",
+            "is-active",
+            "--quiet",
+            serviceName,
+          ])) === 0
+    if (!loaded) {
+      return yield* Cli.failReported(
+        `atc service status: installed but not running (${unitFile}); run \`atc service start\``,
+      )
+    }
+    // The supervisor thinks it is running; the health probe says whether the
+    // server actually answers on its settled address.
+    const probeHost = Cli.reachableHost(config.bind)
+    const token = Cli.probeNeedsToken(probeHost)
+      ? yield* AuthToken.read.pipe(Effect.orElseSucceed(() => undefined))
+      : undefined
+    const url = `http://${Server.hostForUrl(config.bind)}:${config.port}`
+    if (yield* Cli.probeHealth(probeHost, config.port, 2_000, token)) {
+      yield* Console.log(`running on ${url}`)
+      return
+    }
+    return yield* Cli.failReported(
+      `atc service status: supervisor reports running but ${url} is not answering; logs: ${config.logFile}`,
+    )
+  }).pipe(Cli.withSettledConfig("atc service status")),
+).pipe(Command.withDescription("Report service and server health"))
+
+export const service = Command.make("service").pipe(
+  Command.withDescription("Manage atc as a user-scope system service (launchd/systemd)"),
+  Command.withSubcommands([install, uninstall, start, stop, status]),
+)

--- a/app-server/src/main.ts
+++ b/app-server/src/main.ts
@@ -6,6 +6,7 @@ import { fs, health, version } from "./cli/cli.ts"
 import { api, capabilities, context } from "./cli/gateway.ts"
 import { project } from "./cli/projects.ts"
 import { serve, start, status, stop } from "./cli/serve.ts"
+import { service } from "./cli/service.ts"
 import { terminal } from "./cli/terminals.ts"
 import { token } from "./cli/token.ts"
 import { thread } from "./cli/threads.ts"
@@ -22,6 +23,7 @@ const atc = Command.make("atc").pipe(
     start,
     stop,
     status,
+    service,
     api,
     context,
     capabilities,

--- a/app-server/src/platform/buildInfo.ts
+++ b/app-server/src/platform/buildInfo.ts
@@ -2,9 +2,11 @@ import { Context, Layer } from "effect"
 import packageJson from "../../package.json"
 
 // Compile-time constants injected by scripts/build.ts via `bun build --define`.
-// Running from source leaves them undefined, so dev placeholders apply.
+// Running from source leaves them undefined, so dev placeholders apply — and
+// a release build stamps its version over the package.json placeholder.
 declare const ATC_BUILD_COMMIT: string | undefined
 declare const ATC_BUILD_BUILT_AT: string | undefined
+declare const ATC_BUILD_VERSION: string | undefined
 
 /**
  * Build metadata for the running executable. Handlers and the CLI read this
@@ -20,7 +22,7 @@ export class BuildInfo extends Context.Service<
 >()("app-server/BuildInfo") {}
 
 export const buildInfo: BuildInfo["Service"] = {
-  version: packageJson.version,
+  version: typeof ATC_BUILD_VERSION === "string" ? ATC_BUILD_VERSION : packageJson.version,
   commit: typeof ATC_BUILD_COMMIT === "string" ? ATC_BUILD_COMMIT : "dev",
   builtAt: typeof ATC_BUILD_BUILT_AT === "string" ? ATC_BUILD_BUILT_AT : "dev",
 }

--- a/app-server/test/cli/service.test.ts
+++ b/app-server/test/cli/service.test.ts
@@ -1,0 +1,79 @@
+import { isAbsolute } from "node:path"
+import { describe, expect, test } from "vitest"
+import {
+  launchAgentPath,
+  launchAgentPlist,
+  programArguments,
+  serviceName,
+  systemdUnit,
+  systemdUnitPath,
+} from "../../src/cli/service.ts"
+
+// Unit-file generation is the test-covered core of `atc service` (the
+// launchctl/systemctl calls stay thin and untested by design — they would
+// touch the developer's real session).
+
+describe("service unit generation", () => {
+  test("launch agent plist wraps the serve command with restart and PATH", () => {
+    const plist = launchAgentPlist(
+      ["/usr/local/bin/atc", "serve"],
+      "/home/u/state/service.log",
+      "/opt/homebrew/bin:/usr/bin",
+    )
+    expect(plist).toContain(`<string>${serviceName}</string>`)
+    expect(plist).toContain("<string>/usr/local/bin/atc</string>")
+    expect(plist).toContain("<string>serve</string>")
+    expect(plist).toContain("<key>RunAtLoad</key>")
+    expect(plist).toContain("<key>KeepAlive</key>")
+    expect(plist).toContain("<key>EnvironmentVariables</key>")
+    expect(plist).toContain("<string>/opt/homebrew/bin:/usr/bin</string>")
+    expect(plist).toContain("<string>/home/u/state/service.log</string>")
+  })
+
+  test("launch agent plist escapes XML metacharacters in paths", () => {
+    const plist = launchAgentPlist(["/odd & <path>/atc", "serve"], "/log & file.log", "/p&q")
+    expect(plist).toContain("<string>/odd &amp; &lt;path&gt;/atc</string>")
+    expect(plist).toContain("<string>/log &amp; file.log</string>")
+    expect(plist).toContain("<string>/p&amp;q</string>")
+    expect(plist).not.toContain("/odd & <path>")
+  })
+
+  test("systemd unit quotes ExecStart, stamps PATH, and restarts with backoff", () => {
+    const unit = systemdUnit(
+      ["/path with space/atc", "serve"],
+      "/home/u/state/service.log",
+      "/opt/bin:/usr/bin",
+    )
+    expect(unit).toContain('ExecStart="/path with space/atc" "serve"')
+    expect(unit).toContain('Environment="PATH=/opt/bin:/usr/bin"')
+    expect(unit).toContain("Restart=always")
+    expect(unit).toContain("RestartSec=5")
+    expect(unit).toContain("StandardOutput=append:/home/u/state/service.log")
+    expect(unit).toContain("StandardError=append:/home/u/state/service.log")
+    expect(unit).toContain("WantedBy=default.target")
+  })
+
+  test("systemd unit escapes percent and backslash (specifier expansion)", () => {
+    const unit = systemdUnit(["/od%d\\path/atc", "serve"], "/log.log", "/bin")
+    expect(unit).toContain('ExecStart="/od%%d\\\\path/atc" "serve"')
+  })
+
+  test("unit paths follow each platform's convention", () => {
+    expect(launchAgentPath("/Users/u")).toBe(`/Users/u/Library/LaunchAgents/${serviceName}.plist`)
+    expect(systemdUnitPath({ HOME: "/home/u" })).toBe(
+      `/home/u/.config/systemd/user/${serviceName}.service`,
+    )
+    expect(systemdUnitPath({ XDG_CONFIG_HOME: "/xdg", HOME: "/home/u" })).toBe(
+      `/xdg/systemd/user/${serviceName}.service`,
+    )
+  })
+
+  test("program arguments: compiled binary alone, dev via the bun runtime", () => {
+    expect(programArguments(false)).toEqual([process.execPath, "serve"])
+    const dev = programArguments(true)
+    expect(dev[0]).toBe(process.execPath)
+    expect(dev).toHaveLength(3)
+    expect(isAbsolute(dev[1]!)).toBe(true)
+    expect(dev[2]).toBe("serve")
+  })
+})

--- a/app-server/test/cli/startStopStatus.blackbox.test.ts
+++ b/app-server/test/cli/startStopStatus.blackbox.test.ts
@@ -12,10 +12,12 @@ import {
 } from "../blackbox.ts"
 import { makeFakeZmxSandbox } from "../testLayers.ts"
 
-// Black-box lifecycle of the background service commands: `atc start` spawns
-// a detached `atc serve` and owns the pidfile; `status` and `stop` re-verify
-// liveness rather than trusting it. Spawned from source, so the detached
-// child is `bun src/main.ts serve` resolved against the repo cwd.
+// Black-box lifecycle of the self-managed background commands: `atc start`
+// spawns a detached `atc serve` and owns the pidfile; `status` and `stop`
+// re-verify liveness rather than trusting it. Spawned from source, so the
+// detached child is `bun src/main.ts serve` resolved against the repo cwd.
+// (The supervisor-based `atc service` family is a different feature —
+// cli/service.ts — unit-tested in service.test.ts.)
 
 const scratch = mkdtempSync(join(tmpdir(), "atc-service-blackbox-"))
 const startedPids: Array<number> = []

--- a/app-server/test/compiled.blackbox.test.ts
+++ b/app-server/test/compiled.blackbox.test.ts
@@ -98,6 +98,16 @@ describe.skipIf(!enabled)("compiled atc artifact (opt-in: mise run test:compiled
       expect(JSON.parse(versionCli.stdout)).toEqual(body)
       expect(versionCli.exitCode).toBe(0)
 
+      // The service command group ships in the executable. Status checks the
+      // unit file before ever touching launchctl/systemctl, so with HOME and
+      // XDG_CONFIG_HOME isolated this never reaches the host's supervisor.
+      const serviceStatus = await runCli([compiledBinaryPath], ["service", "status"], outsideCwd, {
+        ...env,
+        HOME: outsideCwd,
+      })
+      expect(serviceStatus.exitCode).toBe(1)
+      expect(serviceStatus.stderr).toContain("not installed")
+
       // The full persistence stack works in the compiled binary.
       const created = await runCli(
         [compiledBinaryPath],

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# Install atc (the ATC App Server + CLI) from GitHub Releases.
+set -eu
+
+repo="${ATC_REPO:-jeremytondo/atc}"
+install_dir="${ATC_INSTALL_DIR:-$HOME/.local/bin}"
+version="${ATC_VERSION:-latest}"
+
+usage() {
+  cat <<'EOF'
+Install atc from GitHub Releases.
+
+Usage:
+  ./install.sh [--version vX.Y.Z]
+
+Environment:
+  ATC_REPO         GitHub repository (default: jeremytondo/atc)
+  ATC_INSTALL_DIR  Install directory (default: ~/.local/bin)
+  ATC_VERSION      Release tag, or latest (default: latest)
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --version)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --version" >&2
+        exit 1
+      fi
+      version="$2"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+need curl
+need tar
+need mktemp
+need install
+
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+case "$os" in
+  linux|darwin) ;;
+  *)
+    echo "unsupported OS: $os" >&2
+    exit 1
+    ;;
+esac
+
+# Arch names follow the Bun compile targets (app-server/scripts/build.ts).
+arch="$(uname -m)"
+case "$arch" in
+  x86_64|amd64) arch="x64" ;;
+  arm64|aarch64) arch="arm64" ;;
+  *)
+    echo "unsupported architecture: $arch" >&2
+    exit 1
+    ;;
+esac
+
+archive="atc-${os}-${arch}.tar.gz"
+if [ "$version" = "latest" ]; then
+  download_base="https://github.com/${repo}/releases/latest/download"
+else
+  download_base="https://github.com/${repo}/releases/download/${version}"
+fi
+
+tmp="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp"
+}
+trap cleanup EXIT HUP INT TERM
+
+curl -fsSL "${download_base}/${archive}" -o "${tmp}/${archive}"
+curl -fsSL "${download_base}/checksums.txt" -o "${tmp}/checksums.txt"
+
+expected="$(awk -v file="$archive" '{ name=$NF; sub(/^\*/, "", name); if (name == file) print $1 }' "$tmp/checksums.txt")"
+if [ -z "$expected" ]; then
+  echo "checksums.txt does not include ${archive}" >&2
+  exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "$tmp/$archive" | awk '{ print $1 }')"
+elif command -v shasum >/dev/null 2>&1; then
+  actual="$(shasum -a 256 "$tmp/$archive" | awk '{ print $1 }')"
+else
+  echo "required command not found: sha256sum or shasum" >&2
+  exit 1
+fi
+
+if [ "$actual" != "$expected" ]; then
+  echo "checksum mismatch for ${archive}" >&2
+  echo "expected: ${expected}" >&2
+  echo "actual:   ${actual}" >&2
+  exit 1
+fi
+
+tar -xzf "$tmp/$archive" -C "$tmp"
+mkdir -p "$install_dir"
+install -m 0755 "$tmp/atc" "$install_dir/atc"
+
+echo "installed atc to ${install_dir}/atc"
+case ":$PATH:" in
+  *":$install_dir:"*) ;;
+  *)
+    echo "add ${install_dir} to PATH to run atc directly"
+    ;;
+esac
+echo "run \`atc service install\` to run it as a login service — including re-running it after an update, which restarts onto the new binary — or \`atc serve\` for the foreground"
+echo "a running server serves its console at its base URL (default http://127.0.0.1:7331/) and API docs at /docs"


### PR DESCRIPTION
Implements [ATC-149](https://linear.app/elevenideas/issue/ATC-149/atc-service-release-workflow-and-installsh-pr-1) — PR 1 of [ATC-127](https://linear.app/elevenideas/issue/ATC-127/packaging-service-management-release-automation-and-final-cutover). **Stacked on #148** (base: the ATC-126 branch); merge #148 first, then retarget/merge this.

## What

- **`atc service install|uninstall|start|stop|status`** (`src/cli/service.ts`) — writes a user-scope launchd LaunchAgent (`~/Library/LaunchAgents/atc.server.plist`) or systemd user unit (`~/.config/systemd/user/atc.server.service`) running flagless `atc serve`, so the service reads the same settled config file/defaults as every entrypoint. The installing shell's `PATH` is stamped into the unit — supervisors provide a minimal environment that otherwise could not resolve zmx or the provider CLIs. `install`/`start` pre-check port conflicts and only report success once `/api/v1/health` answers; launchd operations try `gui/$UID` and fall back to `user/$UID` (ssh installs); reinstall drains `bootout` before re-`bootstrap`; `stop` is idempotent. Deliberately separate from the pidfile-based `atc start/stop/status` (ATC-147, unchanged). Unit rendering is pure + unit-tested; supervisor calls stay thin through `Subprocess`.
- **Root `install.sh`** — adapted from `server/install.sh`: OS/arch detection with Bun target names (`x64`/`arm64`), `atc-<os>-<arch>.tar.gz` + `checksums.txt` verification, installs to `~/.local/bin/atc` (`ATC_INSTALL_DIR` override), hints `atc service install`.
- **`.github/workflows/app-server-release.yml`** — manual dispatch, `test`/`stable` channels. Darwin targets build on macos-14 so Bun's ad-hoc signature is applied and `codesign --verify`'d natively (re-sign `-s -` fallback); Linux targets cross-compile on ubuntu. Gates: `mise run check`, a version-stamp assertion on the built binary, and the compiled black-box suite against the release artifacts on macos-14, ubuntu-latest, and ubuntu-24.04-arm (the arm run extracts the packaged tarball, proving the archive layout install.sh relies on). `stable` computes the next tag via `scripts/next-version.sh`, pushes it only after all validation passes, and publishes the release with the `curl | sh` install command in the notes.
- **`scripts/build.ts`** — explicit target arguments (release CI builds per-OS), `--version=X.Y.Z` → `--define ATC_BUILD_VERSION` (consumed by `buildInfo.ts`), unknown-flag validation.
- **Shared CLI plumbing hoisted to `cli.ts`** (`withSettledConfig`, `probeHealth`, `reachableHost`, `probeNeedsToken`, `pollUntil`) — removes serve.ts/service.ts duplication; no behavior change to the existing commands. `test/cli/service.blackbox.test.ts` renamed to `startStopStatus.blackbox.test.ts` so "service" consistently names the new feature.

## Known interim caveat

`scripts/next-version.sh` is a copy of `server/tools/next-version.sh`, and both release pipelines share the `v*` tag series and `releases/latest`. **Do not cut a Go-server release between this merge and PR 2** (which deletes the Go pipeline entirely) — a Go release would repoint `releases/latest` at artifacts the new `install.sh` cannot resolve.

## Tests

- `test/cli/service.test.ts` — unit-file rendering: XML/systemd escaping (`&`, `%`, `\`, spaces), PATH stamping, path conventions, dev-vs-compiled program arguments.
- `test/compiled.blackbox.test.ts` — `atc service status` ships in the binary and short-circuits on the missing unit file (HOME-isolated; never touches the host's supervisor).
- Real launchctl/systemctl interactions are deliberately untested (they would mutate the developer's session) — per the ATC-127 decision that supervisor interactions stay thin.

## Review notes

Two adversarial sub-agent reviews (correctness on Opus, simplicity on Sonnet) ran before this PR. Applied: PATH stamping (a supervised server previously couldn't resolve zmx/codex/claude — the feature's whole point), health verification on install/start, gui→user domain fallback, bootout drain, idempotent stop, artifact-name `run_id` fix, version-stamp CI assertion, `%`/`\` systemd escaping, stdout drains on supervisor calls, scoped workflow permissions + concurrency group, shared-helper extraction. Declined: hoisting next-version.sh to a shared path (PR 2 deletes the twin days later; caveat documented above).

https://claude.ai/code/session_01K8XhAtTPN4LutWHikAeaZE