### PR TITLE
macOS window & performance structure (ATC-176)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ coverage/
 # Provider POC artifacts
 experiments/provider-identity-resume/.generated/
 experiments/provider-identity-resume/runs/
+*.profraw

--- a/macos/ATC/ATCApp.swift
+++ b/macos/ATC/ATCApp.swift
@@ -21,6 +21,10 @@ struct ATCApp: App {
             SettingsView()
                 .environment(appModel)
                 .preferredColorScheme(.dark)
+                // Settings can be reached before any window's task ran
+                // (restoration edges); an unloaded Connection list must
+                // never be observable — a save would persist over it.
+                .task { appModel.start() }
         }
     }
 }
@@ -55,14 +59,14 @@ private struct WindowRootView: View {
             windowState: windowState,
             configStore: configStore
         ) {
-            RootView(configStore: configStore)
+            RootView()
         }
         .environment(windowState)
         .focusedSceneValue(windowState)
         .task {
             configStore.loadAtLaunchIfNeeded()
             appModel.registerWindow(windowState)
-            await appModel.start()
+            appModel.start()
         }
         .onDisappear {
             appModel.unregisterWindow(windowState)

--- a/macos/ATC/ATCApp.swift
+++ b/macos/ATC/ATCApp.swift
@@ -3,38 +3,69 @@ import SwiftUI
 @main
 struct ATCApp: App {
     @State private var appModel = AppModel()
-    /// Single-window today; one WindowState per window is the seam a
-    /// future multi-window pass builds on.
-    @State private var windowState = WindowState()
-    @State private var configurationStore: ConfigurationStore
-
-    init() {
-        let store = ConfigurationStore { preferences in
-            TerminalSessionController.applyTerminalPreferences(preferences)
-        }
-        store.loadAtLaunch()
-        _configurationStore = State(initialValue: store)
+    @State private var configurationStore = ConfigurationStore { preferences in
+        TerminalSessionController.applyTerminalPreferences(preferences)
     }
 
     var body: some Scene {
         WindowGroup {
-            RootView(configStore: configurationStore)
+            WindowRootView(appModel: appModel, configStore: configurationStore)
                 .environment(appModel)
-                .environment(windowState)
                 .environment(configurationStore)
                 .preferredColorScheme(.dark)
         }
         .commands {
-            AppCommands(
-                appModel: appModel,
-                windowState: windowState,
-                configStore: configurationStore
-            )
+            AppCommands(appModel: appModel, configStore: configurationStore)
         }
         Settings {
             SettingsView()
                 .environment(appModel)
                 .preferredColorScheme(.dark)
+        }
+    }
+}
+
+/// The per-window scene root: owns this window's `WindowState` and keyboard
+/// router (one of each per window — the seam multi-window builds on),
+/// publishes the state for menu commands via the focused-scene value, and
+/// registers it with the model for reconciliation. Launch I/O (config file,
+/// Keychain hydration) runs in the awaited task below, off the first frame.
+private struct WindowRootView: View {
+    let appModel: AppModel
+    let configStore: ConfigurationStore
+
+    @State private var windowState: WindowState
+    @State private var router: WindowKeyboardRouter
+
+    init(appModel: AppModel, configStore: ConfigurationStore) {
+        self.appModel = appModel
+        self.configStore = configStore
+        let windowState = WindowState()
+        _windowState = State(initialValue: windowState)
+        _router = State(initialValue: WindowKeyboardRouter.forWindow(
+            appModel: appModel,
+            windowState: windowState,
+            configStore: configStore
+        ))
+    }
+
+    var body: some View {
+        KeyboardRoutingContainer(
+            router: router,
+            windowState: windowState,
+            configStore: configStore
+        ) {
+            RootView(configStore: configStore)
+        }
+        .environment(windowState)
+        .focusedSceneValue(windowState)
+        .task {
+            configStore.loadAtLaunchIfNeeded()
+            appModel.registerWindow(windowState)
+            await appModel.start()
+        }
+        .onDisappear {
+            appModel.unregisterWindow(windowState)
         }
     }
 }

--- a/macos/ATC/AppCommands.swift
+++ b/macos/ATC/AppCommands.swift
@@ -19,6 +19,20 @@ struct AppCommands: Commands {
         }
     }
 
+    /// Context for commands that act on the app, not a window (refresh,
+    /// configuration reload/reveal): they stay available with no key window
+    /// — from Settings, or with every window closed. The throwaway
+    /// WindowState only satisfies the context's shape; app-scoped commands
+    /// never read it.
+    private var appScopedContext: CommandContext {
+        context
+            ?? CommandContext(
+                appModel: appModel,
+                windowState: WindowState(),
+                configStore: configStore
+            )
+    }
+
     var body: some Commands {
         CommandGroup(replacing: .newItem) {
             commandButton(.newThread)
@@ -32,7 +46,7 @@ struct AppCommands: Commands {
         CommandGroup(after: .sidebar) {
             commandButton(.toggleSidebar)
             commandButton(.showDashboard)
-            commandButton(.refresh)
+            commandButton(.refresh, appScoped: true)
             commandButton(.toggleCommandPalette)
             commandButton(.searchThreads)
             commandButton(.searchTerminals)
@@ -40,15 +54,15 @@ struct AppCommands: Commands {
         }
 
         CommandGroup(after: .appSettings) {
-            commandButton(.reloadConfiguration)
-            commandButton(.revealConfiguration)
+            commandButton(.reloadConfiguration, appScoped: true)
+            commandButton(.revealConfiguration, appScoped: true)
         }
     }
 
     @ViewBuilder
-    private func commandButton(_ id: CommandID) -> some View {
+    private func commandButton(_ id: CommandID, appScoped: Bool = false) -> some View {
         let descriptor = CommandRegistry.descriptor(for: id)
-        let context = context
+        let context = appScoped ? appScopedContext : context
         let button = Button(descriptor.title) {
             if let context { CommandRegistry.execute(id, context: context) }
         }

--- a/macos/ATC/AppCommands.swift
+++ b/macos/ATC/AppCommands.swift
@@ -2,15 +2,21 @@ import SwiftUI
 
 struct AppCommands: Commands {
     let appModel: AppModel
-    let windowState: WindowState
     let configStore: ConfigurationStore
 
-    private var context: CommandContext {
-        CommandContext(
-            appModel: appModel,
-            windowState: windowState,
-            configStore: configStore
-        )
+    /// The key window's state, via the platform's answer to "menu commands
+    /// act on the focused window" — nil with no window key, which disables
+    /// every windowed command below.
+    @FocusedValue(WindowState.self) private var windowState
+
+    private var context: CommandContext? {
+        windowState.map { windowState in
+            CommandContext(
+                appModel: appModel,
+                windowState: windowState,
+                configStore: configStore
+            )
+        }
     }
 
     var body: some Commands {
@@ -42,10 +48,11 @@ struct AppCommands: Commands {
     @ViewBuilder
     private func commandButton(_ id: CommandID) -> some View {
         let descriptor = CommandRegistry.descriptor(for: id)
+        let context = context
         let button = Button(descriptor.title) {
-            CommandRegistry.execute(id, context: context)
+            if let context { CommandRegistry.execute(id, context: context) }
         }
-        .disabled(!descriptor.availability(context).isAvailable)
+        .disabled(context.map { !descriptor.availability($0).isAvailable } ?? true)
 
         if let shortcut = configStore.configuration.keymap.menuShortcuts[id]?.menuShortcut {
             button.keyboardShortcut(shortcut.key, modifiers: shortcut.modifiers)

--- a/macos/ATC/AppModel.swift
+++ b/macos/ATC/AppModel.swift
@@ -59,6 +59,20 @@ final class AppModel {
     private let terminalRecoveryMonitor: TerminalRecoveryMonitor
     private let eventStreamFactory: ConnectionRuntime.EventStreamFactory?
 
+    /// The default (real Keychain-backed) construction path defers loading
+    /// and runtime building to `start()` so launch never blocks the first
+    /// frame on file or Keychain I/O (ATC-168 M4); an injected store is the
+    /// test seam and is already loaded, so init builds runtimes directly.
+    @ObservationIgnored private var needsDeferredStart = false
+    /// Window states registered for model-driven reconciliation (weak: a
+    /// closed window's state must deallocate).
+    @ObservationIgnored private var windowReconcilers: [WeakWindowState] = []
+    @ObservationIgnored private var lastNavigationSnapshot: WindowNavigationSnapshot?
+
+    private struct WeakWindowState {
+        weak var value: WindowState?
+    }
+
     init(
         connections: ConnectionsStore? = nil,
         clientFactory: ((ConnectionRecord, URL) -> any APIProtocol)? = nil,
@@ -68,7 +82,12 @@ final class AppModel {
         attachmentBudget: Int = 12
     ) {
         self.attachmentBudget = attachmentBudget
-        self.connections = connections ?? ConnectionsStore()
+        if let connections {
+            self.connections = connections
+        } else {
+            self.connections = ConnectionsStore(loadingDeferred: true)
+            needsDeferredStart = true
+        }
         self.clientFactory = clientFactory ?? { record, url in
             ATCAppServerAPI.makeClient(
                 baseURL: url,
@@ -89,15 +108,64 @@ final class AppModel {
         }
         self.terminalRecoveryMonitor = terminalRecoveryMonitor ?? TerminalRecoveryMonitor()
         self.eventStreamFactory = eventStreamFactory
-        for record in self.connections.connections {
-            if let runtime = makeRuntime(record) {
-                runtimes.append(runtime)
+        if !needsDeferredStart {
+            for record in self.connections.connections {
+                if let runtime = makeRuntime(record) {
+                    runtimes.append(runtime)
+                }
             }
         }
         self.terminalRecoveryMonitor.onRecovery = { [weak self] in
             self?.recoverTerminalsAfterInterruption()
         }
         self.terminalRecoveryMonitor.start()
+        observeNavigationChanges()
+    }
+
+    /// The launch path's second half (see `needsDeferredStart`): loads the
+    /// persisted Connection list (Keychain hydration included) and builds
+    /// the runtimes. Idempotent; called from the window root's task.
+    func start() async {
+        guard needsDeferredStart else { return }
+        needsDeferredStart = false
+        connections.loadNow()
+        for record in connections.connections {
+            if let runtime = makeRuntime(record) {
+                runtimes.append(runtime)
+            }
+        }
+    }
+
+    // MARK: - Window reconciliation (ATC-168 M2)
+
+    /// Reconciliation is a model concern: the model observes its own
+    /// navigation snapshot and reconciles terminal lifecycle plus every
+    /// registered window — instead of each window root observing every
+    /// store array and re-evaluating its whole view tree per SSE refresh.
+    private func observeNavigationChanges() {
+        let snapshot = withObservationTracking {
+            windowNavigationSnapshot()
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.observeNavigationChanges()
+            }
+        }
+        guard snapshot != lastNavigationSnapshot else { return }
+        lastNavigationSnapshot = snapshot
+        reconcileTerminalLifecycle()
+        for entry in windowReconcilers {
+            entry.value?.reconcile(in: self)
+        }
+    }
+
+    func registerWindow(_ windowState: WindowState) {
+        windowReconcilers.removeAll { $0.value == nil }
+        windowReconcilers.append(.init(value: windowState))
+        windowState.reconcile(in: self)
+    }
+
+    func unregisterWindow(_ windowState: WindowState) {
+        windowReconcilers.removeAll { $0.value === windowState || $0.value == nil }
     }
 
     // MARK: - Runtime access

--- a/macos/ATC/AppModel.swift
+++ b/macos/ATC/AppModel.swift
@@ -64,6 +64,10 @@ final class AppModel {
     /// frame on file or Keychain I/O (ATC-168 M4); an injected store is the
     /// test seam and is already loaded, so init builds runtimes directly.
     @ObservationIgnored private var needsDeferredStart = false
+    /// False until the deferred launch load resolves (or immediately on the
+    /// injected-store path): empty-state UI must not flash while the real
+    /// Connection list is still hydrating.
+    private(set) var hasStarted = false
     /// Window states registered for model-driven reconciliation (weak: a
     /// closed window's state must deallocate).
     @ObservationIgnored private var windowReconcilers: [WeakWindowState] = []
@@ -84,6 +88,7 @@ final class AppModel {
         self.attachmentBudget = attachmentBudget
         if let connections {
             self.connections = connections
+            hasStarted = true
         } else {
             self.connections = ConnectionsStore(loadingDeferred: true)
             needsDeferredStart = true
@@ -124,8 +129,10 @@ final class AppModel {
 
     /// The launch path's second half (see `needsDeferredStart`): loads the
     /// persisted Connection list (Keychain hydration included) and builds
-    /// the runtimes. Idempotent; called from the window root's task.
-    func start() async {
+    /// the runtimes. Idempotent; called from the window root's task AND the
+    /// Settings scene's, so reaching Settings before any window cannot
+    /// observe (and then persist over) an unloaded list.
+    func start() {
         guard needsDeferredStart else { return }
         needsDeferredStart = false
         connections.loadNow()
@@ -134,6 +141,7 @@ final class AppModel {
                 runtimes.append(runtime)
             }
         }
+        hasStarted = true
     }
 
     // MARK: - Window reconciliation (ATC-168 M2)
@@ -142,6 +150,8 @@ final class AppModel {
     /// navigation snapshot and reconciles terminal lifecycle plus every
     /// registered window — instead of each window root observing every
     /// store array and re-evaluating its whole view tree per SSE refresh.
+    /// Sound only while every observed store is MainActor-isolated: the
+    /// window between the tracked read and re-arm has no interleaving.
     private func observeNavigationChanges() {
         let snapshot = withObservationTracking {
             windowNavigationSnapshot()
@@ -159,7 +169,7 @@ final class AppModel {
     }
 
     func registerWindow(_ windowState: WindowState) {
-        windowReconcilers.removeAll { $0.value == nil }
+        windowReconcilers.removeAll { $0.value == nil || $0.value === windowState }
         windowReconcilers.append(.init(value: windowState))
         windowState.reconcile(in: self)
     }
@@ -194,6 +204,9 @@ final class AppModel {
         runtime(id: ref.connectionID)?.terminals.terminal(id: ref.terminalID)
     }
 
+    /// Projects are deliberately absent: a project deletion cascades
+    /// server-side into thread/terminal deletions, which this snapshot
+    /// does observe — reconciliation rides that cascade.
     func windowNavigationSnapshot() -> WindowNavigationSnapshot {
         WindowNavigationSnapshot(connections: runtimes.map { runtime in
             WindowNavigationSnapshot.Connection(

--- a/macos/ATC/Commands/KeyboardMonitorHost.swift
+++ b/macos/ATC/Commands/KeyboardMonitorHost.swift
@@ -187,37 +187,23 @@ struct KeyboardMonitorHost: NSViewRepresentable {
 }
 
 struct KeyboardRoutingContainer<Content: View>: View {
-    let appModel: AppModel
+    /// Built once by the per-window root (WindowRootView) — this container
+    /// stores inputs only, so window-root body passes allocate nothing.
+    let router: WindowKeyboardRouter
     let windowState: WindowState
     let configStore: ConfigurationStore
     @ViewBuilder let content: Content
 
-    @State private var router: WindowKeyboardRouter
-
     init(
-        appModel: AppModel,
+        router: WindowKeyboardRouter,
         windowState: WindowState,
         configStore: ConfigurationStore,
         @ViewBuilder content: () -> Content
     ) {
-        self.appModel = appModel
+        self.router = router
         self.windowState = windowState
         self.configStore = configStore
         self.content = content()
-        let context = CommandContext(
-            appModel: appModel,
-            windowState: windowState,
-            configStore: configStore
-        )
-        let router = WindowKeyboardRouter(
-            keymap: configStore.configuration.keymap,
-            context: context
-        )
-        router.isSuspended = { windowState.commandPalettePresentation != nil }
-        router.performJump = { jump in
-            SidebarShortcuts.perform(jump, appModel: appModel, windowState: windowState)
-        }
-        _router = State(initialValue: router)
     }
 
     var body: some View {

--- a/macos/ATC/Commands/WindowKeyboardRouter.swift
+++ b/macos/ATC/Commands/WindowKeyboardRouter.swift
@@ -138,3 +138,29 @@ final class WindowKeyboardRouter {
         }
     }
 }
+
+extension WindowKeyboardRouter {
+    /// The one construction path for a window's router: keymap, command
+    /// context, palette suspension, and sidebar jumps wired together
+    /// (called once per window by the scene root).
+    static func forWindow(
+        appModel: AppModel,
+        windowState: WindowState,
+        configStore: ConfigurationStore
+    ) -> WindowKeyboardRouter {
+        let context = CommandContext(
+            appModel: appModel,
+            windowState: windowState,
+            configStore: configStore
+        )
+        let router = WindowKeyboardRouter(
+            keymap: configStore.configuration.keymap,
+            context: context
+        )
+        router.isSuspended = { windowState.commandPalettePresentation != nil }
+        router.performJump = { jump in
+            SidebarShortcuts.perform(jump, appModel: appModel, windowState: windowState)
+        }
+        return router
+    }
+}

--- a/macos/ATC/Configuration/ConfigurationStore.swift
+++ b/macos/ATC/Configuration/ConfigurationStore.swift
@@ -36,7 +36,18 @@ final class ConfigurationStore {
         self.configuration = Self.defaultConfiguration(generation: 0)
     }
 
+    private var hasLoadedAtLaunch = false
+
     func loadAtLaunch() {
+        load(isLaunch: true)
+    }
+
+    /// The window root's launch hook: the first window loads the config
+    /// file off the first frame; later windows (and re-appearing roots)
+    /// change nothing.
+    func loadAtLaunchIfNeeded() {
+        guard !hasLoadedAtLaunch else { return }
+        hasLoadedAtLaunch = true
         load(isLaunch: true)
     }
 

--- a/macos/ATC/Configuration/ConfigurationStore.swift
+++ b/macos/ATC/Configuration/ConfigurationStore.swift
@@ -36,11 +36,7 @@ final class ConfigurationStore {
         self.configuration = Self.defaultConfiguration(generation: 0)
     }
 
-    private var hasLoadedAtLaunch = false
-
-    func loadAtLaunch() {
-        load(isLaunch: true)
-    }
+    @ObservationIgnored private var hasLoadedAtLaunch = false
 
     /// The window root's launch hook: the first window loads the config
     /// file off the first frame; later windows (and re-appearing roots)

--- a/macos/ATC/Features/Dashboard/DashboardView.swift
+++ b/macos/ATC/Features/Dashboard/DashboardView.swift
@@ -29,7 +29,7 @@ struct DashboardView: View {
             .frame(maxWidth: .infinity, alignment: .top)
         }
         .overlay {
-            if appModel.runtimes.isEmpty {
+            if appModel.hasStarted, appModel.runtimes.isEmpty {
                 noConnectionsState
             } else if model.totalProjectCount == 0 && allProjectsLoaded {
                 noProjectsState

--- a/macos/ATC/RootView.swift
+++ b/macos/ATC/RootView.swift
@@ -13,13 +13,7 @@ struct RootView: View {
     let configStore: ConfigurationStore
 
     var body: some View {
-        KeyboardRoutingContainer(
-            appModel: appModel,
-            windowState: windowState,
-            configStore: configStore
-        ) {
-            rootContent
-        }
+        rootContent
     }
 
     private var rootContent: some View {
@@ -73,10 +67,6 @@ struct RootView: View {
             windowState.requestTerminalFocus()
         }) { ref in
             NewTerminalSheet(projectRef: ref)
-        }
-        .onChange(of: appModel.windowNavigationSnapshot(), initial: true) {
-            appModel.reconcileTerminalLifecycle()
-            windowState.reconcile(in: appModel)
         }
     }
 

--- a/macos/ATC/RootView.swift
+++ b/macos/ATC/RootView.swift
@@ -8,9 +8,6 @@ import SwiftUI
 struct RootView: View {
     @Environment(AppModel.self) private var appModel
     @Environment(WindowState.self) private var windowState
-    /// The one store ATCApp creates and loads; previews and hosting tests
-    /// pass an unloaded throwaway explicitly.
-    let configStore: ConfigurationStore
 
     var body: some View {
         rootContent
@@ -159,8 +156,16 @@ struct RootView: View {
 }
 
 #Preview {
-    RootView(configStore: ConfigurationStore())
-        .environment(AppModel.preview())
-        .environment(WindowState())
+    let appModel = AppModel.preview()
+    let windowState = WindowState()
+    let configStore = ConfigurationStore()
+    RootView()
+        .environment(appModel)
+        .environment(windowState)
+        .environment(WindowKeyboardRouter.forWindow(
+            appModel: appModel,
+            windowState: windowState,
+            configStore: configStore
+        ))
         .preferredColorScheme(.dark)
 }

--- a/macos/ATC/Settings/ConnectionsModel.swift
+++ b/macos/ATC/Settings/ConnectionsModel.swift
@@ -146,16 +146,14 @@ final class ConnectionsStore {
         static let legacyToken = "apiToken"
     }
 
-    init(defaults: UserDefaults = .standard, credentials: any CredentialStore = KeychainCredentialStore()) {
-        self.defaults = defaults
-        self.credentials = credentials
-        loadNow()
-    }
-
-    /// Construction without the load: the launch path defers UserDefaults
-    /// decode and per-record Keychain hydration to `loadNow()`, called off
-    /// the first frame (ATC-168 M4).
-    init(loadingDeferred: Bool, defaults: UserDefaults = .standard, credentials: any CredentialStore = KeychainCredentialStore()) {
+    /// `loadingDeferred` is the launch path (ATC-168 M4): UserDefaults
+    /// decode and per-record Keychain hydration wait for `loadNow()`,
+    /// called off the first frame. Every other caller loads on init.
+    init(
+        loadingDeferred: Bool = false,
+        defaults: UserDefaults = .standard,
+        credentials: any CredentialStore = KeychainCredentialStore()
+    ) {
         self.defaults = defaults
         self.credentials = credentials
         if !loadingDeferred { loadNow() }

--- a/macos/ATC/Settings/ConnectionsModel.swift
+++ b/macos/ATC/Settings/ConnectionsModel.swift
@@ -149,6 +149,22 @@ final class ConnectionsStore {
     init(defaults: UserDefaults = .standard, credentials: any CredentialStore = KeychainCredentialStore()) {
         self.defaults = defaults
         self.credentials = credentials
+        loadNow()
+    }
+
+    /// Construction without the load: the launch path defers UserDefaults
+    /// decode and per-record Keychain hydration to `loadNow()`, called off
+    /// the first frame (ATC-168 M4).
+    init(loadingDeferred: Bool, defaults: UserDefaults = .standard, credentials: any CredentialStore = KeychainCredentialStore()) {
+        self.defaults = defaults
+        self.credentials = credentials
+        if !loadingDeferred { loadNow() }
+    }
+
+    /// Load the persisted list, hydrating tokens from the credential store.
+    /// Idempotent enough for the launch path: re-running replaces the list
+    /// from the same persisted source.
+    func loadNow() {
         let hadPlaintextTokens = load()
         migrateLegacyIfNeeded()
         // One-time migration per record: any token found in the persisted

--- a/macos/ATCTests/ConfigurationStoreTests.swift
+++ b/macos/ATCTests/ConfigurationStoreTests.swift
@@ -25,7 +25,7 @@ struct ConfigurationStoreTests {
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
         let store = ConfigurationStore(configURL: fixture.config)
 
-        store.loadAtLaunch()
+        store.loadAtLaunchIfNeeded()
 
         #expect(store.configuration.keymap.generation == 1)
         #expect(store.notice == nil)
@@ -46,7 +46,7 @@ struct ConfigurationStoreTests {
         """#, to: fixture.config)
         let store = ConfigurationStore(configURL: fixture.config)
 
-        store.loadAtLaunch()
+        store.loadAtLaunchIfNeeded()
 
         #expect(store.configuration.keymap.generation == 1)
         #expect(store.configuration.keymap.menuShortcuts[.toggleSidebar]
@@ -65,7 +65,7 @@ struct ConfigurationStoreTests {
         """#, to: fixture.config)
         let store = ConfigurationStore(configURL: fixture.config)
 
-        store.loadAtLaunch()
+        store.loadAtLaunchIfNeeded()
 
         #expect(store.configuration.keymap.generation == 0)
         #expect(store.configuration.keymap.menuShortcuts[.toggleSidebar]
@@ -80,7 +80,7 @@ struct ConfigurationStoreTests {
         let fixture = try fixture()
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
         let store = ConfigurationStore(configURL: fixture.config)
-        store.loadAtLaunch()
+        store.loadAtLaunchIfNeeded()
         try write(#"""
         [keyboard]
         mystery = true
@@ -112,7 +112,7 @@ struct ConfigurationStoreTests {
         "ctrl+r" = "data.refresh"
         """#, to: fixture.config)
         let store = ConfigurationStore(configURL: fixture.config)
-        store.loadAtLaunch()
+        store.loadAtLaunchIfNeeded()
         let previousGeneration = store.configuration.keymap.generation
         let previousShortcut = store.configuration.keymap.menuShortcuts[.refresh]
 
@@ -149,7 +149,7 @@ struct ConfigurationStoreTests {
         "ctrl+b" = "view.toggle-sidebar"
         """#, to: fixture.config)
         let store = ConfigurationStore(configURL: fixture.config)
-        store.loadAtLaunch()
+        store.loadAtLaunchIfNeeded()
         try FileManager.default.removeItem(at: fixture.config)
 
         store.reload()
@@ -176,7 +176,7 @@ struct ConfigurationStoreTests {
             configURL: fixture.config,
             onTerminalPreferencesApplied: { applied.append($0) }
         )
-        store.loadAtLaunch()
+        store.loadAtLaunchIfNeeded()
         let previous = store.configuration
 
         try write(#"""
@@ -212,7 +212,7 @@ struct ConfigurationStoreTests {
             onTerminalPreferencesApplied: { applied.append($0) }
         )
 
-        store.loadAtLaunch()
+        store.loadAtLaunchIfNeeded()
         try write(#"""
         [terminal]
         padding_x = 8
@@ -238,7 +238,7 @@ struct ConfigurationStoreTests {
             configURL: fixture.config,
             onTerminalPreferencesApplied: { applied.append($0) }
         )
-        store.loadAtLaunch()
+        store.loadAtLaunchIfNeeded()
 
         #expect(applied == [TerminalPreferences()])
         #expect(store.notice?.message.contains("using defaults") == true)

--- a/macos/ATCTests/ConnectionsModelTests.swift
+++ b/macos/ATCTests/ConnectionsModelTests.swift
@@ -165,6 +165,25 @@ struct ConnectionsStoreTests {
         #expect(reloaded.connections[0].token == "t1")
     }
 
+    @Test("deferred loading hydrates nothing until loadNow, then everything")
+    func deferredLoading() throws {
+        let (defaults, suite) = makeDefaults()
+        defer { cleanup(defaults, suite) }
+        let credentials = InMemoryCredentialStore()
+        let seeded = ConnectionsStore(defaults: defaults, credentials: credentials)
+        try seeded.add(name: "First", urlString: "host-a:7331", token: "t1")
+
+        // The launch path (ATC-168 M4): construction touches neither
+        // UserDefaults nor the credential store; loadNow() does both.
+        let deferred = ConnectionsStore(
+            loadingDeferred: true, defaults: defaults, credentials: credentials
+        )
+        #expect(deferred.connections.isEmpty)
+        deferred.loadNow()
+        #expect(deferred.connections.map(\.name) == ["First"])
+        #expect(deferred.connections[0].token == "t1")
+    }
+
     @Test("empty name is rejected on add and update")
     func rejectsEmptyName() throws {
         let (defaults, suite) = makeDefaults()

--- a/macos/ATCTests/ShellHostingSmokeTest.swift
+++ b/macos/ATCTests/ShellHostingSmokeTest.swift
@@ -21,20 +21,25 @@ struct ShellHostingSmokeTest {
     }
 
     private func rootView(_ appModel: AppModel, _ windowState: WindowState) -> some View {
-        // Mirror WindowRootView's per-window wiring: RootView's descendants
-        // (sidebar, palette, feedback overlay) read the window's router
-        // from the environment.
+        // Mirror WindowRootView's per-window wiring, container included, so
+        // this suite still hosts the real boot tree: the key monitor host,
+        // both overlays, and the keymap onChange.
         let configStore = ConfigurationStore(
             configURL: FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
         )
-        return RootView(configStore: configStore)
-            .environment(appModel)
-            .environment(windowState)
-            .environment(WindowKeyboardRouter.forWindow(
+        return KeyboardRoutingContainer(
+            router: WindowKeyboardRouter.forWindow(
                 appModel: appModel,
                 windowState: windowState,
                 configStore: configStore
-            ))
+            ),
+            windowState: windowState,
+            configStore: configStore
+        ) {
+            RootView()
+        }
+        .environment(appModel)
+        .environment(windowState)
     }
 
     @Test("the root view hosts the Dashboard with seeded data without crashing")

--- a/macos/ATCTests/ShellHostingSmokeTest.swift
+++ b/macos/ATCTests/ShellHostingSmokeTest.swift
@@ -21,11 +21,20 @@ struct ShellHostingSmokeTest {
     }
 
     private func rootView(_ appModel: AppModel, _ windowState: WindowState) -> some View {
-        RootView(configStore: ConfigurationStore(
+        // Mirror WindowRootView's per-window wiring: RootView's descendants
+        // (sidebar, palette, feedback overlay) read the window's router
+        // from the environment.
+        let configStore = ConfigurationStore(
             configURL: FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
-        ))
-        .environment(appModel)
-        .environment(windowState)
+        )
+        return RootView(configStore: configStore)
+            .environment(appModel)
+            .environment(windowState)
+            .environment(WindowKeyboardRouter.forWindow(
+                appModel: appModel,
+                windowState: windowState,
+                configStore: configStore
+            ))
     }
 
     @Test("the root view hosts the Dashboard with seeded data without crashing")

--- a/macos/ATCTests/WindowStateTests.swift
+++ b/macos/ATCTests/WindowStateTests.swift
@@ -289,6 +289,31 @@ struct WindowStateTests {
         #expect(test.model.terminals[terminalRef] != nil)
     }
 
+    @Test("an unlinked-but-live terminal keeps its mapping while retained")
+    func keepsMappingWhileRetained() async throws {
+        let client = ScriptableAppServerClient()
+        let test = try await loadedModel(client)
+        let state = WindowState()
+        let ref = test.threadRef("thr1")
+        await state.openThread(ref, in: test.model)
+        let terminalRef = try #require(state.threadTerminals[ref])
+
+        // The thread lets go of its terminal but the terminal row stays
+        // live: lifecycle reconciliation keeps the controller, and the
+        // window keeps the mapping — the retained final frame.
+        client.threads = client.threads.map { thread in
+            guard thread.id == "thr1" else { return thread }
+            var updated = thread
+            updated.linkedTerminalId = nil
+            return updated
+        }
+        await test.runtime.refresh()
+        await settle(until: { test.model.thread(for: ref)?.linkedTerminalId == nil })
+        state.reconcile(in: test.model)
+        #expect(state.threadTerminals[ref] == terminalRef)
+        #expect(test.model.terminals[terminalRef] != nil)
+    }
+
     @Test("a thread whose server-side terminal vanishes drops its mapping")
     func dropsMappingWhenNothingRetained() async throws {
         let client = ScriptableAppServerClient()

--- a/macos/ATCTests/WindowStateTests.swift
+++ b/macos/ATCTests/WindowStateTests.swift
@@ -289,7 +289,7 @@ struct WindowStateTests {
         #expect(test.model.terminals[terminalRef] != nil)
     }
 
-    @Test("a thread with no server-side terminal drops its mapping once nothing is retained")
+    @Test("a thread whose server-side terminal vanishes drops its mapping")
     func dropsMappingWhenNothingRetained() async throws {
         let client = ScriptableAppServerClient()
         let test = try await loadedModel(client)
@@ -306,11 +306,11 @@ struct WindowStateTests {
             return updated
         }
         await test.runtime.refresh()
-        // Still retained for its final frame while the controller lives.
-        state.reconcile(in: test.model)
-        #expect(state.threadTerminals[ref] == terminalRef)
-
-        test.model.disconnectTerminal(ref: terminalRef)
+        // The model observes its own snapshot now (ATC-168 M2): lifecycle
+        // reconciliation drops the vanished row's controller without any
+        // window involvement, and the window reconcile then drops the
+        // mapping (nothing retained).
+        await settle(until: { test.model.terminals[terminalRef] == nil })
         state.reconcile(in: test.model)
         #expect(state.threadTerminals[ref] == nil)
     }


### PR DESCRIPTION
PR 6 of the ATC-170 codebase-hardening effort. Findings: ATC-168 M1–M4. Sub-issue: [ATC-176](https://linear.app/elevenideas/issue/ATC-176).

## Changes

- **M1 — per-window `WindowState`.** A new `WindowRootView` (the WindowGroup's content) owns each window's state and keyboard router, publishes the state to menu commands via `.focusedSceneValue`, and registers it with the model. `AppCommands` reads `@FocusedValue(WindowState.self)` — the platform's answer to "menu commands act on the key window" — and disables windowed commands when no window is key. App-scoped commands (Refresh, Reload/Reveal Configuration) deliberately stay available with no key window via a context whose throwaway WindowState they never read (a regression the correctness review caught: the naive gating greyed them out from Settings).
- **M2 — model-driven reconciliation.** The window-root `.onChange(of: windowNavigationSnapshot())` is gone; `AppModel` observes its own snapshot with a `withObservationTracking` re-arm loop (equality-gated, weak-captured, verified spin-free — the snapshot reads nothing reconciliation writes) and reconciles terminal lifecycle plus every registered window. Windows register on appear/unregister on disappear, with identity-deduped registration.
- **M3 — one-time router.** `WindowKeyboardRouter.forWindow` builds each window's router once in `WindowRootView.init`; `KeyboardRoutingContainer` stores inputs only.
- **M4 — launch I/O off the first frame.** Config-file load (`loadAtLaunchIfNeeded`, once-guarded) and Connection/Keychain hydration (`ConnectionsStore(loadingDeferred:)` + `AppModel.start()`) run from the window root's task. `hasStarted` gates the Dashboard's empty-state so users with connections never see an onboarding flash; the Settings scene also calls `start()` so a restoration edge can't observe (and persist over) an unloaded list. The injected-store path (the test seam) still loads in init.

## Verification

- `mise run macos:test` — 246 passed (244 baseline + a deferred-loading test + a restored retention-branch test).
- Manual launch/navigation smoke check (per the ATC-170 gate): app launched against the live server; the window renders with real data (deferred hydration lands post-frame); the View menu's commands are **enabled** (proving the FocusedValue plumbing) and Toggle Sidebar executes through the focused command path. Screenshots verified. One note from the smoke: a zero-window launch turned out to be stale macOS saved-state from an earlier crashed test instance, cleared with `-ApplePersistenceIgnoreState` — unrelated to this diff.

Review-driven fixes beyond the above: hosting smoke test now hosts the real boot tree (container included), RootView's dead `configStore` parameter dropped and its preview repaired, one unified `ConnectionsStore` init, `loadAtLaunch` deleted (tests repointed), stray `.profraw` removed and gitignored.

Known residuals (recorded): reconciliation lands one main-actor turn after a change (a one-frame delay vs the old in-pass reconcile); `@FocusedValue` behavior with a focused Ghostty surface has no automated coverage — worth a manual check that File ▸ New Thread stays enabled while a terminal has first responder.

https://claude.ai/code/session_019pj9ErmqTfaLoTPksB3fSZ