### PR TITLE
Releases: mise run release:dev|stable builds the whole product in one command

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -116,11 +116,20 @@ clone zmx --branch 'v0.6.0' https://github.com/neurosnap/zmx.git
 """
 
 # --- Releases ---
-# One shape per surface, one mental model: <surface>:release:<channel>, and a
-# release of either channel happens only when you run its task. The App
-# Server tasks dispatch the GitHub Actions pipeline
+# One mental model: release:<channel> releases the whole product;
+# <surface>:release:<channel> releases one surface. Nothing publishes on
+# merge — a release happens only when you run its task. The App Server tasks
+# dispatch the GitHub Actions pipeline
 # (.github/workflows/app-server-release.yml); the macOS tasks build,
 # notarize, and upload locally (signing lives on the developer Mac).
+
+[tasks."release:dev"]
+description = "Full dev release: App Server in CI + macOS DMG locally, in parallel"
+run = "scripts/release.sh dev"
+
+[tasks."release:stable"]
+description = "Full stable release: cut vX.Y.Z in CI, then attach the macOS DMG (usage: mise run release:stable [patch|minor|major])"
+run = "scripts/release.sh stable"
 
 [tasks."app-server:release:stable"]
 description = "Dispatch the stable App Server release (usage: mise run app-server:release:stable [patch|minor|major])"

--- a/scripts/release-macos.sh
+++ b/scripts/release-macos.sh
@@ -83,6 +83,8 @@ TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 # publishes to, and the marketing version stamped into the app.
 if [[ "$CHANNEL" == "stable" ]]; then
   BUNDLE_ID="ElevenIdeas.atc"
+  # Release tags are created in CI, so sync them before resolving the latest.
+  git -C "$REPO_ROOT" fetch --quiet origin 'refs/tags/v*:refs/tags/v*' 2>/dev/null || true
   TAG="$(cd "$REPO_ROOT" && git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=v:refname | tail -1)"
   [[ -n "$TAG" ]] || die "No vX.Y.Z tag found; run the stable App Server release first (mise run app-server:release:stable)"
   MARKETING_VERSION="${TAG#v}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/release.sh dev|stable [patch|minor|major]
+
+Full-product release: the App Server (built in CI) and the macOS DMG (built
+on this Mac) for the same channel, in one command.
+
+  dev     dispatch the rolling App Server dev prerelease, publish the macOS
+          dev DMG while CI builds, then wait for the CI run to finish.
+  stable  dispatch the App Server vX.Y.Z release, wait for CI to publish it,
+          then attach the macOS DMG to that release. The bump argument
+          (default: patch) picks the version increment.
+USAGE
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+CHANNEL="${1:-}"
+BUMP="${2:-patch}"
+case "$CHANNEL" in
+  dev|stable) ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage >&2
+    die "expected channel dev or stable"
+    ;;
+esac
+case "$BUMP" in
+  patch|minor|major) ;;
+  *)
+    usage >&2
+    die "expected bump patch, minor, or major"
+    ;;
+esac
+
+command -v gh >/dev/null 2>&1 || die "Missing required tool: gh"
+
+WORKFLOW="app-server-release.yml"
+
+latest_run_id() {
+  gh run list --workflow "$WORKFLOW" --limit 1 --json databaseId -q '.[0].databaseId' 2>/dev/null || true
+}
+
+# Capture the newest run before dispatching so the dispatched run is
+# recognized by its id changing — `gh workflow run` returns no run id.
+prev_run="$(latest_run_id)"
+
+if [[ "$CHANNEL" == "stable" ]]; then
+  mise run app-server:release:stable "$BUMP"
+else
+  mise run app-server:release:dev
+fi
+
+run_id="$prev_run"
+for _ in $(seq 1 30); do
+  run_id="$(latest_run_id)"
+  if [[ -n "$run_id" && "$run_id" != "$prev_run" ]]; then
+    break
+  fi
+  sleep 2
+done
+if [[ -z "$run_id" || "$run_id" == "$prev_run" ]]; then
+  die "the dispatched App Server run never appeared; check gh run list --workflow $WORKFLOW"
+fi
+
+if [[ "$CHANNEL" == "stable" ]]; then
+  # The DMG attaches to the vX.Y.Z release, so CI must publish it first.
+  echo "waiting for the App Server release run to publish the new version..."
+  gh run watch "$run_id" --exit-status
+  mise run macos:release:stable
+else
+  # CI builds the server while this Mac builds the DMG.
+  mise run macos:release:dev
+  echo "macOS dev DMG published; waiting for the App Server run to finish..."
+  gh run watch "$run_id" --exit-status
+fi
+
+echo "full $CHANNEL release complete"


### PR DESCRIPTION
Adds the product-level wrapper on top of #183. `mise run release:dev` dispatches the App Server CI build and publishes the macOS dev DMG locally **in parallel**, then waits for the CI run; `mise run release:stable [patch|minor|major]` dispatches the vX.Y.Z release, waits for CI to publish it, then attaches the DMG to that release.

Task hierarchy: `release:<channel>` = whole product; `<surface>:release:<channel>` = one surface.

Also fixes a latent bug in `release-macos.sh --channel stable`: release tags are created in CI, so the script now fetches `v*` tags before resolving the latest one.

Stacked on #183.

https://claude.ai/code/session_01BavMRBVDKwTpubKRaabznP