### PR TITLE
Release channels: rolling dev prerelease, channel-aware installer, atc upgrade

### DIFF
--- a/.github/workflows/app-server-release.yml
+++ b/.github/workflows/app-server-release.yml
@@ -1,27 +1,42 @@
-# Manual-dispatch release pipeline for the App Server executable (ATC-127).
+# Release pipeline for the App Server executable (ATC-127).
 #
-# channel=test    build + validate + upload a snapshot workflow artifact
-# channel=stable  additionally tag (vX.Y.Z, bumped from the highest existing
-#                 v tag) and publish a GitHub Release with tarballs + checksums
+# Two channels, one pipeline:
+#
+#   dev     every push to main (app-server paths) — and manual dispatch —
+#           rebuilds the single rolling `dev` prerelease: the tag is force-
+#           moved, the release recreated, so exactly one dev build exists.
+#           Versions stamp as <next-patch>-dev.<UTC minute> so `atc --version`
+#           is self-describing and sorts below the next stable release.
+#   stable  manual dispatch only: tags vX.Y.Z (bumped from the highest
+#           existing v tag per release_type) and publishes a GitHub Release.
+#           `releases/latest` only ever points here — prereleases are
+#           excluded — so install.sh's stable channel needs no manifest.
 #
 # Darwin targets build on macOS so Bun's ad-hoc code signature is applied
 # (and verified) natively; Linux targets cross-compile on ubuntu. Three of
 # the four targets are validated natively with the compiled black-box suite
 # against the release-built binary — darwin-x64 is compile-only best-effort
-# (GitHub's free Intel macOS runners are retired). The tag is only pushed
+# (GitHub's free Intel macOS runners are retired). Tags are only pushed
 # after every build and validation job has passed.
 name: App Server Release
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - "app-server/**"
+      - "install.sh"
+      - "mise.toml"
+      - ".github/workflows/app-server-release.yml"
   workflow_dispatch:
     inputs:
       channel:
-        description: "Build a test artifact or publish a stable GitHub release"
+        description: "Release channel: rolling dev prerelease or stable vX.Y.Z"
         type: choice
         required: true
-        default: test
+        default: dev
         options:
-          - test
+          - dev
           - stable
       release_type:
         description: "Stable release version bump"
@@ -36,7 +51,8 @@ on:
 permissions:
   contents: read
 
-# One release at a time: two stable dispatches would compute the same tag.
+# One release at a time: two stable dispatches would compute the same tag,
+# and two dev runs would race the rolling tag.
 concurrency:
   group: app-server-release
   cancel-in-progress: false
@@ -50,6 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
+      channel: ${{ steps.version.outputs.channel }}
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
     steps:
@@ -57,20 +74,27 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Compute release version
+      - name: Compute channel and version
         id: version
         run: |
-          if [ "${{ inputs.channel }}" = "stable" ]; then
+          if [ "${{ github.event_name }}" = "push" ]; then
+            channel="dev"
+          else
+            channel="${{ inputs.channel }}"
+          fi
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+          if [ "$channel" = "stable" ]; then
             if [ "${GITHUB_REF_NAME}" != "${{ github.event.repository.default_branch }}" ]; then
-              echo "stable releases must run from ${{ github.event.repository.default_branch }}; use channel=test for branch builds" >&2
+              echo "stable releases must run from ${{ github.event.repository.default_branch }}; use channel=dev for branch builds" >&2
               exit 1
             fi
             tag="$(scripts/next-version.sh "${{ inputs.release_type }}")"
             echo "tag=$tag" >> "$GITHUB_OUTPUT"
             echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=" >> "$GITHUB_OUTPUT"
-            echo "version=0.0.0-test.$(echo "$GITHUB_SHA" | cut -c1-7)" >> "$GITHUB_OUTPUT"
+            next="$(scripts/next-version.sh patch)"
+            echo "tag=dev" >> "$GITHUB_OUTPUT"
+            echo "version=${next#v}-dev.$(date -u +%Y%m%d%H%M)" >> "$GITHUB_OUTPUT"
           fi
 
   build-darwin:
@@ -88,7 +112,7 @@ jobs:
       - name: Build darwin targets
         run: |
           mise run install
-          bun run scripts/build.ts --version=${{ needs.plan.outputs.version }} darwin-arm64 darwin-x64
+          bun run scripts/build.ts --version=${{ needs.plan.outputs.version }} --channel=${{ needs.plan.outputs.channel }} darwin-arm64 darwin-x64
 
       # Bun applies an ad-hoc signature at compile time; verify it, and
       # re-sign in place if a Bun upgrade ever stops doing so.
