### PR TITLE
fs/list contract + server endpoint (ATC-152)

### DIFF
--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -1264,6 +1264,57 @@
         },
         "description": "Demand-driven directory health check with a bounded timeout. Takes a server-host absolute path; the result is never persisted."
       }
+    },
+    "/api/v1/fs/list": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "listDirectory",
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\/",
+              "description": "Directory to list; omitted lists the server's home directory."
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "A directory listing for the server-backed folder browser. Never persisted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FsListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The directory does not exist, is not a directory, or cannot be read/traversed. | The directory check did not complete within its bounded timeout. Retryable — a timeout is not proof the path is missing.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/DirectoryUnavailableJsonEncoding"
+                    },
+                    {
+                      "$ref": "#/components/schemas/DirectoryCheckTimedOutJsonEncoding"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "List a directory's subdirectories for the server-backed folder browser: non-recursive, dotfolders excluded, symlinks included when they resolve to directories, sorted case-insensitively. Omitting `path` lists the server's home directory. Same bounded timeout and tagged errors as the health check; nothing is persisted."
+      }
     }
   },
   "components": {
@@ -2090,6 +2141,51 @@
         ],
         "additionalProperties": false,
         "description": "Result of a directory health check. Never persisted."
+      },
+      "FsListEntry": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Directory name within the listed directory."
+          },
+          "path": {
+            "type": "string",
+            "description": "Absolute path of the subdirectory (not symlink-resolved)."
+          }
+        },
+        "required": [
+          "name",
+          "path"
+        ],
+        "additionalProperties": false,
+        "description": "One subdirectory of a listed directory."
+      },
+      "FsListResponse": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Canonical (symlink-resolved) absolute path of the listed directory."
+          },
+          "parent": {
+            "type": "string",
+            "description": "Parent directory of `path`; absent at the filesystem root."
+          },
+          "entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FsListEntry"
+            },
+            "description": "Subdirectories only — non-recursive, dotfolders excluded, symlinks included when they resolve to directories, sorted case-insensitively by name."
+          }
+        },
+        "required": [
+          "path",
+          "entries"
+        ],
+        "additionalProperties": false,
+        "description": "A directory listing for the server-backed folder browser. Never persisted."
       },
       "ResourceChangedEvent": {
         "type": "object",

--- a/app-server/src/api/contract.ts
+++ b/app-server/src/api/contract.ts
@@ -123,6 +123,36 @@ export const FsCheckResponse = Schema.Struct({
   description: "Result of a directory health check. Never persisted.",
 })
 
+export const FsListEntry = Schema.Struct({
+  name: Schema.String.annotate({ description: "Directory name within the listed directory." }),
+  path: Schema.String.annotate({
+    description: "Absolute path of the subdirectory (not symlink-resolved).",
+  }),
+}).annotate({
+  identifier: "FsListEntry",
+  description: "One subdirectory of a listed directory.",
+})
+
+export const FsListResponse = Schema.Struct({
+  path: Schema.String.annotate({
+    description: "Canonical (symlink-resolved) absolute path of the listed directory.",
+  }),
+  // Absent at the filesystem root (not null — see UpdateProjectRequest).
+  parent: Schema.optionalKey(
+    Schema.String.annotate({
+      description: "Parent directory of `path`; absent at the filesystem root.",
+    }),
+  ),
+  entries: Schema.Array(FsListEntry).annotate({
+    description:
+      "Subdirectories only — non-recursive, dotfolders excluded, symlinks included when they " +
+      "resolve to directories, sorted case-insensitively by name.",
+  }),
+}).annotate({
+  identifier: "FsListResponse",
+  description: "A directory listing for the server-backed folder browser. Never persisted.",
+})
+
 export const TerminalStatus = Schema.Literals(["live", "ended"]).annotate({
   identifier: "TerminalStatus",
   description:
@@ -851,6 +881,25 @@ export class V1 extends HttpApiGroup.make("v1")
       .annotate(
         OpenApi.Description,
         "Demand-driven directory health check with a bounded timeout. Takes a server-host absolute path; the result is never persisted.",
+      ),
+    HttpApiEndpoint.get("listDirectory", "/fs/list", {
+      query: {
+        path: Schema.optionalKey(
+          AbsolutePath.annotate({
+            description: "Directory to list; omitted lists the server's home directory.",
+          }),
+        ),
+      },
+      success: FsListResponse,
+      error: [DirectoryUnavailable, DirectoryCheckTimedOut],
+    })
+      .annotate(OpenApi.Identifier, "listDirectory")
+      .annotate(
+        OpenApi.Description,
+        "List a directory's subdirectories for the server-backed folder browser: non-recursive, " +
+          "dotfolders excluded, symlinks included when they resolve to directories, sorted " +
+          "case-insensitively. Omitting `path` lists the server's home directory. Same bounded " +
+          "timeout and tagged errors as the health check; nothing is persisted.",
       ),
   )
   // .prefix only applies to endpoints added above it — add new endpoints

--- a/app-server/src/api/handlers.ts
+++ b/app-server/src/api/handlers.ts
@@ -53,6 +53,7 @@ export const V1Handlers = HttpApiBuilder.group(
         )
         .handle("deleteProject", ({ params }) => projects.delete(params.projectId))
         .handle("checkDirectory", ({ query }) => directories.check(query.path))
+        .handle("listDirectory", ({ query }) => directories.list(query.path))
         .handle("listTerminals", ({ query }) => terminals.list(query.projectId))
         .handle("createTerminal", ({ payload }) => terminals.create(payload))
         .handle("getTerminal", ({ params }) => terminals.get(params.terminalId))

--- a/app-server/src/cli/cli.ts
+++ b/app-server/src/cli/cli.ts
@@ -1,5 +1,5 @@
 import { BunHttpClient } from "@effect/platform-bun"
-import { Console, Effect, FileSystem, Runtime, Schema } from "effect"
+import { Console, Effect, FileSystem, Option, Runtime, Schema } from "effect"
 import { Argument, Command, Flag } from "effect/unstable/cli"
 import { HttpClient } from "effect/unstable/http"
 import * as path from "node:path"
@@ -207,7 +207,18 @@ const fsCheck = clientCommand(
   (client, args) => client.v1.checkDirectory({ query: { path: path.resolve(args.path) } }),
 )
 
+const fsList = clientCommand(
+  "fs list",
+  "List a directory's subdirectories (defaults to the server's home directory)",
+  { path: Argument.optional(Argument.string("path")) },
+  (client, args) =>
+    client.v1.listDirectory({
+      // The contract uses absent keys (not undefined/null) for omitted fields.
+      query: Option.isSome(args.path) ? { path: path.resolve(args.path.value) } : {},
+    }),
+)
+
 export const fs = Command.make("fs").pipe(
   Command.withDescription("Read-only filesystem operations on the server host"),
-  Command.withSubcommands([fsCheck]),
+  Command.withSubcommands([fsCheck, fsList]),
 )

--- a/app-server/src/platform/config.ts
+++ b/app-server/src/platform/config.ts
@@ -77,6 +77,8 @@ export class AppConfig extends Context.Service<
     readonly logLevel: LogLevel.LogLevel
     /** Config file path that was consulted (it may not exist). */
     readonly configFile: string
+    /** The server host's home directory ($HOME, or the OS account database). */
+    readonly home: string
     /** Directory holding durable data (the SQLite database). */
     readonly dataDir: string
     /** Directory holding server state (the log file). */
@@ -313,6 +315,7 @@ export const load = (
       context,
       logLevel: settings.logLevel,
       configFile,
+      home: nonEmpty(env["HOME"]) ?? os.homedir(),
       dataDir,
       stateDir,
       dbFile: path.join(dataDir, "atc.db"),

--- a/app-server/src/platform/directories.ts
+++ b/app-server/src/platform/directories.ts
@@ -1,11 +1,15 @@
 import { Context, Effect, Layer } from "effect"
 import { constants } from "node:fs"
 import * as fs from "node:fs/promises"
+import { dirname, join } from "node:path"
 import { DirectoryCheckTimedOut, DirectoryUnavailable, DirectoryState } from "../api/contract.ts"
+import { AppConfig } from "./config.ts"
 
-// Demand-driven directory health (ATC-121, Domain Model rules): checks run
-// only when an operation needs a directory or a client asks explicitly —
-// results are never persisted and normal reads never touch the filesystem.
+// Demand-driven directory health (ATC-121, Domain Model rules) and the
+// read-only subdirectory listing behind the folder browser (ATC-151): checks
+// and listings run only when an operation needs a directory or a client asks
+// explicitly — results are never persisted and normal reads never touch the
+// filesystem.
 // Validation requires an existing directory with read+traversal access
 // (deliberately not write: testing writability at registration is worse than
 // surfacing a write failure at first use). Identity is the symlink-resolved
@@ -14,12 +18,23 @@ import { DirectoryCheckTimedOut, DirectoryUnavailable, DirectoryState } from "..
 /** Bounded time for any filesystem probe; fail closed beyond it. */
 export const CHECK_TIMEOUT_MILLIS = 2000
 
+/** Concurrent `stat` calls per listing; bounds the work a timeout abandons. */
+export const STAT_CONCURRENCY = 16
+
 export type DirectoryCheckResult = {
   readonly path: string
   readonly state: typeof DirectoryState.Type
   readonly checkedAt: string
   /** Present only when the state is not conclusive (e.g. "timeout"). */
   readonly reason?: string
+}
+
+export type DirectoryListing = {
+  /** Canonical (symlink-resolved) path of the listed directory. */
+  readonly path: string
+  /** Parent of `path`; absent at the filesystem root. */
+  readonly parent?: string
+  readonly entries: ReadonlyArray<{ readonly name: string; readonly path: string }>
 }
 
 export class Directories extends Context.Service<
@@ -38,6 +53,15 @@ export class Directories extends Context.Service<
      * `unknown` with a reason, because it is not proof the path is missing.
      */
     readonly check: (path: string) => Effect.Effect<DirectoryCheckResult>
+    /**
+     * List a directory's subdirectories (omitted `path` = the server's home
+     * directory): non-recursive, dotfolders excluded, symlinks included when
+     * they resolve to directories, sorted case-insensitively. Fails closed
+     * like `canonicalize`, under the same bounded timeout.
+     */
+    readonly list: (
+      path?: string,
+    ) => Effect.Effect<DirectoryListing, DirectoryUnavailable | DirectoryCheckTimedOut>
   }
 >()("app-server/Directories") {}
 
@@ -53,16 +77,7 @@ const probe = (path: string): Promise<Probe> =>
     try {
       canonical = await fs.realpath(path)
     } catch (error) {
-      // ENOTDIR: a path component exists but is not a directory.
-      return {
-        ok: false as const,
-        state:
-          errno(error) === "ENOENT"
-            ? "missing"
-            : errno(error) === "ENOTDIR"
-              ? "not_directory"
-              : "inaccessible",
-      }
+      return { ok: false as const, state: stateFromErrno(error) }
     }
     let isDirectory: boolean
     try {
@@ -82,37 +97,141 @@ const probe = (path: string): Promise<Probe> =>
 const errno = (error: unknown): string | undefined =>
   error instanceof Error && "code" in error ? String(error.code) : undefined
 
-const timedProbe = (path: string) =>
-  Effect.promise(() => probe(path)).pipe(
+// ENOTDIR: a path component exists but is not a directory.
+const stateFromErrno = (error: unknown): DirectoryUnavailable["state"] =>
+  errno(error) === "ENOENT"
+    ? "missing"
+    : errno(error) === "ENOTDIR"
+      ? "not_directory"
+      : "inaccessible"
+
+/** Run a filesystem probe under the bounded timeout; fail closed beyond it. */
+const bounded = <T>(path: string, run: () => Promise<T>) =>
+  Effect.promise(run).pipe(
     Effect.timeoutOrElse({
       duration: CHECK_TIMEOUT_MILLIS,
       orElse: () => Effect.fail(new DirectoryCheckTimedOut({ path })),
     }),
   )
 
-export const layer = Layer.succeed(Directories)({
-  canonicalize: (path) =>
-    timedProbe(path).pipe(
-      Effect.flatMap((result) =>
-        result.ok
-          ? Effect.succeed(result.canonical)
-          : Effect.fail(new DirectoryUnavailable({ path, state: result.state })),
-      ),
-    ),
-  check: (path) =>
-    timedProbe(path).pipe(
-      Effect.map((result): DirectoryCheckResult => ({
-        path: result.ok ? result.canonical : path,
-        state: result.ok ? "available" : result.state,
-        checkedAt: new Date().toISOString(),
-      })),
-      Effect.catch(() =>
-        Effect.succeed<DirectoryCheckResult>({
-          path,
-          state: "unknown",
-          checkedAt: new Date().toISOString(),
-          reason: "timeout",
-        }),
-      ),
-    ),
-})
+type ListProbe =
+  | { readonly ok: true; readonly listing: DirectoryListing }
+  | { readonly ok: false; readonly state: DirectoryUnavailable["state"] }
+
+// Probe the directory, then read its subdirectories. Entry paths are joined,
+// not resolved: a symlink entry keeps its name-path, and descending into it
+// canonicalizes naturally on the next list.
+const listProbe = (path: string): Promise<ListProbe> =>
+  (async () => {
+    const probed = await probe(path)
+    if (!probed.ok) return probed
+    const canonical = probed.canonical
+    let dirents
+    try {
+      dirents = await fs.readdir(canonical, { withFileTypes: true })
+    } catch (error) {
+      // The directory can vanish between probe and readdir.
+      return { ok: false as const, state: stateFromErrno(error) }
+    }
+    const entries: Array<{ name: string; path: string }> = []
+    const unclassified: Array<{ name: string; path: string }> = []
+    for (const dirent of dirents) {
+      if (dirent.name.startsWith(".")) continue
+      const entryPath = join(canonical, dirent.name)
+      if (dirent.isDirectory()) {
+        entries.push({ name: dirent.name, path: entryPath })
+        continue
+      }
+      // Everything else known is not a directory; what remains is a symlink
+      // (included only when it resolves to a directory) or UV_DIRENT_UNKNOWN
+      // (d_type-less filesystems like NFS report every entry unknown), and
+      // both need a stat to classify.
+      if (
+        dirent.isFile() ||
+        dirent.isFIFO() ||
+        dirent.isSocket() ||
+        dirent.isCharacterDevice() ||
+        dirent.isBlockDevice()
+      ) {
+        continue
+      }
+      unclassified.push({ name: dirent.name, path: entryPath })
+    }
+    // Stat the unclassified entries through a small worker pool: d_type-less
+    // filesystems report whole directories this way, and the bounded timeout
+    // abandons rather than cancels these promises — so the pool, not the
+    // timeout, is what keeps a huge directory from piling up thousands of
+    // in-flight stats per request.
+    const classified: Array<{ name: string; path: string } | null> = new Array(unclassified.length)
+    let nextIndex = 0
+    const statWorker = async () => {
+      while (true) {
+        const index = nextIndex++
+        const entry = unclassified[index]
+        if (entry === undefined) return
+        try {
+          classified[index] = (await fs.stat(entry.path)).isDirectory() ? entry : null
+        } catch {
+          // Broken or unreadable symlink, or a vanished entry: skip it.
+          classified[index] = null
+        }
+      }
+    }
+    await Promise.all(
+      Array.from({ length: Math.min(STAT_CONCURRENCY, unclassified.length) }, statWorker),
+    )
+    entries.push(...classified.filter((entry) => entry !== null))
+    // Pinned collation, so the advertised case-insensitive order does not
+    // drift with the server's locale.
+    entries.sort((a, b) => a.name.localeCompare(b.name, "en"))
+    return {
+      ok: true as const,
+      listing: {
+        path: canonical,
+        ...(canonical === "/" ? {} : { parent: dirname(canonical) }),
+        entries,
+      },
+    }
+  })()
+
+export const layer = Layer.effect(Directories)(
+  Effect.gen(function* () {
+    const config = yield* AppConfig
+    return {
+      canonicalize: (path) =>
+        bounded(path, () => probe(path)).pipe(
+          Effect.flatMap((result) =>
+            result.ok
+              ? Effect.succeed(result.canonical)
+              : Effect.fail(new DirectoryUnavailable({ path, state: result.state })),
+          ),
+        ),
+      check: (path) =>
+        bounded(path, () => probe(path)).pipe(
+          Effect.map((result): DirectoryCheckResult => ({
+            path: result.ok ? result.canonical : path,
+            state: result.ok ? "available" : result.state,
+            checkedAt: new Date().toISOString(),
+          })),
+          Effect.catch(() =>
+            Effect.succeed<DirectoryCheckResult>({
+              path,
+              state: "unknown",
+              checkedAt: new Date().toISOString(),
+              reason: "timeout",
+            }),
+          ),
+        ),
+      list: (path) => {
+        const target = path ?? config.home
+        return bounded(target, () => listProbe(target)).pipe(
+          Effect.flatMap((result) =>
+            result.ok
+              ? Effect.succeed(result.listing)
+              : Effect.fail(new DirectoryUnavailable({ path: target, state: result.state })),
+          ),
+        )
+      },
+    } satisfies Directories["Service"]
+  }),
+)

--- a/app-server/test/api/api.test.ts
+++ b/app-server/test/api/api.test.ts
@@ -1,27 +1,52 @@
 import { assert, describe, it } from "@effect/vitest"
-import { BunHttpServer } from "@effect/platform-bun"
-import { Effect, Fiber, Layer, Queue, Stream } from "effect"
+import { Effect, Fiber, Queue, Stream } from "effect"
 import { HttpApiTest } from "effect/unstable/httpapi"
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { realpathSync } from "node:fs"
 import { afterAll } from "vitest"
-import { Api } from "../../src/api/contract.ts"
-import { V1Handlers } from "../../src/api/handlers.ts"
+import { Api, DirectoryUnavailable } from "../../src/api/contract.ts"
 import * as Events from "../../src/events/events.ts"
-import { TestBuildInfoLayer, testBuildInfo } from "../testBuildInfo.ts"
-import { TestRepositoryLayers } from "../testLayers.ts"
+import { testBuildInfo } from "../testBuildInfo.ts"
+import { apiTestLayer, makeTestServiceLayers } from "../testLayers.ts"
+
+// Real directories for validation coverage. macOS tmpdir is itself behind a
+// symlink, so expectations always go through realpathSync.
+const scratch = mkdtempSync(join(tmpdir(), "atc-api-test-"))
+afterAll(() => rmSync(scratch, { recursive: true, force: true }))
+
+const realDir = realpathSync(scratch)
+const linkedDir = join(scratch, "linked")
+symlinkSync(realDir, linkedDir)
+const filePath = join(scratch, "a-file")
+writeFileSync(filePath, "not a directory")
+mkdirSync(join(scratch, "second"))
+
+// A browse-able subtree for /fs/list: mixed-case directories, a dotfolder, a
+// file, and symlinks that do and do not resolve to directories.
+const browseDir = join(scratch, "browse")
+mkdirSync(browseDir)
+mkdirSync(join(browseDir, "Beta"))
+mkdirSync(join(browseDir, "alpha"))
+mkdirSync(join(browseDir, "Éclair"))
+mkdirSync(join(browseDir, ".hidden"))
+writeFileSync(join(browseDir, "a-file"), "not a directory")
+symlinkSync(join(browseDir, "Beta"), join(browseDir, "beta-link"))
+symlinkSync(join(browseDir, "gone"), join(browseDir, "broken-link"))
+symlinkSync(join(browseDir, "a-file"), join(browseDir, "file-link"))
+
+// The "server home" the omitted-path listing resolves to — a scratch fixture,
+// never the developer's (or CI runner's) real home directory.
+const homeDir = join(scratch, "home")
+mkdirSync(homeDir)
+mkdirSync(join(homeDir, "sub"))
 
 // In-process contract tests: the same encode/route/decode pipeline as the real
-// server, but no listener. TestRepositoryLayers is merged in as well (one
+// server, but no listener. The kit's services are merged in as well (one
 // memoized instance) so tests can reach the same domain services the handlers
 // use — the events test drives the Events service directly.
-const TestLayer = Layer.mergeAll(
-  V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, TestRepositoryLayers])),
-  TestRepositoryLayers,
-  BunHttpServer.layerHttpServices,
-)
+const TestLayer = apiTestLayer(makeTestServiceLayers(":memory:", {}, {}, { home: homeDir }))
 
 describe("/api/v1", () => {
   it.effect("health returns ok", () =>
@@ -45,18 +70,6 @@ describe("/api/v1", () => {
     }).pipe(Effect.provide(TestLayer)),
   )
 })
-
-// Real directories for validation coverage. macOS tmpdir is itself behind a
-// symlink, so expectations always go through realpathSync.
-const scratch = mkdtempSync(join(tmpdir(), "atc-api-test-"))
-afterAll(() => rmSync(scratch, { recursive: true, force: true }))
-
-const realDir = realpathSync(scratch)
-const linkedDir = join(scratch, "linked")
-symlinkSync(realDir, linkedDir)
-const filePath = join(scratch, "a-file")
-writeFileSync(filePath, "not a directory")
-mkdirSync(join(scratch, "second"))
 
 describe("/api/v1/projects", () => {
   it.effect("creates, lists, gets, updates, and deletes a project", () =>
@@ -279,6 +292,58 @@ describe("/api/v1/fs/check", () => {
         query: { path: join(filePath, "sub") },
       })
       assert.strictEqual(throughFile.state, "not_directory")
+    }).pipe(Effect.provide(TestLayer)),
+  )
+})
+
+describe("/api/v1/fs/list", () => {
+  it.effect("lists subdirectories only, sorted, dotfolders and files excluded", () =>
+    Effect.gen(function* () {
+      const client = yield* HttpApiTest.groups(Api, ["v1"])
+
+      // The listed path canonicalizes through the symlink; entries keep
+      // their name-paths under the canonical directory.
+      const listing = yield* client.v1.listDirectory({ query: { path: join(linkedDir, "browse") } })
+      assert.strictEqual(listing.path, join(realDir, "browse"))
+      assert.strictEqual(listing.parent, realDir)
+      assert.deepStrictEqual(listing.entries, [
+        { name: "alpha", path: join(realDir, "browse", "alpha") },
+        { name: "Beta", path: join(realDir, "browse", "Beta") },
+        { name: "beta-link", path: join(realDir, "browse", "beta-link") },
+        { name: "Éclair", path: join(realDir, "browse", "Éclair") },
+      ])
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("fails closed on unusable paths with the tagged states", () =>
+    Effect.gen(function* () {
+      const client = yield* HttpApiTest.groups(Api, ["v1"])
+
+      const missing = yield* Effect.flip(
+        client.v1.listDirectory({ query: { path: join(realDir, "nope") } }),
+      )
+      assert.strictEqual(missing._tag, "DirectoryUnavailable")
+      assert.strictEqual((missing as DirectoryUnavailable).state, "missing")
+
+      const notDirectory = yield* Effect.flip(
+        client.v1.listDirectory({ query: { path: filePath } }),
+      )
+      assert.strictEqual(notDirectory._tag, "DirectoryUnavailable")
+      assert.strictEqual((notDirectory as DirectoryUnavailable).state, "not_directory")
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("omitted path lists the configured home directory; the root has no parent", () =>
+    Effect.gen(function* () {
+      const client = yield* HttpApiTest.groups(Api, ["v1"])
+
+      const home = yield* client.v1.listDirectory({ query: {} })
+      assert.strictEqual(home.path, join(realDir, "home"))
+      assert.deepStrictEqual(home.entries, [{ name: "sub", path: join(realDir, "home", "sub") }])
+
+      const root = yield* client.v1.listDirectory({ query: { path: "/" } })
+      assert.strictEqual(root.path, "/")
+      assert.isUndefined(root.parent)
     }).pipe(Effect.provide(TestLayer)),
   )
 })

--- a/app-server/test/api/openapi.test.ts
+++ b/app-server/test/api/openapi.test.ts
@@ -159,6 +159,7 @@ describe("openapi document vs runtime", () => {
       "/api/v1/agents/{agentId}",
       "/api/v1/events",
       "/api/v1/fs/check",
+      "/api/v1/fs/list",
     ])
     // The WebSocket attach endpoint is contract-declared but excluded from
     // the document — REST clients cannot represent an upgrade.
@@ -534,6 +535,36 @@ describe("openapi document vs runtime", () => {
       // reason is optional (absent when conclusive) — and deliberately not a
       // nullable required field, which the pinned Swift generator would drop.
       assert.sameMembers([...schema.required], ["path", "state", "checkedAt"])
+    }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
+  )
+
+  it.effect("GET /api/v1/fs/list returns the documented payload", () =>
+    Effect.gen(function* () {
+      const response = yield* (yield* rawClient).get("http://127.0.0.1/api/v1/fs/list?path=/")
+      assert.strictEqual(response.status, 200)
+      const body = (yield* response.json) as Record<string, unknown>
+      assert.strictEqual(body["path"], "/")
+      assert.isArray(body["entries"])
+
+      const ref = operation("/api/v1/fs/list").responses["200"]!.content["application/json"]!.schema
+      assert.deepStrictEqual(ref, { $ref: "#/components/schemas/FsListResponse" })
+      const schema = componentSchema("FsListResponse")
+      assert.sameMembers(Object.keys(schema.properties), ["path", "parent", "entries"])
+      // parent is optional (absent at the root) — and deliberately not a
+      // nullable required field, which the pinned Swift generator would drop.
+      assert.sameMembers([...schema.required], ["path", "entries"])
+
+      const entry = componentSchema("FsListEntry")
+      assert.sameMembers(Object.keys(entry.properties), ["name", "path"])
+      assert.sameMembers([...entry.required], ["name", "path"])
+
+      // An unusable path is the tagged 422, same as canonicalize.
+      const missing = yield* (yield* rawClient).get(
+        "http://127.0.0.1/api/v1/fs/list?path=/definitely/not/here",
+      )
+      assert.strictEqual(missing.status, 422)
+      const failure = (yield* missing.json) as Record<string, unknown>
+      assert.strictEqual(failure["_tag"], "DirectoryUnavailable")
     }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
   )
 })

--- a/app-server/test/cli/cli.blackbox.test.ts
+++ b/app-server/test/cli/cli.blackbox.test.ts
@@ -297,6 +297,24 @@ describe("atc project / atc fs (black box)", () => {
     expect(missing.exitCode).toBe(0)
     expect((JSON.parse(missing.stdout) as { state: string }).state).toBe("missing")
   }, 30_000)
+
+  test("fs list resolves relative paths client-side and lists subdirectories", async () => {
+    // The CLI resolves "." against its own cwd (appServerRoot) before the
+    // API sees it; the server then canonicalizes and lists it.
+    const listed = await cli(["fs", "list", "."])
+    expect(listed.exitCode).toBe(0)
+    const listing = JSON.parse(listed.stdout) as {
+      path: string
+      entries: ReadonlyArray<{ name: string }>
+    }
+    expect(listing.path.startsWith("/")).toBe(true)
+    expect(listing.entries.map((entry) => entry.name)).toContain("src")
+
+    const missing = await cli(["fs", "list", join(scratch, "does-not-exist")])
+    expect(missing.exitCode).toBe(1)
+    expect(missing.stdout).toBe("")
+    expect(missing.stderr).toContain("atc fs list:")
+  }, 30_000)
 })
 
 describe("atc thread (black box)", () => {

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -65,6 +65,7 @@ export const testAppConfig = (overrides: Partial<AppConfig["Service"]>): Layer.L
     context: {},
     logLevel: "Info",
     configFile: "/dev/null",
+    home: os.homedir(),
     dataDir: "/tmp",
     stateDir: "/tmp",
     dbFile: "/tmp/atc.db",
@@ -91,6 +92,7 @@ export const makeTestServiceLayers = (
   dbFile = ":memory:",
   threadsOptions: Threads.ThreadsOptions = {},
   eventsOptions: Events.EventsOptions = {},
+  configOverrides: Partial<AppConfig["Service"]> = {},
 ): {
   readonly fake: FakeTerminalAdapter
   readonly fakeAgents: { readonly codex: FakeAgentAdapter; readonly claude: FakeAgentAdapter }
@@ -120,7 +122,12 @@ export const makeTestServiceLayers = (
     TerminalRepository.layer,
     ThreadRepository.layer,
   ).pipe(Layer.provide(Persistence.layerFile(dbFile)))
-  const services = Layer.mergeAll(base, Directories.layer, fake.layer, ClaudeHooks.layer)
+  const services = Layer.mergeAll(
+    base,
+    Directories.layer.pipe(Layer.provide(testAppConfig(configOverrides))),
+    fake.layer,
+    ClaudeHooks.layer,
+  )
   const eventsLayer = Events.layerWith(eventsOptions)
   const terminals = Terminals.layer.pipe(Layer.provide([services, eventsLayer]))
   const registry = AgentRegistry.layer.pipe(

--- a/macos/ATC/PreviewSupport/PreviewAppServerClient.swift
+++ b/macos/ATC/PreviewSupport/PreviewAppServerClient.swift
@@ -225,6 +225,19 @@ nonisolated struct PreviewAppServerClient: APIProtocol {
         ))))
     }
 
+    func listDirectory(
+        _ input: Operations.ListDirectory.Input
+    ) async throws -> Operations.ListDirectory.Output {
+        let path = input.query.path ?? "/Users/dev"
+        return .ok(.init(body: .json(.init(
+            path: path,
+            parent: path == "/" ? nil : URL(filePath: path).deletingLastPathComponent().path(percentEncoded: false),
+            entries: ["Documents", "Downloads", "Projects"].map {
+                .init(name: $0, path: path == "/" ? "/\($0)" : "\(path)/\($0)")
+            }
+        ))))
+    }
+
     // MARK: - Projects
 
     func listProjects(_ input: Operations.ListProjects.Input) async throws -> Operations.ListProjects.Output {

--- a/macos/ATCTests/ScriptableAppServerClient.swift
+++ b/macos/ATCTests/ScriptableAppServerClient.swift
@@ -29,6 +29,7 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
         var shouldFail = false
         var delay: Duration?
         var directoryCheck: Components.Schemas.FsCheckResponse?
+        var directoryListings: [String?: Components.Schemas.FsListResponse] = [:]
         var createdThreadRequests: [Components.Schemas.CreateThreadRequest] = []
         var createdTerminalRequests: [Components.Schemas.CreateTerminalRequest] = []
         var listProjectsCount = 0
@@ -117,6 +118,14 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     var directoryCheck: Components.Schemas.FsCheckResponse? {
         get { lock.withLock { state.directoryCheck } }
         set { lock.withLock { state.directoryCheck = newValue } }
+    }
+
+    /// Listings served by `listDirectory`, keyed by the requested path
+    /// (`nil` = the home-directory request). A request for an unseeded path
+    /// throws, standing in for the server's DirectoryUnavailable.
+    var directoryListings: [String?: Components.Schemas.FsListResponse] {
+        get { lock.withLock { state.directoryListings } }
+        set { lock.withLock { state.directoryListings = newValue } }
     }
 
     // MARK: - Captured requests and call counts
@@ -510,6 +519,15 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
         let response = directoryCheck
             ?? Components.Schemas.FsCheckResponse(path: path, state: .available, checkedAt: .now)
         return .ok(.init(body: .json(response)))
+    }
+
+    func listDirectory(_ input: Operations.ListDirectory.Input) async throws
+        -> Operations.ListDirectory.Output {
+        try await gate()
+        guard let listing = directoryListings[input.query.path] else {
+            throw StubUnimplemented("listDirectory \(input.query.path ?? "<home>")")
+        }
+        return .ok(.init(body: .json(listing)))
     }
 
     // MARK: - Unimplemented


### PR DESCRIPTION
Server half of ATC-151 (server-backed folder browser). Adds `GET /api/v1/fs/list`: lists a directory's subdirectories — non-recursive, dotfolders excluded, symlinks included when they resolve to directories, sorted case-insensitively (pinned collation) — with the same bounded 2s timeout and tagged errors as `fs/check`. Omitting `path` lists the server's home directory, which is now settled on `AppConfig.home` ($HOME, else the OS account database) per the everything-reads-AppConfig invariant.

- `Directories.list` in `platform/directories.ts`; the timeout wrapper and errno→state mapping are shared between check and list. Unknown dirent types (d_type-less filesystems like NFS) are stat-classified in parallel rather than dropped.
- `atc fs list [path]` CLI command (relative paths resolve client-side, like `fs check`).
- The two macOS `APIProtocol` test doubles gain `listDirectory` conformance stubs **in this PR** so macOS CI (which triggers on `openapi.json`) stays green standalone; the picker itself is the stacked PR.
- Regenerated OpenAPI artifact; contract:check green; new API, OpenAPI-conformance, and CLI blackbox tests. The omitted-path test lists a scratch fixture home, never the runner's real $HOME.

Linear: ATC-152 (parent ATC-151). Stacked: #153 builds on this branch.

https://claude.ai/code/session_013BegU75begedQiErViRJAn