### PR TITLE
Server reliability & performance hardening (ATC-172)

### DIFF
--- a/app-server/src/agents/agentAdapter.ts
+++ b/app-server/src/agents/agentAdapter.ts
@@ -257,6 +257,14 @@ export interface PreparedTuiSession {
 export interface AgentAdapter {
   readonly provider: AgentProvider
   /**
+   * Whether observeSession's feed stays authoritative once no TUI drives
+   * the session: a shared provider server (Codex) keeps streaming evidence
+   * after the TUI dies, so a busy state under a live observation is
+   * current; a hooks feed (Claude) dies silently with the TUI, so a busy
+   * state must re-derive through checkSession instead.
+   */
+  readonly observationOutlivesTui: boolean
+  /**
    * Create a new provider session in `cwd` and start its first turn. The
    * provider's echoed working directory is verified like resume's — a
    * disagreeing echo is `AgentIdentityMismatch`, never adopted.
@@ -575,38 +583,45 @@ export const readInstalledVersion = (
 
 /**
  * The shared version-drift rule (record + warn, never block), memoized to
- * one check per adapter: resolve the configured executable, read the
- * installed version via `--version`, and log one actionable warning when
- * it is below the floor the adapter was validated against. Any failure to
- * determine the version is itself just a warning.
+ * one single-flight check per adapter: resolve the configured executable,
+ * read the installed version via `--version`, and log one actionable
+ * warning when it is below the floor the adapter was validated against.
+ * Warn-only: a missing executable never fails the gate — every call site
+ * resolves or spawns the executable itself and reports the actionable
+ * diagnostic there — and Effect.cached would otherwise pin that failure
+ * past a mid-session install. Uninterruptible because Effect.cached
+ * memoizes interruption too: a dropped request driving the first check
+ * must not become the cached outcome (the check is bounded — the version
+ * read times out at 5 seconds).
  */
 export const makeVersionGate = (
   subprocess: Subprocess["Service"],
   provider: AgentProvider,
   configured: string,
   testedVersion: string,
-): Effect.Effect<void, AgentUnavailable> => {
-  let checked = false
-  return Effect.gen(function* () {
-    if (checked) return
-    checked = true
-    const executable = yield* resolveProviderExecutable(provider, configured)
-    const installed = yield* readInstalledVersion(subprocess, executable)
-    if (installed === null) {
-      return yield* Effect.logWarning(
-        `could not determine the installed ${provider} version (tested against ${testedVersion})`,
-      )
-    }
-    // Components are small; packing keeps the comparison one expression.
-    const pack = (version: string) =>
-      version
-        .split(".")
-        .map(Number)
-        .reduce((total, part) => total * 1_000 + part, 0)
-    if (pack(installed) < pack(testedVersion)) {
-      yield* Effect.logWarning(
-        `installed ${provider} ${installed} is older than the tested ${testedVersion}; proceeding, but upgrade it if provider behavior misbehaves`,
-      )
-    }
-  })
-}
+): Effect.Effect<Effect.Effect<void>> =>
+  Effect.cached(
+    Effect.gen(function* () {
+      const executable = yield* resolveProviderExecutable(provider, configured)
+      const installed = yield* readInstalledVersion(subprocess, executable)
+      if (installed === null) {
+        return yield* Effect.logWarning(
+          `could not determine the installed ${provider} version (tested against ${testedVersion})`,
+        )
+      }
+      // Components are small; packing keeps the comparison one expression.
+      const pack = (version: string) =>
+        version
+          .split(".")
+          .map(Number)
+          .reduce((total, part) => total * 1_000 + part, 0)
+      if (pack(installed) < pack(testedVersion)) {
+        yield* Effect.logWarning(
+          `installed ${provider} ${installed} is older than the tested ${testedVersion}; proceeding, but upgrade it if provider behavior misbehaves`,
+        )
+      }
+    }).pipe(
+      Effect.catchTag("AgentUnavailable", () => Effect.void),
+      Effect.uninterruptible,
+    ),
+  )

--- a/app-server/src/agents/agentAdapter.ts
+++ b/app-server/src/agents/agentAdapter.ts
@@ -1,4 +1,4 @@
-import { Effect, Schema, Stream } from "effect"
+import { Duration, Effect, Schema, Semaphore, Stream } from "effect"
 import type { Scope } from "effect"
 import { existsSync, realpathSync } from "node:fs"
 import type { AgentId } from "../api/contract.ts"
@@ -588,11 +588,13 @@ export const readInstalledVersion = (
  * warning when it is below the floor the adapter was validated against.
  * Warn-only: a missing executable never fails the gate — every call site
  * resolves or spawns the executable itself and reports the actionable
- * diagnostic there — and Effect.cached would otherwise pin that failure
- * past a mid-session install. Uninterruptible because Effect.cached
- * memoizes interruption too: a dropped request driving the first check
- * must not become the cached outcome (the check is bounded — the version
- * read times out at 5 seconds).
+ * diagnostic there — and a memoized failure would pin "unavailable" past a
+ * mid-session install. NOT plain Effect.cached: the cache memoizes whatever
+ * exit its driving fiber produces, interruption included, so a dropped
+ * request driving the first check would poison every later caller for the
+ * process. Instead the memo is invalidated when its driver is interrupted,
+ * and the semaphore keeps callers out of the cache's waiter path (a waiter
+ * racing an invalidate would replay a cleared exit).
  */
 export const makeVersionGate = (
   subprocess: Subprocess["Service"],
@@ -600,8 +602,9 @@ export const makeVersionGate = (
   configured: string,
   testedVersion: string,
 ): Effect.Effect<Effect.Effect<void>> =>
-  Effect.cached(
-    Effect.gen(function* () {
+  Effect.gen(function* () {
+    const lock = yield* Semaphore.make(1)
+    const check = Effect.gen(function* () {
       const executable = yield* resolveProviderExecutable(provider, configured)
       const installed = yield* readInstalledVersion(subprocess, executable)
       if (installed === null) {
@@ -620,8 +623,7 @@ export const makeVersionGate = (
           `installed ${provider} ${installed} is older than the tested ${testedVersion}; proceeding, but upgrade it if provider behavior misbehaves`,
         )
       }
-    }).pipe(
-      Effect.catchTag("AgentUnavailable", () => Effect.void),
-      Effect.uninterruptible,
-    ),
-  )
+    }).pipe(Effect.catchTag("AgentUnavailable", () => Effect.void))
+    const [cached, invalidate] = yield* Effect.cachedInvalidateWithTTL(check, Duration.infinity)
+    return lock.withPermits(1)(Effect.onInterrupt(cached, () => invalidate))
+  })

--- a/app-server/src/agents/claudeAdapter.ts
+++ b/app-server/src/agents/claudeAdapter.ts
@@ -248,7 +248,10 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
       let nextTurn = 1
 
       const emit = (session: LiveSession, event: AgentEvent): void => {
-        Queue.offerUnsafe(session.queue, event)
+        // Bounded queue: a consumer that stopped draining loses the stream,
+        // not the process — the ended queue tells it to reopen and resync
+        // (the same policy the SSE fan-out applies in events.ts).
+        if (!Queue.offerUnsafe(session.queue, event)) Queue.endUnsafe(session.queue)
       }
 
       const setActivity = (session: LiveSession, activity: AgentActivity): void => {
@@ -475,7 +478,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
           ]),
         )
 
