### PR TITLE
Test infra: survive the freePort claim race when spawning black-box servers

### DIFF
--- a/app-server/test/blackbox.ts
+++ b/app-server/test/blackbox.ts
@@ -100,8 +100,11 @@ export const runCli = async (
 }
 
 // Bind-then-release to pick a port for the child. Racy in principle (another
-// process could grab it in between), but --port 0 is deliberately rejected by
-// validation, so this is the practical option; stderr is surfaced on failure.
+// process could grab it in between — Linux hands the just-released port to
+// the next bind(0) LIFO, so concurrent spawns make the race real, not
+// theoretical), but --port 0 is deliberately rejected by validation, so this
+// is the practical option. Spawns that must survive the race go through
+// `spawnServeHealthy`, which retries on a fresh pick when the child loses.
 export const freePort = async (): Promise<number> => {
   const probe = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response("") })
   const port = probe.port!
@@ -141,17 +144,60 @@ export const rawStatus = (
     }).catch(reject)
   })
 
+/** The spawned server exited before answering healthy — the shape a lost
+ * freePort claim race leaves behind (`spawnServeHealthy` retries on it). */
+export class ServerExitedError extends Error {}
+
 export const waitForHealth = async (base: string, proc: Bun.Subprocess): Promise<Response> => {
   for (let attempt = 0; attempt < 100; attempt++) {
-    try {
-      return await fetch(`${base}/api/v1/health`)
-    } catch {
-      await Bun.sleep(50)
+    // A child that died can never become healthy — and another process may
+    // already answer on its port (the freePort claim race), so waiting
+    // longer would end with a stranger's response. Fail fast with the
+    // child's own diagnostic.
+    if (proc.exitCode !== null || proc.signalCode !== null) {
+      const stderr = await new Response(proc.stderr as ReadableStream).text()
+      throw new ServerExitedError(
+        `server at ${base} exited before becoming healthy; stderr:\n${stderr}`,
+      )
     }
+    try {
+      // Only OUR healthy server returns 2xx here; an interloper on a stolen
+      // port answers 404 and must read as "not up yet", never as the result.
+      const response = await fetch(`${base}/api/v1/health`)
+      if (response.ok) return response
+    } catch {
+      // Not accepting connections yet.
+    }
+    await Bun.sleep(50)
   }
   proc.kill()
   const stderr = await new Response(proc.stderr as ReadableStream).text()
   throw new Error(`server at ${base} never became healthy; stderr:\n${stderr}`)
+}
+
+/**
+ * Pick a free port, spawn a server on it via `spawn`, and wait until that
+ * child answers healthy. A child that exits instead (it lost the freePort
+ * claim race to a concurrent spawn) is respawned on a fresh pick; a child
+ * that hangs without dying is a real bug and fails immediately.
+ */
+export const spawnServeHealthy = async (
+  spawn: (port: number) => Bun.Subprocess,
+  attempts = 3,
+): Promise<{ proc: Bun.Subprocess; port: number; base: string; health: Response }> => {
+  for (let attempt = 0; ; attempt++) {
+    const port = await freePort()
+    const proc = spawn(port)
+    const base = `http://127.0.0.1:${port}`
+    try {
+      const health = await waitForHealth(base, proc)
+      return { proc, port, base, health }
+    } catch (error) {
+      proc.kill()
+      await proc.exited
+      if (!(error instanceof ServerExitedError) || attempt >= attempts - 1) throw error
+    }
+  }
 }
 
 /** POST a JSON body and return the decoded JSON response (asserting 2xx). */

--- a/app-server/test/cli/serve.blackbox.test.ts
+++ b/app-server/test/cli/serve.blackbox.test.ts
@@ -5,12 +5,11 @@ import { afterAll, describe, expect, test } from "vitest"
 import {
   appServerRoot,
   cleanupTempDirs,
-  freePort,
   isolatedEnv,
   rawStatus,
   runCli,
   spawnServe,
-  waitForHealth,
+  spawnServeHealthy,
 } from "../blackbox.ts"
 import { makeFakeZmxSandbox } from "../testLayers.ts"
 
@@ -40,12 +39,15 @@ describe("atc serve (black box)", () => {
   test.each(["SIGTERM", "SIGINT"] as const)(
     "serves both endpoints and shuts down cleanly on %s",
     async (signal) => {
-      const port = await freePort()
-      const base = `http://127.0.0.1:${port}`
-      const env = serveEnv()
-      const proc = spawnFromSource(port, env)
+      // The env is rebuilt per spawn attempt: each serveEnv() allocates a
+      // fresh state home, and the log assertion below must read the one the
+      // surviving server actually wrote to.
+      let env!: ReturnType<typeof serveEnv>
+      const { proc, port, base, health } = await spawnServeHealthy((attemptPort) => {
+        env = serveEnv()
+        return spawnFromSource(attemptPort, env)
+      })
       try {
-        const health = await waitForHealth(base, proc)
         expect(health.status).toBe(200)
         expect(await health.json()).toEqual({ status: "ok" })
 
@@ -92,12 +94,12 @@ describe("atc serve (black box)", () => {
   // (`tailscale serve` preserves the incoming Host) and a DNS-rebinding
   // attempt present, so the token is required for it by design.
   test("generates the auth token on start and enforces rotation live", async () => {
-    const port = await freePort()
-    const env = serveEnv()
-    const proc = spawnFromSource(port, env)
+    let env!: ReturnType<typeof serveEnv>
+    const { proc, port } = await spawnServeHealthy((attemptPort) => {
+      env = serveEnv()
+      return spawnFromSource(attemptPort, env)
+    })
     try {
-      await waitForHealth(`http://127.0.0.1:${port}`, proc)
-
       const tokenFile = `${env.XDG_DATA_HOME}/atc/auth-token`
       expect(statSync(tokenFile).mode & 0o777).toBe(0o600)
       const token = readFileSync(tokenFile, "utf8").trim()
@@ -128,16 +130,44 @@ describe("atc serve (black box)", () => {
   // answers (0.0.0.0 includes it), so local clients keep working. Exercises
   // the serve.ts flag-resolution path end to end.
   test("serves over loopback when bound to 0.0.0.0 via --bind", async () => {
-    const port = await freePort()
-    const base = `http://127.0.0.1:${port}`
-    const proc = Bun.spawn(
-      [process.execPath, "src/main.ts", "serve", "--port", String(port), "--bind", "0.0.0.0"],
-      { cwd: appServerRoot, env: serveEnv(), stdout: "pipe", stderr: "pipe" },
+    const { proc, health } = await spawnServeHealthy((attemptPort) =>
+      Bun.spawn(
+        [
+          process.execPath,
+          "src/main.ts",
+          "serve",
+          "--port",
+          String(attemptPort),
+          "--bind",
+          "0.0.0.0",
+        ],
+        { cwd: appServerRoot, env: serveEnv(), stdout: "pipe", stderr: "pipe" },
+      ),
     )
     try {
-      const health = await waitForHealth(base, proc)
       expect(health.status).toBe(200)
       expect(await health.json()).toEqual({ status: "ok" })
+    } finally {
+      proc.kill()
+      await proc.exited
+    }
+  }, 30_000)
+
+  // The freePort claim race, deterministically: a first child that dies at
+  // startup (as one that lost its port does) costs a retry on a fresh pick,
+  // not the test.
+  test("spawnServeHealthy respawns when the child exits before becoming healthy", async () => {
+    let attempts = 0
+    const { proc, health } = await spawnServeHealthy((port) => {
+      attempts++
+      if (attempts === 1) {
+        return Bun.spawn(["sh", "-c", "exit 1"], { stdout: "pipe", stderr: "pipe" })
+      }
+      return spawnFromSource(port, serveEnv())
+    })
+    try {
+      expect(attempts).toBe(2)
+      expect(health.status).toBe(200)
     } finally {
       proc.kill()
       await proc.exited

--- a/app-server/test/compiled.blackbox.test.ts
+++ b/app-server/test/compiled.blackbox.test.ts
@@ -5,10 +5,10 @@ import { join } from "node:path"
 import { describe, expect, test } from "vitest"
 import {
   compiledBinaryPath,
-  freePort,
   isolatedEnv,
   runCli,
   spawnServe,
+  spawnServeHealthy,
   waitForHealth,
 } from "./blackbox.ts"
 
@@ -36,13 +36,18 @@ describe.skipIf(!enabled)("compiled atc artifact (opt-in: mise run test:compiled
     // compiled behavior must depend on neither the working directory nor the
     // developer's real config/data/state.
     const outsideCwd = mkdtempSync(join(tmpdir(), "atc-compiled-"))
-    const port = await freePort()
-    const env = isolatedEnv(outsideCwd, { ATC_PORT: String(port) })
-    const base = `http://127.0.0.1:${port}`
+    // The env is rebuilt per spawn attempt: it carries the port, and each
+    // isolatedEnv call allocates a fresh state home, which must be the one
+    // the surviving server actually used.
+    let env!: ReturnType<typeof isolatedEnv>
+    const first = await spawnServeHealthy((attemptPort) => {
+      env = isolatedEnv(outsideCwd, { ATC_PORT: String(attemptPort) })
+      return spawnServe([compiledBinaryPath], attemptPort, outsideCwd, env)
+    })
+    const { port, base, health } = first
     const dbFile = join(outsideCwd, "data", "atc", "atc.db")
-    let proc = spawnServe([compiledBinaryPath], port, outsideCwd, env)
+    let proc = first.proc
     try {
-      const health = await waitForHealth(base, proc)
       expect(health.status).toBe(200)
       expect(await health.json()).toEqual({ status: "ok" })
 

--- a/app-server/test/terminals/zmxRecovery.blackbox.test.ts
+++ b/app-server/test/terminals/zmxRecovery.blackbox.test.ts
@@ -5,11 +5,11 @@ import { afterAll, describe, expect, test } from "vitest"
 import { sessionNameForTerminalId } from "../../src/terminals/terminalAdapter.ts"
 import {
   compiledBinaryPath,
-  freePort,
   isolatedEnv,
   makeTerminal,
   openSocket,
   spawnServe,
+  spawnServeHealthy,
   waitForHealth,
   waitUntil,
 } from "../blackbox.ts"
@@ -38,14 +38,19 @@ describe.skipIf(!enabled)("terminal restart recovery (compiled, real zmx)", () =
     ).toBe(true)
     expect(Bun.which("zmx"), "zmx not found on PATH").not.toBeNull()
 
-    const port = await freePort()
-    const env = isolatedEnv(scratch, { ATC_PORT: String(port) })
+    // The env is rebuilt per spawn attempt: it carries the port, and each
+    // isolatedEnv call allocates a fresh state home, which must be the one
+    // the surviving server actually used.
+    let env!: ReturnType<typeof isolatedEnv>
+    const first = await spawnServeHealthy((attemptPort) => {
+      env = isolatedEnv(scratch, { ATC_PORT: String(attemptPort) })
+      return spawnServe([compiledBinaryPath], attemptPort, scratch, env)
+    })
+    const { port, base } = first
     const socketDir = join(env.XDG_STATE_HOME, "atc", "terminals")
-    const base = `http://127.0.0.1:${port}`
 
-    let server = spawnServe([compiledBinaryPath], port, scratch, env)
+    let server = first.proc
     try {
-      await waitForHealth(base, server)
       const terminal = await makeTerminal(base)
       const sessionName = sessionNameForTerminalId(terminal["id"] ?? "")
       expect(zmxList(socketDir)).toContain(sessionName)

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -28,11 +28,10 @@ import * as Zmx from "../src/terminals/zmxAdapter.ts"
 import { V1Handlers } from "../src/api/handlers.ts"
 import {
   appServerRoot,
-  freePort,
   isolatedEnv,
   spawnServe,
+  spawnServeHealthy,
   trackTempDir,
-  waitForHealth,
 } from "./blackbox.ts"
 import { TestBuildInfoLayer } from "./testBuildInfo.ts"
 import { makeFakeAdapter } from "./terminals/fakeTerminalAdapter.ts"
@@ -202,15 +201,19 @@ const fakeZmxFixture = fileURLToPath(new URL("fixtures/fake-zmx.ts", import.meta
  */
 export const startFakeZmxServer = async (extraEnv: Record<string, string> = {}) => {
   const sandbox = makeFakeZmxSandbox()
-  const port = await freePort()
-  const env = isolatedEnv(sandbox.base, {
-    ATC_PORT: String(port),
-    ATC_ZMX_EXECUTABLE: sandbox.wrapper,
-    ...extraEnv,
+  // The env is rebuilt per attempt: it carries the port, and each isolatedEnv
+  // call allocates a fresh state home, which must be the one the surviving
+  // server actually used.
+  let env: ReturnType<typeof isolatedEnv>
+  const { proc, port, base } = await spawnServeHealthy((attemptPort) => {
+    env = isolatedEnv(sandbox.base, {
+      ATC_PORT: String(attemptPort),
+      ATC_ZMX_EXECUTABLE: sandbox.wrapper,
+      ...extraEnv,
+    })
+    return spawnServe([process.execPath, "src/main.ts"], attemptPort, appServerRoot, env)
   })
-  const proc = spawnServe([process.execPath, "src/main.ts"], port, appServerRoot, env)
-  await waitForHealth(`http://127.0.0.1:${port}`, proc)
-  return { base: `http://127.0.0.1:${port}`, port, proc, sandbox, env }
+  return { base, port, proc, sandbox, env: env! }
 }
 
 /** Run `use` against a fake-zmx `atc serve`, always reaping the process. */


### PR DESCRIPTION
## Problem

App Server CI has been failing intermittently on the Linux legs only — a *different* black-box test each run (`serve.blackbox`, `terminalAttach`), always with a spurious 404 from the spawned `atc` server (health 404, `POST /api/v1/projects` "404 not found", 403-expected-got-404). It took PR #173 five reruns to go green, and the same signature hit the ATC-174 branch on 2026-08-11.

## Mechanism

`freePort()` picks ports bind-then-release. Linux hands the just-released ephemeral port to the next `bind(0)` LIFO, so a concurrent spawn — e.g. a detached codex app-server fixture respawn (`codexServer.ts` picks ports the same way) — can steal the pick before the `atc` child binds. The child exits with its friendly port-taken diagnostic, and `waitForHealth` returned the **first** response of any status from whatever process answers on the port, so tests silently asserted against the interloper's 404s. macOS randomizes ephemeral ports, which is why only the Linux legs flaked.

## Fix

- `waitForHealth` fails fast with the child's own stderr once the child exits (typed `ServerExitedError`), and treats non-2xx as "not up yet" instead of returning a stranger's response.
- New `spawnServeHealthy`: pick port → spawn → wait healthy; when the child *died* (the lost-race shape) it respawns on a fresh pick, bounded at 3 attempts. A child that hangs without dying still fails immediately — real startup bugs are not masked, and every failure now carries the child's actual diagnostic instead of a mystery 404.
- Converted the initial-spawn call sites (`serve.blackbox`, `startFakeZmxServer`, `compiled.blackbox`, `zmxRecovery.blackbox`). Deliberate same-port respawns in the restart-recovery tests and the intentional port-taken test are untouched.
- One deterministic regression test for the retry path (first child exits at startup → one respawn, healthy result).

## Verification

- `mise run -C app-server check` — 338 passed.
- `mise run -C app-server test:compiled` and `test:zmx` — green (both opt-in suites touch converted call sites).
- `serve.blackbox` stressed 5×.

https://claude.ai/code/session_01VqpbgTHTW4r9EpVvAaZncB