### PR TITLE
Add oxlint with tested ATC plugin rules, Svelte formatting, and web:check in the standing gate (ATC-187)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,9 +98,12 @@ practices.
 ## Verifying
 
 Run the smallest gate that covers what you changed; `mise tasks` lists them
-all. The ones you will actually reach for:
+all. Autofixable findings have fix tasks (`lint:fix`, `fmt`). Before
+publishing a PR, run root `mise run check` — the single gate CI also
+enforces. The ones you will actually reach for:
 
-- `mise run -C app-server check` — fmt, typecheck, tests, OpenAPI drift.
+- `mise run -C app-server check` — fmt, lint (oxlint + the ATC plugin rules
+  in `app-server/lint/`), typecheck, tests, OpenAPI drift, svelte-check.
 - `mise run contract:check` — after **any** contract change: OpenAPI drift, TS
   client tests, Swift client build.
 - `mise run -C app-server test:zmx` — opt into real-zmx smoke and compiled

--- a/app-server/.oxlintrc.json
+++ b/app-server/.oxlintrc.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["typescript", "unicorn", "oxc"],
+  "jsPlugins": ["./lint/index.ts"],
+  "categories": {
+    "correctness": "error",
+    "suspicious": "error",
+    "perf": "error"
+  },
+  "rules": {
+    "typescript/no-explicit-any": "error",
+    "atc/canonical-namespace-imports": "error",
+    "atc/no-adhoc-spawn": "error",
+    "atc/no-manual-effect-runtime": "error",
+    "atc/no-process-env": "error",
+    "eslint/no-underscore-dangle": ["error", { "allow": ["_tag"] }],
+    "eslint/no-shadow": "off",
+    "unicorn/consistent-function-scoping": "off",
+    "unicorn/prefer-add-event-listener": "off"
+  },
+  "ignorePatterns": [
+    "dist",
+    "web/build",
+    "web/.svelte-kit",
+    "**/*.svelte",
+    "src/adminUi/manifest.generated.ts"
+  ],
+  "overrides": [
+    {
+      "files": ["src/platform/config.ts", "src/platform/subprocess.ts", "src/cli/service.ts"],
+      "rules": { "atc/no-process-env": "off" }
+    },
+    {
+      "files": ["src/platform/subprocess.ts"],
+      "rules": { "atc/no-adhoc-spawn": "off" }
+    },
+    {
+      "files": ["src/main.ts"],
+      "rules": { "atc/no-manual-effect-runtime": "off" }
+    },
+    {
+      "files": ["test/**", "scripts/**", "lint/**"],
+      "rules": {
+        "atc/no-adhoc-spawn": "off",
+        "atc/no-process-env": "off",
+        "eslint/no-await-in-loop": "off"
+      }
+    }
+  ]
+}

--- a/app-server/bun.lock
+++ b/app-server/bun.lock
@@ -12,8 +12,11 @@
       },
       "devDependencies": {
         "@effect/vitest": "4.0.0-beta.102",
+        "@oxlint/plugins": "1.78.0",
         "@types/bun": "1.3.14",
+        "oxlint": "1.78.0",
         "prettier": "3.9.6",
+        "prettier-plugin-svelte": "4.1.1",
         "typescript": "7.0.2",
         "vitest": "4.1.10",
       },
@@ -58,7 +61,15 @@
 
     "@hono/node-server": ["@hono/node-server@2.0.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg=="],
 
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
 
@@ -77,6 +88,46 @@
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.2", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3", "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3" } }, "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.142.0", "", {}, "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ=="],
+
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.78.0", "", { "os": "android", "cpu": "arm" }, "sha512-Bu819lmAfZMUHErrpe0cEWj3iaefuUODHSU8+UbXy67V/r7/7f4K3FL0NmbD85E+wiFLDYuhP8Zlv0XnVeXshw=="],
+
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.78.0", "", { "os": "android", "cpu": "arm64" }, "sha512-CDfxZgB61B7buRdY2FJoAYYPPXCZ1EoC1LKscnC5dg3kjobdxiconvAvvN1BmHyW4PyFT3jRLDag/BY/roSNBQ=="],
+
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.78.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2Y2U9Ahrz+OO0Ej88f9SJYq51/jUBp1Mc7iZu0ukrbeeZ3gpRGfzIFnoqfHDY96xr0GEfNrPUBFEy0nN5aD7HA=="],
+
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.78.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-rpych6eJq6m9jDRypTEaPD1xysaEW5h9+xuxhGK/QhOg+/xaqPZrCrTNoIl/f3nEjuJeCEmstNDlrE9rJi/3/g=="],
+
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.78.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-IcMGrQT3QizkOESUJd5et+rOhVqSkNDfNik1cvrKDqIbzqx9KMtRswpFgkCuNTSwylCFLKhGUu8KmqY1ZnC0Dg=="],
+
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.78.0", "", { "os": "linux", "cpu": "arm" }, "sha512-/uLdoJ0IXE6vo/0f0LKjinQAp+re+VMaCWaNT8ENIv2EOCkSsc8SGaflXAuW0Jua2dq5+GLVWm1NQK7P3UFSNQ=="],
+
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.78.0", "", { "os": "linux", "cpu": "arm" }, "sha512-7xi4Wb/O8NRJhLoUXmDJMUVpNYvB5kefdhFU1Jb8rtae4QoXlTiLwI14X4YvAXVZLNZChP8m5qO9SQAlWQTbkQ=="],
+
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.78.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-4hFW0+fVXa3OIh1Y4A5SPkmvI4wuuBSrCVKzOyE7PTjhc7yEqZ1pmvEEeS5Lj/MaqvegFxXyF33N+6jkehxdyg=="],
+
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.78.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-oC0mvsgBJjlMijSDEhx9KuvR9zYeHXceA9MjbuXB1F8NSR78Yj2unOBrstEvTVaq+pko+kuue6DajC00eqvTdg=="],
+
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.78.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-XAllT5SUZS+ohjuZ3/5S0cwe0r7eboiuigeStCZ5DXRYx/2KVM2UvQXvAfyzXEimtQjAB7cDQ2YxDe2Zl2WNQQ=="],
+
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.78.0", "", { "os": "linux", "cpu": "none" }, "sha512-trucMER/0QtecoXvc1y/UVqE3kwJipDwrx4oHfj+nNm3dq2zjP44WT0CfHNDPM3G1DXIkx/gY6lAD21NSCZVhA=="],
+
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.78.0", "", { "os": "linux", "cpu": "none" }, "sha512-cm3O4F/HQbdzOUX5mKHqG5KDL6E5w0pnlZ+fbBy2rmLryPOowkuLagFHTopQsEIpjcaZoPOrL+BmmAytAG9HFg=="],
+
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.78.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-33wRf6HqGNsybJ3qX4cGaQN2ODPxNmc1rMa0mrTmx3eFq1VzOnvQooi9bIGVYakW8a/wmqVx1mgsUm8R2xfTiw=="],
+
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.78.0", "", { "os": "linux", "cpu": "x64" }, "sha512-rRdISSYegj6VganMZ9tjRjijowfHJ09IZU01i0toBAqr6n5LEtwHq2IeS4FjW2RoskOHlb6efB26H5izYb3GEQ=="],
+
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.78.0", "", { "os": "linux", "cpu": "x64" }, "sha512-GmsP4rW0xTL6u5CVdcDsaN5Fbc7hBc382Wmar1kttbnwSEviM+rSINKOMQ+UQ6iH+AGwC+8gaAiwu134Tgh6Lg=="],
+
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.78.0", "", { "os": "none", "cpu": "arm64" }, "sha512-sy9yeYuADc8a+n4TLBayzMCZiHPW78DcIFVpOXTmdKHWQeM9xe5uzkqIIZmi326D5hY9XVwacipEB1p7tQjPAg=="],
+
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.78.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-rjc2hF1KfMi8fZj1X/m3AmnHbdsF3rL0v6KQg0Uc880Yb2khjz+3U14sfdZ7jWTpRnN1m1NQa/TT7uU9lJWPrA=="],
+
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.78.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zcuXFVrEFHIafRfkCQT8w/Xe41o07ozl/vwHq7p94vB29xVzsB0sZGYORU1jhcYKv3Lr0J3HbJ2T4fHH5rWmvA=="],
+
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.78.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Sb5ocmLSuYeOuXd+CFOToGKp/gjXUEWDnvIGwhnh8aq8wY4TMmEnKnvbogSW7RdMZv77JSARduS7/gv+khYEjA=="],
+
+    "@oxlint/plugins": ["@oxlint/plugins@1.78.0", "", {}, "sha512-Ypt8KeRYw+4jUtlPirfcHWMrn5ms12VrrFPD+Mds477/7tJxG1Kcz2Yrg2nVcTQEUx/GdlhS+BUg1kmxNm04Ug=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.1", "", { "os": "android", "cpu": "arm64" }, "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA=="],
 
