### PR TITLE
Notify on macOS when threads finish or need input

### DIFF
--- a/macos/ATC/ATCApp.swift
+++ b/macos/ATC/ATCApp.swift
@@ -2,7 +2,9 @@ import SwiftUI
 
 @main
 struct ATCApp: App {
-    @State private var appModel = AppModel()
+    // Only this call site gets the system notifier, so tests and previews can
+    // never post to the real Notification Center (see `ThreadNotifier`).
+    @State private var appModel = AppModel(threadNotifier: .system())
     @State private var configurationStore = ConfigurationStore { preferences in
         TerminalSessionController.applyTerminalPreferences(preferences)
     }

--- a/macos/ATC/ATCApp.swift
+++ b/macos/ATC/ATCApp.swift
@@ -42,6 +42,10 @@ private struct WindowRootView: View {
 
     @State private var windowState: WindowState
     @State private var router: WindowKeyboardRouter
+    /// `.key` exactly while this window is the key window; the model keeps
+    /// its window list in key order so banner clicks open where the user
+    /// last worked.
+    @Environment(\.controlActiveState) private var controlActiveState
 
     init(appModel: AppModel, configStore: ConfigurationStore) {
         self.appModel = appModel
@@ -72,6 +76,10 @@ private struct WindowRootView: View {
         }
         .onDisappear {
             appModel.unregisterWindow(windowState)
+        }
+        .onChange(of: controlActiveState) { _, state in
+            guard state == .key else { return }
+            appModel.noteWindowKeyed(windowState)
         }
     }
 }

--- a/macos/ATC/AppModel.swift
+++ b/macos/ATC/AppModel.swift
@@ -16,6 +16,10 @@ struct WindowNavigationSnapshot: Equatable {
             /// In the snapshot so a finish landing under the displayed thread
             /// re-runs reconciliation, which stamps it viewed (ATC-160).
             let isUnread: Bool
+            /// In the snapshot so the thread notifier sees every trigger state
+            /// change (ATC-185). Window reconciliation is idempotent, so the
+            /// passes this adds cost nothing.
+            let activityState: ThreadActivityState
         }
 
         struct TerminalRecord: Equatable {
@@ -57,6 +61,10 @@ final class AppModel {
     /// LRU order over `terminals` keys, least-recently-used first.
     private var attachOrder: [TerminalRef] = []
 
+    /// The app's one thread notifier: app-level so two open windows produce
+    /// one banner, not two. Silent unless the app supplies the system one.
+    private let threadNotifier: ThreadNotifier
+
     private let clientFactory: (ConnectionRecord, URL) -> any APIProtocol
     private let terminalControllerFactory: (String, ConnectionRuntime) -> TerminalSessionController
     private let terminalRecoveryMonitor: TerminalRecoveryMonitor
@@ -75,6 +83,11 @@ final class AppModel {
     /// closed window's state must deallocate).
     @ObservationIgnored private var windowReconcilers: [WeakWindowState] = []
     @ObservationIgnored private var lastNavigationSnapshot: WindowNavigationSnapshot?
+    /// A clicked banner whose thread cannot be opened yet. macOS delivers a
+    /// click that launched the app before any window registers or any store
+    /// has loaded, so the ref waits for reconciliation rather than being
+    /// dropped on the floor. One slot: a newer click supersedes an older one.
+    @ObservationIgnored private var pendingNotificationThread: ThreadRef?
 
     private struct WeakWindowState {
         weak var value: WindowState?
@@ -86,9 +99,11 @@ final class AppModel {
         terminalControllerFactory: ((String, ConnectionRuntime) -> TerminalSessionController)? = nil,
         terminalRecoveryMonitor: TerminalRecoveryMonitor? = nil,
         eventStreamFactory: ConnectionRuntime.EventStreamFactory? = nil,
+        threadNotifier: ThreadNotifier? = nil,
         attachmentBudget: Int = 12
     ) {
         self.attachmentBudget = attachmentBudget
+        self.threadNotifier = threadNotifier ?? ThreadNotifier()
         if let connections {
             self.connections = connections
             hasStarted = true
@@ -124,6 +139,10 @@ final class AppModel {
             self?.recoverTerminalsAfterInterruption()
         }
         self.terminalRecoveryMonitor.start()
+        self.threadNotifier.onOpenThread = { [weak self] ref in
+            self?.pendingNotificationThread = ref
+            self?.openPendingNotificationThread()
+        }
         observeNavigationChanges()
     }
 
@@ -163,15 +182,18 @@ final class AppModel {
         guard snapshot != lastNavigationSnapshot else { return }
         lastNavigationSnapshot = snapshot
         reconcileTerminalLifecycle()
+        threadNotifier.reconcile(connections: runtimes.map(ThreadNotifier.ConnectionInput.init(runtime:)))
         for entry in windowReconcilers {
             entry.value?.reconcile(in: self)
         }
+        openPendingNotificationThread()
     }
 
     func registerWindow(_ windowState: WindowState) {
         windowReconcilers.removeAll { $0.value == nil || $0.value === windowState }
         windowReconcilers.append(.init(value: windowState))
         windowState.reconcile(in: self)
+        openPendingNotificationThread()
     }
 
     func unregisterWindow(_ windowState: WindowState) {
@@ -234,7 +256,8 @@ final class AppModel {
                         id: $0.id,
                         projectID: $0.projectId,
                         isArchived: $0.isArchived,
-                        isUnread: $0.unread
+                        isUnread: $0.unread,
+                        activityState: $0.activityState
                     )
                 },
                 terminals: runtime.terminals.terminals.map {
@@ -471,8 +494,25 @@ final class AppModel {
         return runtime
     }
 
+    /// Honors a clicked banner once a window exists and its Connection has
+    /// answered. The notifier is app-level precisely so no window-routing
+    /// rules are needed here: the most recently registered window takes it.
+    private func openPendingNotificationThread() {
+        guard let ref = pendingNotificationThread,
+              let window = windowReconcilers.compactMap(\.value).last,
+              let runtime = runtime(id: ref.connectionID),
+              runtime.threads.isResolved
+        else { return }
+        // A resolved store is the answer either way: open the thread, or drop
+        // a click for one that no longer exists.
+        pendingNotificationThread = nil
+        guard runtime.threads.thread(id: ref.threadID) != nil else { return }
+        Task { await window.openThread(ref, in: self) }
+    }
+
     private func teardown(_ runtime: ConnectionRuntime) {
         runtime.stop()
+        threadNotifier.forget(connectionID: runtime.id)
         for ref in terminals.keys where ref.connectionID == runtime.id {
             disconnectTerminal(ref: ref)
         }

--- a/macos/ATC/AppModel.swift
+++ b/macos/ATC/AppModel.swift
@@ -200,6 +200,16 @@ final class AppModel {
         windowReconcilers.removeAll { $0.value === windowState || $0.value == nil }
     }
 
+    /// Keeps `windowReconcilers` ordered by key recency, so a banner click
+    /// opens in the window the user last worked in — the one macOS raises on
+    /// activation — not whichever happened to register last.
+    func noteWindowKeyed(_ windowState: WindowState) {
+        guard windowReconcilers.contains(where: { $0.value === windowState }) else { return }
+        windowReconcilers.removeAll { $0.value === windowState || $0.value == nil }
+        windowReconcilers.append(.init(value: windowState))
+        openPendingNotificationThread()
+    }
+
     // MARK: - Runtime access
 
     func runtime(id: UUID) -> ConnectionRuntime? {
@@ -353,6 +363,12 @@ final class AppModel {
     /// window should display.
     @discardableResult
     func openThread(_ ref: ThreadRef, retentionContext: TerminalRetentionContext = .empty) async throws -> TerminalRef {
+        // Every thread open funnels through here, so any open supersedes a
+        // parked banner click: once the user navigates on their own, a click
+        // still waiting on an unreachable server must not replay later and
+        // yank their selection. (The click's own open passes harmlessly —
+        // the slot was cleared when it was honored.)
+        pendingNotificationThread = nil
         guard let runtime = runtime(id: ref.connectionID) else {
             throw AppServerUnavailable()
         }
@@ -495,8 +511,8 @@ final class AppModel {
     }
 
     /// Honors a clicked banner once a window exists and its Connection has
-    /// answered. The notifier is app-level precisely so no window-routing
-    /// rules are needed here: the most recently registered window takes it.
+    /// answered. `windowReconcilers` is ordered by key recency
+    /// (`noteWindowKeyed`), so `.last` is the window the user last worked in.
     private func openPendingNotificationThread() {
         guard let ref = pendingNotificationThread,
               let window = windowReconcilers.compactMap(\.value).last,
@@ -504,15 +520,22 @@ final class AppModel {
               runtime.threads.isResolved
         else { return }
         // A resolved store is the answer either way: open the thread, or drop
-        // a click for one that no longer exists.
+        // a click for one that no longer exists — or was archived, which
+        // `openThread` refuses, so an archived hit must not consume the click
+        // as if it had opened.
         pendingNotificationThread = nil
-        guard runtime.threads.thread(id: ref.threadID) != nil else { return }
+        guard let thread = runtime.threads.thread(id: ref.threadID), !thread.isArchived else { return }
         Task { await window.openThread(ref, in: self) }
     }
 
     private func teardown(_ runtime: ConnectionRuntime) {
         runtime.stop()
         threadNotifier.forget(connectionID: runtime.id)
+        // A parked click for this connection can never resolve; without this
+        // it would be re-checked on every reconcile forever.
+        if pendingNotificationThread?.connectionID == runtime.id {
+            pendingNotificationThread = nil
+        }
         for ref in terminals.keys where ref.connectionID == runtime.id {
             disconnectTerminal(ref: ref)
         }

--- a/macos/ATC/Features/Threads/ThreadNotifier.swift
+++ b/macos/ATC/Features/Threads/ThreadNotifier.swift
@@ -1,0 +1,273 @@
+// The one place the app decides a thread's change is worth interrupting the
+// user for.
+//
+// Invariants:
+//
+// - **App-level and single.** `AppModel` owns exactly one notifier and drives
+//   it from its own navigation observation. Windows never notify: two open
+//   windows must produce one banner, not two.
+// - **A banner fires on a transition but lives on a claim.** Only the two
+//   transitions in `trigger(from:to:)` interrupt the user, and a delivered
+//   banner survives only while what it claims is still true — so answering a
+//   prompt in the TUI or viewing the thread from another client takes this
+//   app's banner down without the user touching it. Notification Center must
+//   never show a state the thread is no longer in.
+// - **A suppressed banner is spent, never deferred.** Anything that happened
+//   while ATC was frontmost is not replayed when the user switches away; the
+//   sidebar's "Done" is the durable record.
+// - **A connection's first resolved load seeds; it does not notify.** Diffing
+//   is the default and silence is the one exception, which covers launch, a
+//   newly added connection, and a rebuilt one. A reconnect needs no rule at
+//   all: its baseline was never cleared, so finishes during a sleep or wifi
+//   gap diff as new and notify.
+
+import AppKit
+import ATCAppServerAPI
+import Foundation
+import UserNotifications
+
+final class ThreadNotifier {
+    /// The UserDefaults key behind the Notifications settings switch. Off on a
+    /// fresh install, so nothing asks for authorization at first launch.
+    static let preferenceKey = "threadNotificationsEnabled"
+
+    /// What a banner asserts about a thread right now. `needsInput` outranks
+    /// `finished`: a turn that ended in a question is one interruption, and
+    /// the question is the actionable half.
+    enum Claim: Equatable {
+        case finished
+        case needsInput
+
+        /// A banner is a poke, not a report: no agent name, no server name,
+        /// and no message text — the API exposes no turn content anyway.
+        func body(project: String?) -> String {
+            let lead = switch self {
+            case .finished: "Finished"
+            case .needsInput: "Needs your input"
+            }
+            guard let project else { return lead }
+            return "\(lead) · \(project)"
+        }
+    }
+
+    /// One connection's threads as the notifier sees them. Archived threads
+    /// are deliberately absent: they are never a live claim, and one leaving
+    /// the active list reads here as a thread that is gone.
+    struct ConnectionInput {
+        let connectionID: UUID
+        /// `ThreadsStore.isResolved`: false while the list is unloaded or its
+        /// last refresh failed. Connection loss must not read as "nothing is
+        /// happening" and take every banner down.
+        let isResolved: Bool
+        let projects: [Project]
+        let threads: [ATCThread]
+    }
+
+    /// Set by the model: a banner click selects its thread.
+    var onOpenThread: ((ThreadRef) -> Void)?
+
+    /// The delivery seam. No-ops by default so tests and previews can never
+    /// reach the developer's real Notification Center; `system()` is the one
+    /// path that wires UserNotifications.
+    var deliver: (_ id: String, _ title: String, _ body: String) -> Void = { _, _, _ in }
+    var withdraw: (_ id: String) -> Void = { _ in }
+
+    var isEnabled: () -> Bool = {
+        UserDefaults.standard.bool(forKey: ThreadNotifier.preferenceKey)
+    }
+
+    /// Frontmost ATC never notifies — not "not this thread", nothing at all.
+    /// Mirrors the seam at `WindowState.isAppActive`.
+    var isAppActive: () -> Bool = { NSApplication.shared.isActive }
+
+    /// The `(unread, activityState)` pair each thread showed on the last pass:
+    /// the diff baseline. Both halves are kept because the triggers are
+    /// transitions, not states — see `trigger(from:to:)`.
+    private struct State: Equatable {
+        let unread: Bool
+        let activityState: ThreadActivityState
+    }
+
+    private var states: [ThreadRef: State] = [:]
+    /// The banner each thread currently has on screen. Nothing was delivered
+    /// while the preference was off or ATC was frontmost, so nothing is
+    /// withdrawn for those; `system()` starts from an empty Notification
+    /// Center, which is what makes this in-memory record authoritative.
+    private var delivered: [ThreadRef: Claim] = [:]
+    private var seeded: Set<UUID> = []
+    /// `UNUserNotificationCenter.delegate` is a weak reference; nothing else
+    /// would keep the click handler alive.
+    private var clickHandler: NotificationClickHandler?
+
+    /// The production notifier. Built from `ATCApp`'s stored state because its
+    /// click delegate has to exist before the app finishes launching.
+    static func system() -> ThreadNotifier {
+        let notifier = ThreadNotifier()
+        notifier.deliver = { id, title, body in
+            let content = UNMutableNotificationContent()
+            content.title = title
+            content.body = body
+            // Muting is System Settings' job, not a second ATC control.
+            content.sound = .default
+            // A nil trigger delivers immediately, and reusing the identifier
+            // replaces the thread's previous banner instead of stacking one.
+            UNUserNotificationCenter.current().add(
+                UNNotificationRequest(identifier: id, content: content, trigger: nil)
+            )
+        }
+        notifier.withdraw = { id in
+            UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [id])
+        }
+        let handler = NotificationClickHandler { [weak notifier] ref in
+            NSApplication.shared.activate()
+            notifier?.onOpenThread?(ref)
+        }
+        notifier.clickHandler = handler
+        UNUserNotificationCenter.current().delegate = handler
+        // Banners this process cannot reason about must not linger: the
+        // baseline starts empty, so anything left from a previous launch could
+        // never be withdrawn once its claim stopped being true. Ordered after
+        // the delegate so a click that launched the app is still delivered.
+        UNUserNotificationCenter.current().removeAllDeliveredNotifications()
+        return notifier
+    }
+
+    /// Diffs every resolved connection against the last pass. Driven by the
+    /// model's navigation observation, which already fires on exactly the
+    /// store changes read here.
+    func reconcile(connections: [ConnectionInput]) {
+        for connection in connections where connection.isResolved {
+            apply(connection)
+        }
+    }
+
+    /// Drops a connection's baseline and banners. Called when its runtime is
+    /// torn down — removal and a URL/token rebuild alike — so the next load
+    /// seeds silently instead of diffing against a server that is gone.
+    func forget(connectionID: UUID) {
+        for ref in Array(states.keys) where ref.connectionID == connectionID {
+            states[ref] = nil
+            takeDown(ref)
+        }
+        seeded.remove(connectionID)
+    }
+
+    // MARK: - Private
+
+    private func apply(_ connection: ConnectionInput) {
+        let isSeeding = !seeded.contains(connection.connectionID)
+        seeded.insert(connection.connectionID)
+
+        var present: Set<ThreadRef> = []
+        for thread in connection.threads {
+            let ref = ThreadRef(connectionID: connection.connectionID, threadID: thread.id)
+            present.insert(ref)
+            let state = State(unread: thread.unread, activityState: thread.activityState)
+            let previous = states[ref]
+            states[ref] = state
+            // No baseline yet means this connection (or this thread) is new:
+            // record it and stay quiet.
+            guard !isSeeding, let previous, previous != state else { continue }
+            if let claim = Self.trigger(from: previous, to: state) {
+                post(claim, for: thread, ref: ref, in: connection)
+                continue
+            }
+            takeDownIfStale(ref, state: state)
+        }
+
+        // A thread that left the active list — archived, deleted, or moved by
+        // another client — cannot still be in the state its banner claims.
+        for ref in Array(states.keys)
+        where ref.connectionID == connection.connectionID && !present.contains(ref) {
+            states[ref] = nil
+            takeDown(ref)
+        }
+    }
+
+    /// The two triggers, stated as transitions rather than states: a thread
+    /// that was already unread when it stopped needing input has not finished
+    /// anything new, and must not alert a second time.
+    private static func trigger(from previous: State, to state: State) -> Claim? {
+        if previous.activityState != .needsInput, state.activityState == .needsInput {
+            return .needsInput
+        }
+        // `unknown` activity never triggers on its own: the server cannot tell
+        // a crashed provider from a slow one. The finish it reports can.
+        if !previous.unread, state.unread { return .finished }
+        return nil
+    }
+
+    private func post(_ claim: Claim, for thread: ATCThread, ref: ThreadRef, in connection: ConnectionInput) {
+        guard isEnabled(), !isAppActive() else { return }
+        let project = connection.projects.first { $0.id == thread.projectId }?.name
+        deliver(ref.notificationIdentifier, thread.displayName, claim.body(project: project))
+        delivered[ref] = claim
+    }
+
+    private func takeDownIfStale(_ ref: ThreadRef, state: State) {
+        guard let claim = delivered[ref] else { return }
+        let stillTrue = switch claim {
+        case .finished: state.unread
+        case .needsInput: state.activityState == .needsInput
+        }
+        guard !stillTrue else { return }
+        takeDown(ref)
+    }
+
+    private func takeDown(_ ref: ThreadRef) {
+        guard delivered.removeValue(forKey: ref) != nil else { return }
+        withdraw(ref.notificationIdentifier)
+    }
+}
+
+/// Routes a banner click back into the app; separate only because the
+/// UserNotifications delegate has to be an NSObject.
+private final class NotificationClickHandler: NSObject, UNUserNotificationCenterDelegate {
+    private let onClick: (ThreadRef) -> Void
+
+    init(onClick: @escaping (ThreadRef) -> Void) {
+        self.onClick = onClick
+        super.init()
+    }
+
+    /// Nonisolated because the delegate is called off the main actor; only the
+    /// identifier crosses back, so no notification object has to be Sendable.
+    nonisolated func userNotificationCenter(
+        _: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        let identifier = response.notification.request.identifier
+        await MainActor.run {
+            guard let ref = ThreadRef(notificationIdentifier: identifier) else { return }
+            onClick(ref)
+        }
+    }
+}
+
+extension ThreadNotifier.ConnectionInput {
+    init(runtime: ConnectionRuntime) {
+        self.init(
+            connectionID: runtime.id,
+            isResolved: runtime.threads.isResolved,
+            projects: runtime.projects.projects,
+            threads: runtime.threads.threads
+        )
+    }
+}
+
+extension ThreadRef {
+    /// Stable per thread, so a new claim replaces that thread's banner instead
+    /// of stacking a second one. Thread IDs are UUIDv7 and connection IDs are
+    /// UUIDs, so neither can contain the separator.
+    var notificationIdentifier: String {
+        "thread/\(connectionID.uuidString)/\(threadID)"
+    }
+
+    init?(notificationIdentifier: String) {
+        let parts = notificationIdentifier.split(separator: "/")
+        guard parts.count == 3, parts[0] == "thread",
+              let connectionID = UUID(uuidString: String(parts[1]))
+        else { return nil }
+        self.init(connectionID: connectionID, threadID: String(parts[2]))
+    }
+}

--- a/macos/ATC/Features/Threads/ThreadNotifier.swift
+++ b/macos/ATC/Features/Threads/ThreadNotifier.swift
@@ -77,8 +77,9 @@ final class ThreadNotifier {
     }
 
     /// Frontmost ATC never notifies — not "not this thread", nothing at all.
-    /// Mirrors the seam at `WindowState.isAppActive`.
-    var isAppActive: () -> Bool = { NSApplication.shared.isActive }
+    /// Same seam shape as `WindowState.isAppActive`; both default to the one
+    /// shared definition.
+    var isAppActive: () -> Bool = { AppActivity.isActive() }
 
     /// The `(unread, activityState)` pair each thread showed on the last pass:
     /// the diff baseline. Both halves are kept because the triggers are
@@ -94,7 +95,6 @@ final class ThreadNotifier {
     /// withdrawn for those; `system()` starts from an empty Notification
     /// Center, which is what makes this in-memory record authoritative.
     private var delivered: [ThreadRef: Claim] = [:]
-    private var seeded: Set<UUID> = []
     /// `UNUserNotificationCenter.delegate` is a weak reference; nothing else
     /// would keep the click handler alive.
     private var clickHandler: NotificationClickHandler?
@@ -149,29 +149,36 @@ final class ThreadNotifier {
             states[ref] = nil
             takeDown(ref)
         }
-        seeded.remove(connectionID)
     }
 
     // MARK: - Private
 
     private func apply(_ connection: ConnectionInput) {
-        let isSeeding = !seeded.contains(connection.connectionID)
-        seeded.insert(connection.connectionID)
-
         var present: Set<ThreadRef> = []
         for thread in connection.threads {
             let ref = ThreadRef(connectionID: connection.connectionID, threadID: thread.id)
             present.insert(ref)
-            let state = State(unread: thread.unread, activityState: thread.activityState)
             let previous = states[ref]
+            // `unknown` is absence of evidence, not evidence of absence: the
+            // server pushes it when it loses sight of a provider (socket blip,
+            // restart), so the last known activity carries forward. Otherwise
+            // every blip would withdraw a needs-input banner and re-post it,
+            // with sound, when sight returned.
+            let activityState = thread.activityState == .unknown
+                ? previous?.activityState ?? .unknown
+                : thread.activityState
+            let state = State(unread: thread.unread, activityState: activityState)
             states[ref] = state
             // No baseline yet means this connection (or this thread) is new:
             // record it and stay quiet.
-            guard !isSeeding, let previous, previous != state else { continue }
+            guard let previous, previous != state else { continue }
             if let claim = Self.trigger(from: previous, to: state) {
                 post(claim, for: thread, ref: ref, in: connection)
-                continue
             }
+            // Unconditional: a delivered banner's claim can go stale on the
+            // very pass whose trigger was suppressed (frontmost, or the
+            // preference off). A fresh post is never stale, so after one this
+            // is a no-op.
             takeDownIfStale(ref, state: state)
         }
 
@@ -191,9 +198,13 @@ final class ThreadNotifier {
         if previous.activityState != .needsInput, state.activityState == .needsInput {
             return .needsInput
         }
-        // `unknown` activity never triggers on its own: the server cannot tell
-        // a crashed provider from a slow one. The finish it reports can.
-        if !previous.unread, state.unread { return .finished }
+        // A finish only counts once the thread is out of needs_input: `unread`
+        // can land a pass behind the needs_input transition, and replacing
+        // "Needs your input" with "Finished" would demote the actionable half
+        // (see `Claim`).
+        if !previous.unread, state.unread, state.activityState != .needsInput {
+            return .finished
+        }
         return nil
     }
 

--- a/macos/ATC/Settings/NotificationsSettingsView.swift
+++ b/macos/ATC/Settings/NotificationsSettingsView.swift
@@ -6,8 +6,9 @@ import UserNotifications
 /// worth surfacing — notifications turned off for atc at the OS level, where
 /// every banner would be dropped silently. Authorization is requested when the
 /// switch is turned on, so a fresh install never sees an unprompted system
-/// dialog, and status is read when the tab appears and when the switch is
-/// flipped rather than polled.
+/// dialog, and status is read when the tab appears, when the switch is
+/// flipped, and when the app re-activates (returning from System Settings
+/// after granting must clear the warning) rather than polled.
 struct NotificationsSettingsView: View {
     @AppStorage(ThreadNotifier.preferenceKey) private var isEnabled = false
     @State private var isDenied = false
@@ -35,6 +36,9 @@ struct NotificationsSettingsView: View {
         }
         .formStyle(.grouped)
         .task { await readAuthorization() }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            Task { await readAuthorization() }
+        }
         .onChange(of: isEnabled) { _, enabled in
             Task {
                 if enabled {

--- a/macos/ATC/Settings/NotificationsSettingsView.swift
+++ b/macos/ATC/Settings/NotificationsSettingsView.swift
@@ -1,0 +1,71 @@
+import AppKit
+import SwiftUI
+import UserNotifications
+
+/// The Notifications settings section: one switch, plus the one failure mode
+/// worth surfacing — notifications turned off for atc at the OS level, where
+/// every banner would be dropped silently. Authorization is requested when the
+/// switch is turned on, so a fresh install never sees an unprompted system
+/// dialog, and status is read when the tab appears and when the switch is
+/// flipped rather than polled.
+struct NotificationsSettingsView: View {
+    @AppStorage(ThreadNotifier.preferenceKey) private var isEnabled = false
+    @State private var isDenied = false
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Notify me when a thread finishes or needs input", isOn: $isEnabled)
+            } footer: {
+                Text("Banners appear only while atc is in the background, and come down once you have seen the thread — from any client.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            if isEnabled, isDenied {
+                Section {
+                    Label(
+                        "Notifications are turned off for atc in System Settings.",
+                        systemImage: "exclamationmark.triangle.fill"
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    Button("Open System Settings") { openSystemSettings() }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .task { await readAuthorization() }
+        .onChange(of: isEnabled) { _, enabled in
+            Task {
+                if enabled {
+                    _ = try? await UNUserNotificationCenter.current()
+                        .requestAuthorization(options: [.alert, .sound])
+                }
+                await readAuthorization()
+            }
+        }
+    }
+
+    private func readAuthorization() async {
+        isDenied = await UNUserNotificationCenter.current()
+            .notificationSettings().authorizationStatus == .denied
+    }
+
+    private func openSystemSettings() {
+        let bundleID = Bundle.main.bundleIdentifier ?? ""
+        guard let url = URL(
+            string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension?id=\(bundleID)"
+        ) else { return }
+        NSWorkspace.shared.open(url)
+    }
+}
+
+#if DEBUG
+
+#Preview("Notifications") {
+    NotificationsSettingsView()
+        .frame(width: 700, height: 450)
+        .preferredColorScheme(.dark)
+}
+
+#endif

--- a/macos/ATC/Settings/SettingsView.swift
+++ b/macos/ATC/Settings/SettingsView.swift
@@ -11,6 +11,10 @@ struct SettingsView: View {
                 ConnectionsSettingsView()
                     .frame(width: Self.windowSize.width, height: Self.windowSize.height)
             }
+            Tab("Notifications", systemImage: "bell") {
+                NotificationsSettingsView()
+                    .frame(width: Self.windowSize.width, height: Self.windowSize.height)
+            }
         }
     }
 }

--- a/macos/ATC/Shared/AppActivity.swift
+++ b/macos/ATC/Shared/AppActivity.swift
@@ -1,0 +1,10 @@
+import AppKit
+
+/// The one production answer to "is ATC frontmost?". `WindowState` (viewing
+/// only counts when the user can see it) and `ThreadNotifier` (frontmost never
+/// notifies) both default their test seams to `{ AppActivity.isActive() }`, so
+/// the definition cannot drift between them. (Closure literals at the seams:
+/// a bare function reference would pin `@MainActor` into the seam type.)
+enum AppActivity {
+    static func isActive() -> Bool { NSApplication.shared.isActive }
+}

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -84,7 +84,7 @@ final class WindowState {
 
     /// Whether the app is frontmost — the seam tests override; production
     /// asks AppKit. Viewing only counts when the user can actually see it.
-    @ObservationIgnored var isAppActive: () -> Bool = { NSApplication.shared.isActive }
+    @ObservationIgnored var isAppActive: () -> Bool = { AppActivity.isActive() }
 
     /// Mark-viewed requests in flight, so a burst of reconciliations does
     /// not re-stamp the same thread before the store merge lands.

--- a/macos/ATCTests/TestSupport.swift
+++ b/macos/ATCTests/TestSupport.swift
@@ -210,6 +210,7 @@ func makeModel(
     events: ScriptedEventStream? = nil,
     attach: AttachHarness = AttachHarness(),
     attachmentBudget: Int = 12,
+    threadNotifier: ThreadNotifier? = nil,
     name: String = "A",
     urlString: String = "http://a:1"
 ) async throws -> TestModel {
@@ -220,6 +221,7 @@ func makeModel(
         client: client,
         events: events,
         attach: attach,
+        threadNotifier: threadNotifier,
         attachmentBudget: attachmentBudget
     )
     // A started runtime probes immediately (first-contact reachability).
@@ -252,6 +254,7 @@ func makeEmptyAppModel(
         client: client,
         events: nil,
         attach: attach,
+        threadNotifier: nil,
         attachmentBudget: 12
     )
 }
@@ -270,6 +273,7 @@ private func makeAppModel(
     client: ScriptableAppServerClient,
     events: ScriptedEventStream?,
     attach: AttachHarness,
+    threadNotifier: ThreadNotifier?,
     attachmentBudget: Int
 ) -> AppModel {
     AppModel(
@@ -286,6 +290,7 @@ private func makeAppModel(
         // An absent factory would leave the runtime on the live SSE stream,
         // pointing the suite at a real socket.
         eventStreamFactory: { _, _ in events?.stream ?? ScriptedEventStream.inert() },
+        threadNotifier: threadNotifier,
         attachmentBudget: attachmentBudget
     )
 }

--- a/macos/ATCTests/ThreadNotifierTests.swift
+++ b/macos/ATCTests/ThreadNotifierTests.swift
@@ -1,0 +1,253 @@
+import Foundation
+import Testing
+import ATCAppServerAPI
+@testable import ATC
+
+/// ThreadNotifier: the trigger, withdraw, and baseline decisions. Every case
+/// here is about *state*, not about a remembered event — a banner claims what
+/// the thread is right now, and a claim that stops being true comes down.
+@MainActor
+@Suite("ThreadNotifier")
+struct ThreadNotifierTests {
+    /// What the delivery seam was asked to show. Nothing in this suite reaches
+    /// `UNUserNotificationCenter`.
+    final class Recorder {
+        struct Banner: Equatable {
+            let id: String
+            let title: String
+            let body: String
+        }
+
+        private(set) var posts: [Banner] = []
+        private(set) var withdrawn: [String] = []
+
+        /// A notifier that is switched on and backgrounded — the state in
+        /// which banners are actually meant to fire.
+        func makeNotifier() -> ThreadNotifier {
+            let notifier = ThreadNotifier()
+            notifier.isEnabled = { true }
+            notifier.isAppActive = { false }
+            notifier.deliver = { id, title, body in
+                self.posts.append(Banner(id: id, title: title, body: body))
+            }
+            notifier.withdraw = { self.withdrawn.append($0) }
+            return notifier
+        }
+    }
+
+    private let connectionID = UUID()
+
+    private func input(_ threads: [ATCThread], isResolved: Bool = true) -> ThreadNotifier.ConnectionInput {
+        ThreadNotifier.ConnectionInput(
+            connectionID: connectionID,
+            isResolved: isResolved,
+            projects: [Fixtures.project(id: "prj", name: "App")],
+            threads: threads
+        )
+    }
+
+    private func ref(_ id: String) -> ThreadRef {
+        ThreadRef(connectionID: connectionID, threadID: id)
+    }
+
+    @Test("a connection's first load seeds the baseline and notifies nothing")
+    func firstLoadIsSilent() {
+        let recorder = Recorder()
+        let notifier = recorder.makeNotifier()
+
+        notifier.reconcile(connections: [input([
+            Fixtures.thread(id: "thr1", unread: true),
+            Fixtures.thread(id: "thr2", activityState: .needsInput),
+        ])])
+
+        #expect(recorder.posts.isEmpty)
+        #expect(recorder.withdrawn.isEmpty)
+    }
+
+    @Test("a finish after the baseline notifies, titled by the thread and bodied by its project")
+    func finishNotifies() {
+        let recorder = Recorder()
+        let notifier = recorder.makeNotifier()
+        notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1", name: "Fix login")])])
+
+        notifier.reconcile(connections: [input([
+            Fixtures.thread(id: "thr1", name: "Fix login", unread: true),
+        ])])
+
+        #expect(recorder.posts == [
+            Recorder.Banner(
+                id: ref("thr1").notificationIdentifier,
+                title: "Fix login",
+                body: "Finished · App"
+            ),
+        ])
+    }
+
+    @Test("needs_input notifies, and outranks the unread a finished turn also sets")
+    func needsInputOutranksFinished() {
+        let recorder = Recorder()
+        let notifier = recorder.makeNotifier()
+        notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1", name: "Fix login")])])
+
+        notifier.reconcile(connections: [input([
+            Fixtures.thread(id: "thr1", name: "Fix login", activityState: .needsInput, unread: true),
+        ])])
+        #expect(recorder.posts.map(\.body) == ["Needs your input · App"])
+
+        // Still needing input is the same claim: no second banner for it.
+        notifier.reconcile(connections: [input([
+            Fixtures.thread(id: "thr1", name: "Fix login", activityState: .needsInput, unread: true),
+        ])])
+        #expect(recorder.posts.count == 1)
+    }
+
+    @Test("nothing notifies while atc is frontmost, and nothing is replayed once it isn't")
+    func frontmostIsSilentAndSpent() {
+        let recorder = Recorder()
+        let notifier = recorder.makeNotifier()
+        notifier.isAppActive = { true }
+        notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1")])])
+
+        notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1", unread: true)])])
+        #expect(recorder.posts.isEmpty)
+
+        // Switching away later must not deliver a backlog about a finish that
+        // already happened: the sidebar's "Done" is the durable record.
+        notifier.isAppActive = { false }
+        notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1", unread: true)])])
+        #expect(recorder.posts.isEmpty)
+    }
+
+    @Test("answering a prompt takes the banner down instead of re-alerting as finished")
+    func leavingNeedsInputNeverRealerts() {
+        let recorder = Recorder()
+        let notifier = recorder.makeNotifier()
+        notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1")])])
+        notifier.reconcile(connections: [input([
+            Fixtures.thread(id: "thr1", activityState: .needsInput, unread: true),
+        ])])
+
+        // Answering in the TUI resumes the turn. Unread was already set, so
+        // nothing finished that the user has not been told about.
+        notifier.reconcile(connections: [input([
+            Fixtures.thread(id: "thr1", activityState: .working, unread: true),
+        ])])
+
+        #expect(recorder.posts.count == 1)
+        #expect(recorder.withdrawn == [ref("thr1").notificationIdentifier])
+    }
+
+    @Test("clearing unread withdraws the banner — viewing the thread anywhere takes it down")
+    func clearedUnreadWithdraws() {
+        let recorder = Recorder()
+        let notifier = recorder.makeNotifier()
+        notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1")])])
+        notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1", unread: true)])])
+
+        notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1")])])
+
+        #expect(recorder.withdrawn == [ref("thr1").notificationIdentifier])
+    }
+
+    @Test("a thread that leaves the active list withdraws its banner")
+    func archivedThreadWithdraws() {
+        let recorder = Recorder()
+        let notifier = recorder.makeNotifier()
+        notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1")])])
+        notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1", unread: true)])])
+
+        notifier.reconcile(connections: [input([])])
+
+        #expect(recorder.withdrawn == [ref("thr1").notificationIdentifier])
+    }
+
+    @Test("an unresolved connection is skipped — connection loss is not a state change")
+    func unresolvedConnectionIsSkipped() {
+        let recorder = Recorder()
+        let notifier = recorder.makeNotifier()
+        notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1")])])
+        notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1", unread: true)])])
+
+        notifier.reconcile(connections: [input([], isResolved: false)])
+
+        #expect(recorder.withdrawn.isEmpty)
+        #expect(recorder.posts.count == 1)
+    }
+
+    @Test("the preference gates posting, not tracking")
+    func disabledPostsNothing() {
+        let recorder = Recorder()
+        let notifier = recorder.makeNotifier()
+        notifier.isEnabled = { false }
+        notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1")])])
+
+        notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1", unread: true)])])
+        #expect(recorder.posts.isEmpty)
+
+        // Nothing was delivered, so nothing is withdrawn when it clears.
+        notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1")])])
+        #expect(recorder.withdrawn.isEmpty)
+    }
+
+    @Test("forgetting a connection withdraws its banners and re-seeds silently")
+    func forgottenConnectionReseeds() {
+        let recorder = Recorder()
+        let notifier = recorder.makeNotifier()
+        notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1")])])
+        notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1", unread: true)])])
+
+        notifier.forget(connectionID: connectionID)
+        #expect(recorder.withdrawn == [ref("thr1").notificationIdentifier])
+
+        // The rebuilt connection's first load is a first load.
+        notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1", unread: true)])])
+        #expect(recorder.posts.count == 1)
+    }
+
+    @Test("a notification identifier round-trips to its thread")
+    func identifierRoundTrip() {
+        let original = ref("019012ab-0000-7000-8000-00000000abcd")
+        #expect(ThreadRef(notificationIdentifier: original.notificationIdentifier) == original)
+        #expect(ThreadRef(notificationIdentifier: "thread/not-a-uuid/thr1") == nil)
+    }
+
+    @Test("a finish arriving through the stores notifies once, however many windows are open")
+    func modelWiringNotifiesOnce() async throws {
+        let recorder = Recorder()
+        let client = ScriptableAppServerClient()
+        Fixtures.seed(client)
+        let test = try await makeModel(client: client, threadNotifier: recorder.makeNotifier())
+        // Held for the test's duration: the model's window registry is weak.
+        let windows = [WindowState(), WindowState()]
+        for window in windows { test.model.registerWindow(window) }
+        // The first load must have seeded before the finish lands, or the
+        // finish would be seeded silently instead of notifying.
+        await drainPendingTasks()
+
+        var threads = client.threads
+        threads[threads.firstIndex { $0.id == "thr3" }!].unread = true
+        client.threads = threads
+        await test.runtime.threads.refresh()
+        await settle(until: { !recorder.posts.isEmpty })
+
+        #expect(recorder.posts.map(\.id) == [test.threadRef("thr3").notificationIdentifier])
+        #expect(recorder.posts.map(\.body) == ["Finished · App"])
+        #expect(windows.count == 2)
+    }
+
+    @Test("a click that launched the app opens its thread once a window exists")
+    func clickBeforeAnyWindowIsHonored() async throws {
+        let recorder = Recorder()
+        let notifier = recorder.makeNotifier()
+        let client = ScriptableAppServerClient()
+        Fixtures.seed(client)
+        let test = try await makeModel(client: client, threadNotifier: notifier)
+
+        notifier.onOpenThread?(test.threadRef("thr3"))
+
+        let window = WindowState()
+        test.model.registerWindow(window)
+        await settle(until: { window.selectedThread == test.threadRef("thr3") })
+        #expect(window.selectedThread == test.threadRef("thr3"))
+    }
+}

--- a/macos/ATCTests/ThreadNotifierTests.swift
+++ b/macos/ATCTests/ThreadNotifierTests.swift
@@ -204,6 +204,84 @@ struct ThreadNotifierTests {
         #expect(recorder.posts.count == 1)
     }
 
+    @Test("a suppressed trigger still withdraws a banner whose claim went stale")
+    func suppressedTriggerStillWithdraws() {
+        let recorder = Recorder()
+        let notifier = recorder.makeNotifier()
+        notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1")])])
+        notifier.reconcile(connections: [input([
+            Fixtures.thread(id: "thr1", activityState: .needsInput),
+        ])])
+        #expect(recorder.posts.count == 1)
+
+        // The turn finishes without input while ATC is frontmost: the
+        // .finished trigger is suppressed, but the needs-input claim is now
+        // false and the banner must still come down.
+        notifier.isAppActive = { true }
+        notifier.reconcile(connections: [input([
+            Fixtures.thread(id: "thr1", activityState: .idle, unread: true),
+        ])])
+
+        #expect(recorder.posts.count == 1)
+        #expect(recorder.withdrawn == [ref("thr1").notificationIdentifier])
+    }
+
+    @Test("an unknown blip neither withdraws nor re-alerts a needs-input banner")
+    func unknownBlipIsTransparent() {
+        let recorder = Recorder()
+        let notifier = recorder.makeNotifier()
+        notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1")])])
+        notifier.reconcile(connections: [input([
+            Fixtures.thread(id: "thr1", activityState: .needsInput),
+        ])])
+        #expect(recorder.posts.count == 1)
+
+        // The server loses sight of the provider (socket blip, restart) and
+        // then finds it again: absence of evidence, not a state change.
+        notifier.reconcile(connections: [input([
+            Fixtures.thread(id: "thr1", activityState: .unknown),
+        ])])
+        notifier.reconcile(connections: [input([
+            Fixtures.thread(id: "thr1", activityState: .needsInput),
+        ])])
+
+        #expect(recorder.posts.count == 1)
+        #expect(recorder.withdrawn.isEmpty)
+    }
+
+    @Test("unread landing a pass behind needs_input never demotes the banner to finished")
+    func lateUnreadKeepsNeedsInput() {
+        let recorder = Recorder()
+        let notifier = recorder.makeNotifier()
+        notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1")])])
+        notifier.reconcile(connections: [input([
+            Fixtures.thread(id: "thr1", activityState: .needsInput),
+        ])])
+
+        // activityState (live provider evidence) and unread (turn
+        // persistence) can land in separate refreshes.
+        notifier.reconcile(connections: [input([
+            Fixtures.thread(id: "thr1", activityState: .needsInput, unread: true),
+        ])])
+
+        #expect(recorder.posts.map(\.body) == ["Needs your input · App"])
+        #expect(recorder.withdrawn.isEmpty)
+    }
+
+    @Test("a thread that appears after the baseline seeds silently")
+    func newThreadSeedsSilently() {
+        let recorder = Recorder()
+        let notifier = recorder.makeNotifier()
+        notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1")])])
+
+        notifier.reconcile(connections: [input([
+            Fixtures.thread(id: "thr1"),
+            Fixtures.thread(id: "thr2", unread: true),
+        ])])
+
+        #expect(recorder.posts.isEmpty)
+    }
+
     @Test("a notification identifier round-trips to its thread")
     func identifierRoundTrip() {
         let original = ref("019012ab-0000-7000-8000-00000000abcd")
@@ -249,5 +327,90 @@ struct ThreadNotifierTests {
         test.model.registerWindow(window)
         await settle(until: { window.selectedThread == test.threadRef("thr3") })
         #expect(window.selectedThread == test.threadRef("thr3"))
+    }
+
+    @Test("a needs_input transition arriving through the stores notifies")
+    func modelWiringNotifiesNeedsInput() async throws {
+        let recorder = Recorder()
+        let client = ScriptableAppServerClient()
+        Fixtures.seed(client)
+        let test = try await makeModel(client: client, threadNotifier: recorder.makeNotifier())
+        // The first load must have seeded before the transition lands.
+        await drainPendingTasks()
+
+        var threads = client.threads
+        threads[threads.firstIndex { $0.id == "thr3" }!].activityState = .needsInput
+        client.threads = threads
+        await test.runtime.threads.refresh()
+        await settle(until: { !recorder.posts.isEmpty })
+
+        #expect(recorder.posts.map(\.id) == [test.threadRef("thr3").notificationIdentifier])
+        #expect(recorder.posts.map(\.body) == ["Needs your input · App"])
+    }
+
+    @Test("a banner click opens in the most recently keyed window, not the last registered")
+    func clickOpensInKeyWindow() async throws {
+        let recorder = Recorder()
+        let notifier = recorder.makeNotifier()
+        let client = ScriptableAppServerClient()
+        Fixtures.seed(client)
+        let test = try await makeModel(client: client, threadNotifier: notifier)
+        let first = WindowState()
+        let second = WindowState()
+        test.model.registerWindow(first)
+        test.model.registerWindow(second)
+        await drainPendingTasks()
+
+        // The user works in the first window; the second merely opened later.
+        test.model.noteWindowKeyed(first)
+        notifier.onOpenThread?(test.threadRef("thr3"))
+
+        await settle(until: { first.selectedThread == test.threadRef("thr3") })
+        #expect(first.selectedThread == test.threadRef("thr3"))
+        #expect(second.selectedThread == nil)
+    }
+
+    @Test("the user's own navigation supersedes a parked banner click")
+    func userNavigationSupersedesParkedClick() async throws {
+        let recorder = Recorder()
+        let notifier = recorder.makeNotifier()
+        let client = ScriptableAppServerClient()
+        Fixtures.seed(client)
+        let test = try await makeModel(client: client, threadNotifier: notifier)
+        // Parked: no window is registered yet.
+        notifier.onOpenThread?(test.threadRef("thr3"))
+
+        _ = try await test.model.openThread(test.threadRef("thr1"))
+
+        // A window arriving later must not replay the superseded click.
+        let window = WindowState()
+        test.model.registerWindow(window)
+        await drainPendingTasks()
+        #expect(window.selectedThread == nil)
+    }
+
+    @Test("a connection rebuild drops a parked banner click")
+    func rebuildDropsParkedClick() async throws {
+        let recorder = Recorder()
+        let notifier = recorder.makeNotifier()
+        let client = ScriptableAppServerClient()
+        Fixtures.seed(client)
+        let test = try await makeModel(client: client, threadNotifier: notifier)
+        // Parked: no window is registered yet.
+        notifier.onOpenThread?(test.threadRef("thr3"))
+
+        // A URL change tears the runtime down and rebuilds it under the same
+        // Connection id; the stale click must not replay against the rebuild.
+        try test.model.updateConnection(
+            id: test.connectionID,
+            name: test.record.name,
+            urlString: "http://b:2",
+            token: test.record.token
+        )
+        let window = WindowState()
+        test.model.registerWindow(window)
+        await settle(until: { test.model.runtime(id: test.connectionID)?.threads.isResolved == true })
+        await drainPendingTasks()
+        #expect(window.selectedThread == nil)
     }
 }


### PR DESCRIPTION
Optional macOS banners when an agent thread finishes a turn or needs input. Closes ATC-185.

## What it does

One app-level `ThreadNotifier`, owned by `AppModel`, diffs every connection's threads on the navigation observation `AppModel` already runs. No polling, no new server work, no contract change.

- **Triggers**, both under one switch: `unread` flips false→true → `Finished · <project>`; `activityState` becomes `needs_input` → `Needs your input · <project>`. Title is the thread's `displayName`. `unknown` activity never triggers on its own.
- **A banner fires on a transition but lives on a claim.** A delivered banner is withdrawn the moment what it claims stops being true — so answering a prompt in the TUI, or viewing the thread from any other client, takes the banner down without the user touching it.
- **Frontmost ATC never notifies**, and a suppressed banner is spent rather than deferred: switching away later delivers no backlog. The sidebar's "Done" is the durable record.
- **A connection's first resolved load seeds the baseline silently** — launch, a newly added connection, and a URL/token rebuild are all first loads. A reconnect needs no rule at all: the baseline is never cleared, so finishes during a sleep or wifi gap diff as new and notify.
- One banner per thread, keyed off `ThreadRef`; a new trigger replaces it. Clicking one activates ATC and selects the thread through the existing `WindowState.openThread` path.

## Settings

A Notifications tab with one switch, off on a fresh install. Authorization is requested when the switch is turned on, so nothing prompts at first launch, and an OS-level denial is surfaced inline with a button to ATC's pane in System Settings rather than dropping every banner silently.

## Notes

- The delivery seam is two closures that no-op by default; only `ATCApp` calls `ThreadNotifier.system()`, so tests and previews can never post to a real Notification Center.
- `system()` clears delivered banners at launch: the baseline starts empty, so a banner left from a previous launch could never be withdrawn once its claim went stale.
- A click that launched the app arrives before any window registers or any store loads, so the ref waits in a single slot and is honored by the reconciliation that already runs.
- `WindowNavigationSnapshot` gained `activityState` so the model's one observer sees every trigger; window reconciliation is idempotent, so the extra passes cost nothing.

## Verification

`mise run macos:test` — 285 tests pass. Thirteen cover the notifier: silent first load, finish and needs-input triggers, needs-input outranking a finish, no re-alert when a thread leaves needs-input while still unread, frontmost silence with no replay, withdrawal on cleared unread and on leaving the active list, connection loss skipped, the preference gating posting rather than tracking, forget-and-reseed, identifier round-trip, one banner across two open windows, and a click honored once a window exists.

Closes ATC-185

https://claude.ai/code/session_0127zcipnFVUa7QPDdxnf4GP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added desktop notifications for actionable thread activity.
  * Added notification preferences with enable/disable controls and macOS permission guidance.
  * Added a Notifications tab to Settings.
  * Notification clicks can open the relevant thread, including when the app window is not yet open.
  * Notifications account for activity across multiple app windows.

* **Bug Fixes**
  * Notifications are suppressed while the app is active or notifications are disabled.
  * Stale notifications are withdrawn when thread activity ends or threads are archived.
  * Pending notification actions are cleared when navigation or connection state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->