### PR TITLE
Server DRY & invariant restoration (ATC-173)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,11 +61,11 @@ apps can connect to and be built on top of. The Web UI is more admin interface
 than API client. It's meant as a place to manage all aspects of the server and
 document the CLI and API. The HTTP API is the complete canonical App Server
 interface; the CLI is an agent gateway over it — `atc api` gives complete
-access to every API operation, and a named command earns its place only by composing
-a workflow, needing local process/filesystem/TTY/streaming behavior, or
-materially improving on supplying raw JSON, never by merely renaming an
-endpoint. CLI commands never duplicate server domain logic, and no tooling
-should enforce an API-to-CLI mapping.
+access to every API operation, and a named command earns its place by
+composing a workflow, needing local process/filesystem/TTY/streaming
+behavior, materially improving on supplying raw JSON, or being a thin
+convenience over a common read/CRUD operation. CLI commands never duplicate
+server domain logic, and no tooling should enforce an API-to-CLI mapping.
 
 ## The ways to hurt yourself
 

--- a/app-server/src/adminUi/adminUi.ts
+++ b/app-server/src/adminUi/adminUi.ts
@@ -61,45 +61,55 @@ const listBuildDir = async (): Promise<Array<readonly [string, string]>> => {
   return files
 }
 
-// Built once per process: the content is fixed for the process lifetime in
-// both modes (embedded files in a compiled binary, the committed build on a
-// source run).
-let assetsMemo: Promise<ReadonlyMap<string, Asset>> | undefined
-const loadAssets = () =>
-  (assetsMemo ??=
-    buildInfo.commit === "dev"
-      ? listBuildDir().then(toAssetMap)
-      : import("./manifest.generated.ts").then((manifest) => toAssetMap(manifest.assets)))
+const loadAssets = (): Promise<ReadonlyMap<string, Asset>> =>
+  buildInfo.commit === "dev"
+    ? listBuildDir().then(toAssetMap)
+    : import("./manifest.generated.ts").then((manifest) => toAssetMap(manifest.assets))
 
-let warnedEmpty = false
-
-export const route = HttpRouter.add(
-  "GET",
-  "*",
+// The asset map is built once at layer build — the content is fixed for the
+// process lifetime in both modes (embedded files in a compiled binary, the
+// committed build on a source run) — and each asset's bytes are read once,
+// on first request, then served from memory.
+export const route = HttpRouter.use((router) =>
   Effect.gen(function* () {
-    const request = yield* HttpServerRequest.HttpServerRequest
     const assets = yield* Effect.promise(loadAssets)
-    if (assets.size === 0 && !warnedEmpty) {
-      warnedEmpty = true
+    if (assets.size === 0) {
       yield* Effect.logWarning("admin UI assets missing — run `mise run web:build`")
     }
-    const rawPath = new URL(request.url, "http://localhost").pathname
-    const pathname = yield* Effect.try(() => decodeURIComponent(rawPath)).pipe(
-      Effect.orElseSucceed(() => rawPath),
+    const loaded = new Map<string, { readonly bytes: Uint8Array; readonly contentType: string }>()
+    yield* router.add(
+      "GET",
+      "*",
+      Effect.gen(function* () {
+        const request = yield* HttpServerRequest.HttpServerRequest
+        const rawPath = new URL(request.url, "http://localhost").pathname
+        const pathname = yield* Effect.try(() => decodeURIComponent(rawPath)).pipe(
+          Effect.orElseSucceed(() => rawPath),
+        )
+        const asset = assets.get(pathname)
+        if (asset === undefined) {
+          // "/docs/" -> "/docs": the prerendered pages use relative asset
+          // URLs, which only resolve from the canonical (slash-less) path.
+          const trimmed = pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : ""
+          if (assets.has(trimmed)) return HttpServerResponse.redirect(trimmed, { status: 308 })
+          return HttpServerResponse.empty({ status: 404 })
+        }
+        const entry =
+          loaded.get(pathname) ??
+          (yield* Effect.promise(async () => {
+            const file = Bun.file(asset.filePath)
+            const read = {
+              bytes: await file.bytes(),
+              contentType: file.type === "" ? "application/octet-stream" : file.type,
+            }
+            loaded.set(pathname, read)
+            return read
+          }))
+        return HttpServerResponse.uint8Array(entry.bytes, {
+          contentType: entry.contentType,
+          headers: { "cache-control": asset.cacheControl },
+        })
+      }),
     )
-    const asset = assets.get(pathname)
-    if (asset === undefined) {
-      // "/docs/" -> "/docs": the prerendered pages use relative asset URLs,
-      // which only resolve from the canonical (slash-less) path.
-      const trimmed = pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : ""
-      if (assets.has(trimmed)) return HttpServerResponse.redirect(trimmed, { status: 308 })
-      return HttpServerResponse.empty({ status: 404 })
-    }
-    const file = Bun.file(asset.filePath)
-    const bytes = yield* Effect.promise(() => file.bytes())
-    return HttpServerResponse.uint8Array(bytes, {
-      contentType: file.type === "" ? "application/octet-stream" : file.type,
-      headers: { "cache-control": asset.cacheControl },
-    })
   }),
 )

--- a/app-server/src/adminUi/adminUi.ts
+++ b/app-server/src/adminUi/adminUi.ts
@@ -55,8 +55,8 @@ const listBuildDir = async (): Promise<Array<readonly [string, string]>> => {
     }
   } catch {
     // No build output (fresh checkout of a broken state, or web/build was
-    // deleted). Serve 404s rather than memoizing a rejection into a
-    // permanent 500; the warning below points at the fix.
+    // deleted). Serve 404s rather than failing the route layer; the warning
+    // at layer build points at the fix.
   }
   return files
 }

--- a/app-server/src/agents/agentAdapter.ts
+++ b/app-server/src/agents/agentAdapter.ts
@@ -457,7 +457,7 @@ export const providerErrors = (provider: AgentProvider) => {
 }
 
 /** Bound on one title one-shot (ATC-155); a hung child/query is cut here. */
-export const TITLE_TIMEOUT = "90 seconds"
+const TITLE_TIMEOUT = "90 seconds"
 
 /** The shared title-generation bound, failing with the provider's protocol error. */
 export const withTitleTimeout =
@@ -479,7 +479,10 @@ export const withTitleTimeout =
  * Deliver one event onto a session's writer feed. Overflow (a bounded
  * queue whose consumer stopped draining) FAILS the stream rather than
  * ending it — a clean end would read as a completed turn to the consumer,
- * not a truncated one (the events.ts subscriber policy, adapted).
+ * not a truncated one (the events.ts subscriber policy, adapted). The
+ * overflow branch arms once the session queues carry capacities (the
+ * ATC-172 reliability change bounds them); on unbounded queues it is
+ * reachable only for an already-ended queue, where failCauseUnsafe no-ops.
  */
 export const emitAgentEvent = (
   queue: Queue.Queue<AgentEvent, AgentProtocolError | Cause.Done>,

--- a/app-server/src/agents/agentAdapter.ts
+++ b/app-server/src/agents/agentAdapter.ts
@@ -1,4 +1,4 @@
-import { Duration, Effect, Schema, Semaphore, Stream } from "effect"
+import { Cause, Duration, Effect, Queue, Schema, Semaphore, Stream } from "effect"
 import type { Scope } from "effect"
 import { existsSync, realpathSync } from "node:fs"
 import type { AgentId } from "../api/contract.ts"
@@ -431,6 +431,66 @@ export class AgentConflict extends Schema.TaggedErrorClass<AgentConflict>()("Age
 }) {
   override get message(): string {
     return `${this.provider} conflict: ${this.reason}`
+  }
+}
+
+/**
+ * The per-provider error constructors and shared conflict-message rules
+ * every adapter otherwise re-declares (ATC-167 M12). The message builders
+ * are the seam's vocabulary: identical situations must read identically
+ * across providers.
+ */
+export const providerErrors = (provider: AgentProvider) => {
+  const conflict = (reason: string) => new AgentConflict({ provider, reason })
+  return {
+    unavailable: (reason: string) => new AgentUnavailable({ provider, reason }),
+    protocolError: (reason: string) => new AgentProtocolError({ provider, reason }),
+    conflict,
+    identityMismatch: (field: "sessionId" | "cwd", expected: string, actual: string) =>
+      new AgentIdentityMismatch({ provider, field, expected, actual }),
+    connectionClosed: () => conflict("the connection is closed"),
+    turnStillActive: (turnId: string) => conflict(`turn ${turnId} is still active`),
+    staleTurn: (turnId: string) => conflict(`turn ${turnId} is not the active turn`),
+    writerConnected: (providerSessionId: string) =>
+      conflict(`a writer is already connected to ${providerSessionId}`),
+  }
+}
+
+/** Bound on one title one-shot (ATC-155); a hung child/query is cut here. */
+export const TITLE_TIMEOUT = "90 seconds"
+
+/** The shared title-generation bound, failing with the provider's protocol error. */
+export const withTitleTimeout =
+  (protocolError: (reason: string) => AgentProtocolError) =>
+  <A, E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E | AgentProtocolError, R> =>
+    self.pipe(
+      Effect.timeoutOrElse({
+        duration: TITLE_TIMEOUT,
+        orElse: () =>
+          Effect.fail(
+            protocolError(
+              `title generation produced no result within ${Duration.format(Duration.fromInputUnsafe(TITLE_TIMEOUT))}`,
+            ),
+          ),
+      }),
+    )
+
+/**
+ * Deliver one event onto a session's writer feed. Overflow (a bounded
+ * queue whose consumer stopped draining) FAILS the stream rather than
+ * ending it — a clean end would read as a completed turn to the consumer,
+ * not a truncated one (the events.ts subscriber policy, adapted).
+ */
+export const emitAgentEvent = (
+  queue: Queue.Queue<AgentEvent, AgentProtocolError | Cause.Done>,
+  event: AgentEvent,
+  protocolError: (reason: string) => AgentProtocolError,
+): void => {
+  if (!Queue.offerUnsafe(queue, event)) {
+    Queue.failCauseUnsafe(
+      queue,
+      Cause.fail(protocolError("session event stream overflowed; reopen and resync")),
+    )
   }
 }
 

--- a/app-server/src/agents/agentRegistry.ts
+++ b/app-server/src/agents/agentRegistry.ts
@@ -1,5 +1,5 @@
 import { Context, Effect, Layer } from "effect"
-import { AGENT_IDS, AgentNotFound } from "../api/contract.ts"
+import { AGENT_IDS, AgentNotFound, isAgentId } from "../api/contract.ts"
 import type { Agent as AgentSchema, AgentId } from "../api/contract.ts"
 import { AppConfig } from "../platform/config.ts"
 import * as Subprocess from "../platform/subprocess.ts"
@@ -65,9 +65,6 @@ export const layer = Layer.effect(AgentRegistry)(
         ),
       )
     }