@@ -114,6 +165,8 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
+    "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.13", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-wgKggnhZVL9Bfx1OaKKTrYY9BFRk6C8UAkQNUcIv1+llzYrIqy+RZm5HPKzn0NpEBvTVhTqB4kQyllZywsRBRQ=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
@@ -125,6 +178,8 @@
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
     "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
@@ -184,11 +239,17 @@
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
+    "acorn": ["acorn@8.18.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ=="],
+
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
+    "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
+
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
     "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
 
@@ -201,6 +262,8 @@
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
@@ -222,6 +285,8 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
+    "devalue": ["devalue@5.9.0", "", {}, "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A=="],
+
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
@@ -239,6 +304,10 @@
     "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
+
+    "esrap": ["esrap@2.3.3", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" }, "peerDependencies": { "@typescript-eslint/types": "^8.2.0" }, "optionalPeers": ["@typescript-eslint/types"] }, "sha512-OETBYYsX6L8btUkOyi8AcdtlfpsyNO9nCmP92U/Cxm07epHeLo5we1ck6z0HsbB/jxWlfmEBF9oobZKqSBWD4Q=="],
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
@@ -302,6 +371,8 @@
 
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
+    "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
+
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jose": ["jose@6.2.7", "", {}, "sha512-hq1OB1bALKfydZNoViyg6hPVGV4i93ny9Op+n4zP5RSf7SCZEXa/TsG2O3IEr7+WlHRTPnpqDmHfMH6qXAD60w=="],
@@ -337,6 +408,8 @@
     "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.33.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA=="],
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.33.0", "", { "os": "win32", "cpu": "x64" }, "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA=="],
+
+    "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -374,6 +447,8 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
+    "oxlint": ["oxlint@1.78.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.78.0", "@oxlint/binding-android-arm64": "1.78.0", "@oxlint/binding-darwin-arm64": "1.78.0", "@oxlint/binding-darwin-x64": "1.78.0", "@oxlint/binding-freebsd-x64": "1.78.0", "@oxlint/binding-linux-arm-gnueabihf": "1.78.0", "@oxlint/binding-linux-arm-musleabihf": "1.78.0", "@oxlint/binding-linux-arm64-gnu": "1.78.0", "@oxlint/binding-linux-arm64-musl": "1.78.0", "@oxlint/binding-linux-ppc64-gnu": "1.78.0", "@oxlint/binding-linux-riscv64-gnu": "1.78.0", "@oxlint/binding-linux-riscv64-musl": "1.78.0", "@oxlint/binding-linux-s390x-gnu": "1.78.0", "@oxlint/binding-linux-x64-gnu": "1.78.0", "@oxlint/binding-linux-x64-musl": "1.78.0", "@oxlint/binding-openharmony-arm64": "1.78.0", "@oxlint/binding-win32-arm64-msvc": "1.78.0", "@oxlint/binding-win32-ia32-msvc": "1.78.0", "@oxlint/binding-win32-x64-msvc": "1.78.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-QgQePuxIqKOzo1KSjG2EnITEeWvWnKAm77eq8nrMtf6AGoA+zyGc4PFYtDNJSD25g/ibOwfQ851hZ4/SPkMVoA=="],
+
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -391,6 +466,8 @@
     "postcss": ["postcss@8.5.25", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw=="],
 
     "prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
+
+    "prettier-plugin-svelte": ["prettier-plugin-svelte@4.1.1", "", { "peerDependencies": { "prettier": "^3.0.0", "svelte": "^5.0.0" } }, "sha512-wXvbXMjSvb4C9ENWTHXyd+ihakKCsJ6rJhLP6/8HFNj4GkZr48jqL9PoKsl2sk7SyCZRTnJ7O2TTowUpOxP/KA=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
@@ -440,6 +517,8 @@
 
     "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
 
+    "svelte": ["svelte@5.56.9", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.12", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-VT8kSnlEg8069w7AiCcAk3Yf5xvMnrGTagVOmU/OpOLHaHnNqXhWZCH/4EVga/bT/HtWhvE6/fHrXLErx7OnJA=="],
+
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
     "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
@@ -481,6 +560,8 @@
     "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 

--- a/app-server/lint/index.ts
+++ b/app-server/lint/index.ts
@@ -1,0 +1,22 @@
+// ATC's project-owned oxlint plugin: the AGENTS.md invariants that a grep
+// can't enforce, as tested lint rules. Wired up via `jsPlugins` in
+// .oxlintrc.json; per-file exemptions (the approved boundary modules) live in
+// that config's overrides, never inside the rules. Tests: test/lint/.
+import { definePlugin } from "@oxlint/plugins"
+
+import canonicalNamespaceImports from "./rules/canonical-namespace-imports.ts"
+import noAdhocSpawn from "./rules/no-adhoc-spawn.ts"
+import noManualEffectRuntime from "./rules/no-manual-effect-runtime.ts"
+import noProcessEnv from "./rules/no-process-env.ts"
+
+export default definePlugin({
+  meta: {
+    name: "atc",
+  },
+  rules: {
+    "canonical-namespace-imports": canonicalNamespaceImports,
+    "no-adhoc-spawn": noAdhocSpawn,
+    "no-manual-effect-runtime": noManualEffectRuntime,
+    "no-process-env": noProcessEnv,
+  },
+})

--- a/app-server/lint/rules/canonical-namespace-imports.ts
+++ b/app-server/lint/rules/canonical-namespace-imports.ts
@@ -1,0 +1,64 @@
+// AGENTS.md invariant: own modules are referenced by their canonical name so
+// one grep finds every call site — `import * as Terminals from
+// ".../terminals.ts"`, never an alias. Named imports of a module's exports
+// (service classes, commands, helpers) are fine because they already carry
+// the exported name; what this rule bans is renaming: a namespace import
+// that isn't the module's canonical name, or a named specifier imported
+// `as` something else.
+import { defineRule } from "@oxlint/plugins"
+
+import { getImportSource, getPropertyName } from "../utils.ts"
+
+// Canonical names that are not simply the capitalized file basename.
+const CANONICAL_EXCEPTIONS: ReadonlyMap<string, string> = new Map([["zmxAdapter", "Zmx"]])
+
+const canonicalName = (source: string): string | undefined => {
+  const basename = source.split("/").at(-1)?.replace(/\.ts$/, "")
+  if (basename === undefined || basename.length === 0) return undefined
+  const exception = CANONICAL_EXCEPTIONS.get(basename)
+  if (exception !== undefined) return exception
+  // PascalCase across separator characters so hyphenated basenames still
+  // yield a valid identifier (no-adhoc-spawn.ts -> NoAdhocSpawn).
+  const name = basename
+    .split(/[-_.]/)
+    .filter((segment) => segment.length > 0)
+    .map((segment) => segment[0]!.toUpperCase() + segment.slice(1))
+    .join("")
+  return name.length > 0 ? name : undefined
+}
+
+export default defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Require canonical, unaliased names when importing the project's own modules.",
+    },
+  },
+  createOnce(context) {
+    return {
+      ImportDeclaration(node) {
+        const source = getImportSource(node)
+        if (source === undefined || !source.startsWith(".")) return
+
+        for (const specifier of node.specifiers) {
+          if (specifier.type === "ImportNamespaceSpecifier") {
+            const expected = canonicalName(source)
+            if (expected === undefined || specifier.local.name === expected) continue
+            context.report({
+              node: specifier,
+              message: `Import ${source} under its canonical name \`${expected}\` so one grep finds every call site.`,
+            })
+            continue
+          }
+          if (specifier.type !== "ImportSpecifier") continue
+          const imported = getPropertyName(specifier.imported)
+          if (imported === undefined || imported === specifier.local.name) continue
+          context.report({
+            node: specifier,
+            message: `Never alias an import: \`${imported} as ${specifier.local.name}\` hides the exported name from grep. Use a canonical namespace import instead.`,
+          })
+        }
+      },
+    }
+  },
+})

