### PR TITLE
Run CI on every PR with job-level path filters and required aggregate checks (ATC-187)

### DIFF
--- a/.github/workflows/app-server-ci.yml
+++ b/.github/workflows/app-server-ci.yml
@@ -1,12 +1,10 @@
 name: App Server CI
 
+# Runs on every PR so the required `app-server-ci-ok` check always reports.
+# Path awareness lives at the job level (the `changes` job): a required check
+# from a workflow-level path filter would hang pending on non-matching PRs.
 on:
   pull_request:
-    paths:
-      - "app-server/**"
-      - "mise.toml"
-      - "install.sh"
-      - ".github/workflows/app-server-ci.yml"
   push:
     branches:
       - main
@@ -23,14 +21,34 @@ concurrency:
   group: app-server-ci-${{ github.ref }}
   cancel-in-progress: true
 
-defaults:
-  run:
-    working-directory: app-server
-
 jobs:
+  # Decides whether this PR touches the App Server surface. Push events are
+  # already path-filtered at the workflow level, so they always run everything.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      relevant: ${{ github.event_name == 'push' || steps.filter.outputs.relevant }}
+    steps:
+      - uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - "app-server/**"
+              - "mise.toml"
+              - "install.sh"
+              - ".github/workflows/app-server-ci.yml"
+
   validate:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: app-server
     steps:
       - uses: actions/checkout@v7
 
@@ -55,8 +73,13 @@ jobs:
   # nothing about runtime behavior — that is what native-validate is for.
   cross-compile:
     name: cross-compile (build only, no runtime validation)
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: app-server
     steps:
       - uses: actions/checkout@v7
 
@@ -80,11 +103,16 @@ jobs:
   # until the release/packaging milestone adds native coverage.
   native-validate:
     name: native compiled validation (${{ matrix.os }})
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     strategy:
       matrix:
         os: [macos-14, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: app-server
     steps:
       - uses: actions/checkout@v7
 
@@ -100,3 +128,17 @@ jobs:
 
       - name: Compiled artifact black-box tests
         run: mise run test:compiled
+
+  # The single required check for this workflow: reports on every PR (skipped
+  # upstream jobs are fine, failed or cancelled ones are not), so the `main`
+  # ruleset can require it without hanging non-matching PRs.
+  ci-ok:
+    name: app-server-ci-ok
+    needs: [changes, validate, cross-compile, native-validate]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fail if any needed job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -1,15 +1,10 @@
 name: macOS CI
 
+# Runs on every PR so the required `macos-ci-ok` check always reports.
+# Path awareness lives at the job level (the `changes` job): a required check
+# from a workflow-level path filter would hang pending on non-matching PRs.
 on:
   pull_request:
-    paths:
-      - "macos/**"
-      - "packages/**"
-      # The ATCAppServerAPI Swift client is generated from this artifact at
-      # build time, so contract changes must rebuild the Swift surfaces.
-      - "app-server/openapi.json"
-      - "mise.toml"
-      - ".github/workflows/macos-ci.yml"
   push:
     branches:
       - main
@@ -28,7 +23,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Decides whether this PR touches the Swift surfaces. Push events are
+  # already path-filtered at the workflow level, so they always run everything.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      relevant: ${{ github.event_name == 'push' || steps.filter.outputs.relevant }}
+    steps:
+      - uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - "macos/**"
+              - "packages/**"
+              # The ATCAppServerAPI Swift client is generated from this
+              # artifact at build time, so contract changes must rebuild the
+              # Swift surfaces.
+              - "app-server/openapi.json"
+              - "mise.toml"
+              - ".github/workflows/macos-ci.yml"
+
   validate:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: macos-26
     timeout-minutes: 30
     steps:
@@ -47,3 +67,17 @@ jobs:
 
       - name: macOS app tests
         run: mise run macos:test
+
+  # The single required check for this workflow: reports on every PR (skipped
+  # upstream jobs are fine, failed or cancelled ones are not), so the `main`
+  # ruleset can require it without hanging non-matching PRs.
+  ci-ok:
+    name: macos-ci-ok
+    needs: [changes, validate]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fail if any needed job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1


### PR DESCRIPTION
Part 1 of the ATC-187 linting stack.

Removes the workflow-level PR path filters (a required check from a path-filtered workflow hangs pending on non-matching PRs) and moves path awareness into a `changes` job (dorny/paths-filter). Each workflow gains an `if: always()` aggregate job — `app-server-ci-ok` / `macos-ci-ok` — that fails when any needed job failed or was cancelled and passes when jobs were skipped as irrelevant. These two names become the required checks in the `main` ruleset. Push triggers on main keep their path filters.

https://claude.ai/code/session_0144WKu2f2AofZEnHyV1onAM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved pull request validation coverage for App Server and macOS changes.
  * Checks now automatically determine whether relevant files were modified before running applicable validation.
  * Required status checks now consistently report failures or cancellations, improving visibility into incomplete or unsuccessful builds.
  * Existing push-based validation behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->