@@ -136,7 +160,7 @@ jobs:
       - name: Build linux targets
         run: |
           mise run install
-          bun run scripts/build.ts --version=${{ needs.plan.outputs.version }} linux-x64 linux-arm64
+          bun run scripts/build.ts --version=${{ needs.plan.outputs.version }} --channel=${{ needs.plan.outputs.channel }} linux-x64 linux-arm64
 
       - name: Standing gates (fmt, typecheck, tests, drift)
         run: mise run check
@@ -211,16 +235,26 @@ jobs:
           rm checksums-*.txt
           ls -l
 
-      - name: Upload test release artifact
-        if: inputs.channel == 'test'
-        uses: actions/upload-artifact@v6
-        with:
-          name: atc-test-release-${{ github.run_id }}
-          path: app-server/release/*
-          if-no-files-found: error
+      # Exactly one dev release exists: the previous one is deleted, the tag
+      # force-moved to this commit, and the release recreated as a prerelease
+      # (which keeps it out of releases/latest, the stable-channel URL).
+      - name: Publish rolling dev prerelease
+        if: needs.plan.outputs.channel == 'dev'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release delete dev --yes || true
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -f dev
+          git push -f origin dev
+          gh release create dev release/*.tar.gz release/checksums.txt \
+            --prerelease \
+            --title "dev (${{ needs.plan.outputs.version }})" \
+            --notes "$(printf 'Rolling dev-channel build of commit %s.\n\nInstall or update:\n\n    curl -fsSL https://raw.githubusercontent.com/%s/main/install.sh | sh -s -- --channel dev\n\nInstalled builds update with `atc upgrade`.' "$GITHUB_SHA" "$GITHUB_REPOSITORY")"
 
       - name: Publish stable GitHub release
-        if: inputs.channel == 'stable'
+        if: needs.plan.outputs.channel == 'stable'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -231,4 +265,4 @@ jobs:
           git push origin "$tag"
           gh release create "$tag" release/*.tar.gz release/checksums.txt \
             --title "$tag" \
-            --notes "$(printf 'Install or update:\n\n    curl -fsSL https://raw.githubusercontent.com/%s/main/install.sh | sh\n\nThen run `atc service install` to start it as a login service.' "$GITHUB_REPOSITORY")"
+            --notes "$(printf 'Install or update:\n\n    curl -fsSL https://raw.githubusercontent.com/%s/main/install.sh | sh\n\nThen run `atc service install` to start it as a login service. Installed builds update with `atc upgrade`.' "$GITHUB_REPOSITORY")"

--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ Effect + Bun).
 curl -fsSL https://raw.githubusercontent.com/jeremytondo/atc/main/install.sh | sh
 ```
 
-This downloads the latest GitHub Release for your platform, verifies its
-checksum, and installs `atc` to `~/.local/bin` (`ATC_INSTALL_DIR` overrides).
-Run `atc service install` to start it as a login service, or `atc serve` for
-the foreground. A running server serves its console at
-`http://127.0.0.1:7331/` and the API reference at `/docs`. To update,
-re-run the installer, then `atc service install` again — it restarts the
-service onto the new binary.
+This downloads the latest stable GitHub Release for your platform, verifies
+its checksum, and installs `atc` to `~/.local/bin` (`ATC_INSTALL_DIR`
+overrides). Append `-s -- --channel dev` to ride the dev channel — a rolling
+prerelease rebuilt from every merge to `main`. Run `atc service install` to
+start it as a login service, or `atc serve` for the foreground. A running
+server serves its console at `http://127.0.0.1:7331/` and the API reference
+at `/docs`. To update, run `atc upgrade` — it reinstalls from the binary's
+own channel and restarts the service.
 
 ## Development
 

--- a/app-server/scripts/build.ts
+++ b/app-server/scripts/build.ts
@@ -1,9 +1,11 @@
 // Compiles src/main.ts into standalone `atc` executables with Bun.
 //
-// Usage: bun run scripts/build.ts [--all] [--version=X.Y.Z] [target ...]
+// Usage: bun run scripts/build.ts [--all] [--version=X.Y.Z] [--channel=C] [target ...]
 //   default          compile for the host platform only
 //   --all            cross-compile every release target
 //   --version=X.Y.Z  stamp a release version (default: package.json version)
+//   --channel=C      stamp a release channel (stable|dev); local builds carry
+//                    none, which makes `atc upgrade` refuse to touch them
 //   target ...       compile exactly these targets (release CI builds darwin
 //                    targets on macOS so Bun's ad-hoc code signature is
 //                    applied natively)
@@ -42,12 +44,20 @@ const args = process.argv.slice(2)
 // A typo'd flag must not silently release with the package.json fallback
 // version, so anything dash-prefixed and unrecognized is fatal.
 const unknownFlags = args.filter(
-  (arg) => arg.startsWith("--") && arg !== "--all" && !arg.startsWith("--version="),
+  (arg) =>
+    arg.startsWith("--") &&
+    arg !== "--all" &&
+    !arg.startsWith("--version=") &&
+    !arg.startsWith("--channel="),
 )
 if (unknownFlags.length > 0) {
   throw new Error(`unknown flag(s): ${unknownFlags.join(", ")}`)
 }
 const version = args.find((arg) => arg.startsWith("--version="))?.slice("--version=".length)
+const channel = args.find((arg) => arg.startsWith("--channel="))?.slice("--channel=".length)
+if (channel !== undefined && channel !== "stable" && channel !== "dev") {
+  throw new Error(`unknown channel ${channel}; expected stable or dev`)
+}
 const requested = args.filter((arg) => !arg.startsWith("--"))
 const invalid = requested.filter((target) => !(TARGETS as readonly string[]).includes(target))
 if (invalid.length > 0) {
@@ -80,6 +90,7 @@ for (const target of targets) {
     `--define=ATC_BUILD_COMMIT=${JSON.stringify(commit)}`,
     `--define=ATC_BUILD_BUILT_AT=${JSON.stringify(builtAt)}`,
     ...(version === undefined ? [] : [`--define=ATC_BUILD_VERSION=${JSON.stringify(version)}`]),
+    ...(channel === undefined ? [] : [`--define=ATC_BUILD_CHANNEL=${JSON.stringify(channel)}`]),
     `--outfile=${outfile}`,
     "src/main.ts",
   ])

--- a/app-server/src/cli/service.ts
+++ b/app-server/src/cli/service.ts
@@ -226,6 +226,21 @@ const launchdBootstrap = (subprocess: Subprocess["Service"], command: string, un
     yield* run(subprocess, command, "launchctl", ["bootstrap", fallback, unitFile])
   })
 
+/**
+ * The installed unit file's path, or undefined when no service is installed
+ * (or the platform has no supervisor). `atc upgrade` reads this to decide
+ * whether a reinstall must also restart the service onto the new binary.
+ */
+export const installedUnitFile = Effect.gen(function* () {
+  const platform = process.platform
+  if (platform !== "darwin" && platform !== "linux") return undefined
+  const config = yield* AppConfig
+  const fs = yield* FileSystem.FileSystem
+  const unitFile = unitFileFor(platform, config.home)
+  const exists = yield* fs.exists(unitFile).pipe(Effect.orElseSucceed(() => false))
+  return exists ? unitFile : undefined
+})
+
 const unitFileFor = (platform: Platform, home: string): string =>
   platform === "darwin"
     ? launchAgentPath(home)