--- a/app-server/lint/rules/no-adhoc-spawn.ts
+++ b/app-server/lint/rules/no-adhoc-spawn.ts
@@ -1,0 +1,44 @@
+// AGENTS.md invariant: all child processes go through the Subprocess service
+// (src/platform/subprocess.ts) so kill+reap and PTY guarantees hold. That
+// module, tests, fixtures, and build scripts are exempted via config
+// overrides in .oxlintrc.json.
+import { defineRule } from "@oxlint/plugins"
+
+import { getImportSource, getPropertyName, isIdentifier, unwrapExpression } from "../utils.ts"
+
+const SPAWN_PROPERTIES = new Set(["spawn", "spawnSync"])
+const CHILD_PROCESS_MODULES = new Set(["node:child_process", "child_process"])
+
+const isBunObject = (node: unknown): boolean => {
+  const expression = unwrapExpression(node)
+  if (isIdentifier(expression, "Bun")) return true
+  if (expression === undefined || expression.type !== "MemberExpression") return false
+  const object = unwrapExpression(expression.object)
+  return isIdentifier(object, "globalThis") && getPropertyName(expression.property) === "Bun"
+}
+
+export default defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow spawning child processes outside the Subprocess service.",
+    },
+  },
+  createOnce(context) {
+    const message =
+      "Spawn child processes through the Subprocess service (src/platform/subprocess.ts); ad-hoc spawns escape its scoped kill+reap guarantees."
+    return {
+      MemberExpression(node) {
+        const property = getPropertyName(node.property)
+        if (property === undefined || !SPAWN_PROPERTIES.has(property)) return
+        if (!isBunObject(node.object)) return
+        context.report({ node, message })
+      },
+      ImportDeclaration(node) {
+        const source = getImportSource(node)
+        if (source === undefined || !CHILD_PROCESS_MODULES.has(source)) return
+        context.report({ node, message })
+      },
+    }
+  },
+})

