### PR TITLE
Enable Remote Control for Claude TUI threads

### DIFF
--- a/app-server/src/agents/claudeAdapter.ts
+++ b/app-server/src/agents/claudeAdapter.ts
@@ -126,6 +126,25 @@ const claudeEnvironment = (): Record<string, string> => {
   return env
 }
 
+/**
+ * Every Claude TUI opts into Remote Control as part of the same interactive
+ * driver. An ineligible account still gets the normal TUI with Claude's own
+ * failure notification, so remote availability never becomes a launch gate.
+ */
+const claudeTuiCommand = (
+  executable: string,
+  sessionFlag: "--resume" | "--session-id",
+  providerSessionId: string,
+  settingsFile: string,
+): ReadonlyArray<string> => [
+  executable,
+  sessionFlag,
+  providerSessionId,
+  "--settings",
+  settingsFile,
+  "--remote-control",
+]
+
 /** The hook vocabulary delivered in-process while ATC drives (and via the
  * webhook while a TUI drives — same normalization, claudeHooks.ts). The
  * subagent/task lifecycle events carry the background evidence the
@@ -709,13 +728,12 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
             )
             return {
               launchSpec: {
-                command: [
+                command: claudeTuiCommand(
                   executable,
                   "--resume",
                   options.providerSessionId,
-                  "--settings",
                   settingsFile,
-                ],
+                ),
                 env: {},
               },
               // Always handed back: when the caller had no metadata this
@@ -752,13 +770,12 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
             )
             return {
               launchSpec: {
-                command: [
+                command: claudeTuiCommand(
                   executable,
                   "--session-id",
                   providerSessionId,
-                  "--settings",
                   settingsFile,
-                ],
+                ),
                 env: {},
               },
               identity: Effect.sync(() => {

--- a/app-server/src/agents/claudeAdapter.ts
+++ b/app-server/src/agents/claudeAdapter.ts
@@ -130,6 +130,10 @@ const claudeEnvironment = (): Record<string, string> => {
  * Every Claude TUI opts into Remote Control as part of the same interactive
  * driver. An ineligible account still gets the normal TUI with Claude's own
  * failure notification, so remote availability never becomes a launch gate.
+ *
+ * `--remote-control` takes an optional session name, so it must stay the
+ * last token in argv — anything appended after it would be swallowed as
+ * the name.
  */
 const claudeTuiCommand = (
   executable: string,
@@ -722,6 +726,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
         tuiLaunch: (options) =>
           Effect.gen(function* () {
             const executable = yield* resolveProviderExecutable("claude", config.claudeExecutable)
+            yield* versionCheck
             const { secret, settingsFile } = yield* ensureHookPlumbing(
               options.providerSessionId,
               options.providerMetadata,

--- a/app-server/test/agents/claudeAdapter.test.ts
+++ b/app-server/test/agents/claudeAdapter.test.ts
@@ -434,7 +434,7 @@ describe("ClaudeAdapter", () => {
     }),
   )
 
-  it.live("tuiLaunch registers a webhook secret and builds the hooks settings", () =>
+  it.live("tuiLaunch enables Remote Control and builds the hook plumbing", () =>
     Effect.gen(function* () {
       const { layer } = adapterStack()
       yield* Effect.gen(function* () {
@@ -449,11 +449,16 @@ describe("ClaudeAdapter", () => {
         // A launch that minted the secret hands the metadata back so the
         // caller can persist it.
         assert.isString(launch.providerMetadata)
-        assert.strictEqual(spec.command[0], "/bin/echo")
-        assert.deepStrictEqual(spec.command.slice(1, 3), ["--resume", "session-t"])
-        assert.strictEqual(spec.command[3], "--settings")
         // The settings live in a 0600 file, never in argv.
         const settingsFile = spec.command[4] ?? ""
+        assert.deepStrictEqual(spec.command, [
+          "/bin/echo",
+          "--resume",
+          "session-t",
+          "--settings",
+          settingsFile,
+          "--remote-control",
+        ])
         assert.strictEqual((fs.statSync(settingsFile).mode & 0o777).toString(8), "600")
         const settings = JSON.parse(fs.readFileSync(settingsFile, "utf8")) as {
           hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>
@@ -540,7 +545,7 @@ describe("ClaudeAdapter TUI session plumbing", () => {
       }
     })
 
-  it.live("prepareTuiSession pre-assigns identity and writes the hook plumbing", () =>
+  it.live("prepareTuiSession pre-assigns identity and enables Remote Control", () =>
     Effect.gen(function* () {
       const cwd = workDir()
       const dir = stateDir()
@@ -557,11 +562,15 @@ describe("ClaudeAdapter TUI session plumbing", () => {
               /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
             )
             assert.strictEqual(identity.cwd, cwd)
-            assert.deepStrictEqual(prepared.launchSpec.command.slice(1, 3), [
+            const settingsFile = prepared.launchSpec.command[4]!
+            assert.deepStrictEqual(prepared.launchSpec.command, [
+              "/bin/echo",
               "--session-id",
               identity.providerSessionId,
+              "--settings",
+              settingsFile,
+              "--remote-control",
             ])
-            const settingsFile = prepared.launchSpec.command[4]!
             assert.isTrue(fs.existsSync(settingsFile))
             // The metadata carries the secret; the registration accepts it.
             const metadata = JSON.parse(identity.providerMetadata ?? "{}") as {


### PR DESCRIPTION
## Summary

- start fresh and resumed Claude TUI threads with `--remote-control`
- centralize Claude TUI argv construction so every launch path keeps the same Remote Control invariant
- assert the complete fresh and resume argv in the Claude adapter tests

## Why

Claude threads launched through ATC currently run only in the local TUI. Enabling Claude Code Remote Control on that same interactive process makes them available from claude.ai and the Claude mobile app without changing the provider-neutral Threads domain or the future native Agent SDK path.

Remote Control eligibility remains Claude Code's responsibility: an unavailable bridge reports through the TUI and does not become an ATC terminal-launch gate.

## Validation

- `bun --bun vitest run test/agents/claudeAdapter.test.ts` — 25 tests passed
- `mise run -C app-server check` — formatting, type checking, OpenAPI drift, and 328 tests passed