-      const versionCheck = makeVersionGate(
+      const versionCheck = yield* makeVersionGate(
         subprocess,
         "claude",
         config.claudeExecutable,
@@ -558,7 +561,11 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
           const executable = yield* resolveProviderExecutable("claude", config.claudeExecutable)
           yield* versionCheck
           const input = makeInputQueue()
-          const queue = yield* Queue.make<AgentEvent, AgentProtocolError | Cause.Done>()
+          // Bounded (overflow ends the stream — see emit); a session that
+          // buffers 256 undrained events has lost its consumer.
+          const queue = yield* Queue.make<AgentEvent, AgentProtocolError | Cause.Done>({
+            capacity: 256,
+          })
           const initGate = yield* Deferred.make<void, GateError>()
           const session: LiveSession = {
             expectedSessionId: options.resume ?? null,
@@ -700,6 +707,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
 
       const adapter: AgentAdapter = {
         provider: "claude",
+        observationOutlivesTui: false,
         createSession: (options) =>
           Effect.gen(function* () {
             const session = yield* openSession({ cwd: options.cwd })
@@ -799,7 +807,12 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
             // validating only because the thread's metadata carries it.
             const known = metadataSecret(options.providerMetadata)
             if (known !== null) yield* hooks.adoptSecret(options.providerSessionId, known)
-            const queue = yield* Queue.make<AgentSessionEvent, Cause.Done>()
+            // Sliding: hook evidence is coarse and newest-wins; a slow
+            // consumer drops stale events instead of buffering unbounded.
+            const queue = yield* Queue.make<AgentSessionEvent, Cause.Done>({
+              capacity: 32,
+              strategy: "sliding",
+            })
             // Registered before the subscription so it runs after it on
             // scope close: unsubscribe first, then end the queue.
             yield* Effect.addFinalizer(() => Effect.sync(() => Queue.endUnsafe(queue)))

--- a/app-server/src/agents/claudeAdapter.ts
+++ b/app-server/src/agents/claudeAdapter.ts
@@ -249,9 +249,15 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
 
       const emit = (session: LiveSession, event: AgentEvent): void => {
         // Bounded queue: a consumer that stopped draining loses the stream,
-        // not the process — the ended queue tells it to reopen and resync
-        // (the same policy the SSE fan-out applies in events.ts).
-        if (!Queue.offerUnsafe(session.queue, event)) Queue.endUnsafe(session.queue)
+        // not the process (the events.ts subscriber policy). Overflow FAILS
+        // the stream rather than ending it — a clean end would read as a
+        // completed turn to the consumer, not a truncated one.
+        if (!Queue.offerUnsafe(session.queue, event)) {
+          Queue.failCauseUnsafe(
+            session.queue,
+            Cause.fail(protocolError("session event stream overflowed; reopen and resync")),
+          )
+        }
       }
 
       const setActivity = (session: LiveSession, activity: AgentActivity): void => {
@@ -807,17 +813,16 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
             // validating only because the thread's metadata carries it.
             const known = metadataSecret(options.providerMetadata)
             if (known !== null) yield* hooks.adoptSecret(options.providerSessionId, known)
-            // Sliding: hook evidence is coarse and newest-wins; a slow
-            // consumer drops stale events instead of buffering unbounded.
-            const queue = yield* Queue.make<AgentSessionEvent, Cause.Done>({
-              capacity: 32,
-              strategy: "sliding",
-            })
+            // Bounded (overflow ends the feed — see the subscriber below);
+            // dropping hook events silently would lose confirm/auto-name
+            // evidence, while an ended feed makes the consumer re-observe.
+            const queue = yield* Queue.make<AgentSessionEvent, Cause.Done>({ capacity: 32 })
             // Registered before the subscription so it runs after it on
             // scope close: unsubscribe first, then end the queue.
             yield* Effect.addFinalizer(() => Effect.sync(() => Queue.endUnsafe(queue)))
             yield* hooks.subscribe((sessionId, event) => {
-              if (sessionId === options.providerSessionId) Queue.offerUnsafe(queue, event)
+              if (sessionId !== options.providerSessionId) return
+              if (!Queue.offerUnsafe(queue, event)) Queue.endUnsafe(queue)
             })
             return Stream.fromQueue(queue)
           }),

--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -248,7 +248,11 @@ export const layer = Layer.effect(CodexAdapter)(
     const emitAggregate = (rootId: string): void => {
       const aggregate = aggregateFor(rootId)
       for (const queue of observers.get(rootId) ?? []) {
-        Queue.offerUnsafe(queue, aggregate)
+        // Overflow ends the observation: dropping intermediate transitions
+        // would be silent evidence loss (the first busy drives the confirm
+        // marker), while an ended feed makes the consumer re-observe and
+        // re-derive.
+        if (!Queue.offerUnsafe(queue, aggregate)) Queue.endUnsafe(queue)
       }
       const session = sessions.get(rootId)
       if (session !== undefined && aggregate !== session.activity) {
@@ -311,9 +315,15 @@ export const layer = Layer.effect(CodexAdapter)(
 
     const emit = (session: LiveSession, event: AgentEvent): void => {
       // Bounded queue: a consumer that stopped draining loses the stream,
-      // not the process — the ended queue tells it to reopen and resync
-      // (the same policy the SSE fan-out applies in events.ts).
-      if (!Queue.offerUnsafe(session.queue, event)) Queue.endUnsafe(session.queue)
+      // not the process (the events.ts subscriber policy). Overflow FAILS
+      // the stream rather than ending it — a clean end would read as a
+      // completed turn to the consumer, not a truncated one.
+      if (!Queue.offerUnsafe(session.queue, event)) {
+        Queue.failCauseUnsafe(
+          session.queue,
+          Cause.fail(protocolError("session event stream overflowed; reopen and resync")),
+        )
+      }
     }
 
     const teardown = (state: ClientState, reason: string): void => {
@@ -340,7 +350,9 @@ export const layer = Layer.effect(CodexAdapter)(
         // it: tell them honestly rather than letting the last busy state
         // sit stale while the provider moves on unheard (ATC-158).
         for (const set of observers.values()) {
-          for (const queue of set) Queue.offerUnsafe(queue, "unknown")
+          for (const queue of set) {
+            if (!Queue.offerUnsafe(queue, "unknown")) Queue.endUnsafe(queue)
+          }
         }
         // An armed capture fails closed with the connection: the caller
         // abandons the launch and retries rather than adopting anything
@@ -593,22 +605,27 @@ export const layer = Layer.effect(CodexAdapter)(
     // every record behind those timeouts (ATC-167 H4). The memo also records
     // interruption (cachedWithTTL caches whatever exit the driver produced),
     // so an interrupted driver invalidates on the way out rather than making
-    // later callers replay its interrupt.
+    // later callers replay its interrupt. cachedConnect may only be entered
+    // under connectLock: without it, an invalidate racing a just-released
+    // cache waiter would replay a cleared exit. The window also briefly
+    // shadows codexServer's own crash-restart watcher — a retry schedule
+    // against getClient shorter than the window would spin on the memo.
     const [cachedConnect, invalidateConnect] = yield* Effect.cachedInvalidateWithTTL(
       connect,
       "5 seconds",
     )
+    const attemptConnect = Effect.onInterrupt(cachedConnect, () => invalidateConnect)
 
     /** The shared connection: reuse, or ensure the server and handshake. */
     const getClient = connectLock.withPermits(1)(
       Effect.gen(function* () {
         if (current !== null && current.alive) return current
-        const state = yield* Effect.onInterrupt(cachedConnect, () => invalidateConnect)
+        const state = yield* attemptConnect
         if (state.alive) return state
         // A memoized success can predate a teardown; never hand out a dead
         // connection — drop the memo and probe fresh.
         yield* invalidateConnect
-        return yield* Effect.onInterrupt(cachedConnect, () => invalidateConnect)
+        return yield* attemptConnect
       }),
     )
 
@@ -1055,12 +1072,9 @@ export const layer = Layer.effect(CodexAdapter)(
         Effect.gen(function* () {
           // Ensure the shared connection exists — it is the evidence source.
           yield* getClientRetryable
-          // Sliding: only the newest activity matters, so a slow consumer
-          // drops stale states instead of buffering without bound.
-          const queue = yield* Queue.make<AgentActivity, Cause.Done>({
-            capacity: 16,
-            strategy: "sliding",
-          })
+          // Bounded (overflow ends the feed — see emitAggregate); a
+          // 16-deep undrained backlog means the observer is gone.
+          const queue = yield* Queue.make<AgentActivity, Cause.Done>({ capacity: 16 })
           const set = observers.get(options.providerSessionId) ?? new Set()
           set.add(queue)
           observers.set(options.providerSessionId, set)
@@ -1089,12 +1103,9 @@ export const layer = Layer.effect(CodexAdapter)(
           // attempt for good (logged at debug). The feed never lies — it
           // just goes without prompt evidence.
           const scope = yield* Effect.scope
-          // Sliding: prompts arrive one per turn start; a slow consumer
-          // loses old auto-name evidence, never the process.
-          const promptQueue = yield* Queue.make<AgentSessionEvent, Cause.Done>({
-            capacity: 16,
-            strategy: "sliding",
-          })
+          // Bounded like the activity queues; prompts arrive one per turn
+          // start, so 16 undrained means the observation is dead anyway.
+          const promptQueue = yield* Queue.make<AgentSessionEvent, Cause.Done>({ capacity: 16 })
           yield* Effect.addFinalizer(() => Effect.sync(() => Queue.endUnsafe(promptQueue)))
           let promptPhase: "pending" | "reading" | "done" = "pending"
           const readPreview = Effect.gen(function* () {
@@ -1116,7 +1127,9 @@ export const layer = Layer.effect(CodexAdapter)(
               const text = yield* readPreview
               if (text !== null) {
                 promptPhase = "done"
-                Queue.offerUnsafe(promptQueue, { type: "userPrompt", text })
+                if (!Queue.offerUnsafe(promptQueue, { type: "userPrompt", text })) {
+                  Queue.endUnsafe(promptQueue)
+                }
                 return
               }
             }

--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -310,7 +310,10 @@ export const layer = Layer.effect(CodexAdapter)(
     }
 
     const emit = (session: LiveSession, event: AgentEvent): void => {
-      Queue.offerUnsafe(session.queue, event)
+      // Bounded queue: a consumer that stopped draining loses the stream,
+      // not the process — the ended queue tells it to reopen and resync
+      // (the same policy the SSE fan-out applies in events.ts).
+      if (!Queue.offerUnsafe(session.queue, event)) Queue.endUnsafe(session.queue)
     }
 
     const teardown = (state: ClientState, reason: string): void => {
@@ -533,7 +536,7 @@ export const layer = Layer.effect(CodexAdapter)(
       )
 
     // Record + warn version drift, once, on first use (never blocks).
-    const versionCheck = makeVersionGate(
+    const versionCheck = yield* makeVersionGate(
       subprocess,
       "codex",
       config.codexExecutable,
@@ -561,30 +564,51 @@ export const layer = Layer.effect(CodexAdapter)(
         }),
       )
 
+    const connect = Effect.gen(function* () {
+      yield* versionCheck
+      const info = yield* codexServer.ensure()
+      const state = yield* openSocket(info.url)
+      // A failed or interrupted handshake must close this socket: a
+      // half-open connection would double-deliver broadcasts and, on its
+      // eventual death, could not be told apart from the live one.
+      yield* request(state, "initialize", {
+        clientInfo: { name: "atc", title: "ATC App Server", version: build.version },
+        capabilities: null,
+      }).pipe(
+        Effect.mapError(rpcToProtocol),
+        Effect.onExit((exit) =>
+          Effect.sync(() => {
+            if (exit._tag === "Failure") teardown(state, "the handshake failed")
+          }),
+        ),
+      )
+      state.socket.send(JSON.stringify({ method: "initialized", params: {} }))
+      current = state
+      return state
+    })
+
+    // The connection attempt's outcome is memoized for a short window so a
+    // dead Codex costs ONE probe (with its full connect timeouts) per window
+    // instead of one per caller — a thread-list fan-out otherwise serializes
+    // every record behind those timeouts (ATC-167 H4). The memo also records
+    // interruption (cachedWithTTL caches whatever exit the driver produced),
+    // so an interrupted driver invalidates on the way out rather than making
+    // later callers replay its interrupt.
+    const [cachedConnect, invalidateConnect] = yield* Effect.cachedInvalidateWithTTL(
+      connect,
+      "5 seconds",
+    )
+
     /** The shared connection: reuse, or ensure the server and handshake. */
     const getClient = connectLock.withPermits(1)(
       Effect.gen(function* () {
         if (current !== null && current.alive) return current
-        yield* versionCheck
-        const info = yield* codexServer.ensure()
-        const state = yield* openSocket(info.url)
-        // A failed or interrupted handshake must close this socket: a
-        // half-open connection would double-deliver broadcasts and, on its
-        // eventual death, could not be told apart from the live one.
-        yield* request(state, "initialize", {
-          clientInfo: { name: "atc", title: "ATC App Server", version: build.version },
-          capabilities: null,
-        }).pipe(
-          Effect.mapError(rpcToProtocol),
-          Effect.onExit((exit) =>
-            Effect.sync(() => {
-              if (exit._tag === "Failure") teardown(state, "the handshake failed")
-            }),
-          ),
-        )
-        state.socket.send(JSON.stringify({ method: "initialized", params: {} }))
-        current = state
-        return state
+        const state = yield* Effect.onInterrupt(cachedConnect, () => invalidateConnect)
+        if (state.alive) return state
+        // A memoized success can predate a teardown; never hand out a dead
+        // connection — drop the memo and probe fresh.
+        yield* invalidateConnect
+        return yield* Effect.onInterrupt(cachedConnect, () => invalidateConnect)
       }),
     )
 
@@ -608,7 +632,11 @@ export const layer = Layer.effect(CodexAdapter)(
       initialStatus: unknown,
     ) =>
       Effect.gen(function* () {
-        const queue = yield* Queue.make<AgentEvent, AgentProtocolError | Cause.Done>()
+        // Bounded (overflow ends the stream — see emit); a session that
+        // buffers 256 undrained events has lost its consumer.
+        const queue = yield* Queue.make<AgentEvent, AgentProtocolError | Cause.Done>({
+          capacity: 256,
+        })
         // Seeded from the provider's own thread status — never a guess —
         // folded with any descendants already tracked for this root.
         ownStatus.set(threadId, statusToActivity(initialStatus))
@@ -854,6 +882,7 @@ export const layer = Layer.effect(CodexAdapter)(
 
     const adapter: AgentAdapter = {
       provider: "codex",
+      observationOutlivesTui: true,
       createSession: (options) =>
         Effect.gen(function* () {
           // thread/start broadcasts thread/started to every socket — ours
@@ -1026,7 +1055,12 @@ export const layer = Layer.effect(CodexAdapter)(
         Effect.gen(function* () {
           // Ensure the shared connection exists — it is the evidence source.
           yield* getClientRetryable
-          const queue = yield* Queue.make<AgentActivity, Cause.Done>()
+          // Sliding: only the newest activity matters, so a slow consumer
+          // drops stale states instead of buffering without bound.
+          const queue = yield* Queue.make<AgentActivity, Cause.Done>({
+            capacity: 16,
+            strategy: "sliding",
+          })
           const set = observers.get(options.providerSessionId) ?? new Set()
           set.add(queue)
           observers.set(options.providerSessionId, set)
@@ -1055,7 +1089,12 @@ export const layer = Layer.effect(CodexAdapter)(
           // attempt for good (logged at debug). The feed never lies — it
           // just goes without prompt evidence.
           const scope = yield* Effect.scope
-          const promptQueue = yield* Queue.make<AgentSessionEvent, Cause.Done>()
+          // Sliding: prompts arrive one per turn start; a slow consumer
+          // loses old auto-name evidence, never the process.
+          const promptQueue = yield* Queue.make<AgentSessionEvent, Cause.Done>({
+            capacity: 16,
+            strategy: "sliding",
+          })
           yield* Effect.addFinalizer(() => Effect.sync(() => Queue.endUnsafe(promptQueue)))
           let promptPhase: "pending" | "reading" | "done" = "pending"
           const readPreview = Effect.gen(function* () {

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -351,8 +351,11 @@ export const layerWith = (options: ThreadsOptions) =>
 
       /**
        * The activity snapshot for one read. A busy state whose driver (the
-       * live linked terminal) is gone is stale: re-derive it from the
-       * adapter's reconciliation check instead of reporting a dead turn.
+       * live linked terminal) is gone is presumed stale and re-derived
+       * from the adapter's reconciliation check — unless a live observation
+       * whose feed outlives the TUI still covers the session (the
+       * shared-server short-circuit below), in which case the feed is the
+       * evidence and no re-derivation is owed.
        */
       const resolveActivity = (
         record: ThreadRecord,

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -363,6 +363,19 @@ export const layerWith = (options: ThreadsOptions) =>
           const live = liveActivity.get(record.id) ?? "unknown"
           if (!isBusy(live) || linked !== undefined) return live
           const adapter = adapterFor(record)
+          // A live observation whose feed outlives the TUI (shared-server
+          // providers) is already authoritative — it drives liveActivity —
+          // so a busy snapshot under it is current, not a dead turn to
+          // re-derive. Hooks-fed observations die silently with the TUI,
+          // so their busy states must still re-derive below (for Codex the
+          // re-derivation costs paginated provider walks; skipping it here
+          // is what keeps the listing hot path off the provider).
+          if (
+            adapter?.observationOutlivesTui === true &&
+            observed.get(record.id)?.providerSessionId === record.providerSessionId
+          ) {
+            return live
+          }
           const providerSessionId = record.providerSessionId
           const checked =
             adapter === undefined
@@ -756,8 +769,13 @@ export const layerWith = (options: ThreadsOptions) =>
                 linked.set(terminal.threadId, terminal)
               }
             }
-            return yield* Effect.forEach(wanted, (record) =>
-              assemble(record, linked.get(record.id)),
+            // Bounded fan-out: assembly can hit the provider (resolveActivity
+            // re-derivation), so a page of stale-busy records must neither
+            // serialize behind each other nor stampede the adapter.
+            return yield* Effect.forEach(
+              wanted,
+              (record) => assemble(record, linked.get(record.id)),
+              { concurrency: 8 },
             )
           }),
         get: (id) => repository.require(id).pipe(Effect.flatMap(assembleAlone)),

--- a/app-server/test/agents/agentAdapter.test.ts
+++ b/app-server/test/agents/agentAdapter.test.ts
@@ -1,11 +1,13 @@
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Stream } from "effect"
+import { Deferred, Effect, Fiber, Stream } from "effect"
 import type { AgentEvent } from "../../src/agents/agentAdapter.ts"
 import {
   aggregateActivity,
+  makeVersionGate,
   sanitizeTitle,
   titleInstruction,
 } from "../../src/agents/agentAdapter.ts"
+import type { Subprocess } from "../../src/platform/subprocess.ts"
 import { makeFakeAgentAdapter } from "./fakeAgentAdapter.ts"
 
 // Seam-semantics tests over the fake adapter: the observable rules every
@@ -229,5 +231,88 @@ describe("AgentAdapter seam semantics (fake adapter)", () => {
       const failure = yield* Effect.flip(fake.adapter.createSession({ cwd: "/work", input: "hi" }))
       assert.strictEqual(failure._tag, "AgentUnavailable")
     }).pipe(Effect.scoped),
+  )
+})
+
+/**
+ * A scripted Subprocess whose spawns are counted and optionally held on a
+ * gate, so the gate tests control exactly when the version read completes.
+ */
+const gatedSubprocess = () => {
+  let spawns = 0
+  let gate: Deferred.Deferred<void> | null = null
+  const service: Subprocess["Service"] = {
+    spawn: () =>
+      Effect.gen(function* () {
+        spawns++
+        const held = gate
+        if (held !== null) yield* Deferred.await(held)
+        return {
+          pid: 1,
+          stdoutLines: Stream.make("codex-cli 9.9.9"),
+          stderrTail: Effect.succeed([]),
+          writeLine: () => Effect.void,
+          endInput: Effect.void,
+          exitCode: Effect.succeed(0),
+        }
+      }),
+    spawnPty: () => Effect.die("unused"),
+    spawnDetached: () => Effect.die("unused"),
+  }
+  return {
+    service,
+    spawns: () => spawns,
+    hold: () => {
+      gate = Deferred.makeUnsafe<void>()
+    },
+    release: () => {
+      if (gate !== null) Deferred.doneUnsafe(gate, Effect.void)
+      gate = null
+    },
+  }
+}
+
+const untilSpawns = (fake: { spawns: () => number }, count: number) =>
+  Effect.gen(function* () {
+    for (let attempt = 0; fake.spawns() < count; attempt++) {
+      assert.isBelow(attempt, 100, `never reached ${count} spawns (at ${fake.spawns()})`)
+      yield* Effect.yieldNow
+    }
+  })
+
+describe("makeVersionGate", () => {
+  it.effect("single-flight: concurrent callers share one version read, memoized after", () =>
+    Effect.gen(function* () {
+      const fake = gatedSubprocess()
+      const gate = yield* makeVersionGate(fake.service, "codex", "/bin/echo", "1.0.0")
+      fake.hold()
+      const first = yield* Effect.forkChild(gate)
+      const second = yield* Effect.forkChild(gate)
+      yield* untilSpawns(fake, 1)
+      fake.release()
+      yield* Fiber.join(first)
+      yield* Fiber.join(second)
+      assert.strictEqual(fake.spawns(), 1)
+      // A later caller replays the memo without re-reading.
+      yield* gate
+      assert.strictEqual(fake.spawns(), 1)
+    }),
+  )
+
+  it.effect("an interrupted first caller never poisons the gate", () =>
+    Effect.gen(function* () {
+      const fake = gatedSubprocess()
+      const gate = yield* makeVersionGate(fake.service, "codex", "/bin/echo", "1.0.0")
+      fake.hold()
+      const first = yield* Effect.forkChild(gate)
+      yield* untilSpawns(fake, 1)
+      // The driver's interruption must be invalidated on the way out, not
+      // memoized — a poisoned memo would replay the interrupt to every
+      // later caller for the life of the process.
+      yield* Fiber.interrupt(first)
+      fake.release()
+      yield* gate
+      assert.strictEqual(fake.spawns(), 2)
+    }),
   )
 })

--- a/app-server/test/agents/codexAdapter.test.ts
+++ b/app-server/test/agents/codexAdapter.test.ts
@@ -1136,4 +1136,29 @@ describe("CodexAdapter descendant aggregation", () => {
       }),
     30_000,
   )
+
+  it.live("a failed connection attempt is memoized: one probe serves the whole window", () =>
+    Effect.gen(function* () {
+      const sandbox = makeCodexSandbox()
+      // Break the wrapper: every spawn logs itself then dies immediately,
+      // so each real probe fails fast and leaves a visible mark.
+      const spawnLog = path.join(sandbox.base, "spawns.log")
+      fs.writeFileSync(sandbox.wrapper, `#!/bin/sh\necho probe >> "${spawnLog}"\nexit 1\n`)
+      const probes = () =>
+        fs.existsSync(spawnLog) ? fs.readFileSync(spawnLog, "utf8").trim().split("\n").length : 0
+      yield* withAdapter(sandbox, (adapter) =>
+        Effect.gen(function* () {
+          const first = yield* Effect.flip(adapter.checkSession({ providerSessionId: "t" }))
+          assert.strictEqual(first._tag, "AgentUnavailable")
+          const paid = probes()
+          assert.isAtLeast(paid, 1, "the first call must really probe")
+          // Within the memo window the failure is replayed, not re-probed —
+          // a dead Codex costs one probe per window, not one per caller.
+          const second = yield* Effect.flip(adapter.checkSession({ providerSessionId: "t" }))
+          assert.strictEqual(second._tag, "AgentUnavailable")
+          assert.strictEqual(probes(), paid)
+        }),
+      )
+    }),
+  )
 })

--- a/app-server/test/agents/fakeAgentAdapter.ts
+++ b/app-server/test/agents/fakeAgentAdapter.ts
@@ -80,6 +80,8 @@ export interface FakeAgentAdapter {
   readonly setCheckHangs: (hangs: boolean) => void
   /** High-water mark of concurrent checkSession calls. */
   readonly maxConcurrentChecks: () => number
+  /** Zero the checkSession log and concurrency high-water mark. */
+  readonly resetCheckStats: () => void
   /** Mark a session as pruned provider-side: tuiLaunch's existence probe
    * fails AgentResumeFailed (the Codex reopen-probe behavior). */
   readonly setSessionPruned: (providerSessionId: string, pruned: boolean) => void
@@ -474,6 +476,10 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
       checkGate = null
     },
     maxConcurrentChecks: () => maxInFlightChecks,
+    resetCheckStats: () => {
+      checkCalls.length = 0
+      maxInFlightChecks = 0
+    },
     setSessionPruned: (providerSessionId, pruned) => {
       if (pruned) prunedSessions.add(providerSessionId)
       else prunedSessions.delete(providerSessionId)

--- a/app-server/test/agents/fakeAgentAdapter.ts
+++ b/app-server/test/agents/fakeAgentAdapter.ts
@@ -69,8 +69,17 @@ export interface FakeAgentAdapter {
   readonly setTitleHangs: (hangs: boolean) => void
   /** Live observeSession subscriptions for `providerSessionId`. */
   readonly observerCount: (providerSessionId: string) => number
+  /** End every live observation feed for `providerSessionId` — models an
+   * evidence source dying out from under its subscribers. */
+  readonly endObservations: (providerSessionId: string) => void
   /** Script what checkSession reports for `providerSessionId`. */
   readonly setCheckActivity: (providerSessionId: string, activity: AgentActivity | null) => void
+  /** checkSession calls (providerSessionIds), in order. */
+  readonly checkCalls: Array<string>
+  /** While set, checkSession waits on a gate; unsetting releases waiters. */
+  readonly setCheckHangs: (hangs: boolean) => void
+  /** High-water mark of concurrent checkSession calls. */
+  readonly maxConcurrentChecks: () => number
   /** Mark a session as pruned provider-side: tuiLaunch's existence probe
    * fails AgentResumeFailed (the Codex reopen-probe behavior). */
   readonly setSessionPruned: (providerSessionId: string, pruned: boolean) => void
@@ -78,6 +87,11 @@ export interface FakeAgentAdapter {
   readonly prepared: Array<{ providerSessionId: string; cwd: string }>
   /** releaseSession calls, in order. */
   readonly released: Array<{ providerSessionId: string; providerMetadata: string | undefined }>
+}
+
+export interface FakeAgentAdapterOptions {
+  /** Adapter's observation-authority shape (default true — codex-like). */
+  readonly observationOutlivesTui?: boolean
 }
 
 interface LiveConnection {
@@ -88,7 +102,7 @@ interface LiveConnection {
   readonly openRequests: Set<string>
 }
 
-export const makeFakeAgentAdapter = (): FakeAgentAdapter => {
+export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): FakeAgentAdapter => {
   const sessions = new Map<string, FakeAgentSession>()
   // One live connection per session — the single-writer rule.
   const connections = new Map<string, LiveConnection>()
@@ -103,6 +117,10 @@ export const makeFakeAgentAdapter = (): FakeAgentAdapter => {
   let titleFailsReason: string | null = null
   let titleGate: Deferred.Deferred<void> | null = null
   let identityGate: Deferred.Deferred<void> | null = null
+  let checkGate: Deferred.Deferred<void> | null = null
+  const checkCalls: FakeAgentAdapter["checkCalls"] = []
+  let inFlightChecks = 0
+  let maxInFlightChecks = 0
   let unavailableReason: string | null = null
   let nextSessionId = 1
   let nextTurnId = 1
@@ -231,6 +249,7 @@ export const makeFakeAgentAdapter = (): FakeAgentAdapter => {
 
   const adapter: AgentAdapter = {
     provider: "codex",
+    observationOutlivesTui: options.observationOutlivesTui ?? true,
     createSession: (options) =>
       Effect.gen(function* () {
         yield* requireAvailable
@@ -351,9 +370,20 @@ export const makeFakeAgentAdapter = (): FakeAgentAdapter => {
         return scriptedTitle
       }),
     checkSession: (options) =>
-      requireAvailable.pipe(
-        Effect.map(() => checkActivity.get(options.providerSessionId) ?? "unknown"),
-      ),
+      Effect.gen(function* () {
+        checkCalls.push(options.providerSessionId)
+        inFlightChecks++
+        maxInFlightChecks = Math.max(maxInFlightChecks, inFlightChecks)
+        const gate = checkGate
+        yield* Effect.ensuring(
+          gate !== null ? Deferred.await(gate) : Effect.void,
+          Effect.sync(() => {
+            inFlightChecks--
+          }),
+        )
+        yield* requireAvailable
+        return checkActivity.get(options.providerSessionId) ?? "unknown"
+      }),
     releaseSession: (options) =>
       Effect.sync(() => {
         released.push({
@@ -426,10 +456,24 @@ export const makeFakeAgentAdapter = (): FakeAgentAdapter => {
       titleGate = null
     },
     observerCount: (providerSessionId) => observers.get(providerSessionId)?.size ?? 0,
+    endObservations: (providerSessionId) => {
+      for (const queue of observers.get(providerSessionId) ?? []) Queue.endUnsafe(queue)
+      observers.delete(providerSessionId)
+    },
     setCheckActivity: (providerSessionId, activity) => {
       if (activity === null) checkActivity.delete(providerSessionId)
       else checkActivity.set(providerSessionId, activity)
     },
+    checkCalls,
+    setCheckHangs: (hangs) => {
+      if (hangs) {
+        checkGate = Deferred.makeUnsafe<void>()
+        return
+      }
+      if (checkGate !== null) Deferred.doneUnsafe(checkGate, Effect.void)
+      checkGate = null
+    },
+    maxConcurrentChecks: () => maxInFlightChecks,
     setSessionPruned: (providerSessionId, pruned) => {
       if (pruned) prunedSessions.add(providerSessionId)
       else prunedSessions.delete(providerSessionId)

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -112,7 +112,11 @@ export const makeTestServiceLayers = (
   const fake = makeFakeAdapter()
   const fakeAgents = {
     codex: makeFakeAgentAdapter(),
-    claude: makeFakeAgentAdapter(),
+    claude: makeFakeAgentAdapter({
+      // Hooks-shaped: its observation feed dies silently with the TUI, so
+      // stale-busy re-derivation stays reachable through this fake.
+      observationOutlivesTui: false,
+    }),
   }
   const base = Layer.mergeAll(
     ProjectRepository.layer,

--- a/app-server/test/threads/threadOpen.test.ts
+++ b/app-server/test/threads/threadOpen.test.ts
@@ -465,7 +465,7 @@ describe("threads.openTerminal", () => {
     }),
   )
 
-  it.live("a busy state with no live driver re-derives from the adapter on read", () =>
+  it.live("a live shared-server observation stays authoritative after its terminal dies", () =>
     Effect.gen(function* () {
       const { client, thread } = yield* setup
       const repository = yield* ThreadRepository
@@ -477,16 +477,138 @@ describe("threads.openTerminal", () => {
         (t) => t.activityState === "working",
       )
 
-      // The driver dies out from under ATC: stale `working` must re-derive
-      // from the adapter's reconciliation check, not persist as a lie.
+      // The TUI terminal dies but the shared-server feed is still live: the
+      // busy state is current evidence, so reads must NOT burn a provider
+      // reconciliation walk (the scripted "idle" would betray one).
       kit.fake.sessions.delete(sessionNameForTerminalId(terminal.id))
       kit.fakeAgents.codex.setCheckActivity(sessionId, "idle")
       const read = yield* client.v1.getThread({ params: { threadId: thread.id } })
       assert.isUndefined(read.linkedTerminalId)
-      assert.strictEqual(read.activityState, "idle")
+      assert.strictEqual(read.activityState, "working")
+      assert.notInclude(kit.fakeAgents.codex.checkCalls, sessionId)
 
       kit.fakeAgents.codex.setCheckActivity(sessionId, null)
       yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.live("a busy state with no live observation re-derives from the adapter on read", () =>
+    Effect.gen(function* () {
+      const { client, thread } = yield* setup
+      const repository = yield* ThreadRepository
+      const terminal = yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+      const sessionId = Option.getOrThrow(yield* repository.get(thread.id)).providerSessionId ?? ""
+      kit.fakeAgents.codex.emitActivity(sessionId, "working")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId: thread.id } }),
+        (t) => t.activityState === "working",
+      )
+
+      // The driver AND its evidence source die out from under ATC: stale
+      // `working` must re-derive from the adapter's reconciliation check,
+      // not persist as a lie.
+      kit.fake.sessions.delete(sessionNameForTerminalId(terminal.id))
+      kit.fakeAgents.codex.endObservations(sessionId)
+      kit.fakeAgents.codex.setCheckActivity(sessionId, "idle")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId: thread.id } }),
+        (t) => t.linkedTerminalId === undefined && t.activityState === "idle",
+      )
+
+      kit.fakeAgents.codex.setCheckActivity(sessionId, null)
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.live("a hooks-shaped observation never shields a busy state from re-derivation", () =>
+    Effect.gen(function* () {
+      const { client, project } = yield* setup
+      const repository = yield* ThreadRepository
+      const thread = yield* client.v1.createThread({
+        payload: { projectId: project.id, agentId: "claude-code" },
+      })
+      const terminal = yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+      const sessionId = Option.getOrThrow(yield* repository.get(thread.id)).providerSessionId ?? ""
+      kit.fakeAgents.claude.emitActivity(sessionId, "working")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId: thread.id } }),
+        (t) => t.activityState === "working",
+      )
+
+      // The hooks feed dies silently with the TUI — its subscription is
+      // still registered, but it is no evidence. A busy snapshot must
+      // re-derive through checkSession, never ride the dead feed.
+      kit.fake.sessions.delete(sessionNameForTerminalId(terminal.id))
+      kit.fakeAgents.claude.setCheckActivity(sessionId, "idle")
+      const read = yield* client.v1.getThread({ params: { threadId: thread.id } })
+      assert.strictEqual(read.activityState, "idle")
+      assert.include(kit.fakeAgents.claude.checkCalls, sessionId)
+
+      kit.fakeAgents.claude.setCheckActivity(sessionId, null)
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.live("a page of stale-busy threads fans out bounded, never serialized (dead provider)", () =>
+    Effect.gen(function* () {
+      const client = yield* HttpApiTest.groups(Api, ["v1"])
+      const repository = yield* ThreadRepository
+      const fake = kit.fakeAgents.codex
+      const project = yield* client.v1.createProject({
+        payload: { name: "FanOut", defaultWorkingDirectory: realDir },
+      })
+
+      // Ten threads, each left stale-busy with no live observation: the
+      // shape a dead provider leaves behind, where every read must consult
+      // checkSession (kept scripted busy so each listing re-derives).
+      const sessionIds: Array<string> = []
+      for (let i = 0; i < 10; i++) {
+        const thread = yield* client.v1.createThread({
+          payload: { projectId: project.id, agentId: "codex" },
+        })
+        const terminal = yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+        const sessionId =
+          Option.getOrThrow(yield* repository.get(thread.id)).providerSessionId ?? ""
+        sessionIds.push(sessionId)
+        fake.emitActivity(sessionId, "working")
+        yield* eventually(
+          client.v1.getThread({ params: { threadId: thread.id } }),
+          (t) => t.activityState === "working",
+        )
+        kit.fake.sessions.delete(sessionNameForTerminalId(terminal.id))
+        fake.endObservations(sessionId)
+        fake.setCheckActivity(sessionId, "working")
+        // Settle the observation claim release: once the read consults
+        // checkSession, re-derivation (not the dead feed) owns this thread.
+        yield* eventually(
+          client.v1
+            .getThread({ params: { threadId: thread.id } })
+            .pipe(Effect.map(() => fake.checkCalls.includes(sessionId))),
+          (consulted) => consulted,
+        )
+      }
+
+      // One listing over the page: every record re-derives concurrently,
+      // capped at 8 in flight — neither serialized (minutes against a dead
+      // provider) nor a stampede.
+      const before = fake.checkCalls.length
+      fake.setCheckHangs(true)
+      const listing = yield* Effect.forkChild(
+        client.v1.listThreads({ query: { projectId: project.id } }),
+      )
+      yield* eventually(
+        Effect.sync(() => fake.maxConcurrentChecks()),
+        (max) => max === 8,
+      )
+      fake.setCheckHangs(false)
+      const listed = yield* Fiber.join(listing)
+      assert.strictEqual(listed.length, 10)
+      assert.isTrue(listed.every((t) => t.activityState === "working"))
+      assert.strictEqual(fake.checkCalls.length - before, 10)
+      assert.strictEqual(fake.maxConcurrentChecks(), 8)
+
+      for (const sessionId of sessionIds) fake.setCheckActivity(sessionId, null)
+      yield* client.v1.deleteProject({ params: { projectId: project.id } })
     }).pipe(Effect.provide(TestLayer)),
   )
 })

--- a/app-server/test/threads/threadOpen.test.ts
+++ b/app-server/test/threads/threadOpen.test.ts
@@ -591,6 +591,7 @@ describe("threads.openTerminal", () => {
       // One listing over the page: every record re-derives concurrently,
       // capped at 8 in flight — neither serialized (minutes against a dead
       // provider) nor a stampede.
+      fake.resetCheckStats()
       const before = fake.checkCalls.length
       fake.setCheckHangs(true)
       const listing = yield* Effect.forkChild(


### PR DESCRIPTION
PR 2 of the ATC-170 codebase-hardening effort. Findings: ATC-167 H4, M1, L6. Sub-issue: [ATC-172](https://linear.app/elevenideas/issue/ATC-172).

## Changes

- **H4 — `Threads.list` fan-out.** Three fixes: (1) a busy state under a live observation short-circuits re-derivation when the adapter's feed outlives the TUI — expressed as a new documented `AgentAdapter.observationOutlivesTui` flag (codex `true`: the shared app-server feed keeps streaming after the TUI dies; claude `false`: the hooks feed dies silently, so stale busy states must still re-derive to `unknown`); (2) codex connection attempts are memoized for a 5s window (`Effect.cachedInvalidateWithTTL`) so a dead Codex costs one probe per window instead of one full connect-timeout per listed record; (3) list assembly runs under `Effect.forEach(..., {concurrency: 8})`. New tests: feed-authoritative vs re-derivation behavior (both adapter shapes), a 10-thread bounded fan-out test proving the cap deterministically via a gated fake, and a codex test proving one probe serves the window (counted via wrapper spawn log).
- **M1 — version gate.** The `checked = true`-before-the-work flag (failed first check never retried, concurrent callers skipped the gate) is replaced with a single-flight memo. Not plain `Effect.cached`: verified against the pinned Effect (and empirically) that the cache memoizes whatever exit the driving fiber produces — *interruption included* — so a dropped request driving the first check would permanently poison the gate. The memo invalidates on driver interruption, is serialized by a semaphore (keeping callers out of the cache's waiter path), and is warn-only (a missing executable is reported by each call site's own resolution, never pinned into the memo). Two tests pin single-flight and interruption-immunity.
- **L6 — bounded adapter queues.** All five adapter session/observer queues get explicit capacities and overflow policies: writer session streams (256) *fail* with a protocol error on overflow (a clean end would read as a completed turn), observer/prompt feeds (16/32) *end* on overflow so the consumer re-observes and re-derives — the same honest-loss policy the SSE fan-out uses in events.ts.

## Verification

`mise run -C app-server check` — 334 passed.

Two adversarial reviews applied. The correctness review caught a genuine blocker in the first version-gate implementation (`Effect.uninterruptible` does not stop `Effect.cached` from memoizing the interrupt — the interrupt materializes inside the cached exit), which drove the final memo design. Accepted-as-designed residual (recorded on the sub-issue): for codex, a busy state under a live healthy observation is never re-derived — a transition the provider fails to broadcast on a healthy connection would persist until connection teardown pushes `unknown`; that is the H4 tradeoff as specified.

Stack note: this PR is part of the ATC-170 stack (#161 → #168, each based on the previous). All cross-PR conflicts are already resolved in the branches themselves — merge bottom-up in order and each merge retargets the next PR automatically; no manual resolution needed.

https://claude.ai/code/session_019pj9ErmqTfaLoTPksB3fSZ
