### PR TITLE
Server contract & API surface hardening (ATC-171)

### DIFF
--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -12,7 +12,6 @@
         ],
         "operationId": "getHealth",
         "parameters": [],
-        "security": [],
         "responses": {
           "200": {
             "description": "Result of the liveness probe.",
@@ -35,7 +34,6 @@
         ],
         "operationId": "getVersion",
         "parameters": [],
-        "security": [],
         "responses": {
           "200": {
             "description": "Build and contract version information for the running server.",
@@ -58,7 +56,6 @@
         ],
         "operationId": "listProjects",
         "parameters": [],
-        "security": [],
         "responses": {
           "200": {
             "description": "All projects, newest first.",
@@ -79,7 +76,6 @@
         ],
         "operationId": "createProject",
         "parameters": [],
-        "security": [],
         "responses": {
           "200": {
             "description": "A Project: the user-facing container organizing a body of work.",
@@ -138,7 +134,6 @@
             "required": true
           }
         ],
-        "security": [],
         "responses": {
           "200": {
             "description": "A Project: the user-facing container organizing a body of work.",
@@ -178,7 +173,6 @@
             "required": true
           }
         ],
-        "security": [],
         "responses": {
           "200": {
             "description": "A Project: the user-facing container organizing a body of work.",
@@ -245,7 +239,6 @@
             "required": true
           }
         ],
-        "security": [],
         "responses": {
           "204": {
             "description": "<No Content>"
@@ -300,7 +293,6 @@
             "required": false
           }
         ],
-        "security": [],
         "responses": {
           "200": {
             "description": "Terminals, newest first.",
@@ -321,7 +313,6 @@
         ],
         "operationId": "createTerminal",
         "parameters": [],
-        "security": [],
         "responses": {
           "200": {
             "description": "A durable, project-scoped terminal backed by a zmx session.",
@@ -403,7 +394,6 @@
             "required": true
           }
         ],
-        "security": [],
         "responses": {
           "200": {
             "description": "A durable, project-scoped terminal backed by a zmx session.",
@@ -443,7 +433,6 @@
             "required": true
           }
         ],
-        "security": [],
         "responses": {
           "200": {
             "description": "A durable, project-scoped terminal backed by a zmx session.",
@@ -493,7 +482,6 @@
             "required": true
           }
         ],
-        "security": [],
         "responses": {
           "204": {
             "description": "<No Content>"
@@ -553,7 +541,6 @@
             "required": false
           }
         ],
-        "security": [],
         "responses": {
           "200": {
             "description": "Threads, newest first.",
@@ -574,7 +561,6 @@
         ],
         "operationId": "createThread",
         "parameters": [],
-        "security": [],
         "responses": {
           "200": {
             "description": "A durable Thread: the primary unit of agent work. Its ATC identity is separate from provider identity, and it never requires a Terminal.",
@@ -643,7 +629,6 @@
             "required": true
           }
         ],
-        "security": [],
         "responses": {
           "200": {
             "description": "A durable Thread: the primary unit of agent work. Its ATC identity is separate from provider identity, and it never requires a Terminal.",
@@ -683,7 +668,6 @@
             "required": true
           }
         ],
-        "security": [],
         "responses": {
           "200": {
             "description": "A durable Thread: the primary unit of agent work. Its ATC identity is separate from provider identity, and it never requires a Terminal.",
@@ -733,7 +717,6 @@
             "required": true
           }
         ],
-        "security": [],
         "responses": {
           "204": {
             "description": "<No Content>"
@@ -778,7 +761,6 @@
             "required": true
           }
         ],
-        "security": [],
         "responses": {
           "200": {
             "description": "A durable Thread: the primary unit of agent work. Its ATC identity is separate from provider identity, and it never requires a Terminal.",
@@ -840,7 +822,6 @@
             "required": true
           }
         ],
-        "security": [],
         "responses": {
           "200": {
             "description": "A durable Thread: the primary unit of agent work. Its ATC identity is separate from provider identity, and it never requires a Terminal.",
@@ -882,7 +863,6 @@
             "required": true
           }
         ],
-        "security": [],
         "responses": {
           "200": {
             "description": "A durable Thread: the primary unit of agent work. Its ATC identity is separate from provider identity, and it never requires a Terminal.",
@@ -934,7 +914,6 @@
             "required": true
           }
         ],
-        "security": [],
         "responses": {
           "200": {
             "description": "A durable Thread: the primary unit of agent work. Its ATC identity is separate from provider identity, and it never requires a Terminal.",
@@ -976,7 +955,6 @@
             "required": true
           }
         ],
-        "security": [],
         "responses": {
           "200": {
             "description": "A durable, project-scoped terminal backed by a zmx session.",
@@ -1063,7 +1041,6 @@
         ],
         "operationId": "listAgents",
         "parameters": [],
-        "security": [],
         "responses": {
           "200": {
             "description": "The built-in agent registry.",
@@ -1076,7 +1053,7 @@
             }
           }
         },
-        "description": "List the built-in agents with availability and capabilities, detected on demand."
+        "description": "List the built-in agents with availability, detected on demand."
       }
     },
     "/api/v1/agents/{agentId}": {
@@ -1095,10 +1072,9 @@
             "required": true
           }
         ],
-        "security": [],
         "responses": {
           "200": {
-            "description": "A built-in agent provider: availability and capability report, detected on demand and never persisted.",
+            "description": "A built-in agent provider: availability report, detected on demand and never persisted.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1128,7 +1104,6 @@
         ],
         "operationId": "subscribeEvents",
         "parameters": [],
-        "security": [],
         "responses": {
           "200": {
             "description": "A data-only SSE byte stream. Each event is a single `data:` line whose payload is a JSON-encoded ResourceChangedEvent (see that component schema); frames never carry `id:` or `event:` lines. Comment lines are protocol control, ignored by conforming SSE parsers: the stream opens with `: connected` (the resync handshake) and a `: heartbeat` follows roughly every 25 seconds. Example:\n\n```\n: connected\n\n: heartbeat\n\ndata: {\"resource\":\"thread\",\"id\":\"0198aaf1\",\"change\":\"updated\"}\n```",
@@ -1162,7 +1137,6 @@
             "required": true
           }
         ],
-        "security": [],
         "responses": {
           "200": {
             "description": "Result of a directory health check. Never persisted.",
@@ -1196,7 +1170,6 @@
             "required": false
           }
         ],
-        "security": [],
         "responses": {
           "200": {
             "description": "A directory listing for the server-backed folder browser. Never persisted.",
@@ -1909,7 +1882,7 @@
           "available"
         ],
         "additionalProperties": false,
-        "description": "A built-in agent provider: availability and capability report, detected on demand and never persisted."
+        "description": "A built-in agent provider: availability report, detected on demand and never persisted."
       },
       "AgentList": {
         "type": "array",

--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -289,6 +289,15 @@
               "description": "Restrict the listing to one project."
             },
             "required": false
+          },
+          {
+            "name": "threadId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "description": "Restrict the listing to one thread's terminals."
+            },
+            "required": false
           }
         ],
         "security": [],
@@ -536,9 +545,10 @@
               "type": "string",
               "enum": [
                 "true",
-                "false"
+                "false",
+                "all"
               ],
-              "description": "\"true\" lists archived threads only; the default lists active threads."
+              "description": "\"true\" lists archived threads only, \"all\" lists active and archived together; omitted (or \"false\") lists active threads only."
             },
             "required": false
           }
