### PR TITLE
Archive Threads by terminating their linked zmx sessions (ATC-157)

### DIFF
--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -799,9 +799,19 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "The zmx multiplexer cannot be consulted right now. Retryable; stored terminal state is untouched.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ZmxUnavailableJsonEncoding"
+                }
+              }
+            }
           }
         },
-        "description": "Archive the thread (idempotent). Refused while the agent session is actively working."
+        "description": "Archive the thread (idempotent and convergent): its live linked terminal is killed first, so an archived thread consumes no multiplexer session; the provider conversation survives for a later exact resume via unarchive + open. Refused while the agent session is actively working, and refused (retryably) when terminal death cannot be verified."
       }
     },
     "/api/v1/threads/{threadId}/unarchive": {

--- a/app-server/src/api/contract.ts
+++ b/app-server/src/api/contract.ts
@@ -750,12 +750,12 @@ export class V1 extends HttpApiGroup.make("v1")
     HttpApiEndpoint.post("archiveThread", "/threads/:threadId/archive", {
       params: threadIdParam,
       success: Thread,
-      error: [ThreadNotFound, ThreadBusy],
+      error: [ThreadNotFound, ThreadBusy, ZmxUnavailable],
     })
       .annotate(OpenApi.Identifier, "archiveThread")
       .annotate(
         OpenApi.Description,
-        "Archive the thread (idempotent). Refused while the agent session is actively working.",
+        "Archive the thread (idempotent and convergent): its live linked terminal is killed first, so an archived thread consumes no multiplexer session; the provider conversation survives for a later exact resume via unarchive + open. Refused while the agent session is actively working, and refused (retryably) when terminal death cannot be verified.",
       ),
     HttpApiEndpoint.post("unarchiveThread", "/threads/:threadId/unarchive", {
       params: threadIdParam,

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -1,4 +1,4 @@
-import { Context, Duration, Effect, Exit, Layer, Option, Scope, Stream } from "effect"
+import { Context, Duration, Effect, Exit, Layer, Option, Scope, Semaphore, Stream } from "effect"
 import { AgentRegistry } from "../agents/agentRegistry.ts"
 import type {
   AgentActivity,
@@ -78,6 +78,20 @@ export type Thread = typeof ThreadSchema.Type
 //   - archived threads are never pinned: pin refuses archived records, and
 //     archive clears the pin in the same repository write so no client can
 //     observe or restore an archived pin.
+//   - archive suspends the thread's runtime (ATC-157): the live linked TUI
+//     terminal is killed (the terminals confirmed-kill rules) and
+//     adapter-owned session resources are released before archivedAt is
+//     written, so an archived thread consumes no zmx session while the
+//     provider conversation survives for an exact resume after unarchive.
+//     Re-archive converges: a lingering live terminal (legacy rows from
+//     before archive killed terminals) is killed on repeat; archive
+//     refuses mid-turn (`unknown` is never guessed to be busy).
+//   - archive, delete, and a launching openTerminal serialize per thread
+//     behind a lazily created per-id semaphore: archive/delete queue
+//     behind an in-flight open and then act on the resulting terminal, so
+//     a concurrent open can never leave an archived thread with a live
+//     terminal. Open-vs-open keeps its fail-fast conflict, and the
+//     idempotent open return never queues.
 //   - delete kills the live linked TUI terminal first (the terminals
 //     confirmed-kill rules), releases adapter-owned session resources,
 //     then removes the row; ended linked terminals stay as unlinked
@@ -110,8 +124,12 @@ export class Threads extends Context.Service<
       id: string,
       patch: { readonly name?: string | undefined },
     ) => Effect.Effect<Thread, ThreadNotFound>
-    /** Idempotent; refused while the agent session is actively working. */
-    readonly archive: (id: string) => Effect.Effect<Thread, ThreadNotFound | ThreadBusy>
+    /** Kill the live linked terminal and release adapter runtime resources,
+     * then set archivedAt (idempotent and convergent — see the header);
+     * refused while the agent session is actively working. */
+    readonly archive: (
+      id: string,
+    ) => Effect.Effect<Thread, ThreadNotFound | ThreadBusy | ZmxUnavailable>
     /** Idempotent. */
     readonly unarchive: (id: string) => Effect.Effect<Thread, ThreadNotFound>
     /** Idempotent; archived threads cannot be pinned. */
@@ -168,6 +186,20 @@ export const layerWith = (options: ThreadsOptions) =>
       const observed = new Map<string, Observation>()
       /** Threads with an openTerminal in flight — the one-open guard. */
       const opening = new Set<string>()
+      /**
+       * Per-thread lifecycle serialization (the header's serialization
+       * bullet). Entries are dropped when the thread row is deleted; a
+       * waiter still queued on a dropped semaphore just finds the row gone.
+       */
+      const lifecycleLocks = new Map<string, Semaphore.Semaphore>()
+      const withLifecycleLock =
+        (id: string) =>
+        <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+          Effect.suspend(() => {
+            const lock = lifecycleLocks.get(id) ?? Semaphore.makeUnsafe(1)
+            lifecycleLocks.set(id, lock)
+            return lock.withPermit(effect)
+          })
 
       const adapterFor = (record: ThreadRecord): AgentAdapter | undefined =>
         isAgentId(record.agentId) ? registry.adapterFor(record.agentId) : undefined
@@ -523,7 +555,12 @@ export const layerWith = (options: ThreadsOptions) =>
           return terminal
         })
 
-      const openTerminal: Threads["Service"]["openTerminal"] = (id) =>
+      /**
+       * The launching path, run under the thread's lifecycle lock. Every
+       * pre-lock check is repeated here: a queued-ahead archive, delete, or
+       * open may have changed the world while this caller waited.
+       */
+      const openUnderLock = (id: string): ReturnType<Threads["Service"]["openTerminal"]> =>
         Effect.gen(function* () {
           const record = yield* repository.require(id)
           if (record.archivedAt !== undefined) {
@@ -584,37 +621,66 @@ export const layerWith = (options: ThreadsOptions) =>
           )
         })
 
-      const del: Threads["Service"]["delete"] = (id) =>
+      const openTerminal: Threads["Service"]["openTerminal"] = (id) =>
         Effect.gen(function* () {
+          // Fast paths stay ahead of the lifecycle lock: the idempotent
+          // return must not wait behind an in-flight open's identity await,
+          // and open-vs-open keeps its fail-fast conflict instead of
+          // queueing a second launch.
           const record = yield* repository.require(id)
+          if (record.archivedAt !== undefined) {
+            return yield* Effect.fail(new ThreadArchived({ threadId: id }))
+          }
           const linked = yield* linkedFor(record)
           if (linked !== undefined) {
-            // Confirmed-kill rules live in Terminals.delete; a terminal that
-            // vanished since the lookup is already the goal state.
-            yield* terminals
-              .delete(linked.id)
-              .pipe(Effect.catchTag("TerminalNotFound", () => Effect.void))
+            if (!opening.has(id)) yield* ensureObserved(record)
+            return linked
           }
-          const adapter = adapterFor(record)
-          if (adapter !== undefined && record.providerSessionId !== undefined) {
-            yield* adapter.releaseSession({
-              providerSessionId: record.providerSessionId,
-              providerMetadata: record.providerMetadata,
-            })
+          if (opening.has(id)) {
+            return yield* Effect.fail(
+              new ProviderSessionConflict({
+                threadId: id,
+                reason: "an open of this thread's terminal is already in progress",
+              }),
+            )
           }
-          yield* unobserve(id)
-          // Ended linked terminals survive as unlinked tombstones (FK SET
-          // NULL) — their client-visible threadId changes with the delete,
-          // so each publishes alongside the thread's own event.
-          const orphaned = (yield* terminals.list(record.projectId)).filter(
-            (terminal) => terminal.threadId === id,
-          )
-          yield* repository.delete(id)
-          yield* events.publish({ resource: "thread", id, change: "deleted" })
-          yield* Effect.forEach(orphaned, (terminal) =>
-            events.publish({ resource: "terminal", id: terminal.id, change: "updated" }),
-          )
+          return yield* withLifecycleLock(id)(openUnderLock(id))
         })
+
+      const del: Threads["Service"]["delete"] = (id) =>
+        withLifecycleLock(id)(
+          Effect.gen(function* () {
+            const record = yield* repository.require(id)
+            const linked = yield* linkedFor(record)
+            if (linked !== undefined) {
+              // Confirmed-kill rules live in Terminals.delete; a terminal
+              // that vanished since the lookup is already the goal state.
+              yield* terminals
+                .delete(linked.id)
+                .pipe(Effect.catchTag("TerminalNotFound", () => Effect.void))
+            }
+            const adapter = adapterFor(record)
+            if (adapter !== undefined && record.providerSessionId !== undefined) {
+              yield* adapter.releaseSession({
+                providerSessionId: record.providerSessionId,
+                providerMetadata: record.providerMetadata,
+              })
+            }
+            yield* unobserve(id)
+            // Ended linked terminals survive as unlinked tombstones (FK SET
+            // NULL) — their client-visible threadId changes with the delete,
+            // so each publishes alongside the thread's own event.
+            const orphaned = (yield* terminals.list(record.projectId)).filter(
+              (terminal) => terminal.threadId === id,
+            )
+            yield* repository.delete(id)
+            lifecycleLocks.delete(id)
+            yield* events.publish({ resource: "thread", id, change: "deleted" })
+            yield* Effect.forEach(orphaned, (terminal) =>
+              events.publish({ resource: "terminal", id: terminal.id, change: "updated" }),
+            )
+          }),
+        )
 
       return {
         list: (listOptions) =>
@@ -669,19 +735,49 @@ export const layerWith = (options: ThreadsOptions) =>
                 Effect.flatMap(assembleAlone),
               ),
         archive: (id) =>
-          Effect.gen(function* () {
-            const record = yield* repository.require(id)
-            const linked = yield* linkedFor(record)
-            // Busy covers needs_input too: a turn parked on an approval is
-            // still mid-turn.
-            if (isBusy(yield* resolveActivity(record, linked?.id))) {
-              return yield* Effect.fail(new ThreadBusy({ threadId: id }))
-            }
-            if (record.archivedAt !== undefined) return yield* assemble(record, linked)
-            const updated = yield* repository.setArchived(id, true)
-            yield* events.publish({ resource: "thread", id, change: "updated" })
-            return yield* assemble(updated, linked)
-          }),
+          withLifecycleLock(id)(
+            Effect.gen(function* () {
+              const record = yield* repository.require(id)
+              const linked = yield* linkedFor(record)
+              // Repeat archive with nothing live left is a pure no-op; with
+              // a lingering live terminal (a legacy row) it falls through to
+              // the kill below and converges.
+              if (record.archivedAt !== undefined && linked === undefined) {
+                return yield* assemble(record, undefined)
+              }
+              // Busy covers needs_input too: a turn parked on an approval is
+              // still mid-turn.
+              if (isBusy(yield* resolveActivity(record, linked?.id))) {
+                return yield* Effect.fail(new ThreadBusy({ threadId: id }))
+              }
+              if (linked !== undefined) {
+                // Confirmed-kill rules live in Terminals.delete: a kill that
+                // cannot verify death fails ZmxUnavailable and the thread
+                // stays active; a terminal that vanished since the lookup is
+                // already the goal state.
+                yield* terminals
+                  .delete(linked.id)
+                  .pipe(Effect.catchTag("TerminalNotFound", () => Effect.void))
+              }
+              // Suspend the runtime only after terminal death is confirmed:
+              // release adapter-owned session resources (Claude revokes its
+              // hook plumbing; the next tuiLaunch recreates it) and stop
+              // observation. The provider conversation itself is untouched,
+              // so unarchive + open resumes it exactly.
+              const adapter = adapterFor(record)
+              if (adapter !== undefined && record.providerSessionId !== undefined) {
+                yield* adapter.releaseSession({
+                  providerSessionId: record.providerSessionId,
+                  providerMetadata: record.providerMetadata,
+                })
+              }
+              yield* unobserve(id)
+              if (record.archivedAt !== undefined) return yield* assemble(record, undefined)
+              const updated = yield* repository.setArchived(id, true)
+              yield* events.publish({ resource: "thread", id, change: "updated" })
+              return yield* assemble(updated, undefined)
+            }),
+          ),
         unarchive: (id) =>
           Effect.gen(function* () {
             const record = yield* repository.require(id)

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -556,9 +556,10 @@ export const layerWith = (options: ThreadsOptions) =>
         })
 
       /**
-       * The launching path, run under the thread's lifecycle lock. Every
-       * pre-lock check is repeated here: a queued-ahead archive, delete, or
-       * open may have changed the world while this caller waited.
+       * The launching path, run under the thread's lifecycle lock with the
+       * caller already holding the thread's `opening` claim. The record and
+       * linked-terminal checks are repeated here: a queued-ahead archive or
+       * delete may have changed the world while this caller waited.
        */
       const openUnderLock = (id: string): ReturnType<Threads["Service"]["openTerminal"]> =>
         Effect.gen(function* () {
@@ -575,24 +576,11 @@ export const layerWith = (options: ThreadsOptions) =>
               }),
             )
           }
