### PR TITLE
Keyboard: leader timeout and ASCII-capable layout fallback (ATC-181)

### DIFF
--- a/macos/ATC/Commands/KeyboardMonitorHost.swift
+++ b/macos/ATC/Commands/KeyboardMonitorHost.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Carbon.HIToolbox
 import SwiftUI
 
 struct NativeShortcutDispatch {
@@ -276,12 +277,70 @@ extension KeyStroke {
         if event.keyCode == 53 {
             return .escape
         }
-        guard let characters = event.characters(byApplyingModifiers: [])
-                ?? event.charactersIgnoringModifiers,
-              characters.count == 1,
-              let scalar = characters.lowercased().unicodeScalars.first,
+        let produced = event.characters(byApplyingModifiers: [])
+            ?? event.charactersIgnoringModifiers
+        guard let key = resolveKey(
+            produced: produced,
+            asciiFallback: { asciiCharacter(for: event.keyCode) }
+        ) else { return nil }
+        return KeyStroke(key: key, modifiers: modifiers)
+    }
+
+    /// Routing is semantic-first for Latin layouts, with the physical key's
+    /// current ASCII-capable-layout meaning as a fallback for non-ASCII,
+    /// empty, or combining output. Consequently, a literal non-ASCII binding
+    /// matches its physical key's ASCII interpretation rather than the
+    /// produced character.
+    static func resolveKey(
+        produced: String?,
+        asciiFallback: () -> String?
+    ) -> String? {
+        if let produced = printableASCIIKey(produced) {
+            return produced
+        }
+        return printableASCIIKey(asciiFallback())
+    }
+
+    private static func printableASCIIKey(_ characters: String?) -> String? {
+        guard let characters,
+              characters.count == 1
+        else { return nil }
+        let lowercased = characters.lowercased()
+        guard lowercased.count == 1,
+              lowercased.unicodeScalars.count == 1,
+              let scalar = lowercased.unicodeScalars.first,
+              scalar.value < 128,
               isPrintable(scalar)
         else { return nil }
-        return KeyStroke(key: characters.lowercased(), modifiers: modifiers)
+        return lowercased
+    }
+
+    private static func asciiCharacter(for keyCode: UInt16) -> String? {
+        guard let source = TISCopyCurrentASCIICapableKeyboardLayoutInputSource()?.takeRetainedValue(),
+              let property = TISGetInputSourceProperty(
+                  source,
+                  kTISPropertyUnicodeKeyLayoutData
+              )
+        else { return nil }
+        let data = unsafeBitCast(property, to: CFData.self)
+        guard let bytes = CFDataGetBytePtr(data) else { return nil }
+        let layout = UnsafeRawPointer(bytes).assumingMemoryBound(to: UCKeyboardLayout.self)
+        var deadKeyState: UInt32 = 0
+        var characters = [UniChar](repeating: 0, count: 4)
+        var length = 0
+        let status = UCKeyTranslate(
+            layout,
+            keyCode,
+            UInt16(kUCKeyActionDown),
+            0,
+            UInt32(LMGetKbdType()),
+            OptionBits(kUCKeyTranslateNoDeadKeysMask),
+            &deadKeyState,
+            characters.count,
+            &length,
+            &characters
+        )
+        guard status == noErr, length > 0 else { return nil }
+        return String(decoding: characters.prefix(Int(length)), as: UTF16.self)
     }
 }

