### PR TITLE
Replace resolver-driven thread naming with context-based refinement

### DIFF
--- a/app-server/README.md
+++ b/app-server/README.md
@@ -46,21 +46,9 @@ Environment variables are flat `ATC_<KEY>`: `ATC_PORT`, `ATC_BIND`,
 `ATC_TAILSCALE_EXECUTABLE`, `ATC_CODEX_EXECUTABLE`, `ATC_CLAUDE_EXECUTABLE`, and
 `ATC_CONFIG` (path to an alternate config file). The config file may set
 `port`, `bind`, `tailscale`, `logLevel` (case-insensitive), `dataDir`,
-`zmxExecutable`, `tailscaleExecutable`, `codexExecutable`, `claudeExecutable`,
-and `titleResolvers`; unknown keys are rejected. `atc serve --port`/`--bind`/
+`zmxExecutable`, `tailscaleExecutable`, `codexExecutable`, and
+`claudeExecutable`; unknown keys are rejected. `atc serve --port`/`--bind`/
 `--tailscale` override the configured values for that server only.
-
-`titleResolvers` is a config-file-only table of remote MCP servers the thread
-title generator may consult, each naming the only tools it may call, so a prompt
-that just references an issue or PR still gets a meaningful name. Key each entry
-by the name the server is already authenticated under (`claude mcp list`) —
-stored OAuth is per name, and an unauthenticated resolver is skipped silently:
-
-```toml
-[titleResolvers.linear-server]
-url = "https://mcp.linear.app/mcp"
-tools = ["get_issue"]
-```
 
 Upgrading from the retired Go server: its data is not migrated and nothing
 deletes it automatically. Remove the leftovers by hand if you had one —