--- a/app-server/src/cli/upgrade.ts
+++ b/app-server/src/cli/upgrade.ts
@@ -1,0 +1,131 @@
+import { dirname } from "node:path"
+import { Console, Effect, FileSystem, Option, Stream } from "effect"
+import { Command, Flag } from "effect/unstable/cli"
+import { BuildInfo } from "../platform/buildInfo.ts"
+import { Subprocess } from "../platform/subprocess.ts"
+import * as Cli from "./cli.ts"
+import * as Service from "./service.ts"
+
+// `atc upgrade`: reinstall this binary, in place, from its own release
+// channel, then restart the service unit (if one is installed) onto the new
+// binary. Invariants:
+//
+// - install.sh stays the single implementation of download/checksum/install.
+//   This command fetches it from the repo's main branch and runs it with
+//   ATC_CHANNEL/ATC_INSTALL_DIR pointed at this binary — it never
+//   re-implements the installer.
+// - Only release builds upgrade: the channel is stamped at compile time by
+//   the release pipeline, so source runs and local `mise run install` builds
+//   have none and are refused with the right alternative.
+// - The stable channel is immutable tags, so a version match short-circuits;
+//   the dev channel is a rolling tag whose version is unknowable without
+//   downloading, so dev always reinstalls.
+
+const REPO = "jeremytondo/atc"
+const INSTALLER_URL = `https://raw.githubusercontent.com/${REPO}/main/install.sh`
+
+/** The latest stable release tag (vX.Y.Z), or undefined when unreachable. */
+const latestStableTag = Effect.tryPromise(() =>
+  fetch(`https://api.github.com/repos/${REPO}/releases/latest`, {
+    signal: AbortSignal.timeout(10_000),
+    headers: { accept: "application/vnd.github+json" },
+  }).then((response) => (response.ok ? response.json() : undefined)),
+).pipe(
+  Effect.map((body: unknown) => {
+    if (typeof body !== "object" || body === null) return undefined
+    const tag = (body as { readonly tag_name?: unknown }).tag_name
+    return typeof tag === "string" ? tag : undefined
+  }),
+  Effect.orElseSucceed(() => undefined),
+)
+
+/** Run a child, streaming its stdout through; nonzero exit is a reported failure. */
+const runStreaming = (
+  subprocess: Subprocess["Service"],
+  executable: string,
+  args: ReadonlyArray<string>,
+  env: Record<string, string>,
+) =>
+  Effect.gen(function* () {
+    const child = yield* subprocess.spawn({ executable, args: [...args], env, extendEnv: true })
+    yield* Stream.runForEach(child.stdoutLines, (line) => Console.log(line))
+    const exitCode = yield* child.exitCode
+    if (exitCode !== 0) {
+      const stderr = (yield* child.stderrTail).join(" ").trim()
+      return yield* Cli.failReported(
+        `atc upgrade: ${executable} ${args.join(" ")} failed (exit ${exitCode})${stderr === "" ? "" : `: ${stderr}`}`,
+      )
+    }
+  }).pipe(Effect.scoped)
+
+const channelFlag = Flag.optional(
+  Flag.string("channel").pipe(
+    Flag.withDescription("Switch release channel: stable or dev (default: this build's channel)"),
+  ),
+)
+
+export const upgrade = Command.make("upgrade", { channel: channelFlag }, (parsed) =>
+  Effect.gen(function* () {
+    const build = yield* BuildInfo
+    const subprocess = yield* Subprocess
+    const fs = yield* FileSystem.FileSystem
+    const buildChannel = build.channel
+    if (buildChannel === undefined) {
+      return yield* Cli.failReported(
+        "atc upgrade: this build has no release channel (source run or local build); update with `mise run install`, or install a release build: curl -fsSL " +
+          `${INSTALLER_URL} | sh`,
+      )
+    }
+    const channel = Option.getOrElse(parsed.channel, () => buildChannel)
+    if (channel !== "stable" && channel !== "dev") {
+      return yield* Cli.failReported(
+        `atc upgrade: unknown channel ${channel} (expected stable or dev)`,
+      )
+    }
+    if (channel === "stable" && buildChannel === "stable") {
+      const latest = yield* latestStableTag
+      if (latest === `v${build.version}`) {
+        yield* Console.log(`atc v${build.version} is already the latest stable release`)
+        return
+      }
+    }
+    const installDir = dirname(process.execPath)
+    yield* Console.log(`upgrading atc in ${installDir} (channel: ${channel})`)
+    const script = yield* Effect.tryPromise(() =>
+      fetch(INSTALLER_URL, { signal: AbortSignal.timeout(30_000) }).then((response) => {
+        if (!response.ok) throw new Error(`fetching install.sh failed (HTTP ${response.status})`)
+        return response.text()
+      }),
+    )
+    yield* Effect.gen(function* () {
+      const tmpDir = yield* fs.makeTempDirectoryScoped()
+      const installer = `${tmpDir}/install.sh`
+      yield* fs.writeFileString(installer, script)
+      yield* runStreaming(subprocess, "sh", [installer], {
+        ATC_CHANNEL: channel,
+        ATC_INSTALL_DIR: installDir,
+      })
+    }).pipe(Effect.scoped)
+    // The service unit points at the installed path, so a reinstall restarts
+    // it onto the new binary; run it via that binary so new code does the work.
+    const unitFile = yield* Service.installedUnitFile
+    if (unitFile !== undefined) {
+      yield* Console.log(`restarting ${unitFile} onto the new binary`)
+      yield* runStreaming(subprocess, `${installDir}/atc`, ["service", "install"], {})
+    }
+    const installedVersion = yield* Effect.scoped(
+      Effect.gen(function* () {
+        const child = yield* subprocess.spawn({
+          executable: `${installDir}/atc`,
+          args: ["--version"],
+          env: {},
+          extendEnv: true,
+        })
+        const lines = yield* Stream.runCollect(child.stdoutLines)
+        yield* child.exitCode
+        return lines.join(" ").trim()
+      }),
+    )
+    yield* Console.log(`upgraded: atc v${build.version} -> ${installedVersion}`)
+  }).pipe(Cli.withSettledConfig("atc upgrade")),
+).pipe(Command.withDescription("Reinstall atc from its release channel and restart the service"))

