### PR TITLE
macOS correctness & UX hardening (ATC-175)

### DIFF
--- a/macos/ATC/ConnectionRuntime.swift
+++ b/macos/ATC/ConnectionRuntime.swift
@@ -108,7 +108,10 @@ final class ConnectionRuntime: Identifiable {
         // that never open, so it can't report that failure. Stored so
         // stop() during launch cancels it — a probe outliving its runtime
         // would settle reachability on a dead one.
-        firstContactTask = Task { [weak self] in await self?.refresh() }
+        firstContactTask = Task { [weak self] in
+            await self?.refresh()
+            self?.firstContactTask = nil
+        }
         let stream = eventStreamFactory(baseURL, transportHeaders)
         eventTask = Task { [weak self] in
             for await event in stream {
@@ -146,8 +149,8 @@ final class ConnectionRuntime: Identifiable {
         async let terminalsDone: Void = terminals.refresh()
         async let agentsDone: Void = agents.refresh()
         _ = await (projectsDone, threadsDone, terminalsDone, agentsDone)
-        // A refresh whose task was cancelled mid-flight (stop() during
-        // launch) must not settle reachability on a stopped runtime.
+        // Cancelled mid-flight = stop() ran (see start()); don't settle a
+        // stopped runtime.
         guard !Task.isCancelled else { return }
         settleReachability()
     }

--- a/macos/ATC/ConnectionRuntime.swift
+++ b/macos/ATC/ConnectionRuntime.swift
@@ -62,6 +62,7 @@ final class ConnectionRuntime: Identifiable {
 
     private let eventStreamFactory: (URL, [String: String]) -> AsyncStream<ResourceEventStream.Event>
     private var eventTask: Task<Void, Never>?
+    private var firstContactTask: Task<Void, Never>?
     /// Whether the SSE stream is currently open. `.connected` requires it:
     /// without the stream no invalidations flow, so a green dot would lie
     /// even while plain HTTP requests succeed.
@@ -104,8 +105,10 @@ final class ConnectionRuntime: Identifiable {
         guard eventTask == nil else { return }
         // First-contact probe: a server that is down at launch must go red,
         // not sit gray forever — the stream alone stays silent for attempts
-        // that never open, so it can't report that failure.
-        Task { [weak self] in await self?.refresh() }
+        // that never open, so it can't report that failure. Stored so
+        // stop() during launch cancels it — a probe outliving its runtime
+        // would settle reachability on a dead one.
+        firstContactTask = Task { [weak self] in await self?.refresh() }
         let stream = eventStreamFactory(baseURL, transportHeaders)
         eventTask = Task { [weak self] in
             for await event in stream {
@@ -125,6 +128,8 @@ final class ConnectionRuntime: Identifiable {
     }
 
     func stop() {
+        firstContactTask?.cancel()
+        firstContactTask = nil
         eventTask?.cancel()
         eventTask = nil
         coalesceTask?.cancel()
@@ -141,6 +146,9 @@ final class ConnectionRuntime: Identifiable {
         async let terminalsDone: Void = terminals.refresh()
         async let agentsDone: Void = agents.refresh()
         _ = await (projectsDone, threadsDone, terminalsDone, agentsDone)
+        // A refresh whose task was cancelled mid-flight (stop() during
+        // launch) must not settle reachability on a stopped runtime.
+        guard !Task.isCancelled else { return }
         settleReachability()
     }
 

--- a/macos/ATC/Features/Projects/ProjectsStore.swift
+++ b/macos/ATC/Features/Projects/ProjectsStore.swift
@@ -38,18 +38,31 @@ final class ProjectsStore {
 
     @discardableResult
     func create(name: String, defaultWorkingDirectory: String) async throws -> Project {
-        let project = try await client
+        let project: Project
+        switch try await client
             .createProject(body: .json(.init(name: name, defaultWorkingDirectory: defaultWorkingDirectory)))
-            .ok.body.json
+        {
+        case .ok(let ok): project = try ok.body.json
+        case .unprocessableContent(let failure):
+            let payload = try failure.body.json
+            throw ServerError(anyOf: payload.value1, payload.value2)
+        case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
+        }
         merge(project)
         return project
     }
 
     @discardableResult
     func rename(id: String, name: String) async throws -> Project {
-        let project = try await client
-            .updateProject(path: .init(projectId: id), body: .json(.init(name: name)))
-            .ok.body.json
+        let project: Project
+        switch try await client.updateProject(path: .init(projectId: id), body: .json(.init(name: name))) {
+        case .ok(let ok): project = try ok.body.json
+        case .notFound(let failure): throw ServerError(try failure.body.json)
+        case .unprocessableContent(let failure):
+            let payload = try failure.body.json
+            throw ServerError(anyOf: payload.value1, payload.value2)
+        case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
+        }
         merge(project)
         return project
     }

--- a/macos/ATC/Features/Projects/ProjectsStore.swift
+++ b/macos/ATC/Features/Projects/ProjectsStore.swift
@@ -74,12 +74,9 @@ final class ProjectsStore {
         switch try await client.deleteProject(path: .init(projectId: id)) {
         case .noContent:
             break
-        case .notFound(let failure):
-            throw ServerError(message: try failure.body.json.message)
-        case .serviceUnavailable(let failure):
-            throw ServerError(message: try failure.body.json.message)
-        case .undocumented(statusCode: let status, _):
-            throw ServerError.undocumented(status: status)
+        case .notFound(let failure): throw ServerError(try failure.body.json)
+        case .serviceUnavailable(let failure): throw ServerError(try failure.body.json)
+        case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
         }
         refreshState.invalidateInFlight()
         projects.removeAll { $0.id == id }

--- a/macos/ATC/Features/Terminal/TerminalSessionController.swift
+++ b/macos/ATC/Features/Terminal/TerminalSessionController.swift
@@ -201,7 +201,7 @@ final class TerminalSessionController: Identifiable {
 
     /// Detach: WS close = zmx detach; the terminal keeps running server-side.
     func disconnect() {
-        stop(phase: .ended(.closedByClient))
+        end(.closedByClient, notify: false)
     }
 
     /// A reconciled read proved the terminal ended while this controller was
@@ -209,32 +209,41 @@ final class TerminalSessionController: Identifiable {
     /// the ended state, keeping the surface's final frame.
     func confirmEnded() {
         guard phase != .ended(.terminalEnded) else { return }
-        stop(phase: .ended(.terminalEnded))
+        end(.terminalEnded, notify: false)
     }
 
-    private func stop(phase endPhase: Phase) {
+    /// The one authoritative end sequence: recovery off, retry state
+    /// cleared, the connection released, the final phase published. Every
+    /// path that ends the session — client detach, server end, rejected
+    /// upgrade, dead-terminal verification — funnels here, so no branch can
+    /// drift (a dead-verified terminal left recovery-armed was exactly such
+    /// a drift).
+    private func end(_ reason: AttachEndReason, notify: Bool) {
         automaticRecoveryEnabled = false
         retryAttempt = 0
         cancelRetry()
+        releaseConnection()
+        phase = .ended(reason)
+        if notify { onTerminalEnded?() }
+    }
+
+    /// Shared connection teardown for the enders and the reconnect swap.
+    /// The drain task deliberately survives it: buffered output keeps
+    /// flowing to the retained surface (an ended terminal keeps its final
+    /// frame; a reconnect's replay reset cancels the drain in
+    /// prepareSurfaceForReplayIfNeeded when it swaps the surface).
+    private func releaseConnection() {
         let connection = connection
         self.connection = nil
         connectionRef.set(nil)
         eventTask?.cancel()
         eventTask = nil
-        drainTask?.cancel()
-        drainTask = nil
-        phase = endPhase
         Task { await connection?.close() }
     }
 
     private func beginReconnect() {
         cancelRetry()
-        let connection = connection
-        self.connection = nil
-        connectionRef.set(nil)
-        eventTask?.cancel()
-        eventTask = nil
-        Task { await connection?.close() }
+        releaseConnection()
         connect(isReconnect: true)
     }
 
@@ -304,16 +313,9 @@ final class TerminalSessionController: Identifiable {
             case .terminalEnded, .rejected:
                 // Authoritative (or a pre-upgrade rejection that a refetch
                 // must explain): stop and let stores reconcile.
-                automaticRecoveryEnabled = false
-                retryAttempt = 0
-                cancelRetry()
-                phase = .ended(reason)
-                onTerminalEnded?()
+                end(reason, notify: true)
             case .closedByClient:
-                automaticRecoveryEnabled = false
-                retryAttempt = 0
-                cancelRetry()
-                phase = .ended(reason)
+                end(reason, notify: false)
             }
         }
     }
@@ -331,10 +333,7 @@ final class TerminalSessionController: Identifiable {
                   self.automaticRecoveryEnabled
             else { return }
             if live == false {
-                self.retryAttempt = 0
-                self.cancelRetry()
-                self.phase = .ended(.terminalEnded)
-                self.onTerminalEnded?()
+                self.end(.terminalEnded, notify: true)
                 return
             }
             if !self.scheduleAutomaticReconnect() {
@@ -419,11 +418,14 @@ final class TerminalSessionController: Identifiable {
     private func startDrainIfNeeded() {
         guard drainTask == nil else { return }
         let terminalSession = terminalSession
-        drainTask = Task {
+        // [weak self] like every sibling task: a dropped controller must
+        // deallocate, not live up to 5 seconds writing to an invisible
+        // surface.
+        drainTask = Task { [weak self] in
             // Wait (bounded) for the surface to come up; readViewportText()
             // is nil until Ghostty attaches the surface.
             var attempts = 0
-            while !surfaceIsReady, attempts < 100 {
+            while self?.surfaceIsReady == false, attempts < 100 {
                 guard !Task.isCancelled else { return }
                 if terminalSession.readViewportText() != nil { break }
                 attempts += 1
@@ -435,7 +437,7 @@ final class TerminalSessionController: Identifiable {
             }
             // Proceed either way — receive() safely drops without a surface,
             // and marking ready stops unbounded buffering.
-            guard !Task.isCancelled else { return }
+            guard let self, !Task.isCancelled else { return }
             surfaceIsReady = true
             // Drain by index: repeated removeFirst() is quadratic on a large
             // replay, and the buffer must stay non-empty while draining so

--- a/macos/ATC/Features/Terminal/TerminalSessionController.swift
+++ b/macos/ATC/Features/Terminal/TerminalSessionController.swift
@@ -231,7 +231,9 @@ final class TerminalSessionController: Identifiable {
     /// The drain task deliberately survives it: buffered output keeps
     /// flowing to the retained surface (an ended terminal keeps its final
     /// frame; a reconnect's replay reset cancels the drain in
-    /// prepareSurfaceForReplayIfNeeded when it swaps the surface).
+    /// prepareSurfaceForReplayIfNeeded when it swaps the surface). On the
+    /// detach path the controller is dropped immediately — the drain's
+    /// weak self capture is what bounds it there; the two are a pair.
     private func releaseConnection() {
         let connection = connection
         self.connection = nil

--- a/macos/ATC/Features/Terminals/TerminalsStore.swift
+++ b/macos/ATC/Features/Terminals/TerminalsStore.swift
@@ -63,22 +63,39 @@ final class TerminalsStore {
 
     @discardableResult
     func create(_ request: Components.Schemas.CreateTerminalRequest) async throws -> Terminal {
-        let terminal = try await client.createTerminal(body: .json(request)).ok.body.json
+        let terminal: Terminal
+        switch try await client.createTerminal(body: .json(request)) {
+        case .ok(let ok): terminal = try ok.body.json
+        case .notFound(let failure): throw ServerError(try failure.body.json)
+        case .unprocessableContent(let failure):
+            let payload = try failure.body.json
+            throw ServerError(anyOf: payload.value1, payload.value2, payload.value3)
+        case .serviceUnavailable(let failure): throw ServerError(try failure.body.json)
+        case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
+        }
         merge(terminal)
         return terminal
     }
 
     @discardableResult
     func rename(id: String, name: String) async throws -> Terminal {
-        let terminal = try await client
-            .updateTerminal(path: .init(terminalId: id), body: .json(.init(name: name)))
-            .ok.body.json
+        let terminal: Terminal
+        switch try await client.updateTerminal(path: .init(terminalId: id), body: .json(.init(name: name))) {
+        case .ok(let ok): terminal = try ok.body.json
+        case .notFound(let failure): throw ServerError(try failure.body.json)
+        case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
+        }
         merge(terminal)
         return terminal
     }
 
     func delete(id: String) async throws {
-        _ = try await client.deleteTerminal(path: .init(terminalId: id)).noContent
+        switch try await client.deleteTerminal(path: .init(terminalId: id)) {
+        case .noContent: break
+        case .notFound(let failure): throw ServerError(try failure.body.json)
+        case .serviceUnavailable(let failure): throw ServerError(try failure.body.json)
+        case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
+        }
         refreshState.invalidateInFlight()
         terminals.removeAll { $0.id == id }
     }

--- a/macos/ATC/Features/Threads/ThreadsStore.swift
+++ b/macos/ATC/Features/Threads/ThreadsStore.swift
@@ -68,59 +68,113 @@ final class ThreadsStore {
 
     @discardableResult
     func create(_ request: Components.Schemas.CreateThreadRequest) async throws -> ATCThread {
-        let thread = try await client.createThread(body: .json(request)).ok.body.json
+        let thread: ATCThread
+        switch try await client.createThread(body: .json(request)) {
+        case .ok(let ok): thread = try ok.body.json
+        case .notFound(let failure): throw ServerError(try failure.body.json)
+        case .unprocessableContent(let failure):
+            let payload = try failure.body.json
+            throw ServerError(anyOf: payload.value1, payload.value2)
+        case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
+        }
         merge(thread)
         return thread
     }
 
     @discardableResult
     func rename(id: String, name: String) async throws -> ATCThread {
-        let thread = try await client
-            .updateThread(path: .init(threadId: id), body: .json(.init(name: name)))
-            .ok.body.json
+        let thread: ATCThread
+        switch try await client.updateThread(path: .init(threadId: id), body: .json(.init(name: name))) {
+        case .ok(let ok): thread = try ok.body.json
+        case .notFound(let failure): throw ServerError(try failure.body.json)
+        case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
+        }
         merge(thread)
         return thread
     }
 
     @discardableResult
     func pin(id: String) async throws -> ATCThread {
-        let thread = try await client.pinThread(path: .init(threadId: id)).ok.body.json
+        let thread: ATCThread
+        switch try await client.pinThread(path: .init(threadId: id)) {
+        case .ok(let ok): thread = try ok.body.json
+        case .notFound(let failure): throw ServerError(try failure.body.json)
+        case .conflict(let failure): throw ServerError(try failure.body.json)
+        case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
+        }
         merge(thread)
         return thread
     }
 
     @discardableResult
     func unpin(id: String) async throws -> ATCThread {
-        let thread = try await client.unpinThread(path: .init(threadId: id)).ok.body.json
+        let thread: ATCThread
+        switch try await client.unpinThread(path: .init(threadId: id)) {
+        case .ok(let ok): thread = try ok.body.json
+        case .notFound(let failure): throw ServerError(try failure.body.json)
+        case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
+        }
         merge(thread)
         return thread
     }
 
     @discardableResult
     func archive(id: String) async throws -> ATCThread {
-        let thread = try await client.archiveThread(path: .init(threadId: id)).ok.body.json
+        let thread: ATCThread
+        switch try await client.archiveThread(path: .init(threadId: id)) {
+        case .ok(let ok): thread = try ok.body.json
+        case .notFound(let failure): throw ServerError(try failure.body.json)
+        case .conflict(let failure): throw ServerError(try failure.body.json)
+        case .serviceUnavailable(let failure): throw ServerError(try failure.body.json)
+        case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
+        }
         merge(thread)
         return thread
     }
 
     @discardableResult
     func unarchive(id: String) async throws -> ATCThread {
-        let thread = try await client.unarchiveThread(path: .init(threadId: id)).ok.body.json
+        let thread: ATCThread
+        switch try await client.unarchiveThread(path: .init(threadId: id)) {
+        case .ok(let ok): thread = try ok.body.json
+        case .notFound(let failure): throw ServerError(try failure.body.json)
+        case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
+        }
         merge(thread)
         return thread
     }
 
     func delete(id: String) async throws {
-        _ = try await client.deleteThread(path: .init(threadId: id)).noContent
+        switch try await client.deleteThread(path: .init(threadId: id)) {
+        case .noContent: break
+        case .notFound(let failure): throw ServerError(try failure.body.json)
+        case .serviceUnavailable(let failure): throw ServerError(try failure.body.json)
+        case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
+        }
         refreshState.invalidateInFlight()
         threads.removeAll { $0.id == id }
         archivedThreads.removeAll { $0.id == id }
     }
 
     /// Idempotent open of the thread's TUI terminal: a live linked terminal
-    /// is returned as-is, otherwise the provider TUI is (re)launched.
+    /// is returned as-is, otherwise the provider TUI is (re)launched. The
+    /// failure messages here are the install-or-configure guidance the
+    /// server exists to provide — never collapse them into a status dump.
     func openTerminal(threadID: String) async throws -> Terminal {
-        try await client.openThreadTerminal(path: .init(threadId: threadID)).ok.body.json
+        switch try await client.openThreadTerminal(path: .init(threadId: threadID)) {
+        case .ok(let ok): return try ok.body.json
+        case .notFound(let failure): throw ServerError(try failure.body.json)
+        case .conflict(let failure):
+            let payload = try failure.body.json
+            throw ServerError(anyOf: payload.value1, payload.value2)
+        case .unprocessableContent(let failure):
+            let payload = try failure.body.json
+            throw ServerError(anyOf: payload.value1, payload.value2, payload.value3)
+        case .serviceUnavailable(let failure):
+            let payload = try failure.body.json
+            throw ServerError(anyOf: payload.value1, payload.value2)
+        case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
+        }
     }
 
     /// Places a server-returned thread into whichever list its archive state

--- a/macos/ATC/Shared/ServerError.swift
+++ b/macos/ATC/Shared/ServerError.swift
@@ -1,11 +1,12 @@
+import ATCAppServerAPI
 import Foundation
 
 /// A contract-modeled server failure rendered for alerts: the payload's
 /// `message` is written for humans, so surfacing it beats the generated
 /// throwing accessors' "Unexpected response…" dump. Stores switch on the
 /// generated `Output` enum, pull `message` out of each documented failure
-/// case, and throw this; `undocumented(status:)` covers the enum's
-/// catch-all case.
+/// case through the `ServerError(...)` initializers below, and throw this;
+/// `undocumented(status:)` covers the enum's catch-all case.
 struct ServerError: LocalizedError {
     let message: String
 
@@ -13,5 +14,40 @@ struct ServerError: LocalizedError {
 
     static func undocumented(status: Int) -> ServerError {
         ServerError(message: "Unexpected server response (\(status)).")
+    }
+}
+
+/// Every documented failure schema carries the server's human-readable
+/// `message` — the one field this seam needs. Conformances below cover the
+/// contract's full error vocabulary; a new tagged error added to the
+/// contract joins the list or fails to compile at its first unwrap site.
+protocol ServerErrorPayload {
+    var message: String { get }
+}
+
+extension Components.Schemas.ProjectNotFoundJsonEncoding: ServerErrorPayload {}
+extension Components.Schemas.DirectoryUnavailableJsonEncoding: ServerErrorPayload {}
+extension Components.Schemas.DirectoryCheckTimedOutJsonEncoding: ServerErrorPayload {}
+extension Components.Schemas.TerminalNotFoundJsonEncoding: ServerErrorPayload {}
+extension Components.Schemas.ZmxUnavailableJsonEncoding: ServerErrorPayload {}
+extension Components.Schemas.TerminalLaunchFailedJsonEncoding: ServerErrorPayload {}
+extension Components.Schemas.AgentNotFoundJsonEncoding: ServerErrorPayload {}
+extension Components.Schemas.ThreadNotFoundJsonEncoding: ServerErrorPayload {}
+extension Components.Schemas.ThreadArchivedJsonEncoding: ServerErrorPayload {}
+extension Components.Schemas.ThreadBusyJsonEncoding: ServerErrorPayload {}
+extension Components.Schemas.ProviderUnavailableJsonEncoding: ServerErrorPayload {}
+extension Components.Schemas.ProviderSessionConflictJsonEncoding: ServerErrorPayload {}
+
+extension ServerError {
+    /// Wrap a single-schema failure payload.
+    init(_ payload: some ServerErrorPayload) {
+        self.init(message: payload.message)
+    }
+
+    /// Wrap an anyOf failure payload (a status documented with several
+    /// tagged errors): the first populated branch's message. The generated
+    /// decoder guarantees at least one branch is populated.
+    init(anyOf branches: (any ServerErrorPayload)?...) {
+        self.init(message: branches.compactMap { $0?.message }.first ?? "Unknown server error.")
     }
 }

--- a/macos/ATC/Shared/ServerError.swift
+++ b/macos/ATC/Shared/ServerError.swift
@@ -18,9 +18,12 @@ struct ServerError: LocalizedError {
 }
 
 /// Every documented failure schema carries the server's human-readable
-/// `message` — the one field this seam needs. Conformances below cover the
-/// contract's full error vocabulary; a new tagged error added to the
-/// contract joins the list or fails to compile at its first unwrap site.
+/// `message` — the one field this seam needs. Conformances are added on
+/// demand: a schema without one fails to compile at its first unwrap site.
+/// (A NEW branch appended to an existing anyOf status is the blind spot —
+/// the variadic initializer below cannot see a `valueN` a call site forgot
+/// to pass, so contract changes to anyOf statuses need their unwrap sites
+/// re-checked by hand.)
 protocol ServerErrorPayload {
     var message: String { get }
 }
@@ -31,7 +34,6 @@ extension Components.Schemas.DirectoryCheckTimedOutJsonEncoding: ServerErrorPayl
 extension Components.Schemas.TerminalNotFoundJsonEncoding: ServerErrorPayload {}
 extension Components.Schemas.ZmxUnavailableJsonEncoding: ServerErrorPayload {}
 extension Components.Schemas.TerminalLaunchFailedJsonEncoding: ServerErrorPayload {}
-extension Components.Schemas.AgentNotFoundJsonEncoding: ServerErrorPayload {}
 extension Components.Schemas.ThreadNotFoundJsonEncoding: ServerErrorPayload {}
 extension Components.Schemas.ThreadArchivedJsonEncoding: ServerErrorPayload {}
 extension Components.Schemas.ThreadBusyJsonEncoding: ServerErrorPayload {}
@@ -47,7 +49,8 @@ extension ServerError {
     /// Wrap an anyOf failure payload (a status documented with several
     /// tagged errors): the first populated branch's message. The generated
     /// decoder guarantees at least one branch is populated.
-    init(anyOf branches: (any ServerErrorPayload)?...) {
+    init(anyOf first: (any ServerErrorPayload)?, _ rest: (any ServerErrorPayload)?...) {
+        let branches = [first] + rest
         self.init(message: branches.compactMap { $0?.message }.first ?? "Unknown server error.")
     }
 }

--- a/macos/ATCTests/ScriptableAppServerClient.swift
+++ b/macos/ATCTests/ScriptableAppServerClient.swift
@@ -31,6 +31,9 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
         var directoryCheck: Components.Schemas.FsCheckResponse?
         var directoryListings: [String?: Components.Schemas.FsListResponse] = [:]
         var directoryListingFailure: Components.Schemas.DirectoryUnavailableJsonEncoding?
+        /// While set, openThreadTerminal fails 503 with this payload — the
+        /// install-or-configure message the unwrap seam must surface.
+        var openThreadTerminalFailure: Components.Schemas.ProviderUnavailableJsonEncoding?
         var createdThreadRequests: [Components.Schemas.CreateThreadRequest] = []
         var createdTerminalRequests: [Components.Schemas.CreateTerminalRequest] = []
         var listProjectsCount = 0
@@ -134,6 +137,11 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     var directoryListingFailure: Components.Schemas.DirectoryUnavailableJsonEncoding? {
         get { lock.withLock { state.directoryListingFailure } }
         set { lock.withLock { state.directoryListingFailure = newValue } }
+    }
+
+    var openThreadTerminalFailure: Components.Schemas.ProviderUnavailableJsonEncoding? {
+        get { lock.withLock { state.openThreadTerminalFailure } }
+        set { lock.withLock { state.openThreadTerminalFailure = newValue } }
     }
 
     // MARK: - Captured requests and call counts
@@ -469,6 +477,9 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     func openThreadTerminal(_ input: Operations.OpenThreadTerminal.Input) async throws
         -> Operations.OpenThreadTerminal.Output {
         try await gate()
+        if let failure = openThreadTerminalFailure {
+            return .serviceUnavailable(.init(body: .json(.init(value1: failure))))
+        }
         let id = input.path.threadId
         return mutate { model -> Operations.OpenThreadTerminal.Output in
             model.openThreadTerminalCount += 1

--- a/macos/ATCTests/TerminalReconnectTests.swift
+++ b/macos/ATCTests/TerminalReconnectTests.swift
@@ -83,6 +83,27 @@ struct TerminalReconnectTests {
         #expect(live.callCount == 1)
     }
 
+    @Test("a dead-verified terminal never auto-recovers")
+    func deadVerifiedTerminalStaysEnded() async {
+        let harness = AttachHarness()
+        let delays = RetryDelayRecorder()
+        let live = CheckLiveStub(result: false)
+        let controller = makeController(harness: harness, delays: delays, live: live)
+        defer { controller.disconnect() }
+
+        harness.send(.ended(.retryable("socket closed")), attempt: 0, finish: true)
+        await settle(until: { controller.phase == .ended(.terminalEnded) })
+
+        // The drift this pins: a verification-driven end must disarm
+        // recovery like every other end path — a wake signal must never
+        // reopen a socket to a terminal the server already said is gone.
+        controller.recoverAfterInterruption()
+        await drainPendingTasks()
+        #expect(harness.attemptCount == 1)
+        #expect(controller.phase == .ended(.terminalEnded))
+        #expect(delays.delays.isEmpty)
+    }
+
     @Test("a retryable close whose server read says live reconnects on backoff")
     func retryableWithLiveTerminalReconnects() async {
         let harness = AttachHarness()

--- a/macos/ATCTests/ThreadsStoreTests.swift
+++ b/macos/ATCTests/ThreadsStoreTests.swift
@@ -179,6 +179,27 @@ struct ThreadsStoreTests {
         #expect(store.hasLoadedOnce)
     }
 
+    @Test("a modeled failure surfaces the server's message, not a status dump")
+    func openTerminalSurfacesServerMessage() async throws {
+        let (store, client) = await loadedStore()
+        client.openThreadTerminalFailure = .init(
+            _tag: .providerUnavailable,
+            agentId: "codex",
+            reason: "install the Codex CLI or set codexExecutable",
+            message: "install the Codex CLI or set codexExecutable"
+        )
+        do {
+            _ = try await store.openTerminal(threadID: "thr1")
+            Issue.record("openTerminal should have thrown")
+        } catch {
+            // The whole point of the unwrap seam: the alert text IS the
+            // server's actionable guidance.
+            #expect(
+                error.localizedDescription == "install the Codex CLI or set codexExecutable"
+            )
+        }
+    }
+
     @Test("openTerminal is idempotent: a live linked terminal is returned as-is")
     func openTerminalIsIdempotent() async throws {
         let (store, client) = await loadedStore()

--- a/macos/ATCTests/ThreadsStoreTests.swift
+++ b/macos/ATCTests/ThreadsStoreTests.swift
@@ -180,7 +180,7 @@ struct ThreadsStoreTests {
     }
 
     @Test("a modeled failure surfaces the server's message, not a status dump")
-    func openTerminalSurfacesServerMessage() async throws {
+    func openTerminalSurfacesServerMessage() async {
         let (store, client) = await loadedStore()
         client.openThreadTerminalFailure = .init(
             _tag: .providerUnavailable,


### PR DESCRIPTION
PR 5 of the ATC-170 codebase-hardening effort. Findings: ATC-168 H1, H2, L7, L8. Sub-issue: [ATC-175](https://linear.app/elevenideas/issue/ATC-175).

## Changes

- **H1 — server messages surface.** `ServerError.swift` gains a `ServerErrorPayload` seam (per-schema conformances + `ServerError(_:)`/`ServerError(anyOf:)`); every store mutation (ThreadsStore ×8, TerminalsStore ×3, ProjectsStore ×3 including the pre-existing delete precedent) now switches on the generated `Output` enum and throws the server's human-readable `message` instead of the runtime's status dump. Because the generated enums are `@frozen` and the switches are exhaustive, a contract status change is now a build break. A scripted 503 + test proves `openTerminal` surfaces "install the Codex CLI…" verbatim. Documented residual: a *new branch* appended to an existing anyOf status can't be caught at compile time — recorded at the seam.
- **H2 — one end sequence.** The four drifted end paths in `TerminalSessionController` funnel through `end(_:notify:)` + `releaseConnection()`. The drift bug is fixed: a dead-verified terminal now disarms `automaticRecoveryEnabled`, so a wake signal can no longer flip `.ended(.terminalEnded)` back to `.reconnecting` against a terminal the server said is gone — pinned by a new regression test. The drainTask deliberately survives teardown (buffered output keeps flowing to the retained surface; documented, and paired with L7's weak capture on the detach path).
- **L7 —** drainTask captures self weakly like every sibling task.
- **L8 —** the first-contact probe is stored, cancelled in `stop()`, self-clears on completion; `refresh()` won't settle reachability on a cancelled (stopped) runtime.

## Verification

`mise run macos:test` — 246 passed (244 baseline + the message-surfacing test + the recovery-drift regression test).

The correctness review verified every switch's case set and anyOf argument order against the generated Types.swift, and the full old-vs-new field table for all six end paths (no unintended deltas). Known pre-existing gap noted for the record: the Dashboard Retry refresh runs in an uncancelled Task, so a stop() during it can still settle a stopped runtime — same shape as L8's bug, different trigger, out of this PR's scope.

https://claude.ai/code/session_019pj9ErmqTfaLoTPksB3fSZ