--- a/app-server/src/agents/agentAdapter.ts
+++ b/app-server/src/agents/agentAdapter.ts
@@ -344,14 +344,29 @@ export interface AgentAdapter {
    * One bounded, session-less completion: a short display title for a
    * thread whose first user prompt is `prompt` (ATC-155). Runs as the
    * provider's cheapest ephemeral invocation — never a persisted provider
-   * session, never a writer on any existing one. Returns the model's raw
-   * text; callers apply `sanitizeTitle`. Failures are ordinary typed
+   * session, never a writer on any existing one. With `refine` (ATC-190)
+   * the same one-shot re-titles from collected conversation context and is
+   * told to keep a current title that already fits. Returns the model's
+   * raw text; callers apply `sanitizeTitle`. Failures are ordinary typed
    * errors — the caller decides that a missing title is not an error.
    */
   readonly generateTitle: (options: {
     readonly cwd: string
     readonly prompt: string
+    readonly refine?: TitleRefinement
   }) => Effect.Effect<string, AgentUnavailable | AgentProtocolError>
+  /**
+   * Best-effort recent conversation text for one session, feeding the one
+   * title refinement (ATC-190): whatever the adapter can reach cheaply —
+   * an on-demand transcript read (Claude) or the in-memory retention of
+   * observed message items (Codex) — as plain `user:`/`assistant:` lines
+   * capped near 8KB (`buildTitleContext`). Null when nothing usable
+   * exists. Never fails and never touches provider session state.
+   */
+  readonly collectTitleContext: (options: {
+    readonly providerSessionId: string
+    readonly cwd: string
+  }) => Effect.Effect<string | null>
   /**
    * Demand-driven reconciliation: the provider's current word on the
    * session's activity, `unknown` when it offers no evidence. Never
@@ -532,18 +547,44 @@ export const resolveProviderExecutable = (
     )
   })
 
+/** The refinement inputs (ATC-190): collected conversation context plus the
+ * title the thread currently carries (null when the first pass adopted
+ * nothing). */
+export interface TitleRefinement {
+  readonly context: string
+  readonly currentTitle: string | null
+}
+
+/** Cap on collected refinement context (T3Code precedent): the one-shot
+ * needs the gist of the conversation, never a transcript. */
+export const TITLE_CONTEXT_LIMIT = 8_192
+
+/**
+ * Assemble `collectTitleContext` output from labeled conversation lines:
+ * the most recent text within `TITLE_CONTEXT_LIMIT`, or null when nothing
+ * usable remains. Shared so every adapter's context reads the same to the
+ * shared instruction.
+ */
+export const buildTitleContext = (entries: ReadonlyArray<string>): string | null => {
+  const lines = entries.map((entry) => entry.trim()).filter((entry) => entry !== "")
+  if (lines.length === 0) return null
+  const text = lines.join("\n")
+  return text.length > TITLE_CONTEXT_LIMIT ? text.slice(-TITLE_CONTEXT_LIMIT) : text
+}
+
 /**
  * The one thread-title instruction (ATC-155), shared by every adapter's
  * generateTitle so Claude and Codex titles read the same. The user prompt
  * is capped so a pasted wall of text cannot blow up the one-shot's cost —
  * the opening lines are what a title needs.
  *
- * The reference rules (ATC-186) are unconditional: whether a lookup tool
- * exists is the provider's business (Claude's configured resolvers, Codex's
- * own connectors), and a run with none takes the same fallback the rules
- * demand when a lookup fails.
+ * The run is tool-free by design (ATC-190): a referenced identifier is
+ * never looked up here. The refinement variant carries the conversation
+ * the primary agent already produced — which names what any identifier
+ * turned out to mean — and demands no churn: a current title that already
+ * fits comes back verbatim.
  */
-export const titleInstruction = (prompt: string): string =>
+export const titleInstruction = (prompt: string, refine?: TitleRefinement): string =>
   [
     "You write concise titles for coding-agent conversation threads.",
     "Reply with the title only: a single line of plain text, with nothing before or after it.",
@@ -561,9 +602,24 @@ export const titleInstruction = (prompt: string): string =>
     "- If no category clearly matches, omit the prefix.",
     "- Keep every identifier the request names — issue id, PR number, URL — verbatim, and put it ahead of the descriptive part; identifiers do not count toward the word budget.",
     "- A leading $name or /name is a skill invocation: the name is the action being asked for (for example $grill means grill whatever follows).",
-    "- If your tools include one that can look up a referenced identifier, call it once — really call it, never describe calling it — and add the resource's real title. Use no other tool and never retry.",
-    "- If you have no such tool, or the lookup fails, title from the message alone: it may then say nothing about the resource beyond the identifier itself. Never guess what the identifier refers to, and never announce what you are about to do.",
-    "- Example: '$implement ATC-123' becomes 'Build - ATC-123 Restore terminal sessions' when the lookup resolves, and 'Build - ATC-123' when it does not.",
+    "- Never guess what a referenced identifier points to: without evidence of what it means, the title may say nothing about the resource beyond the identifier itself.",
+    ...(refine === undefined
+      ? []
+      : [
+          "",
+          "The conversation below shows what the work actually turned out to be — including what any referenced identifier means. Title the actual work.",
+          ...(refine.currentTitle === null
+            ? []
+            : [
+                `The thread's current title: ${refine.currentTitle}`,
+                "If that title already describes the actual work, reply with it exactly, unchanged. Replace it only when the conversation reveals something it misses.",
+              ]),
+          "",
+          "The conversation so far:",
+          // Already capped: refinement context only ever comes from
+          // collectTitleContext, whose contract is buildTitleContext.
+          refine.context,
+        ]),
     "",
     "The user's first message:",
     prompt.length > 4_000 ? `${prompt.slice(0, 4_000)}…` : prompt,
@@ -590,9 +646,8 @@ const WRAPPING_QUOTES = [
  * a title that long would not be a title.
  *
  * The line taken is the LAST non-empty one (ATC-186): a small model that
- * ignores "the title only" narrates first and answers last — reliably so
- * once a resolver tool is in play ("I don't have that tool… \n\n Build -
- * ATC-186") — and the narration is never the title.
+ * ignores "the title only" narrates first and answers last ("I can't look
+ * that up… \n\n Build - ATC-186") — and the narration is never the title.
  */
 export const sanitizeTitle = (raw: string): string | null => {
   const line = raw

--- a/app-server/src/agents/claudeAdapter.ts
+++ b/app-server/src/agents/claudeAdapter.ts
@@ -5,8 +5,9 @@ import type {
   Options,
   SDKMessage,
   SDKUserMessage,
+  SessionMessage,
 } from "@anthropic-ai/claude-agent-sdk"
-import { query } from "@anthropic-ai/claude-agent-sdk"
+import { getSessionMessages, query } from "@anthropic-ai/claude-agent-sdk"
 import {
   Cause,
   Context,
@@ -33,6 +34,7 @@ import type {
 } from "./agentAdapter.ts"
 import {
   AgentResumeFailed,
+  buildTitleContext,
   emitAgentEvent,
   makeVersionGate,
   NESTED_SESSION_ENV_VARIABLES,
@@ -106,6 +108,8 @@ export type ClaudeQueryFn = (args: {
 
 export interface ClaudeAdapterOptions {
   readonly queryFn?: ClaudeQueryFn
+  /** The getSessionMessages seam, injectable so tests can script transcripts. */
+  readonly sessionMessagesFn?: typeof getSessionMessages
   /** How long create/first-turn waits for the SDK's identity evidence. */
   readonly initTimeout?: Duration.Input
 }
@@ -189,6 +193,40 @@ const userMessage = (text: string): SDKUserMessage => ({
   parent_tool_use_id: null,
 })
 
+/**
+ * Labeled plain-text lines from a transcript read (ATC-190): root user and
+ * assistant text blocks only — tool payloads, tool results, and system
+ * entries carry no title signal, and tool-nested messages are dispatch,
+ * not conversation.
+ */
+const transcriptLines = (messages: ReadonlyArray<SessionMessage>): Array<string> => {
+  const lines: Array<string> = []
+  for (const entry of messages) {
+    if (
+      (entry.type !== "user" && entry.type !== "assistant") ||
+      entry.parent_tool_use_id !== null
+    ) {
+      continue
+    }
+    const content = (entry.message as { content?: unknown } | null)?.content
+    const text =
+      typeof content === "string"
+        ? content
+        : Array.isArray(content)
+          ? content
+              .flatMap((block) => {
+                const candidate = block as { type?: unknown; text?: unknown }
+                return candidate.type === "text" && typeof candidate.text === "string"
+                  ? [candidate.text]
+                  : []
+              })
+              .join("\n")
+          : ""
+    if (text.trim() !== "") lines.push(`${entry.type}: ${text.trim()}`)
+  }
+  return lines
+}
+
 type GateError = AgentResumeFailed | AgentIdentityMismatch | AgentProtocolError
 
 interface LiveSession {
@@ -221,6 +259,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
       const fs = yield* FileSystem.FileSystem
       const hooks = yield* ClaudeHooks.ClaudeHooks
       const queryFn: ClaudeQueryFn = adapterOptions.queryFn ?? (query as unknown as ClaudeQueryFn)
+      const sessionMessagesFn = adapterOptions.sessionMessagesFn ?? getSessionMessages
       const initTimeout = adapterOptions.initTimeout ?? "60 seconds"
 
       /** Live sessions by verified (and, for resumes, expected) session id. */
@@ -455,40 +494,6 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
         yield* versionCheck
         return executable
       })
-
-      /**
-       * The title one-shot's resolver wiring (ATC-186). Only the configured
-       * tools are pre-approved; `dontAsk` denies the rest, so a resolver
-       * that also exposes write tools cannot be talked into using them.
-       * Server names must match what the provider stores credentials under
-       * — a name it cannot authenticate is skipped as `needs-auth`. With no
-       * resolvers this is the original locked-down shape: one turn, nothing
-       * to call.
-       */
-      const resolvers = Object.entries(config.titleResolvers)
-      const titleResolverOptions = {
-        mcpServers: Object.fromEntries(
-          resolvers.map(([name, resolver]) => [
-            name,
-            {
-              type: "http" as const,
-              url: resolver.url,
-              // A deferred tool would cost a tool-search turn the one-shot
-              // does not have; loading blocks only until the server
-              // connects (SDK-capped at 5s), inside the title timeout.
-              alwaysLoad: true,
-              ...(resolver.headers !== undefined ? { headers: resolver.headers } : {}),
-            },
-          ]),
-        ),
-        allowedTools: resolvers.flatMap(([name, resolver]) =>
-          resolver.tools.map((tool) => `mcp__${name}__${tool}`),
-        ),
-        // Room for the lookup turn, the reply, and one recovery: too few
-        // turns means no title at all, while the 90s timeout below is what
-        // actually bounds the run.
-        maxTurns: resolvers.length === 0 ? 1 : 4,
-      }
 
       const hookFilePaths = (providerSessionId: string) => ({
         headerFile: path.join(config.stateDir, `claude-hooks-${providerSessionId}.header`),
@@ -838,14 +843,13 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
             Effect.gen(function* () {
               const executable = yield* resolvedExecutable
               // The smoke-test one-shot shape (smoke.ts claudeRoundTrip):
-              // no built-in tools, nothing persisted — plus a haiku-class
-              // model, since a title needs speed, not depth. Turn count and
-              // any MCP resolver come from titleResolverOptions; strict MCP
+              // one turn, no tools, nothing persisted — plus a haiku-class
+              // model, since a title needs speed, not depth. Strict MCP
               // keeps the project's own .mcp.json out of an unattended run.
               const abort = new AbortController()
               yield* Effect.addFinalizer(() => Effect.sync(() => abort.abort()))
               const prompt = yield* Stream.toAsyncIterableEffect(
-                Stream.make(userMessage(titleInstruction(options.prompt))),
+                Stream.make(userMessage(titleInstruction(options.prompt, options.refine))),
               )
               // Wrapped so a synchronous SDK setup throw is the promised
               // typed error, not a defect.
@@ -862,9 +866,9 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
                       strictMcpConfig: true,
                       permissionMode: "dontAsk",
                       tools: [],
+                      maxTurns: 1,
                       persistSession: false,
                       model: "haiku",
-                      ...titleResolverOptions,
                     },
                   }),
                 catch: (error) =>
@@ -893,6 +897,32 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
                   ),
               }).pipe(withTitleTimeout(protocolError))
             }),
+          ),
+        // On-demand transcript read via the SDK (ATC-190) — the session
+        // JSONL under the project directory is the conversation the primary
+        // agent already produced; nothing is retained here. Best-effort by
+        // contract: any read failure — a hung read included, hence the
+        // bound — is debug-logged and reads as "nothing usable".
+        collectTitleContext: (options) =>
+          Effect.tryPromise({
+            try: () => sessionMessagesFn(options.providerSessionId, { dir: options.cwd }),
+            catch: (error) => (error instanceof Error ? error.message : String(error)),
+          }).pipe(
+            Effect.timeoutOrElse({
+              duration: "10 seconds",
+              orElse: () => Effect.fail("the transcript read timed out"),
+            }),
+            Effect.map(transcriptLines),
+            Effect.map(buildTitleContext),
+            Effect.catch((reason) =>
+              Effect.logDebug("claude title-context read failed").pipe(
+                Effect.annotateLogs({
+                  providerSessionId: options.providerSessionId,
+                  reason,
+                }),
+                Effect.as(null),
+              ),
+            ),
           ),
         // Claude offers no cheap truthful liveness query for a session it
         // is not driving; the domain's linked-terminal liveness carries

--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -30,6 +30,7 @@ import type {
 import {
   AgentResumeFailed,
   aggregateActivity,
+  buildTitleContext,
   emitAgentEvent,
   makeVersionGate,
   NESTED_SESSION_ENV_VARIABLES,
@@ -162,6 +163,28 @@ const SubAgentActivityNotification = Schema.Struct({
     agentThreadId: Schema.String,
   }),
 })
+// The full-text conversation items on the shared server's fan-out
+// (ATC-190): the only conversation evidence a passive socket can reach for
+// a TUI-created thread — thread/read {includeTurns: true} is rejected for
+// them outright (probed live 2026-08-10). agentMessage carries top-level
+// `text`; userMessage carries `content` text blocks — both accepted, and
+// an item carrying neither is skipped like any other unrecognized shape.
+const MessageItemNotification = Schema.Struct({
+  threadId: Schema.String,
+  item: Schema.Struct({
+    type: Schema.Literals(["userMessage", "agentMessage"]),
+    text: Schema.optional(Schema.String),
+    content: Schema.optional(
+      Schema.Array(Schema.Struct({ type: Schema.String, text: Schema.optional(Schema.String) })),
+    ),
+  }),
+})
+
+const messageItemText = (item: typeof MessageItemNotification.Type.item): string =>
+  item.text ??
+  (item.content ?? [])
+    .flatMap((block) => (block.type === "text" && block.text !== undefined ? [block.text] : []))
+    .join("\n")
 const StatusChangedNotification = Schema.Struct({
   threadId: Schema.String,
   status: Schema.optional(Schema.Unknown),
@@ -185,6 +208,7 @@ const ThreadStartedNotification = Schema.Struct({
   }),
 })
 const decodeSubAgentActivity = Schema.decodeUnknownOption(SubAgentActivityNotification)
+const decodeMessageItem = Schema.decodeUnknownOption(MessageItemNotification)
 const decodeStatusChanged = Schema.decodeUnknownOption(StatusChangedNotification)
 const decodeTurnStarted = Schema.decodeUnknownOption(TurnStartedNotification)
 const decodeTurnCompleted = Schema.decodeUnknownOption(TurnCompletedNotification)
@@ -377,6 +401,24 @@ export const layer = Layer.effect(CodexAdapter)(
     const parentOf = new Map<string, string>()
     const descendants = new Map<string, Map<string, AgentActivity>>()
 
+    // Recent conversation text per OBSERVED session (ATC-190), retained
+    // from the userMessage/agentMessage items already arriving on the held
+    // socket — no new RPCs, no polling. Folded through buildTitleContext on
+    // every message, so the stored value is always the already-capped
+    // context itself. In-memory only and pruned with the rest of the
+    // per-root bookkeeping; losing it merely costs a title refinement its
+    // context.
+    const recentMessages = new Map<string, string>()
+
+    const retainMessage = (threadId: string, kind: "userMessage" | "agentMessage", raw: string) => {
+      if (!observers.has(threadId)) return
+      const text = raw.trim()
+      if (text === "") return
+      const line = `${kind === "userMessage" ? "user" : "assistant"}: ${text}`
+      const context = buildTitleContext([recentMessages.get(threadId) ?? "", line])
+      if (context !== null) recentMessages.set(threadId, context)
+    }
+
     /** Follow parent links to the tree's root (bounded against cycles). */
     const resolveRoot = (threadId: string): string => {
       let current = threadId
@@ -439,6 +481,7 @@ export const layer = Layer.effect(CodexAdapter)(
         }
       }
       ownStatus.delete(rootId)
+      recentMessages.delete(rootId)
     }
     // Raw frames arrive on a sync WebSocket callback with no fiber to log
     // from, so the header's "raw events are logged at debug level" runs
@@ -577,10 +620,24 @@ export const layer = Layer.effect(CodexAdapter)(
       // PARENT's feed — descendants do not broadcast thread/started
       // (probed, experiments/subagent-activity).
       if (message.method === "item/started" || message.method === "item/completed") {
-        const decoded = decodeSubAgentActivity(params)
-        if (Option.isNone(decoded)) return
-        registerDescendant(decoded.value.threadId, decoded.value.item.agentThreadId)
-        emitAggregate(resolveRoot(decoded.value.threadId))
+        const subAgent = decodeSubAgentActivity(params)
+        if (Option.isSome(subAgent)) {
+          registerDescendant(subAgent.value.threadId, subAgent.value.item.agentThreadId)
+          emitAggregate(resolveRoot(subAgent.value.threadId))
+          return
+        }
+        // Completed conversation items feed the title-context retention;
+        // anything else stays the deliberate silent skip.
+        if (message.method === "item/completed") {
+          const item = decodeMessageItem(params)
+          if (Option.isSome(item)) {
+            retainMessage(
+              item.value.threadId,
+              item.value.item.type,
+              messageItemText(item.value.item),
+            )
+          }
+        }
         return
       }
       // Coarse status fans out for EVERY thread on the shared server
@@ -1263,7 +1320,7 @@ export const layer = Layer.effect(CodexAdapter)(
                 )
               // Keep the pipe drained so a chatty exec can never block on it.
               yield* Stream.runDrain(child.stdoutLines).pipe(Effect.ignore, Effect.forkScoped)
-              yield* child.writeLine(titleInstruction(options.prompt)).pipe(
+              yield* child.writeLine(titleInstruction(options.prompt, options.refine)).pipe(
                 Effect.andThen(child.endInput),
                 Effect.mapError((error) =>
                   protocolError(`could not write the title prompt: ${error.message}`),
@@ -1291,6 +1348,8 @@ export const layer = Layer.effect(CodexAdapter)(
             }).pipe(withTitleTimeout(protocolError))
           }),
         ),
+      collectTitleContext: (options) =>
+        Effect.sync(() => recentMessages.get(options.providerSessionId) ?? null),
       checkSession: (options) =>
         Effect.gen(function* () {
           const state = yield* getClientRetryable

--- a/app-server/src/platform/config.ts
+++ b/app-server/src/platform/config.ts
@@ -40,53 +40,6 @@ export const CONTEXT_VARIABLES = [
 
 export type ContextVariable = (typeof CONTEXT_VARIABLES)[number]
 
-/**
- * One MCP server the thread-title one-shot may consult to resolve an
- * identifier the first prompt only references (ATC-186). Remote (URL)
- * servers only — a stdio entry would boot a process per title run — and
- * `tools` names exactly what that run may call: titling is unattended and
- * pre-approved, so a resolver must never reach a write tool. Tool names are
- * literal for the same reason: the adapter turns them into permission
- * rules, where `*` or a comma would widen the grant.
- */
-export const TitleResolver = Schema.Struct({
-  url: Schema.String.check(
-    Schema.makeFilter((url) => {
-      const protocol = URL.canParse(url) ? new URL(url).protocol : undefined
-      return protocol === "http:" || protocol === "https:"
-        ? true
-        : `"${url}" must be an http(s) MCP endpoint URL`
-    }),
-  ),
-  headers: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
-  tools: Schema.Array(
-    Schema.String.check(
-      Schema.isPattern(/^[a-zA-Z0-9_-]+$/, { description: "a literal MCP tool name" }),
-    ),
-  ).check(
-    Schema.isMinLength(1, {
-      description: "at least one tool name the resolver may be called with",
-    }),
-  ),
-})
-
-export type TitleResolver = typeof TitleResolver.Type
-
-// The SDK normalizes anything outside [a-zA-Z0-9_-] in a server name to "_"
-// when it builds `mcp__<server>__<tool>`, so a name with other characters
-// would never match the rule the adapter derives from it. Checked over the
-// whole record rather than as a key schema, which would silently drop the
-// rejected entry instead of failing the boot.
-const SERVER_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/
-
-const TitleResolvers = Schema.Record(Schema.String, TitleResolver).check(
-  Schema.makeFilter((servers) =>
-    Object.keys(servers)
-      .filter((name) => !SERVER_NAME.test(name))
-      .map((name) => `server name "${name}" must be letters, digits, underscores, or dashes`),
-  ),
-)
-
 /** Invalid or malformed configuration. `source` names the offending origin. */
 export class ConfigLoadError extends Schema.TaggedErrorClass<ConfigLoadError>()("ConfigLoadError", {
   source: Schema.String,
@@ -154,13 +107,6 @@ export class AppConfig extends Context.Service<
      * orphan sockets are provably ours. Debug with `ZMX_DIR=<dir> zmx list`.
      */
     readonly terminalSocketDir: string
-    /**
-     * MCP servers the thread-title one-shot may consult, keyed by server
-     * name. Empty (the default) leaves that run fully locked down, which is
-     * exactly the pre-ATC-186 behavior. Config file only: a server map has
-     * no sensible flat `ATC_*` spelling.
-     */
-    readonly titleResolvers: Readonly<Record<string, TitleResolver>>
   }
 >()("app-server/AppConfig") {}
 
@@ -194,7 +140,6 @@ const FILE_KEYS = [
   "tailscaleExecutable",
   "codexExecutable",
   "claudeExecutable",
-  "titleResolvers",
 ] as const
 
 const parseToml = (source: string, text: string) =>
@@ -351,22 +296,6 @@ export const load = (
       }
     }
 
-    // Table-valued, so it never reaches the scalar ConfigProvider above:
-    // read straight off the file table, absent meaning "no resolvers". Keys
-    // inside it fail fast like the top-level ones — a typo that silently
-    // dropped `tools` would quietly widen what the title run may call.
-    const titleResolvers = yield* Schema.decodeUnknownEffect(TitleResolvers, {
-      onExcessProperty: "error",
-    })(fileTable["titleResolvers"] ?? {}).pipe(
-      Effect.mapError(
-        (error) =>
-          new ConfigLoadError({
-            source: configFile,
-            message: `titleResolvers: ${error.message.replace(/\s*\n\s*/g, " ")}`,
-          }),
-      ),
-    )
-
     // Agent context is captured verbatim (present means non-empty). Only
     // ATC_ENDPOINT is interpreted, so only it is validated: a malformed
     // value would otherwise surface as a confusing request failure.
@@ -418,7 +347,6 @@ export const load = (
       codexExecutable: settings.codexExecutable,
       claudeExecutable: settings.claudeExecutable,
       terminalSocketDir: path.join(stateDir, "terminals"),
-      titleResolvers,
     }
   })
 

--- a/app-server/src/threads/threadRepository.ts
+++ b/app-server/src/threads/threadRepository.ts
@@ -88,14 +88,18 @@ export class ThreadRepository extends Context.Service<
     /** Update the display label; callers hold the record — a vanished row is a bug. */
     readonly rename: (id: string, name: string) => Effect.Effect<ThreadRecord>
     /**
-     * Adopt a generated name ONLY while the thread is still unnamed
-     * (ATC-155): the name-IS-NULL guard is in the UPDATE itself, so a
-     * manual rename landing mid-generation wins the race atomically. None
-     * when nothing changed — already named, or the row vanished.
+     * Adopt a generated name ONLY while the name is still exactly
+     * `expected` (null = still unnamed): the null-safe guard is in the
+     * UPDATE itself, so a manual rename landing mid-generation wins the
+     * race atomically (ATC-155), and the refinement pass (ATC-190) can
+     * only replace the very title it seeded — any other writer's name
+     * survives untouched. None when nothing changed — the guard
+     * mismatched, or the row vanished.
      */
-    readonly renameIfUnnamed: (
+    readonly renameIfUnchanged: (
       id: string,
       name: string,
+      expected: string | null,
     ) => Effect.Effect<Option.Option<ThreadRecord>>
     /**
      * Adopt a freshly established provider identity: session id and opaque
@@ -177,12 +181,20 @@ export const layer = Layer.effect(ThreadRepository)(
       `,
     })
 
-    const renameIfUnnamedRows = SqlSchema.findAll({
-      Request: Schema.Struct({ id: Schema.String, name: Schema.String, updated_at: Schema.String }),
+    // SQLite `IS` is null-safe equality, so one guard covers both the
+    // first-pass adoption (expected null → name IS NULL) and the
+    // refinement's seed check (expected = the first-pass title).
+    const renameIfUnchangedRows = SqlSchema.findAll({
+      Request: Schema.Struct({
+        id: Schema.String,
+        name: Schema.String,
+        expected: Schema.NullOr(Schema.String),
+        updated_at: Schema.String,
+      }),
       Result: ThreadRow,
       execute: (patch) => sql`
         UPDATE threads SET name = ${patch.name}, updated_at = ${patch.updated_at}
-        WHERE id = ${patch.id} AND name IS NULL
+        WHERE id = ${patch.id} AND name IS ${patch.expected}
         RETURNING *
       `,
     })
@@ -349,9 +361,9 @@ export const layer = Layer.effect(ThreadRepository)(
           Effect.orDie,
           Effect.flatMap(requireFirst("rename")),
         ),
-      renameIfUnnamed: (id, name) =>
+      renameIfUnchanged: (id, name, expected) =>
         Effect.suspend(() =>
-          renameIfUnnamedRows({ id, name, updated_at: new Date().toISOString() }),
+          renameIfUnchangedRows({ id, name, expected, updated_at: new Date().toISOString() }),
         ).pipe(Effect.orDie, Effect.map(firstRecord)),
       setProviderSession: (id, providerSessionId, providerMetadata) =>
         Effect.suspend(() =>

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -1,5 +1,6 @@
 import {
   Context,
+  Deferred,
   Duration,
   Effect,
   Exit,
@@ -95,8 +96,20 @@ export type Thread = typeof ThreadSchema.Type
 //     that was unnamed AND unconfirmed when its subscription started forks
 //     one fire-and-forget title generation through the adapter seam. A
 //     creation-time or manual name always wins — checked before the
-//     generation call and enforced atomically by the guarded rename (name
-//     IS NULL) — and every failure leaves the fallback name, silently.
+//     generation call and enforced atomically by the guarded rename — and
+//     every failure leaves the fallback name, silently.
+//   - Title refinement (ATC-190): each auto-name-eligible thread gets at
+//     most ONE bounded refinement, from the conversation the primary agent
+//     naturally produces (collectTitleContext). Armed by the first busy
+//     evidence on the subscription, it fires at the refine delay or the
+//     busy→idle turn end, whichever comes first, with one catch-up at turn
+//     end when the early collect found nothing usable. The guarded rename
+//     binds the first-pass title as its expected value (the seed), so a
+//     manual rename racing the refinement wins atomically and the guard is
+//     self-verifying; a restart between the passes loses the seed and the
+//     refinement simply does not happen. Every failure is silent — a
+//     thread never ends up worse than its first-pass name, and its name
+//     visibly changes at most once after the instant one.
 //   - archived threads are never pinned: pin refuses archived records, and
 //     archive clears the pin in the same repository write so no client can
 //     observe or restore an archived pin.
@@ -126,6 +139,9 @@ export interface ThreadsOptions {
   /** Initial delay before the identity wait's first TUI-liveness check;
    * subsequent checks back off from it (see watchForEarlyDeath). */
   readonly launchWatchInterval?: Duration.Input
+  /** How far into a thread's first turn the title refinement fires when
+   * the turn has not ended yet (ATC-190). */
+  readonly titleRefineDelay?: Duration.Input
 }
 
 export class Threads extends Context.Service<
@@ -194,6 +210,7 @@ export const layerWith = (options: ThreadsOptions) =>
       const serviceScope = yield* Effect.scope
       const identityTimeout = options.identityTimeout ?? "30 seconds"
       const launchWatchInterval = options.launchWatchInterval ?? "500 millis"
+      const titleRefineDelay = options.titleRefineDelay ?? "30 seconds"
 
       // Live activity evidence by thread id, fed by the per-session
       // subscriptions below. In-memory only — restart resets to no
@@ -244,13 +261,36 @@ export const layerWith = (options: ThreadsOptions) =>
         (record.lastViewedAt === undefined || record.lastViewedAt < record.lastFinishedAt)
 
       /**
+       * Per-observation naming state (ATC-155/ATC-190), shared between the
+       * drain loop and the fire-and-forget naming fibers. In-memory only —
+       * a restart forfeits the pending refinement, never a name.
+       */
+      interface NamingState {
+        /** First observed user prompt (best-effort; Codex discovery can lag
+         * busy and even a short turn's idle edge). */
+        prompt: string | null
+        /** The adopted first-pass title — the refinement's write guard. */
+        seed: string | null
+        /** The one refinement fiber is armed (first busy evidence seen). */
+        armed: boolean
+        /** Resolved when the first prompt lands. */
+        readonly promptArrived: Deferred.Deferred<void>
+        /** Resolved at the first busy→idle edge, or when observation ends. */
+        readonly turnEnded: Deferred.Deferred<void>
+      }
+
+      /**
        * The auto-naming transition (ATC-155): one title one-shot through
        * the adapter seam, adopted only while the thread is still unnamed
        * (pre-checked here, enforced atomically by the guarded rename).
        * Every failure logs and leaves the fallback name — a missing title
        * is never an error, so the effect itself cannot fail.
        */
-      const generateThreadTitle = (record: ThreadRecord, prompt: string): Effect.Effect<void> =>
+      const generateThreadTitle = (
+        record: ThreadRecord,
+        prompt: string,
+        naming: NamingState,
+      ): Effect.Effect<void> =>
         Effect.gen(function* () {
           const adapter = adapterFor(record)
           if (adapter === undefined) return
@@ -265,8 +305,9 @@ export const layerWith = (options: ThreadsOptions) =>
           })
           const title = sanitizeTitle(raw)
           if (title === null) return
-          const renamed = yield* repository.renameIfUnnamed(record.id, title)
+          const renamed = yield* repository.renameIfUnchanged(record.id, title, null)
           if (Option.isNone(renamed)) return
+          naming.seed = title
           yield* events.publish({ resource: "thread", id: record.id, change: "updated" })
         }).pipe(
           Effect.catch((error) =>
@@ -275,6 +316,90 @@ export const layerWith = (options: ThreadsOptions) =>
             ),
           ),
         )
+
+      /**
+       * One refinement attempt (ATC-190): pre-check the seed guard, collect
+       * context through the adapter seam, rerun the titler, and write
+       * through the seed-guarded rename. "noPrompt" and "noContext" report
+       * which evidence was still missing (the caller may retry once);
+       * every other outcome — success, guard mismatch, unusable title —
+       * spends the refinement.
+       */
+      const attemptRefineTitle = (
+        record: ThreadRecord,
+        naming: NamingState,
+      ): Effect.Effect<"done" | "noPrompt" | "noContext", never, never> =>
+        Effect.gen(function* () {
+          const adapter = adapterFor(record)
+          const providerSessionId = record.providerSessionId
+          if (adapter === undefined || providerSessionId === undefined) return "done" as const
+          const prompt = naming.prompt
+          if (prompt === null) return "noPrompt" as const
+          const current = yield* repository.get(record.id)
+          if (Option.isNone(current)) return "done" as const
+          // The seed check: any name the server did not seed (manual or
+          // creation-time) already won. Both null means the first pass
+          // adopted nothing (or is still in flight) — the refinement may
+          // still name the thread, guarded exactly the same way.
+          const name = current.value.name ?? null
+          if (name !== naming.seed) return "done" as const
+          const context = yield* adapter.collectTitleContext({
+            providerSessionId,
+            cwd: record.workingDirectory,
+          })
+          if (context === null) return "noContext" as const
+          const raw = yield* adapter.generateTitle({
+            cwd: record.workingDirectory,
+            prompt,
+            refine: { context, currentTitle: name },
+          })
+          const title = sanitizeTitle(raw)
+          // An unchanged title is the instructed no-churn outcome: no
+          // write, no publish, and the refinement is still spent.
+          if (title === null || title === name) return "done" as const
+          const renamed = yield* repository.renameIfUnchanged(record.id, title, name)
+          if (Option.isNone(renamed)) return "done" as const
+          yield* events.publish({ resource: "thread", id: record.id, change: "updated" })
+          return "done" as const
+        }).pipe(
+          Effect.catch((error) =>
+            Effect.logDebug("thread title refinement failed").pipe(
+              Effect.annotateLogs({ threadId: record.id, reason: error.message }),
+              Effect.as("done" as const),
+            ),
+          ),
+        )
+
+      /**
+       * The one bounded title refinement (ATC-190): wait for the refine
+       * delay or the turn's end — whichever comes first — attempt, and
+       * catch up at most once when evidence was still missing. Missing
+       * CONTEXT retries at turn end (it accrues over the turn) and gives
+       * up silently when the turn already ended. A missing PROMPT is
+       * different: Codex discovers it by polling and it can lag even a
+       * short turn's idle edge, so the catch-up waits for its arrival —
+       * bounded by the turn's end or one more refine delay, so the fiber
+       * always ends. After the catch-up the thread is spent for good.
+       */
+      const refineThreadTitle = (record: ThreadRecord, naming: NamingState): Effect.Effect<void> =>
+        Effect.gen(function* () {
+          const trigger = yield* Effect.raceFirst(
+            Effect.sleep(titleRefineDelay).pipe(Effect.as("delay" as const)),
+            Deferred.await(naming.turnEnded).pipe(Effect.as("turnEnd" as const)),
+          )
+          const outcome = yield* attemptRefineTitle(record, naming)
+          if (outcome === "done") return
+          if (outcome === "noContext" && trigger === "turnEnd") return
+          yield* outcome === "noContext"
+            ? Deferred.await(naming.turnEnded)
+            : Effect.raceFirst(
+                Deferred.await(naming.promptArrived),
+                trigger === "turnEnd"
+                  ? Effect.sleep(titleRefineDelay)
+                  : Deferred.await(naming.turnEnded),
+              )
+          yield* attemptRefineTitle(record, naming)
+        })
 
       /**
        * Start (once) the thread's normalized activity subscription. The
@@ -327,18 +452,29 @@ export const layerWith = (options: ThreadsOptions) =>
             // Auto-name eligibility is fixed at subscription start: a name
             // or a confirmed first turn already on the record rules the
             // thread out (retro-naming is a non-goal), and the first prompt
-            // event spends the one attempt.
-            let untitled = record.name === undefined && record.confirmedAt === undefined
+            // event spends the one attempt (`naming.prompt` set). The same
+            // eligibility governs the refinement (ATC-190).
+            const eligible = record.name === undefined && record.confirmedAt === undefined
+            const naming: NamingState = {
+              prompt: null,
+              seed: null,
+              armed: false,
+              promptArrived: Deferred.makeUnsafe<void>(),
+              turnEnded: Deferred.makeUnsafe<void>(),
+            }
             yield* stream.pipe(
               Stream.runForEach((event) =>
                 Effect.gen(function* () {
                   if (event.type === "userPrompt") {
-                    if (!untitled) return
-                    untitled = false
+                    if (!eligible || naming.prompt !== null) return
+                    naming.prompt = event.text
                     // Fire-and-forget in the SERVICE scope: the generation
                     // outlives observation churn (a closed terminal) but
                     // not the server.
-                    yield* generateThreadTitle(record, event.text).pipe(Effect.forkIn(serviceScope))
+                    yield* generateThreadTitle(record, event.text, naming).pipe(
+                      Effect.forkIn(serviceScope),
+                    )
+                    Deferred.doneUnsafe(naming.promptArrived, Effect.void)
                     return
                   }
                   const activity = event.activity
@@ -348,11 +484,21 @@ export const layerWith = (options: ThreadsOptions) =>
                     confirmed = true
                     yield* repository.confirm(record.id)
                   }
+                  // The first busy evidence arms the one refinement fiber
+                  // (ATC-190), in the service scope for the same reason as
+                  // the generation above. Armed even before the prompt is
+                  // known (Codex prompt discovery lags busy) — the attempt
+                  // reads the state at fire time.
+                  if (eligible && !naming.armed && isBusy(activity)) {
+                    naming.armed = true
+                    yield* refineThreadTitle(record, naming).pipe(Effect.forkIn(serviceScope))
+                  }
                   // The busy→idle drop IS the turn-finished signal (ATC-160):
                   // stamp before publishing so the refetch the event triggers
                   // already sees the thread unread.
                   if (previous !== undefined && isBusy(previous) && activity === "idle") {
                     yield* repository.markFinished(record.id)
+                    Deferred.doneUnsafe(naming.turnEnded, Effect.void)
                   }
                   // One publish covers both the activity transition and the
                   // confirm write above (which only happens on a transition).
@@ -363,8 +509,14 @@ export const layerWith = (options: ThreadsOptions) =>
               ),
               // A feed that ends on its own must not pin the entry (the
               // next read re-subscribes instead of trusting a dead stream)
-              // nor leak its child scope into the service scope.
-              Effect.ensuring(releaseClaim),
+              // nor leak its child scope into the service scope. An ended
+              // observation also ends the refinement's wait — its turn-end
+              // evidence is gone, so the catch-up must not park forever.
+              Effect.ensuring(
+                Effect.sync(() => Deferred.doneUnsafe(naming.turnEnded, Effect.void)).pipe(
+                  Effect.andThen(releaseClaim),
+                ),
+              ),
               Effect.forkIn(child),
             )
           }).pipe(

--- a/app-server/test/agents/agentAdapter.test.ts
+++ b/app-server/test/agents/agentAdapter.test.ts
@@ -3,6 +3,7 @@ import { Deferred, Effect, Fiber, Stream } from "effect"
 import type { AgentEvent } from "../../src/agents/agentAdapter.ts"
 import {
   aggregateActivity,
+  buildTitleContext,
   makeVersionGate,
   sanitizeTitle,
   titleInstruction,
@@ -99,15 +100,16 @@ describe("titleInstruction", () => {
     assert.include(instruction, "If no category clearly matches, omit the prefix.")
   })
 
-  it("asks for resolved references, and for prompt-only titling when it cannot", () => {
+  it("is tool-free: identifiers stay verbatim and are never guessed at", () => {
     const instruction = titleInstruction("$implement ATC-186")
     // Ahead of the prose, so sanitizeTitle's length cap cuts the
     // description rather than the identifier.
     assert.include(instruction, "put it ahead of the descriptive part")
     assert.include(instruction, "$name or /name is a skill invocation")
-    assert.include(instruction, "really call it, never describe calling it")
-    assert.include(instruction, "title from the message alone")
-    assert.include(instruction, "Never guess what the identifier refers to")
+    assert.include(instruction, "Never guess what a referenced identifier points to")
+    // The ATC-186 resolver-tool rules are gone (ATC-190).
+    assert.notInclude(instruction, "your tools")
+    assert.notInclude(instruction, "look up")
   })
 
   it("carries a capped prompt", () => {
@@ -115,6 +117,38 @@ describe("titleInstruction", () => {
     assert.include(instruction, "add a login page")
     const capped = titleInstruction("x".repeat(10_000))
     assert.isBelow(capped.length, 6_000)
+  })
+
+  it("the refinement variant carries context, the current title, and the no-churn rule", () => {
+    const refined = titleInstruction("$implement ATC-190", {
+      context: "user: /implement ATC-190\nassistant: Replacing resolver-driven thread naming.",
+      currentTitle: "Build - ATC-190",
+    })
+    assert.include(refined, "The thread's current title: Build - ATC-190")
+    assert.include(refined, "reply with it exactly, unchanged")
+    assert.include(refined, "assistant: Replacing resolver-driven thread naming.")
+    assert.include(refined, "The user's first message:")
+    // No adopted first-pass title: no keep-it rule to state.
+    const untitled = titleInstruction("$implement ATC-190", {
+      context: "assistant: context",
+      currentTitle: null,
+    })
+    assert.notInclude(untitled, "current title")
+  })
+})
+
+describe("buildTitleContext", () => {
+  it("joins trimmed lines, keeps the recent tail within the cap, and nulls on nothing", () => {
+    assert.strictEqual(
+      buildTitleContext(["  user: hi  ", "", "assistant: ok"]),
+      "user: hi\nassistant: ok",
+    )
+    assert.isNull(buildTitleContext([]))
+    assert.isNull(buildTitleContext(["   ", "\n"]))
+    const long = buildTitleContext(["x".repeat(9_000), "assistant: THE-END"])
+    assert.isNotNull(long)
+    assert.isAtMost(long!.length, 8_192)
+    assert.isTrue(long!.endsWith("assistant: THE-END"))
   })
 })
 

--- a/app-server/test/agents/claudeAdapter.test.ts
+++ b/app-server/test/agents/claudeAdapter.test.ts
@@ -1,3 +1,4 @@
+import type { SessionMessage } from "@anthropic-ai/claude-agent-sdk"
 import { assert, describe, it } from "@effect/vitest"
 import { Effect, Layer, Stream } from "effect"
 import * as fs from "node:fs"
@@ -837,53 +838,11 @@ describe("ClaudeAdapter generateTitle", () => {
         assert.strictEqual(captured?.["model"], "haiku")
         assert.deepStrictEqual(captured?.["tools"], [])
         assert.strictEqual(captured?.["cwd"], cwd)
-        // No resolver configured: no servers, nothing pre-approved.
-        assert.deepStrictEqual(captured?.["mcpServers"], {})
-        assert.deepStrictEqual(captured?.["allowedTools"], [])
-        assert.strictEqual(captured?.["strictMcpConfig"], true)
-      }).pipe(Effect.provide(layer))
-    }),
-  )
-
-  it.live("configured resolvers become MCP servers with exactly their tools allowed", () =>
-    Effect.gen(function* () {
-      const fake = makeFakeClaudeQuery()
-      let captured: Record<string, unknown> | undefined
-      const layer = claudeAdapterLayer(
-        {
-          queryFn: (args) => {
-            captured = args.options as unknown as Record<string, unknown>
-            return fake.queryFn(args)
-          },
-        },
-        "/bin/echo",
-        {
-          titleResolvers: {
-            linear: {
-              url: "https://mcp.linear.app/mcp",
-              headers: { "X-Probe": "1" },
-              tools: ["get_issue", "get_document"],
-            },
-          },
-        },
-      )
-      yield* Effect.gen(function* () {
-        const adapter = yield* ClaudeAdapter.ClaudeAdapter
-        yield* adapter.generateTitle({ cwd: workDir(), prompt: "$implement ATC-186" })
-        assert.deepStrictEqual(captured?.["mcpServers"], {
-          linear: {
-            type: "http",
-            url: "https://mcp.linear.app/mcp",
-            alwaysLoad: true,
-            headers: { "X-Probe": "1" },
-          },
-        })
-        assert.deepStrictEqual(captured?.["allowedTools"], [
-          "mcp__linear__get_issue",
-          "mcp__linear__get_document",
-        ])
-        // Enough turns for one lookup plus the reply; still bounded.
-        assert.strictEqual(captured?.["maxTurns"], 4)
+        // The resolver machinery is gone (ATC-190): no MCP servers, no
+        // pre-approvals — and strict MCP still keeps the project's own
+        // .mcp.json out of the unattended run.
+        assert.isUndefined(captured?.["mcpServers"])
+        assert.isUndefined(captured?.["allowedTools"])
         assert.strictEqual(captured?.["strictMcpConfig"], true)
       }).pipe(Effect.provide(layer))
     }),
@@ -916,6 +875,78 @@ describe("ClaudeAdapter generateTitle", () => {
         if (failure._tag === "AgentProtocolError") {
           assert.include(failure.reason, "sync setup boom")
         }
+      }).pipe(Effect.provide(layer))
+    }),
+  )
+})
+
+describe("ClaudeAdapter collectTitleContext", () => {
+  const transcriptMessage = (
+    type: "user" | "assistant" | "system",
+    content: unknown,
+    parentToolUseId: string | null = null,
+  ): SessionMessage =>
+    ({
+      type,
+      uuid: crypto.randomUUID(),
+      session_id: "context-session",
+      message: { role: type, content },
+      parent_tool_use_id: parentToolUseId,
+      parent_agent_id: null,
+    }) as SessionMessage
+
+  it.live("reads the transcript on demand into labeled conversation text", () =>
+    Effect.gen(function* () {
+      const calls: Array<{ sessionId: string; dir: string | undefined }> = []
+      const layer = claudeAdapterLayer({
+        sessionMessagesFn: (sessionId, options) => {
+          calls.push({ sessionId, dir: options?.dir })
+          return Promise.resolve([
+            transcriptMessage("user", "/implement ATC-190"),
+            transcriptMessage("assistant", [
+              { type: "text", text: "Reading the issue: replace resolver-driven naming." },
+              { type: "tool_use", id: "t1", name: "Read", input: {} },
+            ]),
+            // Tool results, tool-nested messages, and system entries carry
+            // no title signal and stay out of the context.
+            transcriptMessage("user", [{ type: "tool_result", tool_use_id: "t1", content: "…" }]),
+            transcriptMessage("assistant", "tool-nested narration", "tool-1"),
+            transcriptMessage("system", "compact boundary"),
+          ])
+        },
+      })
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        const context = yield* adapter.collectTitleContext({
+          providerSessionId: "context-session",
+          cwd: "/work",
+        })
+        assert.strictEqual(
+          context,
+          "user: /implement ATC-190\n" +
+            "assistant: Reading the issue: replace resolver-driven naming.",
+        )
+        assert.deepStrictEqual(calls, [{ sessionId: "context-session", dir: "/work" }])
+      }).pipe(Effect.provide(layer))
+    }),
+  )
+
+  it.live("a failed or empty transcript read is silently no context", () =>
+    Effect.gen(function* () {
+      const layer = claudeAdapterLayer({
+        sessionMessagesFn: (sessionId) =>
+          sessionId === "empty-session"
+            ? Promise.resolve([])
+            : Promise.reject(new Error("no transcript")),
+      })
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        assert.isNull(
+          yield* adapter.collectTitleContext({ providerSessionId: "empty-session", cwd: "/work" }),
+        )
+        assert.isNull(
+          yield* adapter.collectTitleContext({ providerSessionId: "gone-session", cwd: "/work" }),
+        )
       }).pipe(Effect.provide(layer))
     }),
   )

--- a/app-server/test/agents/codexAdapter.test.ts
+++ b/app-server/test/agents/codexAdapter.test.ts
@@ -1154,3 +1154,62 @@ describe("CodexAdapter descendant aggregation", () => {
     }),
   )
 })
+
+describe("CodexAdapter collectTitleContext", () => {
+  it.live(
+    "retains observed conversation items as labeled context, pruned with the root",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.gen(function* () {
+            const threadId = yield* Effect.scoped(
+              Effect.gen(function* () {
+                const { connection, turn } = yield* adapter.createSession({
+                  cwd: sandbox.cwd,
+                  input: "seed turn",
+                })
+                const id = connection.providerSessionId
+                const sink = yield* collectAgentEvents(connection.events)
+                yield* waitForAgentEvent(
+                  sink,
+                  (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
+                )
+                // Nothing observed the first turn, so nothing was retained.
+                assert.isNull(
+                  yield* adapter.collectTitleContext({
+                    providerSessionId: id,
+                    cwd: sandbox.cwd,
+                  }),
+                )
+                yield* adapter.observeSession({
+                  providerSessionId: id,
+                  providerMetadata: undefined,
+                })
+                const second = yield* connection.startTurn("hello context")
+                yield* waitForAgentEvent(
+                  sink,
+                  (event) => event.type === "turnCompleted" && event.turnId === second.turnId,
+                )
+                // Both the echoed user message and the reply, in order.
+                yield* eventually(
+                  adapter.collectTitleContext({ providerSessionId: id, cwd: sandbox.cwd }),
+                  (context) => context === "user: hello context\nassistant: fake: hello context",
+                )
+                return id
+              }),
+            )
+            // Writer and observer are gone: the retention went with the
+            // root's bookkeeping.
+            assert.isNull(
+              yield* adapter.collectTitleContext({
+                providerSessionId: threadId,
+                cwd: sandbox.cwd,
+              }),
+            )
+          }),
+        )
+      }),
+    30_000,
+  )
+})

--- a/app-server/test/agents/fakeAgentAdapter.ts
+++ b/app-server/test/agents/fakeAgentAdapter.ts
@@ -57,12 +57,20 @@ export interface FakeAgentAdapter {
   /** Push one userPrompt event to every observer of `providerSessionId`. */
   readonly emitUserPrompt: (providerSessionId: string, text: string) => void
   /** generateTitle calls observed, in order. */
-  readonly titleRequests: Array<{ cwd: string; prompt: string }>
+  readonly titleRequests: Array<{
+    cwd: string
+    prompt: string
+    refine?: { context: string; currentTitle: string | null }
+  }>
   /** generateTitle outcomes (the raw title or the failure), in order —
    * the deterministic completion signal for race tests. */
   readonly titleOutcomes: Array<{ title?: string; error?: string }>
   /** Script what generateTitle returns (default "Fake generated title"). */
   readonly setTitle: (title: string) => void
+  /** collectTitleContext calls (providerSessionIds), in order. */
+  readonly contextRequests: Array<string>
+  /** Script what collectTitleContext returns for a session (default null). */
+  readonly setTitleContext: (providerSessionId: string, context: string | null) => void
   /** While set, generateTitle fails with AgentProtocolError(reason). */
   readonly setTitleFails: (reason: string | null) => void
   /** While set, generateTitle waits on a gate; unsetting releases waiters. */
@@ -115,6 +123,8 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
   const released: FakeAgentAdapter["released"] = []
   const titleRequests: FakeAgentAdapter["titleRequests"] = []
   const titleOutcomes: FakeAgentAdapter["titleOutcomes"] = []
+  const contextRequests: FakeAgentAdapter["contextRequests"] = []
+  const titleContexts = new Map<string, string>()
   let scriptedTitle = "Fake generated title"
   let titleFailsReason: string | null = null
   let titleGate: Deferred.Deferred<void> | null = null
@@ -359,7 +369,11 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
     generateTitle: (options) =>
       Effect.gen(function* () {
         yield* requireAvailable
-        titleRequests.push({ cwd: options.cwd, prompt: options.prompt })
+        titleRequests.push({
+          cwd: options.cwd,
+          prompt: options.prompt,
+          ...(options.refine !== undefined ? { refine: options.refine } : {}),
+        })
         const gate = titleGate
         if (gate !== null) yield* Deferred.await(gate)
         if (titleFailsReason !== null) {
@@ -370,6 +384,11 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
         }
         titleOutcomes.push({ title: scriptedTitle })
         return scriptedTitle
+      }),
+    collectTitleContext: (options) =>
+      Effect.sync(() => {
+        contextRequests.push(options.providerSessionId)
+        return titleContexts.get(options.providerSessionId) ?? null
       }),
     checkSession: (options) =>
       Effect.gen(function* () {
@@ -445,6 +464,11 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
     titleOutcomes,
     setTitle: (title) => {
       scriptedTitle = title
+    },
+    contextRequests,
+    setTitleContext: (providerSessionId, context) => {
+      if (context === null) titleContexts.delete(providerSessionId)
+      else titleContexts.set(providerSessionId, context)
     },
     setTitleFails: (reason) => {
       titleFailsReason = reason

--- a/app-server/test/fixtures/fake-codex-listener.ts
+++ b/app-server/test/fixtures/fake-codex-listener.ts
@@ -313,6 +313,14 @@ const handle = (
         status: { type: "active", activeFlags: [] },
       })
       broadcast("turn/started", { threadId, turn: { id: turnId } })
+      // The real server broadcasts the turn's input back as a completed
+      // userMessage item — content text blocks, unlike agentMessage's
+      // top-level text — the retention evidence for title refinement.
+      broadcast("item/completed", {
+        threadId,
+        turnId,
+        item: { id: crypto.randomUUID(), type: "userMessage", content: [{ type: "text", text }] },
+      })
       if (text.includes("HANG")) {
         hangingTurns.add(threadId)
         return

--- a/app-server/test/platform/config.test.ts
+++ b/app-server/test/platform/config.test.ts
@@ -195,60 +195,12 @@ describe("configuration", () => {
       const error = yield* loadError({ ATC_CONFIG: file })
       assert.strictEqual(error.source, file)
       assert.include(error.message, '"prot"')
-    }),
-  )
-
-  it.effect("title resolvers default to none and parse from the config file", () =>
-    Effect.gen(function* () {
-      assert.deepStrictEqual((yield* load({})).titleResolvers, {})
-      const file = writeConfig(
-        `[titleResolvers.linear]\nurl = "https://mcp.linear.app/mcp"\ntools = ["get_issue"]\n\n` +
-          `[titleResolvers.linear.headers]\n"X-Probe" = "1"\n`,
+      // The retired ATC-186 resolver table (removed in ATC-190) is now an
+      // unknown key like any other — it fails the boot, never half-applies.
+      const legacy = writeConfig(
+        `[titleResolvers.linear]\nurl = "https://mcp.linear.app/mcp"\ntools = ["get_issue"]\n`,
       )
-      const config = yield* load({ ATC_CONFIG: file })
-      assert.deepStrictEqual(config.titleResolvers, {
-        linear: {
-          url: "https://mcp.linear.app/mcp",
-          tools: ["get_issue"],
-          headers: { "X-Probe": "1" },
-        },
-      })
-    }),
-  )
-
-  it.effect("a title resolver that could not be reached or trusted fails naming the file", () =>
-    Effect.gen(function* () {
-      // A non-http endpoint would silently never resolve anything.
-      const badUrl = writeConfig(
-        `[titleResolvers.linear]\nurl = "mcp.linear.app"\ntools = ["get_issue"]\n`,
-      )
-      const urlError = yield* loadError({ ATC_CONFIG: badUrl })
-      assert.strictEqual(urlError.source, badUrl)
-      assert.include(urlError.message, "titleResolvers")
-      assert.notInclude(urlError.message, "\n")
-
-      // Tools are the whole pre-approval: an empty list is a configuration
-      // mistake, and a wildcard would grant the server's write tools too.
-      const noTools = writeConfig(
-        `[titleResolvers.linear]\nurl = "https://mcp.linear.app/mcp"\ntools = []\n`,
-      )
-      assert.include((yield* loadError({ ATC_CONFIG: noTools })).message, "titleResolvers")
-      const wildcard = writeConfig(
-        `[titleResolvers.linear]\nurl = "https://mcp.linear.app/mcp"\ntools = ["*"]\n`,
-      )
-      assert.include((yield* loadError({ ATC_CONFIG: wildcard })).message, "titleResolvers")
-
-      // The name becomes the mcp__<server>__<tool> prefix.
-      const badName = writeConfig(
-        `[titleResolvers."my server"]\nurl = "https://example.com/mcp"\ntools = ["get_issue"]\n`,
-      )
-      assert.include((yield* loadError({ ATC_CONFIG: badName })).message, "titleResolvers")
-
-      // Unknown keys fail fast inside the table too, not just above it.
-      const typo = writeConfig(
-        `[titleResolvers.linear]\nurl = "https://mcp.linear.app/mcp"\ntools = ["get_issue"]\ntool = "get_issue"\n`,
-      )
-      assert.include((yield* loadError({ ATC_CONFIG: typo })).message, "titleResolvers")
+      assert.include((yield* loadError({ ATC_CONFIG: legacy })).message, '"titleResolvers"')
     }),
   )
 

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -85,7 +85,6 @@ export const testAppConfig = (overrides: Partial<AppConfig["Service"]>): Layer.L
     codexExecutable: "codex",
     claudeExecutable: "claude",
     terminalSocketDir: "/tmp/atc-sockets",
-    titleResolvers: {},
     ...overrides,
   })
 

--- a/app-server/test/threads/threadTitle.test.ts
+++ b/app-server/test/threads/threadTitle.test.ts
@@ -97,19 +97,25 @@ describe("thread auto-naming", () => {
     ).pipe(Effect.provide(TestLayer)),
   )
 
-  it.live("a creation-time name suppresses generation entirely", () =>
+  it.live("a creation-time name suppresses generation and refinement entirely", () =>
     Effect.gen(function* () {
       const { client, threadId, sessionId } = yield* openedThread("Named at birth")
       const requestsBefore = kit.fakeAgents.codex.titleRequests.length
+      const contextsBefore = kit.fakeAgents.codex.contextRequests.length
 
       kit.fakeAgents.codex.emitUserPrompt(sessionId, "first prompt")
-      // Barrier: a later event observed proves the prompt was consumed.
+      // A whole first turn passes: neither its busy onset nor its idle
+      // edge may trigger any title work on a creation-named thread.
+      kit.fakeAgents.codex.emitActivity(sessionId, "working")
+      kit.fakeAgents.codex.emitActivity(sessionId, "idle")
+      // Barrier: a later event observed proves the edges were consumed.
       kit.fakeAgents.codex.emitActivity(sessionId, "working")
       yield* eventually(
         client.v1.getThread({ params: { threadId } }),
         (read) => read.activityState === "working",
       )
       assert.strictEqual(kit.fakeAgents.codex.titleRequests.length, requestsBefore)
+      assert.strictEqual(kit.fakeAgents.codex.contextRequests.length, contextsBefore)
       assert.strictEqual(
         (yield* client.v1.getThread({ params: { threadId } })).name,
         "Named at birth",
@@ -172,7 +178,7 @@ describe("thread auto-naming", () => {
     }).pipe(Effect.provide(TestLayer)),
   )
 
-  it.live("the guarded rename is atomic: an existing name is never overwritten", () =>
+  it.live("the guarded rename is atomic: only the expected name is ever replaced", () =>
     Effect.gen(function* () {
       const client = yield* HttpApiTest.groups(Api, ["v1"])
       const repository = yield* ThreadRepository
@@ -182,19 +188,25 @@ describe("thread auto-naming", () => {
       const thread = yield* client.v1.createThread({
         payload: { projectId: project.id, agentId: "codex" },
       })
-      // Unnamed: the guarded write adopts.
-      const adopted = yield* repository.renameIfUnnamed(thread.id, "Generated")
+      // Unnamed: the first-pass write (expected null) adopts.
+      const adopted = yield* repository.renameIfUnchanged(thread.id, "Generated", null)
       assert.strictEqual(Option.getOrThrow(adopted).name, "Generated")
-      // Named: the guarded write refuses — even against another generated name.
-      const refused = yield* repository.renameIfUnnamed(thread.id, "Generated again")
+      // Named: expected-null refuses — even against another generated name.
+      const refused = yield* repository.renameIfUnchanged(thread.id, "Generated again", null)
       assert.isTrue(Option.isNone(refused))
+      // The refinement's seed guard: the exact current name replaces, any
+      // other expected value no-ops.
+      const stale = yield* repository.renameIfUnchanged(thread.id, "Refined", "Some other seed")
+      assert.isTrue(Option.isNone(stale))
+      const refined = yield* repository.renameIfUnchanged(thread.id, "Refined", "Generated")
+      assert.strictEqual(Option.getOrThrow(refined).name, "Refined")
       assert.strictEqual(
         (yield* client.v1.getThread({ params: { threadId: thread.id } })).name,
-        "Generated",
+        "Refined",
       )
       // A vanished row is a silent no-op, not a crash.
       yield* client.v1.deleteThread({ params: { threadId: thread.id } })
-      const gone = yield* repository.renameIfUnnamed(thread.id, "Ghost")
+      const gone = yield* repository.renameIfUnchanged(thread.id, "Ghost", null)
       assert.isTrue(Option.isNone(gone))
     }).pipe(Effect.provide(TestLayer)),
   )

--- a/app-server/test/threads/threadTitleRefine.test.ts
+++ b/app-server/test/threads/threadTitleRefine.test.ts
@@ -1,0 +1,287 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Option } from "effect"
+import { HttpApiTest } from "effect/unstable/httpapi"
+import { mkdtempSync, realpathSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll } from "vitest"
+import { Api } from "../../src/api/contract.ts"
+import { ThreadRepository } from "../../src/threads/threadRepository.ts"
+import { apiTestLayer, eventually, makeTestServiceLayers } from "../testLayers.ts"
+
+// Title refinement (ATC-190) through the uniform seam contract: an
+// auto-named thread's title is refined at most once from collected
+// conversation context — at the refine delay or the turn's end — with
+// manual names always winning and every failure silent. All through the
+// fake adapters — no provider knowledge, no real 30-second waits (the
+// delay is a ThreadsOptions seam; assertions wait on conditions).
+
+// Two kits: one whose refine delay fires promptly inside a test (the "30s
+// elapsed" path) and one whose delay never fires (the turn-end path).
+const fastKit = makeTestServiceLayers(":memory:", { titleRefineDelay: "20 millis" })
+const FastLayer = apiTestLayer(fastKit)
+const slowKit = makeTestServiceLayers(":memory:", { titleRefineDelay: "1 hour" })
+const SlowLayer = apiTestLayer(slowKit)
+
+const scratch = mkdtempSync(join(tmpdir(), "atc-thread-refine-"))
+afterAll(() => rmSync(scratch, { recursive: true, force: true }))
+const realDir = realpathSync(scratch)
+
+/** One opened thread with its observation live. */
+const openedThread = (name?: string) =>
+  Effect.gen(function* () {
+    const client = yield* HttpApiTest.groups(Api, ["v1"])
+    const repository = yield* ThreadRepository
+    const project = yield* client.v1.createProject({
+      payload: {
+        name: `Refine ${name ?? "unnamed"} ${Date.now()}`,
+        defaultWorkingDirectory: realDir,
+      },
+    })
+    const thread = yield* client.v1.createThread({
+      payload: { projectId: project.id, agentId: "codex", ...(name !== undefined ? { name } : {}) },
+    })
+    yield* client.v1.openThreadTerminal({ params: { threadId: thread.id } })
+    const record = Option.getOrThrow(yield* repository.get(thread.id))
+    return { client, threadId: thread.id, sessionId: record.providerSessionId ?? "" }
+  })
+
+describe("thread title refinement", () => {
+  it.live("the elapsed delay refines mid-turn, once, and never re-arms", () =>
+    Effect.gen(function* () {
+      const fake = fastKit.fakeAgents.codex
+      const { client, threadId, sessionId } = yield* openedThread()
+      const requestsBefore = fake.titleRequests.length
+      const contextsBefore = fake.contextRequests.length
+
+      // First pass: the instant name from the opaque prompt.
+      fake.setTitle("Build - ATC-128")
+      fake.emitUserPrompt(sessionId, "/implement ATC-128")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId } }),
+        (read) => read.name === "Build - ATC-128",
+      )
+
+      // The turn starts; the delay elapses long before any idle edge.
+      fake.setTitleContext(sessionId, "user: /implement ATC-128\nassistant: Restoring terminals")
+      fake.setTitle("Build - ATC-128 Restore terminal sessions")
+      fake.emitActivity(sessionId, "working")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId } }),
+        (read) => read.name === "Build - ATC-128 Restore terminal sessions",
+      )
+      // The refine call carried the first prompt, the collected context,
+      // and the seed as the current title.
+      assert.deepStrictEqual(fake.titleRequests[fake.titleRequests.length - 1], {
+        cwd: realDir,
+        prompt: "/implement ATC-128",
+        refine: {
+          context: "user: /implement ATC-128\nassistant: Restoring terminals",
+          currentTitle: "Build - ATC-128",
+        },
+      })
+      assert.strictEqual(fake.contextRequests.length, contextsBefore + 1)
+
+      // A later turn never refines again: the thread is spent.
+      fake.emitActivity(sessionId, "idle")
+      fake.emitActivity(sessionId, "working")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId } }),
+        (read) => read.activityState === "working",
+      )
+      assert.strictEqual(fake.contextRequests.length, contextsBefore + 1)
+      assert.strictEqual(fake.titleRequests.length, requestsBefore + 2)
+
+      yield* client.v1.deleteThread({ params: { threadId } })
+    }).pipe(Effect.provide(FastLayer)),
+  )
+
+  it.live("a turn ending before the delay fires the refinement at the idle edge", () =>
+    Effect.gen(function* () {
+      const fake = slowKit.fakeAgents.codex
+      const { client, threadId, sessionId } = yield* openedThread()
+
+      fake.setTitle("Build - ATC-128")
+      fake.emitUserPrompt(sessionId, "/implement ATC-128")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId } }),
+        (read) => read.name === "Build - ATC-128",
+      )
+
+      fake.setTitleContext(sessionId, "assistant: Short turn, real work")
+      fake.setTitle("Build - ATC-128 Short but real")
+      fake.emitActivity(sessionId, "working")
+      fake.emitActivity(sessionId, "idle")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId } }),
+        (read) => read.name === "Build - ATC-128 Short but real",
+      )
+
+      yield* client.v1.deleteThread({ params: { threadId } })
+    }).pipe(Effect.provide(SlowLayer)),
+  )
+
+  it.live("an empty early collect gets exactly one catch-up at turn end", () =>
+    Effect.gen(function* () {
+      const fake = fastKit.fakeAgents.codex
+      const { client, threadId, sessionId } = yield* openedThread()
+      const contextsBefore = fake.contextRequests.length
+
+      fake.setTitle("First pass")
+      fake.emitUserPrompt(sessionId, "opaque prompt")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId } }),
+        (read) => read.name === "First pass",
+      )
+
+      // No context yet: the early attempt collects nothing and waits.
+      fake.emitActivity(sessionId, "working")
+      yield* eventually(
+        Effect.sync(() => fake.contextRequests.length),
+        (count) => count === contextsBefore + 1,
+      )
+      assert.strictEqual((yield* client.v1.getThread({ params: { threadId } })).name, "First pass")
+
+      // Context exists by turn end: the catch-up refines.
+      fake.setTitleContext(sessionId, "assistant: The work took shape late")
+      fake.setTitle("Refined at turn end")
+      fake.emitActivity(sessionId, "idle")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId } }),
+        (read) => read.name === "Refined at turn end",
+      )
+      assert.strictEqual(fake.contextRequests.length, contextsBefore + 2)
+
+      yield* client.v1.deleteThread({ params: { threadId } })
+    }).pipe(Effect.provide(FastLayer)),
+  )
+
+  it.live("a manual rename racing the refinement wins", () =>
+    Effect.gen(function* () {
+      const fake = fastKit.fakeAgents.codex
+      const { client, threadId, sessionId } = yield* openedThread()
+      const requestsBefore = fake.titleRequests.length
+
+      fake.setTitle("First pass")
+      fake.emitUserPrompt(sessionId, "race prompt")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId } }),
+        (read) => read.name === "First pass",
+      )
+
+      fake.setTitleContext(sessionId, "assistant: racing")
+      fake.setTitle("Refined too late")
+      fake.setTitleHangs(true)
+      fake.emitActivity(sessionId, "working")
+      // The refine one-shot is in flight (hanging) when the rename lands.
+      yield* eventually(
+        Effect.sync(() => fake.titleRequests.length),
+        (count) => count === requestsBefore + 2,
+      )
+      const outcomesBefore = fake.titleOutcomes.length
+      yield* client.v1.updateThread({ params: { threadId }, payload: { name: "Manual" } })
+      fake.setTitleHangs(false)
+      yield* eventually(
+        Effect.sync(() => fake.titleOutcomes.length),
+        (count) => count === outcomesBefore + 1,
+      )
+      // The refinement completed with its own title, yet the manual name
+      // holds — the seed guard no-ops atomically.
+      yield* eventually(
+        client.v1.getThread({ params: { threadId } }),
+        (read) => read.name === "Manual",
+      )
+
+      yield* client.v1.deleteThread({ params: { threadId } })
+    }).pipe(Effect.provide(FastLayer)),
+  )
+
+  it.live("context unavailable at turn end keeps the first-pass name silently", () =>
+    Effect.gen(function* () {
+      const fake = fastKit.fakeAgents.codex
+      const { client, threadId, sessionId } = yield* openedThread()
+      const requestsBefore = fake.titleRequests.length
+
+      fake.setTitle("First pass")
+      fake.emitUserPrompt(sessionId, "opaque prompt")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId } }),
+        (read) => read.name === "First pass",
+      )
+
+      // The turn ends with no context ever collected (the provider emitted
+      // nothing): the refinement gives up without a title call.
+      fake.emitActivity(sessionId, "working")
+      fake.emitActivity(sessionId, "idle")
+      // Barrier: a later event observed proves the edges were consumed.
+      fake.emitActivity(sessionId, "working")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId } }),
+        (read) => read.activityState === "working",
+      )
+      assert.strictEqual(fake.titleRequests.length, requestsBefore + 1)
+      assert.strictEqual((yield* client.v1.getThread({ params: { threadId } })).name, "First pass")
+
+      yield* client.v1.deleteThread({ params: { threadId } })
+    }).pipe(Effect.provide(FastLayer)),
+  )
+
+  it.live("a prompt discovered only after a short turn's end still refines", () =>
+    Effect.gen(function* () {
+      const fake = slowKit.fakeAgents.codex
+      const { client, threadId, sessionId } = yield* openedThread()
+      const requestsBefore = fake.titleRequests.length
+
+      // The whole turn passes before any prompt evidence (the Codex
+      // preview poll can lag even the idle edge).
+      fake.setTitleContext(sessionId, "assistant: Restored the terminal sessions")
+      fake.setTitle("Build - ATC-128 Restore terminals")
+      fake.emitActivity(sessionId, "working")
+      fake.emitActivity(sessionId, "idle")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId } }),
+        (read) => read.activityState === "idle",
+      )
+
+      // The late prompt fires the instant pass AND wakes the refinement.
+      fake.emitUserPrompt(sessionId, "/implement ATC-128")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId } }),
+        (read) => read.name === "Build - ATC-128 Restore terminals",
+      )
+      yield* eventually(
+        Effect.sync(() => fake.titleRequests.slice(requestsBefore)),
+        (requests) => requests.some((request) => request.refine !== undefined),
+      )
+
+      yield* client.v1.deleteThread({ params: { threadId } })
+    }).pipe(Effect.provide(SlowLayer)),
+  )
+
+  it.live("a failing refine one-shot leaves the first-pass name, silently", () =>
+    Effect.gen(function* () {
+      const fake = fastKit.fakeAgents.codex
+      const { client, threadId, sessionId } = yield* openedThread()
+
+      fake.setTitle("First pass")
+      fake.emitUserPrompt(sessionId, "doomed refine")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId } }),
+        (read) => read.name === "First pass",
+      )
+
+      fake.setTitleContext(sessionId, "assistant: about to fail")
+      fake.setTitleFails("provider exploded")
+      const outcomesBefore = fake.titleOutcomes.length
+      fake.emitActivity(sessionId, "working")
+      yield* eventually(
+        Effect.sync(() => fake.titleOutcomes.length),
+        (count) => count === outcomesBefore + 1,
+      )
+      assert.strictEqual((yield* client.v1.getThread({ params: { threadId } })).name, "First pass")
+
+      fake.setTitleFails(null)
+      yield* client.v1.deleteThread({ params: { threadId } })
+    }).pipe(Effect.provide(FastLayer)),
+  )
+})


