### PR TITLE
Add Shift+Enter newline keybind as an ATC terminal default (ATC-194)

### DIFF
--- a/macos/ATC/TerminalBridge/TerminalPresentation.swift
+++ b/macos/ATC/TerminalBridge/TerminalPresentation.swift
@@ -50,6 +50,9 @@ enum TerminalPresentation {
             }
             builder.withWindowPaddingX(preferences.paddingX ?? defaultPaddingX)
             builder.withWindowPaddingY(preferences.paddingY ?? defaultPaddingY)
+            // ATC owns newline-in-prompt for coding CLIs without reading the
+            // user's Ghostty configuration.
+            builder.withCustom("keybind", "shift+enter=text:\\x1b\\r")
             // background is rendered through the theme (themes render after
             // this configuration, so only a theme-level value wins).
         }

--- a/macos/ATCTests/TerminalPresentationTests.swift
+++ b/macos/ATCTests/TerminalPresentationTests.swift
@@ -13,6 +13,7 @@ struct TerminalPresentationTests {
             ) == """
                 window-padding-x = 8
                 window-padding-y = 6
+                keybind = shift+enter=text:\\x1b\\r
                 """)
     }
 
@@ -21,19 +22,19 @@ struct TerminalPresentationTests {
         let cases: [(TerminalPreferences, String)] = [
             (
                 .init(fontFamily: "Berkeley Mono"),
-                "font-family = Berkeley Mono\nwindow-padding-x = 8\nwindow-padding-y = 6"
+                "font-family = Berkeley Mono\nwindow-padding-x = 8\nwindow-padding-y = 6\nkeybind = shift+enter=text:\\x1b\\r"
             ),
             (
                 .init(fontSize: 14),
-                "font-size = 14\nwindow-padding-x = 8\nwindow-padding-y = 6"
+                "font-size = 14\nwindow-padding-x = 8\nwindow-padding-y = 6\nkeybind = shift+enter=text:\\x1b\\r"
             ),
             (
                 .init(paddingX: 12),
-                "window-padding-x = 12\nwindow-padding-y = 6"
+                "window-padding-x = 12\nwindow-padding-y = 6\nkeybind = shift+enter=text:\\x1b\\r"
             ),
             (
                 .init(paddingY: 9),
-                "window-padding-x = 8\nwindow-padding-y = 9"
+                "window-padding-x = 8\nwindow-padding-y = 9\nkeybind = shift+enter=text:\\x1b\\r"
             ),
         ]
 
@@ -53,6 +54,7 @@ struct TerminalPresentationTests {
             ) == """
                 window-padding-x = 0
                 window-padding-y = 0
+                keybind = shift+enter=text:\\x1b\\r
                 """)
     }
 
@@ -65,6 +67,7 @@ struct TerminalPresentationTests {
             rendered == """
                 window-padding-x = 8
                 window-padding-y = 6
+                keybind = shift+enter=text:\\x1b\\r
                 """)
         #expect(!rendered.contains("theme"))
     }
@@ -72,12 +75,13 @@ struct TerminalPresentationTests {
     @Test("unset preferences apply safe padding and the app-owned canvas background")
     func compiledDefaultsController() {
         // Unset preferences keep libghostty's compiled defaults except for
-        // safe content padding and the app-owned background.
+        // safe content padding, the coding CLI keybind, and the app-owned background.
         let controller = TerminalPresentation.makeController(preferences: .init())
         #expect(
             controller.renderedConfig == """
                 window-padding-x = 8
                 window-padding-y = 6
+                keybind = shift+enter=text:\\x1b\\r
                 background = 141416
 
                 """)


### PR DESCRIPTION
Fixes ATC-194.

Shift+Enter did not insert a newline in coding CLIs (Codex etc.) inside the native ATC terminal, because ATC intentionally does not read the user's Ghostty configuration and its generated config had no such binding.

## Change

- `TerminalPresentation.configuration` now emits an unconditional ATC-owned default via the builder's escape hatch: `keybind = shift+enter=text:\x1b\r` (the `\x1b\r` escapes are literal text in the rendered config; libghostty parses them).
- All exact rendered-configuration assertions in `TerminalPresentationTests` updated to pin the new line; the full-string comparisons guarantee exactly one Shift+Enter binding.

Plain Enter, Ctrl+J, and all other terminal input are untouched — this only adds one keybind line to the generated config. Scoped entirely to the native presentation layer; the App Server and zmx stay client-agnostic.

## Verification

- `mise run macos:test` — 293 tests in 33 suites pass.
- `mise run swift:fmt:check` and `mise run swift:lint` pass.

https://claude.ai/code/session_01QadNnmAm9aZSkhDmkKtDcN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `Shift+Enter` support in the terminal to insert a newline.

* **Bug Fixes**
  * Updated terminal configuration handling so the shortcut is consistently included across default and customized setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->