### PR TITLE
Clarify dev release titles

### DIFF
--- a/.github/workflows/app-server-release.yml
+++ b/.github/workflows/app-server-release.yml
@@ -241,7 +241,7 @@ jobs:
           git push -f origin dev
           gh release create dev release/*.tar.gz release/checksums.txt \
             --prerelease \
-            --title "dev (${{ needs.plan.outputs.version }})" \
+            --title "App Server dev (${{ needs.plan.outputs.version }})" \
             --notes "$(printf 'Rolling dev-channel build of commit %s.\n\nInstall or update:\n\n    curl -fsSL https://raw.githubusercontent.com/%s/main/install.sh | sh -s -- --channel dev\n\nInstalled builds update with `atc upgrade`.' "$GITHUB_SHA" "$GITHUB_REPOSITORY")"
 
       - name: Publish stable GitHub release

--- a/scripts/release-macos.sh
+++ b/scripts/release-macos.sh
@@ -100,7 +100,7 @@ else
   BUNDLE_ID="ElevenIdeas.atc.dev"
   TAG="dev-$TIMESTAMP"
   MARKETING_VERSION=""
-  TITLE="atc Dev $TIMESTAMP"
+  TITLE="macOS App dev ($TIMESTAMP)"
   DMG_BASENAME="atc-dev-$TIMESTAMP.dmg"
 fi
 


### PR DESCRIPTION
## Summary

- Label the rolling dev release as an App Server release.
- Label timestamped macOS dev releases as macOS App releases.
- Preserve the existing tags, versions, artifact names, and publishing behavior.

## Why

The previous titles were ambiguous about which product surface each GitHub prerelease contained. Explicit surface names make the release list easier to understand without changing either release channel.

## Impact

Dev GitHub Releases now follow the consistent `<surface> dev (<version>)` naming pattern. Installation and upgrade URLs are unchanged.

## Validation

- `bash -n scripts/release-macos.sh`
- Inspected the generated GitHub Actions release command after the string-only title update.