### PR DESCRIPTION
Implements [ATC-190](https://linear.app/elevenideas/issue/ATC-190/replace-resolver-driven-thread-naming-with-context-based-refinement).

## What

**Removes the ATC-186 resolver machinery** (shipped in #189): the `titleResolvers` config table, the Claude title one-shot's MCP server/allowed-tools wiring, the tool-use rules in the shared title instruction, and the README section. The title one-shot is fully locked down again (`maxTurns: 1`, no tools, `strictMcpConfig` kept), and `titleResolvers` in config.toml now fails the boot as an unknown key.

**Adds one bounded title refinement per auto-named thread**, from the conversation the primary agent naturally produces:

- New `AgentAdapter.collectTitleContext` — best-effort, never fails, ~8KB cap (`buildTitleContext`). Claude reads the session transcript on demand via the SDK's `getSessionMessages`; Codex retains observed `userMessage`/`agentMessage` items from the already-held socket (no new RPCs), folded into one capped string and pruned with the root bookkeeping.
- The refinement fires at 30s into the thread's first turn or its busy→idle end, whichever comes first (`ThreadsOptions.titleRefineDelay` seam for tests). Missing context retries once at turn end; a prompt still undiscovered at turn end (Codex preview polling can lag even a short turn's idle edge) waits for its arrival, bounded.
- The titler reruns with a refinement variant of the shared instruction: first prompt + collected context + current title, instructed to keep a title that already fits (no churn).
- Manual names always win: `renameIfUnnamed` is generalized to `renameIfUnchanged(id, name, expected)` with a null-safe `name IS ?` guard, so the refinement can only ever replace the exact title it seeded, atomically. Every failure is silent; a thread's name visibly changes at most once after the instant name.

## Notes

- No contract/OpenAPI or client changes; `titleResolvers` was server-internal.
- A server restart between the two passes loses the in-memory seed and the refinement simply doesn't happen (accepted in the issue).
- Reviewed adversarially (correctness + simplicity) with fixes applied; residuals accepted by design: a manual rename to the *identical* seed text can still be refined over (no provenance column, per the issue), and an observation dying mid-turn is treated as the turn ending for refinement purposes (bounded fiber lifetime wins).

https://claude.ai/code/session_01ETRGGA2bANrYjJLYQjCxpu


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Thread titles can be refined automatically as conversation context becomes available.
  * Refinement preserves suitable existing titles and avoids unnecessary renames.
  * Conversation context is capped and gathered from supported agent sessions.

* **Changes**
  * Removed support for configurable title resolvers.
  * Title generation no longer uses external tools to resolve identifiers.
  * Thread renames are protected against stale updates and manual changes.

* **Bug Fixes**
  * Improved handling of unavailable, empty, or failed conversation context without disrupting activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->