--- a/app-server/lint/rules/no-manual-effect-runtime.ts
+++ b/app-server/lint/rules/no-manual-effect-runtime.ts
@@ -1,0 +1,96 @@
+// AGENTS.md invariant: exactly one runtime entrypoint — BunRuntime.runMain in
+// src/main.ts (exempted via config override in .oxlintrc.json). Everywhere
+// else, including tests, Effects stay lazy values: @effect/vitest's it.effect
+// manages the runtime in tests, and hand-run Effects escape structured
+// concurrency and scope-based resource release.
+import { defineRule } from "@oxlint/plugins"
+
+import { getImportSource, getPropertyName, unwrapExpression } from "../utils.ts"
+
+// Namespace-like bindings whose members are runtime executors, keyed by the
+// member-name test applied to them.
+const RUN_MEMBER_SOURCES: ReadonlyArray<{
+  readonly module: string
+  readonly exported: string
+  readonly isRunMember: (property: string) => boolean
+}> = [
+  { module: "effect", exported: "Effect", isRunMember: (p) => /^run[A-Z]/.test(p) },
+  { module: "effect", exported: "ManagedRuntime", isRunMember: (p) => p === "make" },
+  { module: "@effect/platform-bun", exported: "BunRuntime", isRunMember: (p) => p === "runMain" },
+]
+
+const NAMESPACE_MODULES: ReadonlyMap<string, (property: string) => boolean> = new Map([
+  ["effect/Effect", (p: string) => /^run[A-Z]/.test(p)],
+  ["effect/ManagedRuntime", (p: string) => p === "make"],
+  ["@effect/platform-bun/BunRuntime", (p: string) => p === "runMain"],
+])
+
+const MESSAGE =
+  "Exactly one runtime entrypoint: BunRuntime.runMain in src/main.ts. Tests use @effect/vitest (it.effect); nothing else hand-runs Effects."
+
+export default defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow manual Effect runtimes outside the src/main.ts entrypoint.",
+    },
+  },
+  createOnce(context) {
+    // Local binding name -> predicate deciding whether a member access on it
+    // is a runtime executor.
+    const runtimeBindings = new Map<string, (property: string) => boolean>()
+    // Local binding names of directly imported executors, e.g.
+    // `import { runPromise } from "effect/Effect"`.
+    const directExecutors = new Set<string>()
+
+    return {
+      before() {
+        runtimeBindings.clear()
+        directExecutors.clear()
+      },
+      ImportDeclaration(node) {
+        const source = getImportSource(node)
+        if (source === undefined) return
+
+        for (const specifier of node.specifiers) {
+          if (specifier.type === "ImportNamespaceSpecifier") {
+            const isRunMember = NAMESPACE_MODULES.get(source)
+            if (isRunMember !== undefined) runtimeBindings.set(specifier.local.name, isRunMember)
+            continue
+          }
+          if (specifier.type !== "ImportSpecifier") continue
+          const imported = getPropertyName(specifier.imported)
+          if (imported === undefined) continue
+          for (const entry of RUN_MEMBER_SOURCES) {
+            if (source === entry.module && imported === entry.exported) {
+              runtimeBindings.set(specifier.local.name, entry.isRunMember)
+            }
+          }
+          // A named import of an executor itself: the module's member test
+          // applies to the imported name, and calls go through the local one.
+          const isRunMember = NAMESPACE_MODULES.get(source)
+          if (isRunMember !== undefined && isRunMember(imported)) {
+            directExecutors.add(specifier.local.name)
+          }
+        }
+      },
+      CallExpression(node) {
+        const callee = unwrapExpression(node.callee)
+        if (callee === undefined || callee.type !== "Identifier") return
+        if (!directExecutors.has(callee.name)) return
+        context.report({ node, message: MESSAGE })
+      },
+      MemberExpression(node) {
+        const object = unwrapExpression(node.object)
+        if (object === undefined || object.type !== "Identifier") return
+        const isRunMember = runtimeBindings.get(object.name)
+        if (isRunMember === undefined) return
+
+        const property = getPropertyName(node.property)
+        if (property === undefined || !isRunMember(property)) return
+
+        context.report({ node, message: MESSAGE })
+      },
+    }
+  },
+})

--- a/app-server/lint/rules/no-process-env.ts
+++ b/app-server/lint/rules/no-process-env.ts
@@ -1,0 +1,39 @@
+// AGENTS.md invariant: everything reads AppConfig — never process.env. The
+// approved boundary modules (config.ts itself, subprocess.ts's child-env
+// builder, service.ts's sanctioned PATH read) are exempted via config
+// overrides in .oxlintrc.json, not here, so the exemption list is visible in
+// one place.
+import { defineRule } from "@oxlint/plugins"
+
+import { getPropertyName, isIdentifier, unwrapExpression } from "../utils.ts"
+
+const isProcessObject = (node: unknown): boolean => {
+  const expression = unwrapExpression(node)
+  if (isIdentifier(expression, "process")) return true
+  if (expression === undefined || expression.type !== "MemberExpression") return false
+  const object = unwrapExpression(expression.object)
+  return isIdentifier(object, "globalThis") && getPropertyName(expression.property) === "process"
+}
+
+export default defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow process.env reads outside the approved configuration boundary modules.",
+    },
+  },
+  createOnce(context) {
+    return {
+      MemberExpression(node) {
+        if (getPropertyName(node.property) !== "env") return
+        if (!isProcessObject(node.object)) return
+        context.report({
+          node,
+          message:
+            "Read configuration through AppConfig (src/platform/config.ts), never process.env; flags > environment > config file > defaults is settled in one place.",
+        })
+      },
+    }
+  },
+})

--- a/app-server/lint/utils.ts
+++ b/app-server/lint/utils.ts
@@ -1,0 +1,58 @@
+// Shared AST helpers for the ATC oxlint plugin. Rules receive ESTree nodes
+// typed loosely by oxlint, so these narrow `unknown` into the shapes rules
+// care about. The plugin is lint tooling that runs inside oxlint's runtime,
+// not server code, so it deliberately stays plain TypeScript (no Effect).
+import type { ESTree } from "@oxlint/plugins"
+
+type AstNode = ESTree.Node
+
+type ExpressionWrapper =
+  | ESTree.ChainExpression
+  | ESTree.ParenthesizedExpression
+  | ESTree.TSNonNullExpression
+  | ESTree.TSAsExpression
+  | ESTree.TSTypeAssertion
+
+export const asAstNode = (node: unknown): AstNode | undefined =>
+  typeof node === "object" && node !== null && "type" in node && typeof node.type === "string"
+    ? (node as AstNode)
+    : undefined
+
+const isExpressionWrapper = (node: AstNode): node is ExpressionWrapper =>
+  node.type === "ChainExpression" ||
+  node.type === "ParenthesizedExpression" ||
+  node.type === "TSNonNullExpression" ||
+  node.type === "TSAsExpression" ||
+  node.type === "TSTypeAssertion"
+
+/** Strips chain/parenthesis/TS-assertion wrappers so `(Bun!).spawn` and
+ * `Bun?.spawn` resolve to the same underlying expression. */
+export const unwrapExpression = (node: unknown): AstNode | undefined => {
+  let current = asAstNode(node)
+  while (current !== undefined && isExpressionWrapper(current)) {
+    current = asAstNode(current.expression)
+  }
+  return current
+}
+
+/** Identifier, private identifier, or string-literal property name. */
+export const getPropertyName = (node: unknown): string | undefined => {
+  const expression = asAstNode(node)
+  if (expression === undefined) return undefined
+  if (expression.type === "Identifier" && typeof expression.name === "string") {
+    return expression.name
+  }
+  if (expression.type === "Literal" && typeof expression.value === "string") {
+    return expression.value
+  }
+  return undefined
+}
+
+export const isIdentifier = (node: AstNode | undefined, name: string): boolean =>
+  node !== undefined && node.type === "Identifier" && node.name === name
+
+export const getImportSource = (node: unknown): string | undefined => {
+  const declaration = asAstNode(node)
+  if (declaration === undefined || declaration.type !== "ImportDeclaration") return undefined
+  return typeof declaration.source.value === "string" ? declaration.source.value : undefined
+}

