### PR TITLE
Adopt swift-format: config, mechanical baseline, and strict gate (ATC-187)

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -65,9 +65,13 @@ jobs:
       - name: Show Xcode version
         run: xcodebuild -version
 
-      # Same commands as local `mise run swift:lint` / `kit:test` / `macos:test`.
+      # Same commands as local `mise run swift:lint` / `swift:fmt:check` /
+      # `kit:test` / `macos:test`.
       - name: SwiftLint
         run: mise run swift:lint
+
+      - name: swift-format check
+        run: mise run swift:fmt:check
 
       - name: ATCKit tests
         run: mise run kit:test

--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "lineLength": 120,
+  "indentation": { "spaces": 4 },
+  "maximumBlankLines": 1,
+  "respectsExistingLineBreaks": true,
+  "multiElementCollectionTrailingCommas": true,
+  "rules": {
+    "OrderedImports": true
+  }
+}

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -25,6 +25,10 @@ disabled_rules:
   # Byte streams from terminals and SSE decode lossily on purpose:
   # replacement characters beat dropped frames.
   - optional_data_string_conversion
+  # swift-format owns brace placement (it breaks before `{` after a
+  # multiline clause, which this rule would fight); the swift:fmt:check
+  # gate already enforces it deterministically.
+  - opening_brace
 
 type_name:
   excluded:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,9 +104,10 @@ enforces. The ones you will actually reach for:
 
 - `mise run -C app-server check` — fmt, lint (oxlint + the ATC plugin rules
   in `app-server/lint/`), typecheck, tests, OpenAPI drift, svelte-check.
-- `mise run swift:lint` — SwiftLint over `macos/` and ATCKit (strict). CI
-  also promotes Swift compiler warnings to errors (`ATC_STRICT_WARNINGS=1`);
-  local builds stay permissive.
+- `mise run swift:lint` / `swift:fmt:check` — SwiftLint and swift-format
+  over `macos/` and ATCKit (strict); `swift:lint:fix` and `swift:fmt` apply
+  the fixes. CI also promotes Swift compiler warnings to errors
+  (`ATC_STRICT_WARNINGS=1`); local builds stay permissive.
 - `mise run contract:check` — after **any** contract change: OpenAPI drift, TS
   client tests, Swift client build.
 - `mise run -C app-server test:zmx` — opt into real-zmx smoke and compiled
@@ -136,7 +137,10 @@ will give you v3 idioms that do not compile here.**
   "../terminals/terminals.ts"` — and reference `Terminals.layer`. Always use
   the module's canonical name (`terminals/terminals.ts` is `Terminals`
   everywhere, `zmxAdapter.ts` is `Zmx` everywhere), so one grep finds every
-  call site. Never alias an import. The exception is `cli/` command modules:
+  call site. Never alias an import; importing an export by its exported name
+  (`import { Events }`) is fine, renaming it is not — that is the enforced
+  invariant (`atc/canonical-namespace-imports`). The exception is `cli/`
+  command modules:
   they export commands (`project`, `terminal`, ...) consumed by named import
   in `main.ts`, so their basenames may mirror the domain folders without
   colliding.

--- a/macos/ATC/ATCApp.swift
+++ b/macos/ATC/ATCApp.swift
@@ -52,11 +52,12 @@ private struct WindowRootView: View {
         self.configStore = configStore
         let windowState = WindowState()
         _windowState = State(initialValue: windowState)
-        _router = State(initialValue: WindowKeyboardRouter.forWindow(
-            appModel: appModel,
-            windowState: windowState,
-            configStore: configStore
-        ))
+        _router = State(
+            initialValue: WindowKeyboardRouter.forWindow(
+                appModel: appModel,
+                windowState: windowState,
+                configStore: configStore
+            ))
     }
 
     var body: some View {

--- a/macos/ATC/AppModel.swift
+++ b/macos/ATC/AppModel.swift
@@ -1,7 +1,7 @@
-import Foundation
-import Observation
-import OSLog
 import ATCAppServerAPI
+import Foundation
+import OSLog
+import Observation
 
 private let logger = Logger(subsystem: "ElevenIdeas.atc", category: "appmodel")
 
@@ -111,21 +111,23 @@ final class AppModel {
             self.connections = ConnectionsStore(loadingDeferred: true)
             needsDeferredStart = true
         }
-        self.clientFactory = clientFactory ?? { record, url in
-            ConnectionClient.make(baseURL: url, token: record.token)
-        }
-        self.terminalControllerFactory = terminalControllerFactory ?? { terminalID, runtime in
-            TerminalSessionController(
-                terminalID: terminalID,
-                endpoint: AttachEndpoint(
-                    baseURL: runtime.baseURL,
-                    headers: runtime.transportHeaders
-                ),
-                checkLive: { [weak runtime] in
-                    await runtime?.terminals.checkLive(id: terminalID) ?? nil
-                }
-            )
-        }
+        self.clientFactory =
+            clientFactory ?? { record, url in
+                ConnectionClient.make(baseURL: url, token: record.token)
+            }
+        self.terminalControllerFactory =
+            terminalControllerFactory ?? { terminalID, runtime in
+                TerminalSessionController(
+                    terminalID: terminalID,
+                    endpoint: AttachEndpoint(
+                        baseURL: runtime.baseURL,
+                        headers: runtime.transportHeaders
+                    ),
+                    checkLive: { [weak runtime] in
+                        await runtime?.terminals.checkLive(id: terminalID) ?? nil
+                    }
+                )
+            }
         self.terminalRecoveryMonitor = terminalRecoveryMonitor ?? TerminalRecoveryMonitor()
         self.eventStreamFactory = eventStreamFactory
         if !needsDeferredStart {
@@ -256,25 +258,26 @@ final class AppModel {
     /// server-side into thread/terminal deletions, which this snapshot
     /// does observe — reconciliation rides that cascade.
     func windowNavigationSnapshot() -> WindowNavigationSnapshot {
-        WindowNavigationSnapshot(connections: runtimes.map { runtime in
-            WindowNavigationSnapshot.Connection(
-                id: runtime.id,
-                threadsCurrent: runtime.threads.isResolved,
-                terminalsCurrent: runtime.terminals.isResolved,
-                threads: (runtime.threads.threads + runtime.threads.archivedThreads).map {
-                    .init(
-                        id: $0.id,
-                        projectID: $0.projectId,
-                        isArchived: $0.isArchived,
-                        isUnread: $0.unread,
-                        activityState: $0.activityState
-                    )
-                },
-                terminals: runtime.terminals.terminals.map {
-                    .init(id: $0.id, projectID: $0.projectId, threadID: $0.threadId, isLive: $0.isLive)
-                }
-            )
-        })
+        WindowNavigationSnapshot(
+            connections: runtimes.map { runtime in
+                WindowNavigationSnapshot.Connection(
+                    id: runtime.id,
+                    threadsCurrent: runtime.threads.isResolved,
+                    terminalsCurrent: runtime.terminals.isResolved,
+                    threads: (runtime.threads.threads + runtime.threads.archivedThreads).map {
+                        .init(
+                            id: $0.id,
+                            projectID: $0.projectId,
+                            isArchived: $0.isArchived,
+                            isUnread: $0.unread,
+                            activityState: $0.activityState
+                        )
+                    },
+                    terminals: runtime.terminals.terminals.map {
+                        .init(id: $0.id, projectID: $0.projectId, threadID: $0.threadId, isLive: $0.isLive)
+                    }
+                )
+            })
     }
 
     /// Refreshes every Connection concurrently so one unreachable server
@@ -439,7 +442,7 @@ final class AppModel {
     func reconcileTerminalLifecycle() {
         for ref in Array(terminals.keys) {
             guard let runtime = runtime(id: ref.connectionID),
-                  runtime.terminals.isResolved
+                runtime.terminals.isResolved
             else { continue }
             guard let terminal = runtime.terminals.terminal(id: ref.terminalID) else {
                 disconnectTerminal(ref: ref)
@@ -515,9 +518,9 @@ final class AppModel {
     /// (`noteWindowKeyed`), so `.last` is the window the user last worked in.
     private func openPendingNotificationThread() {
         guard let ref = pendingNotificationThread,
-              let window = windowReconcilers.compactMap(\.value).last,
-              let runtime = runtime(id: ref.connectionID),
-              runtime.threads.isResolved
+            let window = windowReconcilers.compactMap(\.value).last,
+            let runtime = runtime(id: ref.connectionID),
+            runtime.threads.isResolved
         else { return }
         // A resolved store is the answer either way: open the thread, or drop
         // a click for one that no longer exists — or was archived, which

--- a/macos/ATC/Commands/CommandRegistry.swift
+++ b/macos/ATC/Commands/CommandRegistry.swift
@@ -137,7 +137,8 @@ enum CommandRegistry {
                 perform: { context in
                     let fileURL = context.configStore.configURL
                     let directoryURL = context.configStore.configDirectoryURL
-                    let selectedURL = FileManager.default.fileExists(atPath: fileURL.path)
+                    let selectedURL =
+                        FileManager.default.fileExists(atPath: fileURL.path)
                         ? fileURL
                         : directoryURL
                     NSWorkspace.shared.activateFileViewerSelecting([selectedURL])

--- a/macos/ATC/Commands/KeyStroke.swift
+++ b/macos/ATC/Commands/KeyStroke.swift
@@ -92,15 +92,17 @@ nonisolated struct KeyStroke: Hashable, Sendable, CustomStringConvertible {
         }
 
         guard keyToken != "escape" else {
-            return .failure(.init(
-                message: "Named key 'escape' is deferred beyond the MVP"
-            ))
+            return .failure(
+                .init(
+                    message: "Named key 'escape' is deferred beyond the MVP"
+                ))
         }
         guard keyToken.count == 1,
-              let scalar = keyToken.unicodeScalars.first,
-              isPrintable(scalar)
+            let scalar = keyToken.unicodeScalars.first,
+            isPrintable(scalar)
         else {
-            let kind = keyToken.hasPrefix("f") && Int(keyToken.dropFirst()) != nil
+            let kind =
+                keyToken.hasPrefix("f") && Int(keyToken.dropFirst()) != nil
                 ? "Function key '\(keyToken)'"
                 : "Key '\(keyToken)'"
             return .failure(.init(message: "\(kind) is deferred beyond the MVP"))
@@ -108,9 +110,10 @@ nonisolated struct KeyStroke: Hashable, Sendable, CustomStringConvertible {
         let stroke = KeyStroke(key: keyToken, modifiers: modifiers)
         guard !requiresPrimaryModifier || stroke.hasPrimaryModifier else {
             let detail = modifiers == [.shift] ? "shift-only" : "unmodified"
-            return .failure(.init(
-                message: "A \(detail) direct trigger is deferred beyond the MVP"
-            ))
+            return .failure(
+                .init(
+                    message: "A \(detail) direct trigger is deferred beyond the MVP"
+                ))
         }
         return .success(stroke)
     }
@@ -139,29 +142,33 @@ nonisolated enum ParsedKeySequence: Equatable {
         switch steps.count {
         case 1:
             guard steps[0].lowercased() != "leader" else {
-                return .failure(.init(
-                    message: "'leader' is reserved for the first step of leader>X"
-                ))
+                return .failure(
+                    .init(
+                        message: "'leader' is reserved for the first step of leader>X"
+                    ))
             }
             return KeyStroke.parse(steps[0]).map(ParsedKeySequence.direct)
         case 2:
             guard steps[0].lowercased() == "leader" else {
-                return .failure(.init(
-                    message: "Only leader>X sequences are supported in the MVP"
-                ))
+                return .failure(
+                    .init(
+                        message: "Only leader>X sequences are supported in the MVP"
+                    ))
             }
             guard steps[1].lowercased() != "leader" else {
-                return .failure(.init(
-                    message: "'leader' is only valid as the first sequence step"
-                ))
+                return .failure(
+                    .init(
+                        message: "'leader' is only valid as the first sequence step"
+                    ))
             }
             return KeyStroke.parseContinuation(steps[1]).map {
                 .leader(continuation: $0)
             }
         default:
-            return .failure(.init(
-                message: "Only two-step leader>X sequences are supported in the MVP"
-            ))
+            return .failure(
+                .init(
+                    message: "Only two-step leader>X sequences are supported in the MVP"
+                ))
         }
     }
 }

--- a/macos/ATC/Commands/KeyboardMonitorHost.swift
+++ b/macos/ATC/Commands/KeyboardMonitorHost.swift
@@ -77,8 +77,8 @@ struct KeyboardMonitorHost: View {
             hostWindow = window
             monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self, weak window] event in
                 guard let self, let window,
-                      event.window === window,
-                      window.isKeyWindow
+                    event.window === window,
+                    window.isKeyWindow
                 else { return event }
                 return self.handleKeyDown(event: event, in: window)
             }
@@ -96,39 +96,42 @@ struct KeyboardMonitorHost: View {
             // Becoming key reseeds from the live hardware state: flags
             // changed while another window was key (⌘Tab back with ⌘ still
             // down) never produced a flagsChanged event here.
-            observers.append(center.addObserver(
-                forName: NSWindow.didBecomeKeyNotification,
-                object: window,
-                queue: .main
-            ) { [weak self] _ in
-                MainActor.assumeIsolated {
-                    self?.router.heldModifiers = KeyStroke.Modifiers(NSEvent.modifierFlags)
-                }
-            })
-            observers.append(center.addObserver(
-                forName: NSWindow.didResignKeyNotification,
-                object: window,
-                queue: .main
-            ) { [weak self] _ in
-                MainActor.assumeIsolated {
-                    self?.router.cancel()
-                    self?.router.heldModifiers = []
-                    self?.onDeactivate()
-                    self?.restoreOrphanedResponder()
-                }
-            })
-            observers.append(center.addObserver(
-                forName: NSApplication.didResignActiveNotification,
-                object: NSApp,
-                queue: .main
-            ) { [weak self] _ in
-                MainActor.assumeIsolated {
-                    self?.router.cancel()
-                    self?.router.heldModifiers = []
-                    self?.onDeactivate()
-                    self?.restoreOrphanedResponder()
-                }
-            })
+            observers.append(
+                center.addObserver(
+                    forName: NSWindow.didBecomeKeyNotification,
+                    object: window,
+                    queue: .main
+                ) { [weak self] _ in
+                    MainActor.assumeIsolated {
+                        self?.router.heldModifiers = KeyStroke.Modifiers(NSEvent.modifierFlags)
+                    }
+                })
+            observers.append(
+                center.addObserver(
+                    forName: NSWindow.didResignKeyNotification,
+                    object: window,
+                    queue: .main
+                ) { [weak self] _ in
+                    MainActor.assumeIsolated {
+                        self?.router.cancel()
+                        self?.router.heldModifiers = []
+                        self?.onDeactivate()
+                        self?.restoreOrphanedResponder()
+                    }
+                })
+            observers.append(
+                center.addObserver(
+                    forName: NSApplication.didResignActiveNotification,
+                    object: NSApp,
+                    queue: .main
+                ) { [weak self] _ in
+                    MainActor.assumeIsolated {
+                        self?.router.cancel()
+                        self?.router.heldModifiers = []
+                        self?.onDeactivate()
+                        self?.restoreOrphanedResponder()
+                    }
+                })
         }
 
         // Seam below the window guards lets tests use synthesized events
@@ -165,10 +168,11 @@ struct KeyboardMonitorHost: View {
             guard let stashed = router.responderBeforeSuspension else { return }
             router.responderBeforeSuspension = nil
             if let window = hostWindow,
-               let view = stashed as? NSView,
-               view.window === window,
-               view.acceptsFirstResponder,
-               window.makeFirstResponder(view) {
+                let view = stashed as? NSView,
+                view.window === window,
+                view.acceptsFirstResponder,
+                window.makeFirstResponder(view)
+            {
                 return
             }
             focusFallback()
@@ -237,11 +241,13 @@ struct KeyboardRoutingContainer<Content: View>: View {
             }
             .environment(configStore)
             .environment(router)
-            .background(KeyboardMonitorHost(
-                router: router,
-                onDeactivate: { windowState.commandPalettePresentation = nil },
-                focusFallback: { windowState.requestTerminalFocus() }
-            ))
+            .background(
+                KeyboardMonitorHost(
+                    router: router,
+                    onDeactivate: { windowState.commandPalettePresentation = nil },
+                    focusFallback: { windowState.requestTerminalFocus() }
+                )
+            )
             .onChange(of: configStore.configuration.keymap.generation, initial: true) {
                 router.keymap = configStore.configuration.keymap
             }
@@ -275,12 +281,15 @@ extension KeyStroke {
         if event.keyCode == 53 {
             return .escape
         }
-        let produced = event.characters(byApplyingModifiers: [])
+        let produced =
+            event.characters(byApplyingModifiers: [])
             ?? event.charactersIgnoringModifiers
-        guard let key = resolveKey(
-            produced: produced,
-            asciiFallback: { asciiCharacter(for: event.keyCode) }
-        ) else { return nil }
+        guard
+            let key = resolveKey(
+                produced: produced,
+                asciiFallback: { asciiCharacter(for: event.keyCode) }
+            )
+        else { return nil }
         return KeyStroke(key: key, modifiers: modifiers)
     }
 
@@ -301,24 +310,24 @@ extension KeyStroke {
 
     private static func printableASCIIKey(_ characters: String?) -> String? {
         guard let characters,
-              characters.count == 1
+            characters.count == 1
         else { return nil }
         let lowercased = characters.lowercased()
         guard lowercased.count == 1,
-              lowercased.unicodeScalars.count == 1,
-              let scalar = lowercased.unicodeScalars.first,
-              scalar.value < 128,
-              isPrintable(scalar)
+            lowercased.unicodeScalars.count == 1,
+            let scalar = lowercased.unicodeScalars.first,
+            scalar.value < 128,
+            isPrintable(scalar)
         else { return nil }
         return lowercased
     }
 
     private static func asciiCharacter(for keyCode: UInt16) -> String? {
         guard let source = TISCopyCurrentASCIICapableKeyboardLayoutInputSource()?.takeRetainedValue(),
-              let property = TISGetInputSourceProperty(
-                  source,
-                  kTISPropertyUnicodeKeyLayoutData
-              )
+            let property = TISGetInputSourceProperty(
+                source,
+                kTISPropertyUnicodeKeyLayoutData
+            )
         else { return nil }
         let data = unsafeBitCast(property, to: CFData.self)
         guard let bytes = CFDataGetBytePtr(data) else { return nil }

--- a/macos/ATC/Commands/Keymap.swift
+++ b/macos/ATC/Commands/Keymap.swift
@@ -39,27 +39,30 @@ enum Keymap {
             switch entry.key {
             case "leader":
                 guard case .string(let text) = entry.value else {
-                    diagnostics.append(.init(
-                        severity: .error,
-                        message: "[keyboard].leader must be a quoted trigger string"
-                    ))
+                    diagnostics.append(
+                        .init(
+                            severity: .error,
+                            message: "[keyboard].leader must be a quoted trigger string"
+                        ))
                     continue
                 }
                 switch KeyStroke.parse(text) {
                 case .success(let stroke):
                     leader = stroke
                 case .failure(let error):
-                    diagnostics.append(.init(
-                        severity: .error,
-                        message: "[keyboard].leader has invalid trigger '\(text)': \(error.message)"
-                    ))
+                    diagnostics.append(
+                        .init(
+                            severity: .error,
+                            message: "[keyboard].leader has invalid trigger '\(text)': \(error.message)"
+                        ))
                 }
             case "clear_default_keybindings":
                 guard case .boolean(let value) = entry.value else {
-                    diagnostics.append(.init(
-                        severity: .error,
-                        message: "[keyboard].clear_default_keybindings must be a boolean"
-                    ))
+                    diagnostics.append(
+                        .init(
+                            severity: .error,
+                            message: "[keyboard].clear_default_keybindings must be a boolean"
+                        ))
                     continue
                 }
                 clearDefaults = value
@@ -86,17 +89,20 @@ enum Keymap {
         let userOffset = ordered.count
         for (offset, entry) in user.tables["keybindings", default: []].enumerated() {
             guard case .string(let command) = entry.value else {
-                diagnostics.append(.init(
-                    severity: .error,
-                    message: "\(configurationKeyPath(table: "keybindings", key: entry.key)) must be a string command id or \"unbind\""
-                ))
+                diagnostics.append(
+                    .init(
+                        severity: .error,
+                        message:
+                            "\(configurationKeyPath(table: "keybindings", key: entry.key)) must be a string command id or \"unbind\""
+                    ))
                 continue
             }
-            ordered.append(.init(
-                sequenceText: entry.key,
-                commandText: command,
-                order: userOffset + offset
-            ))
+            ordered.append(
+                .init(
+                    sequenceText: entry.key,
+                    commandText: command,
+                    order: userOffset + offset
+                ))
         }
 
         struct FoldedBinding {
@@ -109,10 +115,12 @@ enum Keymap {
             switch ParsedKeySequence.parse(entry.sequenceText) {
             case .success(let value): parsed = value
             case .failure(let error):
-                diagnostics.append(.init(
-                    severity: .error,
-                    message: "\(configurationKeyPath(table: "keybindings", key: entry.sequenceText)) has an invalid trigger: \(error.message)"
-                ))
+                diagnostics.append(
+                    .init(
+                        severity: .error,
+                        message:
+                            "\(configurationKeyPath(table: "keybindings", key: entry.sequenceText)) has an invalid trigger: \(error.message)"
+                    ))
                 continue
             }
             let sequence: KeySequence
@@ -126,10 +134,12 @@ enum Keymap {
                 continue
             }
             guard let command = CommandID(rawValue: entry.commandText) else {
-                diagnostics.append(.init(
-                    severity: .error,
-                    message: "\(configurationKeyPath(table: "keybindings", key: entry.sequenceText)): unknown command id '\(entry.commandText)'"
-                ))
+                diagnostics.append(
+                    .init(
+                        severity: .error,
+                        message:
+                            "\(configurationKeyPath(table: "keybindings", key: entry.sequenceText)): unknown command id '\(entry.commandText)'"
+                    ))
                 continue
             }
             folded[sequence] = FoldedBinding(
@@ -144,23 +154,27 @@ enum Keymap {
         let directTriggers = Set(folded.keys.filter { $0.count == 1 }.map { $0[0] })
         let prefixTriggers = Set(folded.keys.filter { $0.count > 1 }.map { $0[0] })
         for trigger in directTriggers.intersection(prefixTriggers).sorted(by: descriptionOrder) {
-            diagnostics.append(.init(
-                severity: .error,
-                message: "[keybindings] trigger '\(trigger)' is both a direct shortcut and a sequence prefix; unbind the direct shortcut or choose another leader"
-            ))
+            diagnostics.append(
+                .init(
+                    severity: .error,
+                    message:
+                        "[keybindings] trigger '\(trigger)' is both a direct shortcut and a sequence prefix; unbind the direct shortcut or choose another leader"
+                ))
         }
 
         let protected = protectedTriggers
         let protectedCandidates = directTriggers.union(prefixTriggers).union([leader])
         for trigger in protectedCandidates.sorted(by: descriptionOrder) {
             if let name = protected[trigger] {
-                let source = trigger == leader
+                let source =
+                    trigger == leader
                     ? "[keyboard].leader '\(trigger)'"
                     : "[keybindings] trigger '\(trigger)'"
-                diagnostics.append(.init(
-                    severity: .error,
-                    message: "\(source) is reserved for \(name)"
-                ))
+                diagnostics.append(
+                    .init(
+                        severity: .error,
+                        message: "\(source) is reserved for \(name)"
+                    ))
             }
         }
 
@@ -191,11 +205,12 @@ enum Keymap {
                 menuCandidates[binding.command] = (sequence[0], binding.order)
             }
         }
-        return .success(ResolvedKeymap(
-            root: root,
-            menuShortcuts: menuCandidates.mapValues(\.stroke),
-            generation: generation
-        ))
+        return .success(
+            ResolvedKeymap(
+                root: root,
+                menuShortcuts: menuCandidates.mapValues(\.stroke),
+                generation: generation
+            ))
     }
 
     // The sidebar jump scheme owns its own triggers; splice them in

--- a/macos/ATC/Commands/NativeShortcuts.swift
+++ b/macos/ATC/Commands/NativeShortcuts.swift
@@ -35,9 +35,10 @@ nonisolated enum NativeShortcuts {
             ("cmd+a", "Select All", .responderOwned),
             ("cmd+m", "Minimize", .responderOwned),
         ]
-        return Dictionary(uniqueKeysWithValues: values.map {
-            (requiredStroke($0.0), Entry(name: $0.1, owner: $0.2))
-        })
+        return Dictionary(
+            uniqueKeysWithValues: values.map {
+                (requiredStroke($0.0), Entry(name: $0.1, owner: $0.2))
+            })
     }()
 
     static let protectedTriggers: [KeyStroke: String] = entries.mapValues(\.name)

--- a/macos/ATC/Configuration/ConfigurationDiagnostic.swift
+++ b/macos/ATC/Configuration/ConfigurationDiagnostic.swift
@@ -32,7 +32,8 @@ func configurationKeyPath(table: String, key: String) -> String {
     if key.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "_" || $0 == "-" }) {
         return "[\(table)].\(key)"
     }
-    let escaped = key
+    let escaped =
+        key
         .replacingOccurrences(of: "\\", with: "\\\\")
         .replacingOccurrences(of: "\"", with: "\\\"")
     return "[\(table)].\"\(escaped)\""

--- a/macos/ATC/Configuration/ConfigurationLoader.swift
+++ b/macos/ATC/Configuration/ConfigurationLoader.swift
@@ -60,13 +60,15 @@ enum ConfigurationLoader {
             guard recognizedTables.contains(key) else {
                 do {
                     _ = try root.table(forKey: key)
-                    diagnostics.append(diagnostic(
-                        "[\(key)] is not a recognized table (expected [keyboard], [keybindings], or [terminal])"
-                    ))
+                    diagnostics.append(
+                        diagnostic(
+                            "[\(key)] is not a recognized table (expected [keyboard], [keybindings], or [terminal])"
+                        ))
                 } catch {
-                    diagnostics.append(diagnostic(
-                        "Top-level key '\(key)' is unsupported; expected [keyboard], [keybindings], or [terminal]"
-                    ))
+                    diagnostics.append(
+                        diagnostic(
+                            "Top-level key '\(key)' is unsupported; expected [keyboard], [keybindings], or [terminal]"
+                        ))
                 }
                 continue
             }
@@ -105,32 +107,36 @@ enum ConfigurationLoader {
         var entries: [ParsedConfig.Entry] = []
         for key in table.keys.sorted() {
             guard keyboardKeys.contains(key) else {
-                diagnostics.append(diagnostic(
-                    "\(configurationKeyPath(table: "keyboard", key: key)) is not recognized"
-                ))
+                diagnostics.append(
+                    diagnostic(
+                        "\(configurationKeyPath(table: "keyboard", key: key)) is not recognized"
+                    ))
                 continue
             }
 
             switch key {
             case "leader":
                 do {
-                    entries.append(.init(
-                        key: key,
-                        value: .string(try table.string(forKey: key))
-                    ))
+                    entries.append(
+                        .init(
+                            key: key,
+                            value: .string(try table.string(forKey: key))
+                        ))
                 } catch {
                     diagnostics.append(diagnostic("[keyboard].leader must be a string"))
                 }
             case "clear_default_keybindings":
                 do {
-                    entries.append(.init(
-                        key: key,
-                        value: .boolean(try table.bool(forKey: key))
-                    ))
+                    entries.append(
+                        .init(
+                            key: key,
+                            value: .boolean(try table.bool(forKey: key))
+                        ))
                 } catch {
-                    diagnostics.append(diagnostic(
-                        "[keyboard].clear_default_keybindings must be a boolean"
-                    ))
+                    diagnostics.append(
+                        diagnostic(
+                            "[keyboard].clear_default_keybindings must be a boolean"
+                        ))
                 }
             default:
                 preconditionFailure("Recognized keyboard key is not decoded")
@@ -152,9 +158,10 @@ enum ConfigurationLoader {
                     value: .string(try table.string(forKey: key))
                 )
             } catch {
-                diagnostics.append(diagnostic(
-                    "\(configurationKeyPath(table: "keybindings", key: key)) must be a string command id or \"unbind\""
-                ))
+                diagnostics.append(
+                    diagnostic(
+                        "\(configurationKeyPath(table: "keybindings", key: key)) must be a string command id or \"unbind\""
+                    ))
                 return nil
             }
         }
@@ -172,9 +179,10 @@ enum ConfigurationLoader {
 
         for key in table.keys.sorted() {
             guard terminalKeys.contains(key) else {
-                diagnostics.append(diagnostic(
-                    "\(configurationKeyPath(table: "terminal", key: key)) is not recognized"
-                ))
+                diagnostics.append(
+                    diagnostic(
+                        "\(configurationKeyPath(table: "terminal", key: key)) is not recognized"
+                    ))
                 continue
             }
 
@@ -184,9 +192,10 @@ enum ConfigurationLoader {
                 do {
                     let value = try table.string(forKey: key)
                     guard TerminalPresentation.isKnownTheme(value) else {
-                        diagnostics.append(diagnostic(
-                            "[terminal].theme \"\(value)\" is not a known theme"
-                        ))
+                        diagnostics.append(
+                            diagnostic(
+                                "[terminal].theme \"\(value)\" is not a known theme"
+                            ))
                         continue
                     }
                     theme = value

--- a/macos/ATC/Configuration/ConfigurationStore.swift
+++ b/macos/ATC/Configuration/ConfigurationStore.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Observation
 import OSLog
+import Observation
 
 struct ConfigNotice: Equatable {
     let message: String
@@ -62,12 +62,14 @@ final class ConfigurationStore {
         let base: URL
         if let xdg = environment["XDG_CONFIG_HOME"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
-           !xdg.isEmpty {
+            !xdg.isEmpty
+        {
             base = URL(fileURLWithPath: xdg, isDirectory: true)
         } else {
             base = homeDirectory.appending(path: ".config", directoryHint: .isDirectory)
         }
-        return base
+        return
+            base
             .appending(path: "atc", directoryHint: .isDirectory)
             .appending(path: "macos.toml", directoryHint: .notDirectory)
     }
@@ -87,10 +89,12 @@ final class ConfigurationStore {
             parsed = ConfigurationLoader.parse(data: try Data(contentsOf: configURL))
         } catch {
             fail(
-                diagnostics: [.init(
-                    severity: .error,
-                    message: "Could not read macos.toml: \(error.localizedDescription)"
-                )],
+                diagnostics: [
+                    .init(
+                        severity: .error,
+                        message: "Could not read macos.toml: \(error.localizedDescription)"
+                    )
+                ],
                 isLaunch: isLaunch
             )
             return
@@ -112,7 +116,8 @@ final class ConfigurationStore {
         self.diagnostics = diagnostics
         log(diagnostics)
         let errors = diagnostics.filter { $0.severity == .error }
-        let disposition = isLaunch
+        let disposition =
+            isLaunch
             ? "using defaults"
             : "keeping the previous configuration"
         let firstError = errors.first?.message ?? "unknown error"

--- a/macos/ATC/ConnectionRuntime.swift
+++ b/macos/ATC/ConnectionRuntime.swift
@@ -84,7 +84,8 @@ final class ConnectionRuntime: Identifiable {
         self.record = record
         self.client = client
         self.baseURL = baseURL
-        transportHeaders = record.token.isEmpty
+        transportHeaders =
+            record.token.isEmpty
             ? [:]
             : ["Authorization": "Bearer \(record.token)"]
         self.eventStreamFactory = eventStreamFactory

--- a/macos/ATC/Connections/ConnectionsModel.swift
+++ b/macos/ATC/Connections/ConnectionsModel.swift
@@ -62,19 +62,22 @@ enum ConnectionURL {
 
         // A scheme is present only when the string starts with `scheme://`.
         // Otherwise "host:7331" would be misread as scheme "host".
