### PR TITLE
Simple toolbar: leading Project: Name title in detail toolbar (ATC-159)

### DIFF
--- a/macos/ATC/RootView.swift
+++ b/macos/ATC/RootView.swift
@@ -33,9 +33,12 @@ struct RootView: View {
         .toolbar(removing: .title)
         .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
         .toolbar {
-            ToolbarItem(placement: .principal) {
+            // Plain text, not a control: hide the glass capsule the toolbar
+            // would otherwise draw behind the title.
+            ToolbarItem(placement: .navigation) {
                 contextTitle
             }
+            .sharedBackgroundVisibility(.hidden)
             // The design's exceptional-state surface: needs-input and
             // Connection-unreachable live here; healthy states show nothing.
             ToolbarItem(placement: .status) {
@@ -86,22 +89,27 @@ struct RootView: View {
                 .font(.headline)
         case .thread(let ref):
             if let thread = appModel.thread(for: ref) {
-                Label {
-                    Text("\(thread.displayName) · \(projectName(for: ref.connectionID, projectID: thread.projectId))")
-                        .font(.headline)
-                        .lineLimit(1)
-                } icon: {
-                    Image(systemName: thread.agentId.systemImage)
-                        .accessibilityLabel(thread.agentId.displayName)
-                }
+                titleText(
+                    project: projectName(for: ref.connectionID, projectID: thread.projectId),
+                    name: thread.displayName
+                )
             }
         case .terminal(let ref):
             if let terminal = appModel.terminal(for: ref) {
-                Label(terminal.displayName, systemImage: "terminal")
-                    .font(.headline)
-                    .lineLimit(1)
+                titleText(
+                    project: projectName(for: ref.connectionID, projectID: terminal.projectId),
+                    name: terminal.displayName
+                )
             }
         }
+    }
+
+    private func titleText(project: String, name: String) -> some View {
+        Text("\(Text("\(project):").fontWeight(.semibold)) \(name)")
+            .fontWeight(.regular)
+            .font(.headline)
+            .lineLimit(1)
+            .truncationMode(.tail)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

Implements [ATC-159](https://linear.app/elevenideas/issue/ATC-159/simple-toolbar): the detail-area toolbar title now identifies the visible content, left-aligned after the sidebar controls.

- Dashboard: `atc`
- Thread: `Project: Thread` — project semibold, name regular
- Standalone Terminal: `Project: Terminal` (terminals previously showed no project at all)

## Changes

Single file, `macos/ATC/RootView.swift`:

- Title `ToolbarItem` moved from `.principal` (centered) to `.navigation` (leading edge of the detail toolbar).
- `.sharedBackgroundVisibility(.hidden)` added to the title item: since it's now plain text rather than a control, this hides the Liquid Glass capsule the toolbar would otherwise draw behind it.
- `contextTitle` drops the agent/terminal icons and the old `Thread · Project` order; thread and terminal cases share one `titleText(project:name:)` helper rendering the semibold-prefix format with `lineLimit(1)` + tail truncation.
- Mixed weights use `Text` interpolation rather than `Text` `+` concatenation, which is deprecated on macOS 26.
- Raw project name only — no connection-name disambiguation, per the issue spec.
- Exceptional-status and Inspector toolbar items untouched.

## Testing

- `mise run macos:test` — 256 tests, 29 suites, all passing; no build warnings.
- Visual check of the new build was blocked by an already-running Xcode-attached debug instance (a second app instance won't present a window); the leading placement deserves a quick eyeball by the reviewer.

https://claude.ai/code/session_0148xR9pvLsjD7Fj9eAECrkM
