### PR TITLE
Terminals: expose the derived zmx session name; show it in the thread inspector (ATC-161)

### DIFF
--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -1522,6 +1522,10 @@
           "status": {
             "$ref": "#/components/schemas/TerminalStatus"
           },
+          "sessionName": {
+            "type": "string",
+            "description": "Server-derived zmx session name backing this terminal (exists as a live session only while status is live). Clients display it and never re-derive it."
+          },
           "createdAt": {
             "type": "string",
             "description": "Creation time.",
@@ -1543,6 +1547,7 @@
           "projectId",
           "initialWorkingDirectory",
           "status",
+          "sessionName",
           "createdAt",
           "updatedAt"
         ],

--- a/app-server/src/api/contract.ts
+++ b/app-server/src/api/contract.ts
@@ -188,6 +188,10 @@ export const Terminal = Schema.Struct({
     description: "Canonical directory the terminal was launched in (immutable).",
   }),
   status: TerminalStatus,
+  sessionName: Schema.String.annotate({
+    description:
+      "Server-derived zmx session name backing this terminal (exists as a live session only while status is live). Clients display it and never re-derive it.",
+  }),
   createdAt: timestamp("Creation time."),
   updatedAt: timestamp("Last update time."),
   endedAt: Schema.optionalKey(

--- a/app-server/src/terminals/terminals.ts
+++ b/app-server/src/terminals/terminals.ts
@@ -58,6 +58,7 @@ export type Terminal = typeof TerminalSchema.Type
 const toTerminal = (record: TerminalRecord): Terminal => ({
   ...record,
   status: record.status === "ended" ? "ended" : "live",
+  sessionName: sessionNameForTerminalId(record.id),
 })
 
 export class Terminals extends Context.Service<

--- a/app-server/test/terminals/terminals.test.ts
+++ b/app-server/test/terminals/terminals.test.ts
@@ -37,6 +37,7 @@ describe("Terminals service", () => {
         command: ["bun", "run", "dev"],
       })
       assert.strictEqual(created.status, "live")
+      assert.strictEqual(created.sessionName, sessionNameForTerminalId(created.id))
       assert.strictEqual(created.name, "build")
       assert.deepStrictEqual(created.command, ["bun", "run", "dev"])
       assert.strictEqual(created.initialWorkingDirectory, project.defaultWorkingDirectory)

--- a/macos/ATC/Features/Threads/ThreadInspectorView.swift
+++ b/macos/ATC/Features/Threads/ThreadInspectorView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct ThreadInspectorView: View {
     let thread: ATCThread
     let projectName: String
+    let sessionName: String?
 
     var body: some View {
         Form {
@@ -21,6 +22,13 @@ struct ThreadInspectorView: View {
                     Text(thread.workingDirectory)
                         .font(.callout.monospaced())
                         .textSelection(.enabled)
+                }
+                if let sessionName {
+                    LabeledContent("zmx Session") {
+                        Text(sessionName)
+                            .font(.callout.monospaced())
+                            .textSelection(.enabled)
+                    }
                 }
                 LabeledContent("Activity", value: thread.detailLabel)
             }

--- a/macos/ATC/PreviewSupport/PreviewAppServerClient.swift
+++ b/macos/ATC/PreviewSupport/PreviewAppServerClient.swift
@@ -158,6 +158,7 @@ nonisolated struct PreviewAppServerClient: APIProtocol {
                 threadId: "0192f4b0-0000-7000-8000-000000000001",
                 initialWorkingDirectory: Self.atelier.defaultWorkingDirectory,
                 status: .live,
+                sessionName: "atc-0192f4c0000070008000000000000001",
                 createdAt: Date(timeIntervalSinceNow: -220_000),
                 updatedAt: Date(timeIntervalSinceNow: -30)
             ),
@@ -167,6 +168,7 @@ nonisolated struct PreviewAppServerClient: APIProtocol {
                 name: "Server logs",
                 initialWorkingDirectory: Self.atelier.defaultWorkingDirectory,
                 status: .live,
+                sessionName: "atc-0192f4c0000070008000000000000002",
                 createdAt: Date(timeIntervalSinceNow: -5_000),
                 updatedAt: Date(timeIntervalSinceNow: -60)
             ),
@@ -176,6 +178,7 @@ nonisolated struct PreviewAppServerClient: APIProtocol {
                 command: ["lazygit"],
                 initialWorkingDirectory: Self.atelier.defaultWorkingDirectory,
                 status: .ended,
+                sessionName: "atc-0192f4c0000070008000000000000003",
                 createdAt: Date(timeIntervalSinceNow: -900),
                 updatedAt: Date(timeIntervalSinceNow: -600),
                 endedAt: Date(timeIntervalSinceNow: -600)
@@ -292,13 +295,15 @@ nonisolated struct PreviewAppServerClient: APIProtocol {
     func createTerminal(_ input: Operations.CreateTerminal.Input) async throws -> Operations.CreateTerminal.Output {
         guard case .json(let request) = input.body else { throw PreviewUnavailable() }
         let project = try require(projects.first { $0.id == request.projectId })
+        let id = Self.newID()
         return .ok(.init(body: .json(Terminal(
-            id: Self.newID(),
+            id: id,
             projectId: project.id,
             name: request.name,
             command: request.command,
             initialWorkingDirectory: request.workingDirectory ?? project.defaultWorkingDirectory,
             status: .live,
+            sessionName: "atc-\(id.replacingOccurrences(of: "-", with: ""))",
             createdAt: Date(),
             updatedAt: Date()
         ))))
@@ -401,12 +406,14 @@ nonisolated struct PreviewAppServerClient: APIProtocol {
            let terminal = terminals.first(where: { $0.id == linked }) {
             return .ok(.init(body: .json(terminal)))
         }
+        let id = Self.newID()
         return .ok(.init(body: .json(Terminal(
-            id: Self.newID(),
+            id: id,
             projectId: thread.projectId,
             threadId: thread.id,
             initialWorkingDirectory: thread.workingDirectory,
             status: .live,
+            sessionName: "atc-\(id.replacingOccurrences(of: "-", with: ""))",
             createdAt: Date(),
             updatedAt: Date()
         ))))

--- a/macos/ATC/RootView.swift
+++ b/macos/ATC/RootView.swift
@@ -156,9 +156,13 @@ struct RootView: View {
     @ViewBuilder
     private var inspectorContent: some View {
         if let ref = selectedThread, let thread = appModel.thread(for: ref) {
+            let terminal = thread.linkedTerminalId.flatMap { id in
+                appModel.terminal(for: TerminalRef(connectionID: ref.connectionID, terminalID: id))
+            }
             ThreadInspectorView(
                 thread: thread,
-                projectName: projectName(for: ref.connectionID, projectID: thread.projectId)
+                projectName: projectName(for: ref.connectionID, projectID: thread.projectId),
+                sessionName: terminal?.isLive == true ? terminal?.sessionName : nil
             )
             .inspectorColumnWidth(min: 260, ideal: 320)
         }

--- a/macos/ATCTests/ScriptableAppServerClient.swift
+++ b/macos/ATCTests/ScriptableAppServerClient.swift
@@ -67,14 +67,16 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
             workingDirectory: String
         ) -> Terminal {
             let now = tick()
+            let id = nextID("trm")
             return Terminal(
-                id: nextID("trm"),
+                id: id,
                 projectId: projectId,
                 threadId: threadId,
                 name: name,
                 command: command,
                 initialWorkingDirectory: workingDirectory,
                 status: .live,
+                sessionName: String(format: "atc-%032x", idCounter),
                 createdAt: now,
                 updatedAt: now
             )
@@ -709,6 +711,7 @@ enum Fixtures {
         command: [String]? = nil,
         workingDirectory: String = "/home/dev/app",
         status: TerminalStatus = .live,
+        sessionName: String = "atc-00000000000000000000000000000000",
         createdAt: Date = epoch
     ) -> Terminal {
         Terminal(
@@ -719,6 +722,7 @@ enum Fixtures {
             command: command,
             initialWorkingDirectory: workingDirectory,
             status: status,
+            sessionName: sessionName,
             createdAt: createdAt,
             updatedAt: createdAt,
             endedAt: status == .ended ? createdAt : nil


### PR DESCRIPTION
Implements [ATC-161](https://linear.app/elevenideas/issue/ATC-161/show-zmx-session-in-right-sidebar): the thread inspector (right sidebar) now shows the zmx session the thread's terminal runs in, so it can be found/attached from a shell (`ZMX_DIR=~/.local/state/atc/terminals zmx attach <name>`).

## Design

The session name is a pure server-side derivation (`sessionNameForTerminalId`: `atc-` + the terminal UUID's hex). Per the repo rule that derived facts live on the contract, the `Terminal` schema gains a required `sessionName` field computed in `toTerminal` — the client renders it and never re-derives it.

- **Contract**: `Terminal.sessionName` (required; documented as existing as a live session only while `status` is `live`). OpenAPI regenerated; no endpoint or operation-id changes, so this is additive for clients.
- **Server**: one mapping line in `toTerminal`.
- **macOS**: `RootView` resolves the thread's linked terminal and passes `sessionName` (nil unless the terminal is live) into `ThreadInspectorView`, which renders one monospaced, selectable row next to Working Directory. Wire-contract change and the macOS side land together, so CI stays green.

## Tests

Server: created-terminal response asserts `sessionName == sessionNameForTerminalId(id)`. `mise run contract:check` (app-server check incl. 340 tests, TS client, Swift client build) and the full macOS suite pass.

https://claude.ai/code/session_01JtZDJ6mEi8AGjYfFtFBuEx