--- a/app-server/src/main.ts
+++ b/app-server/src/main.ts
@@ -10,6 +10,7 @@ import { service } from "./cli/service.ts"
 import { terminal } from "./cli/terminals.ts"
 import { token } from "./cli/token.ts"
 import { thread } from "./cli/threads.ts"
+import { upgrade } from "./cli/upgrade.ts"
 import { smoke } from "./agents/smoke.ts"
 import * as Subprocess from "./platform/subprocess.ts"
 
@@ -24,6 +25,7 @@ const atc = Command.make("atc").pipe(
     stop,
     status,
     service,
+    upgrade,
     api,
     context,
     capabilities,

--- a/app-server/src/platform/buildInfo.ts
+++ b/app-server/src/platform/buildInfo.ts
@@ -7,6 +7,7 @@ import packageJson from "../../package.json"
 declare const ATC_BUILD_COMMIT: string | undefined
 declare const ATC_BUILD_BUILT_AT: string | undefined
 declare const ATC_BUILD_VERSION: string | undefined
+declare const ATC_BUILD_CHANNEL: string | undefined
 
 /**
  * Build metadata for the running executable. Handlers and the CLI read this
@@ -18,6 +19,10 @@ export class BuildInfo extends Context.Service<
     readonly version: string
     readonly commit: string
     readonly builtAt: string
+    /** Release channel ("stable" | "dev") stamped by the release pipeline;
+     * undefined for source runs and local builds, which have no channel to
+     * upgrade against. */
+    readonly channel: string | undefined
   }
 >()("app-server/BuildInfo") {}
 