-        let hasScheme = trimmed.range(
-            of: "^[a-zA-Z][a-zA-Z0-9+.-]*://",
-            options: .regularExpression
-        ) != nil
+        let hasScheme =
+            trimmed.range(
+                of: "^[a-zA-Z][a-zA-Z0-9+.-]*://",
+                options: .regularExpression
+            ) != nil
         let candidate = hasScheme ? trimmed : "http://" + trimmed
 
         guard let comps = URLComponents(string: candidate) else { return nil }
         guard let scheme = comps.scheme?.lowercased(),
-              scheme == "http" || scheme == "https" else { return nil }
+            scheme == "http" || scheme == "https"
+        else { return nil }
         guard let host = comps.host, !host.isEmpty else { return nil }
         // Reject userinfo, query, and fragment.
         guard comps.user == nil, comps.password == nil,
-              comps.query == nil, comps.fragment == nil else { return nil }
+            comps.query == nil, comps.fragment == nil
+        else { return nil }
         // Origin-only: allow empty path or a single trailing slash.
         guard comps.path.isEmpty || comps.path == "/" else { return nil }
 
@@ -241,7 +244,8 @@ final class ConnectionsStore {
     /// (pre-Keychain data, or a previously failed credential write).
     private func load() -> Bool {
         guard let data = defaults.data(forKey: Keys.connections),
-              let decoded = try? JSONDecoder().decode([ConnectionRecord].self, from: data) else {
+            let decoded = try? JSONDecoder().decode([ConnectionRecord].self, from: data)
+        else {
             return false
         }
         connections = decoded.map { record in
@@ -287,7 +291,8 @@ final class ConnectionsStore {
         // Don't duplicate if the new store already holds data.
         guard connections.isEmpty else { return }
         guard let legacy = defaults.string(forKey: Keys.legacyURL),
-              let origin = ConnectionURL.parse(legacy) else { return }
+            let origin = ConnectionURL.parse(legacy)
+        else { return }
         let token = defaults.string(forKey: Keys.legacyToken) ?? ""
         let record = ConnectionRecord(
             name: ConnectionURL.derivedName(fromHost: origin.host),

--- a/macos/ATC/Features/CommandPalette/CommandPaletteContent.swift
+++ b/macos/ATC/Features/CommandPalette/CommandPaletteContent.swift
@@ -57,7 +57,8 @@ enum PaletteTypeKeyword: CaseIterable, Equatable {
     case terminals
 
     static func match(_ query: String) -> PaletteTypeKeyword? {
-        let query = query
+        let query =
+            query
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
         guard query.count >= 3 else { return nil }
@@ -121,9 +122,10 @@ enum CommandPaletteContent {
         let expands = keyword == .threads
         return (model.pinned + model.recent).compactMap { item in
             let titleMatch = QueryMatcher.match(query, in: item.thread.displayName)
-            guard expands
-                || titleMatch != nil
-                || QueryMatcher.match(query, in: item.projectLabel) != nil
+            guard
+                expands
+                    || titleMatch != nil
+                    || QueryMatcher.match(query, in: item.projectLabel) != nil
             else { return nil }
             return ThreadResult(
                 ref: item.ref,
@@ -148,12 +150,14 @@ enum CommandPaletteContent {
         return context.appModel.runtimes.flatMap { runtime -> [TerminalResult] in
             runtime.terminals.terminals.compactMap { terminal in
                 guard terminal.threadId == nil else { return nil }
-                let projectName = runtime.projects.project(id: terminal.projectId)?.name
+                let projectName =
+                    runtime.projects.project(id: terminal.projectId)?.name
                     ?? "Unknown Project"
                 let titleMatch = QueryMatcher.match(query, in: terminal.displayName)
-                guard expands
-                    || titleMatch != nil
-                    || QueryMatcher.match(query, in: projectName) != nil
+                guard
+                    expands
+                        || titleMatch != nil
+                        || QueryMatcher.match(query, in: projectName) != nil
                 else { return nil }
                 return TerminalResult(
                     ref: TerminalRef(connectionID: runtime.id, terminalID: terminal.id),
@@ -183,7 +187,7 @@ enum CommandPaletteContent {
     ) -> [CommandPaletteRow] {
         CommandRegistry.allDescriptors.compactMap { descriptor in
             guard descriptor.isPaletteEligible,
-                  let match = QueryMatcher.match(query, in: descriptor.title)
+                let match = QueryMatcher.match(query, in: descriptor.title)
             else { return nil }
             return CommandPaletteRow(
                 id: descriptor.id,
@@ -192,10 +196,12 @@ enum CommandPaletteContent {
                 shortcut: keymap.menuShortcuts[descriptor.id],
                 availability: descriptor.availability(context)
             )
-        }.sorted { isOrderedBefore(
-            title: $0.title, id: $0.id,
-            thanTitle: $1.title, id: $1.id
-        ) }
+        }.sorted {
+            isOrderedBefore(
+                title: $0.title, id: $0.id,
+                thanTitle: $1.title, id: $1.id
+            )
+        }
     }
 
     /// Navigation rows order by title, then Connection, then the row's own

--- a/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
+++ b/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
@@ -55,17 +55,19 @@ struct CommandPaletteView: View {
         .accessibilityLabel("Command Palette")
         .accessibilityAddTraits(.isModal)
         .onExitCommand { dismissPalette() }
-        .background(PaletteWindowAccessor(
-            takeCapturedResponder: {
-                defer { router.responderBeforeSuspension = nil }
-                return router.responderBeforeSuspension as? NSResponder
-            },
-            onAttach: { queryIsFocused = true },
-            shouldRestoreCapturedResponder: {
-                responderRestoration.shouldRestoreCapturedResponder
-            },
-            fallback: { windowState.requestTerminalFocus() }
-        ))
+        .background(
+            PaletteWindowAccessor(
+                takeCapturedResponder: {
+                    defer { router.responderBeforeSuspension = nil }
+                    return router.responderBeforeSuspension as? NSResponder
+                },
+                onAttach: { queryIsFocused = true },
+                shouldRestoreCapturedResponder: {
+                    responderRestoration.shouldRestoreCapturedResponder
+                },
+                fallback: { windowState.requestTerminalFocus() }
+            )
+        )
         .onAppear { resetSelection(for: rows, presentation: presentation) }
         .onChange(of: query) {
             resetSelection(for: rows, presentation: presentation)
@@ -85,7 +87,7 @@ struct CommandPaletteView: View {
         // active row instead.
         .onChange(of: selectedID) {
             guard let selectedID,
-                  let result = rows.first(where: { $0.id == selectedID })
+                let result = rows.first(where: { $0.id == selectedID })
             else { return }
             AccessibilityNotification.Announcement(accessibilityLabel(for: result)).post()
         }
@@ -144,7 +146,11 @@ struct CommandPaletteView: View {
                 }
                 .scrollTargetLayout()
                 .padding(5)
-                .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { listHeight = $0 }
+                .onGeometryChange(for: CGFloat.self) {
+                    $0.size.height
+                } action: {
+                    listHeight = $0
+                }
             }
             .frame(height: min(Self.maxListHeight, listHeight))
             .scrollPosition(id: $scrolledID, anchor: .center)
@@ -168,8 +174,7 @@ struct CommandPaletteView: View {
         .opacity(isAvailable ? 1 : 0.6)
         .background {
             RoundedRectangle(cornerRadius: Radius.control)
-                .fill(isSelected ? Color.accentColor.opacity(0.65) :
-                    isHovered ? Color.primary.opacity(0.08) : .clear)
+                .fill(isSelected ? Color.accentColor.opacity(0.65) : isHovered ? Color.primary.opacity(0.08) : .clear)
         }
         .contentShape(Rectangle())
         .onHover { hovering in hoveredID = hovering ? result.id : nil }
@@ -281,7 +286,7 @@ struct CommandPaletteView: View {
         context: CommandContext
     ) {
         guard let selectedID,
-              let result = rows.first(where: { $0.id == selectedID })
+            let result = rows.first(where: { $0.id == selectedID })
         else {
             dismissPalette()
             return
@@ -431,10 +436,11 @@ private struct PaletteWindowAccessor: View {
         func detach() {
             guard let window = hostWindow else { return }
             if shouldRestoreCapturedResponder(),
-               let view = previousResponder as? NSView,
-               view.window === window,
-               view.acceptsFirstResponder,
-               window.makeFirstResponder(view) {
+                let view = previousResponder as? NSView,
+                view.window === window,
+                view.acceptsFirstResponder,
+                window.makeFirstResponder(view)
+            {
                 return
             }
             fallback()

--- a/macos/ATC/Features/Dashboard/DashboardModel.swift
+++ b/macos/ATC/Features/Dashboard/DashboardModel.swift
@@ -60,12 +60,13 @@ struct DashboardModel {
                     needsInputCount: threads.filter { $0.activityState == .needsInput }.count
                 )
             }
-            sections.append(Section(
-                connectionID: input.connectionID,
-                connectionName: input.connectionName,
-                contextLabel: ConnectionURL.contextLabel(for: input.urlString),
-                cards: cards
-            ))
+            sections.append(
+                Section(
+                    connectionID: input.connectionID,
+                    connectionName: input.connectionName,
+                    contextLabel: ConnectionURL.contextLabel(for: input.urlString),
+                    cards: cards
+                ))
         }
     }
 }

--- a/macos/ATC/Features/Dashboard/DashboardView.swift
+++ b/macos/ATC/Features/Dashboard/DashboardView.swift
@@ -46,7 +46,8 @@ struct DashboardView: View {
         ) {
             Button("Delete Project", role: .destructive) {
                 if let card = deletingProject,
-                   let store = appModel.runtime(id: card.ref.connectionID)?.projects {
+                    let store = appModel.runtime(id: card.ref.connectionID)?.projects
+                {
                     appModel.run(on: card.ref.connectionID, reporting: { actionError = $0 }) {
                         try await store.delete(id: card.project.id)
                     }
@@ -56,11 +57,12 @@ struct DashboardView: View {
             // Counts are the visible (active/standalone) ones; the catch-all
             // phrase covers archived and ended residue the stores don't
             // surface, so it must read as an addition, not a subset.
-            Text("""
-            Also deletes its \(countLabel(deletingProject?.activeThreadCount ?? 0, "thread")) and \
-            \(countLabel(deletingProject?.standaloneTerminalCount ?? 0, "terminal")), plus \
-            any archived or ended ones. The project directory is never touched.
-            """)
+            Text(
+                """
+                Also deletes its \(countLabel(deletingProject?.activeThreadCount ?? 0, "thread")) and \
+                \(countLabel(deletingProject?.standaloneTerminalCount ?? 0, "terminal")), plus \
+                any archived or ended ones. The project directory is never touched.
+                """)
         }
         .actionErrorAlert($actionError)
     }
@@ -131,9 +133,11 @@ struct DashboardView: View {
                 .lineLimit(1)
                 .truncationMode(.head)
 
-            Text("\(countLabel(card.activeThreadCount, "thread")) · \(countLabel(card.standaloneTerminalCount, "terminal"))")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            Text(
+                "\(countLabel(card.activeThreadCount, "thread")) · \(countLabel(card.standaloneTerminalCount, "terminal"))"
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
 
             Button("New Thread", systemImage: "plus.bubble") {
                 windowState.newThreadContext = NewThreadContext(projectRef: card.ref)
@@ -233,11 +237,11 @@ struct DashboardView: View {
 // are not.
 #if DEBUG
 
-#Preview {
-    DashboardView()
-        .environment(AppModel.preview())
-        .environment(WindowState())
-        .preferredColorScheme(.dark)
-}
+    #Preview {
+        DashboardView()
+            .environment(AppModel.preview())
+            .environment(WindowState())
+            .preferredColorScheme(.dark)
+    }
 
 #endif

--- a/macos/ATC/Features/Navigator/NavigatorSidebar.swift
+++ b/macos/ATC/Features/Navigator/NavigatorSidebar.swift
@@ -85,10 +85,11 @@ struct NavigatorSidebar: View {
                 }
             }
         } message: {
-            Text("""
-            This removes the thread from atc and ends its TUI terminal if one is \
-            still running. The agent's own conversation history is not touched.
-            """)
+            Text(
+                """
+                This removes the thread from atc and ends its TUI terminal if one is \
+                still running. The agent's own conversation history is not touched.
+                """)
         }
         .confirmationDialog(
             "Delete Terminal “\(deletingTerminalName)”?",
@@ -96,7 +97,8 @@ struct NavigatorSidebar: View {
         ) {
             Button("Delete Terminal", role: .destructive) {
                 if let ref = deletingTerminal,
-                   let store = appModel.runtime(id: ref.connectionID)?.terminals {
+                    let store = appModel.runtime(id: ref.connectionID)?.terminals
+                {
                     appModel.run(on: ref.connectionID, reporting: { actionError = $0 }) {
                         try await store.delete(id: ref.terminalID)
                     }
@@ -237,7 +239,8 @@ struct NavigatorSidebar: View {
     /// Archived threads are management rows, not navigation: Restore returns
     /// the thread to the list and opens it, Delete is the only other action.
     private func archivedRow(_ item: ThreadListItem) -> some View {
-        let enabled = appModel.canMutate(connectionID: item.ref.connectionID)
+        let enabled =
+            appModel.canMutate(connectionID: item.ref.connectionID)
             && !inFlightThreads.contains(item.ref)
         return HStack(spacing: Spacing.sm) {
             Text("\(item.projectLabel) › \(item.thread.displayName)")
@@ -278,7 +281,8 @@ struct NavigatorSidebar: View {
     @ViewBuilder
     private func terminalsSection(_ project: ProjectRef) -> some View {
         @Bindable var windowState = windowState
-        let terminals = appModel.runtime(id: project.connectionID)?
+        let terminals =
+            appModel.runtime(id: project.connectionID)?
             .terminals.standaloneTerminals(projectID: project.projectID) ?? []
         NavigatorDisclosureHeader(
             title: "Terminals",
@@ -291,7 +295,8 @@ struct NavigatorSidebar: View {
             if terminals.isEmpty {
                 emptyLabel("No Terminals")
             } else {
-                let numbered = areTerminalBadgesVisible
+                let numbered =
+                    areTerminalBadgesVisible
                     ? SidebarShortcuts.terminalTargets(terminals, isSectionExpanded: true).count
                     : 0
                 ForEach(Array(terminals.enumerated()), id: \.element.id) { index, terminal in
@@ -375,9 +380,10 @@ struct NavigatorSidebar: View {
                 isExpanded.wrappedValue.toggle()
             } label: {
                 HStack(spacing: Spacing.xs) {
-                    Text(isExpanded.wrappedValue
-                        ? "Hide"
-                        : "\(total - SidebarShortcuts.initialRowLimit) more")
+                    Text(
+                        isExpanded.wrappedValue
+                            ? "Hide"
+                            : "\(total - SidebarShortcuts.initialRowLimit) more")
                     Image(systemName: isExpanded.wrappedValue ? "chevron.up" : "chevron.down")
                         .font(.caption2)
                 }
@@ -482,24 +488,26 @@ struct NavigatorSidebar: View {
                 title: "All Projects",
                 isSelected: windowState.threadFilter == .all,
                 action: { select(.all) }
-            ),
+            )
         ]
         if !model.projects.isEmpty {
             entries.append(.separator)
             for option in model.projects {
-                entries.append(.item(
-                    title: option.label,
-                    isSelected: windowState.threadFilter == .project(option.ref),
-                    action: { select(.project(option.ref)) }
-                ))
+                entries.append(
+                    .item(
+                        title: option.label,
+                        isSelected: windowState.threadFilter == .project(option.ref),
+                        action: { select(.project(option.ref)) }
+                    ))
             }
         }
         entries.append(.separator)
-        entries.append(.item(
-            title: "Archived",
-            isSelected: windowState.threadFilter == .archived,
-            action: { select(.archived) }
-        ))
+        entries.append(
+            .item(
+                title: "Archived",
+                isSelected: windowState.threadFilter == .archived,
+                action: { select(.archived) }
+            ))
         return entries
     }
 
@@ -529,9 +537,10 @@ struct NavigatorSidebar: View {
             isPinnedExpanded: windowState.isPinnedExpanded,
             isRecentExpanded: windowState.isRecentExpanded
         )
-        return Dictionary(uniqueKeysWithValues: targets.enumerated().map {
-            ($0.element, $0.offset + 1)
-        })
+        return Dictionary(
+            uniqueKeysWithValues: targets.enumerated().map {
+                ($0.element, $0.offset + 1)
+            })
     }
 }
 

--- a/macos/ATC/Features/Projects/CreateProjectSheet.swift
+++ b/macos/ATC/Features/Projects/CreateProjectSheet.swift
@@ -29,10 +29,13 @@ struct CreateProjectSheet: View {
             onSubmit: { Task { await submit() } }
         ) {
             Section {
-                Picker("Connection", selection: Binding(
-                    get: { connectionID },
-                    set: { connectionID = $0 }
-                )) {
+                Picker(
+                    "Connection",
+                    selection: Binding(
+                        get: { connectionID },
+                        set: { connectionID = $0 }
+                    )
+                ) {
                     // The selection is nil until `.task` preselects (and
                     // always when no Connections exist); keep a matching tag
                     // so AppKit doesn't log an invalid selection.

--- a/macos/ATC/Features/Projects/ProjectsStore.swift
+++ b/macos/ATC/Features/Projects/ProjectsStore.swift
@@ -40,7 +40,8 @@ final class ProjectsStore {
     func create(name: String, defaultWorkingDirectory: String) async throws -> Project {
         let project: Project
         switch try await client
-            .createProject(body: .json(.init(name: name, defaultWorkingDirectory: defaultWorkingDirectory))) {
+            .createProject(body: .json(.init(name: name, defaultWorkingDirectory: defaultWorkingDirectory)))
+        {
         case .ok(let ok): project = try ok.body.json
         case .unprocessableContent(let failure):
             let payload = try failure.body.json

--- a/macos/ATC/Features/Terminal/TerminalHostView.swift
+++ b/macos/ATC/Features/Terminal/TerminalHostView.swift
@@ -1,7 +1,7 @@
 import AppKit
+import GhosttyTerminal
 import OSLog
 import SwiftUI
-import GhosttyTerminal
 
 private let logger = Logger(subsystem: "ElevenIdeas.atc", category: "terminal")
 
@@ -149,7 +149,7 @@ final class TerminalContainerView: NSView {
         focusResignTask = Task { [weak window, weak terminalView] in
             try? await Task.sleep(for: Self.focusRetryDelay)
             guard !Task.isCancelled, let window, let terminalView,
-                  window.firstResponder === terminalView
+                window.firstResponder === terminalView
             else { return }
             window.makeFirstResponder(nil)
         }

--- a/macos/ATC/Features/Terminal/TerminalPane.swift
+++ b/macos/ATC/Features/Terminal/TerminalPane.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import ATCAppServerTransport
+import SwiftUI
 
 /// All retained terminal surfaces, stacked; only the selected one is visible.
 /// Hidden surfaces stay in the hierarchy so switching threads never tears

--- a/macos/ATC/Features/Terminal/TerminalSessionController.swift
+++ b/macos/ATC/Features/Terminal/TerminalSessionController.swift
@@ -1,9 +1,9 @@
-import Foundation
-import Observation
-import OSLog
-import Synchronization
 import ATCAppServerTransport
+import Foundation
 import GhosttyTerminal
+import OSLog
+import Observation
+import Synchronization
 
 private let logger = Logger(subsystem: "ElevenIdeas.atc", category: "terminal")
 
@@ -297,7 +297,8 @@ final class TerminalSessionController: Identifiable {
             connectionRef.set(nil)
             eventTask = nil
             if let opened = connectionOpenedAt,
-               now() - opened >= .milliseconds(retryPolicy.maximumDelayMilliseconds) {
+                now() - opened >= .milliseconds(retryPolicy.maximumDelayMilliseconds)
+            {
                 retryAttempt = 0
             }
             connectionOpenedAt = nil
@@ -327,8 +328,8 @@ final class TerminalSessionController: Identifiable {
             guard let self else { return }
             let live = await self.checkLive()
             guard generation == self.connectionGeneration,
-                  self.connection == nil,
-                  self.automaticRecoveryEnabled
+                self.connection == nil,
+                self.automaticRecoveryEnabled
             else { return }
             if live == false {
                 self.end(.terminalEnded, notify: true)
@@ -344,7 +345,8 @@ final class TerminalSessionController: Identifiable {
     /// attempt budget is spent (or recovery is disabled entirely).
     private func scheduleAutomaticReconnect() -> Bool {
         guard automaticRecoveryEnabled, retryTask == nil,
-              retryAttempt < retryPolicy.maximumAttempts else { return false }
+            retryAttempt < retryPolicy.maximumAttempts
+        else { return false }
         let delay = retryPolicy.delay(forAttempt: retryAttempt, jitterUnit: jitterUnit())
         retryAttempt += 1
         retryGeneration += 1
@@ -358,9 +360,9 @@ final class TerminalSessionController: Identifiable {
                 return
             }
             guard !Task.isCancelled, let self,
-                  generation == self.retryGeneration,
-                  self.automaticRecoveryEnabled,
-                  self.connection == nil
+                generation == self.retryGeneration,
+                self.automaticRecoveryEnabled,
+                self.connection == nil
             else { return }
             self.retryTask = nil
             self.connect(isReconnect: true)

--- a/macos/ATC/Features/Terminals/NewTerminalSheet.swift
+++ b/macos/ATC/Features/Terminals/NewTerminalSheet.swift
@@ -75,11 +75,12 @@ struct NewTerminalSheet: View {
         defer { isSubmitting = false }
         let trimmedName = name.trimmingCharacters(in: .whitespaces)
         do {
-            let terminal = try await runtime.terminals.create(.init(
-                projectId: projectRef.projectID,
-                name: trimmedName.isEmpty ? nil : trimmedName,
-                workingDirectory: workingDirectory.trimmingCharacters(in: .whitespaces)
-            ))
+            let terminal = try await runtime.terminals.create(
+                .init(
+                    projectId: projectRef.projectID,
+                    name: trimmedName.isEmpty ? nil : trimmedName,
+                    workingDirectory: workingDirectory.trimmingCharacters(in: .whitespaces)
+                ))
             submitError = nil
             windowState.newTerminalProject = nil
             windowState.selectTerminal(

--- a/macos/ATC/Features/Threads/NewThreadSheet.swift
+++ b/macos/ATC/Features/Threads/NewThreadSheet.swift
@@ -95,8 +95,8 @@ struct NewThreadSheet: View {
             // Mask to the device-independent modifiers: `press.modifiers`
             // also carries capsLock/numericPad, which must not defeat ⌘1–9.
             guard press.modifiers.intersection([.command, .shift, .option, .control]) == .command,
-                  let digit = press.key.character.wholeNumberValue,
-                  digit - 1 < agents.count
+                let digit = press.key.character.wholeNumberValue,
+                digit - 1 < agents.count
             else { return .ignored }
             select(agents[digit - 1])
             return .handled
@@ -167,14 +167,16 @@ struct NewThreadSheet: View {
     /// The list is alphabetical (context Project first), so the header says
     /// what it shows rather than borrowing the mock's "Recent".
     private var resultsHeader: some View {
-        Text(query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            ? "Projects" : "Results")
-            .font(.caption.weight(.semibold))
-            .foregroundStyle(.secondary)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, Self.gutter + Spacing.md)
-            .padding(.bottom, Spacing.xs)
-            .accessibilityAddTraits(.isHeader)
+        Text(
+            query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? "Projects" : "Results"
+        )
+        .font(.caption.weight(.semibold))
+        .foregroundStyle(.secondary)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, Self.gutter + Spacing.md)
+        .padding(.bottom, Spacing.xs)
+        .accessibilityAddTraits(.isHeader)
     }
 
     @ViewBuilder
@@ -399,7 +401,8 @@ struct NewThreadSheet: View {
     private func selectProject(_ ref: ProjectRef?, in rows: [NewThreadLauncherModel.Row]) {
         guard selectedProject != ref else { return }
         selectedProject = ref
-        workingDirectory = rows.first { $0.id == ref }?
+        workingDirectory =
+            rows.first { $0.id == ref }?
             .option.project.defaultWorkingDirectory ?? ""
         if let row = rows.first(where: { $0.id == ref }) {
             AccessibilityNotification.Announcement(
@@ -427,11 +430,12 @@ struct NewThreadSheet: View {
         isSubmitting = true
         defer { isSubmitting = false }
         do {
-            let thread = try await runtime.threads.create(.init(
-                projectId: ref.projectID,
-                agentId: agentID,
-                workingDirectory: workingDirectory.trimmingCharacters(in: .whitespaces)
-            ))
+            let thread = try await runtime.threads.create(
+                .init(
+                    projectId: ref.projectID,
+                    agentId: agentID,
+                    workingDirectory: workingDirectory.trimmingCharacters(in: .whitespaces)
+                ))
             submitError = nil
             lastAgentRaw = agentID.rawValue
             windowState.threadCreated(

--- a/macos/ATC/Features/Threads/ThreadContentView.swift
+++ b/macos/ATC/Features/Threads/ThreadContentView.swift
@@ -76,7 +76,8 @@ struct ThreadContentView: View {
                 ContentUnavailableView(
                     "Terminal Ended",
                     systemImage: "terminal",
-                    description: Text("This terminal is no longer running. Delete it from the sidebar when you are done with it.")
+                    description: Text(
+                        "This terminal is no longer running. Delete it from the sidebar when you are done with it.")
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(AppColors.canvas)

--- a/macos/ATC/Features/Threads/ThreadListModel.swift
+++ b/macos/ATC/Features/Threads/ThreadListModel.swift
@@ -83,17 +83,19 @@ struct ThreadListModel {
         for input in inputs {
             for project in input.projects {
                 let ref = ProjectRef(connectionID: input.connectionID, projectID: project.id)
-                let label = nameCounts[project.name, default: 0] > 1
+                let label =
+                    nameCounts[project.name, default: 0] > 1
                     ? "\(project.name) · \(input.connectionName)"
                     : project.name
                 projectsByRef[ref] = project
                 labelsByRef[ref] = label
-                options.append(ProjectOption(
-                    ref: ref,
-                    project: project,
-                    connectionName: input.connectionName,
-                    label: label
-                ))
+                options.append(
+                    ProjectOption(
+                        ref: ref,
+                        project: project,
+                        connectionName: input.connectionName,
+                        label: label
+                    ))
             }
         }
         projects = options

--- a/macos/ATC/Features/Threads/ThreadNotifier.swift
+++ b/macos/ATC/Features/Threads/ThreadNotifier.swift
@@ -21,8 +21,8 @@
 //   all: its baseline was never cleared, so finishes during a sleep or wifi
 //   gap diff as new and notify.
 
-import AppKit
 import ATCAppServerAPI
+import AppKit
 import Foundation
 import UserNotifications
 
@@ -41,10 +41,11 @@ final class ThreadNotifier {
         /// A banner is a poke, not a report: no agent name, no server name,
         /// and no message text — the API exposes no turn content anyway.
         func body(project: String?) -> String {
-            let lead = switch self {
-            case .finished: "Finished"
-            case .needsInput: "Needs your input"
-            }
+            let lead =
+                switch self {
+                case .finished: "Finished"
+                case .needsInput: "Needs your input"
+                }
             guard let project else { return lead }
             return "\(lead) · \(project)"
         }
@@ -164,7 +165,8 @@ final class ThreadNotifier {
             // restart), so the last known activity carries forward. Otherwise
             // every blip would withdraw a needs-input banner and re-post it,
             // with sound, when sight returned.
-            let activityState = thread.activityState == .unknown
+            let activityState =
+                thread.activityState == .unknown
                 ? previous?.activityState ?? .unknown
                 : thread.activityState
             let state = State(unread: thread.unread, activityState: activityState)
@@ -217,10 +219,11 @@ final class ThreadNotifier {
 
     private func takeDownIfStale(_ ref: ThreadRef, state: State) {
         guard let claim = delivered[ref] else { return }
-        let stillTrue = switch claim {
-        case .finished: state.unread
-        case .needsInput: state.activityState == .needsInput
-        }
+        let stillTrue =
+            switch claim {
+            case .finished: state.unread
+            case .needsInput: state.activityState == .needsInput
+            }
         guard !stillTrue else { return }
         takeDown(ref)
     }
@@ -277,7 +280,7 @@ extension ThreadRef {
     init?(notificationIdentifier: String) {
         let parts = notificationIdentifier.split(separator: "/")
         guard parts.count == 3, parts[0] == "thread",
-              let connectionID = UUID(uuidString: String(parts[1]))
+            let connectionID = UUID(uuidString: String(parts[1]))
         else { return nil }
         self.init(connectionID: connectionID, threadID: String(parts[2]))
     }

--- a/macos/ATC/Features/Threads/ThreadsStore.swift
+++ b/macos/ATC/Features/Threads/ThreadsStore.swift
@@ -36,7 +36,8 @@ final class ThreadsStore {
         let includeArchived = hasLoadedArchivedOnce
         await refreshState.run {
             async let activeList = client.listThreads(query: .init()).ok.body.json
-            let archivedList = includeArchived
+            let archivedList =
+                includeArchived
                 ? try await client.listThreads(query: .init(archived: ._true)).ok.body.json
                 : nil
             return (active: try await activeList, archived: archivedList)

--- a/macos/ATC/PreviewSupport/PreviewAppServerClient.swift
+++ b/macos/ATC/PreviewSupport/PreviewAppServerClient.swift
@@ -14,448 +14,482 @@ import OpenAPIRuntime
 // Fixtures only: previews and tests. Never compiled into a Release build.
 #if DEBUG
 
-extension AppModel {
-    /// Preview/test fixture: an ephemeral Connection store (unique
-    /// UserDefaults suite, nothing persisted to `.standard`) holding one
-    /// Connection backed by the canned client, with terminal attaches stubbed
-    /// out so a preview never opens a socket.
-    static func preview(client: any APIProtocol = PreviewAppServerClient()) -> AppModel {
-        let defaults = UserDefaults(suiteName: "preview.appmodel.\(UUID().uuidString)")!
-        let store = ConnectionsStore(defaults: defaults, credentials: InMemoryCredentialStore())
-        _ = try? store.add(name: "Workstation", urlString: "http://127.0.0.1:7331", token: "")
-        return AppModel(
-            connections: store,
-            clientFactory: { _, _ in client },
-            terminalControllerFactory: { terminalID, runtime in
-                TerminalSessionController(
-                    terminalID: terminalID,
-                    endpoint: AttachEndpoint(baseURL: runtime.baseURL, headers: [:]),
-                    checkLive: { true },
-                    connectionFactory: { _, _ in
-                        TerminalAttachHandle(
-                            // A stream that never yields keeps the controller
-                            // in `.connecting` without any I/O.
-                            start: { AsyncStream { _ in } },
-                            enqueue: { _ in },
-                            enqueueResize: { _, _ in },
-                            close: {}
-                        )
-                    }
-                )
-            },
-            terminalRecoveryMonitor: .disabled(),
-            eventStreamFactory: { _, _ in AsyncStream { $0.yield(.connected) } }
-        )
-    }
-}
-
-nonisolated struct PreviewAppServerClient: APIProtocol {
-    // MARK: - Fixtures
-
-    static let atelier = Project(
-        id: "0192f4a0-0000-7000-8000-000000000001",
-        name: "Atelier",
-        defaultWorkingDirectory: "/Users/dev/Projects/atelier",
-        createdAt: Date(timeIntervalSinceNow: -400_000),
-        updatedAt: Date(timeIntervalSinceNow: -60)
-    )
-
-    static let blazerr = Project(
-        id: "0192f4a0-0000-7000-8000-000000000002",
-        name: "Blazerr",
-        defaultWorkingDirectory: "/Users/dev/Projects/blazerr",
-        createdAt: Date(timeIntervalSinceNow: -300_000),
-        updatedAt: Date(timeIntervalSinceNow: -3_600)
-    )
-
-    var projects: [Project] { [Self.atelier, Self.blazerr] }
-
-    var threads: [ATCThread] {
-        [
-            ATCThread(
-                id: "0192f4b0-0000-7000-8000-000000000001",
-                projectId: Self.atelier.id,
-                agentId: .claudeCode,
-                name: "Parser rewrite",
-                workingDirectory: Self.atelier.defaultWorkingDirectory,
-                activityState: .working,
-                unread: false,
-                linkedTerminalId: "0192f4c0-0000-7000-8000-000000000001",
-                pinnedAt: Date(timeIntervalSinceNow: -200_000),
-                createdAt: Date(timeIntervalSinceNow: -220_000),
-                updatedAt: Date(timeIntervalSinceNow: -30)
-            ),
-            ATCThread(
-                id: "0192f4b0-0000-7000-8000-000000000002",
-                projectId: Self.atelier.id,
-                agentId: .codex,
-                name: "Flaky test triage",
-                workingDirectory: Self.atelier.defaultWorkingDirectory,
-                activityState: .needsInput,
-                unread: false,
-                createdAt: Date(timeIntervalSinceNow: -7_200),
-                updatedAt: Date(timeIntervalSinceNow: -120)
-            ),
-            ATCThread(
-                id: "0192f4b0-0000-7000-8000-000000000003",
-                projectId: Self.atelier.id,
-                agentId: .codex,
-                workingDirectory: "/Users/dev/Projects/atelier/packages/core",
-                activityState: .idle,
-                // The Done card: finished while nobody was looking.
-                unread: true,
-                createdAt: Date(timeIntervalSinceNow: -20_000),
-                updatedAt: Date(timeIntervalSinceNow: -19_000)
-            ),
-            ATCThread(
-                id: "0192f4b0-0000-7000-8000-000000000004",
-                projectId: Self.blazerr.id,
-                agentId: .claudeCode,
-                name: "Spike: streaming uploads",
-                workingDirectory: Self.blazerr.defaultWorkingDirectory,
-                activityState: .idle,
-                unread: false,
-                createdAt: Date(timeIntervalSinceNow: -90_000),
-                updatedAt: Date(timeIntervalSinceNow: -86_400)
-            ),
-            ATCThread(
-                id: "0192f4b0-0000-7000-8000-000000000005",
-                projectId: Self.blazerr.id,
-                agentId: .codex,
-                name: "Dependency bump",
-                workingDirectory: Self.blazerr.defaultWorkingDirectory,
-                activityState: .unknown,
-                unread: false,
-                createdAt: Date(timeIntervalSinceNow: -150_000),
-                updatedAt: Date(timeIntervalSinceNow: -140_000)
-            ),
-        ]
-    }
-
-    var archivedThreads: [ATCThread] {
-        [
-            ATCThread(
-                id: "0192f4b0-0000-7000-8000-000000000006",
-                projectId: Self.atelier.id,
-                agentId: .claudeCode,
-                name: "Abandoned migration",
-                workingDirectory: Self.atelier.defaultWorkingDirectory,
-                activityState: .unknown,
-                unread: false,
-                archivedAt: Date(timeIntervalSinceNow: -40_000),
-                createdAt: Date(timeIntervalSinceNow: -500_000),
-                updatedAt: Date(timeIntervalSinceNow: -40_000)
-            ),
-        ]
-    }
-
-    var terminals: [Terminal] {
-        [
-            // The pinned thread's TUI terminal — never a sidebar row.
-            Terminal(
-                id: "0192f4c0-0000-7000-8000-000000000001",
-                projectId: Self.atelier.id,
-                threadId: "0192f4b0-0000-7000-8000-000000000001",
-                initialWorkingDirectory: Self.atelier.defaultWorkingDirectory,
-                status: .live,
-                sessionName: "atc-0192f4c0000070008000000000000001",
-                createdAt: Date(timeIntervalSinceNow: -220_000),
-                updatedAt: Date(timeIntervalSinceNow: -30)
-            ),
-            Terminal(
-                id: "0192f4c0-0000-7000-8000-000000000002",
-                projectId: Self.atelier.id,
-                name: "Server logs",
-                initialWorkingDirectory: Self.atelier.defaultWorkingDirectory,
-                status: .live,
-                sessionName: "atc-0192f4c0000070008000000000000002",
-                createdAt: Date(timeIntervalSinceNow: -5_000),
-                updatedAt: Date(timeIntervalSinceNow: -60)
-            ),
-            Terminal(
-                id: "0192f4c0-0000-7000-8000-000000000003",
-                projectId: Self.atelier.id,
-                command: ["lazygit"],
-                initialWorkingDirectory: Self.atelier.defaultWorkingDirectory,
-                status: .ended,
-                sessionName: "atc-0192f4c0000070008000000000000003",
-                createdAt: Date(timeIntervalSinceNow: -900),
-                updatedAt: Date(timeIntervalSinceNow: -600),
-                endedAt: Date(timeIntervalSinceNow: -600)
-            ),
-        ]
-    }
-
-    var agents: [Agent] {
-        [
-            Agent(
-                id: .codex,
-                available: true,
-                detectedVersion: "0.52.0"
-            ),
-            Agent(
-                id: .claudeCode,
-                available: false,
-                reason: "Install the Claude Code CLI"
-            ),
-        ]
-    }
-
-    init() {}
-
-    // MARK: - Meta
-
-    func getHealth(_ input: Operations.GetHealth.Input) async throws -> Operations.GetHealth.Output {
-        .ok(.init(body: .json(.init(status: .ok))))
-    }
-
-    func getServerInfo(
-        _ input: Operations.GetServerInfo.Input
-    ) async throws -> Operations.GetServerInfo.Output {
-        .ok(.init(body: .json(.init(tailscale: .init(state: .disabled)))))
-    }
-
-    func getVersion(_ input: Operations.GetVersion.Input) async throws -> Operations.GetVersion.Output {
-        .ok(.init(body: .json(.init(
-            version: "0.0.0-preview",
-            apiVersion: .v1,
-            commit: "dev",
-            builtAt: "dev"
-        ))))
-    }
-
-    func subscribeEvents(
-        _ input: Operations.SubscribeEvents.Input
-    ) async throws -> Operations.SubscribeEvents.Output {
-        .ok(.init(body: .textEventStream(HTTPBody(": connected\n\n"))))
-    }
-
-    func checkDirectory(
-        _ input: Operations.CheckDirectory.Input
-    ) async throws -> Operations.CheckDirectory.Output {
-        .ok(.init(body: .json(.init(
-            path: input.query.path,
-            state: .available,
-            checkedAt: Date()
-        ))))
-    }
-
-    func listDirectory(
-        _ input: Operations.ListDirectory.Input
-    ) async throws -> Operations.ListDirectory.Output {
-        let path = input.query.path ?? "/Users/dev"
-        return .ok(.init(body: .json(.init(
-            path: path,
-            parent: path == "/" ? nil : URL(filePath: path).deletingLastPathComponent().path(percentEncoded: false),
-            entries: ["Documents", "Downloads", "Projects"].map {
-                .init(name: $0, path: path == "/" ? "/\($0)" : "\(path)/\($0)")
-            }
-        ))))
-    }
-
-    // MARK: - Projects
-
-    func listProjects(_ input: Operations.ListProjects.Input) async throws -> Operations.ListProjects.Output {
-        .ok(.init(body: .json(projects)))
-    }
-
-    func createProject(_ input: Operations.CreateProject.Input) async throws -> Operations.CreateProject.Output {
-        guard case .json(let request) = input.body else { throw PreviewUnavailable() }
-        return .ok(.init(body: .json(Project(
-            id: Self.newID(),
-            name: request.name,
-            defaultWorkingDirectory: request.defaultWorkingDirectory,
-            createdAt: Date(),
-            updatedAt: Date()
-        ))))
-    }
-
-    func getProject(_ input: Operations.GetProject.Input) async throws -> Operations.GetProject.Output {
-        .ok(.init(body: .json(try require(projects.first { $0.id == input.path.projectId }))))
-    }
-
-    func updateProject(_ input: Operations.UpdateProject.Input) async throws -> Operations.UpdateProject.Output {
-        guard case .json(let request) = input.body else { throw PreviewUnavailable() }
-        var project = try require(projects.first { $0.id == input.path.projectId })
-        if let name = request.name { project.name = name }
-        if let directory = request.defaultWorkingDirectory {
-            project.defaultWorkingDirectory = directory
+    extension AppModel {
+        /// Preview/test fixture: an ephemeral Connection store (unique
+        /// UserDefaults suite, nothing persisted to `.standard`) holding one
+        /// Connection backed by the canned client, with terminal attaches stubbed
+        /// out so a preview never opens a socket.
+        static func preview(client: any APIProtocol = PreviewAppServerClient()) -> AppModel {
+            let defaults = UserDefaults(suiteName: "preview.appmodel.\(UUID().uuidString)")!
+            let store = ConnectionsStore(defaults: defaults, credentials: InMemoryCredentialStore())
+            _ = try? store.add(name: "Workstation", urlString: "http://127.0.0.1:7331", token: "")
+            return AppModel(
+                connections: store,
+                clientFactory: { _, _ in client },
+                terminalControllerFactory: { terminalID, runtime in
+                    TerminalSessionController(
+                        terminalID: terminalID,
+                        endpoint: AttachEndpoint(baseURL: runtime.baseURL, headers: [:]),
+                        checkLive: { true },
+                        connectionFactory: { _, _ in
+                            TerminalAttachHandle(
+                                // A stream that never yields keeps the controller
+                                // in `.connecting` without any I/O.
+                                start: { AsyncStream { _ in } },
+                                enqueue: { _ in },
+                                enqueueResize: { _, _ in },
+                                close: {}
+                            )
+                        }
+                    )
+                },
+                terminalRecoveryMonitor: .disabled(),
+                eventStreamFactory: { _, _ in AsyncStream { $0.yield(.connected) } }
+            )
         }
-        project.updatedAt = Date()
-        return .ok(.init(body: .json(project)))
     }
 
-    func deleteProject(_ input: Operations.DeleteProject.Input) async throws -> Operations.DeleteProject.Output {
-        .noContent(.init())
-    }
+    nonisolated struct PreviewAppServerClient: APIProtocol {
+        // MARK: - Fixtures
 
-    // MARK: - Terminals
+        static let atelier = Project(
+            id: "0192f4a0-0000-7000-8000-000000000001",
+            name: "Atelier",
+            defaultWorkingDirectory: "/Users/dev/Projects/atelier",
+            createdAt: Date(timeIntervalSinceNow: -400_000),
+            updatedAt: Date(timeIntervalSinceNow: -60)
+        )
 
-    func listTerminals(_ input: Operations.ListTerminals.Input) async throws -> Operations.ListTerminals.Output {
-        let projectID = input.query.projectId
-        return .ok(.init(body: .json(
-            terminals.filter { projectID == nil || $0.projectId == projectID }
-        )))
-    }
+        static let blazerr = Project(
+            id: "0192f4a0-0000-7000-8000-000000000002",
+            name: "Blazerr",
+            defaultWorkingDirectory: "/Users/dev/Projects/blazerr",
+            createdAt: Date(timeIntervalSinceNow: -300_000),
+            updatedAt: Date(timeIntervalSinceNow: -3_600)
+        )
 
-    func createTerminal(_ input: Operations.CreateTerminal.Input) async throws -> Operations.CreateTerminal.Output {
-        guard case .json(let request) = input.body else { throw PreviewUnavailable() }
-        let project = try require(projects.first { $0.id == request.projectId })
-        let id = Self.newID()
-        return .ok(.init(body: .json(Terminal(
-            id: id,
-            projectId: project.id,
-            name: request.name,
-            command: request.command,
-            initialWorkingDirectory: request.workingDirectory ?? project.defaultWorkingDirectory,
-            status: .live,
-            sessionName: "atc-\(id.replacingOccurrences(of: "-", with: ""))",
-            createdAt: Date(),
-            updatedAt: Date()
-        ))))
-    }
+        var projects: [Project] { [Self.atelier, Self.blazerr] }
 
-    func getTerminal(_ input: Operations.GetTerminal.Input) async throws -> Operations.GetTerminal.Output {
-        .ok(.init(body: .json(try require(terminals.first { $0.id == input.path.terminalId }))))
-    }
+        var threads: [ATCThread] {
+            [
+                ATCThread(
+                    id: "0192f4b0-0000-7000-8000-000000000001",
+                    projectId: Self.atelier.id,
+                    agentId: .claudeCode,
+                    name: "Parser rewrite",
+                    workingDirectory: Self.atelier.defaultWorkingDirectory,
+                    activityState: .working,
+                    unread: false,
+                    linkedTerminalId: "0192f4c0-0000-7000-8000-000000000001",
+                    pinnedAt: Date(timeIntervalSinceNow: -200_000),
+                    createdAt: Date(timeIntervalSinceNow: -220_000),
+                    updatedAt: Date(timeIntervalSinceNow: -30)
+                ),
+                ATCThread(
+                    id: "0192f4b0-0000-7000-8000-000000000002",
+                    projectId: Self.atelier.id,
+                    agentId: .codex,
+                    name: "Flaky test triage",
+                    workingDirectory: Self.atelier.defaultWorkingDirectory,
+                    activityState: .needsInput,
+                    unread: false,
+                    createdAt: Date(timeIntervalSinceNow: -7_200),
+                    updatedAt: Date(timeIntervalSinceNow: -120)
+                ),
+                ATCThread(
+                    id: "0192f4b0-0000-7000-8000-000000000003",
+                    projectId: Self.atelier.id,
+                    agentId: .codex,
+                    workingDirectory: "/Users/dev/Projects/atelier/packages/core",
+                    activityState: .idle,
+                    // The Done card: finished while nobody was looking.
+                    unread: true,
+                    createdAt: Date(timeIntervalSinceNow: -20_000),
+                    updatedAt: Date(timeIntervalSinceNow: -19_000)
+                ),
+                ATCThread(
+                    id: "0192f4b0-0000-7000-8000-000000000004",
+                    projectId: Self.blazerr.id,
+                    agentId: .claudeCode,
+                    name: "Spike: streaming uploads",
+                    workingDirectory: Self.blazerr.defaultWorkingDirectory,
+                    activityState: .idle,
+                    unread: false,
+                    createdAt: Date(timeIntervalSinceNow: -90_000),
+                    updatedAt: Date(timeIntervalSinceNow: -86_400)
+                ),
+                ATCThread(
+                    id: "0192f4b0-0000-7000-8000-000000000005",
+                    projectId: Self.blazerr.id,
+                    agentId: .codex,
+                    name: "Dependency bump",
+                    workingDirectory: Self.blazerr.defaultWorkingDirectory,
+                    activityState: .unknown,
+                    unread: false,
+                    createdAt: Date(timeIntervalSinceNow: -150_000),
+                    updatedAt: Date(timeIntervalSinceNow: -140_000)
+                ),
+            ]
+        }
 
-    func updateTerminal(_ input: Operations.UpdateTerminal.Input) async throws -> Operations.UpdateTerminal.Output {
-        guard case .json(let request) = input.body else { throw PreviewUnavailable() }
-        var terminal = try require(terminals.first { $0.id == input.path.terminalId })
-        terminal.name = request.name
-        terminal.updatedAt = Date()
-        return .ok(.init(body: .json(terminal)))
-    }
+        var archivedThreads: [ATCThread] {
+            [
+                ATCThread(
+                    id: "0192f4b0-0000-7000-8000-000000000006",
+                    projectId: Self.atelier.id,
+                    agentId: .claudeCode,
+                    name: "Abandoned migration",
+                    workingDirectory: Self.atelier.defaultWorkingDirectory,
+                    activityState: .unknown,
+                    unread: false,
+                    archivedAt: Date(timeIntervalSinceNow: -40_000),
+                    createdAt: Date(timeIntervalSinceNow: -500_000),
+                    updatedAt: Date(timeIntervalSinceNow: -40_000)
+                )
+            ]
+        }
 
-    func deleteTerminal(_ input: Operations.DeleteTerminal.Input) async throws -> Operations.DeleteTerminal.Output {
-        .noContent(.init())
-    }
+        var terminals: [Terminal] {
+            [
+                // The pinned thread's TUI terminal — never a sidebar row.
+                Terminal(
+                    id: "0192f4c0-0000-7000-8000-000000000001",
+                    projectId: Self.atelier.id,
+                    threadId: "0192f4b0-0000-7000-8000-000000000001",
+                    initialWorkingDirectory: Self.atelier.defaultWorkingDirectory,
+                    status: .live,
+                    sessionName: "atc-0192f4c0000070008000000000000001",
+                    createdAt: Date(timeIntervalSinceNow: -220_000),
+                    updatedAt: Date(timeIntervalSinceNow: -30)
+                ),
+                Terminal(
+                    id: "0192f4c0-0000-7000-8000-000000000002",
+                    projectId: Self.atelier.id,
+                    name: "Server logs",
+                    initialWorkingDirectory: Self.atelier.defaultWorkingDirectory,
+                    status: .live,
+                    sessionName: "atc-0192f4c0000070008000000000000002",
+                    createdAt: Date(timeIntervalSinceNow: -5_000),
+                    updatedAt: Date(timeIntervalSinceNow: -60)
+                ),
+                Terminal(
+                    id: "0192f4c0-0000-7000-8000-000000000003",
+                    projectId: Self.atelier.id,
+                    command: ["lazygit"],
+                    initialWorkingDirectory: Self.atelier.defaultWorkingDirectory,
+                    status: .ended,
+                    sessionName: "atc-0192f4c0000070008000000000000003",
+                    createdAt: Date(timeIntervalSinceNow: -900),
+                    updatedAt: Date(timeIntervalSinceNow: -600),
+                    endedAt: Date(timeIntervalSinceNow: -600)
+                ),
+            ]
+        }
 
-    // MARK: - Threads
+        var agents: [Agent] {
+            [
+                Agent(
+                    id: .codex,
+                    available: true,
+                    detectedVersion: "0.52.0"
+                ),
+                Agent(
+                    id: .claudeCode,
+                    available: false,
+                    reason: "Install the Claude Code CLI"
+                ),
+            ]
+        }
 
-    func listThreads(_ input: Operations.ListThreads.Input) async throws -> Operations.ListThreads.Output {
-        let listing = input.query.archived == ._true ? archivedThreads : threads
-        let projectID = input.query.projectId
-        return .ok(.init(body: .json(
-            listing.filter { projectID == nil || $0.projectId == projectID }
-        )))
-    }
+        init() {}
 
-    func createThread(_ input: Operations.CreateThread.Input) async throws -> Operations.CreateThread.Output {
-        guard case .json(let request) = input.body else { throw PreviewUnavailable() }
-        let project = try require(projects.first { $0.id == request.projectId })
-        return .ok(.init(body: .json(ATCThread(
-            id: Self.newID(),
-            projectId: project.id,
-            agentId: request.agentId,
-            name: request.name,
-            workingDirectory: request.workingDirectory ?? project.defaultWorkingDirectory,
-            activityState: .unknown,
-            unread: false,
-            createdAt: Date(),
-            updatedAt: Date()
-        ))))
-    }
+        // MARK: - Meta
 
-    func getThread(_ input: Operations.GetThread.Input) async throws -> Operations.GetThread.Output {
-        .ok(.init(body: .json(try thread(input.path.threadId))))
-    }
+        func getHealth(_ input: Operations.GetHealth.Input) async throws -> Operations.GetHealth.Output {
+            .ok(.init(body: .json(.init(status: .ok))))
+        }
 
-    func updateThread(_ input: Operations.UpdateThread.Input) async throws -> Operations.UpdateThread.Output {
-        guard case .json(let request) = input.body else { throw PreviewUnavailable() }
-        var thread = try thread(input.path.threadId)
-        thread.name = request.name
-        thread.updatedAt = Date()
-        return .ok(.init(body: .json(thread)))
-    }
+        func getServerInfo(
+            _ input: Operations.GetServerInfo.Input
+        ) async throws -> Operations.GetServerInfo.Output {
+            .ok(.init(body: .json(.init(tailscale: .init(state: .disabled)))))
+        }
 
-    func deleteThread(_ input: Operations.DeleteThread.Input) async throws -> Operations.DeleteThread.Output {
-        .noContent(.init())
-    }
+        func getVersion(_ input: Operations.GetVersion.Input) async throws -> Operations.GetVersion.Output {
+            .ok(
+                .init(
+                    body: .json(
+                        .init(
+                            version: "0.0.0-preview",
+                            apiVersion: .v1,
+                            commit: "dev",
+                            builtAt: "dev"
+                        ))))
+        }
 
-    func archiveThread(_ input: Operations.ArchiveThread.Input) async throws -> Operations.ArchiveThread.Output {
-        var thread = try thread(input.path.threadId)
-        thread.archivedAt = Date()
-        thread.pinnedAt = nil
-        return .ok(.init(body: .json(thread)))
-    }
+        func subscribeEvents(
+            _ input: Operations.SubscribeEvents.Input
+        ) async throws -> Operations.SubscribeEvents.Output {
+            .ok(.init(body: .textEventStream(HTTPBody(": connected\n\n"))))
+        }
 
-    func unarchiveThread(_ input: Operations.UnarchiveThread.Input) async throws -> Operations.UnarchiveThread.Output {
-        var thread = try thread(input.path.threadId)
-        thread.archivedAt = nil
-        return .ok(.init(body: .json(thread)))
-    }
+        func checkDirectory(
+            _ input: Operations.CheckDirectory.Input
+        ) async throws -> Operations.CheckDirectory.Output {
+            .ok(
+                .init(
+                    body: .json(
+                        .init(
+                            path: input.query.path,
+                            state: .available,
+                            checkedAt: Date()
+                        ))))
+        }
 
-    func pinThread(_ input: Operations.PinThread.Input) async throws -> Operations.PinThread.Output {
-        var thread = try thread(input.path.threadId)
-        thread.pinnedAt = Date()
-        return .ok(.init(body: .json(thread)))
-    }
+        func listDirectory(
+            _ input: Operations.ListDirectory.Input
+        ) async throws -> Operations.ListDirectory.Output {
+            let path = input.query.path ?? "/Users/dev"
+            return .ok(
+                .init(
+                    body: .json(
+                        .init(
+                            path: path,
+                            parent: path == "/"
+                                ? nil : URL(filePath: path).deletingLastPathComponent().path(percentEncoded: false),
+                            entries: ["Documents", "Downloads", "Projects"].map {
+                                .init(name: $0, path: path == "/" ? "/\($0)" : "\(path)/\($0)")
+                            }
+                        ))))
+        }
 
-    func unpinThread(_ input: Operations.UnpinThread.Input) async throws -> Operations.UnpinThread.Output {
-        var thread = try thread(input.path.threadId)
-        thread.pinnedAt = nil
-        return .ok(.init(body: .json(thread)))
-    }
+        // MARK: - Projects
 
-    func markThreadViewed(_ input: Operations.MarkThreadViewed.Input) async throws -> Operations.MarkThreadViewed.Output {
-        var thread = try thread(input.path.threadId)
-        thread.unread = false
-        return .ok(.init(body: .json(thread)))
-    }
+        func listProjects(_ input: Operations.ListProjects.Input) async throws -> Operations.ListProjects.Output {
+            .ok(.init(body: .json(projects)))
+        }
 
-    func openThreadTerminal(
-        _ input: Operations.OpenThreadTerminal.Input
-    ) async throws -> Operations.OpenThreadTerminal.Output {
-        let thread = try thread(input.path.threadId)
-        if let linked = thread.linkedTerminalId,
-           let terminal = terminals.first(where: { $0.id == linked }) {
+        func createProject(_ input: Operations.CreateProject.Input) async throws -> Operations.CreateProject.Output {
+            guard case .json(let request) = input.body else { throw PreviewUnavailable() }
+            return .ok(
+                .init(
+                    body: .json(
+                        Project(
+                            id: Self.newID(),
+                            name: request.name,
+                            defaultWorkingDirectory: request.defaultWorkingDirectory,
+                            createdAt: Date(),
+                            updatedAt: Date()
+                        ))))
+        }
+
+        func getProject(_ input: Operations.GetProject.Input) async throws -> Operations.GetProject.Output {
+            .ok(.init(body: .json(try require(projects.first { $0.id == input.path.projectId }))))
+        }
+
+        func updateProject(_ input: Operations.UpdateProject.Input) async throws -> Operations.UpdateProject.Output {
+            guard case .json(let request) = input.body else { throw PreviewUnavailable() }
+            var project = try require(projects.first { $0.id == input.path.projectId })
+            if let name = request.name { project.name = name }
+            if let directory = request.defaultWorkingDirectory {
+                project.defaultWorkingDirectory = directory
+            }
+            project.updatedAt = Date()
+            return .ok(.init(body: .json(project)))
+        }
+
+        func deleteProject(_ input: Operations.DeleteProject.Input) async throws -> Operations.DeleteProject.Output {
+            .noContent(.init())
+        }
+
+        // MARK: - Terminals
+
+        func listTerminals(_ input: Operations.ListTerminals.Input) async throws -> Operations.ListTerminals.Output {
+            let projectID = input.query.projectId
+            return .ok(
+                .init(
+                    body: .json(
+                        terminals.filter { projectID == nil || $0.projectId == projectID }
+                    )))
+        }
+
+        func createTerminal(_ input: Operations.CreateTerminal.Input) async throws -> Operations.CreateTerminal.Output {
+            guard case .json(let request) = input.body else { throw PreviewUnavailable() }
+            let project = try require(projects.first { $0.id == request.projectId })
+            let id = Self.newID()
+            return .ok(
+                .init(
+                    body: .json(
+                        Terminal(
+                            id: id,
+                            projectId: project.id,
+                            name: request.name,
+                            command: request.command,
+                            initialWorkingDirectory: request.workingDirectory ?? project.defaultWorkingDirectory,
+                            status: .live,
+                            sessionName: "atc-\(id.replacingOccurrences(of: "-", with: ""))",
+                            createdAt: Date(),
+                            updatedAt: Date()
+                        ))))
+        }
+
+        func getTerminal(_ input: Operations.GetTerminal.Input) async throws -> Operations.GetTerminal.Output {
+            .ok(.init(body: .json(try require(terminals.first { $0.id == input.path.terminalId }))))
+        }
+
+        func updateTerminal(_ input: Operations.UpdateTerminal.Input) async throws -> Operations.UpdateTerminal.Output {
+            guard case .json(let request) = input.body else { throw PreviewUnavailable() }
+            var terminal = try require(terminals.first { $0.id == input.path.terminalId })
+            terminal.name = request.name
+            terminal.updatedAt = Date()
             return .ok(.init(body: .json(terminal)))
         }
-        let id = Self.newID()
-        return .ok(.init(body: .json(Terminal(
-            id: id,
-            projectId: thread.projectId,
-            threadId: thread.id,
-            initialWorkingDirectory: thread.workingDirectory,
-            status: .live,
-            sessionName: "atc-\(id.replacingOccurrences(of: "-", with: ""))",
-            createdAt: Date(),
-            updatedAt: Date()
-        ))))
+
+        func deleteTerminal(_ input: Operations.DeleteTerminal.Input) async throws -> Operations.DeleteTerminal.Output {
+            .noContent(.init())
+        }
+
+        // MARK: - Threads
+
+        func listThreads(_ input: Operations.ListThreads.Input) async throws -> Operations.ListThreads.Output {
+            let listing = input.query.archived == ._true ? archivedThreads : threads
+            let projectID = input.query.projectId
+            return .ok(
+                .init(
+                    body: .json(
+                        listing.filter { projectID == nil || $0.projectId == projectID }
+                    )))
+        }
+
+        func createThread(_ input: Operations.CreateThread.Input) async throws -> Operations.CreateThread.Output {
+            guard case .json(let request) = input.body else { throw PreviewUnavailable() }
+            let project = try require(projects.first { $0.id == request.projectId })
+            return .ok(
+                .init(
+                    body: .json(
+                        ATCThread(
+                            id: Self.newID(),
+                            projectId: project.id,
+                            agentId: request.agentId,
+                            name: request.name,
+                            workingDirectory: request.workingDirectory ?? project.defaultWorkingDirectory,
+                            activityState: .unknown,
+                            unread: false,
+                            createdAt: Date(),
+                            updatedAt: Date()
+                        ))))
+        }
+
+        func getThread(_ input: Operations.GetThread.Input) async throws -> Operations.GetThread.Output {
+            .ok(.init(body: .json(try thread(input.path.threadId))))
+        }
+
+        func updateThread(_ input: Operations.UpdateThread.Input) async throws -> Operations.UpdateThread.Output {
+            guard case .json(let request) = input.body else { throw PreviewUnavailable() }
+            var thread = try thread(input.path.threadId)
+            thread.name = request.name
+            thread.updatedAt = Date()
+            return .ok(.init(body: .json(thread)))
+        }
+
+        func deleteThread(_ input: Operations.DeleteThread.Input) async throws -> Operations.DeleteThread.Output {
+            .noContent(.init())
+        }
+
+        func archiveThread(_ input: Operations.ArchiveThread.Input) async throws -> Operations.ArchiveThread.Output {
+            var thread = try thread(input.path.threadId)
+            thread.archivedAt = Date()
+            thread.pinnedAt = nil
+            return .ok(.init(body: .json(thread)))
+        }
+
+        func unarchiveThread(_ input: Operations.UnarchiveThread.Input) async throws
+            -> Operations.UnarchiveThread.Output
+        {
+            var thread = try thread(input.path.threadId)
+            thread.archivedAt = nil
+            return .ok(.init(body: .json(thread)))
+        }
+
+        func pinThread(_ input: Operations.PinThread.Input) async throws -> Operations.PinThread.Output {
+            var thread = try thread(input.path.threadId)
+            thread.pinnedAt = Date()
+            return .ok(.init(body: .json(thread)))
+        }
+
+        func unpinThread(_ input: Operations.UnpinThread.Input) async throws -> Operations.UnpinThread.Output {
+            var thread = try thread(input.path.threadId)
+            thread.pinnedAt = nil
+            return .ok(.init(body: .json(thread)))
+        }
+
+        func markThreadViewed(_ input: Operations.MarkThreadViewed.Input) async throws
+            -> Operations.MarkThreadViewed.Output
+        {
+            var thread = try thread(input.path.threadId)
+            thread.unread = false
+            return .ok(.init(body: .json(thread)))
+        }
+
+        func openThreadTerminal(
+            _ input: Operations.OpenThreadTerminal.Input
+        ) async throws -> Operations.OpenThreadTerminal.Output {
+            let thread = try thread(input.path.threadId)
+            if let linked = thread.linkedTerminalId,
+                let terminal = terminals.first(where: { $0.id == linked })
+            {
+                return .ok(.init(body: .json(terminal)))
+            }
+            let id = Self.newID()
+            return .ok(
+                .init(
+                    body: .json(
+                        Terminal(
+                            id: id,
+                            projectId: thread.projectId,
+                            threadId: thread.id,
+                            initialWorkingDirectory: thread.workingDirectory,
+                            status: .live,
+                            sessionName: "atc-\(id.replacingOccurrences(of: "-", with: ""))",
+                            createdAt: Date(),
+                            updatedAt: Date()
+                        ))))
+        }
+
+        // MARK: - Agents
+
+        func listAgents(_ input: Operations.ListAgents.Input) async throws -> Operations.ListAgents.Output {
+            .ok(.init(body: .json(agents)))
+        }
+
+        func getAgent(_ input: Operations.GetAgent.Input) async throws -> Operations.GetAgent.Output {
+            .ok(
+                .init(
+                    body: .json(
+                        try require(
+                            agents.first { $0.id.rawValue == input.path.agentId }
+                        ))))
+        }
+
+        // MARK: - Lookups
+
+        private func thread(_ id: String) throws -> ATCThread {
+            try require((threads + archivedThreads).first { $0.id == id })
+        }
+
+        private func require<T>(_ value: T?) throws -> T {
+            guard let value else { throw PreviewUnavailable() }
+            return value
+        }
+
+        private static func newID() -> String {
+            UUID().uuidString.lowercased()
+        }
     }
 
-    // MARK: - Agents
-
-    func listAgents(_ input: Operations.ListAgents.Input) async throws -> Operations.ListAgents.Output {
-        .ok(.init(body: .json(agents)))
+    /// The preview client's only failure: a lookup that misses the fixtures.
+    struct PreviewUnavailable: LocalizedError {
+        var errorDescription: String? { "Not available in previews." }
     }
-
-    func getAgent(_ input: Operations.GetAgent.Input) async throws -> Operations.GetAgent.Output {
-        .ok(.init(body: .json(try require(
-            agents.first { $0.id.rawValue == input.path.agentId }
-        ))))
-    }
-
-    // MARK: - Lookups
-
-    private func thread(_ id: String) throws -> ATCThread {
-        try require((threads + archivedThreads).first { $0.id == id })
-    }
-
-    private func require<T>(_ value: T?) throws -> T {
-        guard let value else { throw PreviewUnavailable() }
-        return value
-    }
-
-    private static func newID() -> String {
-        UUID().uuidString.lowercased()
-    }
-}
-
-/// The preview client's only failure: a lookup that misses the fixtures.
-struct PreviewUnavailable: LocalizedError {
-    var errorDescription: String? { "Not available in previews." }
-}
 
 #endif

--- a/macos/ATC/RootView.swift
+++ b/macos/ATC/RootView.swift
@@ -59,14 +59,20 @@ struct RootView: View {
         .sheet(isPresented: $windowState.isCreateProjectPresented) {
             CreateProjectSheet()
         }
-        .sheet(item: $windowState.newThreadContext, onDismiss: {
-            windowState.requestTerminalFocus()
-        }) { context in
+        .sheet(
+            item: $windowState.newThreadContext,
+            onDismiss: {
+                windowState.requestTerminalFocus()
+            }
+        ) { context in
             NewThreadSheet(context: context)
         }
-        .sheet(item: $windowState.newTerminalProject, onDismiss: {
-            windowState.requestTerminalFocus()
-        }) { ref in
+        .sheet(
+            item: $windowState.newTerminalProject,
+            onDismiss: {
+                windowState.requestTerminalFocus()
+            }
+        ) { ref in
             NewTerminalSheet(projectRef: ref)
         }
         // Returning to the app with a freshly finished thread on screen
@@ -124,14 +130,15 @@ struct RootView: View {
     private var exceptionalStatus: some View {
         HStack(spacing: Spacing.md) {
             if let ref = selectedThread,
-               appModel.thread(for: ref)?.activityState == .needsInput {
+                appModel.thread(for: ref)?.activityState == .needsInput
+            {
                 Label(
                     ThreadActivityState.needsInput.detailLabel,
                     systemImage: "exclamationmark.bubble.fill"
                 )
-                    .font(.callout.weight(.medium))
-                    .foregroundStyle(Color.accentColor)
-                    .help("The agent is waiting for your input")
+                .font(.callout.weight(.medium))
+                .foregroundStyle(Color.accentColor)
+                .help("The agent is waiting for your input")
             }
             if let name = unreachableConnectionName {
                 Label("\(name) unreachable", systemImage: "wifi.exclamationmark")
@@ -182,19 +189,21 @@ struct RootView: View {
 // are not.
 #if DEBUG
 
-#Preview {
-    let appModel = AppModel.preview()
-    let windowState = WindowState()
-    let configStore = ConfigurationStore()
-    RootView()
-        .environment(appModel)
-        .environment(windowState)
-        .environment(WindowKeyboardRouter.forWindow(
-            appModel: appModel,
-            windowState: windowState,
-            configStore: configStore
-        ))
-        .preferredColorScheme(.dark)
-}
+    #Preview {
+        let appModel = AppModel.preview()
+        let windowState = WindowState()
+        let configStore = ConfigurationStore()
+        RootView()
+            .environment(appModel)
+            .environment(windowState)
+            .environment(
+                WindowKeyboardRouter.forWindow(
+                    appModel: appModel,
+                    windowState: windowState,
+                    configStore: configStore
+                )
+            )
+            .preferredColorScheme(.dark)
+    }
 
 #endif

--- a/macos/ATC/Settings/ConnectionsSettingsView.swift
+++ b/macos/ATC/Settings/ConnectionsSettingsView.swift
@@ -49,7 +49,9 @@ struct ConnectionsSettingsView: View {
                 }
             }
         } message: {
-            Text("This removes the connection from atc only. Its Projects and Terminal Sessions remain on the atc server.")
+            Text(
+                "This removes the connection from atc only. Its Projects and Terminal Sessions remain on the atc server."
+            )
         }
     }
 
@@ -230,7 +232,9 @@ private struct ConnectionEditorView: View {
         ) {
             Button("Save and Disconnect", role: .destructive) { performSave() }
         } message: {
-            Text("Changing the URL or token reconnects this connection, and its open terminals will be disconnected. They keep running on the server.")
+            Text(
+                "Changing the URL or token reconnects this connection, and its open terminals will be disconnected. They keep running on the server."
+            )
         }
     }
 
@@ -256,8 +260,9 @@ private struct ConnectionEditorView: View {
     private func save() {
         saveError = nil
         if let record = currentRecord,
-           appModel.wouldRebuildConnection(id: record.id, urlString: urlString, token: token),
-           appModel.hasLiveTerminals(connectionID: record.id) {
+            appModel.wouldRebuildConnection(id: record.id, urlString: urlString, token: token),
+            appModel.hasLiveTerminals(connectionID: record.id)
+        {
             confirmRebuild = true
             return
         }
@@ -290,7 +295,8 @@ private struct ConnectionEditorView: View {
 
     func testConnection() {
         guard let origin = ConnectionURL.parse(urlString),
-              let url = URL(string: origin.urlString) else { return }
+            let url = URL(string: origin.urlString)
+        else { return }
         testGeneration += 1
         let generation = testGeneration
         let draftToken = token
@@ -325,22 +331,22 @@ private struct ConnectionEditorView: View {
 // are not.
 #if DEBUG
 
-#Preview("Connections — populated") {
-    ConnectionsSettingsView()
-        .environment(AppModel.preview())
-        .frame(width: 700, height: 450)
-        .preferredColorScheme(.dark)
-}
+    #Preview("Connections — populated") {
+        ConnectionsSettingsView()
+            .environment(AppModel.preview())
+            .frame(width: 700, height: 450)
+            .preferredColorScheme(.dark)
+    }
 
-#Preview("Connections — empty") {
-    let store = ConnectionsStore(
-        defaults: UserDefaults(suiteName: "preview.connections.empty")!,
-        credentials: InMemoryCredentialStore()
-    )
-    return ConnectionsSettingsView()
-        .environment(AppModel(connections: store))
-        .frame(width: 700, height: 450)
-        .preferredColorScheme(.dark)
-}
+    #Preview("Connections — empty") {
+        let store = ConnectionsStore(
+            defaults: UserDefaults(suiteName: "preview.connections.empty")!,
+            credentials: InMemoryCredentialStore()
+        )
+        return ConnectionsSettingsView()
+            .environment(AppModel(connections: store))
+            .frame(width: 700, height: 450)
+            .preferredColorScheme(.dark)
+    }
 
 #endif

--- a/macos/ATC/Settings/CredentialStore.swift
+++ b/macos/ATC/Settings/CredentialStore.swift
@@ -36,7 +36,8 @@ nonisolated final class KeychainCredentialStore: CredentialStore {
         query[kSecMatchLimit as String] = kSecMatchLimitOne
         var result: CFTypeRef?
         guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
-              let data = result as? Data else { return nil }
+            let data = result as? Data
+        else { return nil }
         return String(data: data, encoding: .utf8)
     }
 

--- a/macos/ATC/Settings/NotificationsSettingsView.swift
+++ b/macos/ATC/Settings/NotificationsSettingsView.swift
@@ -18,9 +18,11 @@ struct NotificationsSettingsView: View {
             Section {
                 Toggle("Notify me when a thread finishes or needs input", isOn: $isEnabled)
             } footer: {
-                Text("Banners appear only while atc is in the background, and come down once you have seen the thread — from any client.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                Text(
+                    "Banners appear only while atc is in the background, and come down once you have seen the thread — from any client."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
             }
             if isEnabled, isDenied {
                 Section {
@@ -51,25 +53,28 @@ struct NotificationsSettingsView: View {
     }
 
     private func readAuthorization() async {
-        isDenied = await UNUserNotificationCenter.current()
+        isDenied =
+            await UNUserNotificationCenter.current()
             .notificationSettings().authorizationStatus == .denied
     }
 
     private func openSystemSettings() {
         let bundleID = Bundle.main.bundleIdentifier ?? ""
-        guard let url = URL(
-            string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension?id=\(bundleID)"
-        ) else { return }
+        guard
+            let url = URL(
+                string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension?id=\(bundleID)"
+            )
+        else { return }
         NSWorkspace.shared.open(url)
     }
 }
 
 #if DEBUG
 
-#Preview("Notifications") {
-    NotificationsSettingsView()
-        .frame(width: 700, height: 450)
-        .preferredColorScheme(.dark)
-}
+    #Preview("Notifications") {
+        NotificationsSettingsView()
+            .frame(width: 700, height: 450)
+            .preferredColorScheme(.dark)
+    }
 
 #endif

--- a/macos/ATC/Settings/SettingsView.swift
+++ b/macos/ATC/Settings/SettingsView.swift
@@ -23,10 +23,10 @@ struct SettingsView: View {
 // are not.
 #if DEBUG
 
-#Preview("Settings") {
-    SettingsView()
-        .environment(AppModel.preview())
-        .preferredColorScheme(.dark)
-}
+    #Preview("Settings") {
+        SettingsView()
+            .environment(AppModel.preview())
+            .preferredColorScheme(.dark)
+    }
 
 #endif

--- a/macos/ATC/Shared/DirectoryPickerSheet.swift
+++ b/macos/ATC/Shared/DirectoryPickerSheet.swift
@@ -51,7 +51,8 @@ final class DirectoryPickerModel {
                 // The server's tagged diagnostic (missing / inaccessible /
                 // not a directory / timed out) already reads well.
                 let body = try failure.body.json
-                errorMessage = body.value1?.message ?? body.value2?.message
+                errorMessage =
+                    body.value1?.message ?? body.value2?.message
                     ?? "The server couldn't list that folder."
             case .undocumented(statusCode: let status, _):
                 errorMessage = "Unexpected server response (\(status))."

--- a/macos/ATC/Shared/ErrorAlert.swift
+++ b/macos/ATC/Shared/ErrorAlert.swift
@@ -7,10 +7,13 @@ extension View {
         _ error: Binding<String?>,
         title: String = "Action Failed"
     ) -> some View {
-        alert(title, isPresented: Binding(
-            get: { error.wrappedValue != nil },
-            set: { if !$0 { error.wrappedValue = nil } }
-        )) {
+        alert(
+            title,
+            isPresented: Binding(
+                get: { error.wrappedValue != nil },
+                set: { if !$0 { error.wrappedValue = nil } }
+            )
+        ) {
             Button("OK", role: .cancel) {}
         } message: {
             Text(error.wrappedValue ?? "")

--- a/macos/ATC/Shared/QueryMatcher.swift
+++ b/macos/ATC/Shared/QueryMatcher.swift
@@ -14,9 +14,10 @@ enum QueryMatcher {
         }
 
         let wordStarts = wordStartIndices(in: title)
-        let initials = String(wordStarts.compactMap {
-            String(title[$0]).lowercased().first
-        })
+        let initials = String(
+            wordStarts.compactMap {
+                String(title[$0]).lowercased().first
+            })
         guard let match = initials.range(of: trimmed.lowercased()) else { return nil }
 
         let offset = initials.distance(from: initials.startIndex, to: match.lowerBound)

--- a/macos/ATC/SidebarShortcuts.swift
+++ b/macos/ATC/SidebarShortcuts.swift
@@ -58,7 +58,8 @@ enum SidebarShortcuts {
         isPinnedExpanded: Bool,
         isRecentExpanded: Bool
     ) -> [ThreadRef] {
-        let rows = limited(model.pinned, expanded: isPinnedExpanded)
+        let rows =
+            limited(model.pinned, expanded: isPinnedExpanded)
             + limited(model.recent, expanded: isRecentExpanded)
         return rows.prefix(slotCount).map(\.ref)
     }
@@ -98,7 +99,7 @@ enum SidebarShortcuts {
             Task { await windowState.openThread(ref, in: appModel) }
         case .terminal(let slot):
             guard let project = windowState.activeProject,
-                  let store = appModel.runtime(id: project.connectionID)?.terminals
+                let store = appModel.runtime(id: project.connectionID)?.terminals
             else { return }
             let targets = terminalTargets(
                 store.standaloneTerminals(projectID: project.projectID),

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -1,7 +1,7 @@
-import AppKit
 import ATCAppServerAPI
-import SwiftUI
+import AppKit
 import Observation
+import SwiftUI
 
 enum MainContentSelection: Equatable, Sendable {
     case dashboard
@@ -230,7 +230,8 @@ final class WindowState {
         if case .project(let ref) = threadFilter {
             if let runtime = appModel.runtime(id: ref.connectionID) {
                 if runtime.projects.isResolved,
-                   runtime.projects.project(id: ref.projectID) == nil {
+                    runtime.projects.project(id: ref.projectID) == nil
+                {
                     threadFilter = .all
                 }
             } else {
@@ -241,7 +242,8 @@ final class WindowState {
         if let activeProject {
             if let runtime = appModel.runtime(id: activeProject.connectionID) {
                 if runtime.projects.isResolved,
-                   runtime.projects.project(id: activeProject.projectID) == nil {
+                    runtime.projects.project(id: activeProject.projectID) == nil
+                {
                     self.activeProject = nil
                 }
             } else {
@@ -261,7 +263,8 @@ final class WindowState {
         if let ref = returnThread {
             if let runtime = appModel.runtime(id: ref.connectionID) {
                 if runtime.threads.isResolved,
-                   appModel.thread(for: ref)?.isArchived != false {
+                    appModel.thread(for: ref)?.isArchived != false
+                {
                     returnThread = nil
                 }
             } else {
@@ -315,7 +318,8 @@ final class WindowState {
     /// returns, so the displayed thread must not keep reading "Done".
     func markSelectedThreadViewedIfNeeded(in appModel: AppModel) {
         guard case .thread(let ref) = selectedContent,
-              let thread = appModel.thread(for: ref) else { return }
+            let thread = appModel.thread(for: ref)
+        else { return }
         markViewedIfDisplayed(ref, thread: thread, in: appModel)
     }
 
@@ -350,7 +354,8 @@ final class WindowState {
             let linkedRef = TerminalRef(connectionID: ref.connectionID, terminalID: linkedID)
             threadTerminals[ref] = linkedRef
             if let terminal = appModel.terminal(for: linkedRef), terminal.isLive,
-               appModel.terminals[linkedRef] == nil {
+                appModel.terminals[linkedRef] == nil
+            {
                 appModel.attachIfNeeded(
                     to: terminal,
                     connectionID: ref.connectionID,

--- a/macos/ATCTests/AppModelRuntimeTests.swift
+++ b/macos/ATCTests/AppModelRuntimeTests.swift
@@ -1,6 +1,7 @@
+import ATCAppServerAPI
 import Foundation
 import Testing
-import ATCAppServerAPI
+
 @testable import ATC
 
 /// Runtime lifecycle (add / name-only edit / rebuild / delete), thread
@@ -97,8 +98,9 @@ struct AppModelRuntimeTests {
         #expect(warm.connections[0].threadsCurrent)
         #expect(warm.connections[0].terminalsCurrent)
         // Both lists feed the snapshot so archived threads reconcile too.
-        #expect(Set(warm.connections[0].threads.map(\.id))
-            == ["thr1", "thr2", "thr3", "thr_archived"])
+        #expect(
+            Set(warm.connections[0].threads.map(\.id))
+                == ["thr1", "thr2", "thr3", "thr_archived"])
         #expect(warm.connections[0].threads.filter(\.isArchived).map(\.id) == ["thr_archived"])
         #expect(Set(warm.connections[0].terminals.map(\.id)) == ["trm_live", "trm_ended"])
         #expect(warm.connections[0].terminals.filter(\.isLive).map(\.id) == ["trm_live"])

--- a/macos/ATCTests/AttachmentBudgetTests.swift
+++ b/macos/ATCTests/AttachmentBudgetTests.swift
@@ -1,6 +1,7 @@
+import ATCAppServerAPI
 import Foundation
 import Testing
-import ATCAppServerAPI
+
 @testable import ATC
 
 /// The LRU attachment budget: attaching past the budget evicts the

--- a/macos/ATCTests/CommandPaletteContentTests.swift
+++ b/macos/ATCTests/CommandPaletteContentTests.swift
@@ -1,6 +1,7 @@
+import ATCAppServerAPI
 import Foundation
 import Testing
-import ATCAppServerAPI
+
 @testable import ATC
 
 /// What the palette offers, per presentation. Assertions stay structural —

--- a/macos/ATCTests/CommandRegistryTests.swift
+++ b/macos/ATCTests/CommandRegistryTests.swift
@@ -1,7 +1,8 @@
+import ATCAppServerAPI
 import Foundation
 import SwiftUI
 import Testing
-import ATCAppServerAPI
+
 @testable import ATC
 
 /// The command surface: every id has a descriptor, availability gates the
@@ -21,10 +22,11 @@ struct CommandRegistryTests {
         CommandContext(
             appModel: model,
             windowState: state,
-            configStore: store ?? ConfigurationStore(
-                configURL: FileManager.default.temporaryDirectory
-                    .appending(path: UUID().uuidString)
-            )
+            configStore: store
+                ?? ConfigurationStore(
+                    configURL: FileManager.default.temporaryDirectory
+                        .appending(path: UUID().uuidString)
+                )
         )
     }
 
@@ -45,20 +47,22 @@ struct CommandRegistryTests {
 
     @Test("every command id has exactly one titled descriptor")
     func descriptors() {
-        #expect(CommandID.allCases.map(\.rawValue) == [
-            "view.toggle-sidebar", "view.toggle-command-palette",
-            "view.search-threads", "view.search-terminals",
-            "view.show-dashboard", "thread.new", "terminal.new",
-            "project.new", "data.refresh", "configuration.reload",
-            "configuration.reveal",
-        ])
+        #expect(
+            CommandID.allCases.map(\.rawValue) == [
+                "view.toggle-sidebar", "view.toggle-command-palette",
+                "view.search-threads", "view.search-terminals",
+                "view.show-dashboard", "thread.new", "terminal.new",
+                "project.new", "data.refresh", "configuration.reload",
+                "configuration.reveal",
+            ])
         let descriptors = CommandRegistry.allDescriptors
         #expect(descriptors.map(\.id) == CommandID.allCases)
         #expect(Set(descriptors.map(\.id)).count == descriptors.count)
         #expect(descriptors.allSatisfy { !$0.title.isEmpty })
         // The palette openers never list themselves.
-        #expect(descriptors.filter { !$0.isPaletteEligible }.map(\.id)
-            == [.toggleCommandPalette, .searchThreads, .searchTerminals])
+        #expect(
+            descriptors.filter { !$0.isPaletteEligible }.map(\.id)
+                == [.toggleCommandPalette, .searchThreads, .searchTerminals])
     }
 
     @Test("commands that need no server are always available")

--- a/macos/ATCTests/ConfigurationLoaderTests.swift
+++ b/macos/ATCTests/ConfigurationLoaderTests.swift
@@ -1,94 +1,109 @@
 import Foundation
 import Testing
+
 @testable import ATC
 
 @Suite("Configuration loader")
 struct ConfigurationLoaderTests {
     @Test("supported tables decode with spec-compliant TOML strings and whitespace")
     func validRealTOML() throws {
-        let parsed = ConfigurationLoader.parse(#"""
-          [keyboard]
-          leader = 'cmd+k'
-          clear_default_keybindings = false
+        let parsed = ConfigurationLoader.parse(
+            #"""
+              [keyboard]
+              leader = 'cmd+k'
+              clear_default_keybindings = false
 
-          [keybindings]
-          'cmd+b'='view.toggle-sidebar'
-          'leader>b' = "view.toggle-sidebar"
-        """#)
+              [keybindings]
+              'cmd+b'='view.toggle-sidebar'
+              'leader>b' = "view.toggle-sidebar"
+            """#)
 
         #expect(parsed.diagnostics.isEmpty)
         #expect(parsed.tables["keyboard"]?.count == 2)
         #expect(parsed.tables["keybindings"]?.map(\.key) == ["cmd+b", "leader>b"])
-        #expect(try Keymap.resolve(user: parsed).get().menuShortcuts[.toggleSidebar]
-            == KeyStroke(key: "b", modifiers: .command))
+        #expect(
+            try Keymap.resolve(user: parsed).get().menuShortcuts[.toggleSidebar]
+                == KeyStroke(key: "b", modifiers: .command))
     }
 
     @Test("unknown top-level tables are rejected")
     func unknownTable() {
-        let parsed = ConfigurationLoader.parse(#"""
-        [display]
-        scale = 2
-        """#)
+        let parsed = ConfigurationLoader.parse(
+            #"""
+            [display]
+            scale = 2
+            """#)
 
-        #expect(parsed.diagnostics.contains {
-            $0.severity == .error
-                && $0.message.contains("[display]")
-                && $0.message.contains("not a recognized table")
-        })
+        #expect(
+            parsed.diagnostics.contains {
+                $0.severity == .error
+                    && $0.message.contains("[display]")
+                    && $0.message.contains("not a recognized table")
+            })
     }
 
     @Test("top-level bare keys are rejected")
     func topLevelKey() {
         let parsed = ConfigurationLoader.parse("leader = \"cmd+k\"")
-        #expect(parsed.diagnostics.contains {
-            $0.message.contains("Top-level key 'leader'")
-        })
+        #expect(
+            parsed.diagnostics.contains {
+                $0.message.contains("Top-level key 'leader'")
+            })
     }
 
     @Test("unknown keyboard keys are errors with their full path")
     func unknownKeyboardKey() {
-        let parsed = ConfigurationLoader.parse(#"""
-        [keyboard]
-        typo = true
-        """#)
+        let parsed = ConfigurationLoader.parse(
+            #"""
+            [keyboard]
+            typo = true
+            """#)
 
-        #expect(parsed.diagnostics == [.init(
-            severity: .error,
-            message: "[keyboard].typo is not recognized"
-        )])
+        #expect(
+            parsed.diagnostics == [
+                .init(
+                    severity: .error,
+                    message: "[keyboard].typo is not recognized"
+                )
+            ])
     }
 
     @Test("wrong scalar types name every affected table and key")
     func wrongTypes() {
-        let parsed = ConfigurationLoader.parse(#"""
-        [keyboard]
-        leader = false
-        clear_default_keybindings = "no"
+        let parsed = ConfigurationLoader.parse(
+            #"""
+            [keyboard]
+            leader = false
+            clear_default_keybindings = "no"
 
-        [keybindings]
-        "cmd+b" = true
-        """#)
+            [keybindings]
+            "cmd+b" = true
+            """#)
         let messages = parsed.diagnostics.map(\.message)
 
-        #expect(messages.contains {
-            $0.contains("[keyboard].leader") && $0.contains("string")
-        })
-        #expect(messages.contains {
-            $0.contains("[keyboard].clear_default_keybindings")
-                && $0.contains("boolean")
-        })
-        #expect(messages.contains {
-            $0.contains(#"[keybindings]."cmd+b""#) && $0.contains("string")
-        })
+        #expect(
+            messages.contains {
+                $0.contains("[keyboard].leader") && $0.contains("string")
+            })
+        #expect(
+            messages.contains {
+                $0.contains("[keyboard].clear_default_keybindings")
+                    && $0.contains("boolean")
+            })
+        #expect(
+            messages.contains {
+                $0.contains(#"[keybindings]."cmd+b""#) && $0.contains("string")
+            })
     }
 
     @Test("duplicate keys are TOML parser errors")
     func duplicateKey() {
-        let parsed = ConfigurationLoader.parse(#"""
-        [keybindings]
-        "cmd+b" = "data.refresh"
-        "cmd+b" = "view.toggle-sidebar"
-        """#)
+        let parsed = ConfigurationLoader.parse(
+            #"""
+            [keybindings]
+            "cmd+b" = "data.refresh"
+            "cmd+b" = "view.toggle-sidebar"
+            """#)
 
         #expect(parsed.tables.isEmpty)
         #expect(parsed.diagnostics.count == 1)
@@ -100,11 +115,12 @@ struct ConfigurationLoaderTests {
 
     @Test("TOML syntax errors retain the decoder's line context")
     func syntaxErrorLine() {
-        let parsed = ConfigurationLoader.parse(#"""
-        [keyboard]
-        leader = "cmd+k"
-        broken =
-        """#)
+        let parsed = ConfigurationLoader.parse(
+            #"""
+            [keyboard]
+            leader = "cmd+k"
+            broken =
+            """#)
 
         #expect(parsed.tables.isEmpty)
         #expect(parsed.diagnostics.count == 1)
@@ -120,31 +136,35 @@ struct ConfigurationLoaderTests {
 
     @Test("terminal table decodes every supported preference")
     func terminalHappyPath() {
-        let parsed = ConfigurationLoader.parse(#"""
-        [terminal]
-        theme = "Catppuccin Mocha"
-        font_family = "Berkeley Mono"
-        font_size = 14.0
-        padding_x = 8
-        padding_y = 9
-        """#)
+        let parsed = ConfigurationLoader.parse(
+            #"""
+            [terminal]
+            theme = "Catppuccin Mocha"
+            font_family = "Berkeley Mono"
+            font_size = 14.0
+            padding_x = 8
+            padding_y = 9
+            """#)
 
         #expect(parsed.diagnostics.isEmpty)
-        #expect(parsed.terminal == TerminalPreferences(
-            theme: "Catppuccin Mocha",
-            fontFamily: "Berkeley Mono",
-            fontSize: 14,
-            paddingX: 8,
-            paddingY: 9
-        ))
+        #expect(
+            parsed.terminal
+                == TerminalPreferences(
+                    theme: "Catppuccin Mocha",
+                    fontFamily: "Berkeley Mono",
+                    fontSize: 14,
+                    paddingX: 8,
+                    paddingY: 9
+                ))
     }
 
     @Test("terminal accepts integer font size")
     func terminalIntegerFontSize() {
-        let parsed = ConfigurationLoader.parse(#"""
-        [terminal]
-        font_size = 14
-        """#)
+        let parsed = ConfigurationLoader.parse(
+            #"""
+            [terminal]
+            font_size = 14
+            """#)
 
         #expect(parsed.diagnostics.isEmpty)
         #expect(parsed.terminal.fontSize == 14)
@@ -152,15 +172,16 @@ struct ConfigurationLoaderTests {
 
     @Test("terminal rejects unknown keys and wrong scalar types with full paths")
     func terminalSchemaAndTypes() {
-        let parsed = ConfigurationLoader.parse(#"""
-        [terminal]
-        typo = true
-        theme = 1
-        font_family = false
-        font_size = "14"
-        padding_x = 1.5
-        padding_y = "8"
-        """#)
+        let parsed = ConfigurationLoader.parse(
+            #"""
+            [terminal]
+            typo = true
+            theme = 1
+            font_family = false
+            font_size = "14"
+            padding_x = 1.5
+            padding_y = "8"
+            """#)
         let messages = parsed.diagnostics.map(\.message)
 
         for key in [
@@ -176,17 +197,19 @@ struct ConfigurationLoaderTests {
     func terminalBackgroundKeysRemoved() {
         // The terminal background is app-owned; the old customization keys
         // must fail loudly instead of silently doing nothing.
-        let parsed = ConfigurationLoader.parse(#"""
-        [terminal]
-        background = "1e1e2e"
-        background_opacity = 0.95
-        """#)
+        let parsed = ConfigurationLoader.parse(
+            #"""
+            [terminal]
+            background = "1e1e2e"
+            background_opacity = 0.95
+            """#)
         let messages = parsed.diagnostics.map(\.message)
 
         for key in ["background", "background_opacity"] {
-            #expect(messages.contains {
-                $0.contains("[terminal].\(key)") && $0.contains("not recognized")
-            })
+            #expect(
+                messages.contains {
+                    $0.contains("[terminal].\(key)") && $0.contains("not recognized")
+                })
         }
     }
 
@@ -194,47 +217,60 @@ struct ConfigurationLoaderTests {
     func terminalNumericRanges() {
         for value in ["0", "-1", "inf", "nan", "1e300"] {
             let parsed = ConfigurationLoader.parse("[terminal]\nfont_size = \(value)")
-            #expect(parsed.diagnostics.contains {
-                $0.message.contains("[terminal].font_size")
-            })
+            #expect(
+                parsed.diagnostics.contains {
+                    $0.message.contains("[terminal].font_size")
+                })
         }
 
         for key in ["padding_x", "padding_y"] {
             let parsed = ConfigurationLoader.parse("[terminal]\n\(key) = -1")
-            #expect(parsed.diagnostics.contains {
-                $0.message.contains("[terminal].\(key)")
-                    && $0.message.contains("non-negative")
-            })
+            #expect(
+                parsed.diagnostics.contains {
+                    $0.message.contains("[terminal].\(key)")
+                        && $0.message.contains("non-negative")
+                })
         }
     }
 
     @Test("terminal requires non-empty font family")
     func terminalEmptyFontFamily() {
-        let parsed = ConfigurationLoader.parse(#"""
-        [terminal]
-        font_family = "   "
-        """#)
+        let parsed = ConfigurationLoader.parse(
+            #"""
+            [terminal]
+            font_family = "   "
+            """#)
 
-        #expect(parsed.diagnostics == [.init(
-            severity: .error,
-            message: "[terminal].font_family must be a non-empty string"
-        )])
+        #expect(
+            parsed.diagnostics == [
+                .init(
+                    severity: .error,
+                    message: "[terminal].font_family must be a non-empty string"
+                )
+            ])
     }
 
     @Test("terminal theme names are validated against the real catalog")
     func terminalThemeValidation() {
-        #expect(ConfigurationLoader.parse(#"""
-        [terminal]
-        theme = "Catppuccin Mocha"
-        """#).diagnostics.isEmpty)
+        #expect(
+            ConfigurationLoader.parse(
+                #"""
+                [terminal]
+                theme = "Catppuccin Mocha"
+                """#
+            ).diagnostics.isEmpty)
 
-        let unknown = ConfigurationLoader.parse(#"""
-        [terminal]
-        theme = "Definitely Not A Real Theme"
-        """#)
-        #expect(unknown.diagnostics == [.init(
-            severity: .error,
-            message: #"[terminal].theme "Definitely Not A Real Theme" is not a known theme"#
-        )])
+        let unknown = ConfigurationLoader.parse(
+            #"""
+            [terminal]
+            theme = "Definitely Not A Real Theme"
+            """#)
+        #expect(
+            unknown.diagnostics == [
+                .init(
+                    severity: .error,
+                    message: #"[terminal].theme "Definitely Not A Real Theme" is not a known theme"#
+                )
+            ])
     }
 }

--- a/macos/ATCTests/ConfigurationStoreTests.swift
+++ b/macos/ATCTests/ConfigurationStoreTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+
 @testable import ATC
 
 @MainActor
@@ -30,27 +31,30 @@ struct ConfigurationStoreTests {
         #expect(store.configuration.keymap.generation == 1)
         #expect(store.notice == nil)
         #expect(store.diagnostics.isEmpty)
-        #expect(store.configuration.keymap.menuShortcuts[.toggleSidebar]
-            == KeyStroke(key: "b", modifiers: .command))
+        #expect(
+            store.configuration.keymap.menuShortcuts[.toggleSidebar]
+                == KeyStroke(key: "b", modifiers: .command))
     }
 
     @Test("launch with a valid file publishes its complete configuration")
     func validLaunch() throws {
         let fixture = try fixture()
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
-        try write(#"""
-        [keyboard]
-        clear_default_keybindings = true
-        [keybindings]
-        "ctrl+b" = "view.toggle-sidebar"
-        """#, to: fixture.config)
+        try write(
+            #"""
+            [keyboard]
+            clear_default_keybindings = true
+            [keybindings]
+            "ctrl+b" = "view.toggle-sidebar"
+            """#, to: fixture.config)
         let store = ConfigurationStore(configURL: fixture.config)
 
         store.loadAtLaunchIfNeeded()
 
         #expect(store.configuration.keymap.generation == 1)
-        #expect(store.configuration.keymap.menuShortcuts[.toggleSidebar]
-            == KeyStroke(key: "b", modifiers: .control))
+        #expect(
+            store.configuration.keymap.menuShortcuts[.toggleSidebar]
+                == KeyStroke(key: "b", modifiers: .control))
         #expect(store.notice == nil)
     }
 
@@ -58,18 +62,20 @@ struct ConfigurationStoreTests {
     func invalidLaunch() throws {
         let fixture = try fixture()
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
-        try write(#"""
-        [keybindings]
-        "cmd+c" = "data.refresh"
-        "cmd+shift+x" = "unknown.command"
-        """#, to: fixture.config)
+        try write(
+            #"""
+            [keybindings]
+            "cmd+c" = "data.refresh"
+            "cmd+shift+x" = "unknown.command"
+            """#, to: fixture.config)
         let store = ConfigurationStore(configURL: fixture.config)
 
         store.loadAtLaunchIfNeeded()
 
         #expect(store.configuration.keymap.generation == 0)
-        #expect(store.configuration.keymap.menuShortcuts[.toggleSidebar]
-            == KeyStroke(key: "b", modifiers: .command))
+        #expect(
+            store.configuration.keymap.menuShortcuts[.toggleSidebar]
+                == KeyStroke(key: "b", modifiers: .command))
         #expect(store.notice?.message.contains("using defaults") == true)
         #expect(store.notice?.message.contains("First error:") == true)
         #expect(store.diagnostics.count { $0.severity == .error } == 2)
@@ -81,25 +87,28 @@ struct ConfigurationStoreTests {
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
         let store = ConfigurationStore(configURL: fixture.config)
         store.loadAtLaunchIfNeeded()
-        try write(#"""
-        [keyboard]
-        mystery = true
-        """#, to: fixture.config)
+        try write(
+            #"""
+            [keyboard]
+            mystery = true
+            """#, to: fixture.config)
         store.reload()
         #expect(store.notice != nil)
 
-        try write(#"""
-        [keyboard]
-        clear_default_keybindings = true
-        [keybindings]
-        "ctrl+r" = "data.refresh"
-        """#, to: fixture.config)
+        try write(
+            #"""
+            [keyboard]
+            clear_default_keybindings = true
+            [keybindings]
+            "ctrl+r" = "data.refresh"
+            """#, to: fixture.config)
 
         store.reload()
 
         #expect(store.configuration.keymap.generation == 2)
-        #expect(store.configuration.keymap.menuShortcuts[.refresh]
-            == KeyStroke(key: "r", modifiers: .control))
+        #expect(
+            store.configuration.keymap.menuShortcuts[.refresh]
+                == KeyStroke(key: "r", modifiers: .control))
         #expect(store.notice == nil)
     }
 
@@ -107,32 +116,36 @@ struct ConfigurationStoreTests {
     func failedReload() throws {
         let fixture = try fixture()
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
-        try write(#"""
-        [keybindings]
-        "ctrl+r" = "data.refresh"
-        """#, to: fixture.config)
+        try write(
+            #"""
+            [keybindings]
+            "ctrl+r" = "data.refresh"
+            """#, to: fixture.config)
         let store = ConfigurationStore(configURL: fixture.config)
         store.loadAtLaunchIfNeeded()
         let previousGeneration = store.configuration.keymap.generation
         let previousShortcut = store.configuration.keymap.menuShortcuts[.refresh]
 
-        try write(#"""
-        [keyboard]
-        leader = false
-        mystery = true
-        """#, to: fixture.config)
+        try write(
+            #"""
+            [keyboard]
+            leader = false
+            mystery = true
+            """#, to: fixture.config)
         store.reload()
 
         #expect(store.configuration.keymap.generation == previousGeneration)
         #expect(store.configuration.keymap.menuShortcuts[.refresh] == previousShortcut)
         #expect(store.notice?.message.contains("keeping the previous configuration") == true)
         #expect(store.notice?.message.contains("[keyboard]") == true)
-        #expect(store.diagnostics.contains {
-            $0.severity == .error && $0.message.contains("[keyboard].leader")
-        })
-        #expect(store.diagnostics.contains {
-            $0.severity == .error && $0.message.contains("[keyboard].mystery")
-        })
+        #expect(
+            store.diagnostics.contains {
+                $0.severity == .error && $0.message.contains("[keyboard].leader")
+            })
+        #expect(
+            store.diagnostics.contains {
+                $0.severity == .error && $0.message.contains("[keyboard].mystery")
+            })
 
         store.dismissNotice()
         #expect(store.notice == nil)
@@ -142,12 +155,13 @@ struct ConfigurationStoreTests {
     func deletedReload() throws {
         let fixture = try fixture()
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
-        try write(#"""
-        [keyboard]
-        clear_default_keybindings = true
-        [keybindings]
-        "ctrl+b" = "view.toggle-sidebar"
-        """#, to: fixture.config)
+        try write(
+            #"""
+            [keyboard]
+            clear_default_keybindings = true
+            [keybindings]
+            "ctrl+b" = "view.toggle-sidebar"
+            """#, to: fixture.config)
         let store = ConfigurationStore(configURL: fixture.config)
         store.loadAtLaunchIfNeeded()
         try FileManager.default.removeItem(at: fixture.config)
@@ -155,8 +169,9 @@ struct ConfigurationStoreTests {
         store.reload()
 
         #expect(store.configuration.keymap.generation == 2)
-        #expect(store.configuration.keymap.menuShortcuts[.toggleSidebar]
-            == KeyStroke(key: "b", modifiers: .command))
+        #expect(
+            store.configuration.keymap.menuShortcuts[.toggleSidebar]
+                == KeyStroke(key: "b", modifiers: .command))
         #expect(store.notice == nil)
         #expect(store.diagnostics.isEmpty)
     }
@@ -165,12 +180,13 @@ struct ConfigurationStoreTests {
     func terminalFailureIsTransactional() throws {
         let fixture = try fixture()
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
-        try write(#"""
-        [terminal]
-        font_family = "Berkeley Mono"
-        [keybindings]
-        "ctrl+r" = "data.refresh"
-        """#, to: fixture.config)
+        try write(
+            #"""
+            [terminal]
+            font_family = "Berkeley Mono"
+            [keybindings]
+            "ctrl+r" = "data.refresh"
+            """#, to: fixture.config)
         var applied: [TerminalPreferences] = []
         let store = ConfigurationStore(
             configURL: fixture.config,
@@ -179,19 +195,21 @@ struct ConfigurationStoreTests {
         store.loadAtLaunchIfNeeded()
         let previous = store.configuration
 
-        try write(#"""
-        [keyboard]
-        clear_default_keybindings = true
-        [keybindings]
-        "ctrl+b" = "view.toggle-sidebar"
-        [terminal]
-        padding_x = -1
-        """#, to: fixture.config)
+        try write(
+            #"""
+            [keyboard]
+            clear_default_keybindings = true
+            [keybindings]
+            "ctrl+b" = "view.toggle-sidebar"
+            [terminal]
+            padding_x = -1
+            """#, to: fixture.config)
         store.reload()
 
         #expect(store.configuration.keymap.generation == previous.keymap.generation)
-        #expect(store.configuration.keymap.menuShortcuts[.toggleSidebar]
-            == previous.keymap.menuShortcuts[.toggleSidebar])
+        #expect(
+            store.configuration.keymap.menuShortcuts[.toggleSidebar]
+                == previous.keymap.menuShortcuts[.toggleSidebar])
         #expect(store.configuration.terminal == previous.terminal)
         #expect(applied == [previous.terminal])
         #expect(store.notice?.message.contains("[terminal].padding_x") == true)
@@ -202,10 +220,11 @@ struct ConfigurationStoreTests {
     func terminalPreferencesApplyAndReset() throws {
         let fixture = try fixture()
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
-        try write(#"""
-        [terminal]
-        padding_x = 4
-        """#, to: fixture.config)
+        try write(
+            #"""
+            [terminal]
+            padding_x = 4
+            """#, to: fixture.config)
         var applied: [TerminalPreferences] = []
         let store = ConfigurationStore(
             configURL: fixture.config,
@@ -213,10 +232,11 @@ struct ConfigurationStoreTests {
         )
 
         store.loadAtLaunchIfNeeded()
-        try write(#"""
-        [terminal]
-        padding_x = 8
-        """#, to: fixture.config)
+        try write(
+            #"""
+            [terminal]
+            padding_x = 8
+            """#, to: fixture.config)
         store.reload()
         try FileManager.default.removeItem(at: fixture.config)
         store.reload()
@@ -229,10 +249,11 @@ struct ConfigurationStoreTests {
     func invalidLaunchAppliesDefaultTerminal() throws {
         let fixture = try fixture()
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
-        try write(#"""
-        [terminal]
-        theme = "Definitely Not A Real Theme"
-        """#, to: fixture.config)
+        try write(
+            #"""
+            [terminal]
+            theme = "Definitely Not A Real Theme"
+            """#, to: fixture.config)
         var applied: [TerminalPreferences] = []
         let store = ConfigurationStore(
             configURL: fixture.config,
@@ -247,13 +268,15 @@ struct ConfigurationStoreTests {
     @Test("configuration location honors non-empty XDG_CONFIG_HOME")
     func configLocation() {
         let home = URL(fileURLWithPath: "/tmp/example-home")
-        #expect(ConfigurationStore.defaultConfigURL(
-            environment: ["XDG_CONFIG_HOME": "/tmp/xdg"],
-            homeDirectory: home
-        ).path == "/tmp/xdg/atc/macos.toml")
-        #expect(ConfigurationStore.defaultConfigURL(
-            environment: ["XDG_CONFIG_HOME": "  "],
-            homeDirectory: home
-        ).path == "/tmp/example-home/.config/atc/macos.toml")
+        #expect(
+            ConfigurationStore.defaultConfigURL(
+                environment: ["XDG_CONFIG_HOME": "/tmp/xdg"],
+                homeDirectory: home
+            ).path == "/tmp/xdg/atc/macos.toml")
+        #expect(
+            ConfigurationStore.defaultConfigURL(
+                environment: ["XDG_CONFIG_HOME": "  "],
+                homeDirectory: home
+            ).path == "/tmp/example-home/.config/atc/macos.toml")
     }
 }

--- a/macos/ATCTests/ConnectionRuntimeTests.swift
+++ b/macos/ATCTests/ConnectionRuntimeTests.swift
@@ -1,7 +1,8 @@
-import Foundation
-import Testing
 import ATCAppServerAPI
 import ATCAppServerTransport
+import Foundation
+import Testing
+
 @testable import ATC
 
 /// The SSE-driven liveness model: `.connected` resyncs everything, `.change`
@@ -149,12 +150,13 @@ struct ConnectionRuntimeTests {
         defer { runtime.stop() }
 
         let threads = runtime.threads
-        runtime.updateRecord(ConnectionRecord(
-            id: runtime.id,
-            name: "Renamed",
-            urlString: runtime.record.urlString,
-            token: ""
-        ))
+        runtime.updateRecord(
+            ConnectionRecord(
+                id: runtime.id,
+                name: "Renamed",
+                urlString: runtime.record.urlString,
+                token: ""
+            ))
         #expect(runtime.record.name == "Renamed")
         #expect(runtime.threads === threads)
     }

--- a/macos/ATCTests/ConnectionsModelTests.swift
+++ b/macos/ATCTests/ConnectionsModelTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+
 @testable import ATC
 
 /// Pure URL validation/normalization and duplicate rules for Connections.
@@ -96,8 +97,8 @@ struct ConnectionURLTests {
 
     @Test("http vs https default ports do not collide")
     func differentEffectivePorts() {
-        let existing = [record("http://h")] // port 80
-        #expect(!ConnectionURL.isDuplicate("https://h", against: existing)) // port 443
+        let existing = [record("http://h")]  // port 80
+        #expect(!ConnectionURL.isDuplicate("https://h", against: existing))  // port 443
     }
 
     @Test("same host, different explicit port is not a duplicate")

--- a/macos/ATCTests/DashboardModelTests.swift
+++ b/macos/ATCTests/DashboardModelTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+
 @testable import ATC
 
 @Suite("Dashboard model")
@@ -47,7 +48,7 @@ struct DashboardModelTests {
                     // A thread's TUI terminal belongs to the thread.
                     Fixtures.terminal(id: "tui", projectId: "p1", threadId: "t1"),
                 ]
-            ),
+            )
         ])
         let cards = try #require(model.sections.first?.cards)
         #expect(cards.map(\.project.id) == ["p1", "p2"])

--- a/macos/ATCTests/DirectoryPickerModelTests.swift
+++ b/macos/ATCTests/DirectoryPickerModelTests.swift
@@ -1,6 +1,7 @@
+import ATCAppServerAPI
 import Foundation
 import Testing
-import ATCAppServerAPI
+
 @testable import ATC
 
 /// DirectoryPickerModel: server-backed navigation and the keep-last-listing

--- a/macos/ATCTests/EventNormalizationTests.swift
+++ b/macos/ATCTests/EventNormalizationTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Testing
+
 @testable import ATC
 
 @Suite("Keyboard event normalization")
@@ -9,10 +10,12 @@ struct EventNormalizationTests {
         #expect(KeyStroke.resolveKey(produced: "т", asciiFallback: { "t" }) == "t")
 
         var consultedFallback = false
-        let producedASCII = KeyStroke.resolveKey(produced: "t", asciiFallback: {
-            consultedFallback = true
-            return "x"
-        })
+        let producedASCII = KeyStroke.resolveKey(
+            produced: "t",
+            asciiFallback: {
+                consultedFallback = true
+                return "x"
+            })
         #expect(producedASCII == "t")
         #expect(!consultedFallback)
 
@@ -23,68 +26,79 @@ struct EventNormalizationTests {
 
     @Test("layout-resolved command, shift, and option events normalize")
     func printableEvents() throws {
-        let commandB = try #require(event(
-            flags: .command,
-            characters: "b",
-            ignoringModifiers: "b",
-            keyCode: 11
-        ))
-        #expect(KeyStroke.normalize(event: commandB)
-            == KeyStroke(key: "b", modifiers: .command))
+        let commandB = try #require(
+            event(
+                flags: .command,
+                characters: "b",
+                ignoringModifiers: "b",
+                keyCode: 11
+            ))
+        #expect(
+            KeyStroke.normalize(event: commandB)
+                == KeyStroke(key: "b", modifiers: .command))
 
-        let shiftedOne = try #require(event(
-            flags: [.command, .shift],
-            characters: "!",
-            ignoringModifiers: "1",
-            keyCode: 18
-        ))
-        #expect(KeyStroke.normalize(event: shiftedOne)
-            == KeyStroke(key: "1", modifiers: [.command, .shift]))
+        let shiftedOne = try #require(
+            event(
+                flags: [.command, .shift],
+                characters: "!",
+                ignoringModifiers: "1",
+                keyCode: 18
+            ))
+        #expect(
+            KeyStroke.normalize(event: shiftedOne)
+                == KeyStroke(key: "1", modifiers: [.command, .shift]))
 
-        let optionB = try #require(event(
-            flags: .option,
-            characters: "∫",
-            ignoringModifiers: "b",
-            keyCode: 11
-        ))
-        #expect(KeyStroke.normalize(event: optionB)
-            == KeyStroke(key: "b", modifiers: .option))
+        let optionB = try #require(
+            event(
+                flags: .option,
+                characters: "∫",
+                ignoringModifiers: "b",
+                keyCode: 11
+            ))
+        #expect(
+            KeyStroke.normalize(event: optionB)
+                == KeyStroke(key: "b", modifiers: .option))
     }
 
     @Test("escape normalizes and function keys forward as unmappable")
     func specialEvents() throws {
-        let escape = try #require(event(
-            flags: [], characters: "\u{1b}", ignoringModifiers: "\u{1b}", keyCode: 53
-        ))
+        let escape = try #require(
+            event(
+                flags: [], characters: "\u{1b}", ignoringModifiers: "\u{1b}", keyCode: 53
+            ))
         #expect(KeyStroke.normalize(event: escape) == .escape)
 
         // Held modifiers never produce a distinct escape stroke; a pending
         // sequence cancels silently for shift+esc just like bare esc.
-        let shiftedEscape = try #require(event(
-            flags: .shift, characters: "\u{1b}", ignoringModifiers: "\u{1b}", keyCode: 53
-        ))
+        let shiftedEscape = try #require(
+            event(
+                flags: .shift, characters: "\u{1b}", ignoringModifiers: "\u{1b}", keyCode: 53
+            ))
         #expect(KeyStroke.normalize(event: shiftedEscape) == .escape)
 
         let functionCharacter = String(UnicodeScalar(NSF1FunctionKey)!)
-        let function = try #require(event(
-            flags: [],
-            characters: functionCharacter,
-            ignoringModifiers: functionCharacter,
-            keyCode: 122
-        ))
+        let function = try #require(
+            event(
+                flags: [],
+                characters: functionCharacter,
+                ignoringModifiers: functionCharacter,
+                keyCode: 122
+            ))
         #expect(KeyStroke.normalize(event: function) == nil)
     }
 
     @Test("a Cyrillic event uses its physical key's ASCII interpretation")
     func cyrillicEvent() throws {
-        let commandT = try #require(event(
-            flags: .command,
-            characters: "т",
-            ignoringModifiers: "т",
-            keyCode: 17
-        ))
-        #expect(KeyStroke.normalize(event: commandT)
-            == KeyStroke(key: "t", modifiers: .command))
+        let commandT = try #require(
+            event(
+                flags: .command,
+                characters: "т",
+                ignoringModifiers: "т",
+                keyCode: 17
+            ))
+        #expect(
+            KeyStroke.normalize(event: commandT)
+                == KeyStroke(key: "t", modifiers: .command))
     }
 
     private func event(

--- a/macos/ATCTests/KeyboardMonitorHostTests.swift
+++ b/macos/ATCTests/KeyboardMonitorHostTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Testing
+
 @testable import ATC
 
 @MainActor
@@ -30,12 +31,13 @@ struct KeyboardMonitorHostTests {
         #expect(coordinator.handleKeyDown(event: quit, in: window) == nil)
         #expect(actions == [.terminate])
 
-        let quitRepeat = try #require(event(
-            flags: .command,
-            characters: "q",
-            keyCode: 12,
-            isRepeat: true
-        ))
+        let quitRepeat = try #require(
+            event(
+                flags: .command,
+                characters: "q",
+                keyCode: 12,
+                isRepeat: true
+            ))
         #expect(coordinator.handleKeyDown(event: quitRepeat, in: window) == nil)
         #expect(actions == [.terminate])
 

--- a/macos/ATCTests/KeyboardRouterTests.swift
+++ b/macos/ATCTests/KeyboardRouterTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Testing
+
 @testable import ATC
 
 @MainActor
@@ -100,13 +101,14 @@ struct KeyboardRouterTests {
     @Test("modified continuations are never retried against root")
     func continuationDoesNotRetryRoot() throws {
         var executions: [CommandID] = []
-        let map = try keymap(#"""
-        [keyboard]
-        clear_default_keybindings = true
-        [keybindings]
-        "cmd+shift+y" = "data.refresh"
-        "leader>x" = "view.toggle-sidebar"
-        """#)
+        let map = try keymap(
+            #"""
+            [keyboard]
+            clear_default_keybindings = true
+            [keybindings]
+            "cmd+shift+y" = "data.refresh"
+            "leader>x" = "view.toggle-sidebar"
+            """#)
         let router = WindowKeyboardRouter(keymap: map) {
             executions.append($0)
             return .available
@@ -178,11 +180,12 @@ struct KeyboardRouterTests {
 
     @Test("a configured leader with no surviving sequences forwards")
     func unreservedLeader() throws {
-        let map = try keymap(#"""
-        [keyboard]
-        clear_default_keybindings = true
-        leader = "ctrl+j"
-        """#)
+        let map = try keymap(
+            #"""
+            [keyboard]
+            clear_default_keybindings = true
+            leader = "ctrl+j"
+            """#)
         let router = WindowKeyboardRouter(keymap: map) { _ in .available }
         #expect(!router.handle(try stroke("ctrl+j"), isRepeat: false))
     }

--- a/macos/ATCTests/KeymapResolutionTests.swift
+++ b/macos/ATCTests/KeymapResolutionTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+
 @testable import ATC
 
 @Suite("Keyboard keymap resolution")
@@ -20,11 +21,13 @@ struct KeymapResolutionTests {
         let keymap = try resolve()
         #expect(keymap.generation == 1)
         #expect(command(at: try stroke("cmd+b"), in: keymap) == .toggleSidebar)
-        #expect(command(at: try stroke("cmd+shift+p"), in: keymap)
-            == .toggleCommandPalette)
+        #expect(
+            command(at: try stroke("cmd+shift+p"), in: keymap)
+                == .toggleCommandPalette)
         let paletteShortcut = try stroke("cmd+shift+p")
-        #expect(keymap.menuShortcuts[.toggleCommandPalette]
-            == paletteShortcut)
+        #expect(
+            keymap.menuShortcuts[.toggleCommandPalette]
+                == paletteShortcut)
         let scopedBindings: [(String, CommandID)] = [
             ("cmd+shift+s", .searchThreads),
             ("cmd+shift+t", .searchTerminals),
@@ -52,38 +55,44 @@ struct KeymapResolutionTests {
 
     @Test("the palette binding can be rebound and unbound")
     func paletteBindingLayering() throws {
-        let rebound = try resolve(#"""
-        [keybindings]
-        "ctrl+shift+p" = "view.toggle-command-palette"
-        """#)
-        #expect(command(at: try stroke("ctrl+shift+p"), in: rebound)
-            == .toggleCommandPalette)
+        let rebound = try resolve(
+            #"""
+            [keybindings]
+            "ctrl+shift+p" = "view.toggle-command-palette"
+            """#)
+        #expect(
+            command(at: try stroke("ctrl+shift+p"), in: rebound)
+                == .toggleCommandPalette)
         let reboundShortcut = try stroke("ctrl+shift+p")
-        #expect(rebound.menuShortcuts[.toggleCommandPalette]
-            == reboundShortcut)
+        #expect(
+            rebound.menuShortcuts[.toggleCommandPalette]
+                == reboundShortcut)
 
-        let unbound = try resolve(#"""
-        [keybindings]
-        "cmd+shift+p" = "unbind"
-        """#)
+        let unbound = try resolve(
+            #"""
+            [keybindings]
+            "cmd+shift+p" = "unbind"
+            """#)
         #expect(unbound.root[try stroke("cmd+shift+p")] == nil)
         #expect(unbound.menuShortcuts[.toggleCommandPalette] == nil)
     }
 
     @Test("a scoped search command can be rebound and unbound")
     func scopedSearchBindingLayering() throws {
-        let rebound = try resolve(#"""
-        [keybindings]
-        "ctrl+shift+s" = "view.search-threads"
-        """#)
+        let rebound = try resolve(
+            #"""
+            [keybindings]
+            "ctrl+shift+s" = "view.search-threads"
+            """#)
         let reboundShortcut = try stroke("ctrl+shift+s")
         #expect(command(at: reboundShortcut, in: rebound) == .searchThreads)
         #expect(rebound.menuShortcuts[.searchThreads] == reboundShortcut)
 
-        let unbound = try resolve(#"""
-        [keybindings]
-        "cmd+shift+s" = "unbind"
-        """#)
+        let unbound = try resolve(
+            #"""
+            [keybindings]
+            "cmd+shift+s" = "unbind"
+            """#)
         #expect(unbound.root[try stroke("cmd+shift+s")] == nil)
         #expect(unbound.menuShortcuts[.searchThreads] == nil)
         let leader = try #require(prefix(at: try stroke("cmd+k"), in: unbound))
@@ -92,27 +101,30 @@ struct KeymapResolutionTests {
 
     @Test("user entries replace, unbind, and can rebind defaults")
     func layering() throws {
-        let replaced = try resolve(#"""
-        [keybindings]
-        "cmd+b" = "data.refresh"
-        "cmd+n" = "terminal.new"
-        """#)
+        let replaced = try resolve(
+            #"""
+            [keybindings]
+            "cmd+b" = "data.refresh"
+            "cmd+n" = "terminal.new"
+            """#)
         #expect(command(at: try stroke("cmd+b"), in: replaced) == .refresh)
         #expect(command(at: try stroke("cmd+n"), in: replaced) == .newTerminal)
 
-        let unbound = try resolve(#"""
-        [keybindings]
-        "cmd+b" = "unbind"
-        """#)
+        let unbound = try resolve(
+            #"""
+            [keybindings]
+            "cmd+b" = "unbind"
+            """#)
         #expect(unbound.root[try stroke("cmd+b")] == nil)
     }
 
     @Test("clearing defaults leaves no leader reservation without sequences")
     func clearDefaults() throws {
-        let keymap = try resolve(#"""
-        [keyboard]
-        clear_default_keybindings = true
-        """#)
+        let keymap = try resolve(
+            #"""
+            [keyboard]
+            clear_default_keybindings = true
+            """#)
         #expect(keymap.root.isEmpty)
         #expect(keymap.menuShortcuts.isEmpty)
         #expect(keymap.root[try stroke("cmd+k")] == nil)
@@ -120,12 +132,13 @@ struct KeymapResolutionTests {
 
     @Test("custom leaders expand all symbolic sequences")
     func customLeader() throws {
-        let keymap = try resolve(#"""
-        [keyboard]
-        leader = "ctrl+j"
-        [keybindings]
-        "leader>x" = "project.new"
-        """#)
+        let keymap = try resolve(
+            #"""
+            [keyboard]
+            leader = "ctrl+j"
+            [keybindings]
+            "leader>x" = "project.new"
+            """#)
         let node = try #require(prefix(at: try stroke("ctrl+j"), in: keymap))
         #expect(command(in: node[KeyStroke(key: "x", modifiers: [])]) == .newProject)
         #expect(keymap.root[try stroke("cmd+k")] == nil)
@@ -133,118 +146,145 @@ struct KeymapResolutionTests {
 
     @Test("direct and expanded-prefix conflicts invalidate the candidate")
     func prefixConflicts() throws {
-        let directConflict = Keymap.resolve(user: ConfigurationLoader.parse(#"""
-        [keybindings]
-        "cmd+k" = "data.refresh"
-        """#))
+        let directConflict = Keymap.resolve(
+            user: ConfigurationLoader.parse(
+                #"""
+                [keybindings]
+                "cmd+k" = "data.refresh"
+                """#))
         let directDiagnostics = try failure(directConflict)
-        #expect(directDiagnostics.contains {
-            $0.message.contains("cmd+k") && $0.message.contains("both")
-        })
+        #expect(
+            directDiagnostics.contains {
+                $0.message.contains("cmd+k") && $0.message.contains("both")
+            })
 
-        let expandedConflict = Keymap.resolve(user: ConfigurationLoader.parse(#"""
-        [keyboard]
-        leader = "cmd+b"
-        """#))
+        let expandedConflict = Keymap.resolve(
+            user: ConfigurationLoader.parse(
+                #"""
+                [keyboard]
+                leader = "cmd+b"
+                """#))
         let expandedDiagnostics = try failure(expandedConflict)
-        #expect(expandedDiagnostics.contains {
-            $0.message.contains("cmd+b") && $0.message.contains("unbind")
-        })
+        #expect(
+            expandedDiagnostics.contains {
+                $0.message.contains("cmd+b") && $0.message.contains("unbind")
+            })
     }
 
     @Test("protected shortcuts and leaders name the native command")
     func protectedShortcuts() throws {
-        let quit = Keymap.resolve(user: ConfigurationLoader.parse(#"""
-        [keyboard]
-        clear_default_keybindings = true
-        [keybindings]
-        "cmd+q" = "data.refresh"
-        """#))
-        #expect(try failure(quit).map(\.message) == [
-            "[keybindings] trigger 'cmd+q' is reserved for Quit"
-        ])
+        let quit = Keymap.resolve(
+            user: ConfigurationLoader.parse(
+                #"""
+                [keyboard]
+                clear_default_keybindings = true
+                [keybindings]
+                "cmd+q" = "data.refresh"
+                """#))
+        #expect(
+            try failure(quit).map(\.message) == [
+                "[keybindings] trigger 'cmd+q' is reserved for Quit"
+            ])
 
-        let copy = Keymap.resolve(user: ConfigurationLoader.parse(#"""
-        [keyboard]
-        clear_default_keybindings = true
-        [keybindings]
-        "cmd+c" = "data.refresh"
-        """#))
-        #expect(try failure(copy).map(\.message) == [
-            "[keybindings] trigger 'cmd+c' is reserved for Copy"
-        ])
+        let copy = Keymap.resolve(
+            user: ConfigurationLoader.parse(
+                #"""
+                [keyboard]
+                clear_default_keybindings = true
+                [keybindings]
+                "cmd+c" = "data.refresh"
+                """#))
+        #expect(
+            try failure(copy).map(\.message) == [
+                "[keybindings] trigger 'cmd+c' is reserved for Copy"
+            ])
 
-        let leader = Keymap.resolve(user: ConfigurationLoader.parse(#"""
-        [keyboard]
-        clear_default_keybindings = true
-        leader = "cmd+q"
-        """#))
-        #expect(try failure(leader).map(\.message) == [
-            "[keyboard].leader 'cmd+q' is reserved for Quit"
-        ])
+        let leader = Keymap.resolve(
+            user: ConfigurationLoader.parse(
+                #"""
+                [keyboard]
+                clear_default_keybindings = true
+                leader = "cmd+q"
+                """#))
+        #expect(
+            try failure(leader).map(\.message) == [
+                "[keyboard].leader 'cmd+q' is reserved for Quit"
+            ])
     }
 
     @Test("sidebar jump digits are reserved in both modifier sets")
     func reservedJumpDigits() throws {
-        let thread = Keymap.resolve(user: ConfigurationLoader.parse(#"""
-        [keybindings]
-        "cmd+1" = "data.refresh"
-        """#))
-        #expect(try failure(thread).contains {
-            $0.message.contains("cmd+1") && $0.message.contains("Thread Shortcuts")
-        })
+        let thread = Keymap.resolve(
+            user: ConfigurationLoader.parse(
+                #"""
+                [keybindings]
+                "cmd+1" = "data.refresh"
+                """#))
+        #expect(
+            try failure(thread).contains {
+                $0.message.contains("cmd+1") && $0.message.contains("Thread Shortcuts")
+            })
 
-        let terminal = Keymap.resolve(user: ConfigurationLoader.parse(#"""
-        [keybindings]
-        "cmd+opt+4" = "data.refresh"
-        """#))
-        #expect(try failure(terminal).contains {
-            $0.message.contains("cmd+opt+4") && $0.message.contains("Terminal Shortcuts")
-        })
+        let terminal = Keymap.resolve(
+            user: ConfigurationLoader.parse(
+                #"""
+                [keybindings]
+                "cmd+opt+4" = "data.refresh"
+                """#))
+        #expect(
+            try failure(terminal).contains {
+                $0.message.contains("cmd+opt+4") && $0.message.contains("Terminal Shortcuts")
+            })
     }
 
     @Test("unknown command ids invalidate the entire candidate")
     func unknownCommand() throws {
-        let result = Keymap.resolve(user: ConfigurationLoader.parse(#"""
-        [keybindings]
-        "cmd+shift+b" = "missing.command"
-        """#))
+        let result = Keymap.resolve(
+            user: ConfigurationLoader.parse(
+                #"""
+                [keybindings]
+                "cmd+shift+b" = "missing.command"
+                """#))
         let diagnostics = try failure(result)
-        #expect(diagnostics.contains {
-            $0.message.contains(#"[keybindings]."cmd+shift+b""#)
-                && $0.message.contains("missing.command")
-        })
+        #expect(
+            diagnostics.contains {
+                $0.message.contains(#"[keybindings]."cmd+shift+b""#)
+                    && $0.message.contains("missing.command")
+            })
     }
 
     @Test("menu selection uses deterministic order among remaining direct bindings")
     func menuSelection() throws {
-        let selected = try resolve(#"""
-        [keybindings]
-        "cmd+shift+b" = "view.toggle-sidebar"
-        "ctrl+b" = "view.toggle-sidebar"
-        """#)
+        let selected = try resolve(
+            #"""
+            [keybindings]
+            "cmd+shift+b" = "view.toggle-sidebar"
+            "ctrl+b" = "view.toggle-sidebar"
+            """#)
         let selectedStroke = try stroke("ctrl+b")
         #expect(selected.menuShortcuts[.toggleSidebar] == selectedStroke)
 
-        let fallback = try resolve(#"""
-        [keybindings]
-        "cmd+b" = "unbind"
-        "cmd+shift+b" = "view.toggle-sidebar"
-        """#)
+        let fallback = try resolve(
+            #"""
+            [keybindings]
+            "cmd+b" = "unbind"
+            "cmd+shift+b" = "view.toggle-sidebar"
+            """#)
         let fallbackStroke = try stroke("cmd+shift+b")
         #expect(fallback.menuShortcuts[.toggleSidebar] == fallbackStroke)
     }
 
     @Test("leader-only commands have no menu shortcut and commands may have many triggers")
     func menuEligibility() throws {
-        let keymap = try resolve(#"""
-        [keyboard]
-        clear_default_keybindings = true
-        [keybindings]
-        "leader>p" = "project.new"
-        "cmd+b" = "data.refresh"
-        "ctrl+b" = "data.refresh"
-        """#)
+        let keymap = try resolve(
+            #"""
+            [keyboard]
+            clear_default_keybindings = true
+            [keybindings]
+            "leader>p" = "project.new"
+            "cmd+b" = "data.refresh"
+            "ctrl+b" = "data.refresh"
+            """#)
         #expect(keymap.menuShortcuts[.newProject] == nil)
         let latestStroke = try stroke("ctrl+b")
         #expect(keymap.menuShortcuts[.refresh] == latestStroke)
@@ -254,11 +294,13 @@ struct KeymapResolutionTests {
 
     @Test("one error prevents every otherwise-valid binding from publishing")
     func atomicFailure() throws {
-        let result = Keymap.resolve(user: ConfigurationLoader.parse(#"""
-        [keybindings]
-        "cmd+shift+b" = "data.refresh"
-        "cmd+shift+x" = "unknown"
-        """#))
+        let result = Keymap.resolve(
+            user: ConfigurationLoader.parse(
+                #"""
+                [keybindings]
+                "cmd+shift+b" = "data.refresh"
+                "cmd+shift+x" = "unknown"
+                """#))
         if case .success = result {
             Issue.record("Expected the complete candidate to fail")
         }

--- a/macos/ATCTests/NativeShortcutsTests.swift
+++ b/macos/ATCTests/NativeShortcutsTests.swift
@@ -1,4 +1,5 @@
 import Testing
+
 @testable import ATC
 
 @Suite("Native shortcut classification")
@@ -22,9 +23,10 @@ struct NativeShortcutsTests {
             #expect(NativeShortcuts.appAction(for: try stroke(trigger)) == nil)
         }
         #expect(NativeShortcuts.appAction(for: try stroke("cmd+y")) == nil)
-        #expect(NativeShortcuts.appAction(
-            for: KeyStroke(key: "x", modifiers: [])
-        ) == nil)
+        #expect(
+            NativeShortcuts.appAction(
+                for: KeyStroke(key: "x", modifiers: [])
+            ) == nil)
     }
 
     private func stroke(_ text: String) throws -> KeyStroke {

--- a/macos/ATCTests/NewThreadLauncherModelTests.swift
+++ b/macos/ATCTests/NewThreadLauncherModelTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+
 @testable import ATC
 
 @Suite("New Thread launcher model")

--- a/macos/ATCTests/ProjectsStoreTests.swift
+++ b/macos/ATCTests/ProjectsStoreTests.swift
@@ -1,6 +1,7 @@
+import ATCAppServerAPI
 import Foundation
 import Testing
-import ATCAppServerAPI
+
 @testable import ATC
 
 /// ProjectsStore: refresh, and the merge placement every server-confirmed

--- a/macos/ATCTests/QueryMatcherTests.swift
+++ b/macos/ATCTests/QueryMatcherTests.swift
@@ -1,4 +1,5 @@
 import Testing
+
 @testable import ATC
 
 @Suite("Command palette query matcher")

--- a/macos/ATCTests/RefreshStateTests.swift
+++ b/macos/ATCTests/RefreshStateTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+
 @testable import ATC
 
 @Suite("RefreshState")
@@ -8,7 +9,10 @@ struct RefreshStateTests {
     func failureRecorded() async {
         let state = RefreshState(category: "test")
         struct Boom: Error, LocalizedError { var errorDescription: String? { "boom" } }
-        await state.run { throw Boom() } apply: { (_: Int) in }
+        await state.run {
+            throw Boom()
+        } apply: { (_: Int) in
+        }
         #expect(state.lastError == "boom")
         #expect(state.hasLoadedOnce)
         #expect(!state.isResolved)
@@ -17,7 +21,10 @@ struct RefreshStateTests {
     @Test("a cancelled refresh is not a failure and never resolves the store")
     func cancellationIgnored() async {
         let state = RefreshState(category: "test")
-        await state.run { throw CancellationError() } apply: { (_: Int) in }
+        await state.run {
+            throw CancellationError()
+        } apply: { (_: Int) in
+        }
         #expect(state.lastError == nil)
         #expect(!state.hasLoadedOnce)
     }
@@ -33,7 +40,8 @@ struct RefreshStateTests {
                 try? await Task.sleep(for: .seconds(10))
                 if Task.isCancelled { throw TransportTornDown() }
                 return 0
-            } apply: { (_: Int) in }
+            } apply: { (_: Int) in
+            }
         }
         task.cancel()
         await task.value
@@ -44,9 +52,16 @@ struct RefreshStateTests {
     @Test("a successful refresh after a cancelled one resolves cleanly")
     func recoveryAfterCancellation() async {
         let state = RefreshState(category: "test")
-        await state.run { throw CancellationError() } apply: { (_: Int) in }
+        await state.run {
+            throw CancellationError()
+        } apply: { (_: Int) in
+        }
         var applied: Int?
-        await state.run { 7 } apply: { applied = $0 }
+        await state.run {
+            7
+        } apply: {
+            applied = $0
+        }
         #expect(applied == 7)
         #expect(state.isResolved)
     }

--- a/macos/ATCTests/ScriptableAppServerClient.swift
+++ b/macos/ATCTests/ScriptableAppServerClient.swift
@@ -1,5 +1,6 @@
-import Foundation
 import ATCAppServerAPI
+import Foundation
+
 @testable import ATC
 
 /// An in-memory App Server standing in for the generated `Client`. Tests seed
@@ -167,7 +168,8 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     // MARK: - Projects
 
     func listProjects(_ input: Operations.ListProjects.Input) async throws
-        -> Operations.ListProjects.Output {
+        -> Operations.ListProjects.Output
+    {
         let payload = mutate { model -> [Project] in
             model.listProjectsCount += 1
             return model.projects.sorted { $0.createdAt > $1.createdAt }
@@ -177,25 +179,30 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     }
 
     func createProject(_ input: Operations.CreateProject.Input) async throws
-        -> Operations.CreateProject.Output {
+        -> Operations.CreateProject.Output
+    {
         guard case .json(let request) = input.body else { throw StubUnimplemented("createProject") }
         try await gate()
-        return .ok(.init(body: .json(mutate { model -> Project in
-            let now = model.tick()
-            let project = Project(
-                id: model.nextID("prj"),
-                name: request.name,
-                defaultWorkingDirectory: request.defaultWorkingDirectory,
-                createdAt: now,
-                updatedAt: now
-            )
-            model.projects.append(project)
-            return project
-        })))
+        return .ok(
+            .init(
+                body: .json(
+                    mutate { model -> Project in
+                        let now = model.tick()
+                        let project = Project(
+                            id: model.nextID("prj"),
+                            name: request.name,
+                            defaultWorkingDirectory: request.defaultWorkingDirectory,
+                            createdAt: now,
+                            updatedAt: now
+                        )
+                        model.projects.append(project)
+                        return project
+                    })))
     }
 
     func getProject(_ input: Operations.GetProject.Input) async throws
-        -> Operations.GetProject.Output {
+        -> Operations.GetProject.Output
+    {
         try await gate()
         let id = input.path.projectId
         guard let project = projects.first(where: { $0.id == id }) else {
@@ -205,7 +212,8 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     }
 
     func updateProject(_ input: Operations.UpdateProject.Input) async throws
-        -> Operations.UpdateProject.Output {
+        -> Operations.UpdateProject.Output
+    {
         guard case .json(let request) = input.body else { throw StubUnimplemented("updateProject") }
         try await gate()
         let id = input.path.projectId
@@ -223,7 +231,8 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     }
 
     func deleteProject(_ input: Operations.DeleteProject.Input) async throws
-        -> Operations.DeleteProject.Output {
+        -> Operations.DeleteProject.Output
+    {
         try await gate()
         let id = input.path.projectId
         return mutate { model -> Operations.DeleteProject.Output in
@@ -242,7 +251,8 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     // MARK: - Terminals
 
     func listTerminals(_ input: Operations.ListTerminals.Input) async throws
-        -> Operations.ListTerminals.Output {
+        -> Operations.ListTerminals.Output
+    {
         let projectID = input.query.projectId
         let payload = mutate { model -> [Terminal] in
             model.listTerminalsCount += 1
@@ -255,7 +265,8 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     }
 
     func createTerminal(_ input: Operations.CreateTerminal.Input) async throws
-        -> Operations.CreateTerminal.Output {
+        -> Operations.CreateTerminal.Output
+    {
         guard case .json(let request) = input.body else { throw StubUnimplemented("createTerminal") }
         try await gate()
         return mutate { model -> Operations.CreateTerminal.Output in
@@ -276,7 +287,8 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     }
 
     func getTerminal(_ input: Operations.GetTerminal.Input) async throws
-        -> Operations.GetTerminal.Output {
+        -> Operations.GetTerminal.Output
+    {
         try await gate()
         let id = input.path.terminalId
         guard let terminal = terminals.first(where: { $0.id == id }) else {
@@ -286,7 +298,8 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     }
 
     func updateTerminal(_ input: Operations.UpdateTerminal.Input) async throws
-        -> Operations.UpdateTerminal.Output {
+        -> Operations.UpdateTerminal.Output
+    {
         guard case .json(let request) = input.body else { throw StubUnimplemented("updateTerminal") }
         try await gate()
         let id = input.path.terminalId
@@ -301,7 +314,8 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     }
 
     func deleteTerminal(_ input: Operations.DeleteTerminal.Input) async throws
-        -> Operations.DeleteTerminal.Output {
+        -> Operations.DeleteTerminal.Output
+    {
         try await gate()
         let id = input.path.terminalId
         return mutate { model -> Operations.DeleteTerminal.Output in
@@ -320,7 +334,8 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     // MARK: - Threads
 
     func listThreads(_ input: Operations.ListThreads.Input) async throws
-        -> Operations.ListThreads.Output {
+        -> Operations.ListThreads.Output
+    {
         let wantsArchived = input.query.archived == ._true
         let projectID = input.query.projectId
         let payload = mutate { model -> [ATCThread] in
@@ -341,7 +356,8 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     }
 
     func createThread(_ input: Operations.CreateThread.Input) async throws
-        -> Operations.CreateThread.Output {
+        -> Operations.CreateThread.Output
+    {
         guard case .json(let request) = input.body else { throw StubUnimplemented("createThread") }
         try await gate()
         return mutate { model -> Operations.CreateThread.Output in
@@ -367,7 +383,8 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     }
 
     func getThread(_ input: Operations.GetThread.Input) async throws
-        -> Operations.GetThread.Output {
+        -> Operations.GetThread.Output
+    {
         try await gate()
         let id = input.path.threadId
         guard let thread = threads.first(where: { $0.id == id }) else {
@@ -377,7 +394,8 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     }
 
     func updateThread(_ input: Operations.UpdateThread.Input) async throws
-        -> Operations.UpdateThread.Output {
+        -> Operations.UpdateThread.Output
+    {
         guard case .json(let request) = input.body else { throw StubUnimplemented("updateThread") }
         try await gate()
         let id = input.path.threadId
@@ -392,7 +410,8 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     }
 
     func deleteThread(_ input: Operations.DeleteThread.Input) async throws
-        -> Operations.DeleteThread.Output {
+        -> Operations.DeleteThread.Output
+    {
         try await gate()
         let id = input.path.threadId
         return mutate { model -> Operations.DeleteThread.Output in
@@ -406,7 +425,8 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     }
 
     func archiveThread(_ input: Operations.ArchiveThread.Input) async throws
-        -> Operations.ArchiveThread.Output {
+        -> Operations.ArchiveThread.Output
+    {
         try await gate()
         let id = input.path.threadId
         return mutate { model -> Operations.ArchiveThread.Output in
@@ -426,7 +446,8 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     }
 
     func unarchiveThread(_ input: Operations.UnarchiveThread.Input) async throws
-        -> Operations.UnarchiveThread.Output {
+        -> Operations.UnarchiveThread.Output
+    {
         try await gate()
         let id = input.path.threadId
         return mutate { model -> Operations.UnarchiveThread.Output in
@@ -440,7 +461,8 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     }
 
     func pinThread(_ input: Operations.PinThread.Input) async throws
-        -> Operations.PinThread.Output {
+        -> Operations.PinThread.Output
+    {
         try await gate()
         let id = input.path.threadId
         return mutate { model -> Operations.PinThread.Output in
@@ -448,11 +470,14 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
                 return .notFound(.init(body: .json(threadNotFound(id))))
             }
             guard model.threads[index].archivedAt == nil else {
-                return .conflict(.init(body: .json(.init(
-                    _tag: .threadArchived,
-                    threadId: id,
-                    message: "Thread \(id) is archived"
-                ))))
+                return .conflict(
+                    .init(
+                        body: .json(
+                            .init(
+                                _tag: .threadArchived,
+                                threadId: id,
+                                message: "Thread \(id) is archived"
+                            ))))
             }
             let now = model.tick()
             if model.threads[index].pinnedAt == nil {
@@ -466,7 +491,8 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     /// Idempotent per the contract: only an unread thread is written (and
     /// timestamped); a read one comes back unchanged.
     func markThreadViewed(_ input: Operations.MarkThreadViewed.Input) async throws
-        -> Operations.MarkThreadViewed.Output {
+        -> Operations.MarkThreadViewed.Output
+    {
         try await gate()
         let id = input.path.threadId
         return mutate { model -> Operations.MarkThreadViewed.Output in
@@ -483,7 +509,8 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     }
 
     func unpinThread(_ input: Operations.UnpinThread.Input) async throws
-        -> Operations.UnpinThread.Output {
+        -> Operations.UnpinThread.Output
+    {
         try await gate()
         let id = input.path.threadId
         return mutate { model -> Operations.UnpinThread.Output in
@@ -499,7 +526,8 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     /// Idempotent per the contract: a live linked terminal is returned as-is,
     /// otherwise a fresh live terminal is created and linked.
     func openThreadTerminal(_ input: Operations.OpenThreadTerminal.Input) async throws
-        -> Operations.OpenThreadTerminal.Output {
+        -> Operations.OpenThreadTerminal.Output
+    {
         try await gate()
         if let failure = openThreadTerminalFailure {
             return .serviceUnavailable(.init(body: .json(.init(value1: failure))))
@@ -512,9 +540,10 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
             }
             let thread = model.threads[index]
             if let linkedID = thread.linkedTerminalId,
-               let existing = model.terminals.first(where: {
-                   $0.id == linkedID && $0.status == .live
-               }) {
+                let existing = model.terminals.first(where: {
+                    $0.id == linkedID && $0.status == .live
+                })
+            {
                 return .ok(.init(body: .json(existing)))
             }
             let terminal = model.makeTerminal(
@@ -534,7 +563,8 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     // MARK: - Agents
 
     func listAgents(_ input: Operations.ListAgents.Input) async throws
-        -> Operations.ListAgents.Output {
+        -> Operations.ListAgents.Output
+    {
         let payload = mutate { model -> [Agent] in
             model.listAgentsCount += 1
             return model.agents
@@ -544,15 +574,19 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     }
 
     func getAgent(_ input: Operations.GetAgent.Input) async throws
-        -> Operations.GetAgent.Output {
+        -> Operations.GetAgent.Output
+    {
         try await gate()
         let id = input.path.agentId
         guard let agent = agents.first(where: { $0.id.rawValue == id }) else {
-            return .notFound(.init(body: .json(.init(
-                _tag: .agentNotFound,
-                agentId: id,
-                message: "No agent \(id)"
-            ))))
+            return .notFound(
+                .init(
+                    body: .json(
+                        .init(
+                            _tag: .agentNotFound,
+                            agentId: id,
+                            message: "No agent \(id)"
+                        ))))
         }
         return .ok(.init(body: .json(agent)))
     }
@@ -560,16 +594,19 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     // MARK: - Filesystem
 
     func checkDirectory(_ input: Operations.CheckDirectory.Input) async throws
-        -> Operations.CheckDirectory.Output {
+        -> Operations.CheckDirectory.Output
+    {
         try await gate()
         let path = input.query.path
-        let response = directoryCheck
+        let response =
+            directoryCheck
             ?? Components.Schemas.FsCheckResponse(path: path, state: .available, checkedAt: .now)
         return .ok(.init(body: .json(response)))
     }
 
     func listDirectory(_ input: Operations.ListDirectory.Input) async throws
-        -> Operations.ListDirectory.Output {
+        -> Operations.ListDirectory.Output
+    {
         try await gate()
         if let failure = directoryListingFailure {
             return .unprocessableContent(.init(body: .json(.init(value1: failure))))
@@ -583,24 +620,28 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     // MARK: - Unimplemented
 
     func getHealth(_ input: Operations.GetHealth.Input) async throws
-        -> Operations.GetHealth.Output {
+        -> Operations.GetHealth.Output
+    {
         throw StubUnimplemented("getHealth")
     }
 
     func getVersion(_ input: Operations.GetVersion.Input) async throws
-        -> Operations.GetVersion.Output {
+        -> Operations.GetVersion.Output
+    {
         throw StubUnimplemented("getVersion")
     }
 
     func getServerInfo(_ input: Operations.GetServerInfo.Input) async throws
-        -> Operations.GetServerInfo.Output {
+        -> Operations.GetServerInfo.Output
+    {
         throw StubUnimplemented("getServerInfo")
     }
 
     /// The app reaches the event stream through `ResourceEventStream`, never
     /// the contract client; `ScriptedEventStream` is the seam tests drive.
     func subscribeEvents(_ input: Operations.SubscribeEvents.Input) async throws
-        -> Operations.SubscribeEvents.Output {
+        -> Operations.SubscribeEvents.Output
+    {
         throw StubUnimplemented("subscribeEvents")
     }
 

--- a/macos/ATCTests/SettingsHostingSmokeTest.swift
+++ b/macos/ATCTests/SettingsHostingSmokeTest.swift
@@ -1,6 +1,7 @@
 import AppKit
 import SwiftUI
 import Testing
+
 @testable import ATC
 
 /// Hosts the Settings window in a real window and pumps the run loop,

--- a/macos/ATCTests/ShellHostingSmokeTest.swift
+++ b/macos/ATCTests/ShellHostingSmokeTest.swift
@@ -1,6 +1,7 @@
 import AppKit
 import SwiftUI
 import Testing
+
 @testable import ATC
 
 /// Hosts the window the app actually boots into, in a real NSWindow, and

--- a/macos/ATCTests/SidebarShortcutsTests.swift
+++ b/macos/ATCTests/SidebarShortcutsTests.swift
@@ -1,6 +1,7 @@
+import ATCAppServerAPI
 import Foundation
 import Testing
-import ATCAppServerAPI
+
 @testable import ATC
 
 /// The jump-shortcut ordering authority: numbering follows what the collapse
@@ -16,13 +17,15 @@ struct SidebarShortcutsTests {
         filter: ThreadFilter = .all
     ) -> ThreadListModel {
         ThreadListModel(
-            inputs: [.init(
-                connectionID: connectionID,
-                connectionName: "A",
-                projects: [Fixtures.project(id: "prj")],
-                threads: threads,
-                archivedThreads: []
-            )],
+            inputs: [
+                .init(
+                    connectionID: connectionID,
+                    connectionName: "A",
+                    projects: [Fixtures.project(id: "prj")],
+                    threads: threads,
+                    archivedThreads: []
+                )
+            ],
             filter: filter
         )
     }
@@ -35,14 +38,17 @@ struct SidebarShortcutsTests {
 
     @Test("only exact ⌘digit and ⌥⌘digit map to jumps")
     func strokeMatching() {
-        #expect(SidebarShortcuts.jump(for: KeyStroke(key: "1", modifiers: [.command]))
-            == .thread(slot: 0))
-        #expect(SidebarShortcuts.jump(for: KeyStroke(key: "9", modifiers: [.command, .option]))
-            == .terminal(slot: 8))
+        #expect(
+            SidebarShortcuts.jump(for: KeyStroke(key: "1", modifiers: [.command]))
+                == .thread(slot: 0))
+        #expect(
+            SidebarShortcuts.jump(for: KeyStroke(key: "9", modifiers: [.command, .option]))
+                == .terminal(slot: 8))
         #expect(SidebarShortcuts.jump(for: KeyStroke(key: "0", modifiers: [.command])) == nil)
         #expect(SidebarShortcuts.jump(for: KeyStroke(key: "1", modifiers: [])) == nil)
-        #expect(SidebarShortcuts.jump(for: KeyStroke(key: "1", modifiers: [.command, .shift]))
-            == nil)
+        #expect(
+            SidebarShortcuts.jump(for: KeyStroke(key: "1", modifiers: [.command, .shift]))
+                == nil)
         #expect(SidebarShortcuts.jump(for: KeyStroke(key: "1", modifiers: [.option])) == nil)
         #expect(SidebarShortcuts.jump(for: KeyStroke(key: "b", modifiers: [.command])) == nil)
     }
@@ -51,11 +57,13 @@ struct SidebarShortcutsTests {
 
     @Test("pinned rows precede recent and collapsed sections stop at five")
     func threadOrdering() {
-        let threads = (1...7).map {
-            Fixtures.thread(id: "pin\($0)", pinnedAt: Fixtures.date(Double($0)))
-        } + (1...3).map {
-            Fixtures.thread(id: "rec\($0)", createdAt: Fixtures.date(100 + Double($0)))
-        }
+        let threads =
+            (1...7).map {
+                Fixtures.thread(id: "pin\($0)", pinnedAt: Fixtures.date(Double($0)))
+            }
+            + (1...3).map {
+                Fixtures.thread(id: "rec\($0)", createdAt: Fixtures.date(100 + Double($0)))
+            }
         let collapsed = SidebarShortcuts.threadTargets(
             model: model(threads: threads),
             isPinnedExpanded: false,
@@ -63,10 +71,11 @@ struct SidebarShortcutsTests {
         )
         // Five visible pinned rows (oldest pin first), then recent rows
         // newest-created-first; rows behind "N more" get no number.
-        #expect(collapsed == [
-            ref("pin1"), ref("pin2"), ref("pin3"), ref("pin4"), ref("pin5"),
-            ref("rec3"), ref("rec2"), ref("rec1"),
-        ])
+        #expect(
+            collapsed == [
+                ref("pin1"), ref("pin2"), ref("pin3"), ref("pin4"), ref("pin5"),
+                ref("rec3"), ref("rec2"), ref("rec1"),
+            ])
 
         let expanded = SidebarShortcuts.threadTargets(
             model: model(threads: threads),

--- a/macos/ATCTests/TerminalLivenessTests.swift
+++ b/macos/ATCTests/TerminalLivenessTests.swift
@@ -1,6 +1,7 @@
+import ATCAppServerTransport
 import Foundation
 import Testing
-import ATCAppServerTransport
+
 @testable import ATC
 
 /// Registry membership in `AppModel.terminals` means ownership (scrollback

--- a/macos/ATCTests/TerminalPresentationTests.swift
+++ b/macos/ATCTests/TerminalPresentationTests.swift
@@ -1,4 +1,5 @@
 import Testing
+
 @testable import ATC
 
 @MainActor
@@ -6,12 +7,13 @@ import Testing
 struct TerminalPresentationTests {
     @Test("unset preferences render safe padding defaults")
     func defaultPaddingRendering() {
-        #expect(TerminalPresentation.renderedConfiguration(
-            preferences: TerminalPreferences()
-        ) == """
-        window-padding-x = 8
-        window-padding-y = 6
-        """)
+        #expect(
+            TerminalPresentation.renderedConfiguration(
+                preferences: TerminalPreferences()
+            ) == """
+                window-padding-x = 8
+                window-padding-y = 6
+                """)
     }
 
     @Test("generated preferences render with padding defaults or overrides")
@@ -36,20 +38,22 @@ struct TerminalPresentationTests {
         ]
 
         for (preferences, expected) in cases {
-            #expect(TerminalPresentation.renderedConfiguration(
-                preferences: preferences
-            ) == expected)
+            #expect(
+                TerminalPresentation.renderedConfiguration(
+                    preferences: preferences
+                ) == expected)
         }
     }
 
     @Test("explicit zero padding renders edge-to-edge overrides")
     func zeroPaddingRendering() {
-        #expect(TerminalPresentation.renderedConfiguration(
-            preferences: TerminalPreferences(paddingX: 0, paddingY: 0)
-        ) == """
-        window-padding-x = 0
-        window-padding-y = 0
-        """)
+        #expect(
+            TerminalPresentation.renderedConfiguration(
+                preferences: TerminalPreferences(paddingX: 0, paddingY: 0)
+            ) == """
+                window-padding-x = 0
+                window-padding-y = 0
+                """)
     }
 
     @Test("theme is resolved separately and does not emit a config key")
@@ -57,10 +61,11 @@ struct TerminalPresentationTests {
         let rendered = TerminalPresentation.renderedConfiguration(
             preferences: TerminalPreferences(theme: "Catppuccin Mocha")
         )
-        #expect(rendered == """
-        window-padding-x = 8
-        window-padding-y = 6
-        """)
+        #expect(
+            rendered == """
+                window-padding-x = 8
+                window-padding-y = 6
+                """)
         #expect(!rendered.contains("theme"))
     }
 
@@ -69,19 +74,21 @@ struct TerminalPresentationTests {
         // Unset preferences keep libghostty's compiled defaults except for
         // safe content padding and the app-owned background.
         let controller = TerminalPresentation.makeController(preferences: .init())
-        #expect(controller.renderedConfig == """
-        window-padding-x = 8
-        window-padding-y = 6
-        background = 141416
+        #expect(
+            controller.renderedConfig == """
+                window-padding-x = 8
+                window-padding-y = 6
+                background = 141416
 
-        """)
+                """)
     }
 
     @Test("a selected theme keeps its palette but the canvas background wins")
     func themeBackgroundIsAlwaysCanvas() {
-        let controller = TerminalPresentation.makeController(preferences: .init(
-            theme: "Catppuccin Mocha"
-        ))
+        let controller = TerminalPresentation.makeController(
+            preferences: .init(
+                theme: "Catppuccin Mocha"
+            ))
         let lines = controller.renderedConfig.split(separator: "\n")
         // The theme's own background may render first; the app-owned canvas
         // must be the value that ends up applied.

--- a/macos/ATCTests/TerminalReconnectTests.swift
+++ b/macos/ATCTests/TerminalReconnectTests.swift
@@ -1,7 +1,8 @@
-import Foundation
-import Testing
 import ATCAppServerTransport
+import Foundation
 import GhosttyTerminal
+import Testing
+
 @testable import ATC
 
 /// Counts `onTerminalEnded` firings. A reference box keeps the callback's
@@ -50,14 +51,15 @@ struct TerminalReconnectTests {
         #expect(policy.delay(forAttempt: 0, jitterUnit: 0) == .milliseconds(400))
         #expect(policy.delay(forAttempt: 0, jitterUnit: 0.5) == .milliseconds(500))
         #expect(policy.delay(forAttempt: 0, jitterUnit: 1) == .milliseconds(600))
-        #expect((0...5).map { policy.delay(forAttempt: $0, jitterUnit: 0.5) } == [
-            .milliseconds(500),
-            .seconds(1),
-            .seconds(2),
-            .seconds(4),
-            .seconds(8),
-            .seconds(8),
-        ])
+        #expect(
+            (0...5).map { policy.delay(forAttempt: $0, jitterUnit: 0.5) } == [
+                .milliseconds(500),
+                .seconds(1),
+                .seconds(2),
+                .seconds(4),
+                .seconds(8),
+                .seconds(8),
+            ])
         #expect(policy.delay(forAttempt: 20, jitterUnit: 1) == .seconds(8))
     }
 

--- a/macos/ATCTests/TerminalsStoreTests.swift
+++ b/macos/ATCTests/TerminalsStoreTests.swift
@@ -1,6 +1,7 @@
+import ATCAppServerAPI
 import Foundation
 import Testing
-import ATCAppServerAPI
+
 @testable import ATC
 
 /// TerminalsStore: the sidebar's standalone-terminal projection and
@@ -31,8 +32,9 @@ struct TerminalsStoreTests {
         let (store, _) = await loadedStore()
         #expect(store.hasLoadedOnce)
         #expect(store.lastError == nil)
-        #expect(store.terminals.map(\.id)
-            == ["trm_new", "trm_linked", "trm_ended", "trm_old", "trm_other"])
+        #expect(
+            store.terminals.map(\.id)
+                == ["trm_new", "trm_linked", "trm_ended", "trm_old", "trm_other"])
         #expect(store.terminal(id: "trm_old")?.id == "trm_old")
         #expect(store.terminal(id: "nope") == nil)
     }
@@ -42,8 +44,9 @@ struct TerminalsStoreTests {
         let (store, _) = await loadedStore()
         // Ended tombstones stay (the sidebar renders them); the thread's TUI
         // terminal and other projects' terminals do not.
-        #expect(store.standaloneTerminals(projectID: "prj").map(\.id)
-            == ["trm_old", "trm_ended", "trm_new"])
+        #expect(
+            store.standaloneTerminals(projectID: "prj").map(\.id)
+                == ["trm_old", "trm_ended", "trm_new"])
         #expect(store.standaloneTerminals(projectID: "other").map(\.id) == ["trm_other"])
         #expect(store.standaloneTerminals(projectID: "missing").isEmpty)
     }

--- a/macos/ATCTests/TestSupport.swift
+++ b/macos/ATCTests/TestSupport.swift
@@ -1,7 +1,8 @@
-import AppKit
-import Foundation
 import ATCAppServerAPI
 import ATCAppServerTransport
+import AppKit
+import Foundation
+
 @testable import ATC
 
 // Shared harness for the App Server-era suites: an isolated AppModel wired to

--- a/macos/ATCTests/ThreadDisplayTests.swift
+++ b/macos/ATCTests/ThreadDisplayTests.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Testing
+
 @testable import ATC
 
 /// The ATC-160 display translation: `idle + unread` reads "Done" in the

--- a/macos/ATCTests/ThreadListModelTests.swift
+++ b/macos/ATCTests/ThreadListModelTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+
 @testable import ATC
 
 @Suite("Thread list model")
@@ -29,13 +30,17 @@ struct ThreadListModelTests {
     func duplicateProjectNames() {
         let model = ThreadListModel(
             inputs: [
-                input(local, name: "Local", projects: [
-                    Fixtures.project(id: "p1", name: "App"),
-                    Fixtures.project(id: "p2", name: "Website"),
-                ]),
-                input(remote, name: "Production", projects: [
-                    Fixtures.project(id: "p3", name: "App"),
-                ]),
+                input(
+                    local, name: "Local",
+                    projects: [
+                        Fixtures.project(id: "p1", name: "App"),
+                        Fixtures.project(id: "p2", name: "Website"),
+                    ]),
+                input(
+                    remote, name: "Production",
+                    projects: [
+                        Fixtures.project(id: "p3", name: "App")
+                    ]),
             ],
             filter: .all
         )
@@ -53,7 +58,7 @@ struct ThreadListModelTests {
                         Fixtures.thread(id: "t1", projectId: "prj"),
                         Fixtures.thread(id: "t2", projectId: "gone"),
                     ]
-                ),
+                )
             ],
             filter: .all
         )
@@ -75,7 +80,7 @@ struct ThreadListModelTests {
                         Fixtures.thread(id: "same", workingDirectory: "/src/app", createdAt: Fixtures.date(10)),
                         Fixtures.thread(id: "other", workingDirectory: "/src/app/pkg", createdAt: Fixtures.date(20)),
                     ]
-                ),
+                )
             ],
             filter: .all
         )
@@ -104,7 +109,7 @@ struct ThreadListModelTests {
                         Fixtures.thread(id: "arch_old", archivedAt: Fixtures.date(300)),
                         Fixtures.thread(id: "arch_new", archivedAt: Fixtures.date(400)),
                     ]
-                ),
+                )
             ],
             filter: .all
         )
@@ -131,7 +136,7 @@ struct ThreadListModelTests {
                     Fixtures.thread(id: "pinned", projectId: "p2", pinnedAt: Fixtures.date(1)),
                 ],
                 archived: [Fixtures.thread(id: "arch", projectId: "p2", archivedAt: Fixtures.date(2))]
-            ),
+            )
         ]
         let filtered = ThreadListModel(
             inputs: inputs,
@@ -170,7 +175,7 @@ struct ThreadListModelTests {
                     local,
                     name: "Local",
                     threads: [Fixtures.thread(id: "t1", pinnedAt: Fixtures.date(1))]
-                ),
+                )
             ],
             filter: .all
         )

--- a/macos/ATCTests/ThreadNotifierTests.swift
+++ b/macos/ATCTests/ThreadNotifierTests.swift
@@ -1,6 +1,7 @@
+import ATCAppServerAPI
 import Foundation
 import Testing
-import ATCAppServerAPI
+
 @testable import ATC
 
 /// ThreadNotifier: the trigger, withdraw, and baseline decisions. Every case
@@ -55,10 +56,12 @@ struct ThreadNotifierTests {
         let recorder = Recorder()
         let notifier = recorder.makeNotifier()
 
-        notifier.reconcile(connections: [input([
-            Fixtures.thread(id: "thr1", unread: true),
-            Fixtures.thread(id: "thr2", activityState: .needsInput),
-        ])])
+        notifier.reconcile(connections: [
+            input([
+                Fixtures.thread(id: "thr1", unread: true),
+                Fixtures.thread(id: "thr2", activityState: .needsInput),
+            ])
+        ])
 
         #expect(recorder.posts.isEmpty)
         #expect(recorder.withdrawn.isEmpty)
@@ -70,17 +73,20 @@ struct ThreadNotifierTests {
         let notifier = recorder.makeNotifier()
         notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1", name: "Fix login")])])
 
-        notifier.reconcile(connections: [input([
-            Fixtures.thread(id: "thr1", name: "Fix login", unread: true),
-        ])])
-
-        #expect(recorder.posts == [
-            Recorder.Banner(
-                id: ref("thr1").notificationIdentifier,
-                title: "Fix login",
-                body: "Finished · App"
-            ),
+        notifier.reconcile(connections: [
+            input([
+                Fixtures.thread(id: "thr1", name: "Fix login", unread: true)
+            ])
         ])
+
+        #expect(
+            recorder.posts == [
+                Recorder.Banner(
+                    id: ref("thr1").notificationIdentifier,
+                    title: "Fix login",
+                    body: "Finished · App"
+                )
+            ])
     }
 
     @Test("needs_input notifies, and outranks the unread a finished turn also sets")
@@ -89,15 +95,19 @@ struct ThreadNotifierTests {
         let notifier = recorder.makeNotifier()
         notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1", name: "Fix login")])])
 
-        notifier.reconcile(connections: [input([
-            Fixtures.thread(id: "thr1", name: "Fix login", activityState: .needsInput, unread: true),
-        ])])
+        notifier.reconcile(connections: [
+            input([
+                Fixtures.thread(id: "thr1", name: "Fix login", activityState: .needsInput, unread: true)
+            ])
+        ])
         #expect(recorder.posts.map(\.body) == ["Needs your input · App"])
 
         // Still needing input is the same claim: no second banner for it.
-        notifier.reconcile(connections: [input([
-            Fixtures.thread(id: "thr1", name: "Fix login", activityState: .needsInput, unread: true),
-        ])])
+        notifier.reconcile(connections: [
+            input([
+                Fixtures.thread(id: "thr1", name: "Fix login", activityState: .needsInput, unread: true)
+            ])
+        ])
         #expect(recorder.posts.count == 1)
     }
 
@@ -123,15 +133,19 @@ struct ThreadNotifierTests {
         let recorder = Recorder()
         let notifier = recorder.makeNotifier()
         notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1")])])
-        notifier.reconcile(connections: [input([
-            Fixtures.thread(id: "thr1", activityState: .needsInput, unread: true),
-        ])])
+        notifier.reconcile(connections: [
+            input([
+                Fixtures.thread(id: "thr1", activityState: .needsInput, unread: true)
+            ])
+        ])
 
         // Answering in the TUI resumes the turn. Unread was already set, so
         // nothing finished that the user has not been told about.
-        notifier.reconcile(connections: [input([
-            Fixtures.thread(id: "thr1", activityState: .working, unread: true),
-        ])])
+        notifier.reconcile(connections: [
+            input([
+                Fixtures.thread(id: "thr1", activityState: .working, unread: true)
+            ])
+        ])
 
         #expect(recorder.posts.count == 1)
         #expect(recorder.withdrawn == [ref("thr1").notificationIdentifier])
@@ -209,18 +223,22 @@ struct ThreadNotifierTests {
         let recorder = Recorder()
         let notifier = recorder.makeNotifier()
         notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1")])])
-        notifier.reconcile(connections: [input([
-            Fixtures.thread(id: "thr1", activityState: .needsInput),
-        ])])
+        notifier.reconcile(connections: [
+            input([
+                Fixtures.thread(id: "thr1", activityState: .needsInput)
+            ])
+        ])
         #expect(recorder.posts.count == 1)
 
         // The turn finishes without input while ATC is frontmost: the
         // .finished trigger is suppressed, but the needs-input claim is now
         // false and the banner must still come down.
         notifier.isAppActive = { true }
-        notifier.reconcile(connections: [input([
-            Fixtures.thread(id: "thr1", activityState: .idle, unread: true),
-        ])])
+        notifier.reconcile(connections: [
+            input([
+                Fixtures.thread(id: "thr1", activityState: .idle, unread: true)
+            ])
+        ])
 
         #expect(recorder.posts.count == 1)
         #expect(recorder.withdrawn == [ref("thr1").notificationIdentifier])
@@ -231,19 +249,25 @@ struct ThreadNotifierTests {
         let recorder = Recorder()
         let notifier = recorder.makeNotifier()
         notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1")])])
-        notifier.reconcile(connections: [input([
-            Fixtures.thread(id: "thr1", activityState: .needsInput),
-        ])])
+        notifier.reconcile(connections: [
+            input([
+                Fixtures.thread(id: "thr1", activityState: .needsInput)
+            ])
+        ])
         #expect(recorder.posts.count == 1)
 
         // The server loses sight of the provider (socket blip, restart) and
         // then finds it again: absence of evidence, not a state change.
-        notifier.reconcile(connections: [input([
-            Fixtures.thread(id: "thr1", activityState: .unknown),
-        ])])
-        notifier.reconcile(connections: [input([
-            Fixtures.thread(id: "thr1", activityState: .needsInput),
-        ])])
+        notifier.reconcile(connections: [
+            input([
+                Fixtures.thread(id: "thr1", activityState: .unknown)
+            ])
+        ])
+        notifier.reconcile(connections: [
+            input([
+                Fixtures.thread(id: "thr1", activityState: .needsInput)
+            ])
+        ])
 
         #expect(recorder.posts.count == 1)
         #expect(recorder.withdrawn.isEmpty)
@@ -254,15 +278,19 @@ struct ThreadNotifierTests {
         let recorder = Recorder()
         let notifier = recorder.makeNotifier()
         notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1")])])
-        notifier.reconcile(connections: [input([
-            Fixtures.thread(id: "thr1", activityState: .needsInput),
-        ])])
+        notifier.reconcile(connections: [
+            input([
+                Fixtures.thread(id: "thr1", activityState: .needsInput)
+            ])
+        ])
 
         // activityState (live provider evidence) and unread (turn
         // persistence) can land in separate refreshes.
-        notifier.reconcile(connections: [input([
-            Fixtures.thread(id: "thr1", activityState: .needsInput, unread: true),
-        ])])
+        notifier.reconcile(connections: [
+            input([
+                Fixtures.thread(id: "thr1", activityState: .needsInput, unread: true)
+            ])
+        ])
 
         #expect(recorder.posts.map(\.body) == ["Needs your input · App"])
         #expect(recorder.withdrawn.isEmpty)
@@ -274,10 +302,12 @@ struct ThreadNotifierTests {
         let notifier = recorder.makeNotifier()
         notifier.reconcile(connections: [input([Fixtures.thread(id: "thr1")])])
 
-        notifier.reconcile(connections: [input([
-            Fixtures.thread(id: "thr1"),
-            Fixtures.thread(id: "thr2", unread: true),
-        ])])
+        notifier.reconcile(connections: [
+            input([
+                Fixtures.thread(id: "thr1"),
+                Fixtures.thread(id: "thr2", unread: true),
+            ])
+        ])
 
         #expect(recorder.posts.isEmpty)
     }

--- a/macos/ATCTests/ThreadsStoreTests.swift
+++ b/macos/ATCTests/ThreadsStoreTests.swift
@@ -1,6 +1,7 @@
+import ATCAppServerAPI
 import Foundation
 import Testing
-import ATCAppServerAPI
+
 @testable import ATC
 
 /// ThreadsStore: the active/archived split, the lazy archived load, and the
@@ -45,11 +46,12 @@ struct ThreadsStoreTests {
         await store.loadArchivedIfNeeded()
         #expect(client.listThreadsCount == afterFirstLoad)
 
-        client.threads.append(Fixtures.thread(
-            id: "thr_archived2",
-            archivedAt: Fixtures.date(70),
-            createdAt: Fixtures.date(6)
-        ))
+        client.threads.append(
+            Fixtures.thread(
+                id: "thr_archived2",
+                archivedAt: Fixtures.date(70),
+                createdAt: Fixtures.date(6)
+            ))
         await store.refresh()
         #expect(store.archivedThreads.map(\.id) == ["thr_archived2", "thr_archived"])
         #expect(client.listThreadsCount == afterFirstLoad + 2)

--- a/macos/ATCTests/TriggerParsingTests.swift
+++ b/macos/ATCTests/TriggerParsingTests.swift
@@ -1,4 +1,5 @@
 import Testing
+
 @testable import ATC
 
 @Suite("Keyboard trigger parsing")
@@ -10,10 +11,12 @@ struct TriggerParsingTests {
             let stroke = try #require(try? KeyStroke.parse(alias).get())
             #expect(stroke == KeyStroke(key: "b", modifiers: .command))
         }
-        #expect(try KeyStroke.parse("Control+B").get()
-            == KeyStroke(key: "b", modifiers: .control))
-        #expect(try KeyStroke.parse("ALT+B").get()
-            == KeyStroke(key: "b", modifiers: .option))
+        #expect(
+            try KeyStroke.parse("Control+B").get()
+                == KeyStroke(key: "b", modifiers: .control))
+        #expect(
+            try KeyStroke.parse("ALT+B").get()
+                == KeyStroke(key: "b", modifiers: .option))
     }
 
     @Test("shift and multiple modifiers normalize independently of spelling")
@@ -26,23 +29,28 @@ struct TriggerParsingTests {
 
     @Test("spoken shortcuts name modifiers in glyph order")
     func spokenDescription() {
-        #expect(KeyStroke(
-            key: "p",
-            modifiers: [.control, .option, .shift, .command]
-        ).spokenDescription == "Control Option Shift Command P")
+        #expect(
+            KeyStroke(
+                key: "p",
+                modifiers: [.control, .option, .shift, .command]
+            ).spokenDescription == "Control Option Shift Command P")
         #expect(KeyStroke.escape.spokenDescription == "Escape")
     }
 
     @Test("sequence parsing reserves leader for step one")
     func sequences() throws {
-        #expect(try ParsedKeySequence.parse("cmd+b").get()
-            == .direct(KeyStroke(key: "b", modifiers: .command)))
-        #expect(try ParsedKeySequence.parse(" leader > b ").get()
-            == .leader(continuation: KeyStroke(key: "b", modifiers: [])))
-        #expect(try ParsedKeySequence.parse("leader>cmd+shift+b").get()
-            == .leader(continuation: KeyStroke(
-                key: "b", modifiers: [.command, .shift]
-            )))
+        #expect(
+            try ParsedKeySequence.parse("cmd+b").get()
+                == .direct(KeyStroke(key: "b", modifiers: .command)))
+        #expect(
+            try ParsedKeySequence.parse(" leader > b ").get()
+                == .leader(continuation: KeyStroke(key: "b", modifiers: [])))
+        #expect(
+            try ParsedKeySequence.parse("leader>cmd+shift+b").get()
+                == .leader(
+                    continuation: KeyStroke(
+                        key: "b", modifiers: [.command, .shift]
+                    )))
     }
 
     @Test("invalid direct triggers are rejected with actionable tokens")

--- a/macos/ATCTests/WindowStateTests.swift
+++ b/macos/ATCTests/WindowStateTests.swift
@@ -1,7 +1,8 @@
+import ATCAppServerAPI
 import Foundation
 import SwiftUI
 import Testing
-import ATCAppServerAPI
+
 @testable import ATC
 
 /// Per-window navigation: the one thread-open transition, and the

--- a/mise.toml
+++ b/mise.toml
@@ -32,8 +32,8 @@ echo "installed $dir/atc ($("$dir/atc" --version))"
 """
 
 [tasks.check]
-description = "All gates: App Server check, Swift lint, Kit tests, macOS app tests"
-depends = ["app-server:check", "swift:lint", "kit:test", "macos:test"]
+description = "All gates: App Server check, Swift lint+format, Kit tests, macOS app tests"
+depends = ["app-server:check", "swift:lint", "swift:fmt:check", "kit:test", "macos:test"]
 
 [tasks.test]
 description = "All tests: App Server, ATCKit, macOS app"
@@ -80,6 +80,16 @@ run = "swiftlint lint --strict --quiet"
 [tasks."swift:lint:fix"]
 description = "Apply SwiftLint autocorrections"
 run = "swiftlint lint --fix --quiet"
+
+# swift format ships with the Swift toolchain; explicit paths keep it out of
+# packages/ATCKit/.build (dependency checkouts).
+[tasks."swift:fmt"]
+description = "Format Swift sources with swift format (.swift-format config)"
+run = "swift format --in-place --recursive macos packages/ATCKit/Sources packages/ATCKit/Tests packages/ATCKit/Package.swift"
+
+[tasks."swift:fmt:check"]
+description = "Fail if any Swift source is not swift-format-clean"
+run = "swift format lint --strict --recursive macos packages/ATCKit/Sources packages/ATCKit/Tests packages/ATCKit/Package.swift"
 
 # ATC_STRICT_WARNINGS=1 (set in CI) promotes compiler warnings to errors in
 # our targets only — SPM suppresses dependency warnings. Local runs stay

--- a/packages/ATCKit/Package.swift
+++ b/packages/ATCKit/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "ATCKit",
     platforms: [
-        .macOS(.v26),
+        .macOS(.v26)
     ],
     products: [
         // Client generated from the App Server OpenAPI contract
@@ -31,7 +31,7 @@ let package = Package(
                 .product(name: "HTTPTypes", package: "swift-http-types"),
             ],
             plugins: [
-                .plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator"),
+                .plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator")
             ]
         ),
         .target(

--- a/packages/ATCKit/Sources/ATCAppServerTransport/AttachSocket.swift
+++ b/packages/ATCKit/Sources/ATCAppServerTransport/AttachSocket.swift
@@ -54,10 +54,11 @@ protocol AttachWebSocketTask: Sendable {
 }
 
 /// Opens one connection; `onOpen` fires when the handshake completes.
-typealias AttachTransport = @Sendable (
-    _ request: URLRequest,
-    _ onOpen: @escaping @Sendable () -> Void
-) -> any AttachWebSocketTask
+typealias AttachTransport =
+    @Sendable (
+        _ request: URLRequest,
+        _ onOpen: @escaping @Sendable () -> Void
+    ) -> any AttachWebSocketTask
 
 public actor AttachSocket {
     /// Protocol-level pings are a liveness backstop for sleeping Macs and

--- a/packages/ATCKit/Sources/ATCAppServerTransport/ResourceEventStream.swift
+++ b/packages/ATCKit/Sources/ATCAppServerTransport/ResourceEventStream.swift
@@ -47,7 +47,8 @@ public enum ResourceEventStream {
 
     /// A single connection attempt: HTTP status plus the raw byte chunks.
     /// Injected in tests; live path wraps URLSession.bytes.
-    typealias Connector = @Sendable (URL, [String: String]) async throws
+    typealias Connector =
+        @Sendable (URL, [String: String]) async throws
         -> (statusCode: Int, chunks: AsyncThrowingStream<[UInt8], any Error>)
 
     public static func live(
@@ -92,7 +93,8 @@ public enum ResourceEventStream {
                     }
                     // Only a connection that lived a while proves the server
                     // healthy; a greet-then-drop cycle keeps escalating.
-                    let wasStable = sawConnected
+                    let wasStable =
+                        sawConnected
                         && clock.now - opened >= configuration.reconnectMaxDelay
                     attempt = wasStable ? 0 : attempt + 1
                     try? await Task.sleep(for: backoff.delay(forAttempt: attempt))

--- a/packages/ATCKit/Tests/ATCAppServerAPITests/ClientTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerAPITests/ClientTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import HTTPTypes
 import OpenAPIRuntime
 import Testing
+
 @testable import ATCAppServerAPI
 
 /// Serves one canned JSON body for every request, capturing what the client sent.
@@ -164,7 +165,8 @@ struct ClientTests {
     @Test("pinThread decodes pinnedAt as a date")
     func pinThread() async throws {
         let (client, recorder) = try client(
-            returning: #"{"id":"t1","projectId":"p1","agentId":"codex","workingDirectory":"/code/atc","activityState":"idle","unread":false,"pinnedAt":"2026-08-06T12:34:56.789Z","createdAt":"2026-08-06T12:00:00.000Z","updatedAt":"2026-08-06T12:34:56.789Z"}"#
+            returning:
+                #"{"id":"t1","projectId":"p1","agentId":"codex","workingDirectory":"/code/atc","activityState":"idle","unread":false,"pinnedAt":"2026-08-06T12:34:56.789Z","createdAt":"2026-08-06T12:00:00.000Z","updatedAt":"2026-08-06T12:34:56.789Z"}"#
         )
         let thread = try await client.pinThread(path: .init(threadId: "t1")).ok.body.json
         #expect(thread.pinnedAt == Date(timeIntervalSince1970: 1_786_019_696.789))

--- a/packages/ATCKit/Tests/ATCAppServerTransportTests/AttachProtocolFixtureTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerTransportTests/AttachProtocolFixtureTests.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import Testing
+
 @testable import ATCAppServerTransport
 
 private func fixture<T: Decodable>(_ name: String, as type: T.Type) throws -> T {

--- a/packages/ATCKit/Tests/ATCAppServerTransportTests/AttachSocketTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerTransportTests/AttachSocketTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+
 @testable import ATCAppServerTransport
 
 /// Scripted stand-in for one WebSocket connection: the test delivers server

--- a/packages/ATCKit/Tests/ATCAppServerTransportTests/OutboundQueueTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerTransportTests/OutboundQueueTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+
 @testable import ATCAppServerTransport
 
 @Suite("Attach outbound queue")

--- a/packages/ATCKit/Tests/ATCAppServerTransportTests/ResourceEventStreamTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerTransportTests/ResourceEventStreamTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+
 @testable import ATCAppServerTransport
 
 /// Scripted stand-in for the live URLSession connector: each connection
@@ -184,7 +185,7 @@ struct ResourceEventStreamTests {
                     "data: {\"resource\":\"project\",\"id\":\"p1\",\"change\":\"created\"}\n\n",
                 ],
                 thenHang: true
-            ),
+            )
         ])
         let stream = ResourceEventStream.stream(
             url: eventsURL, configuration: fastConfiguration(), connector: connector.connect()
@@ -210,7 +211,7 @@ struct ResourceEventStreamTests {
                     "data: {\"resource\":\"terminal\",\"id\":\"term1\",\"change\":\"deleted\"}\n\n",
                 ],
                 thenHang: true
-            ),
+            )
         ])
         let stream = ResourceEventStream.stream(
             url: eventsURL, configuration: fastConfiguration(), connector: connector.connect()

--- a/packages/ATCKit/Tests/ATCAppServerTransportTests/SSEParserTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerTransportTests/SSEParserTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+
 @testable import ATCAppServerTransport
 
 @Suite("SSE parser")


### PR DESCRIPTION
Part 4 of the ATC-187 linting stack (base: #194) — Phase 2 of the issue, isolated as three commits so the mechanical change stays reviewable:

1. **Config**: `.swift-format` with explicit decisions — four-space indentation (the repo's existing style), 120-column lines, trailing commas in multiline collections (matching the Swift 6.1 style already in use and the TS surfaces), ordered imports, respect for existing line breaks.
2. **Mechanical baseline**: `swift format --in-place` across `macos/` and ATCKit — formatting only, no behavioral edits. SwiftLint's `opening_brace` rule retires here because swift-format owns brace placement (it breaks before `{` after multiline clauses). Verified with strict SwiftLint, ATCKit tests, and the full macOS suite under `ATC_STRICT_WARNINGS=1`.
3. **Gate**: `swift:fmt` / `swift:fmt:check` tasks; the strict check joins root `mise run check` and macOS CI to hold the clean baseline.

https://claude.ai/code/session_0144WKu2f2AofZEnHyV1onAM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated Swift formatting validation to the project’s quality checks.
  * Standardized Swift formatting, indentation, line lengths, import ordering, and brace conventions.
  * Updated development guidance for running Swift linting and formatting checks.

* **Tests**
  * Reformatted test sources and fixtures for consistency without changing test coverage or behavior.

* **Refactor**
  * Applied formatting-only updates throughout the macOS app and supporting package; no user-facing behavior or public APIs changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->