@@ -1121,111 +1131,11 @@
         "security": [],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "A data-only SSE byte stream. Each event is a single `data:` line whose payload is a JSON-encoded ResourceChangedEvent (see that component schema); frames never carry `id:` or `event:` lines. Comment lines are protocol control, ignored by conforming SSE parsers: the stream opens with `: connected` (the resync handshake) and a `: heartbeat` follows roughly every 25 seconds. Example:\n\n```\n: connected\n\n: heartbeat\n\ndata: {\"resource\":\"thread\",\"id\":\"0198aaf1\",\"change\":\"updated\"}\n```",
             "content": {
               "text/event-stream": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "event": {
-                      "type": "string"
-                    },
-                    "data": {
-                      "$ref": "#/components/schemas/ResourceChangedEventJsonEncoding"
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "event",
-                    "data"
-                  ],
-                  "additionalProperties": false
-                },
-                "x-effect-stream": {
-                  "encoding": "sse",
-                  "causeSchema": {
-                    "type": "array",
-                    "items": {
-                      "anyOf": [
-                        {
-                          "type": "object",
-                          "properties": {
-                            "_tag": {
-                              "type": "string",
-                              "enum": [
-                                "Fail"
-                              ]
-                            },
-                            "error": {
-                              "not": {}
-                            }
-                          },
-                          "required": [
-                            "_tag",
-                            "error"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "_tag": {
-                              "type": "string",
-                              "enum": [
-                                "Die"
-                              ]
-                            },
-                            "defect": {}
-                          },
-                          "required": [
-                            "_tag",
-                            "defect"
-                          ],
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "properties": {
-                            "_tag": {
-                              "type": "string",
-                              "enum": [
-                                "Interrupt"
-                              ]
-                            },
-                            "fiberId": {
-                              "anyOf": [
-                                {
-                                  "type": "number"
-                                },
-                                {
-                                  "type": "null"
-                                }
-                              ]
-                            }
-                          },
-                          "required": [
-                            "_tag",
-                            "fiberId"
-                          ],
-                          "additionalProperties": false
-                        }
-                      ]
-                    }
-                  },
-                  "errorSchema": {
-                    "not": {}
-                  },
-                  "failureEvent": "effect/httpapi/stream/failure"
+                  "$ref": "#/components/schemas/ResourceChangedEventJsonEncoding"
                 }
               }
             }
@@ -1265,7 +1175,7 @@
             }
           }
         },
-        "description": "Demand-driven directory health check with a bounded timeout. Takes a server-host absolute path; the result is never persisted."
+        "description": "Demand-driven directory health check with a bounded timeout. Takes a server-host absolute path; the result is never persisted. A timed-out check is deliberately a 200 with state \"unknown\" and reason \"timeout\" — the check is a report, so an inconclusive result is still a successful report — while /fs/list models the same timeout as a 422 error, because a listing cannot be partially delivered."
       }
     },
     "/api/v1/fs/list": {
@@ -1992,25 +1902,11 @@
           "detectedVersion": {
             "type": "string",
             "description": "Installed CLI version, when it could be determined."
-          },
-          "testedVersion": {
-            "type": "string",
-            "description": "Version the adapter was validated against (drift warns, never blocks)."
-          },
-          "tuiObservation": {
-            "type": "string",
-            "enum": [
-              "shared-server",
-              "hooks"
-            ],
-            "description": "How live activity is observed while a TUI drives a session: full event fan-out from the shared provider server, or coarser provider hook callbacks."
           }
         },
         "required": [
           "id",
-          "available",
-          "testedVersion",
-          "tuiObservation"
+          "available"
         ],
         "additionalProperties": false,
         "description": "A built-in agent provider: availability and capability report, detected on demand and never persisted."
@@ -2169,9 +2065,20 @@
         "description": "Thin invalidation event: names what changed, never carries resource state. Clients coalesce events and refetch through the corresponding GETs, which stay the single source of truth."
       }
     },
-    "securitySchemes": {}
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Required for every non-loopback request; loopback requests are trusted without credentials."
+      }
+    }
   },