@@ -25,6 +30,7 @@ export const buildInfo: BuildInfo["Service"] = {
   version: typeof ATC_BUILD_VERSION === "string" ? ATC_BUILD_VERSION : packageJson.version,
   commit: typeof ATC_BUILD_COMMIT === "string" ? ATC_BUILD_COMMIT : "dev",
   builtAt: typeof ATC_BUILD_BUILT_AT === "string" ? ATC_BUILD_BUILT_AT : "dev",
+  channel: typeof ATC_BUILD_CHANNEL === "string" ? ATC_BUILD_CHANNEL : undefined,
 }
 
 export const layer = Layer.succeed(BuildInfo)(buildInfo)

--- a/app-server/test/testBuildInfo.ts
+++ b/app-server/test/testBuildInfo.ts
@@ -5,6 +5,7 @@ export const testBuildInfo = {
   version: "1.2.3-test",
   commit: "abc1234",
   builtAt: "2026-07-31T00:00:00Z",
+  channel: undefined,
 } as const
 
 export const TestBuildInfoLayer = Layer.succeed(BuildInfo)(testBuildInfo)

--- a/install.sh
+++ b/install.sh
@@ -5,18 +5,21 @@ set -eu
 repo="${ATC_REPO:-jeremytondo/atc}"
 install_dir="${ATC_INSTALL_DIR:-$HOME/.local/bin}"
 version="${ATC_VERSION:-latest}"
+channel="${ATC_CHANNEL:-stable}"
 
 usage() {
   cat <<'EOF'
 Install atc from GitHub Releases.
 
 Usage:
-  ./install.sh [--version vX.Y.Z]
+  ./install.sh [--version vX.Y.Z] [--channel stable|dev]
 
 Environment:
   ATC_REPO         GitHub repository (default: jeremytondo/atc)
   ATC_INSTALL_DIR  Install directory (default: ~/.local/bin)
   ATC_VERSION      Release tag, or latest (default: latest)
+  ATC_CHANNEL      Channel when no version is given: stable, or dev for the
+                   rolling build published from main (default: stable)
 EOF
 }
 
@@ -34,6 +37,14 @@ while [ "$#" -gt 0 ]; do
       version="$2"
       shift 2
       ;;
+    --channel)
+      if [ "$#" -lt 2 ]; then
+        echo "missing value for --channel" >&2
+        exit 1
+      fi
+      channel="$2"
+      shift 2
+      ;;
     *)
       echo "unknown argument: $1" >&2
       usage >&2
