### PR TITLE
Keyboard: intercept app-owned native shortcuts before Ghostty claims them (ATC-34)

### DIFF
--- a/macos/ATC/Commands/KeyboardMonitorHost.swift
+++ b/macos/ATC/Commands/KeyboardMonitorHost.swift
@@ -1,6 +1,32 @@
 import AppKit
 import SwiftUI
 
+struct NativeShortcutDispatch {
+    let perform: @MainActor (AppAction, NSWindow) -> Void
+
+    static let live = NativeShortcutDispatch { action, window in
+        switch action {
+        case .terminate:
+            NSApp.terminate(nil)
+        case .closeWindow:
+            window.performClose(nil)
+        case .closeAllWindows:
+            // Only user-closable windows: performClose beeps on panels and
+            // helper windows without a close button. Key window last so
+            // focus does not hop mid-sweep.
+            let closable = NSApp.windows.filter {
+                $0 !== window && $0.isVisible && $0.styleMask.contains(.closable)
+            }
+            for otherWindow in closable {
+                otherWindow.performClose(nil)
+            }
+            if window.styleMask.contains(.closable) {
+                window.performClose(nil)
+            }
+        }
+    }
+}
+
 struct KeyboardMonitorHost: View {
     let router: WindowKeyboardRouter
     let onDeactivate: () -> Void
@@ -25,6 +51,7 @@ struct KeyboardMonitorHost: View {
         var router: WindowKeyboardRouter
         var onDeactivate: () -> Void
         var focusFallback: () -> Void
+        let nativeShortcutDispatch: NativeShortcutDispatch
         private(set) weak var hostWindow: NSWindow?
         private var monitor: Any?
         private var flagsMonitor: Any?
@@ -33,11 +60,13 @@ struct KeyboardMonitorHost: View {
         init(
             router: WindowKeyboardRouter,
             onDeactivate: @escaping () -> Void,
-            focusFallback: @escaping () -> Void
+            focusFallback: @escaping () -> Void,
+            nativeShortcutDispatch: NativeShortcutDispatch = .live
         ) {
             self.router = router
             self.onDeactivate = onDeactivate
             self.focusFallback = focusFallback
+            self.nativeShortcutDispatch = nativeShortcutDispatch
         }
 
         func attach(to window: NSWindow?) {
@@ -49,22 +78,9 @@ struct KeyboardMonitorHost: View {
                 [weak self, weak window] event in
                 guard let self, let window,
                       event.window === window,
-                      window.isKeyWindow,
-                      let stroke = KeyStroke.normalize(event: event)
+                      window.isKeyWindow
                 else { return event }
-                let wasSuspended = self.router.isSuspended()
-                let handled = self.router.handle(stroke, isRepeat: event.isARepeat)
-                // The palette opener flips suspension synchronously, but the
-                // palette's focus accessor only mounts on the next SwiftUI
-                // commit; keystrokes already queued behind the opener would
-                // land in the still-focused terminal. Clearing focus at the
-                // flip closes that gap, stashing the responder so dismissal
-                // can still restore it.
-                if handled, !wasSuspended, self.router.isSuspended() {
-                    self.router.responderBeforeSuspension = window.firstResponder
-                    window.makeFirstResponder(nil)
-                }
-                return handled ? nil : event
+                return self.handleKeyDown(event: event, in: window)
             }
 
             // Held-modifier state for the sidebar's ⌘/⌥⌘ jump badges. Never
@@ -114,6 +130,32 @@ struct KeyboardMonitorHost: View {
                     self?.restoreOrphanedResponder()
                 }
             })
+        }
+
+        // Seam below the window guards lets tests use synthesized events
+        // without installing a process-wide monitor.
+        func handleKeyDown(event: NSEvent, in window: NSWindow) -> NSEvent? {
+            guard let stroke = KeyStroke.normalize(event: event) else { return event }
+            if let action = NativeShortcuts.appAction(for: stroke) {
+                if !event.isARepeat {
+                    nativeShortcutDispatch.perform(action, window)
+                }
+                return nil
+            }
+
+            let wasSuspended = router.isSuspended()
+            let handled = router.handle(stroke, isRepeat: event.isARepeat)
+            // The palette opener flips suspension synchronously, but the
+            // palette's focus accessor only mounts on the next SwiftUI
+            // commit; keystrokes already queued behind the opener would
+            // land in the still-focused terminal. Clearing focus at the
+            // flip closes that gap, stashing the responder so dismissal
+            // can still restore it.
+            if handled, !wasSuspended, router.isSuspended() {
+                router.responderBeforeSuspension = window.firstResponder
+                window.makeFirstResponder(nil)
+            }
+            return handled ? nil : event
         }
 
         // Dismissal normally restores focus through the palette's window

--- a/macos/ATC/Commands/Keymap.swift
+++ b/macos/ATC/Commands/Keymap.swift
@@ -198,23 +198,13 @@ enum Keymap {
         ))
     }
 
