### PR TITLE
Speed up macOS product releases

### DIFF
--- a/.github/workflows/product-release.yml
+++ b/.github/workflows/product-release.yml
@@ -202,6 +202,10 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 45
     environment: release
+    env:
+      # Keep Xcode's package checkout outside disposable DerivedData so warm
+      # release runs do not clone the resolved dependency graph again.
+      ATC_XCODE_SPM_DIR: ${{ github.workspace }}/.spm-packages
     concurrency:
       group: product-release-macos-${{ needs.plan.outputs.channel == 'dev' && 'dev' || github.run_id }}
       cancel-in-progress: true
@@ -214,14 +218,19 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+      - name: Restore SwiftPM tool cache
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: packages/ATCKit/.build
           key: spm-kit-${{ runner.os }}-${{ hashFiles('packages/ATCKit/Package.resolved') }}
           restore-keys: spm-kit-${{ runner.os }}-
 
-      - name: Test macOS app
-        run: mise run macos:test
+      - name: Restore Xcode package cache
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+        with:
+          path: .spm-packages
+          key: spm-xcode-${{ runner.os }}-${{ hashFiles('macos/atc.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: spm-xcode-${{ runner.os }}-
 
       - name: Install ephemeral signing credentials
         id: signing
@@ -238,6 +247,7 @@ jobs:
           ATC_APP_STORE_CONNECT_KEY_PATH: ${{ steps.signing.outputs.app_store_connect_key_path }}
           ATC_APP_STORE_CONNECT_KEY_ID: ${{ vars.ATC_APP_STORE_CONNECT_KEY_ID }}
           ATC_APP_STORE_CONNECT_ISSUER_ID: ${{ vars.ATC_APP_STORE_CONNECT_ISSUER_ID }}
+          ATC_RELEASE_LOG_DIR: out/macos-release-logs
         run: |
           scripts/release-macos.sh \
             --channel "${{ needs.plan.outputs.channel }}" \
@@ -258,12 +268,14 @@ jobs:
           path: out/atc-macos-arm64.dmg
           if-no-files-found: error
 
-      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
-        if: always()
+      - name: Upload macOS release failure logs
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        if: failure()
         with:
           name: product-release-macos-logs
-          path: .build/release-macos/**/logs/*.log
+          path: out/macos-release-logs
           if-no-files-found: warn
+          retention-days: 7
 
   publish:
     needs:

--- a/scripts/release-macos.sh
+++ b/scripts/release-macos.sh
@@ -94,8 +94,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 PROJECT_PATH="$REPO_ROOT/macos/atc.xcodeproj"
 EXPORT_OPTIONS_PLIST="$SCRIPT_DIR/ExportOptions.DeveloperID.plist"
+PLIST_BUDDY="${ATC_PLIST_BUDDY:-/usr/libexec/PlistBuddy}"
 if [[ "$OUTPUT_PATH" != /* ]]; then
   OUTPUT_PATH="$REPO_ROOT/$OUTPUT_PATH"
+fi
+if [[ "$ATC_ARTIFACT_ROOT" != /* ]]; then
+  ATC_ARTIFACT_ROOT="$REPO_ROOT/$ATC_ARTIFACT_ROOT"
 fi
 
 case "$CHANNEL" in
@@ -103,7 +107,7 @@ case "$CHANNEL" in
   dev) BUNDLE_ID="ElevenIdeas.atc.dev" ;;
 esac
 
-RUN_DIR="$REPO_ROOT/$ATC_ARTIFACT_ROOT/$BUILD_NUMBER-$CHANNEL"
+RUN_DIR="$ATC_ARTIFACT_ROOT/$BUILD_NUMBER-$CHANNEL"
 ARCHIVE_PATH="$RUN_DIR/atc-$CHANNEL.xcarchive"
 EXPORT_PATH="$RUN_DIR/export"
 DERIVED_DATA_PATH="$RUN_DIR/DerivedData"
@@ -152,7 +156,10 @@ configure_notary_credentials() {
   if [[ -n "${ATC_APP_STORE_CONNECT_KEY_PATH:-}" &&
     -n "${ATC_APP_STORE_CONNECT_KEY_ID:-}" &&
     -n "${ATC_APP_STORE_CONNECT_ISSUER_ID:-}" ]]; then
-    [[ -f "$ATC_APP_STORE_CONNECT_KEY_PATH" ]] || die "App Store Connect API key not found: $ATC_APP_STORE_CONNECT_KEY_PATH"
+    if [[ ! -f "$ATC_APP_STORE_CONNECT_KEY_PATH" ]]; then
+      report_error "App Store Connect API key not found: $ATC_APP_STORE_CONNECT_KEY_PATH"
+      return 1
+    fi
     NOTARY_ARGS=(
       --key "$ATC_APP_STORE_CONNECT_KEY_PATH"
       --key-id "$ATC_APP_STORE_CONNECT_KEY_ID"
@@ -191,7 +198,7 @@ validate_prerequisites() {
 }
 
 plist_value() {
-  /usr/libexec/PlistBuddy -c "Print :$1" "$APP_PATH/Contents/Info.plist"
+  "$PLIST_BUDDY" -c "Print :$1" "$APP_PATH/Contents/Info.plist"
 }
 
 validate_exported_app() {
@@ -225,7 +232,7 @@ run_step() {
 
   if [[ "$VERBOSE" -eq 1 ]]; then
     log "$label"
-    if "$@" 2>&1 | tee "$log_path"; then
+    if run_verbose_step "$log_path" "$@"; then
       printf '==> %s complete (%ss)\n' "$label" "$((SECONDS - started_at))"
       return
     else
@@ -249,6 +256,23 @@ run_step() {
   return "$status"
 }
 
+run_verbose_step() {
+  local log_path="$1"
+  local status=0
+  shift
+
+  # Pipeline elements run in subshells. Shell functions can populate signing
+  # state needed by later steps, so capture and replay their usually-small
+  # output while keeping the function in this shell. External build commands
+  # retain live streaming through tee.
+  if declare -F "$1" >/dev/null; then
+    "$@" >"$log_path" 2>&1 || status=$?
+    cat "$log_path"
+    return "$status"
+  fi
+  "$@" 2>&1 | tee "$log_path"
+}
+
 create_dmg() {
   ditto "$APP_PATH" "$DMG_ROOT/$APP_NAME.app" &&
     ln -s /Applications "$DMG_ROOT/Applications" &&
@@ -267,7 +291,7 @@ staple_dmg() {
 for tool in xcodebuild xcrun hdiutil security codesign spctl ditto; do
   require_tool "$tool"
 done
-[[ -x /usr/libexec/PlistBuddy ]] || die "Missing required tool: /usr/libexec/PlistBuddy"
+[[ -x "$PLIST_BUDDY" ]] || die "Missing required tool: $PLIST_BUDDY"
 [[ -d "$PROJECT_PATH" ]] || die "Missing Xcode project: $PROJECT_PATH"
 [[ -f "$EXPORT_OPTIONS_PLIST" ]] || die "Missing export options: $EXPORT_OPTIONS_PLIST"
 

--- a/scripts/release-macos.sh
+++ b/scripts/release-macos.sh
@@ -103,11 +103,18 @@ RUN_DIR="$REPO_ROOT/$ATC_ARTIFACT_ROOT/$BUILD_NUMBER-$CHANNEL"
 ARCHIVE_PATH="$RUN_DIR/atc-$CHANNEL.xcarchive"
 EXPORT_PATH="$RUN_DIR/export"
 DERIVED_DATA_PATH="$RUN_DIR/DerivedData"
-SOURCE_PACKAGES_PATH="$RUN_DIR/SourcePackages"
+SOURCE_PACKAGES_PATH="${ATC_XCODE_SPM_DIR:-$RUN_DIR/SourcePackages}"
 DMG_ROOT="$RUN_DIR/dmg-root"
 DMG_PATH="$RUN_DIR/atc-macos-arm64.dmg"
 APP_PATH="$EXPORT_PATH/$APP_NAME.app"
-LOG_DIR="$RUN_DIR/logs"
+LOG_DIR="${ATC_RELEASE_LOG_DIR:-$RUN_DIR/logs}"
+
+if [[ "$SOURCE_PACKAGES_PATH" != /* ]]; then
+  SOURCE_PACKAGES_PATH="$REPO_ROOT/$SOURCE_PACKAGES_PATH"
+fi
+if [[ "$LOG_DIR" != /* ]]; then
+  LOG_DIR="$REPO_ROOT/$LOG_DIR"
+fi
 
 DEVELOPER_ID_IDENTITY=""
 NOTARY_ARGS=()
@@ -199,28 +206,31 @@ run_step() {
   local label="$1"
   local log_name="$2"
   local log_path="$LOG_DIR/$log_name.log"
+  local started_at=$SECONDS
   local status
   shift 2
 
   if [[ "$VERBOSE" -eq 1 ]]; then
     log "$label"
     if "$@" 2>&1 | tee "$log_path"; then
+      printf '==> %s complete (%ss)\n' "$label" "$((SECONDS - started_at))"
       return
     else
       status=$?
     fi
-    printf 'error: %s failed (full log: %s)\n' "$label" "$log_path" >&2
+    printf 'error: %s failed after %ss (full log: %s)\n' \
+      "$label" "$((SECONDS - started_at))" "$log_path" >&2
     return "$status"
   fi
 
   printf '  %-58s' "$label"
   if "$@" >"$log_path" 2>&1; then
-    printf '✓\n'
+    printf '✓ (%ss)\n' "$((SECONDS - started_at))"
     return
   else
     status=$?
   fi
-  printf '✗\n\n' >&2
+  printf '✗ (%ss)\n\n' "$((SECONDS - started_at))" >&2
   cat "$log_path" >&2
   printf 'error: %s failed (full log: %s)\n' "$label" "$log_path" >&2
   return "$status"
@@ -249,11 +259,13 @@ done
 [[ -f "$EXPORT_OPTIONS_PLIST" ]] || die "Missing export options: $EXPORT_OPTIONS_PLIST"
 
 printf '\nmacOS release artifact (%s, %s)\n\n' "$CHANNEL" "$VERSION"
+RELEASE_STARTED_AT=$SECONDS
+PREREQUISITES_STARTED_AT=$SECONDS
 printf '  %-58s' "Validate signing and notarization prerequisites"
 find_developer_id_identity
 configure_notary_credentials
 validate_notary_credentials
-printf '✓\n'
+printf '✓ (%ss)\n' "$((SECONDS - PREREQUISITES_STARTED_AT))"
 
 mkdir -p "$RUN_DIR" "$EXPORT_PATH" "$DERIVED_DATA_PATH" "$SOURCE_PACKAGES_PATH" "$DMG_ROOT" "$LOG_DIR"
 
@@ -314,3 +326,4 @@ printf 'Commit: %s\n' "$COMMIT"
 printf 'Built at: %s\n' "$BUILT_AT"
 printf 'DMG: %s\n' "$OUTPUT_PATH"
 printf 'Logs: %s\n' "$LOG_DIR"
+printf 'Elapsed: %ss\n' "$((SECONDS - RELEASE_STARTED_AT))"

--- a/scripts/release-macos.sh
+++ b/scripts/release-macos.sh
@@ -24,8 +24,12 @@ log() {
 }
 
 die() {
-  printf 'error: %s\n' "$*" >&2
+  report_error "$*"
   exit 1
+}
+
+report_error() {
+  printf 'error: %s\n' "$*" >&2
 }
 
 usage_error() {
@@ -135,7 +139,8 @@ find_developer_id_identity() {
 
   if [[ -z "$DEVELOPER_ID_IDENTITY" ]]; then
     printf '%s\n' "$identities" >&2
-    die "No valid Developer ID Application identity found for Team ID $ATC_TEAM_ID"
+    report_error "No valid Developer ID Application identity found for Team ID $ATC_TEAM_ID"
+    return 1
   fi
 }
 
@@ -165,7 +170,8 @@ configure_notary_credentials() {
     )
     return
   fi
-  die "configure ATC_NOTARY_PROFILE or the three ATC_APP_STORE_CONNECT_KEY_* credentials"
+  report_error "configure ATC_NOTARY_PROFILE or the three ATC_APP_STORE_CONNECT_KEY_* credentials"
+  return 1
 }
 
 validate_notary_credentials() {
@@ -174,7 +180,14 @@ validate_notary_credentials() {
     return
   fi
   printf '%s\n' "$output" >&2
-  die "notarytool could not use the configured credentials"
+  report_error "notarytool could not use the configured credentials"
+  return 1
+}
+
+validate_prerequisites() {
+  find_developer_id_identity || return
+  configure_notary_credentials || return
+  validate_notary_credentials
 }
 
 plist_value() {
@@ -260,15 +273,9 @@ done
 
 printf '\nmacOS release artifact (%s, %s)\n\n' "$CHANNEL" "$VERSION"
 RELEASE_STARTED_AT=$SECONDS
-PREREQUISITES_STARTED_AT=$SECONDS
-printf '  %-58s' "Validate signing and notarization prerequisites"
-find_developer_id_identity
-configure_notary_credentials
-validate_notary_credentials
-printf '✓ (%ss)\n' "$((SECONDS - PREREQUISITES_STARTED_AT))"
-
 mkdir -p "$RUN_DIR" "$EXPORT_PATH" "$DERIVED_DATA_PATH" "$SOURCE_PACKAGES_PATH" "$DMG_ROOT" "$LOG_DIR"
 
+run_step "Validate signing and notarization prerequisites" "00-prerequisites" validate_prerequisites
 run_step "Generate App Server API sources" "01-generate-api" \
   "$SCRIPT_DIR/prepare-xcode-openapi.sh" "$DERIVED_DATA_PATH"
 

--- a/scripts/release-test.sh
+++ b/scripts/release-test.sh
@@ -169,10 +169,10 @@ printf '%s\n' \
   'fi' > "$fake_bin/security"
 printf '%s\n' \
   '#!/usr/bin/env bash' \
-  'printf '\''xcrun %s\n'\'' "$*" >> "$TOOL_LOG"' > "$fake_bin/xcrun"
+  '{ printf '\''xcrun'\''; for arg in "$@"; do printf '\'' <%s>'\'' "$arg"; done; printf '\''\n'\''; } >> "$TOOL_LOG"' > "$fake_bin/xcrun"
 printf '%s\n' \
   '#!/usr/bin/env bash' \
-  'printf '\''xcodebuild %s\n'\'' "$*" >> "$TOOL_LOG"' \
+  '{ printf '\''xcodebuild'\''; for arg in "$@"; do printf '\'' <%s>'\'' "$arg"; done; printf '\''\n'\''; } >> "$TOOL_LOG"' \
   'exit 1' > "$fake_bin/xcodebuild"
 chmod +x "$fake_bin/security" "$fake_bin/xcrun" "$fake_bin/xcodebuild"
 
@@ -195,7 +195,7 @@ set -e
 [[ $verbose_status -eq 1 ]]
 [[ "$verbose_output" == *"Archive atc.app failed"* ]]
 grep -Fq -- \
-  "-authenticationKeyPath $api_key_path -authenticationKeyID KEY123 -authenticationKeyIssuerID ISSUER123" \
+  "<-authenticationKeyPath> <$api_key_path> <-authenticationKeyID> <KEY123> <-authenticationKeyIssuerID> <ISSUER123>" \
   "$tool_log"
 
 missing_key_path="$TEST_ROOT/missing-key.p8"

--- a/scripts/release-test.sh
+++ b/scripts/release-test.sh
@@ -116,12 +116,24 @@ set -e
 [[ $invalid_timestamp_status -eq 1 ]]
 [[ "$invalid_timestamp_output" == *"not a valid calendar timestamp"* ]]
 
-prerequisite_log_dir="$TEST_ROOT/release-logs"
-set +e
-prerequisite_output="$(
-  PATH="$fake_bin:$PATH" \
-    SECURITY_LOG="$security_log" \
-    ATC_RELEASE_LOG_DIR="$prerequisite_log_dir" \
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf '\''%s\n'\'' "$4"' > "$fake_bin/date"
+for tool in xcodebuild xcrun hdiutil codesign spctl ditto swift PlistBuddy; do
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$fake_bin/$tool"
+done
+chmod +x "$fake_bin/date" "$fake_bin/xcodebuild" "$fake_bin/xcrun" \
+  "$fake_bin/hdiutil" "$fake_bin/codesign" "$fake_bin/spctl" \
+  "$fake_bin/ditto" "$fake_bin/swift" "$fake_bin/PlistBuddy"
+
+run_macos_release_test() {
+  local artifact_root="$1"
+  local log_dir="$2"
+  shift 2
+
+  ATC_ARTIFACT_ROOT="$artifact_root" \
+    ATC_PLIST_BUDDY="$fake_bin/PlistBuddy" \
+    ATC_RELEASE_LOG_DIR="$log_dir" \
     "$SCRIPT_DIR/release-macos.sh" \
     --channel dev \
     --version 1.2.3-dev.2 \
@@ -130,6 +142,15 @@ prerequisite_output="$(
     --commit "$commit" \
     --built-at 2026-08-15T12:34:56Z \
     --output "$TEST_ROOT/atc.dmg" \
+    "$@"
+}
+
+prerequisite_log_dir="$TEST_ROOT/release-logs"
+set +e
+prerequisite_output="$(
+  PATH="$fake_bin:$PATH" \
+    SECURITY_LOG="$security_log" \
+    run_macos_release_test "$TEST_ROOT/release-artifacts" "$prerequisite_log_dir" \
     2>&1
 )"
 prerequisite_status=$?
@@ -138,6 +159,64 @@ set -e
 [[ "$prerequisite_output" == *"Validate signing and notarization prerequisites"* ]]
 grep -Fq "No valid Developer ID Application identity found" \
   "$prerequisite_log_dir/00-prerequisites.log"
+
+tool_log="$TEST_ROOT/release-tools.log"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf '\''security %s\n'\'' "$*" >> "$TOOL_LOG"' \
+  'if [[ "$*" == "find-identity -v -p codesigning" ]]; then' \
+  '  printf '\''1) ABC "Developer ID Application: Test (337D6CNU4E)"\n'\''' \
+  'fi' > "$fake_bin/security"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf '\''xcrun %s\n'\'' "$*" >> "$TOOL_LOG"' > "$fake_bin/xcrun"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf '\''xcodebuild %s\n'\'' "$*" >> "$TOOL_LOG"' \
+  'exit 1' > "$fake_bin/xcodebuild"
+chmod +x "$fake_bin/security" "$fake_bin/xcrun" "$fake_bin/xcodebuild"
+
+api_key_path="$TEST_ROOT/AuthKey_TEST.p8"
+touch "$api_key_path"
+verbose_log_dir="$TEST_ROOT/verbose-release-logs"
+set +e
+verbose_output="$(
+  PATH="$fake_bin:$PATH" \
+    SECURITY_LOG="$security_log" \
+    TOOL_LOG="$tool_log" \
+    ATC_APP_STORE_CONNECT_KEY_PATH="$api_key_path" \
+    ATC_APP_STORE_CONNECT_KEY_ID="KEY123" \
+    ATC_APP_STORE_CONNECT_ISSUER_ID="ISSUER123" \
+    run_macos_release_test "$TEST_ROOT/verbose-release-artifacts" "$verbose_log_dir" --verbose \
+    2>&1
+)"
+verbose_status=$?
+set -e
+[[ $verbose_status -eq 1 ]]
+[[ "$verbose_output" == *"Archive atc.app failed"* ]]
+grep -Fq -- \
+  "-authenticationKeyPath $api_key_path -authenticationKeyID KEY123 -authenticationKeyIssuerID ISSUER123" \
+  "$tool_log"
+
+missing_key_path="$TEST_ROOT/missing-key.p8"
+missing_key_log_dir="$TEST_ROOT/missing-key-logs"
+set +e
+missing_key_output="$(
+  PATH="$fake_bin:$PATH" \
+    SECURITY_LOG="$security_log" \
+    TOOL_LOG="$tool_log" \
+    ATC_APP_STORE_CONNECT_KEY_PATH="$missing_key_path" \
+    ATC_APP_STORE_CONNECT_KEY_ID="KEY123" \
+    ATC_APP_STORE_CONNECT_ISSUER_ID="ISSUER123" \
+    run_macos_release_test "$TEST_ROOT/missing-key-artifacts" "$missing_key_log_dir" \
+    2>&1
+)"
+missing_key_status=$?
+set -e
+[[ $missing_key_status -eq 1 ]]
+[[ "$missing_key_output" == *"Validate signing and notarization prerequisites"* ]]
+grep -Fq "App Store Connect API key not found: $missing_key_path" \
+  "$missing_key_log_dir/00-prerequisites.log"
 
 while IFS= read -r action; do
   if [[ ! "$action" =~ @[0-9a-f]{40}$ ]]; then

--- a/scripts/release-test.sh
+++ b/scripts/release-test.sh
@@ -116,6 +116,29 @@ set -e
 [[ $invalid_timestamp_status -eq 1 ]]
 [[ "$invalid_timestamp_output" == *"not a valid calendar timestamp"* ]]
 
+prerequisite_log_dir="$TEST_ROOT/release-logs"
+set +e
+prerequisite_output="$(
+  PATH="$fake_bin:$PATH" \
+    SECURITY_LOG="$security_log" \
+    ATC_RELEASE_LOG_DIR="$prerequisite_log_dir" \
+    "$SCRIPT_DIR/release-macos.sh" \
+    --channel dev \
+    --version 1.2.3-dev.2 \
+    --marketing-version 1.2.3 \
+    --build-number 2 \
+    --commit "$commit" \
+    --built-at 2026-08-15T12:34:56Z \
+    --output "$TEST_ROOT/atc.dmg" \
+    2>&1
+)"
+prerequisite_status=$?
+set -e
+[[ $prerequisite_status -eq 1 ]]
+[[ "$prerequisite_output" == *"Validate signing and notarization prerequisites"* ]]
+grep -Fq "No valid Developer ID Application identity found" \
+  "$prerequisite_log_dir/00-prerequisites.log"
+
 while IFS= read -r action; do
   if [[ ! "$action" =~ @[0-9a-f]{40}$ ]]; then
     echo "release workflow action is not pinned to a full commit SHA: $action" >&2


### PR DESCRIPTION
## Summary

- remove the duplicate macOS app test build from the product release job; the dedicated macOS CI workflow remains the test gate
- cache Xcode's resolved SwiftPM package checkout and reuse it for the release archive
- write release logs to a shallow output directory and upload them only on failure, with seven-day retention
- report elapsed time for each build, signing, and notarization phase

## Why

The first product release run spent 4m42s repeating macOS tests and 5m13s building, signing, and notarizing the DMG. The 6.4 MB DMG uploaded in three seconds, but the diagnostic-log artifact recursively searched the multi-gigabyte DerivedData tree for roughly 1.5 MB of logs and held the run open for about another 24 minutes.

This change removes the duplicate work and the unbounded log search. Warm release runs should normally complete the macOS job in roughly 5–6 minutes, while retaining failure diagnostics.

## Validation

- `mise run check`
- release tooling tests passed
- 293 macOS app tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS release reliability by preserving package caches between runs.
  * Enhanced failure handling with clearer logs and diagnostic uploads available only when needed.
  * Improved validation for signing credentials and authentication files.
  * Added timing information for individual release steps and overall execution.

* **Chores**
  * Added configurable locations for caches and release logs.
  * Expanded automated coverage for macOS release validation, authentication, signing, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->