### PR TITLE
Server Effect idioms (ATC-174)

### DIFF
--- a/app-server/src/agents/claudeAdapter.ts
+++ b/app-server/src/agents/claudeAdapter.ts
@@ -15,7 +15,9 @@ import {
   Effect,
   FileSystem,
   Layer,
+  Option,
   Queue,
+  Schema,
   Stream,
 } from "effect"
 import type {
@@ -107,6 +109,13 @@ export interface ClaudeAdapterOptions {
   /** How long create/first-turn waits for the SDK's identity evidence. */
   readonly initTimeout?: Duration.Input
 }
+
+// The thread's opaque providerMetadata, as this adapter mints it. Decoded
+// tolerantly: unknown or malformed metadata is "no secret", never an error.
+const ProviderMetadata = Schema.fromJsonString(
+  Schema.Struct({ hookSecret: Schema.optional(Schema.String) }),
+)
+const decodeProviderMetadata = Schema.decodeUnknownOption(ProviderMetadata)
 
 const {
   unavailable,
@@ -462,12 +471,12 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
       /** The persisted hook secret, if the thread's opaque metadata has one. */
       const metadataSecret = (metadata: string | undefined): string | null => {
         if (metadata === undefined) return null
-        try {
-          const parsed = JSON.parse(metadata) as { hookSecret?: unknown }
-          return typeof parsed.hookSecret === "string" ? parsed.hookSecret : null
-        } catch {
-          return null
-        }
+        return decodeProviderMetadata(metadata).pipe(
+          Option.match({
+            onNone: () => null,
+            onSome: (parsed) => parsed.hookSecret ?? null,
+          }),
+        )
       }
 
       /**

--- a/app-server/src/agents/claudeAdapter.ts
+++ b/app-server/src/agents/claudeAdapter.ts
@@ -527,7 +527,11 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
         Effect.gen(function* () {
           const executable = yield* resolvedExecutable
           // The held query() drains this queue as its async input iterable;
-          // push feeds it more turns, end is EOF.
+          // push feeds it more turns, end is EOF. The iterable drives its
+          // pulls on a detached fiber reclaimed only when the queue ends —
+          // closeSession's closeInput (which every exit path reaches via
+          // the acquireRelease below) is what keeps it from parking on an
+          // empty queue forever.
           const inputQueue = yield* Queue.make<SDKUserMessage, Cause.Done>()
           // Bounded (overflow fails the stream — see emit); a session that
           // buffers 256 undrained events has lost its consumer.

--- a/app-server/src/agents/claudeAdapter.ts
+++ b/app-server/src/agents/claudeAdapter.ts
@@ -180,38 +180,6 @@ const userMessage = (text: string): SDKUserMessage => ({
   parent_tool_use_id: null,
 })
 
-/** An async input queue the held query() drains; push feeds it more turns. */
-const makeInputQueue = () => {
-  const pending: Array<SDKUserMessage> = []
-  let wake: (() => void) | null = null
-  let closed = false
-  const push = (message: SDKUserMessage): void => {
-    pending.push(message)
-    wake?.()
-  }
-  const close = (): void => {
-    closed = true
-    wake?.()
-  }
-  async function* stream(): AsyncGenerator<SDKUserMessage> {
-    while (true) {
-      const next = pending.shift()
-      if (next !== undefined) {
-        yield next
-        continue
-      }
-      if (closed) return
-      await new Promise<void>((resolve) => {
-        wake = () => {
-          wake = null
-          resolve()
-        }
-      })
-    }
-  }
-  return { push, close, stream }
-}
-
 type GateError = AgentResumeFailed | AgentIdentityMismatch | AgentProtocolError
 
 interface LiveSession {
@@ -471,6 +439,14 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
         CLAUDE_TESTED_VERSION,
       )
 
+      // The launch preamble every operation shares: resolve the executable
+      // (its failure IS the actionable diagnostic) and run the drift gate.
+      const resolvedExecutable = Effect.gen(function* () {
+        const executable = yield* resolveProviderExecutable("claude", config.claudeExecutable)
+        yield* versionCheck
+        return executable
+      })
+
       const hookFilePaths = (providerSessionId: string) => ({
         headerFile: path.join(config.stateDir, `claude-hooks-${providerSessionId}.header`),
         settingsFile: path.join(config.stateDir, `claude-hooks-${providerSessionId}.json`),
@@ -540,10 +516,11 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
 
       const openSession = (options: { readonly cwd: string; readonly resume?: string }) =>
         Effect.gen(function* () {
-          const executable = yield* resolveProviderExecutable("claude", config.claudeExecutable)
-          yield* versionCheck
-          const input = makeInputQueue()
-          // Bounded (overflow ends the stream — see emit); a session that
+          const executable = yield* resolvedExecutable
+          // The held query() drains this queue as its async input iterable;
+          // push feeds it more turns, end is EOF.
+          const inputQueue = yield* Queue.make<SDKUserMessage, Cause.Done>()
+          // Bounded (overflow fails the stream — see emit); a session that
           // buffers 256 undrained events has lost its consumer.
           const queue = yield* Queue.make<AgentEvent, AgentProtocolError | Cause.Done>({
             capacity: 256,
@@ -555,8 +532,12 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
             queue,
             abort: new AbortController(),
             tracker: ClaudeHooks.makeActivityTracker(),
-            pushInput: (text) => input.push(userMessage(text)),
-            closeInput: input.close,
+            pushInput: (text) => {
+              Queue.offerUnsafe(inputQueue, userMessage(text))
+            },
+            closeInput: () => {
+              Queue.endUnsafe(inputQueue)
+            },
             initGate,
             interrupt: () => Promise.resolve(),
             sessionId: null,
@@ -566,17 +547,29 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
             closed: false,
             over: false,
           }
-          if (options.resume !== undefined) {
-            if (sessions.has(options.resume)) {
-              return yield* Effect.fail(writerConnected(options.resume))
-            }
-            sessions.set(options.resume, session)
+          // Registered before queryFn can fail (an uncleaned registry entry
+          // would lock the session id out of resume for the process's life),
+          // with the single-writer check INSIDE the same sync acquire so no
+          // interleaving can split check from claim, and the close finalizer
+          // armed atomically with it (acquireRelease — ATC-167 M4).
+          const claim = yield* Effect.acquireRelease(
+            Effect.sync(() => {
+              if (options.resume !== undefined) {
+                if (sessions.has(options.resume)) return { conflict: options.resume }
+                sessions.set(options.resume, session)
+              }
+              return "claimed" as const
+            }),
+            (outcome) =>
+              Effect.sync(() => {
+                if (outcome === "claimed") closeSession(session)
+              }),
+          )
+          if (claim !== "claimed") {
+            return yield* Effect.fail(writerConnected(claim.conflict))
           }
-          // Registered before queryFn can fail: an uncleaned registry entry
-          // would lock the session id out of resume for the process's life.
-          yield* Effect.addFinalizer(() => Effect.sync(() => closeSession(session)))
           const handle = queryFn({
-            prompt: input.stream(),
+            prompt: yield* Stream.toAsyncIterableEffect(Stream.fromQueue(inputQueue)),
             options: {
               abortController: session.abort,
               cwd: options.cwd,
@@ -707,8 +700,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
           }),
         tuiLaunch: (options) =>
           Effect.gen(function* () {
-            const executable = yield* resolveProviderExecutable("claude", config.claudeExecutable)
-            yield* versionCheck
+            const executable = yield* resolvedExecutable
             const { secret, settingsFile } = yield* ensureHookPlumbing(
               options.providerSessionId,
               options.providerMetadata,
@@ -731,8 +723,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
           }),
         prepareTuiSession: (options) =>
           Effect.gen(function* () {
-            const executable = yield* resolveProviderExecutable("claude", config.claudeExecutable)
-            yield* versionCheck
+            const executable = yield* resolvedExecutable
             // Pre-assignment (probed 2026-08-05): `--session-id` creates
             // exactly the minted id, and a duplicate launch fails closed —
             // so identity resolves immediately and the first hook payload
@@ -798,22 +789,21 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
         generateTitle: (options) =>
           Effect.scoped(
             Effect.gen(function* () {
-              const executable = yield* resolveProviderExecutable("claude", config.claudeExecutable)
-              yield* versionCheck
+              const executable = yield* resolvedExecutable
               // The smoke-test one-shot shape (smoke.ts claudeRoundTrip):
               // one turn, no tools, nothing persisted — plus a haiku-class
               // model, since a title needs speed, not depth.
               const abort = new AbortController()
               yield* Effect.addFinalizer(() => Effect.sync(() => abort.abort()))
-              const input = makeInputQueue()
-              input.push(userMessage(titleInstruction(options.prompt)))
-              input.close()
+              const prompt = yield* Stream.toAsyncIterableEffect(
+                Stream.make(userMessage(titleInstruction(options.prompt))),
+              )
               // Wrapped so a synchronous SDK setup throw is the promised
               // typed error, not a defect.
               const handle = yield* Effect.try({
                 try: () =>
                   queryFn({
-                    prompt: input.stream(),
+                    prompt,
                     options: {
                       abortController: abort,
                       cwd: options.cwd,

--- a/app-server/src/agents/claudeHooks.ts
+++ b/app-server/src/agents/claudeHooks.ts
@@ -275,10 +275,10 @@ export const layer = Layer.effect(ClaudeHooks)(
           trackers.delete(providerSessionId)
         }),
       subscribe: (listener: HookListener) =>
-        Effect.gen(function* () {
-          listeners.add(listener)
-          yield* Effect.addFinalizer(() => Effect.sync(() => listeners.delete(listener)))
-        }),
+        Effect.acquireRelease(
+          Effect.sync(() => listeners.add(listener)),
+          () => Effect.sync(() => listeners.delete(listener)),
+        ).pipe(Effect.asVoid),
       deliver: (secret: string, payload: unknown) =>
         Effect.gen(function* () {
           const providerSessionId = secrets.get(secret)

--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -7,10 +7,12 @@ import {
   FileSystem,
   Layer,
   Queue,
+  Schedule,
   Schema,
   Semaphore,
   Stream,
 } from "effect"
+import { pollUntil } from "../platform/poll.ts"
 import * as path from "node:path"
 import type {
   AgentActivity,
@@ -191,6 +193,116 @@ interface ClientState {
   nextId: number
   alive: boolean
 }
+
+// --- Closure-free RPC plumbing (ATC-167 M13): everything below talks to a
+// ClientState it is handed, never to layer state, so it lives outside the
+// layer body. ---
+
+const request = (
+  state: ClientState,
+  method: string,
+  params: Record<string, unknown>,
+): Effect.Effect<unknown, RpcError | AgentProtocolError> =>
+  Effect.callback<unknown, RpcError | AgentProtocolError>((resume) => {
+    if (!state.alive) {
+      resume(Effect.fail(protocolError("the app-server connection is closed")))
+      return
+    }
+    const id = state.nextId++
+    state.pending.set(id, {
+      succeed: (result) => resume(Effect.succeed(result)),
+      fail: (error) => resume(Effect.fail(error)),
+    })
+    state.socket.send(JSON.stringify({ id, method, params }))
+    return Effect.sync(() => state.pending.delete(id))
+  }).pipe(
+    Effect.timeoutOrElse({
+      duration: REQUEST_TIMEOUT,
+      orElse: () => Effect.fail(protocolError(`${method} timed out`)),
+    }),
+  )
+
+/** Every non-resume call site: an RPC error is a protocol failure. */
+const rpcToProtocol = (error: RpcError | AgentProtocolError): AgentProtocolError =>
+  error._tag === "RpcError" ? protocolError(error.text) : error
+
+const decodeReply = <S extends Schema.Top>(schema: S, reply: unknown) =>
+  Schema.decodeUnknownEffect(schema)(reply).pipe(
+    Effect.mapError((error) => protocolError(`unexpected reply shape: ${error.message}`)),
+  )
+
+/** The passive seam's error mapping: an RPC failure is "unavailable". */
+const rpcToUnavailable = (error: RpcError | AgentProtocolError): AgentUnavailable =>
+  unavailable(error._tag === "RpcError" ? error.text : error.reason)
+
+/** `decodeReply` for the passive seam, naming the method in the diagnostic. */
+const decodeUnavailable =
+  <S extends Schema.Top>(schema: S, method: string) =>
+  (reply: unknown): Effect.Effect<S["Type"], AgentUnavailable, S["DecodingServices"]> =>
+    Schema.decodeUnknownEffect(schema)(reply).pipe(
+      Effect.mapError((error) => unavailable(`unexpected ${method} reply: ${error.message}`)),
+    )
+
+/**
+ * Drive one paginated codex RPC to completion (the {data, nextCursor} page
+ * shape): `find` inspects each page and may finish early with a value; a
+ * complete walk (cursor exhausted) yields `complete()`; a repeated cursor
+ * or the page cap yields "unknown" — a provider that cannot make
+ * pagination progress, or a pathologically long population.
+ */
+const walkPaginated = <Page extends { readonly nextCursor?: string | null | undefined }, Found, Done, E>(options: {
+  readonly page: (cursor: string | undefined) => Effect.Effect<Page, E>
+  readonly find: (page: Page) => Found | undefined
+  readonly complete: () => Done
+}): Effect.Effect<Found | Done | "unknown", E> =>
+  Effect.gen(function* () {
+    let cursor: string | undefined
+    for (let page = 0; page < 100; page++) {
+      const decoded = yield* options.page(cursor)
+      const found = options.find(decoded)
+      if (found !== undefined) return found
+      const next = decoded.nextCursor
+      if (typeof next !== "string") return options.complete()
+      if (next === cursor) return "unknown" as const
+      cursor = next
+    }
+    return "unknown" as const
+  })
+
+/**
+ * Walk one paginated thread/list population (thread/list returns only
+ * non-archived threads unless `archived: true` — the populations are
+ * disjoint): the found entry, `"absent"` when a complete walk omits the
+ * id, or `"unknown"` when the walk could not be completed.
+ */
+const walkThreadList = (state: ClientState, threadId: string, archived: boolean) =>
+  walkPaginated({
+    page: (cursor) =>
+      request(state, "thread/list", cursor === undefined ? { archived } : { archived, cursor }).pipe(
+        Effect.mapError(rpcToUnavailable),
+        Effect.flatMap(decodeUnavailable(ThreadListReply, "thread/list")),
+      ),
+    find: (page) => page.data.find((t) => t.id === threadId),
+    complete: () => "absent" as const,
+  })
+
+/**
+ * Find one thread across BOTH thread/list populations — a session
+ * archived through another Codex surface still exists and must not be
+ * reported as deleted. `"absent"` only when complete walks of both the
+ * non-archived and archived lists omit the id; `"unknown"` when either
+ * walk was inconclusive. Callers must not treat `"unknown"` as absence.
+ */
+const findThread = (state: ClientState, threadId: string) =>
+  Effect.gen(function* () {
+    const live = yield* walkThreadList(state, threadId, false)
+    if (typeof live !== "string") return live
+    const archived = yield* walkThreadList(state, threadId, true)
+    if (typeof archived !== "string") return archived
+    return live === "absent" && archived === "absent"
+      ? ("absent" as const)
+      : ("unknown" as const)
+  })
 
 export const layer = Layer.effect(CodexAdapter)(
   Effect.gen(function* () {
@@ -523,39 +635,6 @@ export const layer = Layer.effect(CodexAdapter)(
         handleNotification({ method: message.method, params: message.params })
     }
 
-    const request = (
-      state: ClientState,
-      method: string,
-      params: Record<string, unknown>,
-    ): Effect.Effect<unknown, RpcError | AgentProtocolError> =>
-      Effect.callback<unknown, RpcError | AgentProtocolError>((resume) => {
-        if (!state.alive) {
-          resume(Effect.fail(protocolError("the app-server connection is closed")))
-          return
-        }
-        const id = state.nextId++
-        state.pending.set(id, {
-          succeed: (result) => resume(Effect.succeed(result)),
-          fail: (error) => resume(Effect.fail(error)),
-        })
-        state.socket.send(JSON.stringify({ id, method, params }))
-        return Effect.sync(() => state.pending.delete(id))
-      }).pipe(
-        Effect.timeoutOrElse({
-          duration: REQUEST_TIMEOUT,
-          orElse: () => Effect.fail(protocolError(`${method} timed out`)),
-        }),
-      )
-
-    /** Every non-resume call site: an RPC error is a protocol failure. */
-    const rpcToProtocol = (error: RpcError | AgentProtocolError): AgentProtocolError =>
-      error._tag === "RpcError" ? protocolError(error.text) : error
-
-    const decodeReply = <S extends Schema.Top>(schema: S, reply: unknown) =>
-      Schema.decodeUnknownEffect(schema)(reply).pipe(
-        Effect.mapError((error) => protocolError(`unexpected reply shape: ${error.message}`)),
-      )
-
     // Record + warn version drift, once, on first use (never blocks).
     const versionCheck = yield* makeVersionGate(
       subprocess,
@@ -663,9 +742,6 @@ export const layer = Layer.effect(CodexAdapter)(
         const queue = yield* Queue.make<AgentEvent, AgentProtocolError | Cause.Done>({
           capacity: 256,
         })
-        // Seeded from the provider's own thread status — never a guess —
-        // folded with any descendants already tracked for this root.
-        ownStatus.set(threadId, statusToActivity(initialStatus))
         const session: LiveSession = {
           threadId,
           queue,
@@ -674,8 +750,6 @@ export const layer = Layer.effect(CodexAdapter)(
           ownTurn: null,
           failed: false,
         }
-        session.activity = aggregateFor(threadId)
-        sessions.set(threadId, session)
         const unregister = (): void => {
           if (sessions.get(threadId) !== session) return
           sessions.delete(threadId)
@@ -691,7 +765,18 @@ export const layer = Layer.effect(CodexAdapter)(
             )
           }
         }
-        yield* Effect.addFinalizer(() => Effect.sync(unregister))
+        // Registry publication and its finalizer land atomically
+        // (acquireRelease — ATC-167 M4). Seeded from the provider's own
+        // thread status — never a guess — folded with any descendants
+        // already tracked for this root.
+        yield* Effect.acquireRelease(
+          Effect.sync(() => {
+            ownStatus.set(threadId, statusToActivity(initialStatus))
+            session.activity = aggregateFor(threadId)
+            sessions.set(threadId, session)
+          }),
+          () => Effect.sync(unregister),
+        )
 
         // A dead transport is the retryable AgentUnavailable; only a
         // caller-closed connection is a conflict.
@@ -757,61 +842,6 @@ export const layer = Layer.effect(CodexAdapter)(
       })
 
     /**
-     * Walk one paginated thread/list population (thread/list returns only
-     * non-archived threads unless `archived: true` — the populations are
-     * disjoint): the found entry, `"absent"` when a complete walk
-     * (nextCursor exhausted) omits the id, or `"unknown"` when the walk
-     * could not be completed — a repeated cursor or the page cap, either a
-     * provider that cannot make pagination progress or a pathologically
-     * long list.
-     */
-    const walkThreadList = (state: ClientState, threadId: string, archived: boolean) =>
-      Effect.gen(function* () {
-        let cursor: string | undefined
-        for (let page = 0; page < 100; page++) {
-          const reply = yield* request(
-            state,
-            "thread/list",
-            cursor === undefined ? { archived } : { archived, cursor },
-          ).pipe(
-            Effect.mapError((error) =>
-              unavailable(error._tag === "RpcError" ? error.text : error.reason),
-            ),
-          )
-          const decoded = yield* Schema.decodeUnknownEffect(ThreadListReply)(reply).pipe(
-            Effect.mapError((error) =>
-              unavailable(`unexpected thread/list reply: ${error.message}`),
-            ),
-          )
-          const thread = decoded.data.find((t) => t.id === threadId)
-          if (thread !== undefined) return thread
-          const next = decoded.nextCursor
-          if (typeof next !== "string") return "absent" as const
-          if (next === cursor) return "unknown" as const
-          cursor = next
-        }
-        return "unknown" as const
-      })
-
-    /**
-     * Find one thread across BOTH thread/list populations — a session
-     * archived through another Codex surface still exists and must not be
-     * reported as deleted. `"absent"` only when complete walks of both the
-     * non-archived and archived lists omit the id; `"unknown"` when either
-     * walk was inconclusive. Callers must not treat `"unknown"` as absence.
-     */
-    const findThread = (state: ClientState, threadId: string) =>
-      Effect.gen(function* () {
-        const live = yield* walkThreadList(state, threadId, false)
-        if (typeof live !== "string") return live
-        const archived = yield* walkThreadList(state, threadId, true)
-        if (typeof archived !== "string") return archived
-        return live === "absent" && archived === "absent"
-          ? ("absent" as const)
-          : ("unknown" as const)
-      })
-
-    /**
      * Rebuild the root's descendant graph from the provider (ATC-158):
      * walk thread/loaded/list, thread/read every loaded id, and chain
      * parent links back to the root, REPLACING the root's tracked
@@ -829,29 +859,20 @@ export const layer = Layer.effect(CodexAdapter)(
     ): Effect.Effect<"reconciled" | "unknown", AgentUnavailable> =>
       Effect.gen(function* () {
         const loaded: Array<string> = []
-        let cursor: string | undefined
-        for (let page = 0; ; page++) {
-          if (page >= 100) return "unknown" as const
-          const reply = yield* request(
-            state,
-            "thread/loaded/list",
-            cursor === undefined ? {} : { cursor },
-          ).pipe(
-            Effect.mapError((error) =>
-              unavailable(error._tag === "RpcError" ? error.text : error.reason),
+        const walk = yield* walkPaginated({
+          page: (cursor) =>
+            request(state, "thread/loaded/list", cursor === undefined ? {} : { cursor }).pipe(
+              Effect.mapError(rpcToUnavailable),
+              Effect.flatMap(decodeUnavailable(LoadedListReply, "thread/loaded/list")),
             ),
-          )
-          const decoded = yield* Schema.decodeUnknownEffect(LoadedListReply)(reply).pipe(
-            Effect.mapError((error) =>
-              unavailable(`unexpected thread/loaded/list reply: ${error.message}`),
-            ),
-          )
-          loaded.push(...decoded.data)
-          const next = decoded.nextCursor
-          if (typeof next !== "string") break
-          if (next === cursor) return "unknown" as const
-          cursor = next
-        }
+          // Accumulating find: every page feeds `loaded`, none finishes early.
+          find: (page) => {
+            loaded.push(...page.data)
+            return undefined
+          },
+          complete: () => "complete" as const,
+        })
+        if (walk !== "complete") return "unknown" as const
         // Cost bound: the loaded set is normally a handful of sessions on
         // the local in-memory server; a pathological population makes the
         // walk inconclusive rather than open-ended.
@@ -859,15 +880,9 @@ export const layer = Layer.effect(CodexAdapter)(
         const info = new Map<string, { parent: string | null; activity: AgentActivity }>()
         for (const id of loaded) {
           if (id === rootId) continue
-          const reply = yield* request(state, "thread/read", { threadId: id }).pipe(
-            Effect.mapError((error) =>
-              unavailable(error._tag === "RpcError" ? error.text : error.reason),
-            ),
-          )
-          const decoded = yield* Schema.decodeUnknownEffect(ThreadReadReply)(reply).pipe(
-            Effect.mapError((error) =>
-              unavailable(`unexpected thread/read reply: ${error.message}`),
-            ),
+          const decoded = yield* request(state, "thread/read", { threadId: id }).pipe(
+            Effect.mapError(rpcToUnavailable),
+            Effect.flatMap(decodeUnavailable(ThreadReadReply, "thread/read")),
           )
           info.set(id, {
             parent:
@@ -1058,18 +1073,24 @@ export const layer = Layer.effect(CodexAdapter)(
           // Bounded (overflow ends the feed — see emitAggregate); a
           // 16-deep undrained backlog means the observer is gone.
           const queue = yield* Queue.make<AgentActivity, Cause.Done>({ capacity: 16 })
-          const set = observers.get(options.providerSessionId) ?? new Set()
-          set.add(queue)
-          observers.set(options.providerSessionId, set)
-          yield* Effect.addFinalizer(() =>
+          // Observer registration and its finalizer land atomically
+          // (acquireRelease — ATC-167 M4).
+          yield* Effect.acquireRelease(
             Effect.sync(() => {
-              set.delete(queue)
-              if (set.size === 0) {
-                observers.delete(options.providerSessionId)
-                pruneRoot(options.providerSessionId)
-              }
-              Queue.endUnsafe(queue)
+              const set = observers.get(options.providerSessionId) ?? new Set()
+              set.add(queue)
+              observers.set(options.providerSessionId, set)
+              return set
             }),
+            (set) =>
+              Effect.sync(() => {
+                set.delete(queue)
+                if (set.size === 0) {
+                  observers.delete(options.providerSessionId)
+                  pruneRoot(options.providerSessionId)
+                }
+                Queue.endUnsafe(queue)
+              }),
           )
           // User-prompt evidence is demand-driven (ATC-155 probe: item/*
           // notifications never fan out to this passive socket): the first
@@ -1088,8 +1109,10 @@ export const layer = Layer.effect(CodexAdapter)(
           const scope = yield* Effect.scope
           // Bounded like the activity queues; prompts arrive one per turn
           // start, so 16 undrained means the observation is dead anyway.
-          const promptQueue = yield* Queue.make<AgentSessionEvent, Cause.Done>({ capacity: 16 })
-          yield* Effect.addFinalizer(() => Effect.sync(() => Queue.endUnsafe(promptQueue)))
+          const promptQueue = yield* Effect.acquireRelease(
+            Queue.make<AgentSessionEvent, Cause.Done>({ capacity: 16 }),
+            (queue) => Effect.sync(() => Queue.endUnsafe(queue)),
+          )
           let promptPhase: "pending" | "reading" | "done" = "pending"
           const readPreview = Effect.gen(function* () {
             const state = yield* getClientRetryable
@@ -1100,24 +1123,25 @@ export const layer = Layer.effect(CodexAdapter)(
             const preview = (decoded.thread.preview ?? "").trim()
             return preview === "" ? null : preview
           })
-          const discoverPrompt = Effect.gen(function* () {
-            let delay = PROMPT_READ_BACKOFF_MS
-            for (let attempt = 0; attempt < PROMPT_READ_ATTEMPTS; attempt++) {
-              if (attempt > 0) {
-                yield* Effect.sleep(Duration.millis(delay))
-                delay = Math.min(delay * 2, PROMPT_READ_BACKOFF_CAP_MS)
-              }
-              const text = yield* readPreview
-              if (text !== null) {
+          const discoverPrompt = pollUntil(readPreview, {
+            until: (text) => text !== null,
+            schedule: Schedule.min([
+              Schedule.exponential(Duration.millis(PROMPT_READ_BACKOFF_MS)),
+              Schedule.spaced(Duration.millis(PROMPT_READ_BACKOFF_CAP_MS)),
+            ]).pipe(Schedule.upTo({ times: PROMPT_READ_ATTEMPTS - 1 })),
+          }).pipe(
+            Effect.flatMap((text) =>
+              Effect.sync(() => {
+                if (text === null) {
+                  promptPhase = "pending"
+                  return
+                }
                 promptPhase = "done"
                 if (!Queue.offerUnsafe(promptQueue, { type: "userPrompt", text })) {
                   Queue.endUnsafe(promptQueue)
                 }
-                return
-              }
-            }
-            promptPhase = "pending"
-          }).pipe(
+              }),
+            ),
             Effect.catch((error) =>
               Effect.gen(function* () {
                 promptPhase = "done"

--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -13,7 +13,7 @@ import {
   Semaphore,
   Stream,
 } from "effect"
-import { pollUntil } from "../platform/poll.ts"
+import * as Poll from "../platform/poll.ts"
 import * as path from "node:path"
 import type {
   AgentActivity,
@@ -285,10 +285,11 @@ const decodeUnavailable =
 
 /**
  * Drive one paginated codex RPC to completion (the {data, nextCursor} page
- * shape): `find` inspects each page and may finish early with a value; a
- * complete walk (cursor exhausted) yields `complete()`; a repeated cursor
- * or the page cap yields "unknown" — a provider that cannot make
- * pagination progress, or a pathologically long population.
+ * shape): `onPage` sees every page and may finish the walk early by
+ * returning a value; a complete walk (cursor exhausted) yields
+ * `complete()`; a repeated cursor or the page cap yields "unknown" — a
+ * provider that cannot make pagination progress, or a pathologically long
+ * population.
  */
 const walkPaginated = <
   Page extends { readonly nextCursor?: string | null | undefined },
@@ -297,14 +298,14 @@ const walkPaginated = <
   E,
 >(options: {
   readonly page: (cursor: string | undefined) => Effect.Effect<Page, E>
-  readonly find: (page: Page) => Found | undefined
+  readonly onPage: (page: Page) => Found | undefined
   readonly complete: () => Done
 }): Effect.Effect<Found | Done | "unknown", E> =>
   Effect.gen(function* () {
     let cursor: string | undefined
     for (let page = 0; page < 100; page++) {
       const decoded = yield* options.page(cursor)
-      const found = options.find(decoded)
+      const found = options.onPage(decoded)
       if (found !== undefined) return found
       const next = decoded.nextCursor
       if (typeof next !== "string") return options.complete()
@@ -331,7 +332,7 @@ const walkThreadList = (state: ClientState, threadId: string, archived: boolean)
         Effect.mapError(rpcToUnavailable),
         Effect.flatMap(decodeUnavailable(ThreadListReply, "thread/list")),
       ),
-    find: (page) => page.data.find((t) => t.id === threadId),
+    onPage: (page) => page.data.find((t) => t.id === threadId),
     complete: () => "absent" as const,
   })
 
@@ -905,8 +906,7 @@ export const layer = Layer.effect(CodexAdapter)(
               Effect.mapError(rpcToUnavailable),
               Effect.flatMap(decodeUnavailable(LoadedListReply, "thread/loaded/list")),
             ),
-          // Accumulating find: every page feeds `loaded`, none finishes early.
-          find: (page) => {
+          onPage: (page) => {
             loaded.push(...page.data)
             return undefined
           },
@@ -1163,7 +1163,7 @@ export const layer = Layer.effect(CodexAdapter)(
             const preview = (decoded.thread.preview ?? "").trim()
             return preview === "" ? null : preview
           })
-          const discoverPrompt = pollUntil(readPreview, {
+          const discoverPrompt = Poll.pollUntil(readPreview, {
             until: (text) => text !== null,
             schedule: Schedule.min([
               Schedule.exponential(Duration.millis(PROMPT_READ_BACKOFF_MS)),

--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -6,6 +6,7 @@ import {
   Effect,
   FileSystem,
   Layer,
+  Option,
   Queue,
   Schedule,
   Schema,
@@ -150,6 +151,45 @@ const ThreadPreviewReply = Schema.Struct({
   thread: Schema.Struct({ preview: Schema.optional(Schema.NullOr(Schema.String)) }),
 })
 
+// The notification shapes the adapter acts on, decoded with Option-returning
+// decoders: an unrecognized or drifted payload stays the deliberate silent
+// skip (the default branch always tolerated unknown shapes), but a
+// recognized method no longer half-parses through casts.
+const SubAgentActivityNotification = Schema.Struct({
+  threadId: Schema.String,
+  item: Schema.Struct({
+    type: Schema.Literal("subAgentActivity"),
+    agentThreadId: Schema.String,
+  }),
+})
+const StatusChangedNotification = Schema.Struct({
+  threadId: Schema.String,
+  status: Schema.optional(Schema.Unknown),
+})
+const TurnStartedNotification = Schema.Struct({
+  threadId: Schema.String,
+  turn: Schema.Struct({ id: Schema.String }),
+})
+const TurnCompletedNotification = Schema.Struct({
+  threadId: Schema.String,
+  turn: Schema.Struct({ id: Schema.String, status: Schema.optional(Schema.Unknown) }),
+})
+// thread/started, for the armed TUI capture. parentThreadId stays Unknown:
+// its *presence as a string* is the subagent-defense signal, checked at the
+// capture site.
+const ThreadStartedNotification = Schema.Struct({
+  thread: Schema.Struct({
+    id: Schema.String,
+    cwd: Schema.String,
+    parentThreadId: Schema.optional(Schema.Unknown),
+  }),
+})
+const decodeSubAgentActivity = Schema.decodeUnknownOption(SubAgentActivityNotification)
+const decodeStatusChanged = Schema.decodeUnknownOption(StatusChangedNotification)
+const decodeTurnStarted = Schema.decodeUnknownOption(TurnStartedNotification)
+const decodeTurnCompleted = Schema.decodeUnknownOption(TurnCompletedNotification)
+const decodeThreadStarted = Schema.decodeUnknownOption(ThreadStartedNotification)
+
 const statusToActivity = (status: unknown): AgentActivity => {
   if (typeof status !== "object" || status === null) return "unknown"
   const record = status as { type?: unknown; activeFlags?: unknown }
@@ -250,7 +290,12 @@ const decodeUnavailable =
  * or the page cap yields "unknown" — a provider that cannot make
  * pagination progress, or a pathologically long population.
  */
-const walkPaginated = <Page extends { readonly nextCursor?: string | null | undefined }, Found, Done, E>(options: {
+const walkPaginated = <
+  Page extends { readonly nextCursor?: string | null | undefined },
+  Found,
+  Done,
+  E,
+>(options: {
   readonly page: (cursor: string | undefined) => Effect.Effect<Page, E>
   readonly find: (page: Page) => Found | undefined
   readonly complete: () => Done
@@ -278,7 +323,11 @@ const walkPaginated = <Page extends { readonly nextCursor?: string | null | unde
 const walkThreadList = (state: ClientState, threadId: string, archived: boolean) =>
   walkPaginated({
     page: (cursor) =>
-      request(state, "thread/list", cursor === undefined ? { archived } : { archived, cursor }).pipe(
+      request(
+        state,
+        "thread/list",
+        cursor === undefined ? { archived } : { archived, cursor },
+      ).pipe(
         Effect.mapError(rpcToUnavailable),
         Effect.flatMap(decodeUnavailable(ThreadListReply, "thread/list")),
       ),
@@ -299,9 +348,7 @@ const findThread = (state: ClientState, threadId: string) =>
     if (typeof live !== "string") return live
     const archived = yield* walkThreadList(state, threadId, true)
     if (typeof archived !== "string") return archived
-    return live === "absent" && archived === "absent"
-      ? ("absent" as const)
-      : ("unknown" as const)
+    return live === "absent" && archived === "absent" ? ("absent" as const) : ("unknown" as const)
   })
 
 export const layer = Layer.effect(CodexAdapter)(
@@ -427,9 +474,9 @@ export const layer = Layer.effect(CodexAdapter)(
      */
     const captureStarted = (params: Record<string, unknown>): void => {
       if (pendingCapture === null) return
-      const thread = params["thread"] as
-        { id?: unknown; cwd?: unknown; parentThreadId?: unknown } | undefined
-      if (typeof thread?.id !== "string" || typeof thread.cwd !== "string") return
+      const decoded = decodeThreadStarted(params)
+      if (Option.isNone(decoded)) return
+      const thread = decoded.value.thread
       // A subagent thread spawning in the armed capture's cwd must never
       // be adopted as a fresh TUI's identity (ATC-158 robustness; probes
       // show descendants currently skip thread/started, this is defense).
@@ -525,17 +572,14 @@ export const layer = Layer.effect(CodexAdapter)(
     }): void => {
       const params = message.params ?? {}
       if (message.method === "thread/started") return captureStarted(params)
-      const threadId = params["threadId"]
-      if (typeof threadId !== "string") return
       // The child→root mapping arrives as a subAgentActivity item on the
       // PARENT's feed — descendants do not broadcast thread/started
       // (probed, experiments/subagent-activity).
       if (message.method === "item/started" || message.method === "item/completed") {
-        const item = params["item"] as { type?: unknown; agentThreadId?: unknown } | undefined
-        if (item?.type === "subAgentActivity" && typeof item.agentThreadId === "string") {
-          registerDescendant(threadId, item.agentThreadId)
-          emitAggregate(resolveRoot(threadId))
-        }
+        const decoded = decodeSubAgentActivity(params)
+        if (Option.isNone(decoded)) return
+        registerDescendant(decoded.value.threadId, decoded.value.item.agentThreadId)
+        emitAggregate(resolveRoot(decoded.value.threadId))
         return
       }
       // Coarse status fans out for EVERY thread on the shared server
@@ -543,48 +587,44 @@ export const layer = Layer.effect(CodexAdapter)(
       // descendant's change folds into its root's aggregate; a root's
       // change reaches its observers and (deduped) writer feed.
       if (message.method === "thread/status/changed") {
-        const activity = statusToActivity(params["status"])
+        const decoded = decodeStatusChanged(params)
+        if (Option.isNone(decoded)) return
+        const { threadId, status } = decoded.value
+        const activity = statusToActivity(status)
         ownStatus.set(threadId, activity)
         const rootId = resolveRoot(threadId)
         if (rootId !== threadId) descendants.get(rootId)?.set(threadId, activity)
         emitAggregate(rootId)
         return
       }
-      const session = sessions.get(threadId)
-      if (session === undefined) return
-      switch (message.method) {
-        case "turn/started": {
-          const turnId = (params["turn"] as { id?: unknown } | undefined)?.id
-          if (typeof turnId !== "string") return
-          session.activeTurn = turnId
-          emit(session, { type: "turnStarted", turnId })
-          return
-        }
-        case "turn/completed": {
-          const turn = params["turn"] as { id?: unknown; status?: unknown } | undefined
-          const turnId = turn?.id
-          if (typeof turnId !== "string") return
-          if (session.activeTurn === turnId) session.activeTurn = null
-          if (session.ownTurn === turnId) session.ownTurn = null
-          const status = turn?.status
-          const outcome =
-            status === "completed"
-              ? "completed"
-              : status === "interrupted"
-                ? "interrupted"
-                : "failed"
-          emit(
-            session,
-            outcome === "failed"
-              ? { type: "turnCompleted", turnId, outcome, detail: String(status) }
-              : { type: "turnCompleted", turnId, outcome },
-          )
-          return
-        }
-        default:
-          // Item deltas, token usage, MCP startup noise: not status facts.
-          return
+      if (message.method === "turn/started") {
+        const decoded = decodeTurnStarted(params)
+        if (Option.isNone(decoded)) return
+        const session = sessions.get(decoded.value.threadId)
+        if (session === undefined) return
+        session.activeTurn = decoded.value.turn.id
+        emit(session, { type: "turnStarted", turnId: decoded.value.turn.id })
+        return
       }
+      if (message.method === "turn/completed") {
+        const decoded = decodeTurnCompleted(params)
+        if (Option.isNone(decoded)) return
+        const session = sessions.get(decoded.value.threadId)
+        if (session === undefined) return
+        const { id: turnId, status } = decoded.value.turn
+        if (session.activeTurn === turnId) session.activeTurn = null
+        if (session.ownTurn === turnId) session.ownTurn = null
+        const outcome =
+          status === "completed" ? "completed" : status === "interrupted" ? "interrupted" : "failed"
+        emit(
+          session,
+          outcome === "failed"
+            ? { type: "turnCompleted", turnId, outcome, detail: String(status) }
+            : { type: "turnCompleted", turnId, outcome },
+        )
+        return
+      }
+      // Item deltas, token usage, MCP startup noise: not status facts.
     }
 
     const dispatch = (state: ClientState, raw: string): void => {

--- a/app-server/src/cli/cli.ts
+++ b/app-server/src/cli/cli.ts
@@ -1,5 +1,6 @@
 import { BunHttpClient } from "@effect/platform-bun"
-import { Console, Effect, FileSystem, Option, Runtime, Schema } from "effect"
+import { Console, Effect, FileSystem, Option, Runtime, Schedule, Schema } from "effect"
+import * as Poll from "../platform/poll.ts"
 import { Argument, Command, Flag } from "effect/unstable/cli"
 import { HttpClient } from "effect/unstable/http"
 import * as path from "node:path"
@@ -90,13 +91,11 @@ export const pollUntil = (
   intervalMillis: number,
   check: Effect.Effect<boolean>,
 ) =>
-  Effect.gen(function* () {
-    const attempts = Math.ceil(deadlineMillis / intervalMillis)
-    for (let attempt = 0; attempt < attempts; attempt++) {
-      if (yield* check) return true
-      yield* Effect.sleep(intervalMillis)
-    }
-    return yield* check
+  Poll.pollUntil(check, {
+    until: (settled) => settled,
+    schedule: Schedule.spaced(intervalMillis).pipe(
+      Schedule.upTo({ times: Math.ceil(deadlineMillis / intervalMillis) }),
+    ),
   })
 
 // Base-URL resolution seam for client commands: ATC_ENDPOINT (set in the

--- a/app-server/src/cli/service.ts
+++ b/app-server/src/cli/service.ts
@@ -131,6 +131,9 @@ const currentPlatform =
         `atc service: unsupported platform ${process.platform} (launchd on macOS, systemd user units on Linux)`,
       )
 
+// The one sanctioned direct PATH read in the CLI: unit files embed the
+// PATH the installer's shell saw — it is the future service process's
+// environment, not settled ATC configuration.
 const installerPath = () => process.env["PATH"] ?? "/usr/local/bin:/usr/bin:/bin"
 
 /** One thin supervisor call; failure carries the tool's stderr. Stdout is
@@ -223,12 +226,14 @@ const launchdBootstrap = (subprocess: Subprocess["Service"], command: string, un
     yield* run(subprocess, command, "launchctl", ["bootstrap", fallback, unitFile])
   })
 
-const unitFileFor = (platform: Platform): string =>
+const unitFileFor = (platform: Platform, home: string): string =>
   platform === "darwin"
-    ? launchAgentPath(homedir())
+    ? launchAgentPath(home)
     : systemdUnitPath({
+        // XDG_CONFIG_HOME is systemd's own convention (see systemdUnitPath's
+        // header) — a sanctioned direct read; home is settled configuration.
         XDG_CONFIG_HOME: process.env["XDG_CONFIG_HOME"],
-        HOME: process.env["HOME"],
+        HOME: home,
       })
 
 /** Success only when the served address answers health within the deadline. */
@@ -261,7 +266,7 @@ const install = Command.make("install", {}, () =>
     const subprocess = yield* Subprocess
     const args = programArguments(build.commit === "dev")
     const serviceLog = `${config.stateDir}/service.log`
-    const unitFile = unitFileFor(platform)
+    const unitFile = unitFileFor(platform, config.home)
     // Re-running install over our own service is the update path (the unit
     // points at the stable installed binary, so a reinstall restarts onto
     // it). Only an UNMANAGED responder is a conflict: it would make the
@@ -312,9 +317,10 @@ const install = Command.make("install", {}, () =>
 const uninstall = Command.make("uninstall", {}, () =>
   Effect.gen(function* () {
     const platform = yield* currentPlatform
+    const config = yield* AppConfig
     const fs = yield* FileSystem.FileSystem
     const subprocess = yield* Subprocess
-    const unitFile = unitFileFor(platform)
+    const unitFile = unitFileFor(platform, config.home)
     if (platform === "darwin") {
       yield* launchdUnload(subprocess)
     } else {
@@ -337,7 +343,7 @@ const start = Command.make("start", {}, () =>
     const config = yield* AppConfig
     const fs = yield* FileSystem.FileSystem
     const subprocess = yield* Subprocess
-    const unitFile = unitFileFor(platform)
+    const unitFile = unitFileFor(platform, config.home)
     if (!(yield* fs.exists(unitFile).pipe(Effect.orElseSucceed(() => false)))) {
       return yield* Cli.failReported(
         `atc service start: ${unitFile} does not exist; run \`atc service install\` first`,
@@ -393,7 +399,7 @@ const status = Command.make("status", {}, () =>
     const config = yield* AppConfig
     const fs = yield* FileSystem.FileSystem
     const subprocess = yield* Subprocess
-    const unitFile = unitFileFor(platform)
+    const unitFile = unitFileFor(platform, config.home)
     if (!(yield* fs.exists(unitFile).pipe(Effect.orElseSucceed(() => false)))) {
       return yield* Cli.failReported(`atc service status: not installed (no ${unitFile})`)
     }

--- a/app-server/src/platform/directories.ts
+++ b/app-server/src/platform/directories.ts
@@ -18,8 +18,8 @@ import { AppConfig } from "./config.ts"
 // FileSystem service can express neither the traversal (X_OK) access check
 // nor d_type-carrying directory reads (losing d_type would cost a stat per
 // entry). The pipeline around them is Effect, so the bounded timeout
-// interrupts between steps and cancels the stat fan-out instead of
-// abandoning it.
+// interrupts between steps — queued work never starts after the deadline
+// (an already-in-flight OS call still completes harmlessly).
 
 /** Bounded time for any filesystem probe; fail closed beyond it. */
 export const CHECK_TIMEOUT_MILLIS = 2000
@@ -153,9 +153,8 @@ const listProbe = (path: string): Effect.Effect<DirectoryListing, DirectoryUnava
       unclassified.push({ name: dirent.name, path: entryPath })
     }
     // Stat the unclassified entries with bounded concurrency: d_type-less
-    // filesystems report whole directories this way. The fan-out is a real
-    // Effect pool, so the bounded timeout interrupts it — no new stats start
-    // after the deadline, instead of thousands piling up abandoned.
+    // filesystems report whole directories this way (see the header for the
+    // interruption behavior).
     const classified = yield* Effect.forEach(
       unclassified,
       (entry) =>

--- a/app-server/src/platform/directories.ts
+++ b/app-server/src/platform/directories.ts
@@ -14,11 +14,17 @@ import { AppConfig } from "./config.ts"
 // (deliberately not write: testing writability at registration is worse than
 // surfacing a write failure at first use). Identity is the symlink-resolved
 // canonical absolute path; nothing else is stored.
+// The individual calls stay on node:fs/promises deliberately: the platform
+// FileSystem service can express neither the traversal (X_OK) access check
+// nor d_type-carrying directory reads (losing d_type would cost a stat per
+// entry). The pipeline around them is Effect, so the bounded timeout
+// interrupts between steps and cancels the stat fan-out instead of
+// abandoning it.
 
 /** Bounded time for any filesystem probe; fail closed beyond it. */
 export const CHECK_TIMEOUT_MILLIS = 2000
 
-/** Concurrent `stat` calls per listing; bounds the work a timeout abandons. */
+/** Concurrent `stat` calls per listing; bounds the fan-out a listing runs. */
 export const STAT_CONCURRENCY = 16
 
 export type DirectoryCheckResult = {
@@ -65,35 +71,6 @@ export class Directories extends Context.Service<
   }
 >()("app-server/Directories") {}
 
-type Probe =
-  | { readonly ok: true; readonly canonical: string }
-  | { readonly ok: false; readonly state: DirectoryUnavailable["state"] }
-
-// One filesystem probe: canonicalize, require a directory, require
-// read+traversal. Node errno codes map onto the tagged states.
-const probe = (path: string): Promise<Probe> =>
-  (async () => {
-    let canonical: string
-    try {
-      canonical = await fs.realpath(path)
-    } catch (error) {
-      return { ok: false as const, state: stateFromErrno(error) }
-    }
-    let isDirectory: boolean
-    try {
-      isDirectory = (await fs.stat(canonical)).isDirectory()
-    } catch {
-      return { ok: false as const, state: "inaccessible" }
-    }
-    if (!isDirectory) return { ok: false as const, state: "not_directory" }
-    try {
-      await fs.access(canonical, constants.R_OK | constants.X_OK)
-    } catch {
-      return { ok: false as const, state: "inaccessible" }
-    }
-    return { ok: true as const, canonical }
-  })()
-
 const errno = (error: unknown): string | undefined =>
   error instanceof Error && "code" in error ? String(error.code) : undefined
 
@@ -105,34 +82,54 @@ const stateFromErrno = (error: unknown): DirectoryUnavailable["state"] =>
       ? "not_directory"
       : "inaccessible"
 
+const unavailable = (path: string, state: DirectoryUnavailable["state"]) =>
+  new DirectoryUnavailable({ path, state })
+
+// One filesystem probe: canonicalize, require a directory, require
+// read+traversal. Node errno codes map onto the tagged states.
+const probe = (
+  path: string,
+): Effect.Effect<string, DirectoryUnavailable> =>
+  Effect.gen(function* () {
+    const canonical = yield* Effect.tryPromise({
+      try: () => fs.realpath(path),
+      catch: (error) => unavailable(path, stateFromErrno(error)),
+    })
+    const stat = yield* Effect.tryPromise({
+      try: () => fs.stat(canonical),
+      catch: () => unavailable(path, "inaccessible"),
+    })
+    if (!stat.isDirectory()) return yield* Effect.fail(unavailable(path, "not_directory"))
+    yield* Effect.tryPromise({
+      try: () => fs.access(canonical, constants.R_OK | constants.X_OK),
+      catch: () => unavailable(path, "inaccessible"),
+    })
+    return canonical
+  })
+
 /** Run a filesystem probe under the bounded timeout; fail closed beyond it. */
-const bounded = <T>(path: string, run: () => Promise<T>) =>
-  Effect.promise(run).pipe(
+const bounded = <A, E>(
+  path: string,
+  effect: Effect.Effect<A, E>,
+): Effect.Effect<A, E | DirectoryCheckTimedOut> =>
+  effect.pipe(
     Effect.timeoutOrElse({
       duration: CHECK_TIMEOUT_MILLIS,
       orElse: () => Effect.fail(new DirectoryCheckTimedOut({ path })),
     }),
   )
 
-type ListProbe =
-  | { readonly ok: true; readonly listing: DirectoryListing }
-  | { readonly ok: false; readonly state: DirectoryUnavailable["state"] }
-
 // Probe the directory, then read its subdirectories. Entry paths are joined,
 // not resolved: a symlink entry keeps its name-path, and descending into it
 // canonicalizes naturally on the next list.
-const listProbe = (path: string): Promise<ListProbe> =>
-  (async () => {
-    const probed = await probe(path)
-    if (!probed.ok) return probed
-    const canonical = probed.canonical
-    let dirents
-    try {
-      dirents = await fs.readdir(canonical, { withFileTypes: true })
-    } catch (error) {
+const listProbe = (path: string): Effect.Effect<DirectoryListing, DirectoryUnavailable> =>
+  Effect.gen(function* () {
+    const canonical = yield* probe(path)
+    const dirents = yield* Effect.tryPromise({
+      try: () => fs.readdir(canonical, { withFileTypes: true }),
       // The directory can vanish between probe and readdir.
-      return { ok: false as const, state: stateFromErrno(error) }
-    }
+      catch: (error) => unavailable(path, stateFromErrno(error)),
+    })
     const entries: Array<{ name: string; path: string }> = []
     const unclassified: Array<{ name: string; path: string }> = []
     for (const dirent of dirents) {
@@ -157,63 +154,53 @@ const listProbe = (path: string): Promise<ListProbe> =>
       }
       unclassified.push({ name: dirent.name, path: entryPath })
     }
-    // Stat the unclassified entries through a small worker pool: d_type-less
-    // filesystems report whole directories this way, and the bounded timeout
-    // abandons rather than cancels these promises — so the pool, not the
-    // timeout, is what keeps a huge directory from piling up thousands of
-    // in-flight stats per request.
-    const classified: Array<{ name: string; path: string } | null> = new Array(unclassified.length)
-    let nextIndex = 0
-    const statWorker = async () => {
-      while (true) {
-        const index = nextIndex++
-        const entry = unclassified[index]
-        if (entry === undefined) return
-        try {
-          classified[index] = (await fs.stat(entry.path)).isDirectory() ? entry : null
-        } catch {
+    // Stat the unclassified entries with bounded concurrency: d_type-less
+    // filesystems report whole directories this way. The fan-out is a real
+    // Effect pool, so the bounded timeout interrupts it — no new stats start
+    // after the deadline, instead of thousands piling up abandoned.
+    const classified = yield* Effect.forEach(
+      unclassified,
+      (entry) =>
+        Effect.tryPromise({ try: () => fs.stat(entry.path), catch: () => null }).pipe(
+          Effect.map((stat) => (stat.isDirectory() ? entry : null)),
           // Broken or unreadable symlink, or a vanished entry: skip it.
-          classified[index] = null
-        }
-      }
-    }
-    await Promise.all(
-      Array.from({ length: Math.min(STAT_CONCURRENCY, unclassified.length) }, statWorker),
+          Effect.orElseSucceed(() => null),
+        ),
+      { concurrency: STAT_CONCURRENCY },
     )
     entries.push(...classified.filter((entry) => entry !== null))
     // Pinned collation, so the advertised case-insensitive order does not
     // drift with the server's locale.
     entries.sort((a, b) => a.name.localeCompare(b.name, "en"))
     return {
-      ok: true as const,
-      listing: {
-        path: canonical,
-        ...(canonical === "/" ? {} : { parent: dirname(canonical) }),
-        entries,
-      },
+      path: canonical,
+      ...(canonical === "/" ? {} : { parent: dirname(canonical) }),
+      entries,
     }
-  })()
+  })
 
 export const layer = Layer.effect(Directories)(
   Effect.gen(function* () {
     const config = yield* AppConfig
     return {
-      canonicalize: (path) =>
-        bounded(path, () => probe(path)).pipe(
-          Effect.flatMap((result) =>
-            result.ok
-              ? Effect.succeed(result.canonical)
-              : Effect.fail(new DirectoryUnavailable({ path, state: result.state })),
-          ),
-        ),
+      canonicalize: (path) => bounded(path, probe(path)),
       check: (path) =>
-        bounded(path, () => probe(path)).pipe(
-          Effect.map((result): DirectoryCheckResult => ({
-            path: result.ok ? result.canonical : path,
-            state: result.ok ? "available" : result.state,
-            checkedAt: new Date().toISOString(),
-          })),
-          Effect.catch(() =>
+        bounded(path, probe(path)).pipe(
+          Effect.map(
+            (canonical): DirectoryCheckResult => ({
+              path: canonical,
+              state: "available",
+              checkedAt: new Date().toISOString(),
+            }),
+          ),
+          Effect.catchTag("DirectoryUnavailable", (error) =>
+            Effect.succeed<DirectoryCheckResult>({
+              path,
+              state: error.state,
+              checkedAt: new Date().toISOString(),
+            }),
+          ),
+          Effect.catchTag("DirectoryCheckTimedOut", () =>
             Effect.succeed<DirectoryCheckResult>({
               path,
               state: "unknown",
@@ -224,13 +211,7 @@ export const layer = Layer.effect(Directories)(
         ),
       list: (path) => {
         const target = path ?? config.home
-        return bounded(target, () => listProbe(target)).pipe(
-          Effect.flatMap((result) =>
-            result.ok
-              ? Effect.succeed(result.listing)
-              : Effect.fail(new DirectoryUnavailable({ path: target, state: result.state })),
-          ),
-        )
+        return bounded(target, listProbe(target))
       },
     } satisfies Directories["Service"]
   }),

--- a/app-server/src/platform/directories.ts
+++ b/app-server/src/platform/directories.ts
@@ -87,9 +87,7 @@ const unavailable = (path: string, state: DirectoryUnavailable["state"]) =>
 
 // One filesystem probe: canonicalize, require a directory, require
 // read+traversal. Node errno codes map onto the tagged states.
-const probe = (
-  path: string,
-): Effect.Effect<string, DirectoryUnavailable> =>
+const probe = (path: string): Effect.Effect<string, DirectoryUnavailable> =>
   Effect.gen(function* () {
     const canonical = yield* Effect.tryPromise({
       try: () => fs.realpath(path),
@@ -186,13 +184,11 @@ export const layer = Layer.effect(Directories)(
       canonicalize: (path) => bounded(path, probe(path)),
       check: (path) =>
         bounded(path, probe(path)).pipe(
-          Effect.map(
-            (canonical): DirectoryCheckResult => ({
-              path: canonical,
-              state: "available",
-              checkedAt: new Date().toISOString(),
-            }),
-          ),
+          Effect.map((canonical): DirectoryCheckResult => ({
+            path: canonical,
+            state: "available",
+            checkedAt: new Date().toISOString(),
+          })),
           Effect.catchTag("DirectoryUnavailable", (error) =>
             Effect.succeed<DirectoryCheckResult>({
               path,

--- a/app-server/src/platform/poll.ts
+++ b/app-server/src/platform/poll.ts
@@ -1,0 +1,18 @@
+import { Effect } from "effect"
+import type { Schedule } from "effect"
+
+// The one demand-polling loop: run `check` immediately, and while `until`
+// rejects its value, wait out the schedule and check again. Resolves with
+// the last checked value once `until` accepts it or the schedule ends —
+// polling never fails by itself, so what a rejected final value means
+// stays with the caller. Cadence is the caller's Schedule (spaced, capped
+// exponential, bounded with upTo — see the call sites).
+
+export const pollUntil = <A, E = never, R = never>(
+  check: Effect.Effect<A, E, R>,
+  options: {
+    readonly until: (value: A) => boolean
+    readonly schedule: Schedule.Schedule<unknown, A>
+  },
+): Effect.Effect<A, E, R> =>
+  Effect.repeat(check, { schedule: options.schedule, until: options.until })

--- a/app-server/src/platform/subprocess.ts
+++ b/app-server/src/platform/subprocess.ts
@@ -6,10 +6,12 @@ import {
   Effect,
   Layer,
   Queue,
+  Schedule,
   Schema,
   Scope,
   Stream,
 } from "effect"
+import { pollUntil } from "./poll.ts"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { spawn as nodeSpawn } from "node:child_process"
 
@@ -192,13 +194,15 @@ export const waitForProcessExit = (
   pid: number,
   options?: { readonly attempts?: number; readonly interval?: Duration.Input },
 ): Effect.Effect<boolean> =>
-  Effect.gen(function* () {
-    const attempts = options?.attempts ?? 40
-    for (let attempt = 0; attempt < attempts && isProcessAlive(pid); attempt++) {
-      yield* Effect.sleep(options?.interval ?? "50 millis")
-    }
-    return !isProcessAlive(pid)
-  })
+  pollUntil(
+    Effect.sync(() => !isProcessAlive(pid)),
+    {
+      until: (gone) => gone,
+      schedule: Schedule.spaced(options?.interval ?? "50 millis").pipe(
+        Schedule.upTo({ times: options?.attempts ?? 40 }),
+      ),
+    },
+  )
 
 const truncate = (line: string): string =>
   line.length > MAX_CAPTURED_LINE_LENGTH ? `${line.slice(0, MAX_CAPTURED_LINE_LENGTH)}…` : line

--- a/app-server/src/platform/subprocess.ts
+++ b/app-server/src/platform/subprocess.ts
@@ -11,7 +11,7 @@ import {
   Scope,
   Stream,
 } from "effect"
-import { pollUntil } from "./poll.ts"
+import * as Poll from "./poll.ts"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { spawn as nodeSpawn } from "node:child_process"
 
@@ -194,7 +194,7 @@ export const waitForProcessExit = (
   pid: number,
   options?: { readonly attempts?: number; readonly interval?: Duration.Input },
 ): Effect.Effect<boolean> =>
-  pollUntil(
+  Poll.pollUntil(
     Effect.sync(() => !isProcessAlive(pid)),
     {
       until: (gone) => gone,

--- a/app-server/src/terminals/terminalRepository.ts
+++ b/app-server/src/terminals/terminalRepository.ts
@@ -29,7 +29,9 @@ const TerminalRow = Schema.Struct({
   project_id: Schema.String,
   thread_id: Schema.NullOr(Schema.String),
   name: Schema.NullOr(Schema.String),
-  command: Schema.NullOr(Schema.String),
+  // The one JSON column: decoded/encoded through the schema, so a
+  // corrupt value fails the row decode instead of half-parsing.
+  command: Schema.NullOr(Schema.fromJsonString(Schema.Array(Schema.String))),
   initial_working_directory: Schema.String,
   status: Schema.Literals(["starting", "live", "ended"]),
   created_at: Schema.String,
@@ -42,7 +44,7 @@ const toRecord = (row: typeof TerminalRow.Type): TerminalRecord => ({
   projectId: row.project_id,
   ...(row.thread_id !== null ? { threadId: row.thread_id } : {}),
   ...(row.name !== null ? { name: row.name } : {}),
-  ...(row.command !== null ? { command: JSON.parse(row.command) as Array<string> } : {}),
+  ...(row.command !== null ? { command: row.command } : {}),
   initialWorkingDirectory: row.initial_working_directory,
   status: row.status,
   createdAt: row.created_at,
@@ -162,7 +164,7 @@ export const layer = Layer.effect(TerminalRepository)(
             project_id: input.projectId,
             thread_id: input.threadId ?? null,
             name: input.name ?? null,
-            command: input.command !== undefined ? JSON.stringify(input.command) : null,
+            command: input.command !== undefined ? [...input.command] : null,
             initial_working_directory: input.initialWorkingDirectory,
             status: "starting",
             created_at: now,

--- a/app-server/src/terminals/zmxAdapter.ts
+++ b/app-server/src/terminals/zmxAdapter.ts
@@ -211,9 +211,7 @@ export const layerWith = (options: ZmxOptions) =>
       const pollInventory = (predicate: (sessions: ReadonlyArray<SessionInfo>) => boolean) =>
         pollUntil(listSessions(), {
           until: predicate,
-          schedule: Schedule.spaced(pollInterval).pipe(
-            Schedule.upTo({ times: verifyPasses - 1 }),
-          ),
+          schedule: Schedule.spaced(pollInterval).pipe(Schedule.upTo({ times: verifyPasses - 1 })),
         }).pipe(Effect.map((sessions) => (predicate(sessions) ? sessions : undefined)))
 
       const liveSession = (name: string) => (sessions: ReadonlyArray<SessionInfo>) =>

--- a/app-server/src/terminals/zmxAdapter.ts
+++ b/app-server/src/terminals/zmxAdapter.ts
@@ -1,4 +1,5 @@
-import { Effect, FileSystem, Layer, Schema, Stream } from "effect"
+import { Effect, FileSystem, Layer, Schedule, Schema, Stream } from "effect"
+import { pollUntil } from "../platform/poll.ts"
 import type { Duration } from "effect"
 import * as path from "node:path"
 import { AppConfig, CONTEXT_VARIABLES } from "../platform/config.ts"
@@ -208,14 +209,12 @@ export const layerWith = (options: ZmxOptions) =>
        * it without another `zmx list`), or undefined if none was accepted.
        */
       const pollInventory = (predicate: (sessions: ReadonlyArray<SessionInfo>) => boolean) =>
-        Effect.gen(function* () {
-          for (let pass = 0; pass < verifyPasses; pass++) {
-            if (pass > 0) yield* Effect.sleep(pollInterval)
-            const sessions = yield* listSessions()
-            if (predicate(sessions)) return sessions
-          }
-          return undefined
-        })
+        pollUntil(listSessions(), {
+          until: predicate,
+          schedule: Schedule.spaced(pollInterval).pipe(
+            Schedule.upTo({ times: verifyPasses - 1 }),
+          ),
+        }).pipe(Effect.map((sessions) => (predicate(sessions) ? sessions : undefined)))
 
       const liveSession = (name: string) => (sessions: ReadonlyArray<SessionInfo>) =>
         sessions.some((s) => s.name === name && s.reachable)

--- a/app-server/src/terminals/zmxAdapter.ts
+++ b/app-server/src/terminals/zmxAdapter.ts
@@ -1,5 +1,5 @@
 import { Effect, FileSystem, Layer, Schedule, Schema, Stream } from "effect"
-import { pollUntil } from "../platform/poll.ts"
+import * as Poll from "../platform/poll.ts"
 import type { Duration } from "effect"
 import * as path from "node:path"
 import { AppConfig, CONTEXT_VARIABLES } from "../platform/config.ts"
@@ -209,7 +209,7 @@ export const layerWith = (options: ZmxOptions) =>
        * it without another `zmx list`), or undefined if none was accepted.
        */
       const pollInventory = (predicate: (sessions: ReadonlyArray<SessionInfo>) => boolean) =>
-        pollUntil(listSessions(), {
+        Poll.pollUntil(listSessions(), {
           until: predicate,
           schedule: Schedule.spaced(pollInterval).pipe(Schedule.upTo({ times: verifyPasses - 1 })),
         }).pipe(Effect.map((sessions) => (predicate(sessions) ? sessions : undefined)))

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -1,4 +1,15 @@
-import { Context, Duration, Effect, Exit, Layer, Option, Schedule, Scope, Semaphore, Stream } from "effect"
+import {
+  Context,
+  Duration,
+  Effect,
+  Exit,
+  Layer,
+  Option,
+  Schedule,
+  Scope,
+  Semaphore,
+  Stream,
+} from "effect"
 import { AgentRegistry } from "../agents/agentRegistry.ts"
 import type {
   AgentActivity,

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -505,16 +505,21 @@ export const layerWith = (options: ThreadsOptions) =>
         // The deliberate initial delay, then checks backing off from twice
         // that interval to a 5-second ceiling — the loop only ever exits by
         // failing (the launch wait races it against identity resolution).
+        // The repeat wraps ONLY the check: wrapping the initial sleep too
+        // would add it to every scheduled delay.
         return Effect.sleep(launchWatchInterval).pipe(
-          Effect.andThen(requireAlive),
-          Effect.repeat({
-            schedule: Schedule.min([
-              Schedule.exponential(
-                Duration.times(Duration.fromInputUnsafe(launchWatchInterval), 2),
-              ),
-              Schedule.spaced("5 seconds"),
-            ]),
-          }),
+          Effect.andThen(
+            requireAlive.pipe(
+              Effect.repeat({
+                schedule: Schedule.min([
+                  Schedule.exponential(
+                    Duration.times(Duration.fromInputUnsafe(launchWatchInterval), 2),
+                  ),
+                  Schedule.spaced("5 seconds"),
+                ]),
+              }),
+            ),
+          ),
           Effect.andThen(Effect.never),
         )
       }

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -1,4 +1,4 @@
-import { Context, Duration, Effect, Exit, Layer, Option, Scope, Semaphore, Stream } from "effect"
+import { Context, Duration, Effect, Exit, Layer, Option, Schedule, Scope, Semaphore, Stream } from "effect"
 import { AgentRegistry } from "../agents/agentRegistry.ts"
 import type {
   AgentActivity,
@@ -475,27 +475,38 @@ export const layerWith = (options: ThreadsOptions) =>
       const watchForEarlyDeath = (
         record: ThreadRecord,
         terminalId: string,
-      ): Effect.Effect<never, ProviderUnavailable> =>
-        Effect.gen(function* () {
-          let delay = Duration.toMillis(Duration.fromInputUnsafe(launchWatchInterval))
-          for (;;) {
-            yield* Effect.sleep(Duration.millis(delay))
-            delay = Math.min(delay * 2, 5_000)
-            const current = yield* terminals
-              .get(terminalId)
-              .pipe(Effect.catchTag("TerminalNotFound", () => Effect.succeed(undefined)))
-            if (current === undefined || current.status === "ended") {
-              return yield* Effect.fail(
-                new ProviderUnavailable({
-                  agentId: record.agentId,
-                  reason:
-                    `the ${record.agentId} TUI exited before its session was established; ` +
-                    `run it manually in the thread's directory to see why (a missing provider login is the usual cause)`,
-                }),
-              )
-            }
+      ): Effect.Effect<never, ProviderUnavailable> => {
+        const requireAlive = Effect.gen(function* () {
+          const current = yield* terminals
+            .get(terminalId)
+            .pipe(Effect.catchTag("TerminalNotFound", () => Effect.succeed(undefined)))
+          if (current === undefined || current.status === "ended") {
+            return yield* Effect.fail(
+              new ProviderUnavailable({
+                agentId: record.agentId,
+                reason:
+                  `the ${record.agentId} TUI exited before its session was established; ` +
+                  `run it manually in the thread's directory to see why (a missing provider login is the usual cause)`,
+              }),
+            )
           }
         })
+        // The deliberate initial delay, then checks backing off from twice
+        // that interval to a 5-second ceiling — the loop only ever exits by
+        // failing (the launch wait races it against identity resolution).
+        return Effect.sleep(launchWatchInterval).pipe(
+          Effect.andThen(requireAlive),
+          Effect.repeat({
+            schedule: Schedule.min([
+              Schedule.exponential(
+                Duration.times(Duration.fromInputUnsafe(launchWatchInterval), 2),
+              ),
+              Schedule.spaced("5 seconds"),
+            ]),
+          }),
+          Effect.andThen(Effect.never),
+        )
+      }
 
       /** Launch a TUI terminal for the thread from an adapter launch spec,
        * with the nested-session markers scrubbed uniformly. */

--- a/app-server/test/agents/fakeClaudeQuery.ts
+++ b/app-server/test/agents/fakeClaudeQuery.ts
@@ -116,11 +116,13 @@ export const makeFakeClaudeQuery = (options: FakeClaudeQueryOptions = {}): FakeC
       }
       initOnce()
       state("running")
+      // Marked BEFORE the awaited hook fire: an interrupt() arriving while
+      // the hook callback runs must already see the hanging turn, or it
+      // records "(no hanging turn)" and never ends the query.
+      const hangs = text.includes("HANG")
+      if (hangs) hanging = text
       await fireHook("UserPromptSubmit")
-      if (text.includes("HANG")) {
-        hanging = text
-        return
-      }
+      if (hangs) return
       if (text.includes("PERMISSION") || text.includes("ASK")) {
         const toolName = text.includes("ASK") ? "AskUserQuestion" : "Bash"
         state("requires_action")


### PR DESCRIPTION
PR 4 of the ATC-170 codebase-hardening effort. Findings: ATC-167 M2–M7, M13. Sub-issue: [ATC-174](https://linear.app/elevenideas/issue/ATC-174).

## Changes

- **M2 — Schema-decoded provider payloads.** The five codex notification shapes the adapter acts on (subAgentActivity items, thread/status/changed, turn/started, turn/completed, thread/started) decode through module-level `Schema.Struct`s with Option-returning decoders — silent skip on decode failure preserves the deliberate tolerance, but a recognized method no longer half-parses through casts (verified case-by-case equivalent by the correctness review). Claude's `providerMetadata` hookSecret decodes via `Schema.fromJsonString`; the terminals `command` JSON column is now decoded/encoded by the row schema itself (`NullOr(fromJsonString(Array(String)))` — byte-identical wire format, existing rows decode).
- **M3 —** the hand-rolled async input generator became a `Queue` + `Stream.toAsyncIterableEffect`; the title one-shot uses `Stream.make`. This exposed a latent race in the test fixture (an interrupt landing during the awaited hook fire before the hang marker was set) — fixed in the fixture.
- **M4 —** `acquireRelease` pairing at the four structurally-matching sites, with claude's single-writer check moved *inside* the sync acquire so nothing can split check from claim. The two threads.ts sites were deliberately not converted: their claims must stay same-JS-segment-synchronous with their preceding checks (documented at both sites), and acquireRelease introduces a yield boundary.
- **M5 —** one shared `Poll.pollUntil(check, {until, schedule})` replaces five hand-rolled loops; every site's check count and sleep sequence verified equivalent against the pinned Schedule semantics. `watchForEarlyDeath` is a capped `Schedule.exponential` (the review caught my first composition inflating every delay by the initial interval — fixed and documented).
- **M6 —** `atc service` derives home from `AppConfig`; the PATH read is documented as the sanctioned exception (it's the future service process's environment, not ATC configuration).
- **M7 —** directories.ts is an Effect pipeline: typed failures instead of result unions, and the stat fan-out is `Effect.forEach {concurrency: 16}` so the bounded timeout genuinely stops the pool. node:fs stays at the call boundary deliberately — the platform FileSystem service can express neither X_OK traversal checks nor d_type-carrying reads (header documents this).
- **M13 —** codexAdapter's closure shrinks: `request`, reply decoding, the generic paginated cursor walk (`walkPaginated`), `walkThreadList`/`findThread` are module-level; the verbatim-3× error mapping is one helper; claudeAdapter's 4× resolve+version-gate preamble is one shared `resolvedExecutable`.

## Verification

- `mise run -C app-server check` — 328 passed
- `mise run -C app-server test:zmx` — 3 passed (real zmx)

Two adversarial reviews applied. Known latent edge (recorded, unreachable today): `pollInventory` with `verifyPasses: 0` would run one pass where the old loop ran none (Effect.repeat always evaluates once; default is 20).

Stack note: this PR is part of the ATC-170 stack (#161 → #168, each based on the previous). All cross-PR conflicts are already resolved in the branches themselves — merge bottom-up in order and each merge retargets the next PR automatically; no manual resolution needed.

https://claude.ai/code/session_019pj9ErmqTfaLoTPksB3fSZ
