### PR TITLE
Resolve external references during thread title generation

### DIFF
--- a/app-server/README.md
+++ b/app-server/README.md
@@ -46,9 +46,21 @@ Environment variables are flat `ATC_<KEY>`: `ATC_PORT`, `ATC_BIND`,
 `ATC_TAILSCALE_EXECUTABLE`, `ATC_CODEX_EXECUTABLE`, `ATC_CLAUDE_EXECUTABLE`, and
 `ATC_CONFIG` (path to an alternate config file). The config file may set
 `port`, `bind`, `tailscale`, `logLevel` (case-insensitive), `dataDir`,
-`zmxExecutable`, `tailscaleExecutable`, `codexExecutable`, and
-`claudeExecutable`; unknown keys are rejected. `atc serve --port`/`--bind`/
+`zmxExecutable`, `tailscaleExecutable`, `codexExecutable`, `claudeExecutable`,
+and `titleResolvers`; unknown keys are rejected. `atc serve --port`/`--bind`/
 `--tailscale` override the configured values for that server only.
+
+`titleResolvers` is a config-file-only table of remote MCP servers the thread
+title generator may consult, each naming the only tools it may call, so a prompt
+that just references an issue or PR still gets a meaningful name. Key each entry
+by the name the server is already authenticated under (`claude mcp list`) —
+stored OAuth is per name, and an unauthenticated resolver is skipped silently:
+
+```toml
+[titleResolvers.linear-server]
+url = "https://mcp.linear.app/mcp"
+tools = ["get_issue"]
+```
 
 Upgrading from the retired Go server: its data is not migrated and nothing
 deletes it automatically. Remove the leftovers by hand if you had one —