-          // Idempotent: one live linked TUI terminal per thread, returned
-          // as-is (two TUIs into one conversation is the documented
-          // concurrency hazard). Mid-open the row may still name the
-          // superseded session — same rule as `assemble`.
+          // Defense in depth: nothing else can have linked a live terminal
+          // while this caller held the claim, but returning one beats
+          // double-launching if that ever changes.
           const linked = yield* linkedFor(record)
-          if (linked !== undefined) {
-            if (!opening.has(id)) yield* ensureObserved(record)
-            return linked
-          }
-          if (opening.has(id)) {
-            return yield* Effect.fail(
-              new ProviderSessionConflict({
-                threadId: id,
-                reason: "an open of this thread's terminal is already in progress",
-              }),
-            )
-          }
-          opening.add(id)
+          if (linked !== undefined) return linked
           return yield* (
             record.providerSessionId !== undefined && record.confirmedAt !== undefined
               ? reopen(record, adapter)
@@ -617,7 +605,6 @@ export const layerWith = (options: ThreadsOptions) =>
             // The open changed the thread (linked terminal, and possibly
             // provider identity); the idempotent return above changed nothing.
             Effect.tap(() => events.publish({ resource: "thread", id, change: "updated" })),
-            Effect.ensuring(Effect.sync(() => opening.delete(id))),
           )
         })
 