-
-    const isAgentId = (id: string): id is typeof AgentId.Type =>
-      (AGENT_IDS as ReadonlyArray<string>).includes(id)
 
     return {
       list: () => Effect.forEach(AGENT_IDS, describe),

--- a/app-server/src/agents/claudeAdapter.ts
+++ b/app-server/src/agents/claudeAdapter.ts
@@ -21,16 +21,16 @@ import {
 import type {
   AgentActivity,
   AgentAdapter,
+  AgentConflict,
   AgentConnection,
   AgentEvent,
   AgentIdentityMismatch,
   AgentProtocolError,
   AgentSessionEvent,
+  AgentUnavailable,
 } from "./agentAdapter.ts"
 import {
-  AgentConflict,
   AgentResumeFailed,
-  AgentUnavailable,
   emitAgentEvent,
   makeVersionGate,
   NESTED_SESSION_ENV_VARIABLES,

--- a/app-server/src/agents/claudeAdapter.ts
+++ b/app-server/src/agents/claudeAdapter.ts
@@ -23,19 +23,22 @@ import type {
   AgentAdapter,
   AgentConnection,
   AgentEvent,
+  AgentIdentityMismatch,
+  AgentProtocolError,
   AgentSessionEvent,
 } from "./agentAdapter.ts"
 import {
   AgentConflict,
-  AgentIdentityMismatch,
-  AgentProtocolError,
   AgentResumeFailed,
   AgentUnavailable,
+  emitAgentEvent,
   makeVersionGate,
   NESTED_SESSION_ENV_VARIABLES,
+  providerErrors,
   resolveProviderExecutable,
   samePath,
   titleInstruction,
+  withTitleTimeout,
 } from "./agentAdapter.ts"
 import * as path from "node:path"
 import * as ClaudeHooks from "./claudeHooks.ts"
@@ -87,10 +90,7 @@ import * as Subprocess from "../platform/subprocess.ts"
 //     subscriber; consumers stay above the seam.
 
 /** The Claude Code version this adapter was validated against. */
-export const CLAUDE_TESTED_VERSION = "2.1.221"
-
-/** Bound on one title one-shot (ATC-155); a hung child is aborted with it. */
-const TITLE_TIMEOUT = "90 seconds"
+const CLAUDE_TESTED_VERSION = "2.1.221"
 
 export class ClaudeAdapter extends Context.Service<ClaudeAdapter, AgentAdapter>()(
   "app-server/ClaudeAdapter",
@@ -108,8 +108,15 @@ export interface ClaudeAdapterOptions {
   readonly initTimeout?: Duration.Input
 }
 
-const protocolError = (reason: string) => new AgentProtocolError({ provider: "claude", reason })
-const conflict = (reason: string) => new AgentConflict({ provider: "claude", reason })
+const {
+  unavailable,
+  protocolError,
+  identityMismatch,
+  connectionClosed,
+  turnStillActive,
+  staleTurn,
+  writerConnected,
+} = providerErrors("claude")
 
 /**
  * Environment for the SDK child: the user's environment (credentials) plus
@@ -117,12 +124,8 @@ const conflict = (reason: string) => new AgentConflict({ provider: "claude", rea
  * (agentAdapter.ts) a dev-mode ATC would otherwise pass down.
  */
 const claudeEnvironment = (): Record<string, string> => {
-  const env: Record<string, string> = {}
-  for (const [key, value] of Object.entries(process.env)) {
-    if (value !== undefined) env[key] = value
-  }
+  const env = Subprocess.inheritedEnv(NESTED_SESSION_ENV_VARIABLES)
   env["CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS"] = "1"
-  for (const name of NESTED_SESSION_ENV_VARIABLES) delete env[name]
   return env
 }
 
@@ -247,18 +250,8 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
       const sessions = new Map<string, LiveSession>()
       let nextTurn = 1
 
-      const emit = (session: LiveSession, event: AgentEvent): void => {
-        // Bounded queue: a consumer that stopped draining loses the stream,
-        // not the process (the events.ts subscriber policy). Overflow FAILS
-        // the stream rather than ending it — a clean end would read as a
-        // completed turn to the consumer, not a truncated one.
-        if (!Queue.offerUnsafe(session.queue, event)) {
-          Queue.failCauseUnsafe(
-            session.queue,
-            Cause.fail(protocolError("session event stream overflowed; reopen and resync")),
-          )
-        }
-      }
+      const emit = (session: LiveSession, event: AgentEvent): void =>
+        emitAgentEvent(session.queue, event, protocolError)
 
       const setActivity = (session: LiveSession, activity: AgentActivity): void => {
         if (session.closed || session.activity === activity) return
@@ -302,24 +295,11 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
           ) {
             return failGate(
               session,
-              new AgentIdentityMismatch({
-                provider: "claude",
-                field: "sessionId",
-                expected: session.expectedSessionId,
-                actual: message.session_id,
-              }),
+              identityMismatch("sessionId", session.expectedSessionId, message.session_id),
             )
           }
           if (!samePath(message.cwd, session.cwd)) {
-            return failGate(
-              session,
-              new AgentIdentityMismatch({
-                provider: "claude",
-                field: "cwd",
-                expected: session.cwd,
-                actual: message.cwd,
-              }),
-            )
+            return failGate(session, identityMismatch("cwd", session.cwd, message.cwd))
           }
           session.sessionId = message.session_id
           if (!sessions.has(message.session_id)) sessions.set(message.session_id, session)
@@ -541,12 +521,8 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
           yield* fs.makeDirectory(config.stateDir, { recursive: true }).pipe(
             Effect.andThen(write(headerFile, `${ClaudeHooks.SECRET_HEADER}: ${secret}`)),
             Effect.andThen(write(settingsFile, JSON.stringify({ hooks: hookConfig }))),
-            Effect.mapError(
-              (error) =>
-                new AgentUnavailable({
-                  provider: "claude",
-                  reason: `could not write the hook settings files: ${error.message}`,
-                }),
+            Effect.mapError((error) =>
+              unavailable(`could not write the hook settings files: ${error.message}`),
             ),
             // A failed (or interrupted) write sequence must not strand the
             // allocation it sits inside: drop any partial file, and revoke
@@ -592,9 +568,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
           }
           if (options.resume !== undefined) {
             if (sessions.has(options.resume)) {
-              return yield* Effect.fail(
-                conflict(`a writer is already connected to ${options.resume}`),
-              )
+              return yield* Effect.fail(writerConnected(options.resume))
             }
             sessions.set(options.resume, session)
           }
@@ -645,14 +619,9 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
         const requireOpen = Effect.suspend(
           (): Effect.Effect<void, AgentConflict | AgentUnavailable> =>
             session.over
-              ? Effect.fail(
-                  new AgentUnavailable({
-                    provider: "claude",
-                    reason: "the session ended; resume it for a fresh connection",
-                  }),
-                )
+              ? Effect.fail(unavailable("the session ended; resume it for a fresh connection"))
               : session.closed
-                ? Effect.fail(conflict("the connection is closed"))
+                ? Effect.fail(connectionClosed())
                 : Effect.void,
         )
         return {
@@ -666,7 +635,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
             Effect.gen(function* () {
               yield* requireOpen
               if (session.activeTurn !== null) {
-                return yield* Effect.fail(conflict(`turn ${session.activeTurn} is still active`))
+                return yield* Effect.fail(turnStillActive(session.activeTurn))
               }
               const turnId = `claude-turn-${nextTurn++}`
               session.activeTurn = turnId
@@ -692,7 +661,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
             Effect.gen(function* () {
               yield* requireOpen
               if (session.activeTurn !== turn.turnId) {
-                return yield* Effect.fail(conflict(`turn ${turn.turnId} is not the active turn`))
+                return yield* Effect.fail(staleTurn(turn.turnId))
               }
               session.interruptRequested = true
               yield* Effect.tryPromise({
@@ -883,17 +852,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
                   protocolError(
                     `title generation failed: ${error instanceof Error ? error.message : String(error)}`,
                   ),
-              }).pipe(
-                Effect.timeoutOrElse({
-                  duration: TITLE_TIMEOUT,
-                  orElse: () =>
-                    Effect.fail(
-                      protocolError(
-                        `title generation produced no result within ${Duration.format(Duration.fromInputUnsafe(TITLE_TIMEOUT))}`,
-                      ),
-                    ),
-                }),
-              )
+              }).pipe(withTitleTimeout(protocolError))
             }),
           ),
         // Claude offers no cheap truthful liveness query for a session it

--- a/app-server/src/agents/claudeHooks.ts
+++ b/app-server/src/agents/claudeHooks.ts
@@ -203,10 +203,7 @@ export type HookListener = (providerSessionId: string, event: AgentSessionEvent)
  * a payload carrying `agent_id` fired inside a subagent — its prompt is
  * synthetic dispatch, never the user's message (ATC-155).
  */
-export const userPromptOf = (
-  eventName: string,
-  payload: Record<string, unknown>,
-): string | null => {
+const userPromptOf = (eventName: string, payload: Record<string, unknown>): string | null => {
   if (eventName !== "UserPromptSubmit") return null
   if (typeof payload["agent_id"] === "string") return null
   const prompt = payload["prompt"]

--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -15,23 +15,26 @@ import * as path from "node:path"
 import type {
   AgentActivity,
   AgentAdapter,
+  AgentConflict,
   AgentConnection,
   AgentEvent,
+  AgentIdentityMismatch,
+  AgentProtocolError,
   AgentSessionEvent,
+  AgentUnavailable,
   EstablishedIdentity,
 } from "./agentAdapter.ts"
 import {
-  AgentConflict,
-  AgentIdentityMismatch,
-  AgentProtocolError,
   AgentResumeFailed,
-  AgentUnavailable,
   aggregateActivity,
+  emitAgentEvent,
   makeVersionGate,
   NESTED_SESSION_ENV_VARIABLES,
+  providerErrors,
   resolveProviderExecutable,
   samePath,
   titleInstruction,
+  withTitleTimeout,
 } from "./agentAdapter.ts"
 import * as BuildInfo from "../platform/buildInfo.ts"
 import * as CodexServer from "./codexServer.ts"
@@ -64,12 +67,9 @@ import * as Subprocess from "../platform/subprocess.ts"
 //     on teardown, root unobserve/unregister, and release.
 
 /** The codex-cli version this adapter was validated against (record + warn). */
-export const CODEX_TESTED_VERSION = "0.146.0"
+const CODEX_TESTED_VERSION = "0.146.0"
 
 const REQUEST_TIMEOUT = "30 seconds"
-
-/** Bound on one `codex exec` title one-shot (ATC-155). */
-const TITLE_TIMEOUT = "90 seconds"
 
 /** The title one-shot's pinned model (ATC-155): a title needs the cheap
  * high-volume tier (~25× cheaper than the default coding models), never
@@ -88,9 +88,16 @@ export class CodexAdapter extends Context.Service<CodexAdapter, AgentAdapter>()(
   "app-server/CodexAdapter",
 ) {}
 
-const unavailable = (reason: string) => new AgentUnavailable({ provider: "codex", reason })
-const protocolError = (reason: string) => new AgentProtocolError({ provider: "codex", reason })
-const conflict = (reason: string) => new AgentConflict({ provider: "codex", reason })
+const {
+  unavailable,
+  protocolError,
+  conflict,
+  identityMismatch,
+  connectionClosed,
+  turnStillActive,
+  staleTurn,
+  writerConnected,
+} = providerErrors("codex")
 
 /** A JSON-RPC error response — mapped per call site (resume vs the rest). */
 class RpcError extends Schema.TaggedErrorClass<RpcError>()("RpcError", {
@@ -180,7 +187,6 @@ interface PendingReply {
 
 interface ClientState {
   readonly socket: WebSocket
-  readonly url: string
   readonly pending: Map<number, PendingReply>
   nextId: number
   alive: boolean
@@ -274,6 +280,18 @@ export const layer = Layer.effect(CodexAdapter)(
       }
       ownStatus.delete(rootId)
     }
+    // Raw frames arrive on a sync WebSocket callback with no fiber to log
+    // from, so the header's "raw events are logged at debug level" runs
+    // through this bridge: a sliding queue (bursts may drop old frames —
+    // acceptable for diagnostics) drained by one scoped logger fiber.
+    const rawFrames = yield* Queue.make<string>({ capacity: 256, strategy: "sliding" })
+    yield* Stream.fromQueue(rawFrames).pipe(
+      Stream.runForEach((raw) =>
+        Effect.logDebug("codex app-server frame").pipe(Effect.annotateLogs({ raw })),
+      ),
+      Effect.forkScoped,
+    )
+
     const connectLock = yield* Semaphore.make(1)
     const resumeLock = yield* Semaphore.make(1)
     // Serializes TUI launch → thread/started capture (prepareTuiSession).
@@ -313,18 +331,8 @@ export const layer = Layer.effect(CodexAdapter)(
       )
     }
 
-    const emit = (session: LiveSession, event: AgentEvent): void => {
-      // Bounded queue: a consumer that stopped draining loses the stream,
-      // not the process (the events.ts subscriber policy). Overflow FAILS
-      // the stream rather than ending it — a clean end would read as a
-      // completed turn to the consumer, not a truncated one.
-      if (!Queue.offerUnsafe(session.queue, event)) {
-        Queue.failCauseUnsafe(
-          session.queue,
-          Cause.fail(protocolError("session event stream overflowed; reopen and resync")),
-        )
-      }
-    }
+    const emit = (session: LiveSession, event: AgentEvent): void =>
+      emitAgentEvent(session.queue, event, protocolError)
 
     const teardown = (state: ClientState, reason: string): void => {
       if (!state.alive) return
@@ -468,6 +476,7 @@ export const layer = Layer.effect(CodexAdapter)(
     }
 
     const dispatch = (state: ClientState, raw: string): void => {
+      Queue.offerUnsafe(rawFrames, raw)
       let message: {
         id?: number | string
         method?: string
@@ -558,7 +567,7 @@ export const layer = Layer.effect(CodexAdapter)(
     const openSocket = (url: string): Effect.Effect<ClientState, AgentUnavailable> =>
       Effect.callback<ClientState, AgentUnavailable>((resume) => {
         const socket = new WebSocket(url)
-        const state: ClientState = { socket, url, pending: new Map(), nextId: 1, alive: true }
+        const state: ClientState = { socket, pending: new Map(), nextId: 1, alive: true }
         socket.onopen = () => resume(Effect.succeed(state))
         socket.onerror = () => {
           teardown(state, "connection failed")
@@ -689,15 +698,10 @@ export const layer = Layer.effect(CodexAdapter)(
         const requireLive = Effect.suspend(
           (): Effect.Effect<void, AgentConflict | AgentUnavailable> =>
             session.failed || !state.alive
-              ? Effect.fail(
-                  new AgentUnavailable({
-                    provider: "codex",
-                    reason: "the app-server connection was lost; resume the session",
-                  }),
-                )
+              ? Effect.fail(unavailable("the app-server connection was lost; resume the session"))
               : sessions.get(threadId) === session
                 ? Effect.void
-                : Effect.fail(conflict("the connection is closed")),
+                : Effect.fail(connectionClosed()),
         )
 
         const connection: AgentConnection = {
@@ -709,7 +713,7 @@ export const layer = Layer.effect(CodexAdapter)(
             Effect.gen(function* () {
               yield* requireLive
               if (session.activeTurn !== null) {
-                return yield* Effect.fail(conflict(`turn ${session.activeTurn} is still active`))
+                return yield* Effect.fail(turnStillActive(session.activeTurn))
               }
               // Reserve the slot before suspending on the RPC, or two
               // concurrent startTurn calls would both pass the check.
@@ -738,7 +742,7 @@ export const layer = Layer.effect(CodexAdapter)(
             Effect.gen(function* () {
               yield* requireLive
               if (session.activeTurn !== turn.turnId) {
-                return yield* Effect.fail(conflict(`turn ${turn.turnId} is not the active turn`))
+                return yield* Effect.fail(staleTurn(turn.turnId))
               }
               // A provider-side rejection means the target went stale in
               // flight — the same conflict as losing the local race.
@@ -916,14 +920,7 @@ export const layer = Layer.effect(CodexAdapter)(
               }).pipe(Effect.mapError(rpcToProtocol))
               const decoded = yield* decodeReply(ThreadReply, reply)
               if (!samePath(decoded.thread.cwd, options.cwd)) {
-                return yield* Effect.fail(
-                  new AgentIdentityMismatch({
-                    provider: "codex",
-                    field: "cwd",
-                    expected: options.cwd,
-                    actual: decoded.thread.cwd,
-                  }),
-                )
+                return yield* Effect.fail(identityMismatch("cwd", options.cwd, decoded.thread.cwd))
               }
               return yield* registerSession(
                 state,
@@ -950,9 +947,7 @@ export const layer = Layer.effect(CodexAdapter)(
           Effect.gen(function* () {
             const state = yield* getClient
             if (sessions.has(options.providerSessionId)) {
-              return yield* Effect.fail(
-                conflict(`a writer is already connected to ${options.providerSessionId}`),
-              )
+              return yield* Effect.fail(writerConnected(options.providerSessionId))
             }
             const reply = yield* request(state, "thread/resume", {
               threadId: options.providerSessionId,
@@ -971,23 +966,11 @@ export const layer = Layer.effect(CodexAdapter)(
             const decoded = yield* decodeReply(ThreadReply, reply)
             if (decoded.thread.id !== options.providerSessionId) {
               return yield* Effect.fail(
-                new AgentIdentityMismatch({
-                  provider: "codex",
-                  field: "sessionId",
-                  expected: options.providerSessionId,
-                  actual: decoded.thread.id,
-                }),
+                identityMismatch("sessionId", options.providerSessionId, decoded.thread.id),
               )
             }
             if (!samePath(decoded.thread.cwd, options.cwd)) {
-              return yield* Effect.fail(
-                new AgentIdentityMismatch({
-                  provider: "codex",
-                  field: "cwd",
-                  expected: options.cwd,
-                  actual: decoded.thread.cwd,
-                }),
-              )
+              return yield* Effect.fail(identityMismatch("cwd", options.cwd, decoded.thread.cwd))
             }
             const { connection } = yield* registerSession(
               state,
@@ -1241,17 +1224,7 @@ export const layer = Layer.effect(CodexAdapter)(
                     protocolError(`could not read the title output: ${error.message}`),
                   ),
                 )
-            }).pipe(
-              Effect.timeoutOrElse({
-                duration: TITLE_TIMEOUT,
-                orElse: () =>
-                  Effect.fail(
-                    protocolError(
-                      `title generation produced no result within ${Duration.format(Duration.fromInputUnsafe(TITLE_TIMEOUT))}`,
-                    ),
-                  ),
-              }),
-            )
+            }).pipe(withTitleTimeout(protocolError))
           }),
         ),
       checkSession: (options) =>

--- a/app-server/src/agents/codexServer.ts
+++ b/app-server/src/agents/codexServer.ts
@@ -13,7 +13,8 @@ import {
   Stream,
 } from "effect"
 import * as path from "node:path"
-import { AgentUnavailable, resolveProviderExecutable } from "./agentAdapter.ts"
+import { providerErrors, resolveProviderExecutable } from "./agentAdapter.ts"
+import type { AgentUnavailable } from "./agentAdapter.ts"
 import { AppConfig } from "../platform/config.ts"
 import * as Subprocess from "../platform/subprocess.ts"
 
@@ -84,7 +85,7 @@ export class CodexServer extends Context.Service<
   }
 >()("app-server/CodexServer") {}
 
-const unavailable = (reason: string) => new AgentUnavailable({ provider: "codex", reason })
+const { unavailable } = providerErrors("codex")
 
 /** Readiness-gate failure that must stop the retry loop: the pid is gone. */
 class ServerExited extends Schema.TaggedErrorClass<ServerExited>()("ServerExited", {

--- a/app-server/src/agents/smoke.ts
+++ b/app-server/src/agents/smoke.ts
@@ -268,10 +268,7 @@ const claudeRoundTrip = async (
 ): Promise<{ readonly sessionId: string; readonly text: string }> => {
   // Controlled but complete environment: the child needs HOME and any
   // credential configuration the user has; nothing is added or dropped.
-  const env: Record<string, string> = {}
-  for (const [key, value] of Object.entries(process.env)) {
-    if (value !== undefined) env[key] = value
-  }
+  const env = Subprocess.inheritedEnv()
   const stream = query({
     prompt: "Reply with exactly: ATC-SMOKE-OK",
     options: {

--- a/app-server/src/api/contract.ts
+++ b/app-server/src/api/contract.ts
@@ -579,6 +579,8 @@ const threadIdParam = { threadId: Schema.String }
 
 export class V1 extends HttpApiGroup.make("v1")
   .add(
+    // Operation ids (OpenApi.Identifier) are pinned and public API: renaming
+    // one is a breaking change for every generated client.
     HttpApiEndpoint.get("health", "/health", { success: HealthResponse })
       .annotate(OpenApi.Identifier, "getHealth")
       .annotate(OpenApi.Description, "Liveness probe: confirms the server is accepting requests."),

--- a/app-server/src/api/contract.ts
+++ b/app-server/src/api/contract.ts
@@ -9,8 +9,8 @@ import {
 
 // The public HTTP contract. The server implementation (handlers.ts), the
 // checked-in OpenAPI document (openapi.ts), and typed clients all derive from
-// this module. Authoring conventions (pinned operation ids, schema
-// identifiers, descriptions) live in AGENTS.md "OpenAPI Contract".
+// this module. The authoring conventions are stated inline where they bite
+// (pinned operation ids, optionalKey over optional, create returning 200).
 //
 // No listing endpoint paginates, deliberately: a single-user server's
 // collections stay small enough to return whole, and every client consumes
@@ -236,6 +236,10 @@ export const AgentId = Schema.Literals(AGENT_IDS).annotate({
   identifier: "AgentId",
   description: "Built-in agent registry slug.",
 })
+
+/** Whether `id` names a built-in agent (narrows to the registry slug union). */
+export const isAgentId = (id: string): id is typeof AgentId.Type =>
+  (AGENT_IDS as ReadonlyArray<string>).includes(id)
 
 export const Agent = Schema.Struct({
   id: AgentId,

--- a/app-server/src/api/handlers.ts
+++ b/app-server/src/api/handlers.ts
@@ -91,15 +91,9 @@ export const V1Handlers = HttpApiBuilder.group(
         // is exactly what the typed StreamSse pipeline produces.
         .handleRaw("subscribeEvents", () =>
           Effect.gen(function* () {
-            // Reconcile (the "a client showed up" refresh) BEFORE
-            // registering: a queue registered first would sit in the
-            // subscriber set until overflow if the fallible reconcile
-            // failed — or the request died during it — before the stream's
-            // cleanup was armed. Registration still precedes the first
-            // response byte, so a client that resyncs the moment it sees
-            // the comment observes the reconciled state and misses nothing.
-            yield* terminals.list()
-            const feed = yield* events.subscribe()
+            // The reconcile-before-register ordering lives in subscribe();
+            // the handler only names the refresh a new client deserves.
+            const feed = yield* events.subscribe({ reconcile: terminals.list() })
             // Heartbeat ticks become SSE comments: ignored by conforming
             // parsers, but they keep idle-timeout-prone transports alive and
             // surface dead sockets to the server via the failing write.

--- a/app-server/src/cli/cli.ts
+++ b/app-server/src/cli/cli.ts
@@ -161,7 +161,7 @@ export const clientCommand = <Params extends Command.Command.Config, A>(
     params: Command.Command.Config.Infer<Params>,
   ) => Effect.Effect<A, unknown>,
 ) =>
-  Command.make(diagnosticName.split(" ").at(-1)!, params, (parsed) =>
+  Command.make(diagnosticName.split(" ").at(-1) ?? diagnosticName, params, (parsed) =>
     withClient(diagnosticName, (client) =>
       Effect.gen(function* () {
         const result = yield* call(client, parsed)
@@ -185,6 +185,39 @@ export const nameFlag = (description: string) =>
 export const yesFlag = Flag.boolean("yes").pipe(
   Flag.withDescription("Confirm the deletion (required; the CLI never prompts)"),
 )
+
+/** Gate a destructive call behind --yes, naming the consequence refused. */
+export const requireYes = <A, E>(
+  yes: boolean,
+  consequence: string,
+  call: Effect.Effect<A, E>,
+): Effect.Effect<A, E | Error> =>
+  yes ? call : Effect.fail(new Error(`refusing to delete without --yes (${consequence})`))
+
+export const projectFlag = Flag.string("project").pipe(Flag.withDescription("Project id"))
+
+/**
+ * Spread helper for the contract's absent-key convention: `{key: value}`
+ * when the option is set (optionally mapped), `{}` otherwise.
+ */
+export function optionalKey<K extends string, A>(
+  key: K,
+  option: Option.Option<A>,
+): Partial<Record<K, A>>
+export function optionalKey<K extends string, A, B>(
+  key: K,
+  option: Option.Option<A>,
+  map: (value: A) => B,
+): Partial<Record<K, B>>
+export function optionalKey<K extends string, A, B>(
+  key: K,
+  option: Option.Option<A>,
+  map?: (value: A) => B,
+): Partial<Record<K, A | B>> {
+  return Option.isSome(option)
+    ? ({ [key]: map === undefined ? option.value : map(option.value) } as Record<K, A | B>)
+    : {}
+}
 
 export const health = clientCommand(
   "health",
@@ -214,7 +247,7 @@ const fsList = clientCommand(
   (client, args) =>
     client.v1.listDirectory({
       // The contract uses absent keys (not undefined/null) for omitted fields.
-      query: Option.isSome(args.path) ? { path: path.resolve(args.path.value) } : {},
+      query: optionalKey("path", args.path, path.resolve),
     }),
 )
 

--- a/app-server/src/cli/gateway.ts
+++ b/app-server/src/cli/gateway.ts
@@ -19,8 +19,9 @@ const API_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const
 const methodArgument = Argument.string("method").pipe(
   Argument.mapTryCatch(
     (raw) => {
-      const method = raw.toUpperCase() as (typeof API_METHODS)[number]
-      if (!API_METHODS.includes(method)) throw new Error()
+      const upper = raw.toUpperCase()
+      const method = API_METHODS.find((candidate) => candidate === upper)
+      if (method === undefined) throw new Error()
       return method
     },
     () => `method must be one of ${API_METHODS.join(", ")} (case-insensitive)`,

--- a/app-server/src/cli/projects.ts
+++ b/app-server/src/cli/projects.ts
@@ -1,4 +1,3 @@
-import { Effect, Option } from "effect"
 import { Argument, Command, Flag } from "effect/unstable/cli"
 import * as path from "node:path"
 import * as Cli from "./cli.ts"
@@ -45,10 +44,8 @@ const projectUpdate = Cli.clientCommand(
       params: { projectId },
       // The contract uses absent keys (not undefined/null) for omitted fields.
       payload: {
-        ...(Option.isSome(name) ? { name: name.value } : {}),
-        ...(Option.isSome(directory)
-          ? { defaultWorkingDirectory: path.resolve(directory.value) }
-          : {}),
+        ...Cli.optionalKey("name", name),
+        ...Cli.optionalKey("defaultWorkingDirectory", directory, path.resolve),
       },
     }),
 )
@@ -58,13 +55,11 @@ const projectDelete = Cli.clientCommand(
   "Delete a project and every thread and terminal it owns (never touches the filesystem)",
   { projectId: projectIdArgument, yes: Cli.yesFlag },
   (client, { projectId, yes }) =>
-    yes
-      ? client.v1.deleteProject({ params: { projectId } })
-      : Effect.fail(
-          new Error(
-            "refusing to delete without --yes (also deletes the project's threads and terminals, never the directory)",
-          ),
-        ),
+    Cli.requireYes(
+      yes,
+      "also deletes the project's threads and terminals, never the directory",
+      client.v1.deleteProject({ params: { projectId } }),
+    ),
 )
 
 export const project = Command.make("project").pipe(

--- a/app-server/src/cli/service.ts
+++ b/app-server/src/cli/service.ts
@@ -171,7 +171,10 @@ const runIgnoring = (
 // gui first (normal console login), user as the ssh/headless fallback: the
 // gui domain does not exist without an Aqua session.
 const launchdDomains = (): ReadonlyArray<string> => {
-  const uid = process.getuid!()
+  // launchd exists only where getuid does (macOS); reaching this without
+  // one is a bug, not a runtime condition.
+  const uid = process.getuid?.()
+  if (uid === undefined) throw new Error("launchd domains require a POSIX uid")
   return [`gui/${uid}`, `user/${uid}`]
 }
 
@@ -214,11 +217,9 @@ const launchdBootstrap = (subprocess: Subprocess["Service"], command: string, un
         return
       }
     }
-    yield* run(subprocess, command, "launchctl", [
-      "bootstrap",
-      domains[domains.length - 1]!,
-      unitFile,
-    ])
+    const fallback = domains.at(-1)
+    if (fallback === undefined) return
+    yield* run(subprocess, command, "launchctl", ["bootstrap", fallback, unitFile])
   })
 
 const unitFileFor = (platform: Platform): string =>

--- a/app-server/src/cli/service.ts
+++ b/app-server/src/cli/service.ts
@@ -170,18 +170,19 @@ const runIgnoring = (
 
 // gui first (normal console login), user as the ssh/headless fallback: the
 // gui domain does not exist without an Aqua session.
-const launchdDomains = (): ReadonlyArray<string> => {
-  // launchd exists only where getuid does (macOS); reaching this without
-  // one is a bug, not a runtime condition.
+// launchd exists only where getuid does (macOS); reaching this without one
+// is a bug, so it dies rather than modeling a failure nothing can handle.
+const launchdDomains: Effect.Effect<ReadonlyArray<string>> = Effect.suspend(() => {
   const uid = process.getuid?.()
-  if (uid === undefined) throw new Error("launchd domains require a POSIX uid")
-  return [`gui/${uid}`, `user/${uid}`]
-}
+  return uid === undefined
+    ? Effect.die(new Error("launchd domains require a POSIX uid"))
+    : Effect.succeed([`gui/${uid}`, `user/${uid}`])
+})
 
 /** The domain the agent is currently loaded in, or undefined. */
 const launchdLoadedDomain = (subprocess: Subprocess["Service"]) =>
   Effect.gen(function* () {
-    for (const domain of launchdDomains()) {
+    for (const domain of yield* launchdDomains) {
       if (
         (yield* runIgnoring(subprocess, "launchctl", ["print", `${domain}/${serviceName}`])) === 0
       ) {
@@ -198,7 +199,7 @@ const launchdLoaded = (subprocess: Subprocess["Service"]) =>
  * bootstrapping again while the old instance is still winding down fails. */
 const launchdUnload = (subprocess: Subprocess["Service"]) =>
   Effect.gen(function* () {
-    for (const domain of launchdDomains()) {
+    for (const domain of yield* launchdDomains) {
       yield* runIgnoring(subprocess, "launchctl", ["bootout", `${domain}/${serviceName}`])
     }
     yield* Cli.pollUntil(
@@ -211,14 +212,14 @@ const launchdUnload = (subprocess: Subprocess["Service"]) =>
 /** Bootstrap into the first domain that accepts it; report the last failure. */
 const launchdBootstrap = (subprocess: Subprocess["Service"], command: string, unitFile: string) =>
   Effect.gen(function* () {
-    const domains = launchdDomains()
+    const domains = yield* launchdDomains
     for (const domain of domains.slice(0, -1)) {
       if ((yield* runIgnoring(subprocess, "launchctl", ["bootstrap", domain, unitFile])) === 0) {
         return
       }
     }
     const fallback = domains.at(-1)
-    if (fallback === undefined) return
+    if (fallback === undefined) return yield* Effect.die(new Error("no launchd domains"))
     yield* run(subprocess, command, "launchctl", ["bootstrap", fallback, unitFile])
   })
 

--- a/app-server/src/cli/terminals.ts
+++ b/app-server/src/cli/terminals.ts
@@ -1,4 +1,4 @@
-import { Console, Effect, Option } from "effect"
+import { Console, Effect } from "effect"
 import { Argument, Command, Flag } from "effect/unstable/cli"
 import * as path from "node:path"
 import type * as Client from "../api/client.ts"
@@ -11,15 +11,13 @@ import * as Cli from "./cli.ts"
 
 const terminalIdArgument = Argument.string("terminal-id")
 
-const projectFlag = Flag.string("project").pipe(Flag.withDescription("Project id"))
-
 const terminalList = Cli.clientCommand(
   "terminal list",
   "List terminals (reconciled against the zmx inventory)",
-  { project: Flag.optional(projectFlag) },
+  { project: Flag.optional(Cli.projectFlag) },
   (client, { project }) =>
     client.v1.listTerminals({
-      query: Option.isSome(project) ? { projectId: project.value } : {},
+      query: Cli.optionalKey("projectId", project),
     }),
 )
 
@@ -34,7 +32,7 @@ const terminalCreate = Cli.clientCommand(
   "terminal create",
   "Create a terminal and start its zmx session (an interactive shell, or the given command argv)",
   {
-    project: projectFlag,
+    project: Cli.projectFlag,
     name: Flag.optional(Cli.nameFlag("Display label")),
     directory: Flag.optional(
       Cli.directoryFlag("Working directory (may be relative; defaults to the project's default)"),
@@ -48,8 +46,8 @@ const terminalCreate = Cli.clientCommand(
     client.v1.createTerminal({
       payload: {
         projectId: project,
-        ...(Option.isSome(name) ? { name: name.value } : {}),
-        ...(Option.isSome(directory) ? { workingDirectory: path.resolve(directory.value) } : {}),
+        ...Cli.optionalKey("name", name),
+        ...Cli.optionalKey("workingDirectory", directory, path.resolve),
         ...(command.length > 0 ? { command } : {}),
       },
     }),
@@ -68,9 +66,11 @@ const terminalDelete = Cli.clientCommand(
   "Delete a terminal: kill its zmx session, verify absence, remove the record",
   { terminalId: terminalIdArgument, yes: Cli.yesFlag },
   (client, { terminalId, yes }) =>
-    yes
-      ? client.v1.deleteTerminal({ params: { terminalId } })
-      : Effect.fail(new Error("refusing to delete without --yes (kills the running session)")),
+    Cli.requireYes(
+      yes,
+      "kills the running session",
+      client.v1.deleteTerminal({ params: { terminalId } }),
+    ),
 )
 
 /**

--- a/app-server/src/cli/threads.ts
+++ b/app-server/src/cli/threads.ts
@@ -1,4 +1,4 @@
-import { Effect, Option } from "effect"
+import { Effect } from "effect"
 import { Argument, Command, Flag } from "effect/unstable/cli"
 import * as path from "node:path"
 import { AGENT_IDS } from "../api/contract.ts"
@@ -12,13 +12,11 @@ import { attachAndReport } from "./terminals.ts"
 
 const threadIdArgument = Argument.string("thread-id")
 
-const projectFlag = Flag.string("project").pipe(Flag.withDescription("Project id"))
-
 const threadList = Cli.clientCommand(
   "thread list",
   "List threads (archived threads only with --archived)",
   {
-    project: Flag.optional(projectFlag),
+    project: Flag.optional(Cli.projectFlag),
     archived: Flag.boolean("archived").pipe(
       Flag.withDescription("List archived threads instead of active ones"),
     ),
@@ -26,7 +24,7 @@ const threadList = Cli.clientCommand(
   (client, { project, archived }) =>
     client.v1.listThreads({
       query: {
-        ...(Option.isSome(project) ? { projectId: project.value } : {}),
+        ...Cli.optionalKey("projectId", project),
         ...(archived ? { archived: "true" as const } : {}),
       },
     }),
@@ -43,7 +41,7 @@ const threadCreate = Cli.clientCommand(
   "thread create",
   "Create a thread (local record only; the agent session starts on first use)",
   {
-    project: projectFlag,
+    project: Cli.projectFlag,
     agent: Flag.choice("agent", AGENT_IDS).pipe(
       Flag.withDescription("Agent to converse with (codex or claude-code)"),
     ),
@@ -57,8 +55,8 @@ const threadCreate = Cli.clientCommand(
       payload: {
         projectId: project,
         agentId: agent,
-        ...(Option.isSome(name) ? { name: name.value } : {}),
-        ...(Option.isSome(directory) ? { workingDirectory: path.resolve(directory.value) } : {}),
+        ...Cli.optionalKey("name", name),
+        ...Cli.optionalKey("workingDirectory", directory, path.resolve),
       },
     }),
 )
@@ -105,9 +103,11 @@ const threadDelete = Cli.clientCommand(
   "Delete a thread: kill its live linked terminal, remove the record (provider history is untouched)",
   { threadId: threadIdArgument, yes: Cli.yesFlag },
   (client, { threadId, yes }) =>
-    yes
-      ? client.v1.deleteThread({ params: { threadId } })
-      : Effect.fail(new Error("refusing to delete without --yes (kills the thread's terminal)")),
+    Cli.requireYes(
+      yes,
+      "kills the thread's terminal",
+      client.v1.deleteThread({ params: { threadId } }),
+    ),
 )
 
 export const thread = Command.make("thread").pipe(

--- a/app-server/src/events/events.ts
+++ b/app-server/src/events/events.ts
@@ -58,7 +58,7 @@ export class Events extends Context.Service<
      * moment the stream opens observes the reconciled state and misses
      * nothing.
      */
-    readonly subscribe: <E>(options?: {
+    readonly subscribe: <E = never>(options?: {
       readonly reconcile?: Effect.Effect<unknown, E> | undefined
     }) => Effect.Effect<Stream.Stream<ResourceChangedEvent | Heartbeat>, E>
     /** Currently registered subscribers. Exists for tests and diagnostics. */

--- a/app-server/src/events/events.ts
+++ b/app-server/src/events/events.ts
@@ -49,9 +49,18 @@ export class Events extends Context.Service<
     /**
      * Register a subscriber (eagerly — see the header) and return its live
      * stream of events interleaved with heartbeat ticks, which ends on lag
-     * or on close().
+     * or on close(). `reconcile` (the "a client showed up" refresh) runs
+     * BEFORE registration — this ordering is the rule, not the caller's
+     * choice: a queue registered first would sit in the subscriber set
+     * until overflow if the fallible reconcile failed — or the request died
+     * during it — before the stream's cleanup was armed. Registration still
+     * precedes the first delivered event, so a client that resyncs the
+     * moment the stream opens observes the reconciled state and misses
+     * nothing.
      */
-    readonly subscribe: () => Effect.Effect<Stream.Stream<ResourceChangedEvent | Heartbeat>>
+    readonly subscribe: <E>(options?: {
+      readonly reconcile?: Effect.Effect<unknown, E> | undefined
+    }) => Effect.Effect<Stream.Stream<ResourceChangedEvent | Heartbeat>, E>
     /** Currently registered subscribers. Exists for tests and diagnostics. */
     readonly subscriberCount: () => Effect.Effect<number>
     /** End every subscriber stream, current and future. Idempotent. */
@@ -107,8 +116,9 @@ export const layerWith = (options: EventsOptions) =>
 
       return {
         publish: (event) => Effect.sync(() => offer(event)),
-        subscribe: () =>
+        subscribe: (options) =>
           Effect.gen(function* () {
+            if (options?.reconcile !== undefined) yield* options.reconcile
             const queue = yield* Queue.make<ResourceChangedEvent | Heartbeat, Cause.Done>({
               capacity,
             })

--- a/app-server/src/platform/repositoryHelpers.ts
+++ b/app-server/src/platform/repositoryHelpers.ts
@@ -1,11 +1,8 @@
 import { Effect, Option } from "effect"
 
-// Shared result-shaping for the repositories (ATC-167 M9): the row→record
-// plumbing that was copied verbatim across all three. SQL stays inside each
-// repository — these helpers never see a query. Database failures are
-// defects, not domain errors: the API surfaces them as 500s and the CLI's
-// one-line contract reports them; nothing can handle them (each repository
-// applies Effect.orDie at its own boundary).
+// Shared result-shaping for the repositories: the row→record plumbing that
+// was copied verbatim across all three. SQL stays inside each repository —
+// these helpers never see a query.
 
 /** Row→record result helpers for one repository. */
 export const rowHelpers = <Row, Rec>(entity: string, toRecord: (row: Row) => Rec) => ({

--- a/app-server/src/platform/repositoryHelpers.ts
+++ b/app-server/src/platform/repositoryHelpers.ts
@@ -1,0 +1,32 @@
+import { Effect, Option } from "effect"
+
+// Shared result-shaping for the repositories (ATC-167 M9): the row→record
+// plumbing that was copied verbatim across all three. SQL stays inside each
+// repository — these helpers never see a query. Database failures are
+// defects, not domain errors: the API surfaces them as 500s and the CLI's
+// one-line contract reports them; nothing can handle them (each repository
+// applies Effect.orDie at its own boundary).
+
+/** Row→record result helpers for one repository. */
+export const rowHelpers = <Row, Rec>(entity: string, toRecord: (row: Row) => Rec) => ({
+  /** The first row as a mapped Option (id lookups return at most one). */
+  firstRecord: (rows: ReadonlyArray<Row>): Option.Option<Rec> =>
+    Option.fromNullishOr(rows[0]).pipe(Option.map(toRecord)),
+  /** For updates whose caller holds the record: a vanished row is a bug. */
+  requireFirst:
+    (what: string) =>
+    (rows: ReadonlyArray<Row>): Effect.Effect<Rec> =>
+      rows[0] !== undefined
+        ? Effect.succeed(toRecord(rows[0]))
+        : Effect.die(new Error(`${what}: ${entity} row vanished mid-update`)),
+})
+
+/** `require` from `get`: unwrap the Option or fail with the domain error. */
+export const requireFound =
+  <A, E>(notFound: () => E) =>
+  (found: Effect.Effect<Option.Option<A>>): Effect.Effect<A, E> =>
+    found.pipe(
+      Effect.flatMap(
+        Option.match({ onNone: () => Effect.fail(notFound()), onSome: Effect.succeed }),
+      ),
+    )

--- a/app-server/src/platform/subprocess.ts
+++ b/app-server/src/platform/subprocess.ts
@@ -203,18 +203,27 @@ export const waitForProcessExit = (
 const truncate = (line: string): string =>
   line.length > MAX_CAPTURED_LINE_LENGTH ? `${line.slice(0, MAX_CAPTURED_LINE_LENGTH)}…` : line
 
-/** The one place child environments are composed (and the one sanctioned
- * process.env read for them): explicit env, optionally over the parent
- * environment minus `unsetEnv`. */
-const childEnv = (spec: SpawnSpec): Record<string, string> => {
-  const explicit = spec.env ?? {}
-  if (spec.extendEnv !== true) return explicit
+/**
+ * A copy of the parent environment minus `unset` — the one sanctioned
+ * process.env read for child environments. Exported for the two children
+ * ATC does not spawn itself (the Agent SDK's own child, the smoke probe),
+ * which need the same inherited-credentials copy without a SpawnSpec.
+ */
+export const inheritedEnv = (unset: ReadonlyArray<string> = []): Record<string, string> => {
   const env: Record<string, string> = {}
   for (const [key, value] of Object.entries(process.env)) {
     if (value !== undefined) env[key] = value
   }
-  for (const name of spec.unsetEnv ?? []) delete env[name]
-  return { ...env, ...explicit }
+  for (const name of unset) delete env[name]
+  return env
+}
+
+/** The one place child environments are composed: explicit env, optionally
+ * over the parent environment minus `unsetEnv`. */
+const childEnv = (spec: SpawnSpec): Record<string, string> => {
+  const explicit = spec.env ?? {}
+  if (spec.extendEnv !== true) return explicit
+  return { ...inheritedEnv(spec.unsetEnv), ...explicit }
 }
 
 /** The one place a SubprocessError is built from an arbitrary cause. */

--- a/app-server/src/projects/projectRepository.ts
+++ b/app-server/src/projects/projectRepository.ts
@@ -52,8 +52,8 @@ export class ProjectRepository extends Context.Service<
   }
 >()("app-server/ProjectRepository") {}
 
-// Database-failure policy (defects, orDie at this boundary): see
-// platform/repositoryHelpers.ts.
+// Database failures are defects, not domain errors: the API surfaces them as
+// 500s and the one-line CLI contract reports them; nothing can handle them.
 export const layer = Layer.effect(ProjectRepository)(
   Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient

--- a/app-server/src/projects/projectRepository.ts
+++ b/app-server/src/projects/projectRepository.ts
@@ -1,5 +1,6 @@
 import { Context, Effect, Layer, Option, Schema } from "effect"
 import { SqlClient, SqlSchema } from "effect/unstable/sql"
+import { requireFound, rowHelpers } from "../platform/repositoryHelpers.ts"
 import { ProjectNotFound } from "../api/contract.ts"
 import type { Project as ProjectSchema } from "../api/contract.ts"
 
@@ -51,8 +52,8 @@ export class ProjectRepository extends Context.Service<
   }
 >()("app-server/ProjectRepository") {}
 
-// Database failures are defects, not domain errors: the API surfaces them as
-// 500s and the one-line CLI contract reports them; nothing can handle them.
+// Database-failure policy (defects, orDie at this boundary): see
+// platform/repositoryHelpers.ts.
 export const layer = Layer.effect(ProjectRepository)(
   Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient
@@ -98,10 +99,9 @@ export const layer = Layer.effect(ProjectRepository)(
       execute: (id) => sql`DELETE FROM projects WHERE id = ${id} RETURNING id`,
     })
 
-    const firstProject = (rows: ReadonlyArray<typeof ProjectRow.Type>) =>
-      Option.fromNullishOr(rows[0]).pipe(Option.map(toProject))
+    const { firstRecord } = rowHelpers("project", toProject)
 
-    const get = (id: string) => getRows(id).pipe(Effect.map(firstProject), Effect.orDie)
+    const get = (id: string) => getRows(id).pipe(Effect.map(firstRecord), Effect.orDie)
 
     return {
       list: () =>
@@ -121,15 +121,7 @@ export const layer = Layer.effect(ProjectRepository)(
         return insertRow(row).pipe(Effect.as(toProject(row)), Effect.orDie)
       },
       get,
-      require: (id) =>
-        get(id).pipe(
-          Effect.flatMap(
-            Option.match({
-              onNone: () => Effect.fail(new ProjectNotFound({ projectId: id })),
-              onSome: Effect.succeed,
-            }),
-          ),
-        ),
+      require: (id) => get(id).pipe(requireFound(() => new ProjectNotFound({ projectId: id }))),
       update: (id, patch) =>
         // An empty patch changes nothing — including updatedAt.
         patch.name === undefined && patch.defaultWorkingDirectory === undefined
@@ -139,7 +131,7 @@ export const layer = Layer.effect(ProjectRepository)(
               name: patch.name ?? null,
               default_working_directory: patch.defaultWorkingDirectory ?? null,
               updated_at: new Date().toISOString(),
-            }).pipe(Effect.map(firstProject), Effect.orDie),
+            }).pipe(Effect.map(firstRecord), Effect.orDie),
       delete: (id) =>
         deleteRows(id).pipe(
           Effect.map((rows) => rows.length > 0),

--- a/app-server/src/terminals/terminalRepository.ts
+++ b/app-server/src/terminals/terminalRepository.ts
@@ -82,8 +82,8 @@ export class TerminalRepository extends Context.Service<
   }
 >()("app-server/TerminalRepository") {}
 
-// Database-failure policy (defects, orDie at this boundary): see
-// platform/repositoryHelpers.ts.
+// Database failures are defects, not domain errors: the API surfaces them as
+// 500s and the one-line CLI contract reports them; nothing can handle them.
 export const layer = Layer.effect(TerminalRepository)(
   Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient

--- a/app-server/src/terminals/terminalRepository.ts
+++ b/app-server/src/terminals/terminalRepository.ts
@@ -1,5 +1,6 @@
 import { Context, Effect, Layer, Option, Schema } from "effect"
 import { SqlClient, SqlSchema } from "effect/unstable/sql"
+import { requireFound, rowHelpers } from "../platform/repositoryHelpers.ts"
 import { TerminalNotFound } from "../api/contract.ts"
 
 // The Terminals repository (ATC-130): the only module that speaks SQL for
@@ -81,8 +82,8 @@ export class TerminalRepository extends Context.Service<
   }
 >()("app-server/TerminalRepository") {}
 
-// Database failures are defects, not domain errors: the API surfaces them as
-// 500s and the one-line CLI contract reports them; nothing can handle them.
+// Database-failure policy (defects, orDie at this boundary): see
+// platform/repositoryHelpers.ts.
 export const layer = Layer.effect(TerminalRepository)(
   Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient
@@ -145,14 +146,7 @@ export const layer = Layer.effect(TerminalRepository)(
       execute: (id) => sql`DELETE FROM terminals WHERE id = ${id}`,
     })
 
-    const firstRecord = (rows: ReadonlyArray<typeof TerminalRow.Type>) =>
-      Option.fromNullishOr(rows[0]).pipe(Option.map(toRecord))
-
-    /** For updates whose caller holds the record: a vanished row is a bug. */
-    const requireFirst = (what: string) => (rows: ReadonlyArray<typeof TerminalRow.Type>) =>
-      rows[0] !== undefined
-        ? Effect.succeed(toRecord(rows[0]))
-        : Effect.die(new Error(`${what}: terminal row vanished mid-update`))
+    const { firstRecord, requireFirst } = rowHelpers("terminal", toRecord)
 
     const get = (id: string) => getRows(id).pipe(Effect.map(firstRecord), Effect.orDie)
 
@@ -183,15 +177,7 @@ export const layer = Layer.effect(TerminalRepository)(
           Effect.orDie,
         ),
       get,
-      require: (id) =>
-        get(id).pipe(
-          Effect.flatMap(
-            Option.match({
-              onNone: () => Effect.fail(new TerminalNotFound({ terminalId: id })),
-              onSome: Effect.succeed,
-            }),
-          ),
-        ),
+      require: (id) => get(id).pipe(requireFound(() => new TerminalNotFound({ terminalId: id }))),
       markLive: (id) =>
         Effect.suspend(() => markLiveRows({ id, updated_at: new Date().toISOString() })).pipe(
           Effect.orDie,

--- a/app-server/src/terminals/terminals.ts
+++ b/app-server/src/terminals/terminals.ts
@@ -126,11 +126,6 @@ export const layer = Layer.effect(Terminals)(
       .pipe(Effect.map((sessions) => new Set(sessions.map((s) => s.name))))
 
     /**
-     * The one tombstoning step both reconciliation passes share: mark every
-     * live row whose session a complete inventory omits as ended (one batch
-     * statement) and return the records with the tombstones applied.
-     */
-    /**
      * The one publisher for terminal lifecycle transitions: a transition on
      * a thread's TUI terminal also changes that thread's derived fields
      * (linkedTerminalId, activity re-derivation), so the thread's `updated`
@@ -149,6 +144,11 @@ export const layer = Layer.effect(Terminals)(
         }
       })
 
+    /**
+     * The one tombstoning step both reconciliation passes share: mark every
+     * live row whose session a complete inventory omits as ended (one batch
+     * statement) and return the records with the tombstones applied.
+     */
     const tombstoneAbsent = (
       records: ReadonlyArray<TerminalRecord>,
       present: ReadonlySet<string>,
@@ -211,7 +211,7 @@ export const layer = Layer.effect(Terminals)(
             // failed launch leaves no record.
             if (reachable.has(sessionName)) {
               yield* repository.markLive(record.id)
-              yield* events.publish({ resource: "terminal", id: record.id, change: "created" })
+              yield* publishTerminalChange(record, "created")
               claimed.add(sessionName)
             } else if (present.has(sessionName)) {
               claimed.add(sessionName)

--- a/app-server/src/terminals/terminals.ts
+++ b/app-server/src/terminals/terminals.ts
@@ -130,6 +130,25 @@ export const layer = Layer.effect(Terminals)(
      * live row whose session a complete inventory omits as ended (one batch
      * statement) and return the records with the tombstones applied.
      */
+    /**
+     * The one publisher for terminal lifecycle transitions: a transition on
+     * a thread's TUI terminal also changes that thread's derived fields
+     * (linkedTerminalId, activity re-derivation), so the thread's `updated`
+     * always publishes alongside — a mutation that forgot the pair would
+     * leave clients holding a stale linkedTerminalId. (Rename is the one
+     * mutation that publishes solo: a label touches no derived field.)
+     */
+    const publishTerminalChange = (
+      record: { readonly id: string; readonly threadId?: string | undefined },
+      change: "created" | "updated" | "deleted",
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        yield* events.publish({ resource: "terminal", id: record.id, change })
+        if (record.threadId !== undefined) {
+          yield* events.publish({ resource: "thread", id: record.threadId, change: "updated" })
+        }
+      })
+
     const tombstoneAbsent = (
       records: ReadonlyArray<TerminalRecord>,
       present: ReadonlySet<string>,
@@ -141,15 +160,7 @@ export const layer = Layer.effect(Terminals)(
         if (deadRecords.length === 0) return records
         const dead = new Set(deadRecords.map((r) => r.id))
         const endedAt = yield* repository.markEnded([...dead])
-        yield* Effect.forEach(deadRecords, (record) =>
-          events.publish({ resource: "terminal", id: record.id, change: "updated" }),
-        )
-        // A dead TUI terminal also changes its thread's derived fields
-        // (linkedTerminalId, activity re-derivation), so the thread
-        // publishes alongside — the event names no thread otherwise.
-        yield* Effect.forEach(new Set(deadRecords.flatMap((r) => r.threadId ?? [])), (id) =>
-          events.publish({ resource: "thread", id, change: "updated" }),
-        )
+        yield* Effect.forEach(deadRecords, (record) => publishTerminalChange(record, "updated"))
         return records.map((record) =>
           dead.has(record.id)
             ? { ...record, status: "ended" as const, endedAt, updatedAt: endedAt }
@@ -289,13 +300,10 @@ export const layer = Layer.effect(Terminals)(
             Effect.andThen(repository.markLive(record.id)),
             Effect.onExit((exit) => (exit._tag === "Failure" ? cleanup : Effect.void)),
           )
-        yield* events.publish({ resource: "terminal", id: live.id, change: "created" })
-        // A live terminal created into a thread immediately changes that
-        // thread's derived linkedTerminalId; openTerminal's own event lands
-        // only after the identity wait, far too late for this transition.
-        if (input.threadId !== undefined) {
-          yield* events.publish({ resource: "thread", id: input.threadId, change: "updated" })
-        }
+        // The paired thread event matters here especially: openTerminal's
+        // own event lands only after the identity wait, far too late for
+        // the linkedTerminalId transition.
+        yield* publishTerminalChange(live, "created")
         return toTerminal(live)
       })
 
@@ -318,12 +326,7 @@ export const layer = Layer.effect(Terminals)(
             ),
           )
         yield* repository.delete(id)
-        yield* events.publish({ resource: "terminal", id, change: "deleted" })
-        // Deleting a thread's TUI terminal changes that thread's derived
-        // linkedTerminalId (see tombstoneAbsent).
-        if (record.threadId !== undefined) {
-          yield* events.publish({ resource: "thread", id: record.threadId, change: "updated" })
-        }
+        yield* publishTerminalChange(record, "deleted")
       })
 
     return {
@@ -371,14 +374,7 @@ export const layer = Layer.effect(Terminals)(
           const record = yield* repository.get(id)
           yield* repository.markEnded([id])
           if (Option.isSome(record) && record.value.status === "live") {
-            yield* events.publish({ resource: "terminal", id, change: "updated" })
-            if (record.value.threadId !== undefined) {
-              yield* events.publish({
-                resource: "thread",
-                id: record.value.threadId,
-                change: "updated",
-              })
-            }
+            yield* publishTerminalChange(record.value, "updated")
           }
           return true
         }),

--- a/app-server/src/terminals/zmxAdapter.ts
+++ b/app-server/src/terminals/zmxAdapter.ts
@@ -2,8 +2,7 @@ import { Effect, FileSystem, Layer, Schema, Stream } from "effect"
 import type { Duration } from "effect"
 import * as path from "node:path"
 import { AppConfig, CONTEXT_VARIABLES } from "../platform/config.ts"
-import { resolveExecutable as resolveExecutablePath, Subprocess } from "../platform/subprocess.ts"
-import type { SubprocessError } from "../platform/subprocess.ts"
+import * as Subprocess from "../platform/subprocess.ts"
 import { ZmxUnavailable } from "../api/contract.ts"
 import {
   LONGEST_SESSION_NAME,
@@ -86,31 +85,25 @@ export const parseSessionList = (stdout: ReadonlyArray<string>): Array<SessionIn
 }
 
 /**
- * The environment for every zmx child: the parent environment with the
- * mandatory scrubs applied, ATC's private socket directory pinned, and this
- * server's ATC_ENDPOINT injected so agents inside launched sessions can
- * reach the API (ATC-131 context propagation — no secrets, just the URL).
- * Every inherited ATC_* context variable is scrubbed first: a server running
- * inside another ATC session would otherwise leak that session's ids into
- * every terminal it launches, and stale context is worse than none.
+ * The SpawnSpec env fragment for every zmx child — composed by Subprocess,
+ * the one place child environments are built: the parent environment with
+ * the mandatory scrubs applied, ATC's private socket directory pinned, and
+ * this server's ATC_ENDPOINT injected so agents inside launched sessions
+ * can reach the API (ATC-131 context propagation — no secrets, just the
+ * URL). Every inherited ATC_* context variable is scrubbed: a server
+ * running inside another ATC session would otherwise leak that session's
+ * ids into every terminal it launches, and stale context is worse than
+ * none.
  */
-export const zmxChildEnv = (
-  socketDir: string,
-  endpoint: string,
-  parent: Record<string, string | undefined> = process.env,
-): Record<string, string> => {
-  const env: Record<string, string> = {}
-  for (const [key, value] of Object.entries(parent)) {
-    if (value !== undefined) env[key] = value
-  }
-  delete env["ZMX_SESSION"]
-  delete env["ZMX_SESSION_PREFIX"]
-  for (const name of CONTEXT_VARIABLES) delete env[name]
-  env["ZMX_DIR"] = socketDir
-  env["TERM"] = SESSION_TERM_TYPE
-  env["ATC_ENDPOINT"] = endpoint
-  return env
-}
+export const zmxSpawnEnv = (socketDir: string, endpoint: string) => ({
+  env: {
+    ZMX_DIR: socketDir,
+    TERM: SESSION_TERM_TYPE,
+    ATC_ENDPOINT: endpoint,
+  },
+  extendEnv: true,
+  unsetEnv: ["ZMX_SESSION", "ZMX_SESSION_PREFIX", ...CONTEXT_VARIABLES],
+})
 
 /** Printable diagnostic from raw terminal output: control bytes stripped. */
 const printableTail = (tail: string): string =>
@@ -122,7 +115,7 @@ export const layerWith = (options: ZmxOptions) =>
       const pollInterval = options.pollInterval ?? "250 millis"
       const verifyPasses = options.verifyPasses ?? 20
       const config = yield* AppConfig
-      const subprocess = yield* Subprocess
+      const subprocess = yield* Subprocess.Subprocess
       const fs = yield* FileSystem.FileSystem
 
       const socketDir = config.terminalSocketDir
@@ -144,15 +137,15 @@ export const layerWith = (options: ZmxOptions) =>
       yield* fs.makeDirectory(socketDir, { recursive: true, mode: 0o700 })
       yield* fs.chmod(socketDir, 0o700)
 
-      const childEnv = zmxChildEnv(socketDir, `http://127.0.0.1:${config.port}`)
+      const spawnEnv = zmxSpawnEnv(socketDir, `http://127.0.0.1:${config.port}`)
 
       // Explicit resolution, never implicit (the shared resolveExecutable
       // rule), memoized on success — a resolved install does not move mid-run.
       let resolvedExecutable: string | undefined
-      const resolveExecutable = Effect.suspend(() => {
+      const resolveZmxExecutable = Effect.suspend(() => {
         if (resolvedExecutable !== undefined) return Effect.succeed(resolvedExecutable)
         const configured = config.zmxExecutable
-        const resolved = resolveExecutablePath(configured)
+        const resolved = Subprocess.resolveExecutable(configured)
         if (resolved !== null) {
           resolvedExecutable = resolved
           return Effect.succeed(resolved)
@@ -166,7 +159,7 @@ export const layerWith = (options: ZmxOptions) =>
         )
       })
 
-      const unavailable = (error: SubprocessError): ZmxUnavailable =>
+      const unavailable = (error: Subprocess.SubprocessError): ZmxUnavailable =>
         new ZmxUnavailable({
           reason: `cannot run zmx (${error.operation}): ${error.message}`,
         })
@@ -174,8 +167,8 @@ export const layerWith = (options: ZmxOptions) =>
       /** Run a run-to-completion zmx command, capturing stdout + exit code. */
       const runZmx = (args: ReadonlyArray<string>) =>
         Effect.gen(function* () {
-          const executable = yield* resolveExecutable
-          const child = yield* subprocess.spawn({ executable, args, env: childEnv })
+          const executable = yield* resolveZmxExecutable
+          const child = yield* subprocess.spawn({ executable, args, ...spawnEnv })
           yield* child.endInput
           const stdout = yield* Stream.runCollect(child.stdoutLines)
           const exitCode = yield* child.exitCode
@@ -229,7 +222,7 @@ export const layerWith = (options: ZmxOptions) =>
 
       const createSession: TerminalAdapter["Service"]["createSession"] = (options) =>
         Effect.gen(function* () {
-          const executable = yield* resolveExecutable
+          const executable = yield* resolveZmxExecutable
           const fail = (reason: string) =>
             Effect.fail(
               new SessionOperationFailed({
@@ -262,12 +255,20 @@ export const layerWith = (options: ZmxOptions) =>
           // session is in the inventory the scope closes, detaching the
           // client; the session daemon persists. Exec-style commands come
           // from a Schema-typed argv — never a shell string.
-          // Per-session overlay on the base child env; undefined removes a
-          // key (TUI terminals scrub nested-session markers this way).
-          const sessionEnv = { ...childEnv }
-          for (const [key, value] of Object.entries(options.env ?? {})) {
-            if (value === undefined) delete sessionEnv[key]
-            else sessionEnv[key] = value
+          // Per-session overlay on the base fragment; an undefined value
+          // removes the key from the inherited environment (TUI terminals
+          // scrub nested-session markers this way).
+          const overlay = Object.entries(options.env ?? {})
+          const sessionEnv = {
+            env: {
+              ...spawnEnv.env,
+              ...Object.fromEntries(overlay.filter(([, value]) => value !== undefined)),
+            },
+            extendEnv: true,
+            unsetEnv: [
+              ...spawnEnv.unsetEnv,
+              ...overlay.filter(([, value]) => value === undefined).map(([key]) => key),
+            ],
           }
           const client = yield* Effect.gen(function* () {
             const child = yield* subprocess
@@ -275,7 +276,7 @@ export const layerWith = (options: ZmxOptions) =>
                 executable,
                 args: ["attach", options.name, ...(options.command ?? [])],
                 cwd: options.cwd,
-                env: sessionEnv,
+                ...sessionEnv,
                 // The tail is the launch-failure diagnostic below.
                 captureOutputTail: true,
               })
@@ -339,12 +340,12 @@ export const layerWith = (options: ZmxOptions) =>
               }),
             )
           }
-          const executable = yield* resolveExecutable
+          const executable = yield* resolveZmxExecutable
           const child = yield* subprocess
             .spawnPty({
               executable,
               args: ["attach", name],
-              env: childEnv,
+              ...spawnEnv,
               cols: size.cols,
               rows: size.rows,
             })

--- a/app-server/src/terminals/zmxAdapter.ts
+++ b/app-server/src/terminals/zmxAdapter.ts
@@ -256,8 +256,9 @@ export const layerWith = (options: ZmxOptions) =>
           // client; the session daemon persists. Exec-style commands come
           // from a Schema-typed argv — never a shell string.
           // Per-session overlay on the base fragment; an undefined value
-          // removes the key from the inherited environment (TUI terminals
-          // scrub nested-session markers this way).
+          // removes the key from the *inherited* environment (TUI terminals
+          // scrub nested-session markers this way) — the pinned base keys
+          // above always win.
           const overlay = Object.entries(options.env ?? {})
           const sessionEnv = {
             env: {

--- a/app-server/src/threads/threadRepository.ts
+++ b/app-server/src/threads/threadRepository.ts
@@ -1,5 +1,6 @@
 import { Context, Effect, Layer, Option, Schema } from "effect"
 import { SqlClient, SqlSchema } from "effect/unstable/sql"
+import { requireFound, rowHelpers } from "../platform/repositoryHelpers.ts"
 import { ThreadNotFound } from "../api/contract.ts"
 import type { AgentId } from "../api/contract.ts"
 
@@ -117,8 +118,8 @@ export class ThreadRepository extends Context.Service<
   }
 >()("app-server/ThreadRepository") {}
 
-// Database failures are defects, not domain errors: the API surfaces them as
-// 500s and the one-line CLI contract reports them; nothing can handle them.
+// Database-failure policy (defects, orDie at this boundary): see
+// platform/repositoryHelpers.ts.
 export const layer = Layer.effect(ThreadRepository)(
   Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient
@@ -248,14 +249,7 @@ export const layer = Layer.effect(ThreadRepository)(
       execute: (id) => sql`DELETE FROM threads WHERE id = ${id}`,
     })
 
-    const firstRecord = (rows: ReadonlyArray<typeof ThreadRow.Type>) =>
-      Option.fromNullishOr(rows[0]).pipe(Option.map(toRecord))
-
-    /** For updates whose caller holds the record: a vanished row is a bug. */
-    const requireFirst = (what: string) => (rows: ReadonlyArray<typeof ThreadRow.Type>) =>
-      rows[0] !== undefined
-        ? Effect.succeed(toRecord(rows[0]))
-        : Effect.die(new Error(`${what}: thread row vanished mid-update`))
+    const { firstRecord, requireFirst } = rowHelpers("thread", toRecord)
 
     const get = (id: string) => getRows(id).pipe(Effect.map(firstRecord), Effect.orDie)
 
@@ -288,15 +282,7 @@ export const layer = Layer.effect(ThreadRepository)(
           Effect.orDie,
         ),
       get,
-      require: (id) =>
-        get(id).pipe(
-          Effect.flatMap(
-            Option.match({
-              onNone: () => Effect.fail(new ThreadNotFound({ threadId: id })),
-              onSome: Effect.succeed,
-            }),
-          ),
-        ),
+      require: (id) => get(id).pipe(requireFound(() => new ThreadNotFound({ threadId: id }))),
       rename: (id, name) =>
         Effect.suspend(() => renameRows({ id, name, updated_at: new Date().toISOString() })).pipe(
           Effect.orDie,

--- a/app-server/src/threads/threadRepository.ts
+++ b/app-server/src/threads/threadRepository.ts
@@ -118,8 +118,8 @@ export class ThreadRepository extends Context.Service<
   }
 >()("app-server/ThreadRepository") {}
 
-// Database-failure policy (defects, orDie at this boundary): see
-// platform/repositoryHelpers.ts.
+// Database failures are defects, not domain errors: the API surfaces them as
+// 500s and the one-line CLI contract reports them; nothing can handle them.
 export const layer = Layer.effect(ThreadRepository)(
   Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -13,7 +13,7 @@ import type {
 } from "../agents/agentAdapter.ts"
 import { NESTED_SESSION_ENV_VARIABLES, sanitizeTitle } from "../agents/agentAdapter.ts"
 import {
-  AGENT_IDS,
+  isAgentId,
   ProviderSessionConflict,
   ProviderUnavailable,
   Thread as ThreadSchema,
@@ -22,7 +22,6 @@ import {
   ThreadNotFound,
 } from "../api/contract.ts"
 import type {
-  AgentId,
   CreateThreadRequest,
   DirectoryCheckTimedOut,
   DirectoryUnavailable,
@@ -162,9 +161,6 @@ export class Threads extends Context.Service<
     >
   }
 >()("app-server/Threads") {}
-
-const isAgentId = (id: string): id is typeof AgentId.Type =>
-  (AGENT_IDS as ReadonlyArray<string>).includes(id)
 
 export const layerWith = (options: ThreadsOptions) =>
   Layer.effect(Threads)(

--- a/app-server/test/agents/agentTestKit.ts
+++ b/app-server/test/agents/agentTestKit.ts
@@ -1,4 +1,3 @@
-import { assert } from "@effect/vitest"
 import { BunServices } from "@effect/platform-bun"
 import { Duration, Effect, Layer, Stream } from "effect"
 import * as fs from "node:fs"
@@ -12,7 +11,7 @@ import * as CodexAdapter from "../../src/agents/codexAdapter.ts"
 import * as CodexServer from "../../src/agents/codexServer.ts"
 import * as Subprocess from "../../src/platform/subprocess.ts"
 import { trackTempDir } from "../blackbox.ts"
-import { testAppConfig } from "../testLayers.ts"
+import { eventually, testAppConfig } from "../testLayers.ts"
 import { TestBuildInfoLayer } from "../testBuildInfo.ts"
 
 // Shared scaffolding for agent-provider tests (ATC-123): the fake-codex
@@ -118,10 +117,8 @@ export const waitForAgentEvent = (
   predicate: (event: AgentEvent) => boolean,
   options?: { readonly attempts?: number; readonly interval?: Duration.Input },
 ) =>
-  Effect.gen(function* () {
-    const attempts = options?.attempts ?? 200
-    for (let attempt = 0; !sink.some(predicate); attempt++) {
-      assert.isBelow(attempt, attempts, `never saw expected event in ${JSON.stringify(sink)}`)
-      yield* Effect.sleep(options?.interval ?? "25 millis")
-    }
-  })
+  eventually(
+    Effect.sync(() => sink),
+    (events) => events.some(predicate),
+    { attempts: options?.attempts ?? 200, interval: options?.interval ?? "25 millis" },
+  )

--- a/app-server/test/agents/claudeAdapter.test.ts
+++ b/app-server/test/agents/claudeAdapter.test.ts
@@ -7,6 +7,7 @@ import type { AgentSessionEvent } from "../../src/agents/agentAdapter.ts"
 import * as ClaudeAdapter from "../../src/agents/claudeAdapter.ts"
 import * as ClaudeHooks from "../../src/agents/claudeHooks.ts"
 import { claudeAdapterLayer, collectAgentEvents, waitForAgentEvent } from "./agentTestKit.ts"
+import { eventually } from "../testLayers.ts"
 import { trackTempDir } from "../blackbox.ts"
 import { makeFakeClaudeQuery } from "./fakeClaudeQuery.ts"
 import type { FakeClaudeQueryOptions } from "./fakeClaudeQuery.ts"
@@ -538,12 +539,11 @@ describe("ClaudeAdapter TUI session plumbing", () => {
     })
 
   const waitForActivity = (sink: Array<string>, wanted: string) =>
-    Effect.gen(function* () {
-      for (let attempt = 0; !sink.includes(wanted); attempt++) {
-        assert.isBelow(attempt, 200, `never saw ${wanted} in ${JSON.stringify(sink)}`)
-        yield* Effect.sleep("10 millis")
-      }
-    })
+    eventually(
+      Effect.sync(() => sink),
+      (entries) => entries.includes(wanted),
+      { attempts: 200 },
+    )
 
   it.live("prepareTuiSession pre-assigns identity and enables Remote Control", () =>
     Effect.gen(function* () {

--- a/app-server/test/agents/codexAdapter.test.ts
+++ b/app-server/test/agents/codexAdapter.test.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs"
 import * as path from "node:path"
 import * as CodexAdapter from "../../src/agents/codexAdapter.ts"
 import * as CodexServer from "../../src/agents/codexServer.ts"
+import { eventually } from "../testLayers.ts"
 import {
   codexAdapterLayer,
   collectAgentEvents,
@@ -409,12 +410,11 @@ describe("CodexAdapter TUI session plumbing", () => {
     )
 
   const waitForActivity = (sink: Array<string>, wanted: string) =>
-    Effect.gen(function* () {
-      for (let attempt = 0; !sink.includes(wanted); attempt++) {
-        assert.isBelow(attempt, 200, `never saw ${wanted} in ${JSON.stringify(sink)}`)
-        yield* Effect.sleep("25 millis")
-      }
-    })
+    eventually(
+      Effect.sync(() => sink),
+      (entries) => entries.includes(wanted),
+      { attempts: 200, interval: "25 millis" },
+    )
 
   it.live(
     "prepareTuiSession captures the fresh TUI's thread/started identity",
@@ -563,16 +563,11 @@ describe("CodexAdapter TUI session plumbing", () => {
                 threadId,
                 input: [{ type: "text", text: "second message" }],
               })
-              yield* Effect.gen(function* () {
-                for (
-                  let attempt = 0;
-                  sink.filter((entry) => entry === "idle").length < 2;
-                  attempt++
-                ) {
-                  assert.isBelow(attempt, 200, `second turn never settled: ${sink.join(",")}`)
-                  yield* Effect.sleep("25 millis")
-                }
-              })
+              yield* eventually(
+                Effect.sync(() => sink),
+                (entries) => entries.filter((entry) => entry === "idle").length >= 2,
+                { attempts: 200, interval: "25 millis" },
+              )
               assert.deepStrictEqual(
                 sink.filter((entry) => entry.startsWith("prompt:")),
                 ["prompt:please add dark mode"],
@@ -960,12 +955,11 @@ describe("CodexAdapter descendant aggregation", () => {
                 }),
               )
               const waitFor = (wanted: string) =>
-                Effect.gen(function* () {
-                  for (let attempt = 0; !sink.includes(wanted); attempt++) {
-                    assert.isBelow(attempt, 200, `never saw ${wanted}: ${sink.join(",")}`)
-                    yield* Effect.sleep("25 millis")
-                  }
-                })
+                eventually(
+                  Effect.sync(() => sink),
+                  (entries) => entries.includes(wanted),
+                  { attempts: 200, interval: "25 millis" },
+                )
               // The parent's turn completes but the child holds it working.
               yield* waitFor("working")
               yield* finishChild(sandbox, `${rootId}-child-1`)
@@ -1113,21 +1107,19 @@ describe("CodexAdapter descendant aggregation", () => {
                     })
                   }),
                 )
-                yield* Effect.gen(function* () {
-                  for (let attempt = 0; !sink.includes("working"); attempt++) {
-                    assert.isBelow(attempt, 200, `never saw working: ${sink.join(",")}`)
-                    yield* Effect.sleep("25 millis")
-                  }
-                })
+                yield* eventually(
+                  Effect.sync(() => sink),
+                  (entries) => entries.includes("working"),
+                  { attempts: 200, interval: "25 millis" },
+                )
                 // The evidence source dies with the socket: the observer
                 // must hear `unknown`, never sit on the stale busy state.
                 yield* Effect.orDie(codexServer.stop())
-                yield* Effect.gen(function* () {
-                  for (let attempt = 0; !sink.includes("unknown"); attempt++) {
-                    assert.isBelow(attempt, 200, `never saw unknown: ${sink.join(",")}`)
-                    yield* Effect.sleep("25 millis")
-                  }
-                })
+                yield* eventually(
+                  Effect.sync(() => sink),
+                  (entries) => entries.includes("unknown"),
+                  { attempts: 200, interval: "25 millis" },
+                )
               }),
             ),
             Effect.orDie(codexServer.stop()),

--- a/app-server/test/events/eventCascades.test.ts
+++ b/app-server/test/events/eventCascades.test.ts
@@ -1,4 +1,4 @@
-import { assert, describe, it } from "@effect/vitest"
+import { describe, it } from "@effect/vitest"
 import { Effect, Option, Stream } from "effect"
 import { HttpApiTest } from "effect/unstable/httpapi"
 import { mkdtempSync, realpathSync, rmSync } from "node:fs"
@@ -10,7 +10,7 @@ import * as Events from "../../src/events/events.ts"
 import type { ResourceChangedEvent } from "../../src/events/events.ts"
 import { sessionNameForTerminalId } from "../../src/terminals/terminalAdapter.ts"
 import { ThreadRepository } from "../../src/threads/threadRepository.ts"
-import { apiTestLayer, makeTestServiceLayers } from "../testLayers.ts"
+import { eventually, apiTestLayer, makeTestServiceLayers } from "../testLayers.ts"
 
 // Cascade-publish regression tests (ATC-142): the mutations whose events are
 // EASY to lose silently, because the changed resource is not the one the
@@ -38,18 +38,16 @@ const collect = Effect.gen(function* () {
   return sink
 })
 
-/** Poll (real clock, bounded) until `predicate` holds on the sink. */
-const eventually = (sink: Array<ResourceChangedEvent>, predicate: () => boolean) =>
-  Effect.gen(function* () {
-    for (let attempt = 0; !predicate(); attempt++) {
-      assert.isBelow(attempt, 300, `condition never held; saw ${JSON.stringify(sink)}`)
-      yield* Effect.sleep("10 millis")
-    }
-  })
+/** testLayers' `eventually` over a sink snapshot (the sink prints on failure). */
+const eventuallyHolds = (sink: Array<ResourceChangedEvent>, predicate: () => boolean) =>
+  eventually(
+    Effect.sync(() => ({ sink, holds: predicate() })),
+    (snapshot) => snapshot.holds,
+  )
 
 /** `eventually` for the common case: one expected event in the sink. */
 const waitForEvent = (sink: Array<ResourceChangedEvent>, expected: ResourceChangedEvent) =>
-  eventually(sink, () =>
+  eventuallyHolds(sink, () =>
     sink.some(
       (event) =>
         event.resource === expected.resource &&
@@ -123,7 +121,7 @@ describe("cascade event publishes", () => {
       const afterFirst = updates()
       kit.fakeAgents.codex.emitActivity(sessionId, "working")
       kit.fakeAgents.codex.emitActivity(sessionId, "idle")
-      yield* eventually(sink, () => updates() === afterFirst + 1)
+      yield* eventuallyHolds(sink, () => updates() === afterFirst + 1)
       yield* client.v1.deleteThread({ params: { threadId: thread.id } })
     }).pipe(Effect.scoped, Effect.provide(TestLayer)),
   )

--- a/app-server/test/fixtures/print-env.ts
+++ b/app-server/test/fixtures/print-env.ts
@@ -1,0 +1,5 @@
+// Prints every ATC_SUBPROCESS_TEST_* environment variable as KEY=VALUE, one
+// per line — the fixture behind the env-composition subprocess test.
+for (const [key, value] of Object.entries(process.env)) {
+  if (key.startsWith("ATC_SUBPROCESS_TEST_")) console.log(`${key}=${value}`)
+}

--- a/app-server/test/platform/subprocess.test.ts
+++ b/app-server/test/platform/subprocess.test.ts
@@ -28,6 +28,35 @@ const expectDead = (pid: number) =>
   })
 
 describe("Subprocess", () => {
+  it.live("composes the child env: explicit over parent-minus-unsetEnv", () =>
+    Effect.gen(function* () {
+      const subprocess = yield* Subprocess.Subprocess
+      // The composition rule every extendEnv caller (the zmx adapter's
+      // scrub fragment included) relies on: parent copied, unsetEnv keys
+      // dropped, explicit env layered over — so an explicit key survives
+      // its own presence in unsetEnv.
+      process.env["ATC_SUBPROCESS_TEST_INHERITED"] = "from-parent"
+      process.env["ATC_SUBPROCESS_TEST_SCRUBBED"] = "must-not-leak"
+      try {
+        const child = yield* subprocess.spawn({
+          executable: process.execPath,
+          args: ["test/fixtures/print-env.ts"],
+          cwd: appServerRoot,
+          env: { ATC_SUBPROCESS_TEST_SCRUBBED: "explicit-wins" },
+          extendEnv: true,
+          unsetEnv: ["ATC_SUBPROCESS_TEST_SCRUBBED", "ATC_SUBPROCESS_TEST_INHERITED"],
+        })
+        const lines = yield* Stream.runCollect(child.stdoutLines)
+        assert.strictEqual(yield* child.exitCode, 0)
+        assert.include(lines, "ATC_SUBPROCESS_TEST_SCRUBBED=explicit-wins")
+        assert.notInclude(lines, "ATC_SUBPROCESS_TEST_INHERITED=from-parent")
+      } finally {
+        delete process.env["ATC_SUBPROCESS_TEST_INHERITED"]
+        delete process.env["ATC_SUBPROCESS_TEST_SCRUBBED"]
+      }
+    }).pipe(Effect.scoped, Effect.provide(TestLayer)),
+  )
+
   it.live("captures stdout lines and observes a clean exit", () =>
     Effect.gen(function* () {
       const subprocess = yield* Subprocess.Subprocess

--- a/app-server/test/platform/subprocess.test.ts
+++ b/app-server/test/platform/subprocess.test.ts
@@ -35,22 +35,23 @@ describe("Subprocess", () => {
       // scrub fragment included) relies on: parent copied, unsetEnv keys
       // dropped, explicit env layered over — so an explicit key survives
       // its own presence in unsetEnv.
+      process.env["ATC_SUBPROCESS_TEST_KEPT"] = "inherited"
       process.env["ATC_SUBPROCESS_TEST_INHERITED"] = "from-parent"
       process.env["ATC_SUBPROCESS_TEST_SCRUBBED"] = "must-not-leak"
       try {
         const child = yield* subprocess.spawn({
-          executable: process.execPath,
-          args: ["test/fixtures/print-env.ts"],
-          cwd: appServerRoot,
+          ...fixture("print-env"),
           env: { ATC_SUBPROCESS_TEST_SCRUBBED: "explicit-wins" },
           extendEnv: true,
           unsetEnv: ["ATC_SUBPROCESS_TEST_SCRUBBED", "ATC_SUBPROCESS_TEST_INHERITED"],
         })
         const lines = yield* Stream.runCollect(child.stdoutLines)
         assert.strictEqual(yield* child.exitCode, 0)
+        assert.include(lines, "ATC_SUBPROCESS_TEST_KEPT=inherited")
         assert.include(lines, "ATC_SUBPROCESS_TEST_SCRUBBED=explicit-wins")
         assert.notInclude(lines, "ATC_SUBPROCESS_TEST_INHERITED=from-parent")
       } finally {
+        delete process.env["ATC_SUBPROCESS_TEST_KEPT"]
         delete process.env["ATC_SUBPROCESS_TEST_INHERITED"]
         delete process.env["ATC_SUBPROCESS_TEST_SCRUBBED"]
       }

--- a/app-server/test/terminals/terminalAdapter.test.ts
+++ b/app-server/test/terminals/terminalAdapter.test.ts
@@ -69,27 +69,24 @@ describe("parseSessionList", () => {
   })
 })
 
-describe("zmxChildEnv", () => {
+describe("zmxSpawnEnv", () => {
   it("scrubs the nested-client traps and stale ATC_* context; pins ZMX_DIR, TERM, ATC_ENDPOINT", () => {
-    const env = Zmx.zmxChildEnv("/sockets", "http://127.0.0.1:7332", {
-      PATH: "/usr/bin",
-      HOME: "/home/u",
-      ZMX_SESSION: "evil",
-      ZMX_SESSION_PREFIX: "pre-",
-      // A server running inside another ATC session inherits that session's
-      // context; none of it may leak into sessions this server launches.
-      ATC_ENDPOINT: "http://127.0.0.1:9999",
-      ATC_PROJECT_ID: "stale-project",
-      ATC_TERMINAL_ID: "stale-terminal",
-      EMPTY: undefined,
-    })
-    assert.deepStrictEqual(env, {
-      PATH: "/usr/bin",
-      HOME: "/home/u",
+    const spec = Zmx.zmxSpawnEnv("/sockets", "http://127.0.0.1:7332")
+    assert.deepStrictEqual(spec.env, {
       ZMX_DIR: "/sockets",
       TERM: "xterm-256color",
       ATC_ENDPOINT: "http://127.0.0.1:7332",
     })
+    assert.isTrue(spec.extendEnv)
+    // A server running inside another ATC session inherits that session's
+    // context; none of it may leak into sessions this server launches. The
+    // pinned ATC_ENDPOINT survives the scrub because explicit env is
+    // composed OVER the parent copy (see subprocess.test.ts, which pins
+    // that composition rule at its owner).
+    assert.includeMembers(
+      [...spec.unsetEnv],
+      ["ZMX_SESSION", "ZMX_SESSION_PREFIX", "ATC_ENDPOINT", "ATC_PROJECT_ID", "ATC_TERMINAL_ID"],
+    )
   })
 })
 

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -1,6 +1,7 @@
 import { assert } from "@effect/vitest"
 import { BunHttpServer, BunServices } from "@effect/platform-bun"
 import { Context, Effect, Exit, Layer, Scope, Stream } from "effect"
+import type { Duration } from "effect"
 import { HttpServer } from "effect/unstable/http"
 import * as fs from "node:fs"
 import * as os from "node:os"
@@ -270,13 +271,18 @@ export const startServer = <R, E>(layer: Layer.Layer<R | HttpServer.HttpServer, 
   })
 
 /** Poll (real clock) until `predicate` accepts the effect's value; bounded. */
-export const eventually = <A, E>(effect: Effect.Effect<A, E>, predicate: (value: A) => boolean) =>
+export const eventually = <A, E>(
+  effect: Effect.Effect<A, E>,
+  predicate: (value: A) => boolean,
+  options?: { readonly attempts?: number; readonly interval?: Duration.Input },
+) =>
   Effect.gen(function* () {
+    const attempts = options?.attempts ?? 300
     for (let attempt = 0; ; attempt++) {
       const value = yield* effect
       if (predicate(value)) return value
-      assert.isBelow(attempt, 300, `condition never held; last: ${JSON.stringify(value)}`)
-      yield* Effect.sleep("10 millis")
+      assert.isBelow(attempt, attempts, `condition never held; last: ${JSON.stringify(value)}`)
+      yield* Effect.sleep(options?.interval ?? "10 millis")
     }
   })
 
@@ -299,9 +305,8 @@ export const collectText = (output: Stream.Stream<Uint8Array, unknown>) =>
 
 /** Poll until `pattern` shows up in the sink; assertion-bounded. */
 export const waitForText = (sink: { text: string }, pattern: string) =>
-  Effect.gen(function* () {
-    for (let attempt = 0; !sink.text.includes(pattern); attempt++) {
-      assert.isBelow(attempt, 100, `never saw ${JSON.stringify(pattern)} in ${sink.text}`)
-      yield* Effect.sleep("50 millis")
-    }
-  })
+  eventually(
+    Effect.sync(() => sink.text),
+    (text) => text.includes(pattern),
+    { attempts: 100, interval: "50 millis" },
+  )


### PR DESCRIPTION
PR 3 of the ATC-170 codebase-hardening effort. Findings: ATC-167 M8–M12, M14, M15, L1, L7–L12. Sub-issue: [ATC-173](https://linear.app/elevenideas/issue/ATC-173). Mechanical tier — one combined adversarial review applied.

## Changes

- **M8 — env composition has one place again.** `subprocess.ts` exports `inheritedEnv(unset)` (used by the Claude SDK env and the smoke probe — the two children ATC doesn't spawn itself); the zmx adapter's hand-rolled `zmxChildEnv` became a `zmxSpawnEnv` SpawnSpec fragment composed by subprocess's `childEnv`. The composition rule (explicit over parent-minus-unsetEnv, inherited keys pass through) is now pinned by a subprocess test with a print-env fixture.
- **M9 —** `platform/repositoryHelpers.ts` (`rowHelpers`, `requireFound`) replaces the scaffolding copied across all three repositories; SQL stays per-repository.
- **M10 —** `publishTerminalChange` owns the "terminal event + paired thread `updated`" rule at all lifecycle sites, including the startup starting→live adoption (rename deliberately publishes solo — documented at the helper).
- **M11 —** the reconcile-before-register ordering moved into `Events.subscribe({reconcile})`; the SSE handler now only names the refresh. (Literally moving it *behind* `Events` is impossible — Terminals depends on Events, so the reconcile effect is injected while the ordering rule lives with the subscription.)
- **M12 —** `providerErrors(provider)` (constructors + shared conflict-message vocabulary), `withTitleTimeout`, and `emitAgentEvent` consolidate the adapter boilerplate; codexAdapter, claudeAdapter, and codexServer rewired. `emitAgentEvent`'s overflow branch is documented as arming when ATC-172 bounds the queues.
- **M14 —** CLI dedupe (`requireYes`, shared `projectFlag`, overloaded `optionalKey`) and the decided AGENTS.md "Surfaces" soften permitting thin CRUD convenience commands.
- **M15 —** every test polling loop now delegates to `testLayers.eventually` (grown attempts/interval options).
- **L1** `isAgentId` exported once from the contract · **L7** `ClientState.url` + over-exports dropped · **L8** codex raw frames now logged at debug via a sliding-queue bridge (dispatch is a sync WebSocket callback), making the module header true · **L9** stale AGENTS.md pointer replaced, operation-id rule stated inline · **L10** zmx import alias removed, Subprocess namespaced · **L11** non-null assertions replaced with branches/`Effect.die`, gateway cast-before-validate → find-narrowing · **L12** adminUi rebuilt on `HttpRouter.use`: assets map built once at layer build, bytes read once then served from memory, module-global memo gone.

## Verification

`mise run -C app-server check` — 329 passed. (One pre-existing `serve.blackbox` flake appeared under check's parallel load twice and passed in isolation and on reruns; unrelated to this diff.)

Review notes: the combined review caught a doc-comment mis-placement, an `<E = never>` typing regression on `Events.subscribe`, an incomplete type-import move, and a coverage gap in the new env test — all fixed. Notable-but-accepted: debug-level raw-frame logging writes conversation content to the log when enabled (the header always claimed this behavior; L8 makes it true rather than new).

Stack note: this PR is part of the ATC-170 stack (#161 → #168, each based on the previous). All cross-PR conflicts are already resolved in the branches themselves — merge bottom-up in order and each merge retargets the next PR automatically; no manual resolution needed.

https://claude.ai/code/session_019pj9ErmqTfaLoTPksB3fSZ
