### PR TITLE
New Thread sheet visual refresh: consistent gutter, richer project rows, roomier agent chips

### DIFF
--- a/macos/ATC/Features/Threads/NewThreadSheet.swift
+++ b/macos/ATC/Features/Threads/NewThreadSheet.swift
@@ -26,6 +26,13 @@ struct NewThreadSheet: View {
         (1...9).map { KeyEquivalent(Character("\($0)")) }
     )
 
+    /// The sheet's one horizontal rhythm. Every container — search field,
+    /// result row, configuration grid — sits `gutter` in from the sheet edge,
+    /// and its own content sits `Spacing.md` inside that, so the search icon,
+    /// the rows' status dots, and the section header all share a left edge and
+    /// a selected row is exactly as wide as the search field above it.
+    private static let gutter = Spacing.md
+
     /// The results list shows exactly this many rows; more scroll within it.
     private static let visibleRowCount = 6
     private static let rowHeight: CGFloat = 32
@@ -152,7 +159,7 @@ struct NewThreadSheet: View {
             RoundedRectangle(cornerRadius: Radius.chip, style: .continuous)
                 .stroke(Surface.chipBorder, lineWidth: 1)
         }
-        .padding(.horizontal, Spacing.md)
+        .padding(.horizontal, Self.gutter)
         .padding(.top, Spacing.md)
         .padding(.bottom, Spacing.sm)
     }
@@ -165,8 +172,8 @@ struct NewThreadSheet: View {
             .font(.caption.weight(.semibold))
             .foregroundStyle(.secondary)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, Spacing.lg)
-            .padding(.top, Spacing.xs)
+            .padding(.horizontal, Self.gutter + Spacing.md)
+            .padding(.bottom, Spacing.xs)
             .accessibilityAddTraits(.isHeader)
     }
 
@@ -186,7 +193,8 @@ struct NewThreadSheet: View {
                     }
                 }
                 .scrollTargetLayout()
-                .padding(Spacing.xs)
+                .padding(.horizontal, Self.gutter)
+                .padding(.vertical, Spacing.xs)
             }
             .scrollPosition(id: $scrolledProject, anchor: .center)
             .onChange(of: selectedProject) { scrolledProject = selectedProject }
