### PR TITLE
Releases: dev channel is on-demand dispatch only, not on-merge

### DIFF
--- a/.github/workflows/app-server-release.yml
+++ b/.github/workflows/app-server-release.yml
@@ -1,16 +1,18 @@
 # Release pipeline for the App Server executable (ATC-127).
 #
-# Two channels, one pipeline:
+# Two channels, one pipeline, both manual dispatch (mise run
+# app-server:release:dev / app-server:release:stable) — dev releases are
+# on-demand, not on-merge, so both surfaces share one mental model (the
+# macOS DMG can only build on-demand: signing lives on the developer Mac):
 #
-#   dev     every push to main (app-server paths) — and manual dispatch —
-#           rebuilds the single rolling `dev` prerelease: the tag is force-
+#   dev     rebuilds the single rolling `dev` prerelease: the tag is force-
 #           moved, the release recreated, so exactly one dev build exists.
 #           Versions stamp as <next-patch>-dev.<UTC minute> so `atc --version`
 #           is self-describing and sorts below the next stable release.
-#   stable  manual dispatch only: tags vX.Y.Z (bumped from the highest
-#           existing v tag per release_type) and publishes a GitHub Release.
-#           `releases/latest` only ever points here — prereleases are
-#           excluded — so install.sh's stable channel needs no manifest.
+#   stable  tags vX.Y.Z (bumped from the highest existing v tag per
+#           release_type) and publishes a GitHub Release. `releases/latest`
+#           only ever points here — prereleases are excluded — so
+#           install.sh's stable channel needs no manifest.
 #
 # Darwin targets build on macOS so Bun's ad-hoc code signature is applied
 # (and verified) natively; Linux targets cross-compile on ubuntu. Three of
@@ -21,13 +23,6 @@
 name: App Server Release
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "app-server/**"
-      - "install.sh"
-      - "mise.toml"
-      - ".github/workflows/app-server-release.yml"
   workflow_dispatch:
     inputs:
       channel:
@@ -77,11 +72,7 @@ jobs:
       - name: Compute channel and version
         id: version
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            channel="dev"
-          else
-            channel="${{ inputs.channel }}"
-          fi
+          channel="${{ inputs.channel }}"
           echo "channel=$channel" >> "$GITHUB_OUTPUT"
           if [ "$channel" = "stable" ]; then
             if [ "${GITHUB_REF_NAME}" != "${{ github.event.repository.default_branch }}" ]; then

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ curl -fsSL https://raw.githubusercontent.com/jeremytondo/atc/main/install.sh | s
 This downloads the latest stable GitHub Release for your platform, verifies
 its checksum, and installs `atc` to `~/.local/bin` (`ATC_INSTALL_DIR`
 overrides). Append `-s -- --channel dev` to ride the dev channel — a rolling
-prerelease rebuilt from every merge to `main`. Run `atc service install` to
+prerelease published on demand from `main`. Run `atc service install` to
 start it as a login service, or `atc serve` for the foreground. A running
 server serves its console at `http://127.0.0.1:7331/` and the API reference
 at `/docs`. To update, run `atc upgrade` — it reinstalls from the binary's

--- a/mise.toml
+++ b/mise.toml
@@ -116,10 +116,11 @@ clone zmx --branch 'v0.6.0' https://github.com/neurosnap/zmx.git
 """
 
 # --- Releases ---
-# One shape per surface: <surface>:release:<channel>. The App Server pipeline
-# runs in GitHub Actions (.github/workflows/app-server-release.yml) — merges
-# to main publish the rolling dev prerelease automatically, so its tasks just
-# dispatch the workflow. The macOS tasks build, notarize, and upload locally.
+# One shape per surface, one mental model: <surface>:release:<channel>, and a
+# release of either channel happens only when you run its task. The App
+# Server tasks dispatch the GitHub Actions pipeline
+# (.github/workflows/app-server-release.yml); the macOS tasks build,
+# notarize, and upload locally (signing lives on the developer Mac).
 
 [tasks."app-server:release:stable"]
 description = "Dispatch the stable App Server release (usage: mise run app-server:release:stable [patch|minor|major])"
@@ -136,7 +137,7 @@ echo "dispatched stable release ($bump bump); follow with: gh run watch"
 """
 
 [tasks."app-server:release:dev"]
-description = "Dispatch a dev-channel App Server release (merges to main publish one automatically)"
+description = "Build and publish the rolling dev-channel App Server release"
 run = [
   "gh workflow run app-server-release.yml -f channel=dev",
   "echo 'dispatched dev release; follow with: gh run watch'",


### PR DESCRIPTION
Merges to main no longer auto-publish the rolling dev prerelease. Both surfaces now share one mental model: a release happens only when you run its task — `mise run app-server:release:dev|stable` (dispatches the CI pipeline) or `mise run macos:release:dev|stable` (builds locally, since signing lives on the developer Mac). CI on main still validates everything; it just publishes nothing.

https://claude.ai/code/session_01BavMRBVDKwTpubKRaabznP