@@ -41,6 +52,14 @@ while [ "$#" -gt 0 ]; do
       ;;
   esac
 done
+
+case "$channel" in
+  stable|dev) ;;
+  *)
+    echo "unknown channel: $channel (expected stable or dev)" >&2
+    exit 1
+    ;;
+esac
 
 need() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -74,11 +93,15 @@ case "$arch" in
     ;;
 esac
 
+# An explicit version pins a tag; otherwise the channel picks between the
+# latest stable release and the rolling `dev` prerelease tag.
 archive="atc-${os}-${arch}.tar.gz"
-if [ "$version" = "latest" ]; then
-  download_base="https://github.com/${repo}/releases/latest/download"
-else
+if [ "$version" != "latest" ]; then
   download_base="https://github.com/${repo}/releases/download/${version}"
+elif [ "$channel" = "dev" ]; then
+  download_base="https://github.com/${repo}/releases/download/dev"
+else
+  download_base="https://github.com/${repo}/releases/latest/download"
 fi
 
 tmp="$(mktemp -d)"
@@ -123,5 +146,5 @@ case ":$PATH:" in
     echo "add ${install_dir} to PATH to run atc directly"
     ;;
 esac
-echo "run \`atc service install\` to run it as a login service — including re-running it after an update, which restarts onto the new binary — or \`atc serve\` for the foreground"
+echo "run \`atc service install\` to run it as a login service, or \`atc serve\` for the foreground; update later with \`atc upgrade\`"
 echo "a running server serves its console at its base URL (default http://127.0.0.1:7331/) and API docs at /docs"

--- a/mise.toml
+++ b/mise.toml
@@ -115,6 +115,37 @@ clone opencode https://github.com/sst/opencode.git
 clone zmx --branch 'v0.6.0' https://github.com/neurosnap/zmx.git
 """
 
-[tasks."macos:release-dev"]
+# --- Releases ---
+# One shape per surface: <surface>:release:<channel>. The App Server pipeline
+# runs in GitHub Actions (.github/workflows/app-server-release.yml) — merges
+# to main publish the rolling dev prerelease automatically, so its tasks just
+# dispatch the workflow. The macOS tasks build, notarize, and upload locally.
+
+[tasks."app-server:release:stable"]
+description = "Dispatch the stable App Server release (usage: mise run app-server:release:stable [patch|minor|major])"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+bump="${1:-patch}"
+case "$bump" in
+  patch|minor|major) ;;
+  *) echo "usage: mise run app-server:release:stable [patch|minor|major]" >&2; exit 1 ;;
+esac
+gh workflow run app-server-release.yml -f channel=stable -f release_type="$bump"
+echo "dispatched stable release ($bump bump); follow with: gh run watch"
+"""
+
+[tasks."app-server:release:dev"]
+description = "Dispatch a dev-channel App Server release (merges to main publish one automatically)"
+run = [
+  "gh workflow run app-server-release.yml -f channel=dev",
+  "echo 'dispatched dev release; follow with: gh run watch'",
+]
+
+[tasks."macos:release:stable"]
+description = "Build, notarize, and attach the stable macOS DMG to the latest vX.Y.Z release"
+run = "scripts/release-macos.sh --channel stable --upload"
+
+[tasks."macos:release:dev"]
 description = "Build and publish a notarized dev DMG to GitHub Releases"
-run = "scripts/release-dev.sh --upload"
+run = "scripts/release-macos.sh --channel dev --upload"

--- a/scripts/release-macos.sh
+++ b/scripts/release-macos.sh
@@ -3,16 +3,22 @@ set -euo pipefail
 
 usage() {
   cat <<'USAGE'
-Usage: scripts/release-dev.sh [--upload]
+Usage: scripts/release-macos.sh [--channel dev|stable] [--upload]
 
 Builds, exports, packages, notarizes, staples, and verifies a Developer ID
-DMG for atc.app. With --upload, also creates a GitHub prerelease
-and uploads the notarized DMG.
+DMG for atc.app.
+
+  --channel dev     (default) dev bundle id (ElevenIdeas.atc.dev); --upload
+                    creates a dev-<timestamp> GitHub prerelease with the DMG.
+  --channel stable  stable bundle id, marketing version from the latest
+                    vX.Y.Z tag; --upload attaches the DMG to that tag's
+                    existing GitHub release (run the stable App Server
+                    release first: mise run app-server:release:stable).
 
 Environment overrides:
   ATC_TEAM_ID         Apple Developer Team ID (default: 337D6CNU4E)
   ATC_NOTARY_PROFILE  notarytool stored-credentials profile (default: ateliercode-notary)
-  ATC_ARTIFACT_ROOT   artifact root (default: .build/release-dev)
+  ATC_ARTIFACT_ROOT   artifact root (default: .build/release-macos)
 USAGE
 }
 