-    private static let protectedTriggers: [KeyStroke: String] = {
-        let values: [(String, String)] = [
-            ("cmd+q", "Quit"), ("cmd+h", "Hide atc"),
-            ("cmd+opt+h", "Hide Others"), ("cmd+,", "Settings"),
-            ("cmd+w", "Close Window"), ("cmd+shift+w", "Close All Windows"),
-            ("cmd+z", "Undo"), ("cmd+shift+z", "Redo"),
-            ("cmd+x", "Cut"), ("cmd+c", "Copy"), ("cmd+v", "Paste"),
-            ("cmd+a", "Select All"), ("cmd+m", "Minimize"),
-        ]
-        // The sidebar jump scheme owns its own triggers; splice them in
-        // rather than restating the ⌘1–9 / ⌥⌘1–9 layout here. Built with
-        // uniqueKeysWithValues so a future collision traps at launch.
-        return Dictionary(
-            uniqueKeysWithValues: values.map { (requiredStroke($0.0), $0.1) }
-                + SidebarShortcuts.reservedTriggers.map { ($0.key, $0.value) }
-        )
-    }()
+    // The sidebar jump scheme owns its own triggers; splice them in
+    // rather than restating the ⌘1–9 / ⌥⌘1–9 layout here. Built with
+    // uniqueKeysWithValues so a future collision traps at launch.
+    private static let protectedTriggers: [KeyStroke: String] = Dictionary(
+        uniqueKeysWithValues: NativeShortcuts.protectedTriggers.map { ($0.key, $0.value) }
+            + SidebarShortcuts.reservedTriggers.map { ($0.key, $0.value) }
+    )
 
     private static func requiredStroke(_ text: String) -> KeyStroke {
         switch KeyStroke.parse(text) {

--- a/macos/ATC/Commands/NativeShortcuts.swift
+++ b/macos/ATC/Commands/NativeShortcuts.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+// The single registry for native shortcuts protected from configuration and
+// for the subset intercepted before a focused terminal can claim them.
+nonisolated enum AppAction: Equatable, Sendable {
+    case terminate
+    case closeWindow
+    case closeAllWindows
+}
+
+nonisolated enum NativeShortcuts {
+    private enum Owner: Sendable {
+        case appHandled(AppAction)
+        case responderOwned
+    }
+
+    private struct Entry: Sendable {
+        let name: String
+        let owner: Owner
+    }
+
+    private static let entries: [KeyStroke: Entry] = {
+        let values: [(String, String, Owner)] = [
+            ("cmd+q", "Quit", .appHandled(.terminate)),
+            ("cmd+h", "Hide atc", .responderOwned),
+            ("cmd+opt+h", "Hide Others", .responderOwned),
+            ("cmd+,", "Settings", .responderOwned),
+            ("cmd+w", "Close Window", .appHandled(.closeWindow)),
+            ("cmd+shift+w", "Close All Windows", .appHandled(.closeAllWindows)),
+            ("cmd+z", "Undo", .responderOwned),
+            ("cmd+shift+z", "Redo", .responderOwned),
+            ("cmd+x", "Cut", .responderOwned),
+            ("cmd+c", "Copy", .responderOwned),
+            ("cmd+v", "Paste", .responderOwned),
+            ("cmd+a", "Select All", .responderOwned),
+            ("cmd+m", "Minimize", .responderOwned),
+        ]
+        return Dictionary(uniqueKeysWithValues: values.map {
+            (requiredStroke($0.0), Entry(name: $0.1, owner: $0.2))
+        })
+    }()
+
+    static let protectedTriggers: [KeyStroke: String] = entries.mapValues(\.name)
+
+    static func appAction(for stroke: KeyStroke) -> AppAction? {
+        guard case .appHandled(let action)? = entries[stroke]?.owner else { return nil }
+        return action
+    }
+
+    private static func requiredStroke(_ text: String) -> KeyStroke {
+        switch KeyStroke.parse(text) {
+        case .success(let stroke): stroke
+        case .failure(let error): preconditionFailure("Invalid compiled trigger: \(error)")
+        }
+    }
+}

--- a/macos/ATCTests/KeyboardMonitorHostTests.swift
+++ b/macos/ATCTests/KeyboardMonitorHostTests.swift
@@ -1,0 +1,71 @@
+import AppKit
+import Testing
+@testable import ATC
+
+@MainActor
+@Suite("Keyboard monitor host")
+struct KeyboardMonitorHostTests {
+    @Test("native app shortcuts dispatch once and consume while other keys forward")
+    func nativeDispatchAndForwarding() throws {
+        _ = NSApplication.shared
+        var actions: [AppAction] = []
+        let router = WindowKeyboardRouter(keymap: try Keymap.resolve().get()) { _ in .available }
+        router.isSuspended = { true }
+        let coordinator = KeyboardMonitorHost.Coordinator(
+            router: router,
+            onDeactivate: {},
+            focusFallback: {},
+            nativeShortcutDispatch: NativeShortcutDispatch { action, _ in
+                actions.append(action)
+            }
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 100, height: 100),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: true
+        )
+
+        let quit = try #require(event(flags: .command, characters: "q", keyCode: 12))
+        #expect(coordinator.handleKeyDown(event: quit, in: window) == nil)
+        #expect(actions == [.terminate])
+
+        let quitRepeat = try #require(event(
+            flags: .command,
+            characters: "q",
+            keyCode: 12,
+            isRepeat: true
+        ))
+        #expect(coordinator.handleKeyDown(event: quitRepeat, in: window) == nil)
+        #expect(actions == [.terminate])
+
+        let copy = try #require(event(flags: .command, characters: "c", keyCode: 8))
+        #expect(coordinator.handleKeyDown(event: copy, in: window) === copy)
+
+        let character = try #require(event(flags: [], characters: "x", keyCode: 7))
+        #expect(coordinator.handleKeyDown(event: character, in: window) === character)
+        #expect(actions == [.terminate])
+    }
+
+    // Normalization resolves the key through the event's keyCode and the
+    // live layout, so each synthesized event must carry the real keyCode.
+    private func event(
+        flags: NSEvent.ModifierFlags,
+        characters: String,
+        keyCode: UInt16,
+        isRepeat: Bool = false
+    ) -> NSEvent? {
+        NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: flags,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: characters,
+            isARepeat: isRepeat,
+            keyCode: keyCode
+        )
+    }
+}

