### PR TITLE
macOS DirectoryPickerSheet replacing NSOpenPanel (ATC-153)

### DIFF
--- a/macos/ATC/Shared/DirectoryPickerSheet.swift
+++ b/macos/ATC/Shared/DirectoryPickerSheet.swift
@@ -1,0 +1,163 @@
+// Server-backed folder browser (ATC-151): Browse… always lists the server's
+// filesystem through `GET /fs/list` on the selected Connection — loopback or
+// remote, one code path. Directories only, dotfolders excluded server-side;
+// the text field stays the escape hatch for hidden paths. Read-only: no New
+// Folder, no file selection.
+
+import ATCAppServerAPI
+import SwiftUI
+
+@MainActor @Observable
+final class DirectoryPickerModel {
+    private let client: any APIProtocol
+
+    private(set) var listing: Components.Schemas.FsListResponse?
+    private(set) var errorMessage: String?
+    private(set) var isLoading = false
+
+    init(client: any APIProtocol) {
+        self.client = client
+    }
+
+    /// The canonical path Choose commits: the directory currently listed.
+    var currentPath: String? { listing?.path }
+
+    var canGoUp: Bool { listing?.parent != nil }
+
+    /// The picker's opening sequence: the given start when it lists, else
+    /// the server home — a stale typed path never leaves a dead picker.
+    func start(at initialPath: String?) async {
+        await load(path: initialPath)
+        if listing == nil && initialPath != nil {
+            await load(path: nil)
+        }
+    }
+
+    /// List `path` (nil = the server's home directory). One request at a
+    /// time: taps landing while a load is in flight are dropped, so a slow
+    /// response can never overwrite a newer one. A failed load keeps the
+    /// last good listing so navigation survives a directory that vanished
+    /// after it was listed.
+    func load(path: String?) async {
+        guard !isLoading else { return }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            switch try await client.listDirectory(query: .init(path: path)) {
+            case .ok(let ok):
+                listing = try ok.body.json
+                errorMessage = nil
+            case .unprocessableContent(let failure):
+                // The server's tagged diagnostic (missing / inaccessible /
+                // not a directory / timed out) already reads well.
+                let body = try failure.body.json
+                errorMessage = body.value1?.message ?? body.value2?.message
+                    ?? "The server couldn't list that folder."
+            case .undocumented(statusCode: let status, _):
+                errorMessage = "Unexpected server response (\(status))."
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func descend(into entry: Components.Schemas.FsListEntry) async {
+        await load(path: entry.path)
+    }
+
+    func goUp() async {
+        guard let parent = listing?.parent else { return }
+        await load(path: parent)
+    }
+}
+
+struct DirectoryPickerSheet: View {
+    /// Listed first; nil (or a failed first load) starts at the server home.
+    let initialPath: String?
+    var onChoose: (String) -> Void
+    @Environment(\.dismiss) private var dismiss
+    @State private var model: DirectoryPickerModel
+
+    init(client: any APIProtocol, initialPath: String?, onChoose: @escaping (String) -> Void) {
+        self.initialPath = initialPath
+        self.onChoose = onChoose
+        _model = State(initialValue: DirectoryPickerModel(client: client))
+    }
+
+    var body: some View {
+        SheetScaffold(
+            title: "Choose Folder",
+            systemImage: "folder",
+            primaryLabel: "Choose",
+            // Not while loading: the model keeps the last good listing during
+            // a load, so mid-flight Choose would commit the folder the user
+            // just navigated away from.
+            canSubmit: model.currentPath != nil && !model.isLoading,
+            wrapsContentInForm: false,
+            onCancel: { dismiss() },
+            onSubmit: {
+                guard let path = model.currentPath else { return }
+                onChoose(path)
+                dismiss()
+            }
+        ) {
+            pathBar
+            Divider()
+            entryList
+            if let message = model.errorMessage {
+                Divider()
+                Label(message, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .lineLimit(2)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(Spacing.md)
+            }
+        }
+        .frame(width: 480, height: 420)
+        .task { await model.start(at: initialPath) }
+    }
+
+    private var pathBar: some View {
+        HStack(spacing: Spacing.sm) {
+            Button {
+                Task { await model.goUp() }
+            } label: {
+                Image(systemName: "arrow.up")
+            }
+            .help("Enclosing folder")
+            .disabled(!model.canGoUp || model.isLoading)
+            Text(model.currentPath ?? " ")
+                .font(.callout.monospaced())
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            if model.isLoading {
+                ProgressView().controlSize(.small)
+            }
+        }
+        .padding(.horizontal, Spacing.md)
+        .padding(.vertical, Spacing.sm)
+    }
+
+    private var entryList: some View {
+        List(model.listing?.entries ?? [], id: \.path) { entry in
+            Button {
+                Task { await model.descend(into: entry) }
+            } label: {
+                Label(entry.name, systemImage: "folder")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(model.isLoading)
+        }
+        .listStyle(.inset)
+        .overlay {
+            if let listing = model.listing, listing.entries.isEmpty {
+                Text("No subfolders")
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}

--- a/macos/ATC/Shared/SheetScaffold.swift
+++ b/macos/ATC/Shared/SheetScaffold.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 
 /// Standard chrome for form sheets: a Label title header, grouped Form
-/// content, and a trailing button row in the HIG arrangement — Cancel
-/// adjacent-left of the primary action, both trailing.
+/// content by default (see `wrapsContentInForm`), and a trailing button row
+/// in the HIG arrangement — Cancel adjacent-left of the primary action, both
+/// trailing.
 struct SheetScaffold<Content: View>: View {
     let title: String
     let systemImage: String
@@ -10,6 +11,9 @@ struct SheetScaffold<Content: View>: View {
     let primaryLabel: String
     var isBusy = false
     var canSubmit = true
+    /// Grouped-Form content is the default; list-style sheets (the folder
+    /// browser) pass false and lay out their own content edge-to-edge.
+    var wrapsContentInForm = true
     var onCancel: () -> Void
     var onSubmit: () -> Void
     @ViewBuilder var content: () -> Content
@@ -21,8 +25,12 @@ struct SheetScaffold<Content: View>: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(Spacing.md)
             Divider()
-            Form(content: content)
-                .formStyle(.grouped)
+            if wrapsContentInForm {
+                Form(content: content)
+                    .formStyle(.grouped)
+            } else {
+                content()
+            }
             Divider()
             HStack {
                 Spacer()

--- a/macos/ATC/Shared/WorkingDirectoryField.swift
+++ b/macos/ATC/Shared/WorkingDirectoryField.swift
@@ -4,11 +4,10 @@
 // value settles and publishes the outcome; sheets gate submission on
 // `DirectoryCheckState.isAvailable` rather than inspecting paths themselves.
 //
-// Browse opens a local NSOpenPanel, which only matches the server's
-// filesystem for a loopback Connection — validation, never the panel, is what
-// makes a path trustworthy.
+// Browse opens the server-backed DirectoryPickerSheet (`GET /fs/list`), so
+// the browsed filesystem is the server's on every Connection — but
+// validation, never the picker, is what makes a path trustworthy.
 
-import AppKit
 import ATCAppServerAPI
 import SwiftUI
 
@@ -36,6 +35,7 @@ struct WorkingDirectoryField: View {
     /// when the typed path is unchanged.
     let connectionID: UUID?
     @Binding var state: DirectoryCheckState
+    @State private var isBrowsing = false
 
     private struct CheckKey: Equatable {
         let path: String
@@ -47,7 +47,8 @@ struct WorkingDirectoryField: View {
             HStack(spacing: Spacing.sm) {
                 TextField(label, text: $path, prompt: Text("/path/on/the/server"))
                     .autocorrectionDisabled()
-                Button("Browse…") { browse() }
+                Button("Browse…") { isBrowsing = true }
+                    .disabled(client == nil)
             }
             if let message = statusMessage {
                 Label(message.text, systemImage: message.systemImage)
@@ -57,6 +58,22 @@ struct WorkingDirectoryField: View {
             }
         }
         .task(id: CheckKey(path: path, connectionID: connectionID)) { await check() }
+        // A picker browsing one server must not survive into another (or no)
+        // Connection; without this, losing the client mid-browse would leave
+        // an empty, undismissable sheet.
+        .onChange(of: connectionID) { isBrowsing = false }
+        .sheet(isPresented: $isBrowsing) {
+            if let client {
+                DirectoryPickerSheet(
+                    client: client,
+                    // Start where the user already is when the typed path is
+                    // known-good; otherwise the server home.
+                    initialPath: state.isAvailable
+                        ? path.trimmingCharacters(in: .whitespaces) : nil,
+                    onChoose: { path = $0 }
+                )
+            }
+        }
     }
 
     private func check() async {
@@ -87,20 +104,6 @@ struct WorkingDirectoryField: View {
         } catch {
             state = .failed(error.localizedDescription)
         }
-    }
-
-    private func browse() {
-        let panel = NSOpenPanel()
-        panel.canChooseDirectories = true
-        panel.canChooseFiles = false
-        panel.allowsMultipleSelection = false
-        panel.prompt = "Choose"
-        let trimmed = path.trimmingCharacters(in: .whitespaces)
-        if trimmed.hasPrefix("/") {
-            panel.directoryURL = URL(filePath: trimmed)
-        }
-        guard panel.runModal() == .OK, let url = panel.url else { return }
-        path = url.path(percentEncoded: false)
     }
 
     private var statusMessage: (text: String, systemImage: String, color: Color)? {

--- a/macos/ATCTests/DirectoryPickerModelTests.swift
+++ b/macos/ATCTests/DirectoryPickerModelTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+import ATCAppServerAPI
+@testable import ATC
+
+/// DirectoryPickerModel: server-backed navigation and the keep-last-listing
+/// failure behavior the picker relies on.
+@MainActor
+@Suite("DirectoryPickerModel")
+struct DirectoryPickerModelTests {
+    private static func listing(
+        path: String, parent: String?, names: [String]
+    ) -> Components.Schemas.FsListResponse {
+        .init(path: path, parent: parent, entries: names.map { .init(name: $0, path: "\(path)/\($0)") })
+    }
+
+    @Test("lists home for a nil path, descends into an entry, and climbs back up")
+    func navigation() async {
+        let client = ScriptableAppServerClient()
+        client.directoryListings = [
+            nil: Self.listing(path: "/home/dev", parent: "/home", names: ["Projects"]),
+            "/home/dev": Self.listing(path: "/home/dev", parent: "/home", names: ["Projects"]),
+            "/home/dev/Projects": Self.listing(
+                path: "/home/dev/Projects", parent: "/home/dev", names: []),
+        ]
+        let model = DirectoryPickerModel(client: client)
+
+        await model.load(path: nil)
+        #expect(model.currentPath == "/home/dev")
+        #expect(model.canGoUp)
+        #expect(model.listing?.entries.map(\.name) == ["Projects"])
+
+        await model.descend(into: model.listing!.entries[0])
+        #expect(model.currentPath == "/home/dev/Projects")
+        #expect(model.listing?.entries.isEmpty == true)
+
+        await model.goUp()
+        #expect(model.currentPath == "/home/dev")
+    }
+
+    @Test("a 422 surfaces the server's diagnostic and keeps the last good listing")
+    func failureKeepsListing() async {
+        let client = ScriptableAppServerClient()
+        client.directoryListings = [
+            nil: Self.listing(path: "/home/dev", parent: "/home", names: ["gone"])
+        ]
+        let model = DirectoryPickerModel(client: client)
+        await model.load(path: nil)
+
+        client.directoryListingFailure = .init(
+            _tag: .directoryUnavailable,
+            path: "/home/dev/gone",
+            state: .missing,
+            message: "/home/dev/gone does not exist"
+        )
+        await model.load(path: "/home/dev/gone")
+        #expect(model.currentPath == "/home/dev")
+        #expect(model.errorMessage == "/home/dev/gone does not exist")
+
+        client.directoryListingFailure = nil
+        await model.load(path: nil)
+        #expect(model.errorMessage == nil)
+    }
+
+    @Test("start falls back to the server home when the initial path won't list")
+    func startFallsBackToHome() async {
+        let client = ScriptableAppServerClient()
+        client.directoryListings = [
+            nil: Self.listing(path: "/home/dev", parent: "/home", names: [])
+        ]
+        let model = DirectoryPickerModel(client: client)
+
+        await model.start(at: "/stale/typed/path")
+        #expect(model.currentPath == "/home/dev")
+        #expect(model.errorMessage == nil)
+    }
+}

--- a/macos/ATCTests/ScriptableAppServerClient.swift
+++ b/macos/ATCTests/ScriptableAppServerClient.swift
@@ -30,6 +30,7 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
         var delay: Duration?
         var directoryCheck: Components.Schemas.FsCheckResponse?
         var directoryListings: [String?: Components.Schemas.FsListResponse] = [:]
+        var directoryListingFailure: Components.Schemas.DirectoryUnavailableJsonEncoding?
         var createdThreadRequests: [Components.Schemas.CreateThreadRequest] = []
         var createdTerminalRequests: [Components.Schemas.CreateTerminalRequest] = []
         var listProjectsCount = 0
@@ -122,10 +123,17 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
 
     /// Listings served by `listDirectory`, keyed by the requested path
     /// (`nil` = the home-directory request). A request for an unseeded path
-    /// throws, standing in for the server's DirectoryUnavailable.
+    /// throws, standing in for a transport failure.
     var directoryListings: [String?: Components.Schemas.FsListResponse] {
         get { lock.withLock { state.directoryListings } }
         set { lock.withLock { state.directoryListings = newValue } }
+    }
+
+    /// While set, every `listDirectory` answers the documented 422 with this
+    /// payload — the server's tagged DirectoryUnavailable diagnostic.
+    var directoryListingFailure: Components.Schemas.DirectoryUnavailableJsonEncoding? {
+        get { lock.withLock { state.directoryListingFailure } }
+        set { lock.withLock { state.directoryListingFailure = newValue } }
     }
 
     // MARK: - Captured requests and call counts
@@ -524,6 +532,9 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     func listDirectory(_ input: Operations.ListDirectory.Input) async throws
         -> Operations.ListDirectory.Output {
         try await gate()
+        if let failure = directoryListingFailure {
+            return .unprocessableContent(.init(body: .json(.init(value1: failure))))
+        }
         guard let listing = directoryListings[input.query.path] else {
             throw StubUnimplemented("listDirectory \(input.query.path ?? "<home>")")
         }


### PR DESCRIPTION
macOS half of ATC-151, stacked on #152 (needs the regenerated Swift client for `fs/list`).

Browse… now opens a server-backed folder browser driven by `GET /fs/list` through the selected Connection, so the browsed filesystem is always the server's — loopback or remote, one code path. `NSOpenPanel` is removed entirely.

- `DirectoryPickerSheet` + `DirectoryPickerModel`: drill-down list (path bar with Up, descend on click, Choose/Cancel via the shared `SheetScaffold`, which gained a non-Form content mode). One request in flight at a time; a failed load keeps the last good listing and shows the server's tagged diagnostic; a stale starting path falls back to the server home.
- `WorkingDirectoryField`: Browse… disabled with no Connection; the picker starts at the typed path when its check is available; a Connection change dismisses the picker; the existing `/fs/check` flow still validates the chosen value. Covers all three creation sheets.
- Preview + scriptable test clients implement the new operation; new `DirectoryPickerModel` tests.

Linear: ATC-153 (parent ATC-151). Merge #152 into main first, then retarget/merge this.

https://claude.ai/code/session_013BegU75begedQiErViRJAn