@@ -644,7 +631,14 @@ export const layerWith = (options: ThreadsOptions) =>
               }),
             )
           }
-          return yield* withLifecycleLock(id)(openUnderLock(id))
+          // The claim lands HERE, synchronously with the check above and
+          // before enqueueing: a simultaneous second open must fail fast at
+          // that check rather than silently queue behind this launch for
+          // the full identity await. The claim spans the lock wait too.
+          opening.add(id)
+          return yield* withLifecycleLock(id)(openUnderLock(id)).pipe(
+            Effect.ensuring(Effect.sync(() => opening.delete(id))),
+          )
         })
 
       const del: Threads["Service"]["delete"] = (id) =>

--- a/app-server/test/agents/claudeAdapter.test.ts
+++ b/app-server/test/agents/claudeAdapter.test.ts
@@ -647,6 +647,47 @@ describe("ClaudeAdapter TUI session plumbing", () => {
     }),
   )
 
+  it.live("a relaunch after releaseSession recreates the hook plumbing", () =>
+    Effect.gen(function* () {
+      const cwd = workDir()
+      const dir = stateDir()
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        const hooks = yield* ClaudeHooks.ClaudeHooks
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const prepared = yield* adapter.prepareTuiSession({ cwd })
+            const identity = yield* prepared.identity
+            // Archive-time release removes the files and revokes the secret;
+            // the resume relaunch must rebuild both from the persisted
+            // metadata alone (the archive → unarchive → open round trip).
+            yield* adapter.releaseSession({
+              providerSessionId: identity.providerSessionId,
+              providerMetadata: identity.providerMetadata,
+            })
+            const relaunch = yield* adapter.tuiLaunch({
+              providerSessionId: identity.providerSessionId,
+              cwd,
+              providerMetadata: identity.providerMetadata,
+            })
+            const settingsFile = relaunch.launchSpec.command[4] ?? ""
+            assert.strictEqual((fs.statSync(settingsFile).mode & 0o777).toString(8), "600")
+            // The metadata-carried secret is re-adopted, so the relaunched
+            // TUI's hooks deliver again.
+            const metadata = JSON.parse(identity.providerMetadata ?? "{}") as {
+              hookSecret?: string
+            }
+            const status = yield* hooks.deliver(metadata.hookSecret ?? "", {
+              session_id: identity.providerSessionId,
+              hook_event_name: "Stop",
+            })
+            assert.strictEqual(status, 204)
+          }),
+        )
+      }).pipe(Effect.provide(claudeAdapterLayer({}, "/bin/echo", { stateDir: dir })))
+    }),
+  )
+
   it.live("a failed prepare revokes the freshly minted secret", () =>
     Effect.gen(function* () {
       const cwd = workDir()

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -246,6 +246,17 @@ export const makeFakeZmxSandbox = (vars: Record<string, string> = {}) => {
   return { base, stateDir, wrapper }
 }
 
+/** Poll (real clock) until `predicate` accepts the effect's value; bounded. */
+export const eventually = <A, E>(effect: Effect.Effect<A, E>, predicate: (value: A) => boolean) =>
+  Effect.gen(function* () {
+    for (let attempt = 0; ; attempt++) {
+      const value = yield* effect
+      if (predicate(value)) return value
+      assert.isBelow(attempt, 300, `condition never held; last: ${JSON.stringify(value)}`)
+      yield* Effect.sleep("10 millis")
+    }
+  })
+
 /** Collect a byte stream into a text sink in the background (scoped). */
 export const collectText = (output: Stream.Stream<Uint8Array, unknown>) =>
   Effect.gen(function* () {

--- a/app-server/test/threads/threadArchive.test.ts
+++ b/app-server/test/threads/threadArchive.test.ts
@@ -1,0 +1,267 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Fiber, Option } from "effect"
+import { HttpApiTest } from "effect/unstable/httpapi"
+import { mkdtempSync, realpathSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll } from "vitest"
+import { Api } from "../../src/api/contract.ts"
+import { sessionNameForTerminalId } from "../../src/terminals/terminalAdapter.ts"
+import { TerminalRepository } from "../../src/terminals/terminalRepository.ts"
+import { ThreadRepository } from "../../src/threads/threadRepository.ts"
+import { apiTestLayer, eventually, makeTestServiceLayers } from "../testLayers.ts"
+
+// Archive suspends a thread's runtime (ATC-157): the linked zmx-backed TUI
+// terminal is killed and adapter-owned session resources released before
+// archivedAt is written, while the durable thread and its provider
+// conversation identity survive for an exact resume. These tests drive the
+// lifecycle through the public contract with the fake adapters; the
+// attach-side `1000 terminal_ended` close rides the same Terminals.delete
+// the attach bridge suite already proves black-box.
+
+const kit = makeTestServiceLayers()
+const TestLayer = apiTestLayer(kit)
+
+// A dedicated kit whose identity never resolves until released — for the
+// archive-queues-behind-open path, where the open must still hold the
+// thread's lifecycle lock when archive arrives.
+const holdKit = makeTestServiceLayers()
+const HoldLayer = apiTestLayer(holdKit)
+
+const scratch = mkdtempSync(join(tmpdir(), "atc-thread-archive-"))
+afterAll(() => rmSync(scratch, { recursive: true, force: true }))
+const realDir = realpathSync(scratch)
+
+const setup = Effect.gen(function* () {
+  const client = yield* HttpApiTest.groups(Api, ["v1"])
+  const project = yield* client.v1.createProject({
+    payload: { name: "Archive", defaultWorkingDirectory: realDir },
+  })
+  const thread = yield* client.v1.createThread({
+    payload: { projectId: project.id, agentId: "codex" },
+  })
+  return { client, project, thread }
+})
+
+describe("threads.archive", () => {
+  it.live("kills the live linked terminal, releases the runtime, then archives", () =>
+    Effect.gen(function* () {
+      const { client, thread } = yield* setup
+      const repository = yield* ThreadRepository
+      const terminal = yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+      const record = Option.getOrThrow(yield* repository.get(thread.id))
+      const sessionId = record.providerSessionId ?? ""
+
+      const archived = yield* client.v1.archiveThread({ params: { threadId: thread.id } })
+      assert.isString(archived.archivedAt)
+      assert.isUndefined(archived.linkedTerminalId)
+
+      // The zmx session and the terminal record are gone — an archived
+      // thread consumes no live session.
+      assert.isFalse(kit.fake.sessions.has(sessionNameForTerminalId(terminal.id)))
+      const gone = yield* Effect.flip(
+        client.v1.getTerminal({ params: { terminalId: terminal.id } }),
+      )
+      assert.strictEqual(gone._tag, "TerminalNotFound")
+
+      // Adapter runtime released with the persisted metadata; observation
+      // stopped.
+      const release = kit.fakeAgents.codex.released.at(-1)
+      assert.strictEqual(release?.providerSessionId, sessionId)
+      assert.strictEqual(release?.providerMetadata, record.providerMetadata)
+      assert.strictEqual(kit.fakeAgents.codex.observerCount(sessionId), 0)
+
+      // The durable row keeps everything needed for an exact later resume.
+      const after = Option.getOrThrow(yield* repository.get(thread.id))
+      assert.strictEqual(after.providerSessionId, record.providerSessionId)
+      assert.strictEqual(after.providerMetadata, record.providerMetadata)
+      assert.strictEqual(after.workingDirectory, record.workingDirectory)
+
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.live("refuses to archive mid-turn without touching the terminal", () =>
+    Effect.gen(function* () {
+      const { client, thread } = yield* setup
+      const repository = yield* ThreadRepository
+      const terminal = yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+      const sessionId = Option.getOrThrow(yield* repository.get(thread.id)).providerSessionId ?? ""
+
+      // Busy covers needs_input too: a turn parked on an approval is still
+      // mid-turn.
+      for (const activity of ["working", "needs_input"] as const) {
+        kit.fakeAgents.codex.emitActivity(sessionId, activity)
+        yield* eventually(
+          client.v1.getThread({ params: { threadId: thread.id } }),
+          (t) => t.activityState === activity,
+        )
+        const busy = yield* Effect.flip(
+          client.v1.archiveThread({ params: { threadId: thread.id } }),
+        )
+        assert.strictEqual(busy._tag, "ThreadBusy")
+        assert.isTrue(kit.fake.sessions.has(sessionNameForTerminalId(terminal.id)))
+        const read = yield* client.v1.getThread({ params: { threadId: thread.id } })
+        assert.isUndefined(read.archivedAt)
+        assert.strictEqual(read.linkedTerminalId, terminal.id)
+      }
+
+      kit.fakeAgents.codex.emitActivity(sessionId, "idle")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId: thread.id } }),
+        (t) => t.activityState === "idle",
+      )
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.live("a kill that cannot verify death fails ZmxUnavailable and archives nothing", () =>
+    Effect.gen(function* () {
+      const { client, thread } = yield* setup
+      const repository = yield* ThreadRepository
+      const terminal = yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+      const sessionId = Option.getOrThrow(yield* repository.get(thread.id)).providerSessionId ?? ""
+
+      kit.fake.setUnavailable(true)
+      const failure = yield* Effect.flip(
+        client.v1.archiveThread({ params: { threadId: thread.id } }),
+      )
+      assert.strictEqual(failure._tag, "ZmxUnavailable")
+      kit.fake.setUnavailable(false)
+
+      // The thread stays active with its terminal record intact, and the
+      // runtime was NOT released — suspension happens only after confirmed
+      // terminal death.
+      const read = yield* client.v1.getThread({ params: { threadId: thread.id } })
+      assert.isUndefined(read.archivedAt)
+      assert.strictEqual(read.linkedTerminalId, terminal.id)
+      assert.isTrue(kit.fake.sessions.has(sessionNameForTerminalId(terminal.id)))
+      assert.isFalse(kit.fakeAgents.codex.released.some((r) => r.providerSessionId === sessionId))
+
+      // The retry converges once the inventory is back.
+      const archived = yield* client.v1.archiveThread({ params: { threadId: thread.id } })
+      assert.isString(archived.archivedAt)
+      assert.isFalse(kit.fake.sessions.has(sessionNameForTerminalId(terminal.id)))
+
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.live("re-archiving converges: a lingering live terminal on an archived thread is killed", () =>
+    Effect.gen(function* () {
+      const { client, project, thread } = yield* setup
+      const terminalRepository = yield* TerminalRepository
+
+      // Archive with no terminal: the plain metadata flip.
+      const archived = yield* client.v1.archiveThread({ params: { threadId: thread.id } })
+      assert.isString(archived.archivedAt)
+
+      // A legacy row: a live linked terminal owned by an already-archived
+      // thread (from before archive killed terminals).
+      const record = yield* terminalRepository.create({
+        projectId: project.id,
+        threadId: thread.id,
+        initialWorkingDirectory: realDir,
+      })
+      kit.fake.seed(sessionNameForTerminalId(record.id))
+      yield* terminalRepository.markLive(record.id)
+
+      // Repeat archive succeeds and reaps it — the one-click manual cleanup.
+      const again = yield* client.v1.archiveThread({ params: { threadId: thread.id } })
+      assert.strictEqual(again.archivedAt, archived.archivedAt)
+      assert.isUndefined(again.linkedTerminalId)
+      assert.isFalse(kit.fake.sessions.has(sessionNameForTerminalId(record.id)))
+      const gone = yield* Effect.flip(client.v1.getTerminal({ params: { terminalId: record.id } }))
+      assert.strictEqual(gone._tag, "TerminalNotFound")
+
+      // With nothing live left, repeat archive is a pure no-op.
+      const third = yield* client.v1.archiveThread({ params: { threadId: thread.id } })
+      assert.deepStrictEqual(third, again)
+
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+      yield* client.v1.deleteProject({ params: { projectId: project.id } })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.live("archive queues behind an in-flight open, then kills the fresh terminal", () =>
+    Effect.gen(function* () {
+      const { client, thread } = yield* setup
+      holdKit.fakeAgents.codex.setIdentityHangs(true)
+      const openFiber = yield* client.v1
+        .openThreadTerminal({ params: { threadId: thread.id } })
+        .pipe(Effect.forkChild)
+      yield* eventually(
+        Effect.sync(() => holdKit.fake.sessions.size),
+        (size) => size === 1,
+      )
+
+      // Archive arrives while the open still holds the lifecycle lock: it
+      // must queue (not conflict, not act) until the open completes.
+      const archiveFiber = yield* client.v1
+        .archiveThread({ params: { threadId: thread.id } })
+        .pipe(Effect.forkChild)
+      const pending = yield* client.v1.getThread({ params: { threadId: thread.id } })
+      assert.isUndefined(pending.archivedAt)
+
+      // The open wins the queue, then archive acts on the resulting
+      // terminal — last write wins, and the archived-implies-no-live-
+      // terminal invariant holds.
+      holdKit.fakeAgents.codex.setIdentityHangs(false)
+      const opened = yield* Fiber.join(openFiber)
+      const archived = yield* Fiber.join(archiveFiber)
+      assert.isString(archived.archivedAt)
+      assert.isUndefined(archived.linkedTerminalId)
+      assert.isFalse(holdKit.fake.sessions.has(sessionNameForTerminalId(opened.id)))
+      const gone = yield* Effect.flip(client.v1.getTerminal({ params: { terminalId: opened.id } }))
+      assert.strictEqual(gone._tag, "TerminalNotFound")
+      const read = yield* client.v1.getThread({ params: { threadId: thread.id } })
+      assert.isString(read.archivedAt)
+      assert.isUndefined(read.linkedTerminalId)
+
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+    }).pipe(Effect.provide(HoldLayer)),
+  )
+
+  it.live("unarchive launches nothing; the next open resumes the exact confirmed session", () =>
+    Effect.gen(function* () {
+      const { client, project, thread } = yield* setup
+      const repository = yield* ThreadRepository
+      yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+      const sessionId = Option.getOrThrow(yield* repository.get(thread.id)).providerSessionId ?? ""
+
+      // Confirm the session (a completed first turn), then go idle.
+      kit.fakeAgents.codex.emitActivity(sessionId, "working")
+      yield* eventually(
+        repository.get(thread.id),
+        (r) => Option.isSome(r) && r.value.confirmedAt !== undefined,
+      )
+      kit.fakeAgents.codex.emitActivity(sessionId, "idle")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId: thread.id } }),
+        (t) => t.activityState === "idle",
+      )
+      const preparedBefore = kit.fakeAgents.codex.prepared.length
+
+      yield* client.v1.archiveThread({ params: { threadId: thread.id } })
+
+      // Unarchive is local-only: no terminal appears.
+      const restored = yield* client.v1.unarchiveThread({ params: { threadId: thread.id } })
+      assert.isUndefined(restored.archivedAt)
+      assert.isUndefined(restored.linkedTerminalId)
+      assert.deepStrictEqual(
+        yield* client.v1.listTerminals({ query: { projectId: project.id } }),
+        [],
+      )
+
+      // The next open resumes the exact archived-and-released session in a
+      // fresh terminal — no re-materialization.
+      const reopened = yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+      const relaunch = kit.fake.sessions.get(sessionNameForTerminalId(reopened.id))
+      assert.deepStrictEqual(relaunch?.command, ["fake-agent", "resume", sessionId])
+      assert.strictEqual(kit.fakeAgents.codex.prepared.length, preparedBefore)
+
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+      yield* client.v1.deleteProject({ params: { projectId: project.id } })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+})

--- a/app-server/test/threads/threadArchive.test.ts
+++ b/app-server/test/threads/threadArchive.test.ts
@@ -23,9 +23,12 @@ const kit = makeTestServiceLayers()
 const TestLayer = apiTestLayer(kit)
 
 // A dedicated kit whose identity never resolves until released — for the
-// archive-queues-behind-open path, where the open must still hold the
-// thread's lifecycle lock when archive arrives.
-const holdKit = makeTestServiceLayers()
+// queues-behind-open paths, where the open must still hold the thread's
+// lifecycle lock when archive/delete arrives. The tight TUI-liveness watch
+// is the discriminator: an implementation that killed the terminal mid-open
+// instead of queueing would trip watchForEarlyDeath and fail the open
+// fiber, so a successful Fiber.join on the open proves the wait happened.
+const holdKit = makeTestServiceLayers(":memory:", { launchWatchInterval: "25 millis" })
 const HoldLayer = apiTestLayer(holdKit)
 
 const scratch = mkdtempSync(join(tmpdir(), "atc-thread-archive-"))
@@ -205,7 +208,9 @@ describe("threads.archive", () => {
 
       // The open wins the queue, then archive acts on the resulting
       // terminal — last write wins, and the archived-implies-no-live-
-      // terminal invariant holds.
+      // terminal invariant holds. The join succeeding is itself an
+      // assertion (see the kit comment): a kill that jumped the queue
+      // would have failed the open via the liveness watch.
       holdKit.fakeAgents.codex.setIdentityHangs(false)
       const opened = yield* Fiber.join(openFiber)
       const archived = yield* Fiber.join(archiveFiber)
@@ -219,6 +224,48 @@ describe("threads.archive", () => {
       assert.isUndefined(read.linkedTerminalId)
 
       yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+    }).pipe(Effect.provide(HoldLayer)),
+  )
+
+  it.live("delete queues behind an in-flight open, then reaps the fresh terminal", () =>
+    Effect.gen(function* () {
+      const { client, thread } = yield* setup
+      holdKit.fakeAgents.codex.setIdentityHangs(true)
+      const openFiber = yield* client.v1
+        .openThreadTerminal({ params: { threadId: thread.id } })
+        .pipe(Effect.forkChild)
+      yield* eventually(
+        Effect.sync(() => holdKit.fake.sessions.size),
+        (size) => size === 1,
+      )
+
+      // Delete arrives while the open still holds the lifecycle lock: it
+      // queues (the row is still readable), and once the open completes it
+      // reaps the fresh terminal, releases the adopted session, and removes
+      // the row — the same last-write-wins rule as archive.
+      const deleteFiber = yield* client.v1
+        .deleteThread({ params: { threadId: thread.id } })
+        .pipe(Effect.forkChild)
+      const pending = yield* client.v1.getThread({ params: { threadId: thread.id } })
+      assert.strictEqual(pending.id, thread.id)
+
+      holdKit.fakeAgents.codex.setIdentityHangs(false)
+      const opened = yield* Fiber.join(openFiber)
+      yield* Fiber.join(deleteFiber)
+      assert.isFalse(holdKit.fake.sessions.has(sessionNameForTerminalId(opened.id)))
+      const goneTerminal = yield* Effect.flip(
+        client.v1.getTerminal({ params: { terminalId: opened.id } }),
+      )
+      assert.strictEqual(goneTerminal._tag, "TerminalNotFound")
+      const goneThread = yield* Effect.flip(
+        client.v1.getThread({ params: { threadId: thread.id } }),
+      )
+      assert.strictEqual(goneThread._tag, "ThreadNotFound")
+      const fresh = holdKit.fakeAgents.codex.prepared.at(-1)?.providerSessionId ?? ""
+      assert.isTrue(
+        holdKit.fakeAgents.codex.released.some((r) => r.providerSessionId === fresh),
+        "the adopted session was released by the queued delete",
+      )
     }).pipe(Effect.provide(HoldLayer)),
   )
 

--- a/app-server/test/threads/threadOpen.test.ts
+++ b/app-server/test/threads/threadOpen.test.ts
@@ -8,7 +8,7 @@ import { afterAll } from "vitest"
 import { Api } from "../../src/api/contract.ts"
 import { sessionNameForTerminalId } from "../../src/terminals/terminalAdapter.ts"
 import { ThreadRepository } from "../../src/threads/threadRepository.ts"
-import { apiTestLayer, makeTestServiceLayers } from "../testLayers.ts"
+import { apiTestLayer, eventually, makeTestServiceLayers } from "../testLayers.ts"
 
 // The terminal-first workflow (ATC-124 / ATC-141) against the uniform seam
 // contract only — these tests are the proof that threads/ needs no provider
@@ -39,17 +39,6 @@ const WatchLayer = apiTestLayer(watchKit)
 const scratch = mkdtempSync(join(tmpdir(), "atc-thread-open-"))
 afterAll(() => rmSync(scratch, { recursive: true, force: true }))
 const realDir = realpathSync(scratch)
-
-/** Poll (real clock) until `predicate` accepts the effect's value; bounded. */
-const eventually = <A, E>(effect: Effect.Effect<A, E>, predicate: (value: A) => boolean) =>
-  Effect.gen(function* () {
-    for (let attempt = 0; ; attempt++) {
-      const value = yield* effect
-      if (predicate(value)) return value
-      assert.isBelow(attempt, 300, `condition never held; last: ${JSON.stringify(value)}`)
-      yield* Effect.sleep("10 millis")
-    }
-  })
 
 const setup = Effect.gen(function* () {
   const client = yield* HttpApiTest.groups(Api, ["v1"])
@@ -277,6 +266,7 @@ describe("threads.openTerminal", () => {
   it.live("identity resolving after a mid-open delete releases the fresh session", () =>
     Effect.gen(function* () {
       const { client, thread } = yield* setup
+      const threadRepository = yield* ThreadRepository
       holdKit.fakeAgents.codex.setIdentityHangs(true)
       const fiber = yield* client.v1
         .openThreadTerminal({ params: { threadId: thread.id } })
@@ -287,11 +277,14 @@ describe("threads.openTerminal", () => {
       )
       const fresh = holdKit.fakeAgents.codex.prepared.at(-1)?.providerSessionId ?? ""
 
-      // The thread is deleted while identity is still pending; when the
-      // identity then resolves, adoption finds no row — the ownership
-      // bracket must release the fresh session's adapter resources, because
-      // no thread row will ever own (or release) them.
-      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+      // The row vanishes while identity is still pending. Threads.delete
+      // itself now queues behind the in-flight open (ATC-157), so this
+      // models the residual ATC-139 window (a repository-level cascade or
+      // defect) directly at the repository: when the identity then
+      // resolves, adoption finds no row — the ownership bracket must
+      // release the fresh session's adapter resources, because no thread
+      // row will ever own (or release) them.
+      yield* threadRepository.delete(thread.id)
       holdKit.fakeAgents.codex.setIdentityHangs(false)
       const exit = yield* Fiber.await(fiber)
       assert.strictEqual(exit._tag, "Failure")


### PR DESCRIPTION
Archiving a Thread now suspends its runtime resources: the linked zmx-backed TUI terminal is killed through the existing confirmed-kill flow and adapter-owned session resources are released, while the durable Thread and provider conversation identity survive for a later exact resume.

Closes ATC-157.

## What changed

- **Contract**: `archiveThread` gains `ZmxUnavailable` (503, retryable); `openapi.json` regenerated and derived clients verified via `contract:check`.
- **`Threads.archive`**: reconcile → busy check (`working`/`needs_input` → `ThreadBusy`; `unknown` never guessed busy) → kill the linked live terminal via `Terminals.delete` (poll-verified death; `ZmxUnavailable` leaves the thread active) → `releaseSession` + stop observation → only then set `archivedAt`. Re-archive is convergent: a lingering live terminal on an already-archived thread (legacy rows) is killed on repeat; with nothing live left it stays a pure no-op.
- **Per-thread lifecycle lock**: archive, delete, and a launching `openTerminal` serialize behind a lazily created per-id `Semaphore(1)` — archive/delete queue behind an in-flight open (worst case the ~30s identity await) and then act on the resulting terminal. Open-vs-open keeps the fail-fast `ProviderSessionConflict`, with the `opening` claim now taken synchronously in the pre-lock fast path; the idempotent open return never queues.
- **No adapter/resume work needed**: `tuiLaunch` → `ensureHookPlumbing` already recreates Claude's hook files from persisted metadata after an archive-time release (new adapter test proves the round trip); attach clients get `1000 terminal_ended` through the existing confirmed-absence close.

## Tests

- New `threadArchive.test.ts`: kill-then-archive ordering, busy refusal (both states), `ZmxUnavailable` fail-closed + retry convergence, legacy-row convergent re-archive, archive-queues-behind-open, delete-queues-behind-open, unarchive + exact-session resume.
- Queue tests use a tight TUI-liveness watch as the discriminator: an implementation that killed the terminal instead of queueing fails the open fiber.
- The mid-open-delete test now models the residual repository-level window directly (public `deleteThread` intentionally queues now).
- `mise run -C app-server check` (311 tests) and `mise run contract:check` both green.

Reviewed by Codex (Sol, high reasoning): no blocking findings; all three should-fix items addressed in the second commit.

https://claude.ai/code/session_01VRq138CkAWbJP7tJNoVNXq