@@ -221,7 +229,7 @@ struct NewThreadSheet: View {
         .padding(.horizontal, Spacing.md)
         .frame(height: Self.rowHeight)
         .background {
-            RoundedRectangle(cornerRadius: Radius.control)
+            RoundedRectangle(cornerRadius: Radius.chip, style: .continuous)
                 .fill(isSelected ? Color.accentColor : .clear)
         }
         .contentShape(Rectangle())
@@ -239,7 +247,11 @@ struct NewThreadSheet: View {
 
     private var configurationRows: some View {
         VStack(alignment: .leading, spacing: Spacing.md) {
-            Grid(alignment: .topLeading, horizontalSpacing: Spacing.md, verticalSpacing: Spacing.md) {
+            Grid(
+                alignment: .leadingFirstTextBaseline,
+                horizontalSpacing: Spacing.md,
+                verticalSpacing: Spacing.lg
+            ) {
                 GridRow {
                     rowLabel("Agent")
                     VStack(alignment: .leading, spacing: Spacing.xs) {
@@ -277,15 +289,17 @@ struct NewThreadSheet: View {
                     .font(.callout)
             }
         }
-        .padding(Spacing.md)
+        .padding(.horizontal, Self.gutter)
+        .padding(.vertical, Spacing.lg)
     }
 
-    /// Fixed-width row labels keep the Agent and Directory cells aligned.
+    /// Fixed-width row labels keep the Agent and Directory cells aligned, and
+    /// trail toward the controls the way a macOS form's labels do. The Grid's
+    /// baseline alignment does the vertical work, so no nudging here.
     private func rowLabel(_ text: String) -> some View {
         Text(text)
             .foregroundStyle(.secondary)
-            .frame(width: 70, alignment: .leading)
-            .padding(.top, Spacing.xs)
+            .frame(width: 70, alignment: .trailing)
     }
 
     private func agentButton(_ agent: Agent, index: Int) -> some View {
@@ -293,23 +307,24 @@ struct NewThreadSheet: View {
         return Button {
             select(agent)
         } label: {
-            HStack(spacing: Spacing.xs) {
-                Image(systemName: agent.id.systemImage)
-                Text(agent.id.displayName)
+            HStack(spacing: Spacing.sm) {
+                // Label rather than a hand-spaced icon + Text: the system's
+                // own icon-to-title gap is what makes these read as one chip.
+                Label(agent.id.displayName, systemImage: agent.id.systemImage)
                 if let shortcut = shortcutLabel(at: index) {
                     Text(shortcut)
                         .font(.caption.monospaced().weight(.medium))
                         .foregroundStyle(isSelected ? .primary : .secondary)
                 }
             }
-            .padding(.horizontal, Spacing.sm)
-            .padding(.vertical, Spacing.xs)
+            .padding(.horizontal, Spacing.md)
+            .padding(.vertical, Spacing.sm)
             .background {
-                RoundedRectangle(cornerRadius: Radius.control)
+                RoundedRectangle(cornerRadius: Radius.chip, style: .continuous)
                     .fill(isSelected ? Color.accentColor.opacity(0.35) : Surface.chip)
             }
             .overlay {
-                RoundedRectangle(cornerRadius: Radius.control)
+                RoundedRectangle(cornerRadius: Radius.chip, style: .continuous)
                     .stroke(
                         isSelected ? Color.accentColor : Surface.chipBorder,
                         lineWidth: 1
@@ -318,7 +333,7 @@ struct NewThreadSheet: View {
         }
         .buttonStyle(.plain)
         .disabled(!agent.available)
-        .opacity(agent.available ? 1 : 0.5)
+        .opacity(agent.available ? 1 : Dimming.unavailable)
         .accessibilityLabel(agentAccessibilityLabel(agent, index: index))
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }

--- a/macos/ATC/Features/Threads/NewThreadSheet.swift
+++ b/macos/ATC/Features/Threads/NewThreadSheet.swift
@@ -26,6 +26,15 @@ struct NewThreadSheet: View {
         (1...9).map { KeyEquivalent(Character("\($0)")) }
     )
 
+    /// The results list shows exactly this many rows; more scroll within it.
+    private static let visibleRowCount = 6
+    private static let rowHeight: CGFloat = 32
+    private static let rowSpacing: CGFloat = 2
+    private static let resultsHeight: CGFloat =
+        rowHeight * CGFloat(visibleRowCount)
+        + rowSpacing * CGFloat(visibleRowCount - 1)
+        + Spacing.xs * 2
+
     @AppStorage("newThreadLastAgentId") private var lastAgentRaw = ""
 
     @State private var query = ""
@@ -57,18 +66,20 @@ struct NewThreadSheet: View {
             isBusy: isSubmitting,
             canSubmit: canSubmit,
             wrapsContentInForm: false,
+            showsHeader: false,
             onCancel: { windowState.newThreadContext = nil },
             onSubmit: { Task { await submit() } }
         ) {
             VStack(spacing: 0) {
                 searchField(rows: rows)
-                Divider()
+                resultsHeader
                 resultsList(rows: rows)
+                    .frame(height: Self.resultsHeight)
                 Divider()
                 configurationRows
             }
         }
-        .frame(width: 560, height: 500)
+        .frame(width: 560)
         .defaultFocus($searchIsFocused, true)
         // ⌘1…⌘9 select Agents, handled on the sheet rather than on the Agent
         // buttons so an unavailable Agent's shortcut still answers with
@@ -132,7 +143,31 @@ struct NewThreadSheet: View {
         }
         .font(.title3)
         .padding(.horizontal, Spacing.md)
-        .padding(.vertical, Spacing.md)
+        .padding(.vertical, Spacing.sm + 2)
+        .background(
+            Surface.chip,
+            in: RoundedRectangle(cornerRadius: Radius.chip, style: .continuous)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: Radius.chip, style: .continuous)
+                .stroke(Surface.chipBorder, lineWidth: 1)
+        }
+        .padding(.horizontal, Spacing.md)
+        .padding(.top, Spacing.md)
+        .padding(.bottom, Spacing.sm)
+    }
+
+    /// The list is alphabetical (context Project first), so the header says
+    /// what it shows rather than borrowing the mock's "Recent".
+    private var resultsHeader: some View {
+        Text(query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? "Projects" : "Results")
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, Spacing.lg)
+            .padding(.top, Spacing.xs)
+            .accessibilityAddTraits(.isHeader)
     }
 
     @ViewBuilder
@@ -144,7 +179,7 @@ struct NewThreadSheet: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
             ScrollView {
-                LazyVStack(spacing: 2) {
+                LazyVStack(spacing: Self.rowSpacing) {
                     ForEach(rows) { row in
                         resultRow(row)
                             .id(row.id)
@@ -161,25 +196,33 @@ struct NewThreadSheet: View {
     private func resultRow(_ row: NewThreadLauncherModel.Row) -> some View {
         let isSelected = selectedProject == row.id
         return HStack(spacing: Spacing.sm) {
+            StatusDot(reachability: appModel.reachability(of: row.id.connectionID))
             HighlightedText.title(row.option.project.name, ranges: row.nameRanges)
-                .font(.callout)
+                .font(.callout.weight(.medium))
+                .foregroundStyle(isSelected ? Color.white : Color.primary)
                 .lineLimit(1)
-            Spacer(minLength: Spacing.md)
-            Text(row.option.connectionName)
-                .font(.caption)
-                .foregroundStyle(.secondary)
+                .layoutPriority(1)
             Text(row.option.project.defaultWorkingDirectory)
                 .font(.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(isSelected ? Color.white.opacity(0.75) : Color.secondary)
                 .lineLimit(1)
                 .truncationMode(.middle)
-                .frame(maxWidth: 200, alignment: .trailing)
+            Spacer(minLength: Spacing.sm)
+            Text(row.option.connectionName)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(isSelected ? Color.white : Color.secondary)
+                .padding(.horizontal, Spacing.sm)
+                .padding(.vertical, 2)
+                .background(
+                    isSelected ? AnyShapeStyle(.white.opacity(0.2)) : AnyShapeStyle(Surface.raised),
+                    in: RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                )
         }
         .padding(.horizontal, Spacing.md)
-        .padding(.vertical, 7)
+        .frame(height: Self.rowHeight)
         .background {
             RoundedRectangle(cornerRadius: Radius.control)
-                .fill(isSelected ? Color.accentColor.opacity(0.65) : .clear)
+                .fill(isSelected ? Color.accentColor : .clear)
         }
         .contentShape(Rectangle())
         .onTapGesture { selectProject(row.id, in: [row]) }
@@ -263,12 +306,12 @@ struct NewThreadSheet: View {
             .padding(.vertical, Spacing.xs)
             .background {
                 RoundedRectangle(cornerRadius: Radius.control)
-                    .fill(isSelected ? Color.accentColor.opacity(0.35) : Color.primary.opacity(0.06))
+                    .fill(isSelected ? Color.accentColor.opacity(0.35) : Surface.chip)
             }
             .overlay {
                 RoundedRectangle(cornerRadius: Radius.control)
                     .stroke(
-                        isSelected ? Color.accentColor : Color.primary.opacity(0.12),
+                        isSelected ? Color.accentColor : Surface.chipBorder,
                         lineWidth: 1
                     )
             }

--- a/macos/ATC/Shared/DirectoryPickerSheet.swift
+++ b/macos/ATC/Shared/DirectoryPickerSheet.swift
@@ -1,4 +1,4 @@
-// Server-backed folder browser (ATC-151): Browse… always lists the server's
+// Server-backed folder browser (ATC-151): Choose… always lists the server's
 // filesystem through `GET /fs/list` on the selected Connection — loopback or
 // remote, one code path. Directories only, dotfolders excluded server-side;
 // the text field stays the escape hatch for hidden paths. Read-only: no New

--- a/macos/ATC/Shared/SheetScaffold.swift
+++ b/macos/ATC/Shared/SheetScaffold.swift
@@ -14,17 +14,22 @@ struct SheetScaffold<Content: View>: View {
     /// Grouped-Form content is the default; list-style sheets (the folder
     /// browser) pass false and lay out their own content edge-to-edge.
     var wrapsContentInForm = true
+    /// Search-first launchers hide the title header — their search field is
+    /// the visual anchor and the title would just push it down.
+    var showsHeader = true
     var onCancel: () -> Void
     var onSubmit: () -> Void
     @ViewBuilder var content: () -> Content
 
     var body: some View {
         VStack(spacing: 0) {
-            Label(title, systemImage: systemImage)
-                .font(.headline)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(Spacing.md)
-            Divider()
+            if showsHeader {
+                Label(title, systemImage: systemImage)
+                    .font(.headline)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(Spacing.md)
+                Divider()
+            }
             if wrapsContentInForm {
                 Form(content: content)
                     .formStyle(.grouped)

--- a/macos/ATC/Shared/WorkingDirectoryField.swift
+++ b/macos/ATC/Shared/WorkingDirectoryField.swift
@@ -7,7 +7,7 @@
 // `.checking` before the debounce, so a gate can never submit on a verdict
 // that belongs to an earlier value.
 //
-// Browse opens the server-backed DirectoryPickerSheet (`GET /fs/list`), so
+// Choose… opens the server-backed DirectoryPickerSheet (`GET /fs/list`), so
 // the browsed filesystem is the server's on every Connection — but
 // validation, never the picker, is what makes a path trustworthy.
 
@@ -52,7 +52,7 @@ struct WorkingDirectoryField: View {
         VStack(alignment: .leading, spacing: Spacing.xs) {
             HStack(spacing: Spacing.sm) {
                 textField
-                Button("Browse…") { isBrowsing = true }
+                Button("Choose…") { isBrowsing = true }
                     .disabled(client == nil)
             }
             if let message = statusMessage {


### PR DESCRIPTION
Purely visual work on the New Thread launcher, against a design comp. No logic, model, or contract changes — `NewThreadLauncherModel` and the submit path are untouched.

## What changed

**`NewThreadSheet.swift`** — the bulk of it:

- **Headerless.** The "New Thread" title bar is gone so the search field anchors the sheet, as in the comp.
- **One horizontal rhythm.** Each section had invented its own inset: the search field sat 12pt from the sheet edge, the row highlight 4pt, the section header 16pt — so a *selected* row was visibly wider than the search box above it. There's now a single documented `gutter` constant that every container uses, with content another `Spacing.md` inside it. The search icon, the section header, and the rows' status dots all land on the same 24pt column.
- **Search field** is an inset rounded field (`Surface.chip` + border) rather than a full-bleed row.
- **Result rows** gained a reachability `StatusDot`, the working directory beside the name, and the connection name as a trailing chip; selection is a solid accent fill with white text.
- **Six visible rows,** per the design note that six is the cap. The list is sized to exactly six and scrolls beyond that; sheet height is now intrinsic rather than a fixed 500pt.
- **Agent chips** were padded 8×4pt with a hand-spaced icon and label, which read as pinched. Now 12×8pt on `Radius.chip`, with the icon+title as a plain SwiftUI `Label` so the system's own icon-to-title gap applies. At 8pt vertical padding they come out ~32pt tall, matching the project row height.
- **Form labels** are trailing-aligned in their column, and the `Grid` uses `.leadingFirstTextBaseline` so labels align with their controls' text automatically — this replaced a hardcoded 4pt top nudge that would drift as soon as a control's height changed.
- Hardcoded `Color.primary.opacity(0.06)` / `0.12` and a literal `0.5` were swapped for the existing `Surface` and `Dimming` tokens.

**`SheetScaffold.swift`** — new `showsHeader` flag (defaults true) so search-first launchers can drop the title header. Every other sheet is unaffected.

**`WorkingDirectoryField.swift` / `DirectoryPickerSheet.swift`** — "Browse…" is now "Choose…", the HIG term for folder selection. This is the shared field, so it also changes the Create Project and New Terminal sheets.

## Reviewer notes

- **Two deliberate deviations from the comp.** The section header reads "Projects" (or "Results" while searching) rather than "Recent", because the list is alphabetical with the context project first — it is not recency-ordered, and labeling it "Recent" would be a lie. And the agent row shows only Codex and Claude Code, since those are the only two agents the contract defines; the comp's Gemini CLI and Aider don't exist in the repo.
- **The six-row height is fixed, not shrink-to-fit.** With fewer than six projects the list reserves the full height, leaving space below the rows. Sizing to `min(count, 6)` would close that but makes the sheet resize while you type, so it's left as-is pending a call on which feels better.
- No new design tokens were introduced; the `gutter` constant is local to this sheet and defined in terms of `Spacing.md`.

## Verification

- `mise run macos:test` — 256 tests in 29 suites pass.
- Built and driven in the running app: opened the sheet via ⌘N and confirmed the selected row's edges land exactly on the search field's, and that the search icon, header, and status dots share a left edge.