--- a/macos/ATCTests/KeymapResolutionTests.swift
+++ b/macos/ATCTests/KeymapResolutionTests.swift
@@ -154,24 +154,34 @@ struct KeymapResolutionTests {
 
     @Test("protected shortcuts and leaders name the native command")
     func protectedShortcuts() throws {
-        let direct = Keymap.resolve(user: ConfigurationLoader.parse(#"""
+        let quit = Keymap.resolve(user: ConfigurationLoader.parse(#"""
+        [keyboard]
+        clear_default_keybindings = true
+        [keybindings]
+        "cmd+q" = "data.refresh"
+        """#))
+        #expect(try failure(quit).map(\.message) == [
+            "[keybindings] trigger 'cmd+q' is reserved for Quit"
+        ])
+
+        let copy = Keymap.resolve(user: ConfigurationLoader.parse(#"""
         [keyboard]
         clear_default_keybindings = true
         [keybindings]
         "cmd+c" = "data.refresh"
         """#))
-        #expect(try failure(direct).contains {
-            $0.message.contains("cmd+c") && $0.message.contains("Copy")
-        })
+        #expect(try failure(copy).map(\.message) == [
+            "[keybindings] trigger 'cmd+c' is reserved for Copy"
+        ])
 
         let leader = Keymap.resolve(user: ConfigurationLoader.parse(#"""
         [keyboard]
         clear_default_keybindings = true
         leader = "cmd+q"
         """#))
-        #expect(try failure(leader).contains {
-            $0.message.contains("cmd+q") && $0.message.contains("Quit")
-        })
+        #expect(try failure(leader).map(\.message) == [
+            "[keyboard].leader 'cmd+q' is reserved for Quit"
+        ])
     }
 
     @Test("sidebar jump digits are reserved in both modifier sets")

--- a/macos/ATCTests/NativeShortcutsTests.swift
+++ b/macos/ATCTests/NativeShortcutsTests.swift
@@ -1,0 +1,33 @@
+import Testing
+@testable import ATC
+
+@Suite("Native shortcut classification")
+struct NativeShortcutsTests {
+    @Test("app-handled shortcuts map to native actions")
+    func appHandled() throws {
+        let expected: [(String, AppAction)] = [
+            ("cmd+q", .terminate),
+            ("cmd+w", .closeWindow),
+            ("cmd+shift+w", .closeAllWindows),
+        ]
+
+        for (trigger, action) in expected {
+            #expect(NativeShortcuts.appAction(for: try stroke(trigger)) == action)
+        }
+    }
+
+    @Test("responder-owned and unrelated shortcuts have no app action")
+    func passThrough() throws {
+        for trigger in ["cmd+c", "cmd+v", "cmd+z", "cmd+a", "cmd+h", "cmd+m", "cmd+,"] {
+            #expect(NativeShortcuts.appAction(for: try stroke(trigger)) == nil)
+        }
+        #expect(NativeShortcuts.appAction(for: try stroke("cmd+y")) == nil)
+        #expect(NativeShortcuts.appAction(
+            for: KeyStroke(key: "x", modifiers: [])
+        ) == nil)
+    }
+
+    private func stroke(_ text: String) throws -> KeyStroke {
+        try KeyStroke.parse(text).get()
+    }
+}


### PR DESCRIPTION
Fixes [ATC-34](https://linear.app/elevenideas/issue/ATC-34/cmd-q-doesnt-quit-the-app): Cmd-Q (and Cmd-W / Cmd-Shift-W) did nothing while a Ghostty terminal was first responder.

## Cause

The libghostty wrapper's `performKeyEquivalent` claims any key equivalent Ghostty has a compiled default binding for (`super+q → quit`, `super+w → close_surface`, `super+shift+w → close_window`), then the resulting action is dropped — `quit` is application-targeted and fails the wrapper's surface-target guard; `close_surface` has no case in the wrapper's action bridge. The keystroke is consumed and nothing happens.

## Fix

Route app-owned native shortcuts at the same pre-Ghostty boundary the configurable keyboard router already uses (the window-local key-down monitor):

- **`NativeShortcuts`** — new shared registry holding the protected native shortcut definitions (moved out of `Keymap`) plus a binary dispatch classification: app-handled (`cmd+q` → terminate, `cmd+w` → close window, `cmd+shift+w` → close all windows) vs responder-owned (Copy, Paste, Cut, Undo, Redo, Select All, Hide, Minimize, Settings — pass through unchanged). One registry, so config-reservation diagnostics and routing cannot drift.
- **`KeyboardMonitorHost`** — checks app-handled shortcuts before the router (and independent of palette suspension), dispatches through an injected `NativeShortcutDispatch` seam, and consumes the event so Ghostty never sees it. Production dispatch: `NSApp.terminate(nil)`; window closes via `performClose` so `windowShouldClose`/sheet semantics hold; close-all only touches visible, closable windows (key window last) to avoid beeping panels. Repeats consume without re-dispatch.
- No Ghostty config changes — the interception boundary is the single mechanism, per the issue's non-goals.

## Tests

Classification, keymap reservation diagnostics (byte-identical messages), monitor dispatch/consumption/repeat/pass-through with synthesized events via a `handleKeyDown` seam below the window guards. Full macOS suite: 267 tests pass.

https://claude.ai/code/session_01JtZDJ6mEi8AGjYfFtFBuEx