@@ -30,10 +36,16 @@ require_tool() {
 }
 
 UPLOAD=0
+CHANNEL="dev"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --upload)
       UPLOAD=1
+      ;;
+    --channel)
+      [[ $# -ge 2 ]] || die "missing value for --channel"
+      CHANNEL="$2"
+      shift
       ;;
     -h|--help)
       usage
@@ -47,12 +59,16 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
+case "$CHANNEL" in
+  dev|stable) ;;
+  *) die "Unknown channel: $CHANNEL (expected dev or stable)" ;;
+esac
+
 ATC_TEAM_ID="${ATC_TEAM_ID:-337D6CNU4E}"
 ATC_NOTARY_PROFILE="${ATC_NOTARY_PROFILE:-ateliercode-notary}"
-ATC_ARTIFACT_ROOT="${ATC_ARTIFACT_ROOT:-.build/release-dev}"
+ATC_ARTIFACT_ROOT="${ATC_ARTIFACT_ROOT:-.build/release-macos}"
 
 APP_NAME="atc"
-BUNDLE_ID="ElevenIdeas.atc.dev"
 PROJECT_REL="macos/atc.xcodeproj"
 SCHEME="atc"
 CONFIGURATION="Release"
@@ -63,15 +79,30 @@ PROJECT_PATH="$REPO_ROOT/$PROJECT_REL"
 EXPORT_OPTIONS_PLIST="$SCRIPT_DIR/ExportOptions.DeveloperID.plist"
 
 TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
-TAG="dev-$TIMESTAMP"
-TITLE="atc Dev $TIMESTAMP"
+# The two channels differ only here: identity (bundle id), which tag the DMG
+# publishes to, and the marketing version stamped into the app.
+if [[ "$CHANNEL" == "stable" ]]; then
+  BUNDLE_ID="ElevenIdeas.atc"
+  TAG="$(cd "$REPO_ROOT" && git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=v:refname | tail -1)"
+  [[ -n "$TAG" ]] || die "No vX.Y.Z tag found; run the stable App Server release first (mise run app-server:release:stable)"
+  MARKETING_VERSION="${TAG#v}"
+  TITLE=""
+  DMG_BASENAME="atc-macos-arm64.dmg"
+else
+  BUNDLE_ID="ElevenIdeas.atc.dev"
+  TAG="dev-$TIMESTAMP"
+  MARKETING_VERSION=""
+  TITLE="atc Dev $TIMESTAMP"
+  DMG_BASENAME="atc-dev-$TIMESTAMP.dmg"
+fi
+
 RUN_DIR="$REPO_ROOT/$ATC_ARTIFACT_ROOT/$TIMESTAMP"
-ARCHIVE_PATH="$RUN_DIR/atc-dev.xcarchive"
+ARCHIVE_PATH="$RUN_DIR/atc-$CHANNEL.xcarchive"
 EXPORT_PATH="$RUN_DIR/export"
 DERIVED_DATA_PATH="$RUN_DIR/DerivedData"
 SOURCE_PACKAGES_PATH="$RUN_DIR/SourcePackages"
 DMG_ROOT="$RUN_DIR/dmg-root"
-DMG_PATH="$RUN_DIR/atc-dev-$TIMESTAMP.dmg"
+DMG_PATH="$RUN_DIR/$DMG_BASENAME"
 APP_PATH="$EXPORT_PATH/$APP_NAME.app"
 
 DEVELOPER_ID_IDENTITY=""
@@ -110,6 +141,9 @@ validate_github_auth() {
   if [[ "$UPLOAD" -eq 1 ]]; then
     require_tool gh
     gh auth status -h github.com >/dev/null 2>&1 || die "gh is not authenticated for github.com. Run gh auth login, then rerun with --upload."
+    if [[ "$CHANNEL" == "stable" ]]; then
+      gh release view "$TAG" >/dev/null 2>&1 || die "No GitHub release for $TAG; run the stable App Server release first (mise run app-server:release:stable)."
+    fi
   fi
 }
 
@@ -132,7 +166,7 @@ require_tool ditto
 [[ -d "$PROJECT_PATH" ]] || die "Missing Xcode project: $PROJECT_PATH"
 [[ -f "$EXPORT_OPTIONS_PLIST" ]] || die "Missing export options: $EXPORT_OPTIONS_PLIST"
 