--- a/app-server/mise.toml
+++ b/app-server/mise.toml
@@ -9,8 +9,8 @@ depends = ["install"]
 run = "bun run src/main.ts serve"
 
 [tasks.check]
-description = "All App Server gates: format check, strict type check, tests, OpenAPI and admin UI drift"
-depends = ["fmt:check", "typecheck", "test", "openapi:check", "web:assets:check"]
+description = "All App Server gates: format check, lint, strict type check, tests, OpenAPI and admin UI checks"
+depends = ["fmt:check", "lint", "typecheck", "test", "openapi:check", "web:check", "web:assets:check"]
 
 [tasks.build]
 description = "Compile the standalone atc executable for this machine into dist/"
@@ -56,6 +56,20 @@ description = "Strict TypeScript type check (no emit)"
 depends = ["install"]
 run = "bun run tsc --noEmit"
 
+# Semantic lint: oxlint categories plus the ATC plugin rules (lint/) that
+# enforce the AGENTS.md invariants. Svelte files are excluded in
+# .oxlintrc.json — oxlint's .svelte script-block analysis can't see template
+# bindings (false positives), so svelte-check (web:check) owns that surface.
+[tasks.lint]
+description = "Lint TypeScript with oxlint, including the ATC plugin rules"
+depends = ["install"]
+run = "bun run oxlint --report-unused-disable-directives --deny-warnings"
+
+[tasks."lint:fix"]
+description = "Apply oxlint autofixes"
+depends = ["install"]
+run = "bun run oxlint --fix --report-unused-disable-directives"
+
 # --bun forces the Bun runtime (vitest's shebang would otherwise pick node),
 # so tests exercise the same runtime the server ships on.
 [tasks.test]
@@ -66,10 +80,12 @@ run = "bun --bun vitest run"
 # --- Admin UI (web/) ---
 
 # The built UI (web/build) and its embed manifest are committed, so the
-# server and CI never need a web toolchain. The tradeoff: web:assets:check
-# only verifies manifest <-> web/build consistency — nothing in CI detects an
-# edited web/src whose build was never rerun, and no gate type-checks web/src.
-# Run web:check and web:build after changing web/src and commit the result.
+# server binary and its runtime never need a web toolchain. The standing
+# check task does: web:check (svelte-check) type-checks web/src, installing
+# the web dev dependencies via web:install. The remaining tradeoff is that
+# web:assets:check only verifies manifest <-> web/build consistency — nothing
+# detects an edited web/src whose build was never rerun. Run web:build after
+# changing web/src and commit the result.
 
 # dir (not bun's --cwd, which silently no-ops on relative paths): each task
 # runs inside web/ with its own package.json and lockfile.

--- a/app-server/package.json
+++ b/app-server/package.json
@@ -6,7 +6,10 @@
   "description": "ATC App Server — the TypeScript server and atc CLI, built on Effect",
   "prettier": {
     "semi": false,
-    "printWidth": 100
+    "printWidth": 100,
+    "plugins": [
+      "prettier-plugin-svelte"
+    ]
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.220",
@@ -16,8 +19,11 @@
   },
   "devDependencies": {
     "@effect/vitest": "4.0.0-beta.102",
+    "@oxlint/plugins": "1.78.0",
     "@types/bun": "1.3.14",
+    "oxlint": "1.78.0",
     "prettier": "3.9.6",
+    "prettier-plugin-svelte": "4.1.1",
     "typescript": "7.0.2",
     "vitest": "4.1.10"
   }

--- a/app-server/src/agents/agentRegistry.ts
+++ b/app-server/src/agents/agentRegistry.ts
@@ -1,6 +1,7 @@
 import { Context, Effect, Layer } from "effect"
 import { AGENT_IDS, AgentNotFound, isAgentId } from "../api/contract.ts"
-import type { Agent as AgentSchema, AgentId } from "../api/contract.ts"
+import type * as Contract from "../api/contract.ts"
+import type { AgentId } from "../api/contract.ts"
 import { AppConfig } from "../platform/config.ts"
 import * as Subprocess from "../platform/subprocess.ts"
 import type { AgentAdapter } from "./agentAdapter.ts"
@@ -12,7 +13,7 @@ import {
 import { ClaudeAdapter } from "./claudeAdapter.ts"
 import { CodexAdapter } from "./codexAdapter.ts"
 
-export type Agent = typeof AgentSchema.Type
+export type Agent = typeof Contract.Agent.Type
 
 // The read-only built-in agent registry (ATC-124): the one place the public
 // agent slugs meet the provider adapters. Availability and versions are

--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -994,7 +994,7 @@ export const layer = Layer.effect(CodexAdapter)(
         const tracked = descendants.get(rootId)
         if (tracked !== undefined) {
           const loadedSet = new Set(loaded)
-          for (const id of [...tracked.keys()]) {
+          for (const id of tracked.keys()) {
             if (!loadedSet.has(id)) tracked.delete(id)
           }
         }

--- a/app-server/src/agents/smoke.ts
+++ b/app-server/src/agents/smoke.ts
@@ -6,7 +6,8 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { AgentUnavailable, resolveProviderExecutable } from "./agentAdapter.ts"
 import * as BuildInfo from "../platform/buildInfo.ts"
-import { AppConfig, ConfigLoadError, layer as appConfigLayer } from "../platform/config.ts"
+import { AppConfig, ConfigLoadError } from "../platform/config.ts"
+import * as Config from "../platform/config.ts"
 import * as Subprocess from "../platform/subprocess.ts"
 
 // Compiled-artifact provider smoke checks (ATC-88). `atc smoke ...` proves
@@ -401,7 +402,7 @@ const codexCommand = Command.make("codex", {}, () =>
         extendEnv: true,
         forceKillAfter: "2 seconds",
       })
-    }).pipe(Effect.provide(appConfigLayer)),
+    }).pipe(Effect.provide(Config.layer)),
   ),
 ).pipe(Command.withDescription("[unstable] Codex app-server launch and initialize round trip"))
 