--- a/macos/ATC/Commands/WindowKeyboardRouter.swift
+++ b/macos/ATC/Commands/WindowKeyboardRouter.swift
@@ -39,6 +39,9 @@ final class WindowKeyboardRouter {
     @ObservationIgnored private let executeCommand: @MainActor (CommandID) -> CommandAvailability
     @ObservationIgnored private var flashTask: Task<Void, Never>?
     @ObservationIgnored private var flashToken = 0
+    @ObservationIgnored var pendingTimeout: Duration = .seconds(1.2)
+    @ObservationIgnored private(set) var pendingTimeoutTask: Task<Void, Never>?
+    @ObservationIgnored private var pendingToken = 0
 
     init(keymap: ResolvedKeymap, context: CommandContext) {
         self.keymap = keymap
@@ -92,6 +95,9 @@ final class WindowKeyboardRouter {
     }
 
     func cancel() {
+        pendingToken += 1
+        pendingTimeoutTask?.cancel()
+        pendingTimeoutTask = nil
         state = .idle
     }
 
@@ -110,9 +116,26 @@ final class WindowKeyboardRouter {
                 showFlash(reason)
             }
         case .prefix(let continuations):
-            state = .pending(node: continuations)
+            beginPending(continuations)
         }
         return true
+    }
+
+    private func beginPending(_ continuations: [KeyStroke: ResolvedKeymap.Node]) {
+        pendingToken += 1
+        let token = pendingToken
+        let timeout = pendingTimeout
+        state = .pending(node: continuations)
+        pendingTimeoutTask?.cancel()
+        pendingTimeoutTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: timeout)
+            } catch {
+                return
+            }
+            guard let self, token == self.pendingToken else { return }
+            self.cancel()
+        }
     }
 
     private func clearFlash() {

--- a/macos/ATCTests/EventNormalizationTests.swift
+++ b/macos/ATCTests/EventNormalizationTests.swift
@@ -4,6 +4,23 @@ import Testing
 
 @Suite("Keyboard event normalization")
 struct EventNormalizationTests {
+    @Test("produced ASCII wins and unusable output falls back to ASCII")
+    func keyResolutionLayering() {
+        #expect(KeyStroke.resolveKey(produced: "т", asciiFallback: { "t" }) == "t")
+
+        var consultedFallback = false
+        let producedASCII = KeyStroke.resolveKey(produced: "t", asciiFallback: {
+            consultedFallback = true
+            return "x"
+        })
+        #expect(producedASCII == "t")
+        #expect(!consultedFallback)
+
+        #expect(KeyStroke.resolveKey(produced: "т", asciiFallback: { nil }) == nil)
+        #expect(KeyStroke.resolveKey(produced: "", asciiFallback: { "a" }) == "a")
+        #expect(KeyStroke.resolveKey(produced: "ab", asciiFallback: { "b" }) == "b")
+    }
+
     @Test("layout-resolved command, shift, and option events normalize")
     func printableEvents() throws {
         let commandB = try #require(event(
@@ -56,6 +73,18 @@ struct EventNormalizationTests {
             keyCode: 122
         ))
         #expect(KeyStroke.normalize(event: function) == nil)
+    }
+
+    @Test("a Cyrillic event uses its physical key's ASCII interpretation")
+    func cyrillicEvent() throws {
+        let commandT = try #require(event(
+            flags: .command,
+            characters: "т",
+            ignoringModifiers: "т",
+            keyCode: 17
+        ))
+        #expect(KeyStroke.normalize(event: commandT)
+            == KeyStroke(key: "t", modifiers: .command))
     }
 
     private func event(

--- a/macos/ATCTests/KeyboardRouterTests.swift
+++ b/macos/ATCTests/KeyboardRouterTests.swift
@@ -50,6 +50,53 @@ struct KeyboardRouterTests {
         #expect(executions == [.toggleSidebar])
     }
 
+    @Test("an inactive leader sequence times out silently and forwards the next key")
+    func leaderTimeout() async throws {
+        let router = WindowKeyboardRouter(keymap: try keymap()) { _ in .available }
+        router.pendingTimeout = .milliseconds(1)
+
+        #expect(router.handle(try stroke("cmd+k"), isRepeat: false))
+        #expect(router.pendingNode != nil)
+        let timeoutTask = try #require(router.pendingTimeoutTask)
+        await timeoutTask.value
+
+        #expect(router.pendingNode == nil)
+        #expect(router.flash == nil)
+        #expect(!router.handle(KeyStroke(key: "x", modifiers: []), isRepeat: false))
+    }
+
+    @Test("a continuation invalidates its pending timeout")
+    func continuationInvalidatesTimeout() async throws {
+        var executions: [CommandID] = []
+        let router = WindowKeyboardRouter(keymap: try keymap()) {
+            executions.append($0)
+            return .available
+        }
+
+        #expect(router.handle(try stroke("cmd+k"), isRepeat: false))
+        let timeoutTask = try #require(router.pendingTimeoutTask)
+        #expect(router.handle(KeyStroke(key: "b", modifiers: []), isRepeat: false))
+        await timeoutTask.value
+
+        #expect(router.pendingNode == nil)
+        #expect(router.pendingTimeoutTask == nil)
+        #expect(executions == [.toggleSidebar])
+    }
+
+    @Test("cancel invalidates the pending timeout")
+    func cancelInvalidatesTimeout() async throws {
+        let router = WindowKeyboardRouter(keymap: try keymap()) { _ in .available }
+
+        #expect(router.handle(try stroke("cmd+k"), isRepeat: false))
+        let timeoutTask = try #require(router.pendingTimeoutTask)
+        router.cancel()
+        await timeoutTask.value
+
+        #expect(router.pendingNode == nil)
+        #expect(router.pendingTimeoutTask == nil)
+        #expect(router.flash == nil)
+    }
+
     @Test("modified continuations are never retried against root")
     func continuationDoesNotRetryRoot() throws {
         var executions: [CommandID] = []


### PR DESCRIPTION
Implements items 1 and 2 of [ATC-181](https://linear.app/elevenideas/issue/ATC-181/keyboard-routing-hardening-leader-timeout-layout-normalization-named). **Stacked on #175** (shares the keyboard-routing files); retarget to `main` after that merges.

## 1. Leader sequences time out

`WindowKeyboardRouter` stayed `.pending` indefinitely after the leader — a keystroke typed minutes later was swallowed as an invalid continuation. The pending state now expires silently after 1.2 s of inactivity, using the same token-guarded task idiom as the router's flash handling. The pending-hint UI derives from `pendingNode`, so it disappears with the state. The duration and task are internally exposed so tests await the real lifecycle instead of sleeping.

## 2. Layout normalization: semantic-first with ASCII-capable fallback

`KeyStroke.normalize` matched only the layout's produced character, so Latin-configured triggers (`cmd+t`) never matched on non-Latin layouts (Cyrillic Cmd-T produces "т"). Policy, implemented in one place:

- If the produced character is a single printable ASCII character, use it (unchanged for Latin layouts, including option/shift stripping).
- Otherwise translate the physical `keyCode` through the current ASCII-capable layout (`TISCopyCurrentASCIICapableKeyboardLayoutInputSource` + `UCKeyTranslate`, dead keys disabled) and use that when it's printable ASCII.
- Neither usable → forward unchanged.

Documented consequence: a custom trigger bound to a literal non-ASCII key (e.g. `cmd+ф`) matches by its physical key's ASCII interpretation, not the literal character.

Item 3 (named keys, longer sequences) stays deferred per the issue — no trigger-grammar changes.

## Tests

Timeout expiry/invalidation (await the exposed task — no wall-clock sleeps), pure fallback-layering via a `resolveKey` seam (machine-independent), and a synthesized Cyrillic NSEvent normalizing to `cmd+t`. Full macOS suite: 272 tests pass.

https://claude.ai/code/session_01JtZDJ6mEi8AGjYfFtFBuEx