### PR TITLE
Project deletion cascades to owned threads and terminals (ATC-154)

### DIFF
--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -260,25 +260,18 @@
               }
             }
           },
-          "409": {
-            "description": "The project still owns terminals (live or ended); delete them first. | The project still owns threads (active or archived); delete them first.",
+          "503": {
+            "description": "The zmx multiplexer cannot be consulted right now. Retryable; stored terminal state is untouched.",
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/ProjectHasTerminalsJsonEncoding"
-                    },
-                    {
-                      "$ref": "#/components/schemas/ProjectHasThreadsJsonEncoding"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ZmxUnavailableJsonEncoding"
                 }
               }
             }
           }
         },
-        "description": "Delete the project record. Restricted while the project still owns terminals or threads; never touches the filesystem or any directory."
+        "description": "Delete the project and everything it owns: every thread (archived included) and every terminal (ended tombstones included) is deleted through the normal delete flows, then the project record. Never touches the filesystem or any directory. A mid-cascade failure leaves already-deleted children deleted; retrying finishes the job."
       }
     },
     "/api/v1/terminals": {
@@ -1529,20 +1522,17 @@
         "additionalProperties": false,
         "description": "Partial update; affects future Threads and Terminals only."
       },
-      "ProjectHasTerminalsJsonEncoding": {
+      "ZmxUnavailableJsonEncoding": {
         "type": "object",
         "properties": {
           "_tag": {
             "type": "string",
             "enum": [
-              "ProjectHasTerminals"
+              "ZmxUnavailable"
             ]
           },
-          "projectId": {
+          "reason": {
             "type": "string"
-          },
-          "terminalCount": {
-            "type": "integer"
           },
           "message": {
             "type": "string",
@@ -1551,36 +1541,7 @@
         },
         "required": [
           "_tag",
-          "projectId",
-          "terminalCount",
-          "message"
-        ],
-        "additionalProperties": false
-      },
-      "ProjectHasThreadsJsonEncoding": {
-        "type": "object",
-        "properties": {
-          "_tag": {
-            "type": "string",
-            "enum": [
-              "ProjectHasThreads"
-            ]
-          },
-          "projectId": {
-            "type": "string"
-          },
-          "threadCount": {
-            "type": "integer"
-          },
-          "message": {
-            "type": "string",
-            "description": "Human-readable diagnostic derived from the structured fields."
-          }
-        },
-        "required": [
-          "_tag",
-          "projectId",
-          "threadCount",
+          "reason",
           "message"
         ],
         "additionalProperties": false
@@ -1699,30 +1660,6 @@
             "type": "string",
             "enum": [
               "TerminalLaunchFailed"
-            ]
-          },
-          "reason": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string",
-            "description": "Human-readable diagnostic derived from the structured fields."
-          }
-        },
-        "required": [
-          "_tag",
-          "reason",
-          "message"
-        ],
-        "additionalProperties": false
-      },
-      "ZmxUnavailableJsonEncoding": {
-        "type": "object",
-        "properties": {
-          "_tag": {
-            "type": "string",
-            "enum": [
-              "ZmxUnavailable"
             ]
           },
           "reason": {

--- a/app-server/src/api/contract.ts
+++ b/app-server/src/api/contract.ts
@@ -477,42 +477,6 @@ export class TerminalLaunchFailed extends Schema.TaggedErrorClass<TerminalLaunch
   }
 }
 
-/** Project deletion is restricted while it still owns terminals. */
-export class ProjectHasTerminals extends Schema.TaggedErrorClass<ProjectHasTerminals>()(
-  "ProjectHasTerminals",
-  { projectId: Schema.String, terminalCount: Schema.Int, message: errorMessage },
-  {
-    identifier: "ProjectHasTerminals",
-    description: "The project still owns terminals (live or ended); delete them first.",
-    httpApiStatus: 409,
-  },
-) {
-  constructor(props: { readonly projectId: string; readonly terminalCount: number }) {
-    super({
-      ...props,
-      message: `project ${props.projectId} still owns ${props.terminalCount} terminal(s); delete them first`,
-    })
-  }
-}
-
-/** Project deletion is restricted while it still owns threads. */
-export class ProjectHasThreads extends Schema.TaggedErrorClass<ProjectHasThreads>()(
-  "ProjectHasThreads",
-  { projectId: Schema.String, threadCount: Schema.Int, message: errorMessage },
-  {
-    identifier: "ProjectHasThreads",
-    description: "The project still owns threads (active or archived); delete them first.",
-    httpApiStatus: 409,
-  },
-) {
-  constructor(props: { readonly projectId: string; readonly threadCount: number }) {
-    super({
-      ...props,
-      message: `project ${props.projectId} still owns ${props.threadCount} thread(s); delete them first`,
-    })
-  }
-}
-
 /** Unknown agent registry slug. */
 export class AgentNotFound extends Schema.TaggedErrorClass<AgentNotFound>()(
   "AgentNotFound",
@@ -656,12 +620,12 @@ export class V1 extends HttpApiGroup.make("v1")
       ),
     HttpApiEndpoint.delete("deleteProject", "/projects/:projectId", {
       params: projectIdParam,
-      error: [ProjectNotFound, ProjectHasTerminals, ProjectHasThreads],
+      error: [ProjectNotFound, ZmxUnavailable],
     })
       .annotate(OpenApi.Identifier, "deleteProject")
       .annotate(
         OpenApi.Description,
-        "Delete the project record. Restricted while the project still owns terminals or threads; never touches the filesystem or any directory.",
+        "Delete the project and everything it owns: every thread (archived included) and every terminal (ended tombstones included) is deleted through the normal delete flows, then the project record. Never touches the filesystem or any directory. A mid-cascade failure leaves already-deleted children deleted; retrying finishes the job.",
       ),
     HttpApiEndpoint.get("listTerminals", "/terminals", {
       query: {

--- a/app-server/src/cli/projects.ts
+++ b/app-server/src/cli/projects.ts
@@ -55,14 +55,14 @@ const projectUpdate = Cli.clientCommand(
 
 const projectDelete = Cli.clientCommand(
   "project delete",
-  "Delete a project record (never touches the filesystem)",
+  "Delete a project and every thread and terminal it owns (never touches the filesystem)",
   { projectId: projectIdArgument, yes: Cli.yesFlag },
   (client, { projectId, yes }) =>
     yes
       ? client.v1.deleteProject({ params: { projectId } })
       : Effect.fail(
           new Error(
-            "refusing to delete without --yes (deletes the project record only, never the directory)",
+            "refusing to delete without --yes (also deletes the project's threads and terminals, never the directory)",
           ),
         ),
 )

--- a/app-server/src/projects/projects.ts
+++ b/app-server/src/projects/projects.ts
@@ -1,23 +1,26 @@
 import { Context, Effect, Layer, Option } from "effect"
-import { ProjectHasTerminals, ProjectHasThreads, ProjectNotFound } from "../api/contract.ts"
+import { ProjectNotFound } from "../api/contract.ts"
 import type {
   CreateProjectRequest,
   DirectoryCheckTimedOut,
   DirectoryUnavailable,
   UpdateProjectRequest,
+  ZmxUnavailable,
 } from "../api/contract.ts"
 import { Events } from "../events/events.ts"
 import { Directories } from "../platform/directories.ts"
 import { ProjectRepository } from "./projectRepository.ts"
 import type { Project } from "./projectRepository.ts"
+import { Terminals } from "../terminals/terminals.ts"
 import { TerminalRepository } from "../terminals/terminalRepository.ts"
+import { Threads } from "../threads/threads.ts"
 import { ThreadRepository } from "../threads/threadRepository.ts"
 
 // The Projects domain service: the rules above the repository —
 // canonicalize-on-create/update (identity is the symlink-resolved canonical
-// path, validated before anything is stored) and the
-// delete-restricted-while-terminals-exist guard. Handlers delegate here so
-// every surface gets the same rules.
+// path, validated before anything is stored) and the delete cascade to every
+// owned thread and terminal. Handlers delegate here so every surface gets
+// the same rules.
 
 export class Projects extends Context.Service<
   Projects,
@@ -33,10 +36,8 @@ export class Projects extends Context.Service<
       id: string,
       patch: typeof UpdateProjectRequest.Type,
     ) => Effect.Effect<Project, ProjectNotFound | DirectoryUnavailable | DirectoryCheckTimedOut>
-    /** Delete the record; restricted while the project owns terminals or threads. */
-    readonly delete: (
-      id: string,
-    ) => Effect.Effect<void, ProjectNotFound | ProjectHasTerminals | ProjectHasThreads>
+    /** Delete the project, cascading to every owned thread and terminal. */
+    readonly delete: (id: string) => Effect.Effect<void, ProjectNotFound | ZmxUnavailable>
   }
 >()("app-server/Projects") {}
 
@@ -44,7 +45,9 @@ export const layer = Layer.effect(Projects)(
   Effect.gen(function* () {
     const repository = yield* ProjectRepository
     const directories = yield* Directories
+    const terminals = yield* Terminals
     const terminalRepository = yield* TerminalRepository
+    const threads = yield* Threads
     const threadRepository = yield* ThreadRepository
     const events = yield* Events
 
@@ -85,18 +88,33 @@ export const layer = Layer.effect(Projects)(
         }),
       delete: (id) =>
         Effect.gen(function* () {
-          // RESTRICT while terminals exist (tombstones included): the
-          // simplest correct rule for a single-user app. Not transactional
-          // with the delete below — a concurrently created terminal falls
-          // back to the migration's FK RESTRICT (a defect, not a 409).
-          const terminalCount = yield* terminalRepository.countForProject(id)
-          if (terminalCount > 0) {
-            return yield* Effect.fail(new ProjectHasTerminals({ projectId: id, terminalCount }))
-          }
-          const threadCount = yield* threadRepository.countForProject(id)
-          if (threadCount > 0) {
-            return yield* Effect.fail(new ProjectHasThreads({ projectId: id, threadCount }))
-          }
+          // Sequential, best-effort cascade: threads first (a thread delete
+          // kills its live linked terminal and releases provider state; its
+          // ended linked tombstones survive unlinked), then every remaining
+          // terminal — `starting` rows and `ended` tombstones included. A
+          // ZmxUnavailable mid-cascade surfaces to the caller with children
+          // already deleted staying deleted; retrying the project delete
+          // finishes the job. Not transactional — child deletes do external
+          // I/O (zmx kill, hook-file removal) — so a child created
+          // concurrently mid-cascade falls back to the migration's FK
+          // RESTRICT (a defect, not a modeled failure).
+          const ownedThreads = yield* threadRepository.list(id)
+          yield* Effect.forEach(
+            ownedThreads,
+            (thread) =>
+              // A child that vanished since its listing is the goal state.
+              threads.delete(thread.id).pipe(Effect.catchTag("ThreadNotFound", () => Effect.void)),
+            { discard: true },
+          )
+          const ownedTerminals = yield* terminalRepository.list(id)
+          yield* Effect.forEach(
+            ownedTerminals,
+            (terminal) =>
+              terminals
+                .delete(terminal.id)
+                .pipe(Effect.catchTag("TerminalNotFound", () => Effect.void)),
+            { discard: true },
+          )
           const deleted = yield* repository.delete(id)
           if (!deleted) {
             return yield* Effect.fail(new ProjectNotFound({ projectId: id }))

--- a/app-server/src/server.ts
+++ b/app-server/src/server.ts
@@ -123,7 +123,10 @@ export const layer = (options: { readonly port: number; readonly hostname?: stri
 export const production = (options: { readonly port: number; readonly hostname?: string }) =>
   layer(options).pipe(
     Layer.provide(AuthToken.layer),
-    Layer.provide([Projects.layer, Threads.layer]),
+    // Projects sits above Threads (its delete cascades through them), which
+    // sits above Terminals — each provide feeds everything composed so far.
+    Layer.provide(Projects.layer),
+    Layer.provide(Threads.layer),
     Layer.provide([Terminals.layer, AgentRegistry.layer]),
     // Below Terminals (the deepest publisher) so one memoized Events instance
     // serves every domain service, the handlers, and the shutdown drain.

--- a/app-server/src/terminals/terminalRepository.ts
+++ b/app-server/src/terminals/terminalRepository.ts
@@ -78,8 +78,6 @@ export class TerminalRepository extends Context.Service<
     /** Update the display label; callers hold the record (see markLive). */
     readonly rename: (id: string, name: string) => Effect.Effect<TerminalRecord>
     readonly delete: (id: string) => Effect.Effect<void>
-    /** Every record (tombstones included) — the project-deletion guard. */
-    readonly countForProject: (projectId: string) => Effect.Effect<number>
   }
 >()("app-server/TerminalRepository") {}
 
@@ -147,13 +145,6 @@ export const layer = Layer.effect(TerminalRepository)(
       execute: (id) => sql`DELETE FROM terminals WHERE id = ${id}`,
     })
 
-    const countRows = SqlSchema.findAll({
-      Request: Schema.String,
-      Result: Schema.Struct({ n: Schema.Int }),
-      execute: (projectId) =>
-        sql`SELECT COUNT(*) AS n FROM terminals WHERE project_id = ${projectId}`,
-    })
-
     const firstRecord = (rows: ReadonlyArray<typeof TerminalRow.Type>) =>
       Option.fromNullishOr(rows[0]).pipe(Option.map(toRecord))
 
@@ -217,11 +208,6 @@ export const layer = Layer.effect(TerminalRepository)(
           Effect.flatMap(requireFirst("rename")),
         ),
       delete: (id) => deleteRows(id).pipe(Effect.orDie),
-      countForProject: (projectId) =>
-        countRows(projectId).pipe(
-          Effect.map((rows) => rows[0]?.n ?? 0),
-          Effect.orDie,
-        ),
     }
   }),
 )

--- a/app-server/src/terminals/terminals.ts
+++ b/app-server/src/terminals/terminals.ts
@@ -45,7 +45,8 @@ export type Terminal = typeof TerminalSchema.Type
 //     by startup recovery after a crash). Request-time reconciliation never
 //     touches them, which is why the startup pass and the request-time pass
 //     can never be one function: resolving `starting` rows is only safe
-//     while no create can be in flight.
+//     while no create can be in flight. The one operation that accepts them
+//     is delete, so the project-deletion cascade can reap crash residue.
 //   - Orphan cleanup: sessions in ATC's private socket dir that no stored
 //     terminal claims are provably ours and killed (best-effort) at startup.
 
@@ -297,7 +298,12 @@ export const layer = Layer.effect(Terminals)(
 
     const del: Terminals["Service"]["delete"] = (id) =>
       Effect.gen(function* () {
-        const record = yield* requireRecord(id)
+        // Deliberately not requireRecord: delete accepts `starting` rows so
+        // the project-deletion cascade can reap crash residue a startup left
+        // unresolved. Only the in-flight create holds a starting id
+        // otherwise (they are invisible everywhere else), and a create
+        // racing a project cascade is already the FK RESTRICT defect stance.
+        const record = yield* repository.require(id)
         // Kill requiring certainty: a kill that cannot verify death is
         // reported retryably rather than deleting a record whose session
         // may still be alive.

--- a/app-server/src/threads/threadRepository.ts
+++ b/app-server/src/threads/threadRepository.ts
@@ -104,8 +104,6 @@ export class ThreadRepository extends Context.Service<
     /** Set or clear the archive marker; callers hold the record (see rename). */
     readonly setArchived: (id: string, archived: boolean) => Effect.Effect<ThreadRecord>
     readonly delete: (id: string) => Effect.Effect<void>
-    /** Every record (archived included) — the project-deletion guard. */
-    readonly countForProject: (projectId: string) => Effect.Effect<number>
   }
 >()("app-server/ThreadRepository") {}
 
@@ -230,13 +228,6 @@ export const layer = Layer.effect(ThreadRepository)(
       execute: (id) => sql`DELETE FROM threads WHERE id = ${id}`,
     })
 
-    const countRows = SqlSchema.findAll({
-      Request: Schema.String,
-      Result: Schema.Struct({ n: Schema.Int }),
-      execute: (projectId) =>
-        sql`SELECT COUNT(*) AS n FROM threads WHERE project_id = ${projectId}`,
-    })
-
     const firstRecord = (rows: ReadonlyArray<typeof ThreadRow.Type>) =>
       Option.fromNullishOr(rows[0]).pipe(Option.map(toRecord))
 
@@ -323,11 +314,6 @@ export const layer = Layer.effect(ThreadRepository)(
           return setArchivedRows({ id, archived_at: archived ? now : null, updated_at: now })
         }).pipe(Effect.orDie, Effect.flatMap(requireFirst("setArchived"))),
       delete: (id) => deleteRows(id).pipe(Effect.orDie),
-      countForProject: (projectId) =>
-        countRows(projectId).pipe(
-          Effect.map((rows) => rows[0]?.n ?? 0),
-          Effect.orDie,
-        ),
     }
   }),
 )

--- a/app-server/test/api/api.test.ts
+++ b/app-server/test/api/api.test.ts
@@ -8,6 +8,7 @@ import { realpathSync } from "node:fs"
 import { afterAll } from "vitest"
 import { Api, DirectoryUnavailable } from "../../src/api/contract.ts"
 import * as Events from "../../src/events/events.ts"
+import { sessionNameForTerminalId } from "../../src/terminals/terminalAdapter.ts"
 import { testBuildInfo } from "../testBuildInfo.ts"
 import { apiTestLayer, makeTestServiceLayers } from "../testLayers.ts"
 
@@ -46,7 +47,8 @@ mkdirSync(join(homeDir, "sub"))
 // server, but no listener. The kit's services are merged in as well (one
 // memoized instance) so tests can reach the same domain services the handlers
 // use — the events test drives the Events service directly.
-const TestLayer = apiTestLayer(makeTestServiceLayers(":memory:", {}, {}, { home: homeDir }))
+const kit = makeTestServiceLayers(":memory:", {}, {}, { home: homeDir })
+const TestLayer = apiTestLayer(kit)
 
 describe("/api/v1", () => {
   it.effect("health returns ok", () =>
@@ -171,25 +173,93 @@ describe("/api/v1/projects", () => {
     }).pipe(Effect.provide(TestLayer)),
   )
 
-  it.effect("restricts project deletion while terminals exist, tombstones included", () =>
+  it.effect("project deletion cascades to owned terminals, tombstones included", () =>
+    Effect.gen(function* () {
+      const client = yield* HttpApiTest.groups(Api, ["v1"])
+      const events = yield* Events.Events
+      const project = yield* client.v1.createProject({
+        payload: { name: "Cascade", defaultWorkingDirectory: realDir },
+      })
+      const live = yield* client.v1.createTerminal({ payload: { projectId: project.id } })
+      const ended = yield* client.v1.createTerminal({ payload: { projectId: project.id } })
+      // Kill the second session out-of-band and reconcile it into an ended
+      // tombstone — the residue the old 409 guard forced users to hunt down.
+      kit.fake.sessions.delete(sessionNameForTerminalId(ended.id))
+      const listed = yield* client.v1.listTerminals({ query: { projectId: project.id } })
+      assert.deepStrictEqual(listed.map((terminal) => terminal.status).toSorted(), [
+        "ended",
+        "live",
+      ])
+
+      const received = yield* Queue.make<Events.ResourceChangedEvent>()
+      const feed = yield* events.subscribe()
+      const subscriber = yield* Effect.forkChild(
+        Stream.runForEach(feed, (event) =>
+          typeof event === "string" ? Effect.void : Queue.offer(received, event),
+        ),
+      )
+
+      yield* client.v1.deleteProject({ params: { projectId: project.id } })
+
+      // Everything is gone — tombstone included — and the live session was
+      // reaped through the normal terminal-delete path.
+      assert.deepStrictEqual(
+        yield* client.v1.listTerminals({ query: { projectId: project.id } }),
+        [],
+      )
+      assert.isFalse(kit.fake.sessions.has(sessionNameForTerminalId(live.id)))
+      const missing = yield* Effect.flip(
+        client.v1.getProject({ params: { projectId: project.id } }),
+      )
+      assert.strictEqual(missing._tag, "ProjectNotFound")
+
+      // Each child publishes its own deleted event before the project's
+      // (newest-first cascade order).
+      assert.deepStrictEqual(
+        [yield* Queue.take(received), yield* Queue.take(received), yield* Queue.take(received)],
+        [
+          { resource: "terminal", id: ended.id, change: "deleted" },
+          { resource: "terminal", id: live.id, change: "deleted" },
+          { resource: "project", id: project.id, change: "deleted" },
+        ],
+      )
+      yield* Fiber.interrupt(subscriber)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("a zmx outage mid-cascade surfaces retryably; a retry finishes the job", () =>
     Effect.gen(function* () {
       const client = yield* HttpApiTest.groups(Api, ["v1"])
       const project = yield* client.v1.createProject({
-        payload: { name: "Guarded", defaultWorkingDirectory: realDir },
+        payload: { name: "Retryable", defaultWorkingDirectory: realDir },
       })
-      const terminal = yield* client.v1.createTerminal({
-        payload: { projectId: project.id },
+      const thread = yield* client.v1.createThread({
+        payload: { projectId: project.id, agentId: "codex" },
       })
-      const restricted = yield* Effect.flip(
+      yield* client.v1.createTerminal({ payload: { projectId: project.id } })
+
+      kit.fake.setUnavailable(true)
+      const failure = yield* Effect.flip(
         client.v1.deleteProject({ params: { projectId: project.id } }),
       )
-      assert.strictEqual(restricted._tag, "ProjectHasTerminals")
-      if (restricted._tag === "ProjectHasTerminals") {
-        assert.strictEqual(restricted.terminalCount, 1)
-      }
-      // Deleting the terminal (record and session) releases the project.
-      yield* client.v1.deleteTerminal({ params: { terminalId: terminal.id } })
+      assert.strictEqual(failure._tag, "ZmxUnavailable")
+      // Partial completion: the thread (no zmx involvement) is already gone,
+      // the terminal and the project survive for the retry.
+      const threadGone = yield* Effect.flip(
+        client.v1.getThread({ params: { threadId: thread.id } }),
+      )
+      assert.strictEqual(threadGone._tag, "ThreadNotFound")
+      assert.strictEqual(
+        (yield* client.v1.getProject({ params: { projectId: project.id } })).id,
+        project.id,
+      )
+
+      kit.fake.setUnavailable(false)
       yield* client.v1.deleteProject({ params: { projectId: project.id } })
+      const missing = yield* Effect.flip(
+        client.v1.getProject({ params: { projectId: project.id } }),
+      )
+      assert.strictEqual(missing._tag, "ProjectNotFound")
     }).pipe(Effect.provide(TestLayer)),
   )
 

--- a/app-server/test/api/api.test.ts
+++ b/app-server/test/api/api.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Fiber, Queue, Stream } from "effect"
+import { Effect, Fiber, Option, Queue, Stream } from "effect"
 import { HttpApiTest } from "effect/unstable/httpapi"
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
@@ -9,6 +9,7 @@ import { afterAll } from "vitest"
 import { Api, DirectoryUnavailable } from "../../src/api/contract.ts"
 import * as Events from "../../src/events/events.ts"
 import { sessionNameForTerminalId } from "../../src/terminals/terminalAdapter.ts"
+import { TerminalRepository } from "../../src/terminals/terminalRepository.ts"
 import { testBuildInfo } from "../testBuildInfo.ts"
 import { apiTestLayer, makeTestServiceLayers } from "../testLayers.ts"
 
@@ -183,8 +184,15 @@ describe("/api/v1/projects", () => {
       const live = yield* client.v1.createTerminal({ payload: { projectId: project.id } })
       const ended = yield* client.v1.createTerminal({ payload: { projectId: project.id } })
       // Kill the second session out-of-band and reconcile it into an ended
-      // tombstone — the residue the old 409 guard forced users to hunt down.
+      // tombstone, and seed a crash-residue `starting` row directly — the
+      // residue kinds the old 409 guard forced users to hunt down (the
+      // starting row is invisible, so users could not even do that).
       kit.fake.sessions.delete(sessionNameForTerminalId(ended.id))
+      const terminalRepository = yield* TerminalRepository
+      const starting = yield* terminalRepository.create({
+        projectId: project.id,
+        initialWorkingDirectory: realDir,
+      })
       const listed = yield* client.v1.listTerminals({ query: { projectId: project.id } })
       assert.deepStrictEqual(listed.map((terminal) => terminal.status).toSorted(), [
         "ended",
@@ -208,6 +216,7 @@ describe("/api/v1/projects", () => {
         [],
       )
       assert.isFalse(kit.fake.sessions.has(sessionNameForTerminalId(live.id)))
+      assert.isTrue(Option.isNone(yield* terminalRepository.get(starting.id)))
       const missing = yield* Effect.flip(
         client.v1.getProject({ params: { projectId: project.id } }),
       )
@@ -216,8 +225,14 @@ describe("/api/v1/projects", () => {
       // Each child publishes its own deleted event before the project's
       // (newest-first cascade order).
       assert.deepStrictEqual(
-        [yield* Queue.take(received), yield* Queue.take(received), yield* Queue.take(received)],
         [
+          yield* Queue.take(received),
+          yield* Queue.take(received),
+          yield* Queue.take(received),
+          yield* Queue.take(received),
+        ],
+        [
+          { resource: "terminal", id: starting.id, change: "deleted" },
           { resource: "terminal", id: ended.id, change: "deleted" },
           { resource: "terminal", id: live.id, change: "deleted" },
           { resource: "project", id: project.id, change: "deleted" },

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -138,6 +138,9 @@ export const makeTestServiceLayers = (
       Subprocess.layer.pipe(Layer.provide(BunServices.layer)),
     ]),
   )
+  const threads = Threads.layerWith(threadsOptions).pipe(
+    Layer.provide([services, terminals, registry, eventsLayer]),
+  )
   return {
     fake,
     fakeAgents,
@@ -148,10 +151,8 @@ export const makeTestServiceLayers = (
       registry,
       eventsLayer,
       TestAuthTokenLayer,
-      Threads.layerWith(threadsOptions).pipe(
-        Layer.provide([services, terminals, registry, eventsLayer]),
-      ),
-      Projects.layer.pipe(Layer.provide([services, eventsLayer])),
+      threads,
+      Projects.layer.pipe(Layer.provide([services, terminals, threads, eventsLayer])),
     ),
   }
 }

--- a/app-server/test/threads/threads.test.ts
+++ b/app-server/test/threads/threads.test.ts
@@ -196,23 +196,27 @@ describe("/api/v1/threads", () => {
     }).pipe(Effect.provide(TestLayer)),
   )
 
-  it.effect("project deletion is restricted while threads exist, archived included", () =>
+  it.effect("project deletion cascades to owned threads, archived included", () =>
     Effect.gen(function* () {
       const { client, makeProject } = yield* testClient
       const project = yield* makeProject
-      const thread = yield* client.v1.createThread({
+      const active = yield* client.v1.createThread({
         payload: { projectId: project.id, agentId: "codex" },
       })
-      yield* client.v1.archiveThread({ params: { threadId: thread.id } })
-      const restricted = yield* Effect.flip(
-        client.v1.deleteProject({ params: { projectId: project.id } }),
-      )
-      assert.strictEqual(restricted._tag, "ProjectHasThreads")
-      if (restricted._tag === "ProjectHasThreads") {
-        assert.strictEqual(restricted.threadCount, 1)
-      }
-      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+      const archived = yield* client.v1.createThread({
+        payload: { projectId: project.id, agentId: "codex" },
+      })
+      yield* client.v1.archiveThread({ params: { threadId: archived.id } })
+
       yield* client.v1.deleteProject({ params: { projectId: project.id } })
+      for (const threadId of [active.id, archived.id]) {
+        const gone = yield* Effect.flip(client.v1.getThread({ params: { threadId } }))
+        assert.strictEqual(gone._tag, "ThreadNotFound")
+      }
+      const missing = yield* Effect.flip(
+        client.v1.getProject({ params: { projectId: project.id } }),
+      )
+      assert.strictEqual(missing._tag, "ProjectNotFound")
     }).pipe(Effect.provide(TestLayer)),
   )
 

--- a/macos/ATC/Features/Dashboard/DashboardView.swift
+++ b/macos/ATC/Features/Dashboard/DashboardView.swift
@@ -3,8 +3,8 @@ import SwiftUI
 
 /// App-wide Project management rendered as a main-content destination inside
 /// the stable window split view: one section per Connection, one card per
-/// Project. Deletion is server-guarded (a Project owning threads or terminals
-/// is refused), so the card offers it and reports what the server says.
+/// Project. Deletion cascades server-side to everything the Project owns, so
+/// the confirmation spells out the counts before anything is sent.
 struct DashboardView: View {
     @Environment(AppModel.self) private var appModel
     @Environment(WindowState.self) private var windowState
@@ -55,9 +55,12 @@ struct DashboardView: View {
                 }
             }
         } message: {
+            // Counts are the client's view; the catch-all phrase covers
+            // archived and ended residue the stores don't surface.
             Text("""
-            This removes the project from atc. The server refuses while it \
-            still owns threads or terminals, and its directory is never touched.
+            Also deletes its \(countLabel(deletingProject?.activeThreadCount ?? 0, "thread")) and \
+            \(countLabel(deletingProject?.standaloneTerminalCount ?? 0, "terminal")), including \
+            any archived or ended ones. The project directory is never touched.
             """)
         }
         .actionErrorAlert($actionError)

--- a/macos/ATC/Features/Dashboard/DashboardView.swift
+++ b/macos/ATC/Features/Dashboard/DashboardView.swift
@@ -55,11 +55,12 @@ struct DashboardView: View {
                 }
             }
         } message: {
-            // Counts are the client's view; the catch-all phrase covers
-            // archived and ended residue the stores don't surface.
+            // Counts are the visible (active/standalone) ones; the catch-all
+            // phrase covers archived and ended residue the stores don't
+            // surface, so it must read as an addition, not a subset.
             Text("""
             Also deletes its \(countLabel(deletingProject?.activeThreadCount ?? 0, "thread")) and \
-            \(countLabel(deletingProject?.standaloneTerminalCount ?? 0, "terminal")), including \
+            \(countLabel(deletingProject?.standaloneTerminalCount ?? 0, "terminal")), plus \
             any archived or ended ones. The project directory is never touched.
             """)
         }

--- a/macos/ATC/Features/Projects/ProjectsStore.swift
+++ b/macos/ATC/Features/Projects/ProjectsStore.swift
@@ -54,9 +54,20 @@ final class ProjectsStore {
         return project
     }
 
-    /// Server-refused while the project still owns threads or terminals.
+    /// Deletion cascades server-side to every owned thread and terminal.
+    /// Modeled failures surface their payload message (a zmx outage
+    /// mid-cascade is retryable — already-deleted children stay deleted).
     func delete(id: String) async throws {
-        _ = try await client.deleteProject(path: .init(projectId: id)).noContent
+        switch try await client.deleteProject(path: .init(projectId: id)) {
+        case .noContent:
+            break
+        case .notFound(let failure):
+            throw ServerError(message: try failure.body.json.message)
+        case .serviceUnavailable(let failure):
+            throw ServerError(message: try failure.body.json.message)
+        case .undocumented(statusCode: let status, _):
+            throw ServerError.undocumented(status: status)
+        }
         refreshState.invalidateInFlight()
         projects.removeAll { $0.id == id }
     }

--- a/macos/ATC/Shared/ServerError.swift
+++ b/macos/ATC/Shared/ServerError.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// A contract-modeled server failure rendered for alerts: the payload's
+/// `message` is written for humans, so surfacing it beats the generated
+/// throwing accessors' "Unexpected response…" dump. Stores switch on the
+/// generated `Output` enum, pull `message` out of each documented failure
+/// case, and throw this; `undocumented(status:)` covers the enum's
+/// catch-all case.
+struct ServerError: LocalizedError {
+    let message: String
+
+    var errorDescription: String? { message }
+
+    static func undocumented(status: Int) -> ServerError {
+        ServerError(message: "Unexpected server response (\(status)).")
+    }
+}

--- a/macos/ATCTests/ProjectsStoreTests.swift
+++ b/macos/ATCTests/ProjectsStoreTests.swift
@@ -54,6 +54,18 @@ struct ProjectsStoreTests {
         #expect(store.projects.map(\.id) == ["prj_a"])
     }
 
+    @Test("delete surfaces a modeled failure's payload message, changing nothing")
+    func deleteSurfacesModeledMessage() async {
+        let (store, _) = await loadedStore()
+        do {
+            try await store.delete(id: "prj_missing")
+            Issue.record("delete of a missing project should throw")
+        } catch {
+            #expect(error.localizedDescription == "No project prj_missing")
+        }
+        #expect(store.projects.map(\.id) == ["prj_b", "prj_a"])
+    }
+
     @Test("a failed refresh keeps the last-loaded list and records the error")
     func failedRefreshPreservesData() async {
         let (store, client) = await loadedStore()

--- a/macos/ATCTests/ScriptableAppServerClient.swift
+++ b/macos/ATCTests/ScriptableAppServerClient.swift
@@ -218,7 +218,11 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
             guard model.projects.contains(where: { $0.id == id }) else {
                 return .notFound(.init(body: .json(projectNotFound(id))))
             }
+            // Deletion cascades server-side (ATC-154): owned threads and
+            // terminals go with the project.
             model.projects.removeAll { $0.id == id }
+            model.threads.removeAll { $0.projectId == id }
+            model.terminals.removeAll { $0.projectId == id }
             return .noContent(.init())
         }
     }

--- a/macos/CONTEXT.md
+++ b/macos/CONTEXT.md
@@ -16,8 +16,8 @@ _Avoid_: Account
 **Project**:
 A server-owned record for one codebase, carrying the default working directory
 for new Threads and Terminals. atc displays Projects through their Connection
-but does not own the record. A Project can be deleted only once it owns no
-Threads or Terminals; deletion never changes filesystem state.
+but does not own the record. Deleting a Project deletes every Thread and
+Terminal it owns; deletion never changes filesystem state.
 _Avoid_: Local project, app project, Workspace
 
 **Thread**:


### PR DESCRIPTION
Implements [ATC-154](https://linear.app/elevenideas/issue/ATC-154/project-deletion-cascades-to-owned-threads-and-terminals): deleting a project now always cascades to everything it owns — no flag, no opt-in.

## Server

- `Projects.delete` cascades: every owned thread (archived included) deletes through `Threads.delete` (kills the live linked terminal, releases provider state), then every remaining terminal (`starting` rows and `ended` tombstones included) through `Terminals.delete` (zmx reap via the normal path), then the project row, then the project `deleted` event.
- Sequential, best-effort, not transactional: a `ZmxUnavailable` mid-cascade surfaces to the caller, already-deleted children stay deleted, and retrying the project delete finishes the job. The RESTRICT FKs stay as the defect backstop for children created concurrently mid-cascade.
- Contract: `deleteProject` drops the 409 `ProjectHasTerminals`/`ProjectHasThreads` errors (classes deleted) and gains `ZmxUnavailable`; operation id unchanged; OpenAPI regenerated.
- Both repositories lose the now-unused `countForProject`; their existing `list(projectId)` already enumerates every child kind.
- Layer wiring: Projects now sits above Threads and Terminals in `server.ts` and `testLayers.ts`.

## macOS

- The delete confirmation spells out the client-side thread/terminal counts with a catch-all for archived/ended residue; the project directory is never touched.
- `ProjectsStore.delete` switches on the typed generated `Output` instead of the throwing `.noContent` accessor, so modeled failures (`ProjectNotFound`, `ZmxUnavailable`) surface their payload message via the new shared `ServerError` helper (`macos/ATC/Shared/ServerError.swift`) instead of the generic "Unexpected response" dump.

## CLI

- `atc project delete` keeps its exact shape (`--yes` guard, no new flag); help and refusal text now state the cascade.

## Review round (Codex Sol, high reasoning)

The one real catch: `Terminals.delete` rejected `starting` rows (`requireRecord` hides them), so the cascade would have caught the `TerminalNotFound`, stranded crash-residue rows, and defected on the RESTRICT FK. Delete now goes through `repository.require` — starting rows are invisible everywhere else, only the in-flight create holds such an id, and a create racing a project cascade is already the FK-RESTRICT defect stance. Also from review: the dialog says "plus" (not "including") archived/ended ones since the visible counts never contained them, the macOS test stub cascades like the server, a `ProjectsStore` test pins the modeled-failure message path, and `macos/CONTEXT.md` drops the old restriction wording.

## Tests

- The two 409-guard tests became cascade tests: a project owning a live terminal and an ended tombstone deletes cleanly with per-child `deleted` events in cascade order and the fake-zmx session reaped; a project owning active + archived threads deletes cleanly.
- New retryability test: a zmx outage mid-cascade surfaces `ZmxUnavailable`, leaves partial state, and a retry finishes the job.

Gates: `mise run -C app-server check`, `mise run contract:check`, `mise run -C app-server test:zmx`, `mise run macos:test` — all green.

https://claude.ai/code/session_015H9zb9vbbc7ZqWxk6o6vs4
