### PR TITLE
Cmd-digit jump shortcuts for sidebar threads and terminals (ATC-165)

### DIFF
--- a/macos/ATC/Commands/KeyStroke.swift
+++ b/macos/ATC/Commands/KeyStroke.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-struct KeyStroke: Hashable, Sendable, CustomStringConvertible {
+// Nonisolated: pure value logic (parsing and formatting) with no UI ties,
+// callable from any isolation despite the target's MainActor default.
+nonisolated struct KeyStroke: Hashable, Sendable, CustomStringConvertible {
     struct Modifiers: OptionSet, Hashable, Sendable {
         let rawValue: UInt8
 
@@ -122,12 +124,12 @@ struct KeyStroke: Hashable, Sendable, CustomStringConvertible {
 
 typealias KeySequence = [KeyStroke]
 
-struct TriggerError: Error, Equatable, CustomStringConvertible {
+nonisolated struct TriggerError: Error, Equatable, CustomStringConvertible {
     let message: String
     var description: String { message }
 }
 
-enum ParsedKeySequence: Equatable {
+nonisolated enum ParsedKeySequence: Equatable {
     case direct(KeyStroke)
     case leader(continuation: KeyStroke)
 

--- a/macos/ATC/Commands/KeyboardMonitorHost.swift
+++ b/macos/ATC/Commands/KeyboardMonitorHost.swift
@@ -103,6 +103,18 @@ struct KeyboardMonitorHost: NSViewRepresentable {
             }
 
             let center = NotificationCenter.default
+            // Becoming key reseeds from the live hardware state: flags
+            // changed while another window was key (⌘Tab back with ⌘ still
+            // down) never produced a flagsChanged event here.
+            observers.append(center.addObserver(
+                forName: NSWindow.didBecomeKeyNotification,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.router.heldModifiers = KeyStroke.Modifiers(NSEvent.modifierFlags)
+                }
+            })
             observers.append(center.addObserver(
                 forName: NSWindow.didResignKeyNotification,
                 object: window,

--- a/macos/ATC/Commands/KeyboardMonitorHost.swift
+++ b/macos/ATC/Commands/KeyboardMonitorHost.swift
@@ -52,6 +52,7 @@ struct KeyboardMonitorHost: NSViewRepresentable {
         var focusFallback: () -> Void
         private(set) weak var hostWindow: NSWindow?
         private var monitor: Any?
+        private var flagsMonitor: Any?
         private var observers: [NSObjectProtocol] = []
 
         init(
@@ -91,6 +92,16 @@ struct KeyboardMonitorHost: NSViewRepresentable {
                 return handled ? nil : event
             }
 
+            // Held-modifier state for the sidebar's ⌘/⌥⌘ jump badges. Never
+            // consumed; only the key window's monitor records, so a
+            // background window's badges cannot light up.
+            flagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) {
+                [weak self, weak window] event in
+                guard let self, let window, window.isKeyWindow else { return event }
+                self.router.heldModifiers = KeyStroke.Modifiers(event.modifierFlags)
+                return event
+            }
+
             let center = NotificationCenter.default
             observers.append(center.addObserver(
                 forName: NSWindow.didResignKeyNotification,
@@ -99,6 +110,7 @@ struct KeyboardMonitorHost: NSViewRepresentable {
             ) { [weak self] _ in
                 MainActor.assumeIsolated {
                     self?.router.cancel()
+                    self?.router.heldModifiers = []
                     self?.onDeactivate()
                     self?.restoreOrphanedResponder()
                 }
@@ -110,6 +122,7 @@ struct KeyboardMonitorHost: NSViewRepresentable {
             ) { [weak self] _ in
                 MainActor.assumeIsolated {
                     self?.router.cancel()
+                    self?.router.heldModifiers = []
                     self?.onDeactivate()
                     self?.restoreOrphanedResponder()
                 }
@@ -138,16 +151,22 @@ struct KeyboardMonitorHost: NSViewRepresentable {
                 NSEvent.removeMonitor(monitor)
                 self.monitor = nil
             }
+            if let flagsMonitor {
+                NSEvent.removeMonitor(flagsMonitor)
+                self.flagsMonitor = nil
+            }
             for observer in observers {
                 NotificationCenter.default.removeObserver(observer)
             }
             observers.removeAll()
             hostWindow = nil
             router.cancel()
+            router.heldModifiers = []
         }
 
         deinit {
             if let monitor { NSEvent.removeMonitor(monitor) }
+            if let flagsMonitor { NSEvent.removeMonitor(flagsMonitor) }
             for observer in observers {
                 NotificationCenter.default.removeObserver(observer)
             }
@@ -183,6 +202,9 @@ struct KeyboardRoutingContainer<Content: View>: View {
             context: context
         )
         router.isSuspended = { windowState.commandPalettePresentation != nil }
+        router.performJump = { jump in
+            SidebarShortcuts.perform(jump, appModel: appModel, windowState: windowState)
+        }
         _router = State(initialValue: router)
     }
 
@@ -214,14 +236,22 @@ struct KeyboardRoutingContainer<Content: View>: View {
     }
 }
 
+extension KeyStroke.Modifiers {
+    /// The four routable modifiers from an event's flags. Caps Lock and Fn
+    /// are deliberately dropped so they never break an exact match.
+    init(_ flags: NSEvent.ModifierFlags) {
+        self = []
+        let device = flags.intersection(.deviceIndependentFlagsMask)
+        if device.contains(.command) { insert(.command) }
+        if device.contains(.control) { insert(.control) }
+        if device.contains(.option) { insert(.option) }
+        if device.contains(.shift) { insert(.shift) }
+    }
+}
+
 extension KeyStroke {
     static func normalize(event: NSEvent) -> KeyStroke? {
-        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-        var modifiers: Modifiers = []
-        if flags.contains(.command) { modifiers.insert(.command) }
-        if flags.contains(.control) { modifiers.insert(.control) }
-        if flags.contains(.option) { modifiers.insert(.option) }
-        if flags.contains(.shift) { modifiers.insert(.shift) }
+        let modifiers = Modifiers(event.modifierFlags)
 
         // Escape normalizes to the bare stroke regardless of held modifiers
         // so a pending sequence always cancels silently.

--- a/macos/ATC/Commands/Keymap.swift
+++ b/macos/ATC/Commands/Keymap.swift
@@ -199,7 +199,7 @@ enum Keymap {
     }
 
     private static let protectedTriggers: [KeyStroke: String] = {
-        let values: [(String, String)] = [
+        var values: [(String, String)] = [
             ("cmd+q", "Quit"), ("cmd+h", "Hide atc"),
             ("cmd+opt+h", "Hide Others"), ("cmd+,", "Settings"),
             ("cmd+w", "Close Window"), ("cmd+shift+w", "Close All Windows"),
@@ -207,6 +207,12 @@ enum Keymap {
             ("cmd+x", "Cut"), ("cmd+c", "Copy"), ("cmd+v", "Paste"),
             ("cmd+a", "Select All"), ("cmd+m", "Minimize"),
         ]
+        // The hardcoded sidebar jump shortcuts: not keymap commands, so a
+        // user binding would collide silently unless reserved here.
+        for digit in 1...9 {
+            values.append(("cmd+\(digit)", "Thread Shortcuts"))
+            values.append(("cmd+opt+\(digit)", "Terminal Shortcuts"))
+        }
         return Dictionary(uniqueKeysWithValues: values.map { (requiredStroke($0.0), $0.1) })
     }()
 

--- a/macos/ATC/Commands/WindowKeyboardRouter.swift
+++ b/macos/ATC/Commands/WindowKeyboardRouter.swift
@@ -15,6 +15,11 @@ final class WindowKeyboardRouter {
 
     private(set) var state: State = .idle
     private(set) var flash: RouterFlash?
+    /// Modifiers physically held right now, as the flags-changed monitor
+    /// reports them; drives the sidebar's ⌘/⌥⌘ shortcut badges. The monitor
+    /// host resets this on window resign so ⌘Tab-ing away never leaves
+    /// badges stuck on.
+    var heldModifiers: KeyStroke.Modifiers = []
     var keymap: ResolvedKeymap {
         didSet {
             if oldValue.generation != keymap.generation {
@@ -28,6 +33,9 @@ final class WindowKeyboardRouter {
     /// stashes it before clearing window focus so the palette can restore it
     /// on dismissal; AnyObject keeps AppKit out of this file.
     @ObservationIgnored weak var responderBeforeSuspension: AnyObject?
+    /// Sidebar jump dispatch, injected by the routing container so this file
+    /// stays free of navigation concerns.
+    @ObservationIgnored var performJump: @MainActor (SidebarJump) -> Void = { _ in }
     @ObservationIgnored private let executeCommand: @MainActor (CommandID) -> CommandAvailability
     @ObservationIgnored private var flashTask: Task<Void, Never>?
     @ObservationIgnored private var flashToken = 0
@@ -55,6 +63,16 @@ final class WindowKeyboardRouter {
         guard !isSuspended() else { return false }
         switch state {
         case .idle:
+            // ⌘1–9 / ⌥⌘1–9 are hardcoded, reserved ahead of the keymap (the
+            // resolver refuses user bindings on them), and always consumed:
+            // a digit without a target does nothing rather than falling
+            // through to the focused terminal. A pending sequence keeps
+            // sequence semantics instead, like every other direct binding.
+            if let jump = SidebarShortcuts.jump(for: stroke) {
+                clearFlash()
+                if !isRepeat { performJump(jump) }
+                return true
+            }
             guard let node = keymap.root[stroke] else { return false }
             if isRepeat { return true }
             return handle(node)

--- a/macos/ATC/Commands/WindowKeyboardRouter.swift
+++ b/macos/ATC/Commands/WindowKeyboardRouter.swift
@@ -17,8 +17,8 @@ final class WindowKeyboardRouter {
     private(set) var flash: RouterFlash?
     /// Modifiers physically held right now, as the flags-changed monitor
     /// reports them; drives the sidebar's ⌘/⌥⌘ shortcut badges. The monitor
-    /// host resets this on window resign so ⌘Tab-ing away never leaves
-    /// badges stuck on.
+    /// host resets this on window resign (⌘Tab-ing away never leaves badges
+    /// stuck on) and reseeds it from the hardware state on become-key.
     var heldModifiers: KeyStroke.Modifiers = []
     var keymap: ResolvedKeymap {
         didSet {

--- a/macos/ATC/NavigatorSidebar.swift
+++ b/macos/ATC/NavigatorSidebar.swift
@@ -16,11 +16,9 @@ import ATCAppServerAPI
 import SwiftUI
 
 struct NavigatorSidebar: View {
-    /// Rows shown before the inline More control takes over.
-    private static let initialRowLimit = 5
-
     @Environment(AppModel.self) private var appModel
     @Environment(WindowState.self) private var windowState
+    @Environment(WindowKeyboardRouter.self) private var router
 
     @State private var renamingThread: ThreadListItem?
     @State private var renamingTerminal: TerminalRef?
@@ -37,16 +35,21 @@ struct NavigatorSidebar: View {
             inputs: appModel.runtimes.map(ThreadListModel.ConnectionInput.init(runtime:)),
             filter: windowState.threadFilter
         )
+        let threadSlots = threadSlotNumbers(model)
         NavigatorList {
             headerRow
 
             if !model.pinned.isEmpty {
-                threadCards(model.pinned, isExpanded: $windowState.isPinnedExpanded)
+                threadCards(
+                    model.pinned,
+                    isExpanded: $windowState.isPinnedExpanded,
+                    slotNumbers: threadSlots
+                )
                 sectionDivider
             }
 
             filterRow(model)
-            threadListSection(model)
+            threadListSection(model, slotNumbers: threadSlots)
 
             if let project = windowState.activeProject {
                 sectionDivider
@@ -158,7 +161,10 @@ struct NavigatorSidebar: View {
     // MARK: - Thread list
 
     @ViewBuilder
-    private func threadListSection(_ model: ThreadListModel) -> some View {
+    private func threadListSection(
+        _ model: ThreadListModel,
+        slotNumbers: [ThreadRef: Int]
+    ) -> some View {
         @Bindable var windowState = windowState
         if case .archived = windowState.threadFilter {
             if model.archived.isEmpty {
@@ -172,12 +178,20 @@ struct NavigatorSidebar: View {
         } else if model.recent.isEmpty {
             emptyLabel("No Threads")
         } else {
-            threadCards(model.recent, isExpanded: $windowState.isRecentExpanded)
+            threadCards(
+                model.recent,
+                isExpanded: $windowState.isRecentExpanded,
+                slotNumbers: slotNumbers
+            )
         }
     }
 
     @ViewBuilder
-    private func threadCards(_ items: [ThreadListItem], isExpanded: Binding<Bool>) -> some View {
+    private func threadCards(
+        _ items: [ThreadListItem],
+        isExpanded: Binding<Bool>,
+        slotNumbers: [ThreadRef: Int]
+    ) -> some View {
         ForEach(limited(items, expanded: isExpanded.wrappedValue)) { item in
             ThreadCard(
                 item: item,
@@ -185,6 +199,7 @@ struct NavigatorSidebar: View {
                 isSelected: windowState.isThreadHighlighted(item.ref),
                 isBusy: inFlightThreads.contains(item.ref),
                 canMutate: appModel.canMutate(connectionID: item.ref.connectionID),
+                shortcutLabel: slotNumbers[item.ref].map(SidebarShortcuts.threadBadgeLabel),
                 focusedThread: $focusedThread,
                 onOpen: { Task { await windowState.openThread(item.ref, in: appModel) } },
                 onRename: {
@@ -265,14 +280,27 @@ struct NavigatorSidebar: View {
             if terminals.isEmpty {
                 emptyLabel("No Terminals")
             } else {
-                ForEach(terminals, id: \.id) { terminal in
-                    terminalRow(terminal, connectionID: project.connectionID)
+                let numbered = areTerminalBadgesVisible
+                    ? SidebarShortcuts.terminalTargets(terminals, isSectionExpanded: true).count
+                    : 0
+                ForEach(Array(terminals.enumerated()), id: \.element.id) { index, terminal in
+                    terminalRow(
+                        terminal,
+                        connectionID: project.connectionID,
+                        shortcutLabel: index < numbered
+                            ? SidebarShortcuts.terminalBadgeLabel(index + 1)
+                            : nil
+                    )
                 }
             }
         }
     }
 
-    private func terminalRow(_ terminal: Terminal, connectionID: UUID) -> some View {
+    private func terminalRow(
+        _ terminal: Terminal,
+        connectionID: UUID,
+        shortcutLabel: String?
+    ) -> some View {
         let ref = TerminalRef(connectionID: connectionID, terminalID: terminal.id)
         return NavigatorRow(
             isSelected: windowState.selectedContent == .terminal(ref),
@@ -288,6 +316,10 @@ struct NavigatorSidebar: View {
                     Text("Ended")
                         .font(.caption)
                         .foregroundStyle(.tertiary)
+                }
+                if let shortcutLabel {
+                    Spacer(minLength: Spacing.sm)
+                    ShortcutBadge(label: shortcutLabel)
                 }
             }
         } actions: {
@@ -326,14 +358,14 @@ struct NavigatorSidebar: View {
 
     @ViewBuilder
     private func moreControl(total: Int, isExpanded: Binding<Bool>) -> some View {
-        if total > Self.initialRowLimit {
+        if total > SidebarShortcuts.initialRowLimit {
             Button {
                 isExpanded.wrappedValue.toggle()
             } label: {
                 HStack(spacing: Spacing.xs) {
                     Text(isExpanded.wrappedValue
                         ? "Hide"
-                        : "\(total - Self.initialRowLimit) more")
+                        : "\(total - SidebarShortcuts.initialRowLimit) more")
                     Image(systemName: isExpanded.wrappedValue ? "chevron.up" : "chevron.down")
                         .font(.caption2)
                 }
@@ -439,7 +471,52 @@ struct NavigatorSidebar: View {
     }
 
     private func limited<T>(_ items: [T], expanded: Bool) -> [T] {
-        expanded ? items : Array(items.prefix(Self.initialRowLimit))
+        SidebarShortcuts.limited(items, expanded: expanded)
+    }
+
+    // MARK: - Jump shortcut badges
+
+    /// Exact modifier match only: ⌘ alone lights thread badges, ⌥⌘ lights
+    /// terminal badges, any other combination shows neither. The palette
+    /// suspends dispatch, so it suppresses the badges too.
+    private var areThreadBadgesVisible: Bool {
+        router.heldModifiers == [.command]
+            && windowState.commandPalettePresentation == nil
+    }
+
+    private var areTerminalBadgesVisible: Bool {
+        router.heldModifiers == [.command, .option]
+            && windowState.commandPalettePresentation == nil
+    }
+
+    private func threadSlotNumbers(_ model: ThreadListModel) -> [ThreadRef: Int] {
+        guard areThreadBadgesVisible else { return [:] }
+        let targets = SidebarShortcuts.threadTargets(
+            model: model,
+            isPinnedExpanded: windowState.isPinnedExpanded,
+            isRecentExpanded: windowState.isRecentExpanded
+        )
+        return Dictionary(uniqueKeysWithValues: targets.enumerated().map {
+            ($0.element, $0.offset + 1)
+        })
+    }
+}
+
+/// The ⌘N / ⌥⌘N chip shown while the exact modifier combo is held. Matches
+/// the card action chips' height so swapping it in never resizes a row.
+private struct ShortcutBadge: View {
+    let label: String
+
+    var body: some View {
+        Text(label)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, Spacing.xs)
+            .frame(height: NavigatorMetrics.actionSize)
+            .background(
+                Color.white.opacity(0.07),
+                in: RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+            )
     }
 }
 
@@ -452,6 +529,8 @@ private struct ThreadCard: View {
     let isSelected: Bool
     let isBusy: Bool
     let canMutate: Bool
+    /// Non-nil while exact ⌘ is held and this card holds a numbered slot.
+    let shortcutLabel: String?
     @FocusState.Binding var focusedThread: ThreadRef?
     let onOpen: () -> Void
     let onRename: () -> Void
@@ -472,7 +551,11 @@ private struct ThreadCard: View {
                     .font(.caption.weight(.semibold))
                     .lineLimit(1)
                 Spacer(minLength: Spacing.sm)
-                if isHovering || isFocused {
+                // Same slot as the hover chips and the connection status, so
+                // the card never resizes; the held-modifier badge wins.
+                if let shortcutLabel {
+                    ShortcutBadge(label: shortcutLabel)
+                } else if isHovering || isFocused {
                     HStack(spacing: Spacing.xs) {
                         cardAction(
                             systemImage: thread.isPinned ? "pin.slash" : "pin",

--- a/macos/ATC/SidebarShortcuts.swift
+++ b/macos/ATC/SidebarShortcuts.swift
@@ -1,0 +1,103 @@
+// The hardcoded sidebar jump shortcuts (⌘1–9 threads, ⌥⌘1–9 terminals):
+// one ordering authority that feeds both the badges the sidebar renders and
+// the dispatch the keyboard router performs, so display and behavior cannot
+// drift.
+//
+// Numbering is what the collapse state reveals, in render order: visible
+// pinned rows first, then visible recent rows, capped at nine; terminals are
+// the active project's standalone terminals, gated on the section being
+// expanded. The shortcuts deliberately do not consult sidebar visibility —
+// muscle memory keeps working while the sidebar is hidden (⌘B), using the
+// exact ordering the sidebar would show.
+
+import ATCAppServerAPI
+import Foundation
+
+enum SidebarJump: Equatable, Sendable {
+    /// Zero-based slot: ⌘1 is `.thread(slot: 0)`.
+    case thread(slot: Int)
+    case terminal(slot: Int)
+}
+
+enum SidebarShortcuts {
+    /// Rows a sidebar section shows before its More control takes over.
+    static let initialRowLimit = 5
+    /// ⌘1…⌘9 — there is no ⌘0 and nothing past nine.
+    static let slotCount = 9
+
+    /// The jump a stroke maps to, on an exact modifier match only: ⌘ alone
+    /// targets threads, ⌥⌘ targets terminals, anything else is no jump.
+    static func jump(for stroke: KeyStroke) -> SidebarJump? {
+        guard let digit = Int(stroke.key), (1...9).contains(digit) else { return nil }
+        if stroke.modifiers == [.command] { return .thread(slot: digit - 1) }
+        if stroke.modifiers == [.command, .option] { return .terminal(slot: digit - 1) }
+        return nil
+    }
+
+    static func limited<T>(_ items: [T], expanded: Bool) -> [T] {
+        expanded ? items : Array(items.prefix(initialRowLimit))
+    }
+
+    /// Threads in sidebar render order — visible pinned rows, then visible
+    /// recent rows. Under the Archived filter the model's recent list is
+    /// empty, so only pinned rows are numbered; archived rows never are.
+    static func threadTargets(
+        model: ThreadListModel,
+        isPinnedExpanded: Bool,
+        isRecentExpanded: Bool
+    ) -> [ThreadRef] {
+        let rows = limited(model.pinned, expanded: isPinnedExpanded)
+            + limited(model.recent, expanded: isRecentExpanded)
+        return rows.prefix(slotCount).map(\.ref)
+    }
+
+    /// The already-ordered standalone terminals, numbered only while the
+    /// Terminals section is expanded.
+    static func terminalTargets(
+        _ terminals: [Terminal],
+        isSectionExpanded: Bool
+    ) -> [Terminal] {
+        guard isSectionExpanded else { return [] }
+        return Array(terminals.prefix(slotCount))
+    }
+
+    static func threadBadgeLabel(_ number: Int) -> String {
+        KeyStroke(key: "\(number)", modifiers: [.command]).displayDescription
+    }
+
+    static func terminalBadgeLabel(_ number: Int) -> String {
+        KeyStroke(key: "\(number)", modifiers: [.command, .option]).displayDescription
+    }
+
+    @MainActor
+    static func perform(_ jump: SidebarJump, appModel: AppModel, windowState: WindowState) {
+        switch jump {
+        case .thread(let slot):
+            let model = ThreadListModel(
+                inputs: appModel.runtimes.map(ThreadListModel.ConnectionInput.init(runtime:)),
+                filter: windowState.threadFilter
+            )
+            let targets = threadTargets(
+                model: model,
+                isPinnedExpanded: windowState.isPinnedExpanded,
+                isRecentExpanded: windowState.isRecentExpanded
+            )
+            guard targets.indices.contains(slot) else { return }
+            let ref = targets[slot]
+            Task { await windowState.openThread(ref, in: appModel) }
+        case .terminal(let slot):
+            guard let project = windowState.activeProject,
+                  let store = appModel.runtime(id: project.connectionID)?.terminals
+            else { return }
+            let targets = terminalTargets(
+                store.standaloneTerminals(projectID: project.projectID),
+                isSectionExpanded: windowState.isTerminalsSectionExpanded
+            )
+            guard targets.indices.contains(slot) else { return }
+            windowState.selectTerminal(
+                TerminalRef(connectionID: project.connectionID, terminalID: targets[slot].id),
+                in: appModel
+            )
+        }
+    }
+}

--- a/macos/ATC/SidebarShortcuts.swift
+++ b/macos/ATC/SidebarShortcuts.swift
@@ -61,11 +61,13 @@ enum SidebarShortcuts {
         return Array(terminals.prefix(slotCount))
     }
 
-    static func threadBadgeLabel(_ number: Int) -> String {
+    // Nonisolated: pure formatting, usable from nonisolated closure contexts
+    // such as `Optional.map` without an isolation diagnostic.
+    nonisolated static func threadBadgeLabel(_ number: Int) -> String {
         KeyStroke(key: "\(number)", modifiers: [.command]).displayDescription
     }
 
-    static func terminalBadgeLabel(_ number: Int) -> String {
+    nonisolated static func terminalBadgeLabel(_ number: Int) -> String {
         KeyStroke(key: "\(number)", modifiers: [.command, .option]).displayDescription
     }
 

--- a/macos/ATC/SidebarShortcuts.swift
+++ b/macos/ATC/SidebarShortcuts.swift
@@ -61,8 +61,8 @@ enum SidebarShortcuts {
         return Array(terminals.prefix(slotCount))
     }
 
-    // Nonisolated: pure formatting, usable from nonisolated closure contexts
-    // such as `Optional.map` without an isolation diagnostic.
+    // Nonisolated: pure formatting (KeyStroke is a nonisolated type), usable
+    // from nonisolated closure contexts such as `Optional.map`.
     nonisolated static func threadBadgeLabel(_ number: Int) -> String {
         KeyStroke(key: "\(number)", modifiers: [.command]).displayDescription
     }

--- a/macos/ATCTests/KeyboardRouterTests.swift
+++ b/macos/ATCTests/KeyboardRouterTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Testing
 @testable import ATC
 
@@ -155,6 +156,88 @@ struct KeyboardRouterTests {
         isSuspended = false
         #expect(router.handle(refresh, isRepeat: false))
         #expect(executions == [.refresh])
+    }
+
+    @Test("exact ⌘digit and ⌥⌘digit dispatch sidebar jumps and consume")
+    func sidebarJumpDispatch() throws {
+        var jumps: [SidebarJump] = []
+        let router = WindowKeyboardRouter(keymap: try keymap()) { _ in .available }
+        router.performJump = { jumps.append($0) }
+
+        #expect(router.handle(KeyStroke(key: "1", modifiers: [.command]), isRepeat: false))
+        #expect(router.handle(KeyStroke(key: "3", modifiers: [.command, .option]), isRepeat: false))
+        #expect(jumps == [.thread(slot: 0), .terminal(slot: 2)])
+
+        // Repeats are consumed without dispatching again.
+        #expect(router.handle(KeyStroke(key: "1", modifiers: [.command]), isRepeat: true))
+        #expect(jumps.count == 2)
+    }
+
+    @Test("non-exact modifier combos are not jumps")
+    func sidebarJumpExactModifiers() throws {
+        var jumps: [SidebarJump] = []
+        let router = WindowKeyboardRouter(keymap: try keymap()) { _ in .available }
+        router.performJump = { jumps.append($0) }
+
+        #expect(!router.handle(KeyStroke(key: "1", modifiers: [.command, .shift]), isRepeat: false))
+        #expect(!router.handle(KeyStroke(key: "1", modifiers: [.option]), isRepeat: false))
+        #expect(!router.handle(KeyStroke(key: "1", modifiers: []), isRepeat: false))
+        #expect(jumps.isEmpty)
+    }
+
+    @Test("suspension forwards jump shortcuts")
+    func sidebarJumpSuspension() throws {
+        var jumps: [SidebarJump] = []
+        let router = WindowKeyboardRouter(keymap: try keymap()) { _ in .available }
+        router.performJump = { jumps.append($0) }
+        router.isSuspended = { true }
+
+        #expect(!router.handle(KeyStroke(key: "1", modifiers: [.command]), isRepeat: false))
+        #expect(jumps.isEmpty)
+    }
+
+    @Test("a pending sequence keeps sequence semantics for ⌘digit")
+    func sidebarJumpDuringPendingSequence() throws {
+        var jumps: [SidebarJump] = []
+        let router = WindowKeyboardRouter(keymap: try keymap()) { _ in .available }
+        router.performJump = { jumps.append($0) }
+
+        #expect(router.handle(try stroke("cmd+k"), isRepeat: false))
+        #expect(router.handle(KeyStroke(key: "1", modifiers: [.command]), isRepeat: false))
+        #expect(jumps.isEmpty)
+        #expect(router.flash == RouterFlash(message: "No matching command"))
+        #expect(router.pendingNode == nil)
+    }
+
+    @Test("window resign and app deactivation clear held modifiers")
+    func heldModifiersResetOnResign() throws {
+        _ = NSApplication.shared
+        let router = WindowKeyboardRouter(keymap: try keymap()) { _ in .available }
+        let coordinator = KeyboardMonitorHost.Coordinator(
+            router: router,
+            onDeactivate: {},
+            focusFallback: {}
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 100, height: 100),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: true
+        )
+        window.isReleasedWhenClosed = false
+        defer { coordinator.stop() }
+        coordinator.install(for: window)
+
+        router.heldModifiers = [.command]
+        NotificationCenter.default.post(name: NSWindow.didResignKeyNotification, object: window)
+        #expect(router.heldModifiers == [])
+
+        router.heldModifiers = [.command, .option]
+        NotificationCenter.default.post(
+            name: NSApplication.didResignActiveNotification,
+            object: NSApp
+        )
+        #expect(router.heldModifiers == [])
     }
 
     @Test("external unavailable feedback uses the router flash lifecycle")

--- a/macos/ATCTests/KeyboardRouterTests.swift
+++ b/macos/ATCTests/KeyboardRouterTests.swift
@@ -238,6 +238,12 @@ struct KeyboardRouterTests {
             object: NSApp
         )
         #expect(router.heldModifiers == [])
+
+        // Becoming key reseeds from the live hardware state — no modifiers
+        // are physically held in a test run, so a stale value clears.
+        router.heldModifiers = [.command]
+        NotificationCenter.default.post(name: NSWindow.didBecomeKeyNotification, object: window)
+        #expect(router.heldModifiers == KeyStroke.Modifiers(NSEvent.modifierFlags))
     }
 
     @Test("external unavailable feedback uses the router flash lifecycle")

--- a/macos/ATCTests/KeymapResolutionTests.swift
+++ b/macos/ATCTests/KeymapResolutionTests.swift
@@ -174,6 +174,25 @@ struct KeymapResolutionTests {
         })
     }
 
+    @Test("sidebar jump digits are reserved in both modifier sets")
+    func reservedJumpDigits() throws {
+        let thread = Keymap.resolve(user: ConfigurationLoader.parse(#"""
+        [keybindings]
+        "cmd+1" = "data.refresh"
+        """#))
+        #expect(try failure(thread).contains {
+            $0.message.contains("cmd+1") && $0.message.contains("Thread Shortcuts")
+        })
+
+        let terminal = Keymap.resolve(user: ConfigurationLoader.parse(#"""
+        [keybindings]
+        "cmd+opt+4" = "data.refresh"
+        """#))
+        #expect(try failure(terminal).contains {
+            $0.message.contains("cmd+opt+4") && $0.message.contains("Terminal Shortcuts")
+        })
+    }
+
     @Test("unknown command ids invalidate the entire candidate")
     func unknownCommand() throws {
         let result = Keymap.resolve(user: ConfigurationLoader.parse(#"""

--- a/macos/ATCTests/SidebarShortcutsTests.swift
+++ b/macos/ATCTests/SidebarShortcutsTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+import Testing
+import ATCAppServerAPI
+@testable import ATC
+
+/// The jump-shortcut ordering authority: numbering follows what the collapse
+/// state reveals, capped at nine, and dispatch honors the same gates the
+/// sidebar renders under.
+@MainActor
+@Suite("Sidebar jump shortcuts")
+struct SidebarShortcutsTests {
+    private let connectionID = UUID()
+
+    private func model(
+        threads: [ATCThread],
+        filter: ThreadFilter = .all
+    ) -> ThreadListModel {
+        ThreadListModel(
+            inputs: [.init(
+                connectionID: connectionID,
+                connectionName: "A",
+                projects: [Fixtures.project(id: "prj")],
+                threads: threads,
+                archivedThreads: []
+            )],
+            filter: filter
+        )
+    }
+
+    private func ref(_ id: String) -> ThreadRef {
+        ThreadRef(connectionID: connectionID, threadID: id)
+    }
+
+    // MARK: - Stroke matching
+
+    @Test("only exact ⌘digit and ⌥⌘digit map to jumps")
+    func strokeMatching() {
+        #expect(SidebarShortcuts.jump(for: KeyStroke(key: "1", modifiers: [.command]))
+            == .thread(slot: 0))
+        #expect(SidebarShortcuts.jump(for: KeyStroke(key: "9", modifiers: [.command, .option]))
+            == .terminal(slot: 8))
+        #expect(SidebarShortcuts.jump(for: KeyStroke(key: "0", modifiers: [.command])) == nil)
+        #expect(SidebarShortcuts.jump(for: KeyStroke(key: "1", modifiers: [])) == nil)
+        #expect(SidebarShortcuts.jump(for: KeyStroke(key: "1", modifiers: [.command, .shift]))
+            == nil)
+        #expect(SidebarShortcuts.jump(for: KeyStroke(key: "1", modifiers: [.option])) == nil)
+        #expect(SidebarShortcuts.jump(for: KeyStroke(key: "b", modifiers: [.command])) == nil)
+    }
+
+    // MARK: - Thread ordering
+
+    @Test("pinned rows precede recent and collapsed sections stop at five")
+    func threadOrdering() {
+        let threads = (1...7).map {
+            Fixtures.thread(id: "pin\($0)", pinnedAt: Fixtures.date(Double($0)))
+        } + (1...3).map {
+            Fixtures.thread(id: "rec\($0)", createdAt: Fixtures.date(100 + Double($0)))
+        }
+        let collapsed = SidebarShortcuts.threadTargets(
+            model: model(threads: threads),
+            isPinnedExpanded: false,
+            isRecentExpanded: false
+        )
+        // Five visible pinned rows (oldest pin first), then recent rows
+        // newest-created-first; rows behind "N more" get no number.
+        #expect(collapsed == [
+            ref("pin1"), ref("pin2"), ref("pin3"), ref("pin4"), ref("pin5"),
+            ref("rec3"), ref("rec2"), ref("rec1"),
+        ])
+
+        let expanded = SidebarShortcuts.threadTargets(
+            model: model(threads: threads),
+            isPinnedExpanded: true,
+            isRecentExpanded: false
+        )
+        // Expansion reveals all seven pinned rows and the cap trims the
+        // numbered list to nine.
+        #expect(expanded.count == 9)
+        #expect(expanded[6] == ref("pin7"))
+        #expect(expanded.last == ref("rec2"))
+    }
+
+    @Test("the archived filter numbers only pinned rows")
+    func archivedFilter() {
+        let threads = [
+            Fixtures.thread(id: "pin1", pinnedAt: Fixtures.date(1)),
+            Fixtures.thread(id: "rec1", createdAt: Fixtures.date(2)),
+        ]
+        let targets = SidebarShortcuts.threadTargets(
+            model: model(threads: threads, filter: .archived),
+            isPinnedExpanded: false,
+            isRecentExpanded: false
+        )
+        #expect(targets == [ref("pin1")])
+    }
+
+    // MARK: - Terminal ordering
+
+    @Test("terminals number in section order, capped at nine, only while expanded")
+    func terminalOrdering() {
+        let terminals = (1...12).map {
+            Fixtures.terminal(id: "trm\($0)", createdAt: Fixtures.date(Double($0)))
+        }
+        #expect(SidebarShortcuts.terminalTargets(terminals, isSectionExpanded: false).isEmpty)
+        let expanded = SidebarShortcuts.terminalTargets(terminals, isSectionExpanded: true)
+        #expect(expanded.map(\.id) == (1...9).map { "trm\($0)" })
+    }
+
+    // MARK: - Badge labels
+
+    @Test("badge labels use the glyphs in Apple modifier order")
+    func badgeLabels() {
+        #expect(SidebarShortcuts.threadBadgeLabel(3) == "⌘3")
+        #expect(SidebarShortcuts.terminalBadgeLabel(3) == "⌥⌘3")
+    }
+
+    // MARK: - Dispatch
+
+    @Test("perform opens the numbered thread and selects the numbered terminal")
+    func performJumps() async throws {
+        let client = ScriptableAppServerClient()
+        Fixtures.seed(client)
+        let test = try await makeModel(client: client)
+        let state = WindowState()
+
+        // Recent ordering is newest-created-first: thr3, thr2, thr1.
+        SidebarShortcuts.perform(.thread(slot: 0), appModel: test.model, windowState: state)
+        await settle(until: { state.selectedContent == .thread(test.threadRef("thr3")) })
+        #expect(state.selectedContent == .thread(test.threadRef("thr3")))
+        #expect(state.activeProject == test.projectRef("prj"))
+
+        // Standalone terminals oldest-first: trm_live, trm_ended.
+        SidebarShortcuts.perform(.terminal(slot: 1), appModel: test.model, windowState: state)
+        #expect(state.selectedContent == .terminal(test.terminalRef("trm_ended")))
+    }
+
+    @Test("terminal jumps require a collapsed section to be expanded and a project context")
+    func terminalJumpGates() async throws {
+        let client = ScriptableAppServerClient()
+        Fixtures.seed(client)
+        let test = try await makeModel(client: client)
+        let state = WindowState()
+
+        // No active project yet: nothing to jump to.
+        SidebarShortcuts.perform(.terminal(slot: 0), appModel: test.model, windowState: state)
+        #expect(state.selectedContent == .dashboard)
+
+        SidebarShortcuts.perform(.thread(slot: 0), appModel: test.model, windowState: state)
+        await settle(until: { state.selectedThread != nil })
+
+        state.isTerminalsSectionExpanded = false
+        SidebarShortcuts.perform(.terminal(slot: 0), appModel: test.model, windowState: state)
+        #expect(state.selectedThread != nil)
+
+        state.isTerminalsSectionExpanded = true
+        SidebarShortcuts.perform(.terminal(slot: 0), appModel: test.model, windowState: state)
+        #expect(state.selectedContent == .terminal(test.terminalRef("trm_live")))
+    }
+
+    @Test("out-of-range slots do nothing")
+    func outOfRangeSlots() async throws {
+        let client = ScriptableAppServerClient()
+        Fixtures.seed(client)
+        let test = try await makeModel(client: client)
+        let state = WindowState()
+
+        SidebarShortcuts.perform(.thread(slot: 8), appModel: test.model, windowState: state)
+        await drainPendingTasks()
+        #expect(state.selectedContent == .dashboard)
+    }
+}


### PR DESCRIPTION
Implements [ATC-165](https://linear.app/elevenideas/issue/ATC-165/cmd-shortcuts-for-threads-and-terminals): while exact ⌘ is held, sidebar thread cards swap their connection name + status dot for a ⌘N badge (same trailing slot as the hover Pin/Archive chips, so cards never resize) and ⌘1–9 jumps to that thread. Exact ⌥⌘ does the same for the active project's standalone terminals (⌥⌘1–9, badge at the far right of the row).

## How it works

- **`SidebarShortcuts` (new)** is the single ordering authority feeding both the badges and the dispatch: threads number 1–9 over what the collapse state reveals (visible pinned rows first, then visible recent rows; rows behind "N more" get no number), terminals over the expanded Terminals section, capped at nine. Both shortcut sets keep working while the sidebar is hidden (⌘B), using the same ordering.
- **`WindowKeyboardRouter`** intercepts exact ⌘digit / ⌥⌘digit ahead of keymap lookup in the idle state: repeats are consumed without redispatch, the command-palette suspension forwards, and a pending leader sequence keeps sequence semantics. The combos are always consumed so an unnumbered digit never falls through to the focused terminal.
- **`KeyboardMonitorHost`** adds a `.flagsChanged` local monitor publishing window-scoped held modifiers on the router; `didResignKey`/`didResignActive` reset them (⌘Tab-ing away never leaves badges stuck on) and `didBecomeKey` reseeds from `NSEvent.modifierFlags` so returning with ⌘ still held lights badges immediately.
- **`Keymap`** reserves ⌘1–9 and ⌥⌘1–9 as protected triggers: a user binding one in `[keybindings]` gets a conflict diagnostic instead of a silent collision. Not rebindable, not in the command palette.

## Notes

- Caps Lock and Fn deliberately don't break the exact-modifier match (they're latched/hardware states, and the whole keymap already normalizes them away).
- Digit matching is character-based like the rest of the KeyStroke system, so layouts where digits require Shift (AZERTY) don't get these shortcuts — consistent with existing keymap behavior.

## Testing

- New `SidebarShortcutsTests`: ordering across collapse states, the 9 cap, archived-filter behavior, terminal gating, stroke matching, and dispatch through a real `AppModel`/`WindowState`.
- `KeyboardRouterTests`: exact-modifier dispatch, repeat/suspension/pending-sequence handling, and modifier reset on resign + reseed on become-key against a real `NSWindow`.
- `KeymapResolutionTests`: reservation diagnostics for both modifier sets.
- Full macOS suite: 226 tests in 25 suites, all passing. Codex (Sol, high reasoning) review findings addressed (become-key reseed; isolation diagnostic).

https://claude.ai/code/session_01J9E8hwWZwWHz3nDFFrdHJN