### PR TITLE
Unread indicator: Done for threads that finished while you weren't looking (ATC-160)

### DIFF
--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -939,6 +939,47 @@
         "description": "Unpin a thread (idempotent)."
       }
     },
+    "/api/v1/threads/{threadId}/viewed": {
+      "post": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "markThreadViewed",
+        "parameters": [
+          {
+            "name": "threadId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A durable Thread: the primary unit of agent work. Its ATC identity is separate from provider identity, and it never requires a Terminal.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Thread"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No thread exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadNotFoundJsonEncoding"
+                }
+              }
+            }
+          }
+        },
+        "description": "Mark the thread viewed, clearing `unread` for every client (the change is published to the event stream). Idempotent: a thread that is not unread is returned unchanged with nothing written or published, so clients may call this on every view."
+      }
+    },
     "/api/v1/threads/{threadId}/terminal": {
       "post": {
         "tags": [
@@ -1648,6 +1689,10 @@
           "activityState": {
             "$ref": "#/components/schemas/ThreadActivityState"
           },
+          "unread": {
+            "type": "boolean",
+            "description": "Server-derived: the thread finished a turn no client has viewed yet (markThreadViewed clears it). An orthogonal overlay on activityState — there is deliberately no completed activity state — and always false while archived. Clients render it directly and never re-derive it."
+          },
           "linkedTerminalId": {
             "type": "string",
             "description": "The thread's live TUI terminal, when one is open (derived; never required)."
@@ -1679,6 +1724,7 @@
           "agentId",
           "workingDirectory",
           "activityState",
+          "unread",
           "createdAt",
           "updatedAt"
         ],

--- a/app-server/src/api/contract.ts
+++ b/app-server/src/api/contract.ts
@@ -289,6 +289,12 @@ export const Thread = Schema.Struct({
     description: "Canonical directory the thread's agent session works in (immutable).",
   }),
   activityState: ThreadActivityState,
+  unread: Schema.Boolean.annotate({
+    description:
+      "Server-derived: the thread finished a turn no client has viewed yet (markThreadViewed clears it). " +
+      "An orthogonal overlay on activityState — there is deliberately no completed activity state — and always false while archived. " +
+      "Clients render it directly and never re-derive it.",
+  }),
   linkedTerminalId: Schema.optionalKey(
     Schema.String.annotate({
       description: "The thread's live TUI terminal, when one is open (derived; never required).",
@@ -791,6 +797,17 @@ export class V1 extends HttpApiGroup.make("v1")
     })
       .annotate(OpenApi.Identifier, "unpinThread")
       .annotate(OpenApi.Description, "Unpin a thread (idempotent)."),
+    HttpApiEndpoint.post("markThreadViewed", "/threads/:threadId/viewed", {
+      params: threadIdParam,
+      success: Thread,
+      error: ThreadNotFound,
+    })
+      .annotate(OpenApi.Identifier, "markThreadViewed")
+      .annotate(
+        OpenApi.Description,
+        "Mark the thread viewed, clearing `unread` for every client (the change is published to the event stream). " +
+          "Idempotent: a thread that is not unread is returned unchanged with nothing written or published, so clients may call this on every view.",
+      ),
     HttpApiEndpoint.delete("deleteThread", "/threads/:threadId", {
       params: threadIdParam,
       error: [ThreadNotFound, ZmxUnavailable],

--- a/app-server/src/api/handlers.ts
+++ b/app-server/src/api/handlers.ts
@@ -77,6 +77,7 @@ export const V1Handlers = HttpApiBuilder.group(
         .handle("unarchiveThread", ({ params }) => threads.unarchive(params.threadId))
         .handle("pinThread", ({ params }) => threads.pin(params.threadId))
         .handle("unpinThread", ({ params }) => threads.unpin(params.threadId))
+        .handle("markThreadViewed", ({ params }) => threads.markViewed(params.threadId))
         .handle("deleteThread", ({ params }) => threads.delete(params.threadId))
         .handle("openThreadTerminal", ({ params }) => threads.openTerminal(params.threadId))
         .handle("listAgents", () => agents.list())

--- a/app-server/src/platform/migrations.ts
+++ b/app-server/src/platform/migrations.ts
@@ -81,4 +81,12 @@ export const migrations: Record<string, Effect.Effect<void, unknown, SqlClient.S
     const sql = yield* SqlClient.SqlClient
     yield* sql`ALTER TABLE threads ADD COLUMN pinned_at TEXT`
   }),
+  // Unread overlay (ATC-160): `last_finished_at` is stamped at the observed
+  // busy→idle activity drop, `last_viewed_at` by markThreadViewed. Both NULL
+  // on existing rows, so rollout marks nothing unread.
+  "0005_thread_unread": Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+    yield* sql`ALTER TABLE threads ADD COLUMN last_finished_at TEXT`
+    yield* sql`ALTER TABLE threads ADD COLUMN last_viewed_at TEXT`
+  }),
 }

--- a/app-server/src/threads/threadRepository.ts
+++ b/app-server/src/threads/threadRepository.ts
@@ -125,8 +125,12 @@ export class ThreadRepository extends Context.Service<
      * re-stamps.
      */
     readonly markFinished: (id: string) => Effect.Effect<void>
-    /** Stamp the viewed marker; callers hold the record (see rename). */
-    readonly markViewed: (id: string) => Effect.Effect<ThreadRecord>
+    /**
+     * Stamp the viewed marker. None when the row vanished — clients stamp
+     * automatically on every view, so a view racing a delete is an
+     * expected condition (a typed 404), not a bug.
+     */
+    readonly markViewed: (id: string) => Effect.Effect<Option.Option<ThreadRecord>>
     /** Set or clear the pin marker; callers hold the record (see rename). */
     readonly setPinned: (id: string, pinned: boolean) => Effect.Effect<ThreadRecord>
     /** Set or clear the archive marker; callers hold the record (see rename). */
@@ -361,7 +365,7 @@ export const layer = Layer.effect(ThreadRepository)(
       markViewed: (id) =>
         Effect.suspend(() => markViewedRows({ id, viewed_at: new Date().toISOString() })).pipe(
           Effect.orDie,
-          Effect.flatMap(requireFirst("markViewed")),
+          Effect.map(firstRecord),
         ),
       setPinned: (id, pinned) =>
         Effect.suspend(() => {

--- a/app-server/src/threads/threadRepository.ts
+++ b/app-server/src/threads/threadRepository.ts
@@ -122,13 +122,15 @@ export class ThreadRepository extends Context.Service<
      * Stamp the turn-finished marker (an observed busy→idle drop). Tolerant
      * in the style of `confirm`: fed by the live status feed, which can race
      * a delete — a vanished row is a no-op. Unlike `confirm`, every finish
-     * re-stamps.
+     * re-stamps, and the stamp lands strictly after the current viewed
+     * stamp even inside one millisecond (see the marker SQL).
      */
     readonly markFinished: (id: string) => Effect.Effect<void>
     /**
-     * Stamp the viewed marker. None when the row vanished — clients stamp
-     * automatically on every view, so a view racing a delete is an
-     * expected condition (a typed 404), not a bug.
+     * Stamp the viewed marker, at or after the current finished stamp even
+     * inside one millisecond (see the marker SQL). None when the row
+     * vanished — clients stamp automatically on every view, so a view
+     * racing a delete is an expected condition (a typed 404), not a bug.
      */
     readonly markViewed: (id: string) => Effect.Effect<Option.Option<ThreadRecord>>
     /** Set or clear the pin marker; callers hold the record (see rename). */
@@ -232,12 +234,26 @@ export const layer = Layer.effect(ThreadRepository)(
       `,
     })
 
+    // The finish/viewed stamps are millisecond ISO strings, so two writes in
+    // the same millisecond would tie and `unread` (viewed < finished) would
+    // misread write order. Each writer therefore lands strictly ordered
+    // against the opposing stamp: a finish lands strictly after the current
+    // viewed stamp (bumped 1ms past it when the clock has not moved on), and
+    // a view lands at or after the current finish stamp. Write order — which
+    // the single connection serializes — decides unread, never clock
+    // resolution.
     const markFinishedRows = SqlSchema.void({
       Request: Schema.Struct({ id: Schema.String, finished_at: Schema.String }),
       execute: (patch) => sql`
         UPDATE threads SET
-          last_finished_at = ${patch.finished_at},
-          updated_at = ${patch.finished_at}
+          last_finished_at = MAX(
+            ${patch.finished_at},
+            COALESCE(strftime('%Y-%m-%dT%H:%M:%fZ', last_viewed_at, '+0.001 seconds'), '')
+          ),
+          updated_at = MAX(
+            ${patch.finished_at},
+            COALESCE(strftime('%Y-%m-%dT%H:%M:%fZ', last_viewed_at, '+0.001 seconds'), '')
+          )
         WHERE id = ${patch.id}
       `,
     })
@@ -247,8 +263,8 @@ export const layer = Layer.effect(ThreadRepository)(
       Result: ThreadRow,
       execute: (patch) => sql`
         UPDATE threads SET
-          last_viewed_at = ${patch.viewed_at},
-          updated_at = ${patch.viewed_at}
+          last_viewed_at = MAX(${patch.viewed_at}, COALESCE(last_finished_at, '')),
+          updated_at = MAX(${patch.viewed_at}, COALESCE(last_finished_at, ''))
         WHERE id = ${patch.id}
         RETURNING *
       `,

--- a/app-server/src/threads/threadRepository.ts
+++ b/app-server/src/threads/threadRepository.ts
@@ -26,6 +26,10 @@ export interface ThreadRecord {
   readonly confirmedAt?: string
   /** Opaque adapter-owned blob; the domain never reads inside it. */
   readonly providerMetadata?: string
+  /** Last observed busy→idle drop (the turn-finished stamp, ATC-160). */
+  readonly lastFinishedAt?: string
+  /** Last markThreadViewed stamp; unread derives from the two together. */
+  readonly lastViewedAt?: string
   readonly pinnedAt?: string
   readonly archivedAt?: string
   readonly createdAt: string
@@ -42,6 +46,8 @@ const ThreadRow = Schema.Struct({
   provider_session_id: Schema.NullOr(Schema.String),
   confirmed_at: Schema.NullOr(Schema.String),
   provider_metadata: Schema.NullOr(Schema.String),
+  last_finished_at: Schema.NullOr(Schema.String),
+  last_viewed_at: Schema.NullOr(Schema.String),
   pinned_at: Schema.NullOr(Schema.String),
   archived_at: Schema.NullOr(Schema.String),
   created_at: Schema.String,
@@ -57,6 +63,8 @@ const toRecord = (row: typeof ThreadRow.Type): ThreadRecord => ({
   ...(row.provider_session_id !== null ? { providerSessionId: row.provider_session_id } : {}),
   ...(row.confirmed_at !== null ? { confirmedAt: row.confirmed_at } : {}),
   ...(row.provider_metadata !== null ? { providerMetadata: row.provider_metadata } : {}),
+  ...(row.last_finished_at !== null ? { lastFinishedAt: row.last_finished_at } : {}),
+  ...(row.last_viewed_at !== null ? { lastViewedAt: row.last_viewed_at } : {}),
   ...(row.pinned_at !== null ? { pinnedAt: row.pinned_at } : {}),
   ...(row.archived_at !== null ? { archivedAt: row.archived_at } : {}),
   createdAt: row.created_at,
@@ -110,6 +118,15 @@ export class ThreadRepository extends Context.Service<
      * a vanished row is a no-op, and an existing marker is never rewritten.
      */
     readonly confirm: (id: string) => Effect.Effect<void>
+    /**
+     * Stamp the turn-finished marker (an observed busy→idle drop). Tolerant
+     * in the style of `confirm`: fed by the live status feed, which can race
+     * a delete — a vanished row is a no-op. Unlike `confirm`, every finish
+     * re-stamps.
+     */
+    readonly markFinished: (id: string) => Effect.Effect<void>
+    /** Stamp the viewed marker; callers hold the record (see rename). */
+    readonly markViewed: (id: string) => Effect.Effect<ThreadRecord>
     /** Set or clear the pin marker; callers hold the record (see rename). */
     readonly setPinned: (id: string, pinned: boolean) => Effect.Effect<ThreadRecord>
     /** Set or clear the archive marker; callers hold the record (see rename). */
@@ -211,6 +228,28 @@ export const layer = Layer.effect(ThreadRepository)(
       `,
     })
 
+    const markFinishedRows = SqlSchema.void({
+      Request: Schema.Struct({ id: Schema.String, finished_at: Schema.String }),
+      execute: (patch) => sql`
+        UPDATE threads SET
+          last_finished_at = ${patch.finished_at},
+          updated_at = ${patch.finished_at}
+        WHERE id = ${patch.id}
+      `,
+    })
+
+    const markViewedRows = SqlSchema.findAll({
+      Request: Schema.Struct({ id: Schema.String, viewed_at: Schema.String }),
+      Result: ThreadRow,
+      execute: (patch) => sql`
+        UPDATE threads SET
+          last_viewed_at = ${patch.viewed_at},
+          updated_at = ${patch.viewed_at}
+        WHERE id = ${patch.id}
+        RETURNING *
+      `,
+    })
+
     const setArchivedRows = SqlSchema.findAll({
       Request: Schema.Struct({
         id: Schema.String,
@@ -269,6 +308,8 @@ export const layer = Layer.effect(ThreadRepository)(
             provider_session_id: null,
             confirmed_at: null,
             provider_metadata: null,
+            last_finished_at: null,
+            last_viewed_at: null,
             pinned_at: null,
             archived_at: null,
             created_at: now,
@@ -312,6 +353,15 @@ export const layer = Layer.effect(ThreadRepository)(
       confirm: (id) =>
         Effect.suspend(() => confirmRows({ id, confirmed_at: new Date().toISOString() })).pipe(
           Effect.orDie,
+        ),
+      markFinished: (id) =>
+        Effect.suspend(() => markFinishedRows({ id, finished_at: new Date().toISOString() })).pipe(
+          Effect.orDie,
+        ),
+      markViewed: (id) =>
+        Effect.suspend(() => markViewedRows({ id, viewed_at: new Date().toISOString() })).pipe(
+          Effect.orDie,
+          Effect.flatMap(requireFirst("markViewed")),
         ),
       setPinned: (id, pinned) =>
         Effect.suspend(() => {

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -86,6 +86,11 @@ export type Thread = typeof ThreadSchema.Type
 //     worth protecting, and writing at onset (not busy→idle) keeps the
 //     marker across a restart or observer gap mid-first-turn — the same
 //     signal for every provider.
+//   - The unread overlay (ATC-160) is derived, never stored as a flag:
+//     last_finished_at is stamped at the observed busy→idle drop — the
+//     drain loop and the driver-gone re-derivation alike — last_viewed_at
+//     by markViewed, and archived rows are never unread. The activity
+//     vocabulary is untouched; "Done" is client-side display translation.
 //   - Auto-naming (ATC-155): the first user prompt observed on a thread
 //     that was unnamed AND unconfirmed when its subscription started forks
 //     one fire-and-forget title generation through the adapter seam. A
@@ -227,7 +232,9 @@ export const layerWith = (options: ThreadsOptions) =>
        * The unread overlay (ATC-160): a finish no client has viewed yet.
        * Server-derived so every client renders one boolean; the raw stamps
        * stay server-only (like confirmedAt). Archived rows are never unread
-       * — archive is a deliberate put-away, not something to surface.
+       * — archive is a deliberate put-away, not something to surface. The
+       * strict `<` breaks a same-millisecond finish/view tie toward "read":
+       * an indicator that under-fires once beats one that sticks.
        */
       const isUnread = (record: ThreadRecord): boolean =>
         record.archivedAt === undefined &&
@@ -381,16 +388,18 @@ export const layerWith = (options: ThreadsOptions) =>
        * from the adapter's reconciliation check — unless a live observation
        * whose feed outlives the TUI still covers the session (the
        * shared-server short-circuit below), in which case the feed is the
-       * evidence and no re-derivation is owed.
+       * evidence and no re-derivation is owed. Returns the record alongside
+       * the activity: a finish discovered here stamps the row, and the read
+       * that discovered it must itself present the refreshed state.
        */
       const resolveActivity = (
         record: ThreadRecord,
         linked: string | undefined,
-      ): Effect.Effect<AgentActivity> =>
+      ): Effect.Effect<{ readonly activity: AgentActivity; readonly record: ThreadRecord }> =>
         Effect.gen(function* () {
-          if (record.providerSessionId === undefined) return "idle"
+          if (record.providerSessionId === undefined) return { activity: "idle" as const, record }
           const live = liveActivity.get(record.id) ?? "unknown"
-          if (!isBusy(live) || linked !== undefined) return live
+          if (!isBusy(live) || linked !== undefined) return { activity: live, record }
           const adapter = adapterFor(record)
           // A live observation whose feed outlives the TUI (shared-server
           // providers) is already authoritative — it drives liveActivity —
@@ -403,7 +412,7 @@ export const layerWith = (options: ThreadsOptions) =>
             adapter?.observationOutlivesTui === true &&
             observed.get(record.id)?.providerSessionId === record.providerSessionId
           ) {
-            return live
+            return { activity: live, record }
           }
           const providerSessionId = record.providerSessionId
           const checked =
@@ -414,12 +423,19 @@ export const layerWith = (options: ThreadsOptions) =>
                   .pipe(Effect.orElseSucceed(() => "unknown" as const))
           liveActivity.set(record.id, checked)
           // A finish discovered on read stamps too (the busy snapshot was
-          // real evidence and the check says the turn is over). This read
-          // still returns the pre-stamp record; the publish below makes
-          // every client — this one included — refetch and see it unread.
-          if (checked === "idle") {
-            yield* repository.markFinished(record.id)
-          }
+          // real evidence and the check says the turn is over), and the
+          // record is re-read so the discovering response itself presents
+          // the thread unread — never a stale `unread: false` racing the
+          // publish-triggered refetch.
+          const current =
+            checked === "idle"
+              ? yield* repository
+                  .markFinished(record.id)
+                  .pipe(
+                    Effect.andThen(repository.get(record.id)),
+                    Effect.map(Option.getOrElse(() => record)),
+                  )
+              : record
           // Other subscribers must hear about the re-derived state too, not
           // just the client whose read triggered it. Loop-safe: the busy
           // snapshot is gone, so the next event-triggered read returns at
@@ -427,7 +443,7 @@ export const layerWith = (options: ThreadsOptions) =>
           if (checked !== live) {
             yield* events.publish({ resource: "thread", id: record.id, change: "updated" })
           }
-          return checked
+          return { activity: checked, record: current }
         })
 
       const toThread = (
@@ -480,8 +496,8 @@ export const layerWith = (options: ThreadsOptions) =>
           // confirm a session the thread no longer references — the open's
           // own ensureObserved covers the fresh identity.
           if (linked !== undefined && !opening.has(record.id)) yield* ensureObserved(record)
-          const activity = yield* resolveActivity(record, linked?.id)
-          return toThread(record, linked?.id, activity)
+          const resolved = yield* resolveActivity(record, linked?.id)
+          return toThread(resolved.record, linked?.id, resolved.activity)
         })
 
       /** `assemble` for single-record callers (one listing pass of its own). */
@@ -870,7 +886,7 @@ export const layerWith = (options: ThreadsOptions) =>
               }
               // Busy covers needs_input too: a turn parked on an approval is
               // still mid-turn.
-              if (isBusy(yield* resolveActivity(record, linked?.id))) {
+              if (isBusy((yield* resolveActivity(record, linked?.id)).activity)) {
                 return yield* Effect.fail(new ThreadBusy({ threadId: id }))
               }
               if (linked !== undefined) {
@@ -936,8 +952,13 @@ export const layerWith = (options: ThreadsOptions) =>
             // publish, so routine opens never trigger a fleet-wide refetch.
             if (!isUnread(record)) return yield* assembleAlone(record)
             const updated = yield* repository.markViewed(id)
+            // Clients stamp automatically, so a view racing a delete is an
+            // expected condition — the endpoint's typed 404, not a defect.
+            if (Option.isNone(updated)) {
+              return yield* Effect.fail(new ThreadNotFound({ threadId: id }))
+            }
             yield* events.publish({ resource: "thread", id, change: "updated" })
-            return yield* assembleAlone(updated)
+            return yield* assembleAlone(updated.value)
           }),
         delete: del,
         openTerminal,

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -233,8 +233,10 @@ export const layerWith = (options: ThreadsOptions) =>
        * Server-derived so every client renders one boolean; the raw stamps
        * stay server-only (like confirmedAt). Archived rows are never unread
        * — archive is a deliberate put-away, not something to surface. The
-       * strict `<` breaks a same-millisecond finish/view tie toward "read":
-       * an indicator that under-fires once beats one that sticks.
+       * strict `<` is exact, not a tie-break: the repository lands each
+       * stamp strictly ordered against the opposing one, so write order —
+       * never clock resolution — decides unread (a finish and a view in the
+       * same millisecond once made a later finish invisible forever).
        */
       const isUnread = (record: ThreadRecord): boolean =>
         record.archivedAt === undefined &&

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -153,6 +153,8 @@ export class Threads extends Context.Service<
     readonly pin: (id: string) => Effect.Effect<Thread, ThreadNotFound | ThreadArchived>
     /** Idempotent. */
     readonly unpin: (id: string) => Effect.Effect<Thread, ThreadNotFound>
+    /** Stamp the viewed marker, clearing `unread`; a no-op unless unread. */
+    readonly markViewed: (id: string) => Effect.Effect<Thread, ThreadNotFound>
     /** Kill the live linked terminal and release adapter resources, then
      * remove the record. */
     readonly delete: (id: string) => Effect.Effect<void, ThreadNotFound | ZmxUnavailable>
@@ -220,6 +222,17 @@ export const layerWith = (options: ThreadsOptions) =>
 
       const isBusy = (activity: AgentActivity): boolean =>
         activity === "working" || activity === "needs_input"
+
+      /**
+       * The unread overlay (ATC-160): a finish no client has viewed yet.
+       * Server-derived so every client renders one boolean; the raw stamps
+       * stay server-only (like confirmedAt). Archived rows are never unread
+       * — archive is a deliberate put-away, not something to surface.
+       */
+      const isUnread = (record: ThreadRecord): boolean =>
+        record.archivedAt === undefined &&
+        record.lastFinishedAt !== undefined &&
+        (record.lastViewedAt === undefined || record.lastViewedAt < record.lastFinishedAt)
 
       /**
        * The auto-naming transition (ATC-155): one title one-shot through
@@ -326,6 +339,12 @@ export const layerWith = (options: ThreadsOptions) =>
                     confirmed = true
                     yield* repository.confirm(record.id)
                   }
+                  // The busy→idle drop IS the turn-finished signal (ATC-160):
+                  // stamp before publishing so the refetch the event triggers
+                  // already sees the thread unread.
+                  if (previous !== undefined && isBusy(previous) && activity === "idle") {
+                    yield* repository.markFinished(record.id)
+                  }
                   // One publish covers both the activity transition and the
                   // confirm write above (which only happens on a transition).
                   if (previous !== activity) {
@@ -394,6 +413,13 @@ export const layerWith = (options: ThreadsOptions) =>
                   .checkSession({ providerSessionId })
                   .pipe(Effect.orElseSucceed(() => "unknown" as const))
           liveActivity.set(record.id, checked)
+          // A finish discovered on read stamps too (the busy snapshot was
+          // real evidence and the check says the turn is over). This read
+          // still returns the pre-stamp record; the publish below makes
+          // every client — this one included — refetch and see it unread.
+          if (checked === "idle") {
+            yield* repository.markFinished(record.id)
+          }
           // Other subscribers must hear about the re-derived state too, not
           // just the client whose read triggered it. Loop-safe: the busy
           // snapshot is gone, so the next event-triggered read returns at
@@ -417,6 +443,7 @@ export const layerWith = (options: ThreadsOptions) =>
         ...(record.name !== undefined ? { name: record.name } : {}),
         workingDirectory: record.workingDirectory,
         activityState,
+        unread: isUnread(record),
         ...(linkedTerminalId !== undefined ? { linkedTerminalId } : {}),
         ...(record.pinnedAt !== undefined ? { pinnedAt: record.pinnedAt } : {}),
         ...(record.archivedAt !== undefined ? { archivedAt: record.archivedAt } : {}),
@@ -898,6 +925,17 @@ export const layerWith = (options: ThreadsOptions) =>
             const record = yield* repository.require(id)
             if (record.pinnedAt === undefined) return yield* assembleAlone(record)
             const updated = yield* repository.setPinned(id, false)
+            yield* events.publish({ resource: "thread", id, change: "updated" })
+            return yield* assembleAlone(updated)
+          }),
+        markViewed: (id) =>
+          Effect.gen(function* () {
+            const record = yield* repository.require(id)
+            // The no-op guard is what lets clients stamp on EVERY view:
+            // an already-read thread costs no write and — crucially — no
+            // publish, so routine opens never trigger a fleet-wide refetch.
+            if (!isUnread(record)) return yield* assembleAlone(record)
+            const updated = yield* repository.markViewed(id)
             yield* events.publish({ resource: "thread", id, change: "updated" })
             return yield* assembleAlone(updated)
           }),

--- a/app-server/test/api/openapi.test.ts
+++ b/app-server/test/api/openapi.test.ts
@@ -178,6 +178,7 @@ describe("openapi document vs runtime", () => {
       "/api/v1/threads/{threadId}/unarchive",
       "/api/v1/threads/{threadId}/pin",
       "/api/v1/threads/{threadId}/unpin",
+      "/api/v1/threads/{threadId}/viewed",
       "/api/v1/threads/{threadId}/terminal",
       "/api/v1/agents",
       "/api/v1/agents/{agentId}",
@@ -438,6 +439,22 @@ describe("openapi document vs runtime", () => {
       assert.notProperty(restoredBody, "archivedAt")
       assert.deepStrictEqual(
         operation(`/api/v1/threads/{threadId}/unarchive`, "post").responses["200"]!.content[
+          "application/json"
+        ]!.schema,
+        { $ref: "#/components/schemas/Thread" },
+      )
+
+      // The viewed stamp rounds-trips the Thread schema too; on a thread
+      // with no finished turn it is a pure no-op with `unread: false`.
+      const viewed = yield* client.post(
+        `http://127.0.0.1/api/v1/threads/${createdBody.id}/viewed`,
+        { body: HttpBody.empty },
+      )
+      assert.strictEqual(viewed.status, 200)
+      const viewedBody = (yield* viewed.json) as Record<string, unknown>
+      assert.strictEqual(viewedBody["unread"], false)
+      assert.deepStrictEqual(
+        operation(`/api/v1/threads/{threadId}/viewed`, "post").responses["200"]!.content[
           "application/json"
         ]!.schema,
         { $ref: "#/components/schemas/Thread" },

--- a/app-server/test/threads/threadOpen.test.ts
+++ b/app-server/test/threads/threadOpen.test.ts
@@ -190,6 +190,69 @@ describe("threads.openTerminal", () => {
     }).pipe(Effect.provide(TestLayer)),
   )
 
+  it.live("the busy→idle drop marks the thread unread until viewed (ATC-160)", () =>
+    Effect.gen(function* () {
+      const { client, thread } = yield* setup
+      const repository = yield* ThreadRepository
+      yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+      const sessionId = Option.getOrThrow(yield* repository.get(thread.id)).providerSessionId ?? ""
+
+      // Mid-turn is never unread: unread marks a finish, not activity.
+      kit.fakeAgents.codex.emitActivity(sessionId, "working")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId: thread.id } }),
+        (t) => t.activityState === "working",
+      )
+      assert.isFalse((yield* client.v1.getThread({ params: { threadId: thread.id } })).unread)
+
+      // The drop stamps: the thread reads idle AND unread until viewed.
+      kit.fakeAgents.codex.emitActivity(sessionId, "idle")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId: thread.id } }),
+        (t) => t.activityState === "idle" && t.unread,
+      )
+
+      // Viewing clears it everywhere; repeating is a byte-identical no-op.
+      const viewed = yield* client.v1.markThreadViewed({ params: { threadId: thread.id } })
+      assert.isFalse(viewed.unread)
+      assert.deepStrictEqual(
+        yield* client.v1.markThreadViewed({ params: { threadId: thread.id } }),
+        viewed,
+      )
+
+      // The next turn re-arms the overlay.
+      kit.fakeAgents.codex.emitActivity(sessionId, "working")
+      kit.fakeAgents.codex.emitActivity(sessionId, "idle")
+      yield* eventually(client.v1.getThread({ params: { threadId: thread.id } }), (t) => t.unread)
+
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.live("an archived thread is never unread; unarchive resurfaces the pending finish", () =>
+    Effect.gen(function* () {
+      const { client, thread } = yield* setup
+      const repository = yield* ThreadRepository
+      const terminal = yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+      const sessionId = Option.getOrThrow(yield* repository.get(thread.id)).providerSessionId ?? ""
+      kit.fakeAgents.codex.emitActivity(sessionId, "working")
+      kit.fakeAgents.codex.emitActivity(sessionId, "idle")
+      yield* eventually(client.v1.getThread({ params: { threadId: thread.id } }), (t) => t.unread)
+
+      // Archive is a deliberate put-away: the archived row reads not-unread
+      // even though the finish was never viewed…
+      kit.fake.sessions.delete(sessionNameForTerminalId(terminal.id))
+      const archived = yield* client.v1.archiveThread({ params: { threadId: thread.id } })
+      assert.isFalse(archived.unread)
+
+      // …and unarchive resurfaces it: the result is still unseen.
+      const restored = yield* client.v1.unarchiveThread({ params: { threadId: thread.id } })
+      assert.isTrue(restored.unread)
+
+      yield* client.v1.deleteThread({ params: { threadId: thread.id } })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
   it.live("an unconfirmed session re-materializes with fresh identity on the next open", () =>
     Effect.gen(function* () {
       const { client, thread } = yield* setup
@@ -514,6 +577,8 @@ describe("threads.openTerminal", () => {
         client.v1.getThread({ params: { threadId: thread.id } }),
         (t) => t.linkedTerminalId === undefined && t.activityState === "idle",
       )
+      // A finish discovered on read stamps the unread overlay too.
+      yield* eventually(client.v1.getThread({ params: { threadId: thread.id } }), (t) => t.unread)
 
       kit.fakeAgents.codex.setCheckActivity(sessionId, null)
       yield* client.v1.deleteThread({ params: { threadId: thread.id } })

--- a/app-server/test/threads/threads.test.ts
+++ b/app-server/test/threads/threads.test.ts
@@ -61,6 +61,7 @@ describe("/api/v1/threads", () => {
       assert.strictEqual(created.agentId, "codex")
       assert.strictEqual(created.workingDirectory, realDir)
       assert.strictEqual(created.activityState, "idle")
+      assert.isFalse(created.unread)
       assert.isUndefined(created.name)
       assert.isUndefined(created.linkedTerminalId)
       assert.isUndefined(created.pinnedAt)
@@ -87,6 +88,13 @@ describe("/api/v1/threads", () => {
       ])
       assert.deepStrictEqual(
         yield* client.v1.getThread({ params: { threadId: created.id } }),
+        created,
+      )
+
+      // Viewing a thread that never finished a turn is a pure no-op —
+      // nothing written, updatedAt included.
+      assert.deepStrictEqual(
+        yield* client.v1.markThreadViewed({ params: { threadId: created.id } }),
         created,
       )
 
@@ -170,6 +178,7 @@ describe("/api/v1/threads", () => {
         client.v1.unarchiveThread({ params: { threadId: "missing" } }),
         client.v1.pinThread({ params: { threadId: "missing" } }),
         client.v1.unpinThread({ params: { threadId: "missing" } }),
+        client.v1.markThreadViewed({ params: { threadId: "missing" } }),
         client.v1.deleteThread({ params: { threadId: "missing" } }),
       ]
       for (const attempt of attempts) {

--- a/app-server/test/threads/threads.test.ts
+++ b/app-server/test/threads/threads.test.ts
@@ -1,6 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
 import { BunHttpServer } from "@effect/platform-bun"
-import { Effect, Layer } from "effect"
+import { Effect, Layer, Option } from "effect"
 import { HttpApiTest } from "effect/unstable/httpapi"
 import { mkdtempSync, realpathSync, rmSync, symlinkSync } from "node:fs"
 import { tmpdir } from "node:os"
@@ -186,6 +186,11 @@ describe("/api/v1/threads", () => {
         assert.strictEqual(error._tag, "ThreadNotFound")
         assert.strictEqual(error.threadId, "missing")
       }
+      // The viewed stamp racing a delete past the service's require is the
+      // expected condition the repository models as None (mapped to the 404
+      // above), never a defect.
+      const repository = yield* ThreadRepository
+      assert.isTrue(Option.isNone(yield* repository.markViewed("missing")))
     }).pipe(Effect.provide(TestLayer)),
   )
 

--- a/macos/ATC/AppModel.swift
+++ b/macos/ATC/AppModel.swift
@@ -13,6 +13,9 @@ struct WindowNavigationSnapshot: Equatable {
             let id: String
             let projectID: String
             let isArchived: Bool
+            /// In the snapshot so a finish landing under the displayed thread
+            /// re-runs reconciliation, which stamps it viewed (ATC-160).
+            let isUnread: Bool
         }
 
         struct TerminalRecord: Equatable {
@@ -227,7 +230,12 @@ final class AppModel {
                 threadsCurrent: runtime.threads.isResolved,
                 terminalsCurrent: runtime.terminals.isResolved,
                 threads: (runtime.threads.threads + runtime.threads.archivedThreads).map {
-                    .init(id: $0.id, projectID: $0.projectId, isArchived: $0.isArchived)
+                    .init(
+                        id: $0.id,
+                        projectID: $0.projectId,
+                        isArchived: $0.isArchived,
+                        isUnread: $0.unread
+                    )
                 },
                 terminals: runtime.terminals.terminals.map {
                     .init(id: $0.id, projectID: $0.projectId, threadID: $0.threadId, isLive: $0.isLive)
@@ -330,6 +338,14 @@ final class AppModel {
         let terminalRef = TerminalRef(connectionID: ref.connectionID, terminalID: terminal.id)
         attachIfNeeded(to: terminal, connectionID: ref.connectionID, retentionContext: retentionContext)
         return terminalRef
+    }
+
+    /// Stamps the thread viewed on the server; the merged response clears the
+    /// unread indicator everywhere (no optimistic write). Failures are
+    /// deliberately swallowed: the indicator simply stays until the next view.
+    func markThreadViewed(_ ref: ThreadRef) async {
+        guard let runtime = runtime(id: ref.connectionID) else { return }
+        _ = try? await runtime.threads.markViewed(id: ref.threadID)
     }
 
     /// Attaches a live terminal's controller, or reuses the retained one.

--- a/macos/ATC/AppServer/ServerModels.swift
+++ b/macos/ATC/AppServer/ServerModels.swift
@@ -41,6 +41,23 @@ extension ATCThread {
 
     var isArchived: Bool { archivedAt != nil }
     var isPinned: Bool { pinnedAt != nil }
+
+    /// An idle thread whose finish nobody viewed yet reads "Done" (ATC-160).
+    /// A display-only translation of `idle + unread` — the server vocabulary
+    /// has no completed state, and the server alone decides `unread`.
+    private var showsDone: Bool { activityState == .idle && unread }
+
+    /// Card status text; prefer these over the raw `activityState` labels so
+    /// the Done overlay applies uniformly.
+    var statusLabel: String? { showsDone ? "Done" : activityState.statusLabel }
+
+    /// The inspector's and toolbar's longer phrasing (see
+    /// `ThreadActivityState.detailLabel`).
+    var detailLabel: String { showsDone ? "Done" : activityState.detailLabel }
+
+    /// Done gets the app accent — deliberately distinct from Running green
+    /// and from Needs-you orange, so orange keeps its one meaning.
+    var statusColor: Color { showsDone ? .accentColor : activityState.statusColor }
 }
 
 extension ThreadActivityState {

--- a/macos/ATC/Features/Threads/ThreadCard.swift
+++ b/macos/ATC/Features/Threads/ThreadCard.swift
@@ -61,10 +61,10 @@ struct ThreadCard: View {
                             .truncationMode(.head)
                     }
                     Spacer(minLength: Spacing.sm)
-                    if let status = thread.activityState.statusLabel {
+                    if let status = thread.statusLabel {
                         Text(status)
                             .font(.caption.weight(.medium))
-                            .foregroundStyle(thread.activityState.statusColor)
+                            .foregroundStyle(thread.statusColor)
                     }
                     agentBadge
                 }

--- a/macos/ATC/Features/Threads/ThreadInspectorView.swift
+++ b/macos/ATC/Features/Threads/ThreadInspectorView.swift
@@ -22,7 +22,7 @@ struct ThreadInspectorView: View {
                         .font(.callout.monospaced())
                         .textSelection(.enabled)
                 }
-                LabeledContent("Activity", value: thread.activityState.detailLabel)
+                LabeledContent("Activity", value: thread.detailLabel)
             }
             Section {
                 LabeledContent("Created", value: thread.createdAt.formatted(date: .abbreviated, time: .shortened))

--- a/macos/ATC/Features/Threads/ThreadsStore.swift
+++ b/macos/ATC/Features/Threads/ThreadsStore.swift
@@ -118,6 +118,21 @@ final class ThreadsStore {
         return thread
     }
 
+    /// Stamps the thread viewed, clearing `unread` on every client. The
+    /// server treats an already-read thread as a pure no-op, so callers may
+    /// stamp on every view.
+    @discardableResult
+    func markViewed(id: String) async throws -> ATCThread {
+        let thread: ATCThread
+        switch try await client.markThreadViewed(path: .init(threadId: id)) {
+        case .ok(let ok): thread = try ok.body.json
+        case .notFound(let failure): throw ServerError(try failure.body.json)
+        case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
+        }
+        merge(thread)
+        return thread
+    }
+
     @discardableResult
     func archive(id: String) async throws -> ATCThread {
         let thread: ATCThread

--- a/macos/ATC/PreviewSupport/PreviewAppServerClient.swift
+++ b/macos/ATC/PreviewSupport/PreviewAppServerClient.swift
@@ -79,6 +79,7 @@ nonisolated struct PreviewAppServerClient: APIProtocol {
                 name: "Parser rewrite",
                 workingDirectory: Self.atelier.defaultWorkingDirectory,
                 activityState: .working,
+                unread: false,
                 linkedTerminalId: "0192f4c0-0000-7000-8000-000000000001",
                 pinnedAt: Date(timeIntervalSinceNow: -200_000),
                 createdAt: Date(timeIntervalSinceNow: -220_000),
@@ -91,6 +92,7 @@ nonisolated struct PreviewAppServerClient: APIProtocol {
                 name: "Flaky test triage",
                 workingDirectory: Self.atelier.defaultWorkingDirectory,
                 activityState: .needsInput,
+                unread: false,
                 createdAt: Date(timeIntervalSinceNow: -7_200),
                 updatedAt: Date(timeIntervalSinceNow: -120)
             ),
@@ -100,6 +102,8 @@ nonisolated struct PreviewAppServerClient: APIProtocol {
                 agentId: .codex,
                 workingDirectory: "/Users/dev/Projects/atelier/packages/core",
                 activityState: .idle,
+                // The Done card: finished while nobody was looking.
+                unread: true,
                 createdAt: Date(timeIntervalSinceNow: -20_000),
                 updatedAt: Date(timeIntervalSinceNow: -19_000)
             ),
@@ -110,6 +114,7 @@ nonisolated struct PreviewAppServerClient: APIProtocol {
                 name: "Spike: streaming uploads",
                 workingDirectory: Self.blazerr.defaultWorkingDirectory,
                 activityState: .idle,
+                unread: false,
                 createdAt: Date(timeIntervalSinceNow: -90_000),
                 updatedAt: Date(timeIntervalSinceNow: -86_400)
             ),
@@ -120,6 +125,7 @@ nonisolated struct PreviewAppServerClient: APIProtocol {
                 name: "Dependency bump",
                 workingDirectory: Self.blazerr.defaultWorkingDirectory,
                 activityState: .unknown,
+                unread: false,
                 createdAt: Date(timeIntervalSinceNow: -150_000),
                 updatedAt: Date(timeIntervalSinceNow: -140_000)
             ),
@@ -135,6 +141,7 @@ nonisolated struct PreviewAppServerClient: APIProtocol {
                 name: "Abandoned migration",
                 workingDirectory: Self.atelier.defaultWorkingDirectory,
                 activityState: .unknown,
+                unread: false,
                 archivedAt: Date(timeIntervalSinceNow: -40_000),
                 createdAt: Date(timeIntervalSinceNow: -500_000),
                 updatedAt: Date(timeIntervalSinceNow: -40_000)
@@ -333,6 +340,7 @@ nonisolated struct PreviewAppServerClient: APIProtocol {
             name: request.name,
             workingDirectory: request.workingDirectory ?? project.defaultWorkingDirectory,
             activityState: .unknown,
+            unread: false,
             createdAt: Date(),
             updatedAt: Date()
         ))))
@@ -376,6 +384,12 @@ nonisolated struct PreviewAppServerClient: APIProtocol {
     func unpinThread(_ input: Operations.UnpinThread.Input) async throws -> Operations.UnpinThread.Output {
         var thread = try thread(input.path.threadId)
         thread.pinnedAt = nil
+        return .ok(.init(body: .json(thread)))
+    }
+
+    func markThreadViewed(_ input: Operations.MarkThreadViewed.Input) async throws -> Operations.MarkThreadViewed.Output {
+        var thread = try thread(input.path.threadId)
+        thread.unread = false
         return .ok(.init(body: .json(thread)))
     }
 

--- a/macos/ATC/RootView.swift
+++ b/macos/ATC/RootView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct RootView: View {
     @Environment(AppModel.self) private var appModel
     @Environment(WindowState.self) private var windowState
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
         rootContent
@@ -67,6 +68,13 @@ struct RootView: View {
             windowState.requestTerminalFocus()
         }) { ref in
             NewTerminalSheet(projectRef: ref)
+        }
+        // Returning to the app with a freshly finished thread on screen
+        // counts as viewing it (ATC-160) — reconciliation only sees store
+        // changes, so activation needs its own hook.
+        .onChange(of: scenePhase) { _, phase in
+            guard phase == .active else { return }
+            windowState.markSelectedThreadViewedIfNeeded(in: appModel)
         }
     }
 

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -335,6 +335,10 @@ final class WindowState {
         Task {
             await appModel.markThreadViewed(ref)
             markingViewed.remove(ref)
+            // A finish that landed during the request re-armed unread while
+            // the dedup guard was refusing a second stamp — re-check so the
+            // displayed thread never sticks on "Done".
+            markSelectedThreadViewedIfNeeded(in: appModel)
         }
     }
 

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -1,3 +1,4 @@
+import AppKit
 import ATCAppServerAPI
 import SwiftUI
 import Observation
@@ -81,6 +82,14 @@ final class WindowState {
     /// Most recent failed open per thread, cleared on the next attempt.
     private(set) var threadOpenErrors: [ThreadRef: String] = [:]
 
+    /// Whether the app is frontmost — the seam tests override; production
+    /// asks AppKit. Viewing only counts when the user can actually see it.
+    @ObservationIgnored var isAppActive: () -> Bool = { NSApplication.shared.isActive }
+
+    /// Mark-viewed requests in flight, so a burst of reconciliations does
+    /// not re-stamp the same thread before the store merge lands.
+    @ObservationIgnored private var markingViewed: Set<ThreadRef> = []
+
     var isSheetPresented: Bool {
         isCreateProjectPresented || newThreadContext != nil || newTerminalProject != nil
     }
@@ -140,6 +149,10 @@ final class WindowState {
         activeProject = ProjectRef(connectionID: ref.connectionID, projectID: thread.projectId)
         threadOpenErrors[ref] = nil
         requestTerminalFocus()
+        // Opening is viewing (ATC-160). Guarded on the store's unread flag;
+        // a finish the store hasn't refreshed into yet is caught by
+        // reconciliation once it lands (markViewedIfDisplayed).
+        if thread.unread { markViewed(ref, in: appModel) }
 
         guard !openingThreads.contains(ref) else { return }
         openingThreads.insert(ref)
@@ -272,6 +285,7 @@ final class WindowState {
                 showDashboard()
                 return
             }
+            markViewedIfDisplayed(ref, thread: thread, in: appModel)
             reconcileThreadTerminal(ref, thread: thread, in: appModel)
         case .terminal(let ref):
             guard let runtime = appModel.runtime(id: ref.connectionID) else {
@@ -293,6 +307,34 @@ final class WindowState {
                     retentionContext: retentionContext
                 )
             }
+        }
+    }
+
+    /// App-activation hook (RootView's scenePhase): a finish that landed
+    /// while the app was backgrounded is on screen the moment the user
+    /// returns, so the displayed thread must not keep reading "Done".
+    func markSelectedThreadViewedIfNeeded(in appModel: AppModel) {
+        guard case .thread(let ref) = selectedContent,
+              let thread = appModel.thread(for: ref) else { return }
+        markViewedIfDisplayed(ref, thread: thread, in: appModel)
+    }
+
+    /// A finish that lands while its thread is already displayed in the
+    /// frontmost app was watched, not missed: stamp viewed immediately so
+    /// no "Done" flashes for a result the user saw happen (ATC-160).
+    private func markViewedIfDisplayed(_ ref: ThreadRef, thread: ATCThread, in appModel: AppModel) {
+        guard thread.unread, isAppActive() else { return }
+        markViewed(ref, in: appModel)
+    }
+
+    /// The one mark-viewed dispatch: deduplicates in-flight stamps. State
+    /// changes only through the store's merge of the server response.
+    private func markViewed(_ ref: ThreadRef, in appModel: AppModel) {
+        guard !markingViewed.contains(ref) else { return }
+        markingViewed.insert(ref)
+        Task {
+            await appModel.markThreadViewed(ref)
+            markingViewed.remove(ref)
         }
     }
 

--- a/macos/ATCTests/ScriptableAppServerClient.swift
+++ b/macos/ATCTests/ScriptableAppServerClient.swift
@@ -41,6 +41,7 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
         var listTerminalsCount = 0
         var listAgentsCount = 0
         var openThreadTerminalCount = 0
+        var markThreadViewedCount = 0
         /// Server-assigned timestamps advance a whole second per write, so
         /// ordering assertions never depend on wall-clock resolution. The base
         /// sits well after `Fixtures.epoch` so anything the server creates
@@ -159,6 +160,7 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     var listTerminalsCount: Int { lock.withLock { state.listTerminalsCount } }
     var listAgentsCount: Int { lock.withLock { state.listAgentsCount } }
     var openThreadTerminalCount: Int { lock.withLock { state.openThreadTerminalCount } }
+    var markThreadViewedCount: Int { lock.withLock { state.markThreadViewedCount } }
 
     // MARK: - Projects
 
@@ -353,6 +355,7 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
                 name: request.name,
                 workingDirectory: request.workingDirectory ?? project.defaultWorkingDirectory,
                 activityState: .idle,
+                unread: false,
                 createdAt: now,
                 updatedAt: now
             )
@@ -454,6 +457,25 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
                 model.threads[index].pinnedAt = now
             }
             model.threads[index].updatedAt = now
+            return .ok(.init(body: .json(model.threads[index])))
+        }
+    }
+
+    /// Idempotent per the contract: only an unread thread is written (and
+    /// timestamped); a read one comes back unchanged.
+    func markThreadViewed(_ input: Operations.MarkThreadViewed.Input) async throws
+        -> Operations.MarkThreadViewed.Output {
+        try await gate()
+        let id = input.path.threadId
+        return mutate { model -> Operations.MarkThreadViewed.Output in
+            model.markThreadViewedCount += 1
+            guard let index = model.threads.firstIndex(where: { $0.id == id }) else {
+                return .notFound(.init(body: .json(threadNotFound(id))))
+            }
+            if model.threads[index].unread {
+                model.threads[index].unread = false
+                model.threads[index].updatedAt = model.tick()
+            }
             return .ok(.init(body: .json(model.threads[index])))
         }
     }
@@ -657,6 +679,7 @@ enum Fixtures {
         name: String? = nil,
         workingDirectory: String = "/home/dev/app",
         activityState: ThreadActivityState = .idle,
+        unread: Bool = false,
         linkedTerminalId: String? = nil,
         pinnedAt: Date? = nil,
         archivedAt: Date? = nil,
@@ -669,6 +692,7 @@ enum Fixtures {
             name: name,
             workingDirectory: workingDirectory,
             activityState: activityState,
+            unread: unread,
             linkedTerminalId: linkedTerminalId,
             pinnedAt: pinnedAt,
             archivedAt: archivedAt,

--- a/macos/ATCTests/ThreadDisplayTests.swift
+++ b/macos/ATCTests/ThreadDisplayTests.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import Testing
+@testable import ATC
+
+/// The ATC-160 display translation: `idle + unread` reads "Done" in the
+/// accent color; every other combination defers to the activity labels. A
+/// display-only rule — the server vocabulary has no completed state.
+@Suite("Thread display translation")
+struct ThreadDisplayTests {
+    @Test("an idle unread thread reads Done in accent")
+    func doneOverlay() {
+        let done = Fixtures.thread(id: "t", activityState: .idle, unread: true)
+        #expect(done.statusLabel == "Done")
+        #expect(done.detailLabel == "Done")
+        #expect(done.statusColor == .accentColor)
+    }
+
+    @Test("a viewed idle thread fades back to Idle")
+    func viewedFadesBack() {
+        let idle = Fixtures.thread(id: "t", activityState: .idle, unread: false)
+        #expect(idle.statusLabel == "Idle")
+        #expect(idle.detailLabel == "Idle")
+        #expect(idle.statusColor == Color.secondary)
+    }
+
+    @Test("the overlay never rewrites a busy or unknown state")
+    func busyStatesUntouched() {
+        // Unread can be true mid-turn (an unviewed finish followed by a new
+        // prompt); the running state wins until the thread is idle again.
+        let working = Fixtures.thread(id: "t", activityState: .working, unread: true)
+        #expect(working.statusLabel == "Running")
+        #expect(working.statusColor == .green)
+
+        let needsInput = Fixtures.thread(id: "t", activityState: .needsInput, unread: true)
+        #expect(needsInput.statusLabel == "Needs you")
+        #expect(needsInput.statusColor == .orange)
+
+        let unknown = Fixtures.thread(id: "t", activityState: .unknown, unread: true)
+        #expect(unknown.statusLabel == nil)
+    }
+}

--- a/macos/ATCTests/ThreadsStoreTests.swift
+++ b/macos/ATCTests/ThreadsStoreTests.swift
@@ -133,6 +133,27 @@ struct ThreadsStoreTests {
         #expect(store.thread(id: "thr_archived") == nil)
     }
 
+    @Test("markViewed merges the server's cleared unread flag in place")
+    func markViewedMerges() async throws {
+        let client = ScriptableAppServerClient()
+        Fixtures.seed(client)
+        client.threads = client.threads.map { thread in
+            guard thread.id == "thr2" else { return thread }
+            var updated = thread
+            updated.unread = true
+            return updated
+        }
+        let store = ThreadsStore(client: client)
+        await store.refresh()
+        #expect(store.thread(id: "thr2")?.unread == true)
+
+        let viewed = try await store.markViewed(id: "thr2")
+        #expect(!viewed.unread)
+        #expect(store.thread(id: "thr2")?.unread == false)
+        // Merge keeps the creation ordering — viewing never reorders.
+        #expect(store.threads.map(\.id) == ["thr3", "thr2", "thr1"])
+    }
+
     @Test("create merges the new thread at the head of the active list")
     func createMerges() async throws {
         let (store, client) = await loadedStore()

--- a/macos/ATCTests/WindowStateTests.swift
+++ b/macos/ATCTests/WindowStateTests.swift
@@ -340,6 +340,95 @@ struct WindowStateTests {
         #expect(state.threadTerminals[ref] == nil)
     }
 
+    // MARK: - Unread (ATC-160)
+
+    /// Marks one seeded thread unread server-side, as a finish would.
+    private func setUnread(_ id: String, _ unread: Bool, on client: ScriptableAppServerClient) {
+        client.threads = client.threads.map { thread in
+            guard thread.id == id else { return thread }
+            var updated = thread
+            updated.unread = unread
+            return updated
+        }
+    }
+
+    @Test("opening an unread thread stamps it viewed")
+    func openingStampsViewed() async throws {
+        let client = ScriptableAppServerClient()
+        Fixtures.seed(client)
+        setUnread("thr1", true, on: client)
+        let test = try await makeModel(client: client)
+        await test.runtime.refresh()
+        let state = WindowState()
+        let ref = test.threadRef("thr1")
+
+        await state.openThread(ref, in: test.model)
+        // The stamp merges the server's answer back into the store.
+        await settle(until: { test.model.thread(for: ref)?.unread == false })
+        #expect(client.markThreadViewedCount == 1)
+        // A read thread costs nothing: re-opening never stamps again.
+        await state.openThread(ref, in: test.model)
+        #expect(client.markThreadViewedCount == 1)
+    }
+
+    @Test("a finish landing under the displayed frontmost thread is stamped viewed")
+    func finishWhileWatchingIsViewed() async throws {
+        let client = ScriptableAppServerClient()
+        let test = try await loadedModel(client)
+        let state = WindowState()
+        state.isAppActive = { true }
+        let ref = test.threadRef("thr1")
+        await state.openThread(ref, in: test.model)
+        #expect(client.markThreadViewedCount == 0)
+
+        // The turn finishes while the user is watching: the refresh lands
+        // unread, and reconciliation stamps it before any "Done" flash.
+        setUnread("thr1", true, on: client)
+        await test.runtime.refresh()
+        state.reconcile(in: test.model)
+        await settle(until: { client.threads.first { $0.id == "thr1" }?.unread == false })
+        #expect(client.markThreadViewedCount == 1)
+    }
+
+    @Test("a finish while the app is in the background stays unread")
+    func backgroundFinishStaysUnread() async throws {
+        let client = ScriptableAppServerClient()
+        let test = try await loadedModel(client)
+        let state = WindowState()
+        state.isAppActive = { false }
+        let ref = test.threadRef("thr1")
+        await state.openThread(ref, in: test.model)
+
+        setUnread("thr1", true, on: client)
+        await test.runtime.refresh()
+        state.reconcile(in: test.model)
+        #expect(client.markThreadViewedCount == 0)
+        #expect(test.model.thread(for: ref)?.unread == true)
+
+        // Returning to the app with the result on screen counts as viewing
+        // (the RootView scenePhase hook calls exactly this).
+        state.isAppActive = { true }
+        state.markSelectedThreadViewedIfNeeded(in: test.model)
+        await settle(until: { client.threads.first { $0.id == "thr1" }?.unread == false })
+        #expect(client.markThreadViewedCount == 1)
+    }
+
+    @Test("a finish on an unselected thread is never stamped")
+    func unselectedThreadStaysUnread() async throws {
+        let client = ScriptableAppServerClient()
+        let test = try await loadedModel(client)
+        let state = WindowState()
+        state.isAppActive = { true }
+        await state.openThread(test.threadRef("thr1"), in: test.model)
+
+        setUnread("thr2", true, on: client)
+        await test.runtime.refresh()
+        state.reconcile(in: test.model)
+        state.markSelectedThreadViewedIfNeeded(in: test.model)
+        #expect(client.markThreadViewedCount == 0)
+        #expect(test.model.thread(for: test.threadRef("thr2"))?.unread == true)
+    }
+
     // MARK: - Chrome
 
     @Test("toggleSidebar flips between the full layout and detail-only")

--- a/packages/ATCKit/Tests/ATCAppServerAPITests/ClientTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerAPITests/ClientTests.swift
@@ -164,7 +164,7 @@ struct ClientTests {
     @Test("pinThread decodes pinnedAt as a date")
     func pinThread() async throws {
         let (client, recorder) = try client(
-            returning: #"{"id":"t1","projectId":"p1","agentId":"codex","workingDirectory":"/code/atc","activityState":"idle","pinnedAt":"2026-08-06T12:34:56.789Z","createdAt":"2026-08-06T12:00:00.000Z","updatedAt":"2026-08-06T12:34:56.789Z"}"#
+            returning: #"{"id":"t1","projectId":"p1","agentId":"codex","workingDirectory":"/code/atc","activityState":"idle","unread":false,"pinnedAt":"2026-08-06T12:34:56.789Z","createdAt":"2026-08-06T12:00:00.000Z","updatedAt":"2026-08-06T12:34:56.789Z"}"#
         )
         let thread = try await client.pinThread(path: .init(threadId: "t1")).ok.body.json
         #expect(thread.pinnedAt == Date(timeIntervalSince1970: 1_786_019_696.789))


### PR DESCRIPTION
Implements [ATC-160](https://linear.app/elevenideas/issue/ATC-160/unread-indicator-show-when-a-thread-finished-while-you-werent-looking): a seen/unseen overlay so freshly finished threads stand out until viewed, with no change to the activity vocabulary.

## Server

- **Migration `0005_thread_unread`**: `last_finished_at` + `last_viewed_at` on `threads`; NULL on existing rows, so rollout lights nothing up.
- **Finish stamp** at the observed busy→idle activity drop — in the `ensureObserved` drain loop and in the `resolveActivity` driver-gone re-derivation alike (a finish discovered on read stamps too, and that read re-fetches the record so its own response already presents `unread: true`).
- **Contract**: `Thread` gains server-computed `unread: boolean` (never unread while archived; raw stamps stay server-only, like `confirmedAt`). New operation `markThreadViewed` — `POST /threads/:threadId/viewed` → `Thread` — publishes `thread/updated` so other clients clear live. Idempotent: not-unread threads are returned unchanged with nothing written or published, so clients may stamp on every view.

## macOS

- Display rule in `ServerModels`: `idle + unread` renders **Done** in the accent color (distinct from Running green and Needs-you orange); viewed threads fade back to gray Idle. Card and inspector both use the thread-level labels.
- Mark-viewed triggers: opening a thread; a finish arriving for the displayed thread while the app is frontmost (via the window-reconciliation snapshot, which now carries unread); and app activation with the thread displayed (scenePhase hook) — no Done flash for a result you were watching. Responses merge per the store's no-optimistic-writes rule.
- No sidebar reordering, no notifications, no mark-unread action (per the issue's non-goals).

## Review

Codex (Sol, high reasoning) reviewed the full diff; applied: fresh-record response on the re-derived finish path, typed 404 when a viewed stamp races a delete, and a post-completion re-check in the mark-viewed dispatch. Declined a monotonic-revision scheme for same-millisecond stamp ties — the strict `<` deliberately breaks ties toward "read" and is documented.

## Tests

- Server: busy→idle stamps + viewed clearing + re-arm, archived-never-unread + unarchive resurfacing, re-derivation stamping, viewed no-op byte-identity, 404 coverage, OpenAPI path/wire coverage (`app-server check` green, 339 tests).
- macOS: display translation unit tests, store merge test, WindowState trigger tests incl. background/foreground and unselected-thread negatives (`macos:test` green, 268 tests; `kit:test` green).

https://claude.ai/code/session_01UgZEkoXXbj7hZ7Wn1NDfzC