-log "Validating signing, notarization, and upload prerequisites"
+log "Validating signing, notarization, and upload prerequisites ($CHANNEL channel)"
 find_developer_id_identity
 validate_notary_profile
 validate_github_auth
@@ -150,6 +184,9 @@ XCODE_OVERRIDES=(
   "DEVELOPMENT_TEAM=$ATC_TEAM_ID"
   "CODE_SIGN_STYLE=Automatic"
 )
+if [[ -n "$MARKETING_VERSION" ]]; then
+  XCODE_OVERRIDES+=("MARKETING_VERSION=$MARKETING_VERSION")
+fi
 
 log "Archiving $APP_NAME.app"
 xcodebuild archive \
@@ -203,13 +240,19 @@ log "Assessing DMG with Gatekeeper"
 spctl --assess --type open --context context:primary-signature --verbose=4 "$DMG_PATH"
 
 if [[ "$UPLOAD" -eq 1 ]]; then
-  log "Creating GitHub prerelease $TAG"
-  gh release create "$TAG" "$DMG_PATH" \
-    --title "$TITLE" \
-    --notes "Developer ID notarized Apple Silicon dev build for $APP_NAME." \
-    --prerelease
+  if [[ "$CHANNEL" == "stable" ]]; then
+    log "Uploading DMG to release $TAG"
+    gh release upload "$TAG" "$DMG_PATH" --clobber
+  else
+    log "Creating GitHub prerelease $TAG"
+    gh release create "$TAG" "$DMG_PATH" \
+      --title "$TITLE" \
+      --notes "Developer ID notarized Apple Silicon dev build for $APP_NAME." \
+      --prerelease
+  fi
 fi
 
 log "Release artifact ready"
+printf 'Channel: %s\n' "$CHANNEL"
 printf 'Tag: %s\n' "$TAG"
 printf 'DMG: %s\n' "$DMG_PATH"


### PR DESCRIPTION
Sets up the dev/stable release process for the App Server (plus the macOS stable DMG path), following the rolling-dev-tag pattern used by Bun (canary) and Ghostty (tip).

## What changes

**Workflow (`app-server-release.yml`)**
- Every merge to `main` touching `app-server/**` now auto-publishes the **rolling `dev` prerelease**: the `dev` tag is force-moved, the release recreated, so exactly one dev build ever exists. Marked prerelease, so `releases/latest` (the stable URL) is never polluted.
- Stable stays manual dispatch (`channel=stable`, `release_type=patch|minor|major`), tagging `vX.Y.Z` from the highest existing tag.
- Dev versions stamp as `<next-patch>-dev.<UTC minute>`; both channels bake `ATC_BUILD_CHANNEL` into the binary.

**Installer (`install.sh`)**
- `--channel stable|dev` (or `ATC_CHANNEL`) picks between `releases/latest` and the rolling `dev` tag; explicit `--version` still pins a tag.

**`atc upgrade` (new CLI command)**
- Reinstalls in place from the binary's own baked-in channel by fetching and running `install.sh` against its own install directory, then restarts the service unit when one is installed (via the new binary). `--channel` switches channels. Source runs and local `mise run install` builds carry no channel and are refused with the right alternative. Stable-to-stable short-circuits when already on the latest tag.

**mise tasks — one shape per surface: `<surface>:release:<channel>`**
- `mise run app-server:release:stable [patch|minor|major]` and `mise run app-server:release:dev` dispatch the workflow.
- `scripts/release-dev.sh` → `scripts/release-macos.sh --channel dev|stable`: `macos:release:dev` keeps today's `dev-<timestamp>` prerelease DMG flow; `macos:release:stable` uses the real bundle id, stamps `MARKETING_VERSION` from the latest `vX.Y.Z` tag, and attaches the DMG to that existing release.

## Verified
- `mise run -C app-server check` green (fmt, typecheck, 340 tests, OpenAPI + admin UI drift).
- Compiled a host binary with `--version/--channel`: version stamp and channel plumbing confirmed; source-run `atc upgrade` refuses with the one-line diagnostic.
- `sh -n install.sh`, `bash -n release-macos.sh`, and mise task arg validation checked.

Note: the first dev release publishes automatically when this merges; the first stable release is `mise run app-server:release:stable` whenever ready.

https://claude.ai/code/session_01BavMRBVDKwTpubKRaabznP