### PR TITLE
CLI: atc status reports web ui, api, and auth posture (ATC-32)

### DIFF
--- a/app-server/src/cli/serve.ts
+++ b/app-server/src/cli/serve.ts
@@ -267,5 +267,18 @@ export const status = Command.make("status", {}, () =>
       )
     }
     yield* Console.log(`running (pid ${record.pid}) on ${url}`)
+    // The ui/api lines are for pasting into a browser or client, so wildcard
+    // binds report the loopback address that actually connects; the first
+    // line keeps reporting the bind itself.
+    const reachableUrl = `http://${Server.hostForUrl(probeHost)}:${record.port}`
+    yield* Console.log(`  web ui    ${reachableUrl}/`)
+    yield* Console.log(`  api       ${reachableUrl}/api/v1 (openapi: ${reachableUrl}/openapi.json)`)
+    yield* Console.log(
+      Cli.probeNeedsToken(record.bind)
+        ? `  auth      open on ${record.bind}; non-loopback clients need the bearer token (${config.tokenFile})`
+        : `  auth      loopback clients only; no token needed (bind ${record.bind})`,
+    )
+    yield* Console.log(`  log       ${config.logFile}`)
+    yield* Console.log(`  pid-file  ${config.pidFile}`)
   }).pipe(Cli.withSettledConfig("atc status")),
 ).pipe(Command.withDescription("Report background App Server status"))

--- a/app-server/test/cli/startStopStatus.blackbox.test.ts
+++ b/app-server/test/cli/startStopStatus.blackbox.test.ts
@@ -38,6 +38,7 @@ afterAll(() => {
 
 const sandbox = makeFakeZmxSandbox()
 const env = isolatedEnv(scratch, { ATC_ZMX_EXECUTABLE: sandbox.wrapper })
+const logFile = join(env.XDG_STATE_HOME, "atc", "atc.log")
 const pidFile = join(env.XDG_STATE_HOME, "atc", "atc.pid")
 const cli = (...args: Array<string>) =>
   runCli([process.execPath, "src/main.ts"], args, appServerRoot, env)
@@ -82,6 +83,15 @@ describe("atc start / stop / status (black box)", () => {
     const running = await cli("status")
     expect(running.exitCode).toBe(0)
     expect(running.stdout).toContain(`running (pid ${record.pid})`)
+    expect(running.stdout).toContain(`  web ui    http://127.0.0.1:${port}/`)
+    expect(running.stdout).toContain(
+      `  api       http://127.0.0.1:${port}/api/v1 (openapi: http://127.0.0.1:${port}/openapi.json)`,
+    )
+    expect(running.stdout).toContain(
+      "  auth      loopback clients only; no token needed (bind 127.0.0.1)",
+    )
+    expect(running.stdout).toContain(`  log       ${logFile}`)
+    expect(running.stdout).toContain(`  pid-file  ${pidFile}`)
 
     const stopped = await cli("stop")
     expect(stopped.exitCode).toBe(0)


### PR DESCRIPTION
Implements [ATC-32](https://linear.app/elevenideas/issue/ATC-32/running-atc-status-should-give-more-info). A healthy `atc status` now prints:

```
running (pid 88090) on http://0.0.0.0:7331
  web ui    http://127.0.0.1:7331/
  api       http://127.0.0.1:7331/api/v1 (openapi: http://127.0.0.1:7331/openapi.json)
  auth      open on 0.0.0.0; non-loopback clients need the bearer token (/Users/x/.local/share/atc/auth-token)
  log       /Users/x/.local/state/atc/atc.log
  pid-file  /Users/x/.local/state/atc/atc.pid
```

- The first line is unchanged (black-box tests assert on it). The **web ui / api lines use the reachable address** — a wildcard bind like `0.0.0.0` is not connectable, so those lines report loopback while the first line keeps reporting the bind.
- The **auth line reports the running server's trust posture** from the pid record's bind (what the server was actually started with, not current config): loopback bind → `loopback clients only; no token needed`; open bind → token file path shown. Classification passes the raw bind so wildcards correctly read as open.
- No socket line — the output quoted in the issue predates the current server, which has no app socket.
- Not-running and unhealthy diagnostics are unchanged.

Tests: the existing healthy-lifecycle black-box test now asserts every added line (no new server spawns, CI-safe). `mise run -C app-server check` passes (340 tests). Also smoke-tested against the live dev server (output above).

https://claude.ai/code/session_01JtZDJ6mEi8AGjYfFtFBuEx