### PR TITLE
Parallelize macOS CI and cache SPM checkouts (ATC-187)

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -46,11 +46,34 @@ jobs:
               - "mise.toml"
               - ".github/workflows/macos-ci.yml"
 
-  validate:
+  # SwiftLint ships official Linux binaries, so linting runs on a cheap
+  # runner while the macOS jobs spin up.
+  lint:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: jdx/mise-action@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: SwiftLint
+        run: mise run swift:lint
+
+  # Both macOS jobs cache packages/ATCKit/.build keyed on Package.resolved:
+  # SPM source checkouts plus build products, which SPM keeps incrementally
+  # correct (unlike DerivedData, which is never cached here). The app job
+  # needs it too — prepare-xcode-openapi.sh compiles swift-openapi-generator
+  # out of that directory before xcodebuild starts.
+  kit:
+    name: ATCKit tests + swift-format
     needs: changes
     if: needs.changes.outputs.relevant == 'true'
     runs-on: macos-26
-    timeout-minutes: 30
+    timeout-minutes: 15
     env:
       # CI-only: compiler warnings in our targets fail the build. Locally the
       # tasks stay permissive so a new Xcode deprecation can't block iteration.
@@ -62,20 +85,53 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Show Xcode version
-        run: xcodebuild -version
+      - uses: actions/cache@v5
+        with:
+          path: packages/ATCKit/.build
+          key: spm-kit-${{ runner.os }}-${{ hashFiles('packages/ATCKit/Package.resolved') }}
+          restore-keys: spm-kit-${{ runner.os }}-
 
-      # Same commands as local `mise run swift:lint` / `swift:fmt:check` /
-      # `kit:test` / `macos:test`.
-      - name: SwiftLint
-        run: mise run swift:lint
-
+      # Same commands as local `mise run swift:fmt:check` / `kit:test`.
       - name: swift-format check
         run: mise run swift:fmt:check
 
       - name: ATCKit tests
         run: mise run kit:test
 
+  app:
+    name: macOS app tests
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: macos-26
+    timeout-minutes: 30
+    env:
+      ATC_STRICT_WARNINGS: "1"
+      # Pins where xcodebuild clones SPM dependencies so the checkout cache
+      # below has a stable path (DerivedData itself stays per-run).
+      ATC_XCODE_SPM_DIR: ${{ github.workspace }}/.spm-packages
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: jdx/mise-action@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/cache@v5
+        with:
+          path: packages/ATCKit/.build
+          key: spm-kit-${{ runner.os }}-${{ hashFiles('packages/ATCKit/Package.resolved') }}
+          restore-keys: spm-kit-${{ runner.os }}-
+
+      - uses: actions/cache@v5
+        with:
+          path: .spm-packages
+          key: spm-xcode-${{ runner.os }}-${{ hashFiles('macos/atc.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: spm-xcode-${{ runner.os }}-
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      # Same command as local `mise run macos:test`.
       - name: macOS app tests
         run: mise run macos:test
 
@@ -84,7 +140,7 @@ jobs:
   # ruleset can require it without hanging non-matching PRs.
   ci-ok:
     name: macos-ci-ok
-    needs: [changes, validate]
+    needs: [changes, lint, kit, app]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ coverage/
 experiments/provider-identity-resume/.generated/
 experiments/provider-identity-resume/runs/
 *.profraw
+
+# xcodebuild SPM clone dir (ATC_XCODE_SPM_DIR; cached in CI)
+.spm-packages*/

--- a/mise.toml
+++ b/mise.toml
@@ -120,23 +120,32 @@ set -euo pipefail
 derived_data_path="$(mktemp -d "${TMPDIR:-/tmp}/atc-macos-test.XXXXXX")"
 trap 'rm -rf "$derived_data_path"' EXIT
 
+# Optional xcodebuild arguments accumulate here; the ${extra[@]+...}
+# expansion below is the bash 3.2-safe way to expand a possibly-empty array
+# under set -u.
+extra=()
+
 # ATC_SWIFT_STRICT_WARNINGS feeds the indirection in project.pbxproj: only
 # this project's targets reference it, so a global SWIFT_TREAT_WARNINGS_AS_
 # ERRORS override cannot break Swift package dependencies.
-strict_settings=""
 if [ "${ATC_STRICT_WARNINGS:-0}" = "1" ]; then
-  strict_settings="ATC_SWIFT_STRICT_WARNINGS=YES"
+  extra+=("ATC_SWIFT_STRICT_WARNINGS=YES")
+fi
+
+# CI pins where xcodebuild clones SPM dependencies so the checkouts can be
+# cached across runs; unset locally, where Xcode's default location is fine.
+if [ -n "${ATC_XCODE_SPM_DIR:-}" ]; then
+  extra+=(-clonedSourcePackagesDirPath "$ATC_XCODE_SPM_DIR")
 fi
 
 scripts/prepare-xcode-openapi.sh "$derived_data_path"
-# $strict_settings intentionally unquoted: empty must vanish, not become "".
 xcodebuild test \
   -project macos/atc.xcodeproj \
   -scheme atc \
   -destination platform=macOS \
   -derivedDataPath "$derived_data_path" \
   -skipPackagePluginValidation \
-  CODE_SIGNING_ALLOWED=NO $strict_settings
+  CODE_SIGNING_ALLOWED=NO ${extra[@]+"${extra[@]}"}
 """
 
 [tasks.refs]


### PR DESCRIPTION
Part 5 of the ATC-187 stack (base: #195). Speeds up macOS CI using only standard patterns — no DerivedData caching.

- **Parallel jobs**: the serial `validate` job becomes three parallel jobs — SwiftLint on ubuntu (official Linux binaries), ATCKit tests + swift-format check on one macOS runner, app tests on another. Wall clock becomes the slowest single job instead of the sum.
- **SPM caching, sources and package build products only**: `packages/ATCKit/.build` is cached keyed on `Package.resolved` in both macOS jobs — `prepare-xcode-openapi.sh` compiles swift-openapi-generator out of that directory before xcodebuild even starts, so the app job benefits too. xcodebuild's own SPM clones get a stable, cacheable path via `-clonedSourcePackagesDirPath` (new optional `ATC_XCODE_SPM_DIR` seam in `macos:test`; unset locally). DerivedData is deliberately never cached — cross-run DerivedData reuse is the known-flaky pattern this PR avoids.
- `macos-ci-ok` now aggregates `changes`, `lint`, `kit`, and `app`.

Verified locally: full macOS suite green with `ATC_XCODE_SPM_DIR` set (checkouts landed in the pinned dir). First CI run on this PR is a cache miss; I'll re-run the jobs after it completes to confirm cache-hit timings.

https://claude.ai/code/session_0144WKu2f2AofZEnHyV1onAM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * SwiftLint now runs in a dedicated validation job.
  * macOS kit and app tests run as separate jobs with improved build caching.
  * App tests support configurable Swift Package Manager dependency paths and strict-warning checks.
  * Overall CI status now reflects linting, kit tests, and app tests.

* **Chores**
  * Excluded Xcode Swift Package Manager clone directories from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->