@@ -411,7 +412,7 @@ const claudeCommand = Command.make("claude", {}, () =>
       const config = yield* AppConfig
       const executable = yield* resolveProviderExecutable("claude", config.claudeExecutable)
       yield* claudeSmoke(executable)
-    }).pipe(Effect.provide(appConfigLayer)),
+    }).pipe(Effect.provide(Config.layer)),
   ),
 ).pipe(
   Command.withDescription("[unstable] Claude Agent SDK round trip via the packaged executable"),

--- a/app-server/src/cli/cli.ts
+++ b/app-server/src/cli/cli.ts
@@ -6,7 +6,8 @@ import { HttpClient } from "effect/unstable/http"
 import * as path from "node:path"
 import * as Client from "../api/client.ts"
 import * as LocalTrust from "../api/localTrust.ts"
-import { AppConfig, ConfigLoadError, layer as appConfigLayer } from "../platform/config.ts"
+import { AppConfig, ConfigLoadError } from "../platform/config.ts"
+import * as Config from "../platform/config.ts"
 import * as Server from "../server.ts"
 
 // Shared CLI plumbing: the one-line stderr diagnostic contract, the base-URL
@@ -56,7 +57,7 @@ export const describeError = (error: unknown): string =>
  */
 export const withSettledConfig = (prefix: string) => {
   return <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-    effect.pipe(Effect.provide(appConfigLayer), Effect.catch(reportOnce(prefix)))
+    effect.pipe(Effect.provide(Config.layer), Effect.catch(reportOnce(prefix)))
 }
 
 // --- Server liveness probing (shared by serve.ts and service.ts, whose two
@@ -121,7 +122,7 @@ export const withCliContext = <E>(
   effect: Effect.Effect<void, E, HttpClient.HttpClient | AppConfig | FileSystem.FileSystem>,
 ): Effect.Effect<void, ReportedError, FileSystem.FileSystem> =>
   effect.pipe(
-    Effect.provide([BunHttpClient.layer, appConfigLayer]),
+    Effect.provide([BunHttpClient.layer, Config.layer]),
     Effect.catch(reportOnce(`atc ${diagnosticName}`)),
   )
 

--- a/app-server/src/cli/serve.ts
+++ b/app-server/src/cli/serve.ts
@@ -2,7 +2,8 @@ import { Console, Effect, FileSystem, Layer, Option, Schema } from "effect"
 import { Command, Flag } from "effect/unstable/cli"
 import * as AuthToken from "../platform/authToken.ts"
 import { BuildInfo } from "../platform/buildInfo.ts"
-import { AppConfig, layer as appConfigLayer } from "../platform/config.ts"
+import { AppConfig } from "../platform/config.ts"
+import * as Config from "../platform/config.ts"
 import { ServerInfoResponse } from "../api/contract.ts"
 import {
   isProcessAlive,
@@ -87,7 +88,7 @@ export const serve = Command.make("serve", { port, bind, tailscale }, ({ port, b
       Effect.provideService(AppConfig, effective),
     )
   }).pipe(
-    Effect.provide(appConfigLayer),
+    Effect.provide(Config.layer),
     Effect.catch(Cli.reportOnce("atc serve")),
     Effect.catchDefect((defect) =>
       isSystemError(defect) || isMigrationError(defect)

--- a/app-server/src/cli/token.ts
+++ b/app-server/src/cli/token.ts
@@ -1,7 +1,8 @@
 import { Console, Effect, FileSystem } from "effect"
 import { Command } from "effect/unstable/cli"
 import * as AuthToken from "../platform/authToken.ts"
-import { AppConfig, layer as appConfigLayer } from "../platform/config.ts"
+import { AppConfig } from "../platform/config.ts"
+import * as Config from "../platform/config.ts"
 import * as Cli from "./cli.ts"
 
 // `atc token` (ATC-148): the remote-access credential, managed locally.
@@ -17,7 +18,7 @@ const printToken = <E>(
 ) =>
   read.pipe(
     Effect.flatMap((value) => Console.log(value)),
-    Effect.provide(appConfigLayer),
+    Effect.provide(Config.layer),
     Effect.catch(Cli.reportOnce(`atc ${diagnosticName}`)),
   )
 

--- a/app-server/src/events/events.ts
+++ b/app-server/src/events/events.ts
@@ -1,8 +1,8 @@
 import { Context, Duration, Effect, Layer, Queue, Stream } from "effect"
 import type { Cause } from "effect"
-import type { ResourceChangedEvent as ResourceChangedEventSchema } from "../api/contract.ts"
+import type * as Contract from "../api/contract.ts"
 
-export type ResourceChangedEvent = typeof ResourceChangedEventSchema.Type
+export type ResourceChangedEvent = typeof Contract.ResourceChangedEvent.Type
 
 // The Events service (ATC-128): the in-process fan-out for resource-change
 // events. Domain services publish next to each successful mutation; the

--- a/app-server/src/projects/projectRepository.ts
+++ b/app-server/src/projects/projectRepository.ts
@@ -2,13 +2,13 @@ import { Context, Effect, Layer, Option, Schema } from "effect"
 import { SqlClient, SqlSchema } from "effect/unstable/sql"
 import { requireFound, rowHelpers } from "../platform/repositoryHelpers.ts"
 import { ProjectNotFound } from "../api/contract.ts"
-import type { Project as ProjectSchema } from "../api/contract.ts"
+import type * as Contract from "../api/contract.ts"
 
 // The Projects repository (ATC-121): the only module that speaks SQL for
 // projects. Row types stay here — handlers and the contract see plain
 // camelCase project objects shaped like the contract's Project schema.
 
-export type Project = typeof ProjectSchema.Type
+export type Project = typeof Contract.Project.Type
 
 /** Internal row shape (snake_case columns, as stored). */
 const ProjectRow = Schema.Struct({

--- a/app-server/src/terminals/terminals.ts
+++ b/app-server/src/terminals/terminals.ts
@@ -2,11 +2,11 @@ import { Context, Effect, Layer, Option } from "effect"
 import type { Scope } from "effect"
 import {
   ProjectNotFound,
-  Terminal as TerminalSchema,
   TerminalLaunchFailed,
   TerminalNotFound,
   ZmxUnavailable,
 } from "../api/contract.ts"
+import type * as Contract from "../api/contract.ts"
 import type {
   CreateTerminalRequest,
   DirectoryCheckTimedOut,
@@ -25,7 +25,7 @@ import type {
 import { TerminalRepository } from "./terminalRepository.ts"
 import type { TerminalRecord } from "./terminalRepository.ts"
 
-export type Terminal = typeof TerminalSchema.Type
+export type Terminal = typeof Contract.Terminal.Type
 
 // The Terminals domain service (ATC-130): orchestrates the repository, the
 // TerminalAdapter, and directory validation under the ATC-122 reconciliation

--- a/app-server/src/terminals/zmxAdapter.ts
+++ b/app-server/src/terminals/zmxAdapter.ts
@@ -108,6 +108,7 @@ export const zmxSpawnEnv = (socketDir: string, endpoint: string) => ({
 
 /** Printable diagnostic from raw terminal output: control bytes stripped. */
 const printableTail = (tail: string): string =>
+  // oxlint-disable-next-line no-control-regex -- matching control bytes is the point here
   tail.replace(/\x1b\[[0-9;?]*[a-zA-Z]|[\x00-\x09\x0b-\x1f]/g, "").trim()
 
 export const layerWith = (options: ZmxOptions) =>

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -28,11 +28,11 @@ import {
   isAgentId,
   ProviderSessionConflict,
   ProviderUnavailable,
-  Thread as ThreadSchema,
   ThreadArchived,
   ThreadBusy,
   ThreadNotFound,
 } from "../api/contract.ts"
+import type * as Contract from "../api/contract.ts"
 import type {
   CreateThreadRequest,
   DirectoryCheckTimedOut,
@@ -49,7 +49,7 @@ import type { Terminal } from "../terminals/terminals.ts"
 import { ThreadRepository } from "./threadRepository.ts"
 import type { ThreadRecord } from "./threadRepository.ts"
 
-export type Thread = typeof ThreadSchema.Type
+export type Thread = typeof Contract.Thread.Type
 
 // The Threads domain service (ATC-124): Threads are the primary unit of
 // work — durable ATC identity separate from provider identity. Invariants:

--- a/app-server/test/fixtures/fake-codex-listener.ts
+++ b/app-server/test/fixtures/fake-codex-listener.ts
@@ -71,8 +71,7 @@ if (process.argv.includes("exec")) {
     stdin
       .split("\n")
       .map((line) => line.trim())
-      .filter((line) => line !== "")
-      .pop() ?? ""
+      .findLast((line) => line !== "") ?? ""
   if (outFile !== undefined) {
     await Bun.write(outFile, process.env["FAKE_CODEX_TITLE"] ?? `fake title: ${lastLine}`)
   }

--- a/app-server/test/fixtures/pty-report.ts
+++ b/app-server/test/fixtures/pty-report.ts
@@ -2,6 +2,11 @@
 // reports window-size changes, and exits on command — the deterministic
 // counterpart for the Subprocess PTY seam tests.
 
+// No imports or exports, so parsers would otherwise treat this file as a
+// script and reject the top-level `for await`; mark it a module explicitly.
+// oxlint-disable-next-line unicorn/require-module-specifiers -- the empty export is the module marker
+export {}
+
 console.log(`tty:${process.stdout.isTTY === true}`)
 
 process.on("SIGWINCH", () => {

--- a/app-server/test/lint/harness.ts
+++ b/app-server/test/lint/harness.ts
@@ -1,0 +1,55 @@
+// Runs the real oxlint binary against an in-memory fixture with exactly one
+// atc plugin rule enabled, so each rule is tested end to end through oxlint's
+// plugin host rather than against a mocked context. Per-file exemptions live
+// in .oxlintrc.json overrides, not in the rules, so fixtures here never need
+// them; the standing `mise run lint` over the repo covers the override side.
+import { mkdtemp, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { expect, test } from "vitest"
+
+// fileURLToPath, not URL.pathname: the latter percent-encodes spaces and
+// similar characters, which oxlint would then fail to resolve.
+const pluginPath = fileURLToPath(new URL("../../lint/index.ts", import.meta.url))
+const oxlintBin = join(Bun.resolveSync("oxlint/package.json", process.cwd()), "..", "bin/oxlint")
+
+const run = async (rule: string, source: string) => {
+  const dir = await mkdtemp(join(tmpdir(), "atc-oxlint-"))
+  const configPath = join(dir, ".oxlintrc.json")
+  const fixturePath = join(dir, "fixture.ts")
+  await writeFile(
+    configPath,
+    JSON.stringify({ jsPlugins: [pluginPath], rules: { [rule]: "error" } }),
+  )
+  await writeFile(fixturePath, source)
+
+  const proc = Bun.spawnSync([process.execPath, oxlintBin, "--config", configPath, fixturePath], {
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  return { exitCode: proc.exitCode, output: `${proc.stdout.toString()}${proc.stderr.toString()}` }
+}
+
+/** Vitest cases asserting oxlint accepts or reports the given sources. */
+export const ruleTests = (rule: string) => ({
+  valid(name: string, source: string) {
+    test(`${rule}: allows ${name}`, async () => {
+      const result = await run(rule, source)
+      // Exit code is the signal: oxlint's success summary ("Found 0 warnings
+      // and 0 errors.") itself contains the word "error".
+      expect(result.output).not.toContain(`(${rule})`)
+      expect(result.exitCode).toBe(0)
+    })
+  },
+  invalid(name: string, source: string, messageMatch?: string) {
+    test(`${rule}: reports ${name}`, async () => {
+      const result = await run(rule, source)
+      expect(result.exitCode).not.toBe(0)
+      const [pluginName, shortName] = rule.split("/")
+      expect(result.output).toContain(`${pluginName}(${shortName})`)
+      if (messageMatch !== undefined) expect(result.output).toContain(messageMatch)
+    })
+  },
+})

--- a/app-server/test/lint/rules.test.ts
+++ b/app-server/test/lint/rules.test.ts
@@ -1,0 +1,109 @@
+// End-to-end tests for the ATC oxlint plugin rules (lint/). Each case runs
+// the real oxlint binary over a fixture; see harness.ts.
+import { describe } from "vitest"
+import { ruleTests } from "./harness.ts"
+
+describe("atc/no-process-env", () => {
+  const rule = ruleTests("atc/no-process-env")
+
+  rule.valid("reading AppConfig", `export const x = (config: { port: number }) => config.port`)
+  rule.valid("a local object named env", `const app = { env: "prod" }\nexport const e = app.env`)
+  rule.invalid("process.env reads", `export const home = process.env["HOME"]`, "AppConfig")
+  rule.invalid("globalThis.process.env", `export const e = globalThis.process.env`)
+  rule.invalid("optional-chained process?.env", `export const e = process?.env`)
+})
+
+describe("atc/no-adhoc-spawn", () => {
+  const rule = ruleTests("atc/no-adhoc-spawn")
+
+  rule.valid("other Bun APIs", `export const f = Bun.file("x.txt")`)
+  rule.valid(
+    "spawn on non-Bun objects",
+    `const pool = { spawn: () => 1 }\nexport const x = pool.spawn()`,
+  )
+  rule.invalid("Bun.spawn", `export const p = Bun.spawn(["ls"])`, "Subprocess service")
+  rule.invalid("Bun.spawnSync", `export const p = Bun.spawnSync(["ls"])`)
+  rule.invalid("globalThis.Bun.spawn", `export const p = globalThis.Bun.spawn(["ls"])`)
+  rule.invalid(
+    "importing node:child_process",
+    `import { spawn } from "node:child_process"\nexport const p = spawn("ls")`,
+  )
+})
+
+describe("atc/no-manual-effect-runtime", () => {
+  const rule = ruleTests("atc/no-manual-effect-runtime")
+
+  rule.valid(
+    "lazy Effect composition",
+    `import { Effect } from "effect"\nexport const program = Effect.gen(function* () { yield* Effect.void })`,
+  )
+  rule.valid(
+    "run-like members on unrelated bindings",
+    `const scheduler = { runPromise: () => 1 }\nexport const x = scheduler.runPromise()`,
+  )
+  rule.invalid(
+    "Effect.runPromise",
+    `import { Effect } from "effect"\nexport const x = Effect.runPromise(Effect.void)`,
+    "src/main.ts",
+  )
+  rule.invalid(
+    "Effect.runSync via namespace import",
+    `import * as Effect from "effect/Effect"\nexport const x = Effect.runSync(Effect.void)`,
+  )
+  rule.invalid(
+    "ManagedRuntime.make",
+    `import { Layer, ManagedRuntime } from "effect"\nexport const rt = ManagedRuntime.make(Layer.empty)`,
+  )
+  rule.invalid(
+    "BunRuntime.runMain",
+    `import { BunRuntime } from "@effect/platform-bun"\nimport { Effect } from "effect"\nBunRuntime.runMain(Effect.void)`,
+  )
+  rule.invalid(
+    "a directly imported runPromise",
+    `import { runPromise } from "effect/Effect"\nimport { Effect } from "effect"\nexport const x = runPromise(Effect.void)`,
+  )
+  rule.invalid(
+    "a directly imported ManagedRuntime make",
+    `import { make } from "effect/ManagedRuntime"\nimport { Layer } from "effect"\nexport const rt = make(Layer.empty)`,
+  )
+  rule.invalid(
+    "a directly imported runMain",
+    `import { runMain } from "@effect/platform-bun/BunRuntime"\nimport { Effect } from "effect"\nrunMain(Effect.void)`,
+  )
+  rule.valid(
+    "a local function that shares an executor name",
+    `const runPromise = () => 1\nexport const x = runPromise()`,
+  )
+})
+
+describe("atc/canonical-namespace-imports", () => {
+  const rule = ruleTests("atc/canonical-namespace-imports")
+
+  rule.valid(
+    "canonical namespace import",
+    `import * as Terminals from "./terminals.ts"\nexport const t = Terminals`,
+  )
+  rule.valid("the Zmx exception", `import * as Zmx from "./zmxAdapter.ts"\nexport const z = Zmx`)
+  rule.valid(
+    "PascalCase for hyphenated basenames",
+    `import * as FakeZmx from "./fake-zmx.ts"\nexport const f = FakeZmx`,
+  )
+  rule.valid(
+    "unaliased named imports",
+    `import { layer } from "./events.ts"\nexport const l = layer`,
+  )
+  rule.valid(
+    "aliased imports from packages",
+    `import { Option as O } from "effect"\nexport const o = O`,
+  )
+  rule.invalid(
+    "a non-canonical namespace name",
+    `import * as Term from "./terminals.ts"\nexport const t = Term`,
+    "`Terminals`",
+  )
+  rule.invalid(
+    "an aliased named import",
+    `import { layer as eventsLayer } from "./events.ts"\nexport const l = eventsLayer`,
+    "Never alias",
+  )
+})

--- a/app-server/tsconfig.json
+++ b/app-server/tsconfig.json
@@ -19,5 +19,5 @@
     "skipLibCheck": true,
     "types": ["bun"]
   },
-  "include": ["src", "test", "scripts", "vitest.config.ts"]
+  "include": ["src", "test", "scripts", "lint", "vitest.config.ts"]
 }

--- a/app-server/web/src/routes/+page.svelte
+++ b/app-server/web/src/routes/+page.svelte
@@ -94,12 +94,16 @@
     <div class="card">
       <div class="head">Build</div>
       <div class="rows">
-        <div class="row"><span class="k">Version</span><span class="v">{version.version}</span></div>
+        <div class="row">
+          <span class="k">Version</span><span class="v">{version.version}</span>
+        </div>
         <div class="row">
           <span class="k">API version</span><span class="v">{version.apiVersion}</span>
         </div>
         <div class="row"><span class="k">Commit</span><span class="v">{version.commit}</span></div>
-        <div class="row"><span class="k">Built at</span><span class="v">{version.builtAt}</span></div>
+        <div class="row">
+          <span class="k">Built at</span><span class="v">{version.builtAt}</span>
+        </div>
       </div>
     </div>
   {/if}
@@ -115,7 +119,9 @@
             <span class="v"><a href={tailscale.url}>{tailscale.url}</a></span>
           </div>
         {:else if tailscale.state === "error" && tailscale.reason !== undefined}
-          <div class="row"><span class="k">Reason</span><span class="v">{tailscale.reason}</span></div>
+          <div class="row">
+            <span class="k">Reason</span><span class="v">{tailscale.reason}</span>
+          </div>
         {/if}
       </div>
     </div>


### PR DESCRIPTION
Part 2 of the ATC-187 linting stack (base: #192).

- Pins `oxlint`/`@oxlint/plugins` 1.78.0; correctness, suspicious, and perf categories as errors, plus `no-explicit-any` and unused-disable-directive reporting. Noisy rules that fight the codebase's deliberate idioms are turned off with rationale (`no-shadow`, `consistent-function-scoping`, `prefer-add-event-listener`); `no-underscore-dangle` keeps running with `_tag` allowed.
- `app-server/lint/`: project-owned plugin turning the AGENTS.md invariants into tested rules — `atc/no-process-env`, `atc/no-adhoc-spawn`, `atc/no-manual-effect-runtime`, `atc/canonical-namespace-imports`. Boundary exemptions live in `.oxlintrc.json` overrides, and every rule is tested end to end through the real oxlint binary (`test/lint/`).
- Fixes the violations the new rules found: nine aliased imports (contract schema classes and `layer as appConfigLayer`) converted to canonical namespace imports, a useless spread, and `filter().pop()` → `findLast()`.
- `.svelte` files are excluded from oxlint — its script-block analysis can't see template bindings (a `bind:this` var was flagged as never assigned), so `svelte-check` owns that surface and now runs in `mise run check`. `prettier-plugin-svelte` brings `.svelte` sources under `fmt`/`fmt:check`.
- `lint` / `lint:fix` tasks; `check` = fmt:check + lint + typecheck + test + openapi:check + web:check + web:assets:check.

Deferred (per the issue): the hoisted-Schema-compiler rule (perf-category nice-to-have) and type-aware oxlint.

https://claude.ai/code/session_0144WKu2f2AofZEnHyV1onAM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Quality Improvements**
  - Added comprehensive automated checks for code quality, formatting, type safety, and tests.
  - Added safeguards that encourage consistent configuration access, process handling, runtime usage, and import conventions.
  - Added autofix support for applicable code-quality issues.

- **Documentation**
  - Expanded verification guidance and clarified application checks.

- **UI Polish**
  - Improved markup formatting in build and connectivity details without changing displayed information or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->