--- a/app-server/src/agents/agentAdapter.ts
+++ b/app-server/src/agents/agentAdapter.ts
@@ -537,11 +537,16 @@ export const resolveProviderExecutable = (
  * generateTitle so Claude and Codex titles read the same. The user prompt
  * is capped so a pasted wall of text cannot blow up the one-shot's cost —
  * the opening lines are what a title needs.
+ *
+ * The reference rules (ATC-186) are unconditional: whether a lookup tool
+ * exists is the provider's business (Claude's configured resolvers, Codex's
+ * own connectors), and a run with none takes the same fallback the rules
+ * demand when a lookup fails.
  */
 export const titleInstruction = (prompt: string): string =>
   [
     "You write concise titles for coding-agent conversation threads.",
-    "Reply with the title only: a single line of plain text.",
+    "Reply with the title only: a single line of plain text, with nothing before or after it.",
     "Rules:",
     "- Summarize the user's request; never answer it or restate it verbatim.",
     "- Make the descriptive part 3-8 words, specific over generic.",
@@ -554,6 +559,11 @@ export const titleInstruction = (prompt: string): string =>
     "  - Explore: brainstorm, research, compare, or understand options.",
     "  - Investigate: diagnose a suspected bug or problem without asking for a fix.",
     "- If no category clearly matches, omit the prefix.",
+    "- Keep every identifier the request names — issue id, PR number, URL — verbatim in the title; identifiers do not count toward the word budget.",
+    "- A leading $name or /name is a skill invocation: the name is the action being asked for (for example $grill means grill whatever follows).",
+    "- If your tools include one that can look up a referenced identifier, call it once — really call it, never describe calling it — and add the resource's real title. Use no other tool and never retry.",
+    "- If you have no such tool, or the lookup fails, title from the message alone: it may then say nothing about the resource beyond the identifier itself. Never guess what the identifier refers to, and never announce what you are about to do.",
+    "- Example: '$implement ATC-123' becomes 'Build - ATC-123 Restore terminal sessions' when the lookup resolves, and 'Build - ATC-123' when it does not.",
     "",
     "The user's first message:",
     prompt.length > 4_000 ? `${prompt.slice(0, 4_000)}…` : prompt,
@@ -569,16 +579,21 @@ const WRAPPING_QUOTES = [
 
 /**
  * Output hygiene for generated titles, enforced in code rather than trusted
- * to the prompt (T3Code/OpenCode precedent): first non-empty line only,
- * whitespace collapsed, wrapping quotes stripped, trailing punctuation
- * dropped, capped at ~50 characters on a word boundary. Returns null when
- * nothing usable remains — the caller gives up silently.
+ * to the prompt (T3Code/OpenCode precedent): one line only, whitespace
+ * collapsed, wrapping quotes stripped, trailing punctuation dropped, capped
+ * at ~50 characters on a word boundary. Returns null when nothing usable
+ * remains — the caller gives up silently.
+ *
+ * The line taken is the LAST non-empty one (ATC-186): a small model that
+ * ignores "the title only" narrates first and answers last — reliably so
+ * once a resolver tool is in play ("I don't have that tool… \n\n Build -
+ * ATC-186") — and the narration is never the title.
  */
 export const sanitizeTitle = (raw: string): string | null => {
   const line = raw
     .split("\n")
     .map((candidate) => candidate.trim())
-    .find((candidate) => candidate !== "")
+    .findLast((candidate) => candidate !== "")
   if (line === undefined) return null
   let title = line.replace(/\s+/g, " ").trim()
   for (let stripped = true; stripped;) {

--- a/app-server/src/agents/agentAdapter.ts
+++ b/app-server/src/agents/agentAdapter.ts
@@ -559,7 +559,7 @@ export const titleInstruction = (prompt: string): string =>
     "  - Explore: brainstorm, research, compare, or understand options.",
     "  - Investigate: diagnose a suspected bug or problem without asking for a fix.",
     "- If no category clearly matches, omit the prefix.",
-    "- Keep every identifier the request names — issue id, PR number, URL — verbatim in the title; identifiers do not count toward the word budget.",
+    "- Keep every identifier the request names — issue id, PR number, URL — verbatim, and put it ahead of the descriptive part; identifiers do not count toward the word budget.",
     "- A leading $name or /name is a skill invocation: the name is the action being asked for (for example $grill means grill whatever follows).",
     "- If your tools include one that can look up a referenced identifier, call it once — really call it, never describe calling it — and add the resource's real title. Use no other tool and never retry.",
     "- If you have no such tool, or the lookup fails, title from the message alone: it may then say nothing about the resource beyond the identifier itself. Never guess what the identifier refers to, and never announce what you are about to do.",
@@ -583,6 +583,11 @@ const WRAPPING_QUOTES = [
  * collapsed, wrapping quotes stripped, trailing punctuation dropped, capped
  * at ~50 characters on a word boundary. Returns null when nothing usable
  * remains — the caller gives up silently.
+ *
+ * The cap applies to the whole title, identifiers included; the instruction
+ * keeps them ahead of the descriptive part so the cut lands on prose. An
+ * identifier longer than the cap itself (a deep URL) is still truncated —
+ * a title that long would not be a title.
  *
  * The line taken is the LAST non-empty one (ATC-186): a small model that
  * ignores "the title only" narrates first and answers last — reliably so

--- a/app-server/src/agents/claudeAdapter.ts
+++ b/app-server/src/agents/claudeAdapter.ts
@@ -456,6 +456,40 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
         return executable
       })
 
+      /**
+       * The title one-shot's resolver wiring (ATC-186). Only the configured
+       * tools are pre-approved; `dontAsk` denies the rest, so a resolver
+       * that also exposes write tools cannot be talked into using them.
+       * Server names must match what the provider stores credentials under
+       * — a name it cannot authenticate is skipped as `needs-auth`. With no
+       * resolvers this is the original locked-down shape: one turn, nothing
+       * to call.
+       */
+      const resolvers = Object.entries(config.titleResolvers)
+      const titleResolverOptions = {
+        mcpServers: Object.fromEntries(
+          resolvers.map(([name, resolver]) => [
+            name,
+            {
+              type: "http" as const,
+              url: resolver.url,
+              // A deferred tool would cost a tool-search turn the one-shot
+              // does not have; loading blocks only until the server
+              // connects (SDK-capped at 5s), inside the title timeout.
+              alwaysLoad: true,
+              ...(resolver.headers !== undefined ? { headers: resolver.headers } : {}),
+            },
+          ]),
+        ),
+        allowedTools: resolvers.flatMap(([name, resolver]) =>
+          resolver.tools.map((tool) => `mcp__${name}__${tool}`),
+        ),
+        // Room for the lookup turn, the reply, and one recovery: too few
+        // turns means no title at all, while the 90s timeout below is what
+        // actually bounds the run.
+        maxTurns: resolvers.length === 0 ? 1 : 4,
+      }
+
       const hookFilePaths = (providerSessionId: string) => ({
         headerFile: path.join(config.stateDir, `claude-hooks-${providerSessionId}.header`),
         settingsFile: path.join(config.stateDir, `claude-hooks-${providerSessionId}.json`),
@@ -804,8 +838,10 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
             Effect.gen(function* () {
               const executable = yield* resolvedExecutable
               // The smoke-test one-shot shape (smoke.ts claudeRoundTrip):
-              // one turn, no tools, nothing persisted — plus a haiku-class
-              // model, since a title needs speed, not depth.
+              // no built-in tools, nothing persisted — plus a haiku-class
+              // model, since a title needs speed, not depth. Turn count and
+              // any MCP resolver come from titleResolverOptions; strict MCP
+              // keeps the project's own .mcp.json out of an unattended run.
               const abort = new AbortController()
               yield* Effect.addFinalizer(() => Effect.sync(() => abort.abort()))
               const prompt = yield* Stream.toAsyncIterableEffect(
@@ -823,12 +859,12 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
                       env: claudeEnvironment(),
                       pathToClaudeCodeExecutable: executable,
                       settingSources: [],
+                      strictMcpConfig: true,
                       permissionMode: "dontAsk",
-                      allowedTools: [],
                       tools: [],
-                      maxTurns: 1,
                       persistSession: false,
                       model: "haiku",
+                      ...titleResolverOptions,
                     },
                   }),
                 catch: (error) =>

--- a/app-server/src/platform/config.ts
+++ b/app-server/src/platform/config.ts
@@ -40,6 +40,53 @@ export const CONTEXT_VARIABLES = [
 
 export type ContextVariable = (typeof CONTEXT_VARIABLES)[number]
 
+/**
+ * One MCP server the thread-title one-shot may consult to resolve an
+ * identifier the first prompt only references (ATC-186). Remote (URL)
+ * servers only — a stdio entry would boot a process per title run — and
+ * `tools` names exactly what that run may call: titling is unattended and
+ * pre-approved, so a resolver must never reach a write tool. Tool names are
+ * literal for the same reason: the adapter turns them into permission
+ * rules, where `*` or a comma would widen the grant.
+ */
+export const TitleResolver = Schema.Struct({
+  url: Schema.String.check(
+    Schema.makeFilter((url) => {
+      const protocol = URL.canParse(url) ? new URL(url).protocol : undefined
+      return protocol === "http:" || protocol === "https:"
+        ? true
+        : `"${url}" must be an http(s) MCP endpoint URL`
+    }),
+  ),
+  headers: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
+  tools: Schema.Array(
+    Schema.String.check(
+      Schema.isPattern(/^[a-zA-Z0-9_-]+$/, { description: "a literal MCP tool name" }),
+    ),
+  ).check(
+    Schema.isMinLength(1, {
+      description: "at least one tool name the resolver may be called with",
+    }),
+  ),
+})
+
+export type TitleResolver = typeof TitleResolver.Type
+
+// The SDK normalizes anything outside [a-zA-Z0-9_-] in a server name to "_"
+// when it builds `mcp__<server>__<tool>`, so a name with other characters
+// would never match the rule the adapter derives from it. Checked over the
+// whole record rather than as a key schema, which would silently drop the
+// rejected entry instead of failing the boot.
+const SERVER_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/
+
+const TitleResolvers = Schema.Record(Schema.String, TitleResolver).check(
+  Schema.makeFilter((servers) =>
+    Object.keys(servers)
+      .filter((name) => !SERVER_NAME.test(name))
+      .map((name) => `server name "${name}" must be letters, digits, underscores, or dashes`),
+  ),
+)
+
 /** Invalid or malformed configuration. `source` names the offending origin. */
 export class ConfigLoadError extends Schema.TaggedErrorClass<ConfigLoadError>()("ConfigLoadError", {
   source: Schema.String,
@@ -107,6 +154,13 @@ export class AppConfig extends Context.Service<
      * orphan sockets are provably ours. Debug with `ZMX_DIR=<dir> zmx list`.
      */
     readonly terminalSocketDir: string
+    /**
+     * MCP servers the thread-title one-shot may consult, keyed by server
+     * name. Empty (the default) leaves that run fully locked down, which is
+     * exactly the pre-ATC-186 behavior. Config file only: a server map has
+     * no sensible flat `ATC_*` spelling.
+     */
+    readonly titleResolvers: Readonly<Record<string, TitleResolver>>
   }
 >()("app-server/AppConfig") {}
 
@@ -140,6 +194,7 @@ const FILE_KEYS = [
   "tailscaleExecutable",
   "codexExecutable",
   "claudeExecutable",
+  "titleResolvers",
 ] as const
 
 const parseToml = (source: string, text: string) =>
@@ -296,6 +351,22 @@ export const load = (
       }
     }
 
+    // Table-valued, so it never reaches the scalar ConfigProvider above:
+    // read straight off the file table, absent meaning "no resolvers". Keys
+    // inside it fail fast like the top-level ones — a typo that silently
+    // dropped `tools` would quietly widen what the title run may call.
+    const titleResolvers = yield* Schema.decodeUnknownEffect(TitleResolvers, {
+      onExcessProperty: "error",
+    })(fileTable["titleResolvers"] ?? {}).pipe(
+      Effect.mapError(
+        (error) =>
+          new ConfigLoadError({
+            source: configFile,
+            message: `titleResolvers: ${error.message.replace(/\s*\n\s*/g, " ")}`,
+          }),
+      ),
+    )
+
     // Agent context is captured verbatim (present means non-empty). Only
     // ATC_ENDPOINT is interpreted, so only it is validated: a malformed
     // value would otherwise surface as a confusing request failure.
@@ -347,6 +418,7 @@ export const load = (
       codexExecutable: settings.codexExecutable,
       claudeExecutable: settings.claudeExecutable,
       terminalSocketDir: path.join(stateDir, "terminals"),
+      titleResolvers,
     }
   })
 

--- a/app-server/test/agents/agentAdapter.test.ts
+++ b/app-server/test/agents/agentAdapter.test.ts
@@ -55,8 +55,13 @@ describe("aggregateActivity", () => {
 
 describe("sanitizeTitle", () => {
   it("enforces the output hygiene rules in code, not in the prompt", () => {
-    // First non-empty line only, whitespace collapsed.
-    assert.strictEqual(sanitizeTitle("\n\n  Fix   login\tflow  \nsecond line"), "Fix login flow")
+    // One line only, whitespace collapsed — the last non-empty one, so a
+    // model that narrates before answering still yields its title.
+    assert.strictEqual(sanitizeTitle("\n\n  Fix   login\tflow  \n\n"), "Fix login flow")
+    assert.strictEqual(
+      sanitizeTitle("I don't have that tool.\n\nBuild - ATC-186"),
+      "Build - ATC-186",
+    )
     // Wrapping quotes (straight and smart, repeated) stripped.
     assert.strictEqual(sanitizeTitle('"Add dark mode"'), "Add dark mode")
     assert.strictEqual(sanitizeTitle("'“Add dark mode”'"), "Add dark mode")
@@ -94,11 +99,20 @@ describe("titleInstruction", () => {
     assert.include(instruction, "If no category clearly matches, omit the prefix.")
   })
 
+  it("asks for resolved references, and for prompt-only titling when it cannot", () => {
+    const instruction = titleInstruction("$implement ATC-186")
+    assert.include(instruction, "verbatim in the title")
+    assert.include(instruction, "$name or /name is a skill invocation")
+    assert.include(instruction, "really call it, never describe calling it")
+    assert.include(instruction, "title from the message alone")
+    assert.include(instruction, "Never guess what the identifier refers to")
+  })
+
   it("carries a capped prompt", () => {
     const instruction = titleInstruction("add a login page")
     assert.include(instruction, "add a login page")
     const capped = titleInstruction("x".repeat(10_000))
-    assert.isBelow(capped.length, 5_000)
+    assert.isBelow(capped.length, 6_000)
   })
 })
 

--- a/app-server/test/agents/agentAdapter.test.ts
+++ b/app-server/test/agents/agentAdapter.test.ts
@@ -101,7 +101,9 @@ describe("titleInstruction", () => {
 
   it("asks for resolved references, and for prompt-only titling when it cannot", () => {
     const instruction = titleInstruction("$implement ATC-186")
-    assert.include(instruction, "verbatim in the title")
+    // Ahead of the prose, so sanitizeTitle's length cap cuts the
+    // description rather than the identifier.
+    assert.include(instruction, "put it ahead of the descriptive part")
     assert.include(instruction, "$name or /name is a skill invocation")
     assert.include(instruction, "really call it, never describe calling it")
     assert.include(instruction, "title from the message alone")

--- a/app-server/test/agents/claudeAdapter.test.ts
+++ b/app-server/test/agents/claudeAdapter.test.ts
@@ -837,6 +837,54 @@ describe("ClaudeAdapter generateTitle", () => {
         assert.strictEqual(captured?.["model"], "haiku")
         assert.deepStrictEqual(captured?.["tools"], [])
         assert.strictEqual(captured?.["cwd"], cwd)
+        // No resolver configured: no servers, nothing pre-approved.
+        assert.deepStrictEqual(captured?.["mcpServers"], {})
+        assert.deepStrictEqual(captured?.["allowedTools"], [])
+        assert.strictEqual(captured?.["strictMcpConfig"], true)
+      }).pipe(Effect.provide(layer))
+    }),
+  )
+
+  it.live("configured resolvers become MCP servers with exactly their tools allowed", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeClaudeQuery()
+      let captured: Record<string, unknown> | undefined
+      const layer = claudeAdapterLayer(
+        {
+          queryFn: (args) => {
+            captured = args.options as unknown as Record<string, unknown>
+            return fake.queryFn(args)
+          },
+        },
+        "/bin/echo",
+        {
+          titleResolvers: {
+            linear: {
+              url: "https://mcp.linear.app/mcp",
+              headers: { "X-Probe": "1" },
+              tools: ["get_issue", "get_document"],
+            },
+          },
+        },
+      )
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        yield* adapter.generateTitle({ cwd: workDir(), prompt: "$implement ATC-186" })
+        assert.deepStrictEqual(captured?.["mcpServers"], {
+          linear: {
+            type: "http",
+            url: "https://mcp.linear.app/mcp",
+            alwaysLoad: true,
+            headers: { "X-Probe": "1" },
+          },
+        })
+        assert.deepStrictEqual(captured?.["allowedTools"], [
+          "mcp__linear__get_issue",
+          "mcp__linear__get_document",
+        ])
+        // Enough turns for one lookup plus the reply; still bounded.
+        assert.strictEqual(captured?.["maxTurns"], 4)
+        assert.strictEqual(captured?.["strictMcpConfig"], true)
       }).pipe(Effect.provide(layer))
     }),
   )

--- a/app-server/test/platform/config.test.ts
+++ b/app-server/test/platform/config.test.ts
@@ -198,6 +198,60 @@ describe("configuration", () => {
     }),
   )
 
+  it.effect("title resolvers default to none and parse from the config file", () =>
+    Effect.gen(function* () {
+      assert.deepStrictEqual((yield* load({})).titleResolvers, {})
+      const file = writeConfig(
+        `[titleResolvers.linear]\nurl = "https://mcp.linear.app/mcp"\ntools = ["get_issue"]\n\n` +
+          `[titleResolvers.linear.headers]\n"X-Probe" = "1"\n`,
+      )
+      const config = yield* load({ ATC_CONFIG: file })
+      assert.deepStrictEqual(config.titleResolvers, {
+        linear: {
+          url: "https://mcp.linear.app/mcp",
+          tools: ["get_issue"],
+          headers: { "X-Probe": "1" },
+        },
+      })
+    }),
+  )
+
+  it.effect("a title resolver that could not be reached or trusted fails naming the file", () =>
+    Effect.gen(function* () {
+      // A non-http endpoint would silently never resolve anything.
+      const badUrl = writeConfig(
+        `[titleResolvers.linear]\nurl = "mcp.linear.app"\ntools = ["get_issue"]\n`,
+      )
+      const urlError = yield* loadError({ ATC_CONFIG: badUrl })
+      assert.strictEqual(urlError.source, badUrl)
+      assert.include(urlError.message, "titleResolvers")
+      assert.notInclude(urlError.message, "\n")
+
+      // Tools are the whole pre-approval: an empty list is a configuration
+      // mistake, and a wildcard would grant the server's write tools too.
+      const noTools = writeConfig(
+        `[titleResolvers.linear]\nurl = "https://mcp.linear.app/mcp"\ntools = []\n`,
+      )
+      assert.include((yield* loadError({ ATC_CONFIG: noTools })).message, "titleResolvers")
+      const wildcard = writeConfig(
+        `[titleResolvers.linear]\nurl = "https://mcp.linear.app/mcp"\ntools = ["*"]\n`,
+      )
+      assert.include((yield* loadError({ ATC_CONFIG: wildcard })).message, "titleResolvers")
+
+      // The name becomes the mcp__<server>__<tool> prefix.
+      const badName = writeConfig(
+        `[titleResolvers."my server"]\nurl = "https://example.com/mcp"\ntools = ["get_issue"]\n`,
+      )
+      assert.include((yield* loadError({ ATC_CONFIG: badName })).message, "titleResolvers")
+
+      // Unknown keys fail fast inside the table too, not just above it.
+      const typo = writeConfig(
+        `[titleResolvers.linear]\nurl = "https://mcp.linear.app/mcp"\ntools = ["get_issue"]\ntool = "get_issue"\n`,
+      )
+      assert.include((yield* loadError({ ATC_CONFIG: typo })).message, "titleResolvers")
+    }),
+  )
+
   it.effect("an invalid port in the environment fails with a one-line diagnostic", () =>
     Effect.gen(function* () {
       const error = yield* loadError({ ATC_PORT: "70000" })

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -85,6 +85,7 @@ export const testAppConfig = (overrides: Partial<AppConfig["Service"]>): Layer.L
     codexExecutable: "codex",
     claudeExecutable: "claude",
     terminalSocketDir: "/tmp/atc-sockets",
+    titleResolvers: {},
     ...overrides,
   })
 


### PR DESCRIPTION
Closes ATC-186.

Thread auto-naming titles a new thread from its first prompt. Prompts like `$implement ATC-186` carry only an opaque reference, and the Claude title run is locked down (no tools, one turn), so it could only produce a generic name.

## What changed

- **Shared instruction** (`agentAdapter.ts`) — keep canonical identifiers (issue ids, PR numbers, URLs) verbatim; read a leading `$name`/`/name` as the action being asked for; when the run has a lookup tool, call it once and add the resource's real title; otherwise, or on failure, title from the prompt alone without guessing or narrating. The rules are unconditional — whether a lookup tool exists is the provider's business.
- **Claude adapter** — a new config-file-only `titleResolvers` table names remote MCP servers plus exactly the tools the title run may call. Those become `mcpServers` + `allowedTools`; `dontAsk` denies everything else, `strictMcpConfig: true` keeps the project's own `.mcp.json` out of an unattended run, and `maxTurns` goes 1 → 4 only when a resolver exists. Empty config is the original locked-down shape.
- **Codex adapter** — unchanged. Its ephemeral exec already carries the user's connectors, so the instruction alone activates resolution.
- **Title hygiene** — `sanitizeTitle` now takes the last non-empty line instead of the first (see below).

## Verified against the real Claude CLI

- **Resolution**: `$implement ATC-186` with the hosted Linear MCP (`get_issue` only) → `Build - ATC-186 Resolve external references`, 3/3 runs, ~6-10s.
- **Unreachable resolver** (`http://127.0.0.1:9/mcp`): `Build - ATC-186`, 5/5 runs, ~5s — silent fallback, identifier preserved, well inside the existing 90s timeout.
- **No resolvers**: `Build - ATC-186`, unchanged.

Two probe findings shaped the code:

1. With a resolver configured, haiku sometimes narrates before answering (`I don't have that tool.\n\nBuild - ATC-186`). Under the old first-line rule the narration became the title, so hygiene now takes the last non-empty line — the narration is never last.
2. Stored MCP OAuth is keyed by **server name**: a resolver keyed differently from the name it was authenticated under comes back `needs-auth` and is silently skipped. Documented in the README, and the config rejects names the SDK would normalize (anything outside `[a-zA-Z0-9_-]`), since those could never match the permission rule derived from them.

Tool names are validated as literals — `tools = ["*"]` would otherwise become a wildcard permission rule granting the server's write tools.

## Test plan

`mise run -C app-server check` green. New coverage: instruction rules, last-line hygiene, `titleResolvers` parsing plus its rejection cases (non-http URL, empty tools, wildcard tool, bad server name, unknown key inside the table), and the Claude adapter's resolver plumbing with and without configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional configuration for remote services that can help generate thread titles.
  - Resolvers can be limited to specific tools and configured with custom headers.
  - Thread-title generation can preserve identifiers, interpret skill invocations, and perform a single reference lookup.

- **Improvements**
  - Improved title cleanup to select the final meaningful line and provide safer fallback titles.
  - Added strict validation for resolver URLs, tool permissions, server names, and unsupported settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->