### PR TITLE
macOS platform polish & tests: async sequences, Task-based focus, scroll-to-selection, projection-model tests (ATC-178)

### DIFF
--- a/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
+++ b/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
@@ -2,6 +2,9 @@ import AppKit
 import SwiftUI
 
 struct CommandPaletteView: View {
+    /// The palette shrinks to fit its rows up to this height, then scrolls.
+    private static let maxListHeight: CGFloat = 200
+
     @Environment(AppModel.self) private var appModel
     @Environment(WindowState.self) private var windowState
     @Environment(ConfigurationStore.self) private var configStore
@@ -10,6 +13,13 @@ struct CommandPaletteView: View {
     @State private var query = ""
     @State private var selectedID: PaletteResultID?
     @State private var hoveredID: PaletteResultID?
+    /// The row the list is parked on. Separate from `selectedID` because
+    /// SwiftUI writes the scrolled-to row back into it.
+    @State private var scrolledID: PaletteResultID?
+    /// Measured row content, so the list fits the user's text size rather
+    /// than a pixel estimate. Starts at the cap: a zero-height scroll view
+    /// would materialize no rows to measure.
+    @State private var listSize = CGSize(width: 0, height: CommandPaletteView.maxListHeight)
     @State private var responderRestoration = PaletteResponderRestoration()
     @FocusState private var queryIsFocused: Bool
 
@@ -125,40 +135,20 @@ struct CommandPaletteView: View {
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: .infinity, minHeight: 44)
         } else {
-            ScrollViewReader { proxy in
-                ScrollView {
-                    LazyVStack(spacing: 2) {
-                        ForEach(rows) { result in
-                            resultRow(result, context: context)
-                                .id(result.id)
-                        }
-                    }
-                    .padding(5)
-                }
-                .frame(height: min(200, rows.reduce(CGFloat(10)) {
-                    $0 + estimatedRowHeight(for: $1)
-                }))
-                .onChange(of: selectedID) {
-                    if let selectedID {
-                        proxy.scrollTo(selectedID, anchor: .center)
+            ScrollView {
+                LazyVStack(spacing: 2) {
+                    ForEach(rows) { result in
+                        resultRow(result, context: context)
+                            .id(result.id)
                     }
                 }
+                .scrollTargetLayout()
+                .padding(5)
+                .onGeometryChange(for: CGSize.self) { $0.size } action: { listSize = $0 }
             }
-        }
-    }
-
-    /// Shrink-to-fit estimates only: navigation rows carry a context caption
-    /// and unavailable rows an inline reason line, so a short list is not
-    /// initially clipped. The 200 pt cap and the scroll view absorb any
-    /// estimate error on longer lists.
-    private func estimatedRowHeight(for result: PaletteResult) -> CGFloat {
-        switch result {
-        case .command(let row):
-            row.availability.isAvailable ? 42 : 56
-        case .thread(let row):
-            row.availability.isAvailable ? 56 : 70
-        case .terminal:
-            56
+            .frame(height: min(Self.maxListHeight, listSize.height))
+            .scrollPosition(id: $scrolledID, anchor: .center)
+            .onChange(of: selectedID) { scrolledID = selectedID }
         }
     }
 

--- a/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
+++ b/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
@@ -19,7 +19,7 @@ struct CommandPaletteView: View {
     /// Measured row content, so the list fits the user's text size rather
     /// than a pixel estimate. Starts at the cap: a zero-height scroll view
     /// would materialize no rows to measure.
-    @State private var listSize = CGSize(width: 0, height: CommandPaletteView.maxListHeight)
+    @State private var listHeight = CommandPaletteView.maxListHeight
     @State private var responderRestoration = PaletteResponderRestoration()
     @FocusState private var queryIsFocused: Bool
 
@@ -144,9 +144,9 @@ struct CommandPaletteView: View {
                 }
                 .scrollTargetLayout()
                 .padding(5)
-                .onGeometryChange(for: CGSize.self) { $0.size } action: { listSize = $0 }
+                .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { listHeight = $0 }
             }
-            .frame(height: min(Self.maxListHeight, listSize.height))
+            .frame(height: min(Self.maxListHeight, listHeight))
             .scrollPosition(id: $scrolledID, anchor: .center)
             .onChange(of: selectedID) { scrolledID = selectedID }
         }

--- a/macos/ATC/Features/Dashboard/DashboardView.swift
+++ b/macos/ATC/Features/Dashboard/DashboardView.swift
@@ -35,7 +35,7 @@ struct DashboardView: View {
         }
         .renameAlert("Rename Project", item: $renamingProject, draft: $renameDraft) { card, name in
             if let store = appModel.runtime(id: card.ref.connectionID)?.projects {
-                appModel.run(on: card.ref.connectionID, reporting: $actionError) {
+                appModel.run(on: card.ref.connectionID, reporting: { actionError = $0 }) {
                     try await store.rename(id: card.project.id, name: name)
                 }
             }
@@ -47,7 +47,7 @@ struct DashboardView: View {
             Button("Delete Project", role: .destructive) {
                 if let card = deletingProject,
                    let store = appModel.runtime(id: card.ref.connectionID)?.projects {
-                    appModel.run(on: card.ref.connectionID, reporting: $actionError) {
+                    appModel.run(on: card.ref.connectionID, reporting: { actionError = $0 }) {
                         try await store.delete(id: card.project.id)
                     }
                 }

--- a/macos/ATC/Features/Navigator/NavigatorSidebar.swift
+++ b/macos/ATC/Features/Navigator/NavigatorSidebar.swift
@@ -27,6 +27,9 @@ struct NavigatorSidebar: View {
     @State private var deletingTerminal: TerminalRef?
     @State private var inFlightThreads: Set<ThreadRef> = []
     @State private var actionError: String?
+    /// The row the scroll view is parked on. SwiftUI keeps it current as the
+    /// user scrolls; writing to it reveals a row selected from elsewhere.
+    @State private var scrolledRow: NavigatorScrollID?
     @FocusState private var focusedThread: ThreadRef?
 
     var body: some View {
@@ -54,12 +57,20 @@ struct NavigatorSidebar: View {
             }
         }
         .navigationSplitViewColumnWidth(min: 240, ideal: 300)
+        .scrollPosition(id: $scrolledRow, anchor: .center)
+        // The command palette and ⌘1–9 select rows the user cannot see; this
+        // custom list has no `List` scroll-to-selection to inherit. Keyed on
+        // the reveal token, not the selection, so sidebar clicks (reveal:
+        // false) never re-center a row already under the pointer.
+        .onChange(of: windowState.sidebarRevealToken) {
+            scrolledRow = scrollTarget(for: windowState.selectedContent, in: model)
+        }
         .renameAlert("Rename Thread", item: $renamingThread, draft: $renameDraft) { item, name in
             mutateThread(item.ref) { try await $0.rename(id: item.ref.threadID, name: name) }
         }
         .renameAlert("Rename Terminal", item: $renamingTerminal, draft: $renameDraft) { ref, name in
             if let store = appModel.runtime(id: ref.connectionID)?.terminals {
-                appModel.run(on: ref.connectionID, reporting: $actionError) {
+                appModel.run(on: ref.connectionID, reporting: { actionError = $0 }) {
                     try await store.rename(id: ref.terminalID, name: name)
                 }
             }
@@ -86,7 +97,7 @@ struct NavigatorSidebar: View {
             Button("Delete Terminal", role: .destructive) {
                 if let ref = deletingTerminal,
                    let store = appModel.runtime(id: ref.connectionID)?.terminals {
-                    appModel.run(on: ref.connectionID, reporting: $actionError) {
+                    appModel.run(on: ref.connectionID, reporting: { actionError = $0 }) {
                         try await store.delete(id: ref.terminalID)
                     }
                 }
@@ -198,7 +209,7 @@ struct NavigatorSidebar: View {
                 canMutate: appModel.canMutate(connectionID: item.ref.connectionID),
                 shortcutLabel: slotNumbers[item.ref].map(SidebarShortcuts.threadBadgeLabel),
                 focusedThread: $focusedThread,
-                onOpen: { Task { await windowState.openThread(item.ref, in: appModel) } },
+                onOpen: { Task { await windowState.openThread(item.ref, in: appModel, reveal: false) } },
                 onRename: {
                     renameDraft = item.thread.name ?? ""
                     renamingThread = item
@@ -216,6 +227,9 @@ struct NavigatorSidebar: View {
                     mutateThread(item.ref) { try await $0.archive(id: item.ref.threadID) }
                 }
             )
+            // Keeps the section-scoped identity (see ThreadListModel) while
+            // making the row addressable by the scroll position.
+            .id(NavigatorScrollID.thread(item.id))
         }
         moreControl(total: items.count, isExpanded: isExpanded)
     }
@@ -301,7 +315,7 @@ struct NavigatorSidebar: View {
         let ref = TerminalRef(connectionID: connectionID, terminalID: terminal.id)
         return NavigatorRow(
             isSelected: windowState.selectedContent == .terminal(ref),
-            action: { windowState.selectTerminal(ref, in: appModel) }
+            action: { windowState.selectTerminal(ref, in: appModel, reveal: false) }
         ) { _ in
             HStack(spacing: Spacing.sm) {
                 Image(systemName: "terminal")
@@ -334,6 +348,7 @@ struct NavigatorSidebar: View {
             }
             .disabled(!appModel.canMutate(connectionID: connectionID))
         }
+        .id(NavigatorScrollID.terminal(ref))
     }
 
     // MARK: - Shared row chrome
@@ -395,7 +410,7 @@ struct NavigatorSidebar: View {
     private func restore(_ item: ThreadListItem) {
         mutateThread(item.ref) { store in
             try await store.unarchive(id: item.ref.threadID)
-            await windowState.openThread(item.ref, in: appModel)
+            await windowState.openThread(item.ref, in: appModel, reveal: false)
         }
     }
 
@@ -422,6 +437,27 @@ struct NavigatorSidebar: View {
     }
 
     // MARK: - Derived state
+
+    /// Where the scroll view should park for the current selection. A row
+    /// can be absent — filtered out, beyond a collapsed section's row limit,
+    /// or in a collapsed section — and then nothing scrolls; expanding
+    /// sections to force a reveal would be the sidebar overriding the
+    /// user's layout.
+    private func scrollTarget(
+        for selection: MainContentSelection,
+        in model: ThreadListModel
+    ) -> NavigatorScrollID? {
+        switch selection {
+        case .dashboard:
+            nil
+        case .thread(let ref):
+            (model.pinned + model.recent + model.archived)
+                .first { $0.ref == ref }
+                .map { .thread($0.id) }
+        case .terminal(let ref):
+            .terminal(ref)
+        }
+    }
 
     private var canCreateAnywhere: Bool {
         appModel.runtimes.contains { appModel.canMutate(connectionID: $0.id) }
@@ -497,4 +533,11 @@ struct NavigatorSidebar: View {
             ($0.element, $0.offset + 1)
         })
     }
+}
+
+/// Scroll identity for the rows a selection can land on, so one scroll
+/// position binding addresses threads and terminals alike.
+private enum NavigatorScrollID: Hashable {
+    case thread(ThreadListItem.ID)
+    case terminal(TerminalRef)
 }

--- a/macos/ATC/Features/Terminal/TerminalHostView.swift
+++ b/macos/ATC/Features/Terminal/TerminalHostView.swift
@@ -144,6 +144,7 @@ final class TerminalContainerView: NSView {
 
     private func scheduleTerminalFocusResignation() {
         focusResignTask?.cancel()
+        focusResignTask = nil
         guard let window, let terminalView = terminalInputView() else { return }
         focusResignTask = Task { [weak window, weak terminalView] in
             try? await Task.sleep(for: Self.focusRetryDelay)

--- a/macos/ATC/Features/Terminal/TerminalHostView.swift
+++ b/macos/ATC/Features/Terminal/TerminalHostView.swift
@@ -33,16 +33,14 @@ struct TerminalHostView: NSViewRepresentable {
 /// Owns exactly one Ghostty view hierarchy. Scoping the first-responder lookup
 /// to this container prevents one retained terminal from focusing another.
 final class TerminalContainerView: NSView {
-    private static let focusRetryDelay = 0.01
+    private static let focusRetryDelay = Duration.milliseconds(10)
     private static let focusRetryLimit = 100
 
     private let hostingView: NSHostingView<TerminalSurfaceView>
     private var wasVisible = false
     private var lastFocusRequest: UInt?
-    private var focusRetryTimer: Timer?
-    private var focusResignTimer: Timer?
-    private var focusAttempt = 0
-    private var wantsFocus = false
+    private var focusTask: Task<Void, Never>?
+    private var focusResignTask: Task<Void, Never>?
     private var controllerID: ObjectIdentifier
     private var acceptsPointerInput = false
 
@@ -91,14 +89,15 @@ final class TerminalContainerView: NSView {
         alphaValue = isVisible ? 1 : 0
 
         if !isVisible {
-            cancelPendingFocus()
+            focusTask?.cancel()
+            focusTask = nil
             // Only the visible→hidden transition can leave this terminal as
             // the stale first responder; steady-state hidden updates would
-            // just schedule no-op timers.
+            // just schedule no-op work.
             if becameHidden { scheduleTerminalFocusResignation() }
         } else if shouldFocus {
-            focusResignTimer?.invalidate()
-            focusResignTimer = nil
+            focusResignTask?.cancel()
+            focusResignTask = nil
             // Visibility and focus are intentionally ordered in the same
             // AppKit update. The transparent retained views remain mounted,
             // so switching back never waits for SwiftUI to rebuild Ghostty.
@@ -111,88 +110,48 @@ final class TerminalContainerView: NSView {
         return super.hitTest(point)
     }
 
-    override func viewDidMoveToWindow() {
-        super.viewDidMoveToWindow()
-        if wantsFocus { schedulePendingFocus() }
-    }
-
-    private func requestTerminalFocus() {
-        wantsFocus = true
-        focusAttempt = 0
-        schedulePendingFocus()
-    }
-
-    private func cancelPendingFocus() {
-        wantsFocus = false
-        focusRetryTimer?.invalidate()
-        focusRetryTimer = nil
-    }
-
-    private func schedulePendingFocus() {
-        guard wantsFocus else { return }
-        focusRetryTimer?.invalidate()
-        let timer = Timer(timeInterval: Self.focusRetryDelay, repeats: false) { [weak self] _ in
-            MainActor.assumeIsolated {
-                self?.applyPendingFocus()
-            }
-        }
-        focusRetryTimer = timer
-        RunLoop.main.add(timer, forMode: .common)
-    }
-
-    private func applyPendingFocus() {
-        guard wantsFocus else { return }
-        hostingView.layoutSubtreeIfNeeded()
-
-        guard let window, let terminalView = terminalInputView() else {
-            retryPendingFocus()
-            return
-        }
-
-        if window.firstResponder === terminalView || window.makeFirstResponder(terminalView) {
-            wantsFocus = false
-            focusRetryTimer = nil
-        } else {
-            retryPendingFocus()
-        }
-    }
-
     /// SwiftUI can materialize the hosted AppKit terminal a few run-loop
-    /// turns after this representable becomes visible. Keep the request
-    /// alive until that concrete input view exists, with a bounded retry so
-    /// a broken hierarchy cannot schedule work indefinitely.
-    private func retryPendingFocus() {
-        focusAttempt += 1
-        guard focusAttempt < Self.focusRetryLimit else {
-            wantsFocus = false
-            focusRetryTimer = nil
+    /// turns after this representable becomes visible. Keep retrying until
+    /// that concrete input view exists, bounded so a broken hierarchy cannot
+    /// retry indefinitely.
+    private func requestTerminalFocus() {
+        focusTask?.cancel()
+        focusTask = Task { [weak self] in
+            for _ in 0..<Self.focusRetryLimit {
+                try? await Task.sleep(for: Self.focusRetryDelay)
+                guard !Task.isCancelled, let self else { return }
+                if self.takeFocus() { return }
+            }
             logger.error(
                 "Abandoned terminal focus transfer after \(Self.focusRetryLimit) attempts; the surface never produced an input view"
             )
-            return
         }
-        schedulePendingFocus()
+    }
+
+    /// True once this container's terminal input view exists and holds first
+    /// responder.
+    private func takeFocus() -> Bool {
+        hostingView.layoutSubtreeIfNeeded()
+        guard let window, let terminalView = terminalInputView() else { return false }
+        return window.firstResponder === terminalView || window.makeFirstResponder(terminalView)
     }
 
     func tearDown() {
-        cancelPendingFocus()
+        focusTask?.cancel()
+        focusTask = nil
         scheduleTerminalFocusResignation()
     }
 
     private func scheduleTerminalFocusResignation() {
-        focusResignTimer?.invalidate()
+        focusResignTask?.cancel()
         guard let window, let terminalView = terminalInputView() else { return }
-        let timer = Timer(timeInterval: Self.focusRetryDelay, repeats: false) {
-            [weak window, weak terminalView] _ in
-            MainActor.assumeIsolated {
-                guard let window, let terminalView,
-                      window.firstResponder === terminalView
-                else { return }
-                window.makeFirstResponder(nil)
-            }
+        focusResignTask = Task { [weak window, weak terminalView] in
+            try? await Task.sleep(for: Self.focusRetryDelay)
+            guard !Task.isCancelled, let window, let terminalView,
+                  window.firstResponder === terminalView
+            else { return }
+            window.makeFirstResponder(nil)
         }
-        focusResignTimer = timer
-        RunLoop.main.add(timer, forMode: .common)
     }
 
     /// This hosting hierarchy contains exactly one Ghostty surface. Matching

--- a/macos/ATC/Features/Terminal/TerminalRecoveryMonitor.swift
+++ b/macos/ATC/Features/Terminal/TerminalRecoveryMonitor.swift
@@ -11,11 +11,8 @@ final class TerminalRecoveryMonitor {
     private let notificationCenter: NotificationCenter?
     private let wakeNotification: Notification.Name
     private let pathMonitor: NWPathMonitor?
-    private let pathQueue = DispatchQueue(label: "ElevenIdeas.atc.terminal-path")
-    // Read from the nonisolated `deinit` to release the observer. Only
-    // mutated on the main actor while the monitor is alive, and deinit runs
-    // strictly after the last reference is gone, so this cannot race.
-    private nonisolated(unsafe) var wakeObserver: (any NSObjectProtocol)?
+    private var wakeTask: Task<Void, Never>?
+    private var pathTask: Task<Void, Never>?
     private var previousPathWasSatisfied: Bool?
     private var started = false
 
@@ -38,37 +35,35 @@ final class TerminalRecoveryMonitor {
         started = true
 
         if let notificationCenter {
-            wakeObserver = notificationCenter.addObserver(
-                forName: wakeNotification,
-                object: nil,
-                queue: .main
-            ) { [weak self] _ in
-                Task { @MainActor [weak self] in
-                    self?.onRecovery?()
+            let notifications = notificationCenter.notifications(named: wakeNotification)
+            wakeTask = Task { [weak self] in
+                for await _ in notifications {
+                    guard let self else { return }
+                    self.onRecovery?()
                 }
             }
         }
 
+        // Iterating the monitor starts it; `stop()` cancels both the task and
+        // the monitor so the sequence ends.
         if let pathMonitor {
-            pathMonitor.pathUpdateHandler = { [weak self] path in
-                let isSatisfied = path.status == .satisfied
-                Task { @MainActor [weak self] in
-                    self?.recordNetworkPath(isSatisfied: isSatisfied)
+            pathTask = Task { [weak self] in
+                for await path in pathMonitor {
+                    guard let self else { return }
+                    self.recordNetworkPath(isSatisfied: path.status == .satisfied)
                 }
             }
-            pathMonitor.start(queue: pathQueue)
         }
     }
 
     func stop() {
         guard started else { return }
         started = false
-        pathMonitor?.pathUpdateHandler = nil
+        wakeTask?.cancel()
+        wakeTask = nil
+        pathTask?.cancel()
+        pathTask = nil
         pathMonitor?.cancel()
-        if let wakeObserver, let notificationCenter {
-            notificationCenter.removeObserver(wakeObserver)
-        }
-        wakeObserver = nil
     }
 
     /// Internal so transition behavior can be tested without depending on
@@ -77,13 +72,5 @@ final class TerminalRecoveryMonitor {
         defer { previousPathWasSatisfied = isSatisfied }
         guard previousPathWasSatisfied == false, isSatisfied else { return }
         onRecovery?()
-    }
-
-    deinit {
-        pathMonitor?.pathUpdateHandler = nil
-        pathMonitor?.cancel()
-        if let wakeObserver, let notificationCenter {
-            notificationCenter.removeObserver(wakeObserver)
-        }
     }
 }

--- a/macos/ATC/Features/Terminal/TerminalRecoveryMonitor.swift
+++ b/macos/ATC/Features/Terminal/TerminalRecoveryMonitor.swift
@@ -30,6 +30,15 @@ final class TerminalRecoveryMonitor {
         TerminalRecoveryMonitor(notificationCenter: nil, pathMonitor: nil)
     }
 
+    // Production's one monitor lives for the app, but test and preview
+    // AppModels abandon theirs without `stop()` — and the path task holds
+    // the NWPathMonitor, which keeps evaluating paths until cancelled.
+    deinit {
+        wakeTask?.cancel()
+        pathTask?.cancel()
+        pathMonitor?.cancel()
+    }
+
     func start() {
         guard !started else { return }
         started = true

--- a/macos/ATC/Features/Terminal/TerminalSessionController.swift
+++ b/macos/ATC/Features/Terminal/TerminalSessionController.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Observation
 import OSLog
+import Synchronization
 import ATCAppServerTransport
 import GhosttyTerminal
 
@@ -490,27 +491,30 @@ typealias TerminalAttachFactory = (URL, [String: String]) -> TerminalAttachHandl
 
 /// Lock-guarded handle to the current connection so Ghostty's background
 /// callbacks can enqueue synchronously across reconnects.
-private nonisolated final class ConnectionRef: @unchecked Sendable {
-    private let lock = NSLock()
-    private var connection: TerminalAttachHandle?
-    private var viewport: (cols: UInt16, rows: UInt16)?
+private nonisolated final class ConnectionRef: Sendable {
+    private struct State {
+        var connection: TerminalAttachHandle?
+        var viewport: (cols: UInt16, rows: UInt16)?
+    }
+
+    private let state = Mutex(State())
 
     var lastViewport: (cols: UInt16, rows: UInt16)? {
-        lock.withLock { viewport }
+        state.withLock { $0.viewport }
     }
 
     func set(_ connection: TerminalAttachHandle?) {
-        lock.withLock { self.connection = connection }
+        state.withLock { $0.connection = connection }
     }
 
     func enqueue(_ data: Data) {
-        lock.withLock { connection }?.enqueue(data)
+        state.withLock { $0.connection }?.enqueue(data)
     }
 
     func enqueueResize(cols: UInt16, rows: UInt16) {
-        let connection = lock.withLock {
-            viewport = (cols, rows)
-            return self.connection
+        let connection = state.withLock { state in
+            state.viewport = (cols, rows)
+            return state.connection
         }
         connection?.enqueueResize(cols: cols, rows: rows)
     }

--- a/macos/ATC/Features/Threads/NewThreadSheet.swift
+++ b/macos/ATC/Features/Threads/NewThreadSheet.swift
@@ -22,10 +22,17 @@ struct NewThreadSheet: View {
     @Environment(WindowState.self) private var windowState
     let context: NewThreadContext
 
+    private static let agentShortcutKeys: Set<KeyEquivalent> = Set(
+        (1...9).map { KeyEquivalent(Character("\($0)")) }
+    )
+
     @AppStorage("newThreadLastAgentId") private var lastAgentRaw = ""
 
     @State private var query = ""
     @State private var selectedProject: ProjectRef?
+    /// The row the results list is parked on. Separate from
+    /// `selectedProject` because SwiftUI writes the scrolled-to row into it.
+    @State private var scrolledProject: ProjectRef?
     @State private var agentID: AgentID = .codex
     @State private var workingDirectory = ""
     @State private var directoryState: DirectoryCheckState = .idle
@@ -62,9 +69,24 @@ struct NewThreadSheet: View {
             }
         }
         .frame(width: 560, height: 500)
-        .background(hiddenShortcutButtons)
+        .defaultFocus($searchIsFocused, true)
+        // ⌘1…⌘9 select Agents, handled on the sheet rather than on the Agent
+        // buttons so an unavailable Agent's shortcut still answers with
+        // feedback instead of being swallowed by a disabled control.
+        .onKeyPress(keys: Self.agentShortcutKeys, phases: .down) { press in
+            guard press.modifiers == .command,
+                  let digit = press.key.character.wholeNumberValue,
+                  digit - 1 < agents.count
+            else { return .ignored }
+            select(agents[digit - 1])
+            return .handled
+        }
+        .onKeyPress(keys: ["g"], phases: .down) { press in
+            guard press.modifiers == [.command, .shift] else { return .ignored }
+            directoryIsFocused = true
+            return .handled
+        }
         .task {
-            searchIsFocused = true
             agentID = NewThreadLauncherModel.initialAgent(
                 lastUsedRawValue: lastAgentRaw,
                 agents: agents
@@ -117,22 +139,18 @@ struct NewThreadSheet: View {
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
-            ScrollViewReader { proxy in
-                ScrollView {
-                    LazyVStack(spacing: 2) {
-                        ForEach(rows) { row in
-                            resultRow(row)
-                                .id(row.id)
-                        }
-                    }
-                    .padding(Spacing.xs)
-                }
-                .onChange(of: selectedProject) {
-                    if let selectedProject {
-                        proxy.scrollTo(selectedProject, anchor: .center)
+            ScrollView {
+                LazyVStack(spacing: 2) {
+                    ForEach(rows) { row in
+                        resultRow(row)
+                            .id(row.id)
                     }
                 }
+                .scrollTargetLayout()
+                .padding(Spacing.xs)
             }
+            .scrollPosition(id: $scrolledProject, anchor: .center)
+            .onChange(of: selectedProject) { scrolledProject = selectedProject }
         }
     }
 
@@ -256,23 +274,6 @@ struct NewThreadSheet: View {
         .opacity(agent.available ? 1 : 0.5)
         .accessibilityLabel(agentAccessibilityLabel(agent, index: index))
         .accessibilityAddTraits(isSelected ? .isSelected : [])
-    }
-
-    /// The ⌘-digit selectors live on hidden always-enabled buttons so an
-    /// unavailable Agent's shortcut can still answer with feedback — a
-    /// disabled visible button would swallow it silently.
-    private var hiddenShortcutButtons: some View {
-        VStack {
-            ForEach(Array(agents.prefix(9).enumerated()), id: \.element.id) { index, agent in
-                Button("") { select(agent) }
-                    .keyboardShortcut(KeyEquivalent(Character("\(index + 1)")), modifiers: .command)
-            }
-            Button("") { directoryIsFocused = true }
-                .keyboardShortcut("g", modifiers: [.command, .shift])
-        }
-        .frame(width: 0, height: 0)
-        .opacity(0)
-        .accessibilityHidden(true)
     }
 
     private func shortcutLabel(at index: Int) -> String? {

--- a/macos/ATC/Features/Threads/NewThreadSheet.swift
+++ b/macos/ATC/Features/Threads/NewThreadSheet.swift
@@ -74,15 +74,19 @@ struct NewThreadSheet: View {
         // buttons so an unavailable Agent's shortcut still answers with
         // feedback instead of being swallowed by a disabled control.
         .onKeyPress(keys: Self.agentShortcutKeys, phases: .down) { press in
-            guard press.modifiers == .command,
+            // Mask to the device-independent modifiers: `press.modifiers`
+            // also carries capsLock/numericPad, which must not defeat ⌘1–9.
+            guard press.modifiers.intersection([.command, .shift, .option, .control]) == .command,
                   let digit = press.key.character.wholeNumberValue,
                   digit - 1 < agents.count
             else { return .ignored }
             select(agents[digit - 1])
             return .handled
         }
-        .onKeyPress(keys: ["g"], phases: .down) { press in
-            guard press.modifiers == [.command, .shift] else { return .ignored }
+        // Both cases: `press.key` preserves Shift, so a real ⇧⌘G arrives as "G".
+        .onKeyPress(keys: ["g", "G"], phases: .down) { press in
+            guard press.modifiers.intersection([.command, .shift, .option, .control]) == [.command, .shift]
+            else { return .ignored }
             directoryIsFocused = true
             return .handled
         }

--- a/macos/ATC/Features/Threads/ThreadCard.swift
+++ b/macos/ATC/Features/Threads/ThreadCard.swift
@@ -24,78 +24,57 @@ struct ThreadCard: View {
 
     var body: some View {
         let thread = item.thread
-        VStack(alignment: .leading, spacing: Spacing.xs) {
-            // Top row: Project name as compact context; the trailing area
-            // shows the Connection at rest and the actions on hover/focus.
-            HStack(alignment: .center, spacing: Spacing.sm) {
-                Text(item.projectLabel)
-                    .font(.caption.weight(.semibold))
-                    .lineLimit(1)
-                Spacer(minLength: Spacing.sm)
-                // Same slot as the hover chips and the connection status, so
-                // the card never resizes; the held-modifier badge wins.
-                if let shortcutLabel {
-                    ShortcutBadge(label: shortcutLabel)
-                } else if isHovering || isFocused {
-                    HStack(spacing: Spacing.xs) {
-                        cardAction(
-                            systemImage: thread.isPinned ? "pin.slash" : "pin",
-                            help: thread.isPinned ? "Unpin" : "Pin",
-                            isEnabled: canMutate && !isBusy,
-                            action: onTogglePin
-                        )
-                        cardAction(
-                            systemImage: "archivebox",
-                            help: "Archive",
-                            // The server refuses archiving a working thread;
-                            // the control is disabled rather than surfacing
-                            // that as an error the user did not ask for.
-                            isEnabled: canMutate && !isBusy
-                                && thread.activityState != .working,
-                            action: onArchive
-                        )
-                    }
-                } else {
-                    HStack(spacing: Spacing.xs) {
-                        Text(item.connectionName)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                        StatusDot(reachability: reachability, size: .inline)
-                    }
-                    // Match the action chips' height so the card does not
-                    // resize under the pointer.
-                    .frame(height: NavigatorMetrics.actionSize)
-                }
-            }
-
-            // The dominant element.
-            Text(thread.displayName)
-                .font(.body.weight(.medium))
-                .lineLimit(2)
-                .multilineTextAlignment(.leading)
-
-            // Bottom metadata row: working directory when it differs from
-            // the Project default; activity state and Agent trailing.
-            HStack(alignment: .center, spacing: Spacing.sm) {
-                if let directory = item.distinctWorkingDirectory {
-                    Text(directory)
-                        .font(.caption.monospaced())
-                        .foregroundStyle(.tertiary)
+        // One Button for the whole card: it carries the click and the
+        // accessibility action. Return is handled on the composite below — a
+        // nested .plain Button is not activated by the focused container.
+        // The hover chips are Buttons themselves, so they sit in an overlay
+        // rather than nested in this label.
+        Button {
+            focusedThread = item.ref
+            onOpen()
+        } label: {
+            VStack(alignment: .leading, spacing: Spacing.xs) {
+                // Top row: Project name as compact context; the trailing area
+                // shows the Connection at rest and the actions on hover/focus.
+                HStack(alignment: .center, spacing: Spacing.sm) {
+                    Text(item.projectLabel)
+                        .font(.caption.weight(.semibold))
                         .lineLimit(1)
-                        .truncationMode(.head)
+                    Spacer(minLength: Spacing.sm)
+                    trailingSlot
                 }
-                Spacer(minLength: Spacing.sm)
-                if let status = thread.activityState.statusLabel {
-                    Text(status)
-                        .font(.caption.weight(.medium))
-                        .foregroundStyle(thread.activityState.statusColor)
+
+                // The dominant element.
+                Text(thread.displayName)
+                    .font(.body.weight(.medium))
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+
+                // Bottom metadata row: working directory when it differs from
+                // the Project default; activity state and Agent trailing.
+                HStack(alignment: .center, spacing: Spacing.sm) {
+                    if let directory = item.distinctWorkingDirectory {
+                        Text(directory)
+                            .font(.caption.monospaced())
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
+                            .truncationMode(.head)
+                    }
+                    Spacer(minLength: Spacing.sm)
+                    if let status = thread.activityState.statusLabel {
+                        Text(status)
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(thread.activityState.statusColor)
+                    }
+                    agentBadge
                 }
-                agentBadge
             }
+            .padding(Spacing.md)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
         }
-        .padding(Spacing.md)
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
         .background {
             RoundedRectangle(cornerRadius: Radius.card, style: .continuous)
                 .fill(backgroundStyle)
@@ -104,16 +83,12 @@ struct ThreadCard: View {
             RoundedRectangle(cornerRadius: Radius.card, style: .continuous)
                 .strokeBorder(borderColor, lineWidth: 1)
         }
+        .overlay(alignment: .topTrailing) { hoverActions }
         .opacity(isBusy ? Dimming.unavailable : 1)
-        .contentShape(Rectangle())
         .onHover { isHovering = $0 }
         .focusable()
         .focusEffectDisabled()
         .focused($focusedThread, equals: item.ref)
-        .onTapGesture {
-            focusedThread = item.ref
-            onOpen()
-        }
         .onKeyPress(.return) {
             onOpen()
             return .handled
@@ -130,10 +105,59 @@ struct ThreadCard: View {
             Button("Archive", systemImage: "archivebox", action: onArchive)
                 .disabled(!canMutate || isBusy || thread.activityState == .working)
         }
-        .accessibilityElement(children: .contain)
-        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
-        .accessibilityAction(named: "Open", onOpen)
         .navigatorListRow(top: Spacing.xs, bottom: Spacing.xs)
+    }
+
+    /// The card's trailing slot: the held-modifier badge, the Connection at
+    /// rest, or the space the hover actions take over. Everything here is the
+    /// same height, so the card never resizes under the pointer.
+    @ViewBuilder
+    private var trailingSlot: some View {
+        if let shortcutLabel {
+            ShortcutBadge(label: shortcutLabel)
+        } else if isHovering || isFocused {
+            Color.clear
+                .frame(
+                    width: NavigatorMetrics.actionSize * 2 + Spacing.xs,
+                    height: NavigatorMetrics.actionSize
+                )
+        } else {
+            HStack(spacing: Spacing.xs) {
+                Text(item.connectionName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                StatusDot(reachability: reachability, size: .inline)
+            }
+            .frame(height: NavigatorMetrics.actionSize)
+        }
+    }
+
+    /// Pin and Archive, over the slot `trailingSlot` reserves for them. The
+    /// held-modifier badge wins that slot.
+    @ViewBuilder
+    private var hoverActions: some View {
+        if shortcutLabel == nil, isHovering || isFocused {
+            HStack(spacing: Spacing.xs) {
+                cardAction(
+                    systemImage: item.thread.isPinned ? "pin.slash" : "pin",
+                    help: item.thread.isPinned ? "Unpin" : "Pin",
+                    isEnabled: canMutate && !isBusy,
+                    action: onTogglePin
+                )
+                cardAction(
+                    systemImage: "archivebox",
+                    help: "Archive",
+                    // The server refuses archiving a working thread; the
+                    // control is disabled rather than surfacing that as an
+                    // error the user did not ask for.
+                    isEnabled: canMutate && !isBusy
+                        && item.thread.activityState != .working,
+                    action: onArchive
+                )
+            }
+            .padding(Spacing.md)
+        }
     }
 
     /// The Agent icon in a small rounded-square badge, lower-trailing per

--- a/macos/ATC/Settings/ConnectionsSettingsView.swift
+++ b/macos/ATC/Settings/ConnectionsSettingsView.swift
@@ -117,7 +117,8 @@ struct ConnectionsSettingsView: View {
 
 /// Draft editor for one Connection. Holds local `@State` copies seeded from the
 /// selected record (or empty for a new draft); nothing reaches the store until
-/// Save. Recreated per target via `.id(target)`, so seeding happens in `.task`.
+/// Save. Recreated per target via `.id(target)`, so one seed on appearance is
+/// enough.
 private struct ConnectionEditorView: View {
     @Environment(AppModel.self) private var appModel
     let target: ConnectionEditorTarget
@@ -219,7 +220,7 @@ private struct ConnectionEditorView: View {
             }
             .padding(Spacing.md)
         }
-        .task(id: target) { seed() }
+        .onAppear { seed() }
         .onChange(of: name) { invalidateTest() }
         .onChange(of: urlString) { invalidateTest() }
         .onChange(of: token) { invalidateTest() }

--- a/macos/ATC/Shared/ConnectionMutations.swift
+++ b/macos/ATC/Shared/ConnectionMutations.swift
@@ -6,18 +6,18 @@ import SwiftUI
 extension AppModel {
     func run(
         on connectionID: UUID,
-        reporting actionError: Binding<String?>,
+        reporting reportError: @escaping @MainActor (String) -> Void,
         _ operation: @escaping () async throws -> Void
     ) {
         Task {
             guard canMutate(connectionID: connectionID) else {
-                actionError.wrappedValue = "The connection is unavailable."
+                reportError("The connection is unavailable.")
                 return
             }
             do {
                 try await operation()
             } catch {
-                actionError.wrappedValue = error.localizedDescription
+                reportError(error.localizedDescription)
             }
         }
     }

--- a/macos/ATC/Shared/NavigatorComponents.swift
+++ b/macos/ATC/Shared/NavigatorComponents.swift
@@ -32,6 +32,9 @@ struct NavigatorList<Content: View>: View {
             LazyVStack(spacing: 0) {
                 content
             }
+            // Lets a caller's `.scrollPosition(id:)` address the rows, which
+            // is what replaces `List`'s scroll-to-selection here.
+            .scrollTargetLayout()
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, NavigatorMetrics.horizontalPadding)
         }

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -46,6 +46,11 @@ struct NewThreadContext: Identifiable, Hashable {
 @Observable
 final class WindowState {
     private(set) var selectedContent: MainContentSelection = .dashboard
+    /// Bumped when a selection made outside the sidebar (palette, ⌘1–9,
+    /// content-area links) should scroll the sidebar to its row. Sidebar
+    /// clicks pass `reveal: false`, so clicking a visible row never yanks
+    /// it out from under the pointer.
+    private(set) var sidebarRevealToken = 0
     /// Launch-local Project context, established by opening or creating a
     /// Thread. Navigating to Dashboard does not clear it.
     private(set) var activeProject: ProjectRef?
@@ -125,11 +130,12 @@ final class WindowState {
     /// immediately (the content area shows the connecting state), then
     /// idempotently open the TUI terminal and attach. Establishes the
     /// thread's Project as the launch-local context.
-    func openThread(_ ref: ThreadRef, in appModel: AppModel) async {
+    func openThread(_ ref: ThreadRef, in appModel: AppModel, reveal: Bool = true) async {
         guard let thread = appModel.thread(for: ref) else { return }
         guard !thread.isArchived else { return }
 
         selectedContent = .thread(ref)
+        if reveal { sidebarRevealToken += 1 }
         returnThread = ref
         activeProject = ProjectRef(connectionID: ref.connectionID, projectID: thread.projectId)
         threadOpenErrors[ref] = nil
@@ -149,9 +155,10 @@ final class WindowState {
 
     /// Selects a standalone Terminal. Live terminals attach; an ended one
     /// renders as a tombstone.
-    func selectTerminal(_ ref: TerminalRef, in appModel: AppModel) {
+    func selectTerminal(_ ref: TerminalRef, in appModel: AppModel, reveal: Bool = true) {
         guard let terminal = appModel.terminal(for: ref) else { return }
         selectedContent = .terminal(ref)
+        if reveal { sidebarRevealToken += 1 }
         if terminal.isLive {
             appModel.attachIfNeeded(
                 to: terminal,

--- a/macos/ATCTests/DashboardModelTests.swift
+++ b/macos/ATCTests/DashboardModelTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+@testable import ATC
+
+@Suite("Dashboard model")
+struct DashboardModelTests {
+    private let local = UUID()
+    private let remote = UUID()
+
+    private func input(
+        _ connectionID: UUID,
+        name: String,
+        urlString: String = "http://127.0.0.1:7331",
+        projects: [Project],
+        threads: [ATCThread] = [],
+        terminals: [Terminal] = []
+    ) -> DashboardModel.ConnectionInput {
+        DashboardModel.ConnectionInput(
+            connectionID: connectionID,
+            connectionName: name,
+            urlString: urlString,
+            projects: projects,
+            threads: threads,
+            terminals: terminals
+        )
+    }
+
+    @Test("a card counts its own active threads, standalone terminals, and waiting threads")
+    func cardCounts() throws {
+        let model = DashboardModel(inputs: [
+            input(
+                local,
+                name: "Local",
+                projects: [
+                    Fixtures.project(id: "p1", name: "App"),
+                    Fixtures.project(id: "p2", name: "Website"),
+                ],
+                threads: [
+                    Fixtures.thread(id: "t1", projectId: "p1"),
+                    Fixtures.thread(id: "t2", projectId: "p1", activityState: .needsInput),
+                    // Archived threads are not active work.
+                    Fixtures.thread(id: "t3", projectId: "p1", archivedAt: Fixtures.date(1)),
+                    Fixtures.thread(id: "t4", projectId: "p2"),
+                ],
+                terminals: [
+                    Fixtures.terminal(id: "standalone", projectId: "p1"),
+                    // A thread's TUI terminal belongs to the thread.
+                    Fixtures.terminal(id: "tui", projectId: "p1", threadId: "t1"),
+                ]
+            ),
+        ])
+        let cards = try #require(model.sections.first?.cards)
+        #expect(cards.map(\.project.id) == ["p1", "p2"])
+        #expect(cards[0].activeThreadCount == 2)
+        #expect(cards[0].standaloneTerminalCount == 1)
+        #expect(cards[0].needsInputCount == 1)
+        #expect(cards[1].activeThreadCount == 1)
+        #expect(cards[1].standaloneTerminalCount == 0)
+        #expect(cards[1].needsInputCount == 0)
+        #expect(model.totalProjectCount == 2)
+    }
+
+    @Test("each connection is its own section, labeled by where it runs")
+    func sectionsPerConnection() {
+        let model = DashboardModel(inputs: [
+            input(local, name: "Local", projects: [Fixtures.project(id: "p1", name: "App")]),
+            input(
+                remote,
+                name: "Production",
+                urlString: "https://build.example.com:7331",
+                projects: []
+            ),
+        ])
+        #expect(model.sections.map(\.connectionID) == [local, remote])
+        #expect(model.sections.map(\.contextLabel) == ["Local", "build.example.com"])
+        #expect(model.sections.map { $0.cards.count } == [1, 0])
+        #expect(model.totalProjectCount == 1)
+    }
+}

--- a/macos/ATCTests/KeyboardRouterTests.swift
+++ b/macos/ATCTests/KeyboardRouterTests.swift
@@ -251,11 +251,9 @@ struct KeyboardRouterTests {
         let router = WindowKeyboardRouter(keymap: try keymap()) { _ in .available }
         router.showUnavailable(reason: "Unavailable now")
         #expect(router.flash == RouterFlash(message: "Unavailable now"))
-        // Awaiting releases the main actor so the router's clearing task can
+        // Settling releases the main actor so the router's clearing task can
         // run; a run-loop pump would hold the actor and dead-lock the clear.
-        for _ in 0..<100 where router.flash != nil {
-            try await Task.sleep(for: .milliseconds(50))
-        }
+        await settle(until: { router.flash == nil })
         #expect(router.flash == nil)
     }
 }

--- a/macos/ATCTests/ThreadListModelTests.swift
+++ b/macos/ATCTests/ThreadListModelTests.swift
@@ -96,6 +96,7 @@ struct ThreadListModelTests {
                     threads: [
                         Fixtures.thread(id: "pin_new", pinnedAt: Fixtures.date(200), createdAt: Fixtures.date(1)),
                         Fixtures.thread(id: "pin_old", pinnedAt: Fixtures.date(100), createdAt: Fixtures.date(2)),
+                        Fixtures.thread(id: "pin_mid", pinnedAt: Fixtures.date(150), createdAt: Fixtures.date(3)),
                         Fixtures.thread(id: "old", createdAt: Fixtures.date(10)),
                         Fixtures.thread(id: "new", createdAt: Fixtures.date(20)),
                     ],
@@ -107,7 +108,7 @@ struct ThreadListModelTests {
             ],
             filter: .all
         )
-        #expect(model.pinned.map(\.ref.threadID) == ["pin_old", "pin_new"])
+        #expect(model.pinned.map(\.ref.threadID) == ["pin_old", "pin_mid", "pin_new"])
         #expect(model.recent.map(\.ref.threadID) == ["new", "old"])
         #expect(model.archived.map(\.ref.threadID) == ["arch_new", "arch_old"])
     }

--- a/macos/ATCTests/ThreadListModelTests.swift
+++ b/macos/ATCTests/ThreadListModelTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+import Testing
+@testable import ATC
+
+@Suite("Thread list model")
+struct ThreadListModelTests {
+    private let local = UUID()
+    private let remote = UUID()
+
+    private func input(
+        _ connectionID: UUID,
+        name: String,
+        projects: [Project] = [Fixtures.project(id: "prj", name: "App")],
+        threads: [ATCThread] = [],
+        archived: [ATCThread] = []
+    ) -> ThreadListModel.ConnectionInput {
+        ThreadListModel.ConnectionInput(
+            connectionID: connectionID,
+            connectionName: name,
+            projects: projects,
+            threads: threads,
+            archivedThreads: archived
+        )
+    }
+
+    // MARK: - Labels
+
+    @Test("a project name shared across connections carries its connection")
+    func duplicateProjectNames() {
+        let model = ThreadListModel(
+            inputs: [
+                input(local, name: "Local", projects: [
+                    Fixtures.project(id: "p1", name: "App"),
+                    Fixtures.project(id: "p2", name: "Website"),
+                ]),
+                input(remote, name: "Production", projects: [
+                    Fixtures.project(id: "p3", name: "App"),
+                ]),
+            ],
+            filter: .all
+        )
+        #expect(model.projects.map(\.label) == ["App · Local", "Website", "App · Production"])
+    }
+
+    @Test("a thread's label follows its project, and an unknown project reads as such")
+    func threadLabels() {
+        let model = ThreadListModel(
+            inputs: [
+                input(
+                    local,
+                    name: "Local",
+                    threads: [
+                        Fixtures.thread(id: "t1", projectId: "prj"),
+                        Fixtures.thread(id: "t2", projectId: "gone"),
+                    ]
+                ),
+            ],
+            filter: .all
+        )
+        #expect(model.recent.map(\.projectLabel) == ["App", "Unknown Project"])
+        #expect(model.recent.allSatisfy { $0.connectionName == "Local" })
+    }
+
+    // MARK: - Working directory
+
+    @Test("a working directory shows only when it differs from the project default")
+    func distinctWorkingDirectory() {
+        let model = ThreadListModel(
+            inputs: [
+                input(
+                    local,
+                    name: "Local",
+                    projects: [Fixtures.project(id: "prj", name: "App", workingDirectory: "/src/app")],
+                    threads: [
+                        Fixtures.thread(id: "same", workingDirectory: "/src/app", createdAt: Fixtures.date(10)),
+                        Fixtures.thread(id: "other", workingDirectory: "/src/app/pkg", createdAt: Fixtures.date(20)),
+                    ]
+                ),
+            ],
+            filter: .all
+        )
+        let byID = Dictionary(uniqueKeysWithValues: model.recent.map { ($0.ref.threadID, $0) })
+        #expect(byID["same"]?.distinctWorkingDirectory == nil)
+        #expect(byID["other"]?.distinctWorkingDirectory == "/src/app/pkg")
+    }
+
+    // MARK: - Ordering
+
+    @Test("pins are oldest-pin-first, recents newest-created-first, archived newest-archived-first")
+    func ordering() {
+        let model = ThreadListModel(
+            inputs: [
+                input(
+                    local,
+                    name: "Local",
+                    threads: [
+                        Fixtures.thread(id: "pin_new", pinnedAt: Fixtures.date(200), createdAt: Fixtures.date(1)),
+                        Fixtures.thread(id: "pin_old", pinnedAt: Fixtures.date(100), createdAt: Fixtures.date(2)),
+                        Fixtures.thread(id: "old", createdAt: Fixtures.date(10)),
+                        Fixtures.thread(id: "new", createdAt: Fixtures.date(20)),
+                    ],
+                    archived: [
+                        Fixtures.thread(id: "arch_old", archivedAt: Fixtures.date(300)),
+                        Fixtures.thread(id: "arch_new", archivedAt: Fixtures.date(400)),
+                    ]
+                ),
+            ],
+            filter: .all
+        )
+        #expect(model.pinned.map(\.ref.threadID) == ["pin_old", "pin_new"])
+        #expect(model.recent.map(\.ref.threadID) == ["new", "old"])
+        #expect(model.archived.map(\.ref.threadID) == ["arch_new", "arch_old"])
+    }
+
+    // MARK: - Filtering
+
+    @Test("the filter governs the thread list only; pins and archived stay global")
+    func filterScope() {
+        let inputs = [
+            input(
+                local,
+                name: "Local",
+                projects: [
+                    Fixtures.project(id: "p1", name: "App"),
+                    Fixtures.project(id: "p2", name: "Website"),
+                ],
+                threads: [
+                    Fixtures.thread(id: "app", projectId: "p1"),
+                    Fixtures.thread(id: "web", projectId: "p2"),
+                    Fixtures.thread(id: "pinned", projectId: "p2", pinnedAt: Fixtures.date(1)),
+                ],
+                archived: [Fixtures.thread(id: "arch", projectId: "p2", archivedAt: Fixtures.date(2))]
+            ),
+        ]
+        let filtered = ThreadListModel(
+            inputs: inputs,
+            filter: .project(ProjectRef(connectionID: local, projectID: "p1"))
+        )
+        #expect(filtered.recent.map(\.ref.threadID) == ["app"])
+        #expect(filtered.pinned.map(\.ref.threadID) == ["pinned"])
+        #expect(filtered.archived.map(\.ref.threadID) == ["arch"])
+
+        // Same project ID on another Connection is a different project.
+        let otherConnection = ThreadListModel(
+            inputs: inputs,
+            filter: .project(ProjectRef(connectionID: remote, projectID: "p1"))
+        )
+        #expect(otherConnection.recent.isEmpty)
+
+        let archivedFilter = ThreadListModel(inputs: inputs, filter: .archived)
+        #expect(archivedFilter.recent.isEmpty)
+        #expect(archivedFilter.archived.map(\.ref.threadID) == ["arch"])
+    }
+
+    // MARK: - Row identity
+
+    @Test("row identity is section-scoped, so pin and archive are not a move")
+    func sectionScopedIdentity() {
+        let ref = ThreadRef(connectionID: local, threadID: "t1")
+        let plain = ThreadListItem.ID(ref: ref, isPinned: false, isArchived: false)
+        let pinned = ThreadListItem.ID(ref: ref, isPinned: true, isArchived: false)
+        let archived = ThreadListItem.ID(ref: ref, isPinned: false, isArchived: true)
+        #expect(plain != pinned)
+        #expect(plain != archived)
+
+        let model = ThreadListModel(
+            inputs: [
+                input(
+                    local,
+                    name: "Local",
+                    threads: [Fixtures.thread(id: "t1", pinnedAt: Fixtures.date(1))]
+                ),
+            ],
+            filter: .all
+        )
+        #expect(model.pinned.map(\.id) == [pinned])
+    }
+}

--- a/packages/ATCKit/Tests/ATCAppServerTransportTests/AttachSocketTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerTransportTests/AttachSocketTests.swift
@@ -134,17 +134,6 @@ private final class EventLog: @unchecked Sendable {
     }
 }
 
-private func waitUntil(
-    attempts: Int = 2_000,
-    _ condition: () -> Bool
-) async -> Bool {
-    for _ in 0..<attempts {
-        if condition() { return true }
-        try? await Task.sleep(for: .milliseconds(1))
-    }
-    return condition()
-}
-
 @Suite("Attach socket")
 struct AttachSocketTests {
     @Test("server pings are answered with pongs, never echoed as output")

--- a/packages/ATCKit/Tests/ATCAppServerTransportTests/OutboundQueueTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerTransportTests/OutboundQueueTests.swift
@@ -146,17 +146,6 @@ private func patternedData(count: Int) -> Data {
     Data((0..<count).map { UInt8(truncatingIfNeeded: $0) })
 }
 
-private func waitUntil(
-    attempts: Int = 2_000,
-    _ condition: () -> Bool
-) async -> Bool {
-    for _ in 0..<attempts {
-        if condition() { return true }
-        try? await Task.sleep(for: .milliseconds(1))
-    }
-    return condition()
-}
-
 nonisolated private final class ProducerProbe: @unchecked Sendable {
     private let lock = NSLock()
     private var storedStarted = false

--- a/packages/ATCKit/Tests/ATCAppServerTransportTests/TestSupport.swift
+++ b/packages/ATCKit/Tests/ATCAppServerTransportTests/TestSupport.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Suspends until `condition` holds, giving the transport's own tasks room to
+/// run. `attempts` is a failure bound, never the thing under test: every
+/// caller waits on a real observable condition, and a passing test returns as
+/// soon as it holds.
+func waitUntil(
+    attempts: Int = 2_000,
+    _ condition: () -> Bool
+) async -> Bool {
+    for _ in 0..<attempts {
+        if condition() { return true }
+        try? await Task.sleep(for: .milliseconds(1))
+    }
+    return condition()
+}


### PR DESCRIPTION
Implements PR 8 of the ATC-170 hardening plan (sub-issue ATC-178): the macOS platform-polish and test findings from ATC-168 — M5–M8, L9–L14, plus the test-section items.

## What's here

- **M5** — `TerminalRecoveryMonitor` rewritten from a private DispatchQueue + callback observers to two stored Tasks over `NWPathMonitor`'s `AsyncSequence` (@available macOS 14+, verified in the SDK swiftinterface) and `NotificationCenter.notifications(named:)`. The `nonisolated(unsafe)` token and dispatch queue are gone; the three-state path semantics (initial healthy path is not a recovery) are unchanged and still flow through the testable `recordNetworkPath` seam. A `deinit` cancels the tasks and monitor so abandoned test/preview monitors don't keep a live `NWPathMonitor`.
- **M6** — sidebar scroll-to-selection via `.scrollTargetLayout()` + `.scrollPosition(id:)`. Driven by a `sidebarRevealToken` on `WindowState` bumped only by out-of-sidebar navigation (palette, ⌘1–9, content-area links) — sidebar clicks pass `reveal: false`, so clicking a visible row never re-centers it under the pointer.
- **M7** — terminal focus transfer: the `Timer` polling loops (up to 100 timers, `MainActor.assumeIsolated`) replaced with two stored Tasks using `Task.sleep` loops, same 100 × 10 ms bound, weak captures, real cancellation.
- **M8** — `ConnectionMutations.run` takes a `@MainActor (String) -> Void` error callback instead of an escaped SwiftUI `Binding` (4 call sites).
- **L9** — `ConnectionRef`: `NSLock` + `@unchecked Sendable` → `Synchronization.Mutex` + compiler-checked `Sendable`. `OutboundQueue` untouched per the finding.
- **L10–L13** — `.defaultFocus` in NewThreadSheet; `seed()` via `onAppear`; hidden ⌘1–9 shortcut buttons → `.onKeyPress` on the sheet root; palette row-height estimates → measured `onGeometryChange` height (initialized at the cap to avoid a zero-height latch); `ScrollViewReader` → `.scrollPosition(id:)` in palette and launcher.
- **L14** — ThreadCard primary action is one `.plain` Button (click + accessibility); hover chips moved to a top-trailing overlay with exact width reservation, hit-testing verified empirically (chips and card never double-fire, no dead zones).
- **Tests** — new direct `ThreadListModelTests` (7) and `DashboardModelTests` (2) pinning connection-suffix disambiguation, the working-directory display rule, all three sort orders, filter scope, section-scoped row identity, and dashboard counts; `waitUntil` deduped into a shared `TestSupport.swift` (both copies were in the same target); `KeyboardRouterTests` poll loop → `settle(until:)`.

## Review-driven fixes (second commit)

The combined adversarial review probed the SwiftUI claims empirically and caught two real regressions, fixed here:
- A nested `.plain` Button is **not** activated by Return on the focused composite — `.onKeyPress(.return)` restored on the card.
- `press.key` preserves Shift, so ⇧⌘G arrived as `"G"` and the `["g"]` handler never fired; and `press.modifiers` carries capsLock/numericPad, breaking ⌘1–9 under Caps Lock. Both handlers now match `["g", "G"]` and mask to device-independent modifiers.

Plus: the reveal-token design above (the naive `onChange(of: selectedContent)` re-centered on every sidebar click), archived rows included in the scroll-target search, the monitor `deinit`, a third pinned fixture row so the pinned-order test can't pass under a wrong comparator, and small type/lifecycle nits.

## Known residual

`.scrollPosition(id:)`'s write-back on user scroll couldn't be driven in an unbundled test harness; if it misbehaved, a reveal would park on a stale row after manual scrolling. Worth one manual check in the running app.

## Verification

- `mise run macos:test` — 252 tests / 29 suites passed (244 baseline + 8 new, before the review pass added a fixture row).
- `mise run kit:test` — 45 tests / 7 suites passed.
- Zero new build warnings in touched code.

Stack note: this PR is the top of the ATC-170 stack (#161 → #168, each based on the previous). The previously documented `NavigatorSidebar`/`ThreadCard` conflict is already resolved in this branch (the L14 Button rewrite lives in `Features/Threads/ThreadCard.swift` with PR 7's `Surface.*` tokens intact, and only `NavigatorScrollID` plus the scroll wiring landed in the moved sidebar). Merge bottom-up in order; no manual resolution needed. Gates re-verified on the composed stack tip: app-server check + contract:check, macos:test 256/29, kit:test 45/7.

Closes ATC-178.

https://claude.ai/code/session_019pj9ErmqTfaLoTPksB3fSZ