-  "security": [],
+  "security": [
+    {},
+    {
+      "bearerAuth": []
+    }
+  ],
   "tags": [
     {
       "name": "v1"

--- a/app-server/src/agents/agentAdapter.ts
+++ b/app-server/src/agents/agentAdapter.ts
@@ -137,12 +137,6 @@ export interface AgentTurn {
 export interface AgentCapabilities {
   /** Provider version the adapter was validated against (drift warns, never blocks). */
   readonly testedVersion: string
-  /**
-   * How live activity is observed while a TUI drives the session:
-   * `shared-server` = full event fan-out from the multiplexed provider
-   * server; `hooks` = provider hook callbacks (coarser).
-   */
-  readonly tuiObservation: "shared-server" | "hooks"
 }
 
 /**

--- a/app-server/src/agents/agentAdapter.ts
+++ b/app-server/src/agents/agentAdapter.ts
@@ -133,12 +133,6 @@ export interface AgentTurn {
   readonly turnId: string
 }
 
-/** What an adapter supports, for callers that must not guess. */
-export interface AgentCapabilities {
-  /** Provider version the adapter was validated against (drift warns, never blocks). */
-  readonly testedVersion: string
-}
-
 /**
  * How to launch the provider's TUI attached to an existing session. The
  * caller owns the actual launch (a Terminal session); the adapter owns argv
@@ -262,7 +256,6 @@ export interface PreparedTuiSession {
  */
 export interface AgentAdapter {
   readonly provider: AgentProvider
-  readonly capabilities: AgentCapabilities
   /**
    * Create a new provider session in `cwd` and start its first turn. The
    * provider's echoed working directory is verified like resume's — a

--- a/app-server/src/agents/agentRegistry.ts
+++ b/app-server/src/agents/agentRegistry.ts
@@ -49,24 +49,19 @@ export const layer = Layer.effect(AgentRegistry)(
     }
 
     const describe = (id: typeof AgentId.Type): Effect.Effect<Agent> => {
-      const { adapter, executable } = entries[id]
-      const base = {
-        id,
-        testedVersion: adapter.capabilities.testedVersion,
-        tuiObservation: adapter.capabilities.tuiObservation,
-      }
+      const { executable } = entries[id]
       return resolveProviderExecutable(PROVIDER_FOR_AGENT[id], executable).pipe(
         Effect.flatMap((executable) =>
           readInstalledVersion(subprocess, executable).pipe(
             Effect.map((detected) => ({
-              ...base,
+              id,
               available: true,
               ...(detected !== null ? { detectedVersion: detected } : {}),
             })),
           ),
         ),
         Effect.catchTag("AgentUnavailable", (error) =>
-          Effect.succeed({ ...base, available: false, reason: error.reason }),
+          Effect.succeed({ id, available: false, reason: error.reason }),
         ),
       )
     }

--- a/app-server/src/agents/claudeAdapter.ts
+++ b/app-server/src/agents/claudeAdapter.ts
@@ -700,7 +700,6 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
 
       const adapter: AgentAdapter = {
         provider: "claude",
-        capabilities: { testedVersion: CLAUDE_TESTED_VERSION },
         createSession: (options) =>
           Effect.gen(function* () {
             const session = yield* openSession({ cwd: options.cwd })

--- a/app-server/src/agents/claudeAdapter.ts
+++ b/app-server/src/agents/claudeAdapter.ts
@@ -700,7 +700,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
 
       const adapter: AgentAdapter = {
         provider: "claude",
-        capabilities: { testedVersion: CLAUDE_TESTED_VERSION, tuiObservation: "hooks" },
+        capabilities: { testedVersion: CLAUDE_TESTED_VERSION },
         createSession: (options) =>
           Effect.gen(function* () {
             const session = yield* openSession({ cwd: options.cwd })

--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -854,7 +854,6 @@ export const layer = Layer.effect(CodexAdapter)(
 
     const adapter: AgentAdapter = {
       provider: "codex",
-      capabilities: { testedVersion: CODEX_TESTED_VERSION },
       createSession: (options) =>
         Effect.gen(function* () {
           // thread/start broadcasts thread/started to every socket — ours

--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -854,7 +854,7 @@ export const layer = Layer.effect(CodexAdapter)(
 
     const adapter: AgentAdapter = {
       provider: "codex",
-      capabilities: { testedVersion: CODEX_TESTED_VERSION, tuiObservation: "shared-server" },
+      capabilities: { testedVersion: CODEX_TESTED_VERSION },
       createSession: (options) =>
         Effect.gen(function* () {
           // thread/start broadcasts thread/started to every socket — ours

--- a/app-server/src/api/client.ts
+++ b/app-server/src/api/client.ts
@@ -1,4 +1,5 @@
 import type { Effect } from "effect"
+import { HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { HttpApiClient } from "effect/unstable/httpapi"
 import { Api } from "./contract.ts"
 
@@ -10,8 +11,20 @@ import { Api } from "./contract.ts"
 /**
  * Build a client for the App Server at `baseUrl`. Requires an `HttpClient`
  * (e.g. `BunHttpClient.layer`) in the environment.
+ *
+ * `token` is the bearer token non-loopback servers require (the documented
+ * `bearerAuth` scheme); loopback servers ignore it.
  */
-export const make = (options: { readonly baseUrl: string | URL }) =>
-  HttpApiClient.make(Api, { baseUrl: options.baseUrl })
+export const make = (options: {
+  readonly baseUrl: string | URL
+  readonly token?: string | undefined
+}) =>
+  HttpApiClient.make(Api, {
+    baseUrl: options.baseUrl,
+    transformClient:
+      options.token === undefined
+        ? undefined
+        : HttpClient.mapRequest(HttpClientRequest.bearerToken(options.token)),
+  })
 
 export type AppServerClient = Effect.Success<ReturnType<typeof make>>

--- a/app-server/src/api/contract.ts
+++ b/app-server/src/api/contract.ts
@@ -249,13 +249,6 @@ export const Agent = Schema.Struct({
       description: "Installed CLI version, when it could be determined.",
     }),
   ),
-  testedVersion: Schema.String.annotate({
-    description: "Version the adapter was validated against (drift warns, never blocks).",
-  }),
-  tuiObservation: Schema.Literals(["shared-server", "hooks"]).annotate({
-    description:
-      "How live activity is observed while a TUI drives a session: full event fan-out from the shared provider server, or coarser provider hook callbacks.",
-  }),
 }).annotate({
   identifier: "Agent",
   description:
@@ -627,10 +620,18 @@ export class V1 extends HttpApiGroup.make("v1")
         OpenApi.Description,
         "Delete the project and everything it owns: every thread (archived included) and every terminal (ended tombstones included) is deleted through the normal delete flows, then the project record. Never touches the filesystem or any directory. A mid-cascade failure leaves already-deleted children deleted; retrying finishes the job.",
       ),
+    // No listing endpoint paginates, deliberately: a single-user server's
+    // collections stay small enough to return whole, and every client
+    // consumes full lists. Revisit only when a real client needs paging.
     HttpApiEndpoint.get("listTerminals", "/terminals", {
       query: {
         projectId: Schema.optionalKey(
           Schema.String.annotate({ description: "Restrict the listing to one project." }),
+        ),
+        threadId: Schema.optionalKey(
+          Schema.String.annotate({
+            description: "Restrict the listing to one thread's terminals.",
+          }),
         ),
       },
       success: TerminalList,
@@ -710,8 +711,10 @@ export class V1 extends HttpApiGroup.make("v1")
           Schema.String.annotate({ description: "Restrict the listing to one project." }),
         ),
         archived: Schema.optionalKey(
-          Schema.Literals(["true", "false"]).annotate({
-            description: '"true" lists archived threads only; the default lists active threads.',
+          Schema.Literals(["true", "false", "all"]).annotate({
+            description:
+              '"true" lists archived threads only, "all" lists active and archived together; ' +
+              'omitted (or "false") lists active threads only.',
           }),
         ),
       },
@@ -827,6 +830,10 @@ export class V1 extends HttpApiGroup.make("v1")
       success: HttpApiSchema.StreamSse({ data: ResourceChangedEvent }),
     })
       .annotate(OpenApi.Identifier, "subscribeEvents")
+      // The generated 200 for this endpoint documents StreamSse's decoded
+      // frame envelope, not the data-only bytes the server actually emits —
+      // openapi.ts (withDataOnlySseResponse) replaces it with the wire-true
+      // shape, and openapi.test.ts pins that documented shape to the bytes.
       .annotate(
         OpenApi.Description,
         "Subscribe to live resource-change events (SSE). The stream is ephemeral — no replay. " +
@@ -844,7 +851,10 @@ export class V1 extends HttpApiGroup.make("v1")
       .annotate(OpenApi.Identifier, "checkDirectory")
       .annotate(
         OpenApi.Description,
-        "Demand-driven directory health check with a bounded timeout. Takes a server-host absolute path; the result is never persisted.",
+        "Demand-driven directory health check with a bounded timeout. Takes a server-host absolute path; the result is never persisted. " +
+          'A timed-out check is deliberately a 200 with state "unknown" and reason "timeout" — the check is a report, so an inconclusive ' +
+          "result is still a successful report — while /fs/list models the same timeout as a 422 error, because a listing cannot be " +
+          "partially delivered.",
       ),
     HttpApiEndpoint.get("listDirectory", "/fs/list", {
       query: {
@@ -885,5 +895,24 @@ export class Api extends HttpApi.make("atc")
           variables: { port: { default: `${DEFAULT_PORT}` } },
         },
       ],
+      // The server gates every non-loopback request on a bearer token
+      // (localTrust.ts); loopback requests need no credentials. The empty
+      // requirement documents that anonymous (loopback) access is valid, so
+      // generated clients treat the token as optional but know how to send it.
+      transform: (spec) => ({
+        ...spec,
+        security: [{}, { bearerAuth: [] }],
+        components: {
+          ...(spec["components"] as Record<string, unknown>),
+          securitySchemes: {
+            bearerAuth: {
+              type: "http",
+              scheme: "bearer",
+              description:
+                "Required for every non-loopback request; loopback requests are trusted without credentials.",
+            },
+          },
+        },
+      }),
     }),
   ) {}

--- a/app-server/src/api/contract.ts
+++ b/app-server/src/api/contract.ts
@@ -11,6 +11,10 @@ import {
 // checked-in OpenAPI document (openapi.ts), and typed clients all derive from
 // this module. Authoring conventions (pinned operation ids, schema
 // identifiers, descriptions) live in AGENTS.md "OpenAPI Contract".
+//
+// No listing endpoint paginates, deliberately: a single-user server's
+// collections stay small enough to return whole, and every client consumes
+// full lists. Revisit only when a real client needs paging.
 
 /** Default TCP port of a locally running App Server. */
 export const DEFAULT_PORT = 7331
@@ -252,7 +256,7 @@ export const Agent = Schema.Struct({
 }).annotate({
   identifier: "Agent",
   description:
-    "A built-in agent provider: availability and capability report, detected on demand and never persisted.",
+    "A built-in agent provider: availability report, detected on demand and never persisted.",
 })
 
 export const AgentList = Schema.Array(Agent).annotate({
@@ -620,9 +624,6 @@ export class V1 extends HttpApiGroup.make("v1")
         OpenApi.Description,
         "Delete the project and everything it owns: every thread (archived included) and every terminal (ended tombstones included) is deleted through the normal delete flows, then the project record. Never touches the filesystem or any directory. A mid-cascade failure leaves already-deleted children deleted; retrying finishes the job.",
       ),
-    // No listing endpoint paginates, deliberately: a single-user server's
-    // collections stay small enough to return whole, and every client
-    // consumes full lists. Revisit only when a real client needs paging.
     HttpApiEndpoint.get("listTerminals", "/terminals", {
       query: {
         projectId: Schema.optionalKey(
@@ -817,7 +818,7 @@ export class V1 extends HttpApiGroup.make("v1")
       .annotate(OpenApi.Identifier, "listAgents")
       .annotate(
         OpenApi.Description,
-        "List the built-in agents with availability and capabilities, detected on demand.",
+        "List the built-in agents with availability, detected on demand.",
       ),
     HttpApiEndpoint.get("getAgent", "/agents/:agentId", {
       params: { agentId: Schema.String },
@@ -898,13 +899,17 @@ export class Api extends HttpApi.make("atc")
       // The server gates every non-loopback request on a bearer token
       // (localTrust.ts); loopback requests need no credentials. The empty
       // requirement documents that anonymous (loopback) access is valid, so
-      // generated clients treat the token as optional but know how to send it.
+      // generated clients treat the token as optional but know how to send
+      // it. The generator stamps `security: []` on every operation, and an
+      // operation-level array overrides the document default (OpenAPI 3.1),
+      // so those empty arrays must go for the default to mean anything.
       transform: (spec) => ({
         ...spec,
         security: [{}, { bearerAuth: [] }],
         components: {
-          ...(spec["components"] as Record<string, unknown>),
+          ...spec["components"],
           securitySchemes: {
+            ...spec["components"]["securitySchemes"],
             bearerAuth: {
               type: "http",
               scheme: "bearer",
@@ -913,6 +918,22 @@ export class Api extends HttpApi.make("atc")
             },
           },
         },
+        paths: Object.fromEntries(
+          Object.entries(spec["paths"] as Record<string, Record<string, unknown>>).map(
+            ([path, operations]) => [
+              path,
+              Object.fromEntries(
+                Object.entries(operations).map(([method, operation]) => {
+                  const { security, ...rest } = operation as { security?: ReadonlyArray<unknown> }
+                  return [
+                    method,
+                    security === undefined || security.length === 0 ? rest : { ...rest, security },
+                  ]
+                }),
+              ),
+            ],
+          ),
+        ),
       }),
     }),
   ) {}

--- a/app-server/src/api/handlers.ts
+++ b/app-server/src/api/handlers.ts
@@ -54,7 +54,9 @@ export const V1Handlers = HttpApiBuilder.group(
         .handle("deleteProject", ({ params }) => projects.delete(params.projectId))
         .handle("checkDirectory", ({ query }) => directories.check(query.path))
         .handle("listDirectory", ({ query }) => directories.list(query.path))
-        .handle("listTerminals", ({ query }) => terminals.list(query.projectId))
+        .handle("listTerminals", ({ query }) =>
+          terminals.list({ projectId: query.projectId, threadId: query.threadId }),
+        )
         .handle("createTerminal", ({ payload }) => terminals.create(payload))
         .handle("getTerminal", ({ params }) => terminals.get(params.terminalId))
         .handle("updateTerminal", ({ params, payload }) =>
@@ -62,7 +64,11 @@ export const V1Handlers = HttpApiBuilder.group(
         )
         .handle("deleteTerminal", ({ params }) => terminals.delete(params.terminalId))
         .handle("listThreads", ({ query }) =>
-          threads.list({ projectId: query.projectId, archived: query.archived === "true" }),
+          threads.list({
+            projectId: query.projectId,
+            archived:
+              query.archived === "true" ? "archived" : query.archived === "all" ? "all" : "active",
+          }),
         )
         .handle("createThread", ({ payload }) => threads.create(payload))
         .handle("getThread", ({ params }) => threads.get(params.threadId))

--- a/app-server/src/api/openapi.ts
+++ b/app-server/src/api/openapi.ts
@@ -73,8 +73,55 @@ const withSsePayloadComponents = (document: ReturnType<typeof OpenApi.fromApi>) 
   } as ReturnType<typeof OpenApi.fromApi>
 }
 
+/**
+ * Replace the generated `/events` 200 with the shape that actually crosses
+ * the wire. The generator documents StreamSse's decoded frame envelope
+ * ({id, event, data}, all required), but the server emits data-only frames
+ * (`data: <json>`) plus `: connected` / `: heartbeat` comment lines — a
+ * strict decoder generated from the envelope would reject every real frame.
+ * The replacement declares the per-frame data payload (the JSON-encoded
+ * ResourceChangedEvent string) and states the full framing protocol in the
+ * response description; openapi.test.ts pins this documented shape to the
+ * emitted bytes. The guard fails generation loudly if the endpoint moves.
+ */
+const withDataOnlySseResponse = (document: ReturnType<typeof OpenApi.fromApi>) => {
+  const paths = document.paths as Record<string, { get?: { responses?: Record<string, unknown> } }>
+  const operation = paths["/api/v1/events"]?.get
+  if (operation?.responses?.["200"] === undefined) {
+    throw new Error("no GET /api/v1/events 200 response to replace; did the endpoint move?")
+  }
+  const response = {
+    description:
+      "A data-only SSE byte stream. Each event is a single `data:` line whose payload is a " +
+      "JSON-encoded ResourceChangedEvent (see that component schema); frames never carry `id:` " +
+      "or `event:` lines. Comment lines are protocol control, ignored by conforming SSE " +
+      "parsers: the stream opens with `: connected` (the resync handshake) and a `: heartbeat` " +
+      "follows roughly every 25 seconds. Example:\n\n" +
+      "```\n" +
+      ": connected\n\n" +
+      ": heartbeat\n\n" +
+      'data: {"resource":"thread","id":"0198aaf1","change":"updated"}\n' +
+      "```",
+    content: {
+      "text/event-stream": {
+        schema: { $ref: "#/components/schemas/ResourceChangedEventJsonEncoding" },
+      },
+    },
+  }
+  return {
+    ...document,
+    paths: {
+      ...paths,
+      "/api/v1/events": {
+        ...paths["/api/v1/events"],
+        get: { ...operation, responses: { ...operation.responses, "200": response } },
+      },
+    },
+  } as unknown as ReturnType<typeof OpenApi.fromApi>
+}
+
 export const openApiDocument = hoistSingleAllOf(
-  withSsePayloadComponents(OpenApi.fromApi(Api)),
+  withDataOnlySseResponse(withSsePayloadComponents(OpenApi.fromApi(Api))),
 ) as ReturnType<typeof OpenApi.fromApi>
 
 /**

--- a/app-server/src/terminals/terminals.ts
+++ b/app-server/src/terminals/terminals.ts
@@ -64,7 +64,10 @@ export class Terminals extends Context.Service<
   Terminals,
   {
     /** Reconciled listing; an unavailable inventory returns stored state. */
-    readonly list: (projectId?: string) => Effect.Effect<ReadonlyArray<Terminal>>
+    readonly list: (options?: {
+      readonly projectId?: string | undefined
+      readonly threadId?: string | undefined
+    }) => Effect.Effect<ReadonlyArray<Terminal>>
     /** Reconciled read. */
     readonly get: (id: string) => Effect.Effect<Terminal, TerminalNotFound>
     /**
@@ -324,14 +327,15 @@ export const layer = Layer.effect(Terminals)(
       })
 
     return {
-      list: (projectId) =>
+      list: (options) =>
         reconciledRecords.pipe(
           Effect.map((records) =>
             records
               .filter(
                 (record) =>
                   record.status !== "starting" &&
-                  (projectId === undefined || record.projectId === projectId),
+                  (options?.projectId === undefined || record.projectId === options.projectId) &&
+                  (options?.threadId === undefined || record.threadId === options.threadId),
               )
               .map(toTerminal),
           ),

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -116,10 +116,10 @@ export interface ThreadsOptions {
 export class Threads extends Context.Service<
   Threads,
   {
-    /** Listing, newest first; archived threads only on request. */
+    /** Listing, newest first; active-only unless a wider archive scope is asked for. */
     readonly list: (options?: {
       readonly projectId?: string | undefined
-      readonly archived?: boolean | undefined
+      readonly archived?: "active" | "archived" | "all" | undefined
     }) => Effect.Effect<ReadonlyArray<Thread>>
     readonly get: (id: string) => Effect.Effect<Thread, ThreadNotFound>
     /** Write the durable record; no provider call (see the header). */
@@ -408,7 +408,7 @@ export const layerWith = (options: ThreadsOptions) =>
        */
       const linkedFor = (record: ThreadRecord): Effect.Effect<Terminal | undefined> =>
         terminals
-          .list(record.projectId)
+          .list({ projectId: record.projectId })
           .pipe(
             Effect.map((list) => list.find((t) => t.threadId === record.id && t.status === "live")),
           )
@@ -719,7 +719,7 @@ export const layerWith = (options: ThreadsOptions) =>
             // Ended linked terminals survive as unlinked tombstones (FK SET
             // NULL) — their client-visible threadId changes with the delete,
             // so each publishes alongside the thread's own event.
-            const orphaned = (yield* terminals.list(record.projectId)).filter(
+            const orphaned = (yield* terminals.list({ projectId: record.projectId })).filter(
               (terminal) => terminal.threadId === id,
             )
             yield* repository.delete(id)
@@ -735,15 +735,18 @@ export const layerWith = (options: ThreadsOptions) =>
         list: (listOptions) =>
           Effect.gen(function* () {
             const records = yield* repository.list(listOptions?.projectId)
-            const wanted = records.filter((record) =>
-              listOptions?.archived === true
-                ? record.archivedAt !== undefined
-                : record.archivedAt === undefined,
+            const scope = listOptions?.archived ?? "active"
+            const wanted = records.filter(
+              (record) =>
+                scope === "all" ||
+                (scope === "archived"
+                  ? record.archivedAt !== undefined
+                  : record.archivedAt === undefined),
             )
             if (wanted.length === 0) return []
             // One reconciled inventory pass for the whole page.
             const linked = new Map<string, Terminal>()
-            for (const terminal of yield* terminals.list(listOptions?.projectId)) {
+            for (const terminal of yield* terminals.list({ projectId: listOptions?.projectId })) {
               // Newest first, first write wins — the same pick linkedFor makes.
               if (
                 terminal.threadId !== undefined &&

--- a/app-server/test/agents/agentRegistry.test.ts
+++ b/app-server/test/agents/agentRegistry.test.ts
@@ -13,8 +13,8 @@ import { makeTestServiceLayers, testAppConfig } from "../testLayers.ts"
 import { makeFakeAgentAdapter } from "./fakeAgentAdapter.ts"
 
 // The read-only agents registry through the public contract (ATC-140):
-// demand-driven detection over the fake adapters, capability report from
-// the seam, unknown slugs 404. Nothing is persisted anywhere.
+// demand-driven availability detection over the fake adapters, unknown
+// slugs 404. Nothing is persisted anywhere.
 
 const kit = makeTestServiceLayers()
 const TestLayer = Layer.mergeAll(
@@ -24,7 +24,7 @@ const TestLayer = Layer.mergeAll(
 )
 
 describe("/api/v1/agents", () => {
-  it.effect("lists both built-in agents with each adapter's own capability report", () =>
+  it.effect("lists both built-in agents with availability", () =>
     Effect.gen(function* () {
       const client = yield* HttpApiTest.groups(Api, ["v1"])
       const agents = yield* client.v1.listAgents()

--- a/app-server/test/agents/agentRegistry.test.ts
+++ b/app-server/test/agents/agentRegistry.test.ts
@@ -28,17 +28,9 @@ describe("/api/v1/agents", () => {
     Effect.gen(function* () {
       const client = yield* HttpApiTest.groups(Api, ["v1"])
       const agents = yield* client.v1.listAgents()
-      // Per-slug capabilities: a swapped slug→adapter mapping fails here.
       assert.deepStrictEqual(
-        agents.map(({ id, testedVersion, tuiObservation }) => ({
-          id,
-          testedVersion,
-          tuiObservation,
-        })),
-        [
-          { id: "codex", testedVersion: "0.0.0-fake", tuiObservation: "shared-server" },
-          { id: "claude-code", testedVersion: "0.0.0-fake-claude", tuiObservation: "hooks" },
-        ],
+        agents.map(({ id }) => id),
+        ["codex", "claude-code"],
       )
       // /bin/echo resolves, so both are available.
       for (const agent of agents) {

--- a/app-server/test/agents/fakeAgentAdapter.ts
+++ b/app-server/test/agents/fakeAgentAdapter.ts
@@ -238,7 +238,6 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
     provider: "codex",
     capabilities: {
       testedVersion: "0.0.0-fake",
-      tuiObservation: "shared-server",
       ...options.capabilities,
     },
     createSession: (options) =>

--- a/app-server/test/agents/fakeAgentAdapter.ts
+++ b/app-server/test/agents/fakeAgentAdapter.ts
@@ -80,11 +80,6 @@ export interface FakeAgentAdapter {
   readonly released: Array<{ providerSessionId: string; providerMetadata: string | undefined }>
 }
 
-export interface FakeAgentAdapterOptions {
-  /** Capability report overrides, so registry tests can tell fakes apart. */
-  readonly capabilities?: Partial<AgentAdapter["capabilities"]>
-}
-
 interface LiveConnection {
   readonly events: Queue.Queue<AgentEvent, Cause.Done>
   activity: AgentActivity
@@ -93,7 +88,7 @@ interface LiveConnection {
   readonly openRequests: Set<string>
 }
 
-export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): FakeAgentAdapter => {
+export const makeFakeAgentAdapter = (): FakeAgentAdapter => {
   const sessions = new Map<string, FakeAgentSession>()
   // One live connection per session — the single-writer rule.
   const connections = new Map<string, LiveConnection>()
@@ -236,10 +231,6 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
 
   const adapter: AgentAdapter = {
     provider: "codex",
-    capabilities: {
-      testedVersion: "0.0.0-fake",
-      ...options.capabilities,
-    },
     createSession: (options) =>
       Effect.gen(function* () {
         yield* requireAvailable

--- a/app-server/test/api/client.test.ts
+++ b/app-server/test/api/client.test.ts
@@ -1,6 +1,7 @@
 import { assert, describe, it } from "@effect/vitest"
 import { BunHttpClient, BunServices } from "@effect/platform-bun"
 import { Effect, Layer } from "effect"
+import { HttpClient, HttpClientResponse } from "effect/unstable/http"
 import * as Client from "../../src/api/client.ts"
 import * as Server from "../../src/server.ts"
 import { freePort } from "../blackbox.ts"
@@ -27,6 +28,23 @@ describe("contract-derived client", () => {
         assert.deepStrictEqual(yield* client.v1.health(), { status: "ok" })
       }),
     ).pipe(Effect.provide([BunHttpClient.layer, BunServices.layer])),
+  )
+
+  it.effect("attaches the bearer token to every request", () =>
+    Effect.gen(function* () {
+      // No listener needed: capture the outgoing request at the HttpClient
+      // seam and assert the documented bearerAuth header is attached.
+      let authorization: string | undefined
+      const capture = HttpClient.make((request) => {
+        authorization = request.headers["authorization"]
+        return Effect.succeed(HttpClientResponse.fromWeb(request, Response.json({ status: "ok" })))
+      })
+      const client = yield* Client.make({ baseUrl: "http://127.0.0.1", token: "secret" }).pipe(
+        Effect.provideService(HttpClient.HttpClient, capture),
+      )
+      assert.deepStrictEqual(yield* client.v1.health(), { status: "ok" })
+      assert.strictEqual(authorization, "Bearer secret")
+    }),
   )
 
   it.effect("calls version against a real server", () =>

--- a/app-server/test/api/openapi.test.ts
+++ b/app-server/test/api/openapi.test.ts
@@ -1,11 +1,12 @@
 import { assert, describe, it } from "@effect/vitest"
 import { BunHttpServer } from "@effect/platform-bun"
-import { Context, Effect, Layer, Option } from "effect"
+import { Context, Effect, Exit, Layer, Option, Scope } from "effect"
 import {
   HttpBody,
   HttpClient,
   HttpClientRequest,
   HttpRouter,
+  HttpServer,
   HttpServerRequest,
   HttpServerResponse,
 } from "effect/unstable/http"
@@ -74,6 +75,21 @@ describe("openapi document", () => {
       openApiJson,
       "openapi.json is stale — run `mise run openapi` and commit the result",
     )
+  })
+
+  it("documents the optional bearer security scheme", () => {
+    // The server gates every non-loopback request on a bearer token
+    // (localTrust.ts). The empty requirement documents that anonymous
+    // (loopback) access is valid, so generated clients treat the token as
+    // optional but know how to send it.
+    const document = openApiDocument as unknown as {
+      security: ReadonlyArray<Record<string, unknown>>
+      components: { securitySchemes: Record<string, { type: string; scheme: string }> }
+    }
+    assert.deepStrictEqual(document.security, [{}, { bearerAuth: [] }])
+    const scheme = document.components.securitySchemes["bearerAuth"]!
+    assert.strictEqual(scheme.type, "http")
+    assert.strictEqual(scheme.scheme, "bearer")
   })
 
   it("documents every contract operation exactly once, with pinned camelCase ids", () => {
@@ -490,33 +506,78 @@ describe("openapi document vs runtime", () => {
     }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
   )
 
-  it.effect("GET /api/v1/events serves the documented SSE stream", () =>
+  // it.live: real socket I/O — the point is pinning the *documented* frame
+  // shape to the exact bytes a real subscriber receives (H3): data-only
+  // frames plus comment lines, never the id/event envelope fields.
+  it.live("GET /api/v1/events: the documented data-only SSE shape matches the emitted bytes", () =>
     Effect.gen(function* () {
-      const response = yield* (yield* rawClient).get("http://127.0.0.1/api/v1/events")
-      assert.strictEqual(response.status, 200)
-      assert.match(response.headers["content-type"] ?? "", /^text\/event-stream/)
-
-      // The documented payload is the SSE envelope whose data line carries a
-      // JSON-encoded ResourceChangedEvent...
+      // The document declares each frame's payload as the JSON-encoded
+      // ResourceChangedEvent string...
       const content = operation("/api/v1/events").responses["200"]!.content["text/event-stream"]!
-      const envelope = content.schema as unknown as {
-        properties: { data: { $ref?: string } }
-      }
-      assert.deepStrictEqual(envelope.properties.data, {
+      assert.deepStrictEqual(content.schema as unknown, {
         $ref: "#/components/schemas/ResourceChangedEventJsonEncoding",
       })
       assert.deepStrictEqual(componentSchema("ResourceChangedEventJsonEncoding") as unknown, {
         type: "string",
         contentMediaType: "application/json",
       })
-
+      // ...the comment protocol is documented where clients will read it...
+      const description = (
+        operation("/api/v1/events").responses["200"]! as unknown as { description: string }
+      ).description
+      for (const token of [": connected", ": heartbeat", "`data:`"]) {
+        assert.include(description, token)
+      }
       // ...and the plain payload schema is emitted as an ordinary component
       // (openapi.ts), so generated clients get a real model type to decode
-      // that JSON into. Delivery itself is covered in api.test.ts.
+      // that JSON into.
       const payload = componentSchema("ResourceChangedEvent")
       assert.sameMembers(Object.keys(payload.properties), ["resource", "id", "change"])
       assert.sameMembers([...payload.required], ["resource", "id", "change"])
-    }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
+
+      // Now the bytes: a real subscriber sees the documented opening
+      // comment, then a bare `data:` frame whose JSON carries exactly the
+      // documented payload fields — no `id:` or `event:` lines.
+      const scope = yield* Scope.make()
+      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
+      const context = yield* Layer.build(
+        Server.layer({ port: 0 }).pipe(Layer.provide([TestBuildInfoLayer, TestRepositoryLayers])),
+      ).pipe(Effect.provideService(Scope.Scope, scope))
+      const address = Context.get(context, HttpServer.HttpServer).address
+      assert.strictEqual(address._tag, "TcpAddress")
+      const base = `http://127.0.0.1:${(address as { port: number }).port}`
+
+      const response = yield* Effect.promise(() =>
+        fetch(`${base}/api/v1/events`, { headers: { accept: "text/event-stream" } }),
+      )
+      assert.match(response.headers.get("content-type") ?? "", /^text\/event-stream/)
+      const reader = response.body!.getReader()
+      const opening = yield* Effect.promise(() => reader.read())
+      assert.strictEqual(new TextDecoder().decode(opening.value), ": connected\n\n")
+
+      const created = yield* Effect.promise(() =>
+        fetch(`${base}/api/v1/projects`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ name: "SseShape", defaultWorkingDirectory: "/tmp" }),
+        }).then((r) => r.json() as Promise<{ id: string }>),
+      )
+      const decoder = new TextDecoder()
+      let raw = ""
+      for (let attempt = 0; !raw.includes("\n\n"); attempt++) {
+        assert.isBelow(attempt, 10, `no frame arrived; saw ${JSON.stringify(raw)}`)
+        const chunk = yield* Effect.promise(() => reader.read())
+        assert.isFalse(chunk.done, "the stream ended before delivering the event")
+        raw += decoder.decode(chunk.value, { stream: true })
+      }
+      const frame = raw.slice(0, raw.indexOf("\n\n"))
+      const lines = frame.split("\n")
+      assert.strictEqual(lines.length, 1, `expected a single data line, got ${frame}`)
+      assert.match(lines[0]!, /^data: /, "the frame must be data-only")
+      const event = JSON.parse(lines[0]!.slice("data: ".length)) as Record<string, unknown>
+      assert.sameMembers(Object.keys(event), ["resource", "id", "change"])
+      assert.deepStrictEqual(event, { resource: "project", id: created.id, change: "created" })
+    }),
   )
 
   it.effect("GET /api/v1/fs/check returns the documented payload", () =>

--- a/app-server/test/api/openapi.test.ts
+++ b/app-server/test/api/openapi.test.ts
@@ -1,12 +1,11 @@
 import { assert, describe, it } from "@effect/vitest"
 import { BunHttpServer } from "@effect/platform-bun"
-import { Context, Effect, Exit, Layer, Option, Scope } from "effect"
+import { Context, Effect, Layer, Option } from "effect"
 import {
   HttpBody,
   HttpClient,
   HttpClientRequest,
   HttpRouter,
-  HttpServer,
   HttpServerRequest,
   HttpServerResponse,
 } from "effect/unstable/http"
@@ -17,7 +16,7 @@ import { openApiDocument, openApiJson } from "../../src/api/openapi.ts"
 import * as Server from "../../src/server.ts"
 import { appServerRoot } from "../blackbox.ts"
 import { TestBuildInfoLayer, testBuildInfo } from "../testBuildInfo.ts"
-import { TestAuthTokenLayer, TestRepositoryLayers } from "../testLayers.ts"
+import { startServer, TestAuthTokenLayer, TestRepositoryLayers } from "../testLayers.ts"
 
 // Contract-generation tests: the document must be deterministic, match the
 // checked-in artifact, cover every contract operation, and agree with what
@@ -85,11 +84,20 @@ describe("openapi document", () => {
     const document = openApiDocument as unknown as {
       security: ReadonlyArray<Record<string, unknown>>
       components: { securitySchemes: Record<string, { type: string; scheme: string }> }
+      paths: Record<string, Record<string, { security?: unknown }>>
     }
     assert.deepStrictEqual(document.security, [{}, { bearerAuth: [] }])
     const scheme = document.components.securitySchemes["bearerAuth"]!
     assert.strictEqual(scheme.type, "http")
     assert.strictEqual(scheme.scheme, "bearer")
+    // An operation-level `security` array overrides the document default
+    // (OpenAPI 3.1), so no operation may carry one — the generator's empty
+    // stamps would silently declare every operation credential-free.
+    for (const [path, operations] of Object.entries(document.paths)) {
+      for (const [method, operation] of Object.entries(operations)) {
+        assert.notProperty(operation, "security", `${method.toUpperCase()} ${path}`)
+      }
+    }
   })
 
   it("documents every contract operation exactly once, with pinned camelCase ids", () => {
@@ -507,8 +515,8 @@ describe("openapi document vs runtime", () => {
   )
 
   // it.live: real socket I/O — the point is pinning the *documented* frame
-  // shape to the exact bytes a real subscriber receives (H3): data-only
-  // frames plus comment lines, never the id/event envelope fields.
+  // shape to the exact bytes a real subscriber receives: data-only frames
+  // plus comment lines, never the id/event envelope fields.
   it.live("GET /api/v1/events: the documented data-only SSE shape matches the emitted bytes", () =>
     Effect.gen(function* () {
       // The document declares each frame's payload as the JSON-encoded
@@ -538,14 +546,9 @@ describe("openapi document vs runtime", () => {
       // Now the bytes: a real subscriber sees the documented opening
       // comment, then a bare `data:` frame whose JSON carries exactly the
       // documented payload fields — no `id:` or `event:` lines.
-      const scope = yield* Scope.make()
-      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
-      const context = yield* Layer.build(
+      const { base } = yield* startServer(
         Server.layer({ port: 0 }).pipe(Layer.provide([TestBuildInfoLayer, TestRepositoryLayers])),
-      ).pipe(Effect.provideService(Scope.Scope, scope))
-      const address = Context.get(context, HttpServer.HttpServer).address
-      assert.strictEqual(address._tag, "TcpAddress")
-      const base = `http://127.0.0.1:${(address as { port: number }).port}`
+      )
 
       const response = yield* Effect.promise(() =>
         fetch(`${base}/api/v1/events`, { headers: { accept: "text/event-stream" } }),

--- a/app-server/test/server.test.ts
+++ b/app-server/test/server.test.ts
@@ -1,32 +1,9 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Context, Effect, Exit, Layer, Scope } from "effect"
-import { HttpServer } from "effect/unstable/http"
 import * as Events from "../src/events/events.ts"
 import * as Server from "../src/server.ts"
 import { TestBuildInfoLayer } from "./testBuildInfo.ts"
-import { makeTestServiceLayers, TestRepositoryLayers } from "./testLayers.ts"
-
-/**
- * Build a server layer in its own closable scope — closable mid-test, and
- * the finalizer guarantees the listener dies even when an assertion fails
- * first. Returns the built context and the resolved loopback base URL.
- */
-const startServer = <R, E>(layer: Layer.Layer<R | HttpServer.HttpServer, E>) =>
-  Effect.gen(function* () {
-    const scope = yield* Scope.make()
-    yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
-    const context = yield* Layer.build(layer).pipe(Effect.provideService(Scope.Scope, scope))
-    const address = Context.get(context, HttpServer.HttpServer).address
-    if (address._tag !== "TcpAddress") {
-      return yield* Effect.die(`expected a TCP address, got ${address._tag}`)
-    }
-    return {
-      scope,
-      context,
-      hostname: address.hostname,
-      base: `http://127.0.0.1:${address.port}`,
-    }
-  })
+import { makeTestServiceLayers, startServer, TestRepositoryLayers } from "./testLayers.ts"
 
 describe("server layer", () => {
   // it.live: this test does real socket I/O, and the platform's shutdown

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -1,6 +1,7 @@
 import { assert } from "@effect/vitest"
 import { BunHttpServer, BunServices } from "@effect/platform-bun"
-import { Effect, Layer, Stream } from "effect"
+import { Context, Effect, Exit, Layer, Scope, Stream } from "effect"
+import { HttpServer } from "effect/unstable/http"
 import * as fs from "node:fs"
 import * as os from "node:os"
 import * as path from "node:path"
@@ -109,13 +110,9 @@ export const makeTestServiceLayers = (
   >
 } => {
   const fake = makeFakeAdapter()
-  // Distinct tested versions keep the two fake adapters distinguishable in
-  // logs and future assertions (capabilities no longer cross the wire).
   const fakeAgents = {
     codex: makeFakeAgentAdapter(),
-    claude: makeFakeAgentAdapter({
-      capabilities: { testedVersion: "0.0.0-fake-claude" },
-    }),
+    claude: makeFakeAgentAdapter(),
   }
   const base = Layer.mergeAll(
     ProjectRepository.layer,
@@ -245,6 +242,28 @@ export const makeFakeZmxSandbox = (vars: Record<string, string> = {}) => {
   fs.chmodSync(wrapper, 0o755)
   return { base, stateDir, wrapper }
 }
+
+/**
+ * Build a server layer in its own closable scope — closable mid-test, and
+ * the finalizer guarantees the listener dies even when an assertion fails
+ * first. Returns the built context and the resolved loopback base URL.
+ */
+export const startServer = <R, E>(layer: Layer.Layer<R | HttpServer.HttpServer, E>) =>
+  Effect.gen(function* () {
+    const scope = yield* Scope.make()
+    yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
+    const context = yield* Layer.build(layer).pipe(Effect.provideService(Scope.Scope, scope))
+    const address = Context.get(context, HttpServer.HttpServer).address
+    if (address._tag !== "TcpAddress") {
+      return yield* Effect.die(`expected a TCP address, got ${address._tag}`)
+    }
+    return {
+      scope,
+      context,
+      hostname: address.hostname,
+      base: `http://127.0.0.1:${address.port}`,
+    }
+  })
 
 /** Poll (real clock) until `predicate` accepts the effect's value; bounded. */
 export const eventually = <A, E>(effect: Effect.Effect<A, E>, predicate: (value: A) => boolean) =>

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -109,12 +109,12 @@ export const makeTestServiceLayers = (
   >
 } => {
   const fake = makeFakeAdapter()
-  // Distinct capability reports so a swapped slug→adapter mapping cannot
-  // pass the registry tests.
+  // Distinct tested versions keep the two fake adapters distinguishable in
+  // logs and future assertions (capabilities no longer cross the wire).
   const fakeAgents = {
     codex: makeFakeAgentAdapter(),
     claude: makeFakeAgentAdapter({
-      capabilities: { testedVersion: "0.0.0-fake-claude", tuiObservation: "hooks" },
+      capabilities: { testedVersion: "0.0.0-fake-claude" },
     }),
   }
   const base = Layer.mergeAll(

--- a/app-server/test/threads/threads.test.ts
+++ b/app-server/test/threads/threads.test.ts
@@ -139,6 +139,10 @@ describe("/api/v1/threads", () => {
         yield* client.v1.listThreads({ query: { projectId: project.id, archived: "all" } }),
         [canonical, archived],
       )
+      assert.deepStrictEqual(
+        yield* client.v1.listThreads({ query: { projectId: project.id, archived: "false" } }),
+        [canonical],
+      )
       const restored = yield* client.v1.unarchiveThread({ params: { threadId: created.id } })
       assert.isUndefined(restored.archivedAt)
       assert.isUndefined(restored.pinnedAt)
@@ -281,13 +285,20 @@ describe("/api/v1/threads", () => {
       yield* repository.markEnded([ended.id])
 
       // The threadId listing filter scopes to the thread's terminals —
-      // tombstones included — without a client-side pass.
+      // tombstones included — without a client-side pass, and it ANDs with
+      // projectId rather than widening it.
       assert.deepStrictEqual(
         (yield* client.v1.listTerminals({ query: { threadId: thread.id } })).map((t) => t.id),
         [ended.id, record.id],
       )
       assert.deepStrictEqual(
         yield* client.v1.listTerminals({ query: { threadId: "not-a-thread" } }),
+        [],
+      )
+      assert.deepStrictEqual(
+        yield* client.v1.listTerminals({
+          query: { projectId: "someone-else", threadId: thread.id },
+        }),
         [],
       )
 

--- a/app-server/test/threads/threads.test.ts
+++ b/app-server/test/threads/threads.test.ts
@@ -135,6 +135,10 @@ describe("/api/v1/threads", () => {
         yield* client.v1.listThreads({ query: { projectId: project.id, archived: "true" } }),
         [archived],
       )
+      assert.deepStrictEqual(
+        yield* client.v1.listThreads({ query: { projectId: project.id, archived: "all" } }),
+        [canonical, archived],
+      )
       const restored = yield* client.v1.unarchiveThread({ params: { threadId: created.id } })
       assert.isUndefined(restored.archivedAt)
       assert.isUndefined(restored.pinnedAt)
@@ -275,6 +279,17 @@ describe("/api/v1/threads", () => {
       })
       yield* repository.markLive(ended.id)
       yield* repository.markEnded([ended.id])
+
+      // The threadId listing filter scopes to the thread's terminals —
+      // tombstones included — without a client-side pass.
+      assert.deepStrictEqual(
+        (yield* client.v1.listTerminals({ query: { threadId: thread.id } })).map((t) => t.id),
+        [ended.id, record.id],
+      )
+      assert.deepStrictEqual(
+        yield* client.v1.listTerminals({ query: { threadId: "not-a-thread" } }),
+        [],
+      )
 
       yield* client.v1.deleteThread({ params: { threadId: thread.id } })
       // The live terminal's record and session are gone…

--- a/macos/ATC/Features/Threads/NewThreadSheet.swift
+++ b/macos/ATC/Features/Threads/NewThreadSheet.swift
@@ -332,7 +332,7 @@ struct NewThreadSheet: View {
         let detected = selectedRuntime?.agents.agents ?? []
         guard detected.isEmpty else { return detected }
         return AgentID.allCases.map {
-            Agent(id: $0, available: true, testedVersion: "", tuiObservation: .hooks)
+            Agent(id: $0, available: true)
         }
     }
 

--- a/macos/ATC/PreviewSupport/PreviewAppServerClient.swift
+++ b/macos/ATC/PreviewSupport/PreviewAppServerClient.swift
@@ -178,16 +178,12 @@ nonisolated struct PreviewAppServerClient: APIProtocol {
             Agent(
                 id: .codex,
                 available: true,
-                detectedVersion: "0.52.0",
-                testedVersion: "0.52.0",
-                tuiObservation: .sharedServer
+                detectedVersion: "0.52.0"
             ),
             Agent(
                 id: .claudeCode,
                 available: false,
-                reason: "Install the Claude Code CLI",
-                testedVersion: "2.1.0",
-                tuiObservation: .hooks
+                reason: "Install the Claude Code CLI"
             ),
         ]
     }

--- a/macos/ATCTests/NewThreadLauncherModelTests.swift
+++ b/macos/ATCTests/NewThreadLauncherModelTests.swift
@@ -33,9 +33,7 @@ struct NewThreadLauncherModelTests {
         Agent(
             id: id,
             available: available,
-            reason: reason,
-            testedVersion: "",
-            tuiObservation: .hooks
+            reason: reason
         )
     }
 

--- a/macos/ATCTests/ScriptableAppServerClient.swift
+++ b/macos/ATCTests/ScriptableAppServerClient.swift
@@ -695,9 +695,7 @@ enum Fixtures {
             id: id,
             available: available,
             reason: available ? nil : "Not installed",
-            detectedVersion: available ? "1.0.0" : nil,
-            testedVersion: "1.0.0",
-            tuiObservation: id == .codex ? .sharedServer : .hooks
+            detectedVersion: available ? "1.0.0" : nil
         )
     }
 


### PR DESCRIPTION
PR 1 of the ATC-170 codebase-hardening effort. Findings: ATC-167 H2, H3, L2, L3, L4, L5. Sub-issue: [ATC-171](https://linear.app/elevenideas/issue/ATC-171).

## Changes

- **H2 — bearer security scheme.** The document now declares `bearerAuth` (HTTP bearer) with `security: [{}, {bearerAuth: []}]` — the empty requirement documents token-free loopback access. The generator stamps `security: []` on every operation, which per OpenAPI 3.1 overrides the document default, so the contract transform also strips those inert arrays (pinned by a test). The TS client (`Client.make`) gains an optional `token` that attaches `Authorization: Bearer` to every request.
- **H3 — wire-true SSE documentation.** The generated `/events` 200 documented StreamSse's decoded frame envelope (`{id, event, data}` all required) while the server emits bare `data:` lines plus `: connected` / `: heartbeat` comments. `openapi.ts` now replaces that response with the data-only shape and full framing protocol (with an example), and a new `it.live` test pins the documented shape to real emitted bytes.
- **L2 — drop `testedVersion`/`tuiObservation`** from the `Agent` schema (no client reads them). The internal `capabilities` seam on `AgentAdapter` became dead code as a result and is removed too (the version gate reads the module constants directly). macOS Swift construction sites updated in this same PR so CI stays green.
- **L3 —** `archived` filter on `listThreads` gains `"all"`; omitted/`"false"` stays active-only.
- **L4 —** `threadId` filter on `listTerminals`; the deliberate no-pagination decision is recorded in the contract module header.
- **L5 —** `checkDirectory` description now states why a timeout is a 200/`unknown` there but a 422 on `/fs/list`.

## Verification

- `mise run -C app-server check` — 330 passed
- `mise run contract:check` — TS + Swift clients green
- `mise run macos:test` — 244 passed

Two adversarial reviews (correctness + simplicity) were applied; the notable catch was the inert document-level `security` (fixed above). Not done deliberately: the CLI still constructs the client without a token — remote/multi-server wiring is committed later work (ATC-125 territory), not part of this cleanup.

https://claude.ai/code/session_019pj9ErmqTfaLoTPksB3fSZ