### PR TITLE
Unify rolling and PR dev release workflows

### DIFF
--- a/.github/workflows/product-candidate-cleanup.yml
+++ b/.github/workflows/product-candidate-cleanup.yml
@@ -1,0 +1,21 @@
+# PR candidates are rolling, temporary release sets. Closing the PR removes
+# its mutable prerelease and tag so the Releases page reflects active work.
+name: Product Candidate Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Remove candidate release and tag when present
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: gh release delete "dev-pr-${{ github.event.pull_request.number }}" --cleanup-tag --yes || true

--- a/.github/workflows/product-candidate-cleanup.yml
+++ b/.github/workflows/product-candidate-cleanup.yml
@@ -18,4 +18,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-        run: gh release delete "dev-pr-${{ github.event.pull_request.number }}" --cleanup-tag --yes || true
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          tag="dev-pr-$PR_NUMBER"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release delete "$tag" --cleanup-tag --yes
+          else
+            echo "no candidate release for $tag"
+          fi

--- a/.github/workflows/product-release.yml
+++ b/.github/workflows/product-release.yml
@@ -85,12 +85,14 @@ jobs:
       - name: Validate dispatched release request
         if: github.event_name == 'workflow_dispatch'
         env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          DISPATCH_REF: ${{ github.ref_name }}
           RELEASE_MODE: ${{ inputs.mode }}
           PR_NUMBER: ${{ inputs.pr_number }}
         run: |
           if [ "$RELEASE_MODE" = "stable" ]; then
-            test "${{ github.ref_name }}" = "${{ github.event.repository.default_branch }}" || {
-              echo "stable releases must be dispatched against ${{ github.event.repository.default_branch }}" >&2
+            test "$DISPATCH_REF" = "$DEFAULT_BRANCH" || {
+              echo "stable releases must be dispatched against $DEFAULT_BRANCH" >&2
               exit 1
             }
             test -z "$PR_NUMBER" || {
@@ -135,11 +137,7 @@ jobs:
             gh release download "${{ steps.identity.outputs.tag }}" \
               --pattern manifest.json --dir manifests/current || true
           fi
-          if [ "${{ steps.identity.outputs.tag }}" != "dev" ] || [ ! -f manifests/current/manifest.json ]; then
-            gh release download dev --pattern manifest.json --dir manifests/dev || true
-          else
-            mv manifests/current/manifest.json manifests/dev/manifest.json
-          fi
+          gh release download dev --pattern manifest.json --dir manifests/dev || true
 
       - name: Select reusable components
         id: components
@@ -278,7 +276,7 @@ jobs:
           tar -xzf out/atc-linux-arm64.tar.gz -C out
           ATC_COMPILED_BIN="$PWD/out/atc" bun --bun vitest run test/compiled.blackbox.test.ts
 
-  reuse_app_server:
+  reuse-app-server:
     needs: plan
     if: needs.plan.outputs.reuse_app_server == 'true'
     runs-on: ubuntu-latest
@@ -388,7 +386,7 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
-  reuse_macos:
+  reuse-macos:
     needs: plan
     if: needs.plan.outputs.reuse_macos == 'true'
     runs-on: ubuntu-latest
@@ -421,19 +419,19 @@ jobs:
         app-server-darwin,
         app-server-linux,
         validate-linux-arm,
-        reuse_app_server,
+        reuse-app-server,
         macos,
-        reuse_macos,
+        reuse-macos,
       ]
     if: >-
       always() &&
       needs.plan.result == 'success' &&
       (
-        (needs.plan.outputs.reuse_app_server == 'true' && needs.reuse_app_server.result == 'success') ||
+        (needs.plan.outputs.reuse_app_server == 'true' && needs['reuse-app-server'].result == 'success') ||
         (needs.plan.outputs.reuse_app_server != 'true' && needs['app-server-darwin'].result == 'success' && needs['app-server-linux'].result == 'success' && needs['validate-linux-arm'].result == 'success')
       ) &&
       (
-        (needs.plan.outputs.reuse_macos == 'true' && needs.reuse_macos.result == 'success') ||
+        (needs.plan.outputs.reuse_macos == 'true' && needs['reuse-macos'].result == 'success') ||
         (needs.plan.outputs.reuse_macos != 'true' && needs.macos.result == 'success')
       )
     runs-on: ubuntu-latest

--- a/.github/workflows/product-release.yml
+++ b/.github/workflows/product-release.yml
@@ -1,9 +1,9 @@
 # Whole-product release pipeline. Pushes to main replace the rolling dev
-# release; workflow dispatch promotes the current main head to an immutable
-# stable SemVer release. Repository scripts own identity, build, packaging,
-# notarization, and publication mechanics; Actions only orchestrates them.
+# release; workflow dispatch either publishes a PR-scoped rolling candidate or
+# promotes the current main head to an immutable stable SemVer release.
+# Content fingerprints reuse unchanged dev components byte-for-byte.
 name: Product Release
-run-name: Product Release ${{ github.event_name == 'workflow_dispatch' && format('[{0}]', inputs.request_id) || format('[dev {0}]', github.sha) }}
+run-name: Product Release ${{ github.event_name == 'push' && format('[dev {0}]', github.sha) || format('[{0}:{1}]', inputs.mode, inputs.request_id) }}
 
 on:
   push:
@@ -19,12 +19,24 @@ on:
       - ".github/workflows/product-release.yml"
   workflow_dispatch:
     inputs:
+      mode:
+        description: "Dispatched release mode"
+        type: choice
+        required: true
+        default: candidate
+        options:
+          - candidate
+          - stable
       request_id:
         description: "Unique dispatcher correlation ID"
         type: string
         required: true
+      pr_number:
+        description: "Candidate PR number (candidate mode only)"
+        type: string
+        required: false
       release_type:
-        description: "Stable SemVer bump"
+        description: "Stable SemVer bump (stable mode only)"
         type: choice
         required: true
         default: patch
@@ -44,6 +56,7 @@ jobs:
       group: product-release-plan-${{ github.event_name == 'push' && 'dev' || github.run_id }}
       cancel-in-progress: true
     outputs:
+      kind: ${{ steps.identity.outputs.kind }}
       channel: ${{ steps.identity.outputs.channel }}
       tag: ${{ steps.identity.outputs.tag }}
       version: ${{ steps.identity.outputs.version }}
@@ -51,33 +64,99 @@ jobs:
       build_number: ${{ steps.identity.outputs.build_number }}
       commit: ${{ steps.identity.outputs.commit }}
       built_at: ${{ steps.identity.outputs.built_at }}
+      app_server_fingerprint: ${{ steps.fingerprints.outputs.app_server_fingerprint }}
+      macos_fingerprint: ${{ steps.fingerprints.outputs.macos_fingerprint }}
+      reuse_app_server: ${{ steps.components.outputs.reuse_app_server }}
+      app_server_source_tag: ${{ steps.components.outputs.app_server_source_tag }}
+      app_server_version: ${{ steps.components.outputs.app_server_version }}
+      app_server_commit: ${{ steps.components.outputs.app_server_commit }}
+      app_server_built_at: ${{ steps.components.outputs.app_server_built_at }}
+      reuse_macos: ${{ steps.components.outputs.reuse_macos }}
+      macos_source_tag: ${{ steps.components.outputs.macos_source_tag }}
+      macos_version: ${{ steps.components.outputs.macos_version }}
+      macos_commit: ${{ steps.components.outputs.macos_commit }}
+      macos_built_at: ${{ steps.components.outputs.macos_built_at }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Require stable dispatch from main
-        if: github.event_name == 'workflow_dispatch' && github.ref_name != github.event.repository.default_branch
+      - name: Validate dispatched release request
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RELEASE_MODE: ${{ inputs.mode }}
+          PR_NUMBER: ${{ inputs.pr_number }}
         run: |
-          echo "stable releases must be dispatched against ${{ github.event.repository.default_branch }}" >&2
-          exit 1
+          if [ "$RELEASE_MODE" = "stable" ]; then
+            test "${{ github.ref_name }}" = "${{ github.event.repository.default_branch }}" || {
+              echo "stable releases must be dispatched against ${{ github.event.repository.default_branch }}" >&2
+              exit 1
+            }
+            test -z "$PR_NUMBER" || {
+              echo "stable releases do not take a PR number" >&2
+              exit 1
+            }
+          else
+            [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]] || {
+              echo "candidate releases require a PR number" >&2
+              exit 1
+            }
+          fi
 
       - name: Compute shared product identity
         id: identity
+        env:
+          RELEASE_MODE: ${{ inputs.mode }}
+          RELEASE_TYPE: ${{ inputs.release_type }}
+          PR_NUMBER: ${{ inputs.pr_number }}
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
             scripts/release-plan.sh dev >> "$GITHUB_OUTPUT"
+          elif [ "$RELEASE_MODE" = "candidate" ]; then
+            scripts/release-plan.sh dev "dev-pr-$PR_NUMBER" >> "$GITHUB_OUTPUT"
           else
-            scripts/release-plan.sh stable "${{ inputs.release_type }}" >> "$GITHUB_OUTPUT"
+            scripts/release-plan.sh stable "$RELEASE_TYPE" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Fingerprint component inputs
+        id: fingerprints
+        run: |
+          echo "app_server_fingerprint=$(scripts/release-fingerprint.sh app-server)" >> "$GITHUB_OUTPUT"
+          echo "macos_fingerprint=$(scripts/release-fingerprint.sh macos)" >> "$GITHUB_OUTPUT"
+
+      - name: Download reusable release manifests
+        if: steps.identity.outputs.kind != 'stable'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p manifests/current manifests/dev
+          if [ "${{ steps.identity.outputs.kind }}" = "candidate" ]; then
+            gh release download "${{ steps.identity.outputs.tag }}" \
+              --pattern manifest.json --dir manifests/current || true
+          fi
+          if [ "${{ steps.identity.outputs.tag }}" != "dev" ] || [ ! -f manifests/current/manifest.json ]; then
+            gh release download dev --pattern manifest.json --dir manifests/dev || true
+          else
+            mv manifests/current/manifest.json manifests/dev/manifest.json
+          fi
+
+      - name: Select reusable components
+        id: components
+        run: |
+          scripts/select-release-components.sh \
+            "${{ steps.fingerprints.outputs.app_server_fingerprint }}" \
+            "${{ steps.fingerprints.outputs.macos_fingerprint }}" \
+            manifests/current/manifest.json \
+            manifests/dev/manifest.json >> "$GITHUB_OUTPUT"
 
   app-server-darwin:
     needs: plan
+    if: needs.plan.outputs.reuse_app_server != 'true'
     runs-on: macos-14
     timeout-minutes: 20
     concurrency:
-      group: product-release-app-server-darwin-${{ needs.plan.outputs.channel == 'dev' && 'dev' || github.run_id }}
+      group: product-release-app-server-darwin-${{ needs.plan.outputs.tag }}
       cancel-in-progress: true
     defaults:
       run:
@@ -122,10 +201,11 @@ jobs:
 
   app-server-linux:
     needs: plan
+    if: needs.plan.outputs.reuse_app_server != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     concurrency:
-      group: product-release-app-server-linux-${{ needs.plan.outputs.channel == 'dev' && 'dev' || github.run_id }}
+      group: product-release-app-server-linux-${{ needs.plan.outputs.tag }}
       cancel-in-progress: true
     defaults:
       run:
@@ -168,10 +248,11 @@ jobs:
 
   validate-linux-arm:
     needs: [plan, app-server-linux]
+    if: needs.plan.outputs.reuse_app_server != 'true'
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
     concurrency:
-      group: product-release-validate-linux-arm-${{ needs.plan.outputs.channel == 'dev' && 'dev' || github.run_id }}
+      group: product-release-validate-linux-arm-${{ needs.plan.outputs.tag }}
       cancel-in-progress: true
     defaults:
       run:
@@ -197,8 +278,38 @@ jobs:
           tar -xzf out/atc-linux-arm64.tar.gz -C out
           ATC_COMPILED_BIN="$PWD/out/atc" bun --bun vitest run test/compiled.blackbox.test.ts
 
+  reuse_app_server:
+    needs: plan
+    if: needs.plan.outputs.reuse_app_server == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Download and verify reusable App Server assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          scripts/reuse-release-assets.sh \
+            --tag "${{ needs.plan.outputs.app_server_source_tag }}" \
+            --out out \
+            --checksums checksums-app-server-reused.txt \
+            atc-darwin-arm64.tar.gz \
+            atc-darwin-x64.tar.gz \
+            atc-linux-arm64.tar.gz \
+            atc-linux-x64.tar.gz
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: product-release-assets-app-server-reused
+          path: out/*
+          if-no-files-found: error
+
   macos:
     needs: plan
+    if: needs.plan.outputs.reuse_macos != 'true'
     runs-on: macos-26
     timeout-minutes: 45
     environment: release
@@ -207,7 +318,7 @@ jobs:
       # release runs do not clone the resolved dependency graph again.
       ATC_XCODE_SPM_DIR: ${{ github.workspace }}/.spm-packages
     concurrency:
-      group: product-release-macos-${{ needs.plan.outputs.channel == 'dev' && 'dev' || github.run_id }}
+      group: product-release-macos-${{ needs.plan.outputs.tag }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -277,9 +388,54 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
+  reuse_macos:
+    needs: plan
+    if: needs.plan.outputs.reuse_macos == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Download and verify reusable macOS asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          scripts/reuse-release-assets.sh \
+            --tag "${{ needs.plan.outputs.macos_source_tag }}" \
+            --out out \
+            --checksums checksums-macos-reused.txt \
+            atc-macos-arm64.dmg
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: product-release-assets-macos-reused
+          path: out/*
+          if-no-files-found: error
+
   publish:
     needs:
-      [plan, app-server-darwin, app-server-linux, validate-linux-arm, macos]
+      [
+        plan,
+        app-server-darwin,
+        app-server-linux,
+        validate-linux-arm,
+        reuse_app_server,
+        macos,
+        reuse_macos,
+      ]
+    if: >-
+      always() &&
+      needs.plan.result == 'success' &&
+      (
+        (needs.plan.outputs.reuse_app_server == 'true' && needs.reuse_app_server.result == 'success') ||
+        (needs.plan.outputs.reuse_app_server != 'true' && needs['app-server-darwin'].result == 'success' && needs['app-server-linux'].result == 'success' && needs['validate-linux-arm'].result == 'success')
+      ) &&
+      (
+        (needs.plan.outputs.reuse_macos == 'true' && needs.reuse_macos.result == 'success') ||
+        (needs.plan.outputs.reuse_macos != 'true' && needs.macos.result == 'success')
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -303,10 +459,52 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          app_server_version="${{ needs.plan.outputs.version }}"
+          app_server_commit="${{ needs.plan.outputs.commit }}"
+          app_server_built_at="${{ needs.plan.outputs.built_at }}"
+          app_server_reused_from=""
+          if [ "${{ needs.plan.outputs.reuse_app_server }}" = "true" ]; then
+            app_server_version="${{ needs.plan.outputs.app_server_version }}"
+            app_server_commit="${{ needs.plan.outputs.app_server_commit }}"
+            app_server_built_at="${{ needs.plan.outputs.app_server_built_at }}"
+            app_server_reused_from="${{ needs.plan.outputs.app_server_source_tag }}"
+          fi
+
+          macos_version="${{ needs.plan.outputs.version }}"
+          macos_commit="${{ needs.plan.outputs.commit }}"
+          macos_built_at="${{ needs.plan.outputs.built_at }}"
+          macos_reused_from=""
+          if [ "${{ needs.plan.outputs.reuse_macos }}" = "true" ]; then
+            macos_version="${{ needs.plan.outputs.macos_version }}"
+            macos_commit="${{ needs.plan.outputs.macos_commit }}"
+            macos_built_at="${{ needs.plan.outputs.macos_built_at }}"
+            macos_reused_from="${{ needs.plan.outputs.macos_source_tag }}"
+          fi
+
+          scripts/write-release-manifest.sh \
+            --kind "${{ needs.plan.outputs.kind }}" \
+            --tag "${{ needs.plan.outputs.tag }}" \
+            --version "${{ needs.plan.outputs.version }}" \
+            --commit "${{ needs.plan.outputs.commit }}" \
+            --built-at "${{ needs.plan.outputs.built_at }}" \
+            --app-server-fingerprint "${{ needs.plan.outputs.app_server_fingerprint }}" \
+            --app-server-version "$app_server_version" \
+            --app-server-commit "$app_server_commit" \
+            --app-server-built-at "$app_server_built_at" \
+            --app-server-reused-from "$app_server_reused_from" \
+            --macos-fingerprint "${{ needs.plan.outputs.macos_fingerprint }}" \
+            --macos-version "$macos_version" \
+            --macos-commit "$macos_commit" \
+            --macos-built-at "$macos_built_at" \
+            --macos-reused-from "$macos_reused_from" \
+            --output release/manifest.json
+          (cd release && shasum -a 256 manifest.json > checksums-manifest.txt)
           scripts/merge-checksums.sh release
           scripts/publish-release.sh \
+            --kind "${{ needs.plan.outputs.kind }}" \
             --channel "${{ needs.plan.outputs.channel }}" \
             --tag "${{ needs.plan.outputs.tag }}" \
             --version "${{ needs.plan.outputs.version }}" \
             --commit "${{ needs.plan.outputs.commit }}" \
+            --built-at "${{ needs.plan.outputs.built_at }}" \
             --assets release

--- a/macos/ATC/AppCommands.swift
+++ b/macos/ATC/AppCommands.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct AppCommands: Commands {
@@ -34,6 +35,14 @@ struct AppCommands: Commands {
     }
 
     var body: some Commands {
+        CommandGroup(replacing: .appInfo) {
+            Button("About atc") {
+                NSApplication.shared.orderFrontStandardAboutPanel(
+                    options: [.version: displayedBuildVersion]
+                )
+            }
+        }
+
         CommandGroup(replacing: .newItem) {
             commandButton(.newThread)
             commandButton(.newTerminal)
@@ -57,6 +66,21 @@ struct AppCommands: Commands {
             commandButton(.reloadConfiguration, appScoped: true)
             commandButton(.revealConfiguration, appScoped: true)
         }
+    }
+
+    /// Release builds carry the complete stable or CalVer component identity
+    /// in ATCBuildVersion. Local builds fall back to Xcode's marketing version.
+    private var displayedBuildVersion: String {
+        let releaseVersion =
+            Bundle.main.object(
+                forInfoDictionaryKey: "ATCBuildVersion"
+            ) as? String
+        if let releaseVersion, !releaseVersion.isEmpty {
+            return releaseVersion
+        }
+        return Bundle.main.object(
+            forInfoDictionaryKey: "CFBundleShortVersionString"
+        ) as? String ?? "Development Build"
     }
 
     @ViewBuilder

--- a/mise.toml
+++ b/mise.toml
@@ -178,6 +178,10 @@ clone zmx --branch 'v0.6.0' https://github.com/neurosnap/zmx.git
 description = "Dispatch and watch a stable whole-product release from main (usage: mise run release patch|minor|major)"
 run = "scripts/release.sh"
 
+[tasks."dev-build"]
+description = "Dispatch and watch a rolling whole-product dev candidate for the current PR"
+run = "scripts/dev-build.sh"
+
 [tasks."release:check"]
 description = "Validate shared product release identity and packaging scripts"
 run = "scripts/release-test.sh"

--- a/scripts/dev-build.sh
+++ b/scripts/dev-build.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Dispatches one PR-scoped rolling dev candidate and watches it through
+# publication. The remote PR head is the source of truth; local-only work is
+# deliberately never pushed or inferred by release tooling.
+set -euo pipefail
+
+usage() {
+  echo "usage: mise run dev-build [-- --pr NUMBER]" >&2
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+PR_NUMBER=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr) PR_NUMBER="${2:-}"; shift 2 ;;
+    *) usage; exit 2 ;;
+  esac
+done
+[[ -z "$PR_NUMBER" || "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]] || { usage; exit 2; }
+
+command -v gh >/dev/null 2>&1 || die "Missing required tool: gh"
+gh auth status -h github.com >/dev/null 2>&1 || die "gh is not authenticated for github.com"
+
+if [[ -z "$PR_NUMBER" ]]; then
+  PR_NUMBER="$(gh pr view --json number --jq .number 2>/dev/null)" ||
+    die "the current checkout is not associated with an open PR; pass --pr NUMBER"
+fi
+IFS=$'\t' read -r HEAD_REF HEAD_SHA PR_STATE < <(
+  gh pr view "$PR_NUMBER" --json headRefName,headRefOid,state \
+    --jq '[.headRefName, .headRefOid, .state] | @tsv'
+)
+[[ "$PR_STATE" == "OPEN" ]] || die "PR #$PR_NUMBER is not open"
+
+WORKFLOW="product-release.yml"
+REQUEST_ID="$(printf '%s:%s:%s:%s' "$(date -u +%s)" "$$" "$RANDOM" "$RANDOM" | git hash-object --stdin)"
+RUN_TITLE="Product Release [candidate:$REQUEST_ID]"
+
+matching_run_id() {
+  gh run list \
+    --workflow "$WORKFLOW" \
+    --event workflow_dispatch \
+    --branch "$HEAD_REF" \
+    --limit 100 \
+    --json databaseId,displayTitle \
+    -q ".[] | select(.displayTitle == \"$RUN_TITLE\") | .databaseId" \
+    2>/dev/null | head -n 1 || true
+}
+
+printf 'dispatching dev candidate for PR #%s at %s\n' "$PR_NUMBER" "${HEAD_SHA:0:8}"
+gh workflow run "$WORKFLOW" \
+  --ref "$HEAD_REF" \
+  -f mode=candidate \
+  -f pr_number="$PR_NUMBER" \
+  -f request_id="$REQUEST_ID"
+
+RUN_ID=""
+for _ in $(seq 1 30); do
+  RUN_ID="$(matching_run_id)"
+  [[ -z "$RUN_ID" ]] || break
+  sleep 2
+done
+[[ -n "$RUN_ID" ]] || die "the dispatched run never appeared; check gh run list --workflow $WORKFLOW"
+
+gh run watch "$RUN_ID" --exit-status
+RELEASE_URL="$(gh release view "dev-pr-$PR_NUMBER" --json url --jq .url)"
+printf 'dev candidate ready: %s\n' "$RELEASE_URL"

--- a/scripts/dev-build.sh
+++ b/scripts/dev-build.sh
@@ -16,7 +16,11 @@ die() {
 PR_NUMBER=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --pr) PR_NUMBER="${2:-}"; shift 2 ;;
+    --pr)
+      [[ $# -ge 2 && -n "$2" ]] || { usage; exit 2; }
+      PR_NUMBER="$2"
+      shift 2
+      ;;
     *) usage; exit 2 ;;
   esac
 done
@@ -32,7 +36,7 @@ fi
 IFS=$'\t' read -r HEAD_REF HEAD_SHA PR_STATE < <(
   gh pr view "$PR_NUMBER" --json headRefName,headRefOid,state \
     --jq '[.headRefName, .headRefOid, .state] | @tsv'
-)
+) || die "could not read PR #$PR_NUMBER"
 [[ "$PR_STATE" == "OPEN" ]] || die "PR #$PR_NUMBER is not open"
 
 WORKFLOW="product-release.yml"
@@ -51,6 +55,8 @@ matching_run_id() {
 }
 
 printf 'dispatching dev candidate for PR #%s at %s\n' "$PR_NUMBER" "${HEAD_SHA:0:8}"
+# GitHub registers workflow_dispatch inputs from the default branch. This
+# workflow must reach the default branch once before feature refs can use it.
 gh workflow run "$WORKFLOW" \
   --ref "$HEAD_REF" \
   -f mode=candidate \
@@ -66,5 +72,13 @@ done
 [[ -n "$RUN_ID" ]] || die "the dispatched run never appeared; check gh run list --workflow $WORKFLOW"
 
 gh run watch "$RUN_ID" --exit-status
-RELEASE_URL="$(gh release view "dev-pr-$PR_NUMBER" --json url --jq .url)"
+IFS=$'\t' read -r CURRENT_HEAD PR_STATE < <(
+  gh pr view "$PR_NUMBER" --json headRefOid,state --jq '[.headRefOid, .state] | @tsv'
+) || die "could not read PR #$PR_NUMBER after the build"
+[[ "$PR_STATE" == "OPEN" ]] ||
+  die "PR #$PR_NUMBER closed during the build; the candidate was skipped"
+[[ "$CURRENT_HEAD" == "$HEAD_SHA" ]] ||
+  die "PR #$PR_NUMBER moved to ${CURRENT_HEAD:0:8} during the build; the candidate was skipped. Re-run mise run dev-build."
+RELEASE_URL="$(gh release view "dev-pr-$PR_NUMBER" --json url --jq .url)" ||
+  die "the run finished without publishing a candidate; check the run logs"
 printf 'dev candidate ready: %s\n' "$RELEASE_URL"

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -3,30 +3,39 @@
 set -euo pipefail
 
 usage() {
-  echo "usage: scripts/publish-release.sh --channel dev|stable --tag TAG --version VERSION --commit SHA --assets DIR" >&2
+  echo "usage: scripts/publish-release.sh --kind stable|dev|candidate --channel dev|stable --tag TAG --version VERSION --commit SHA --built-at TIME --assets DIR" >&2
 }
 
+KIND=""
 CHANNEL=""
 TAG=""
 VERSION=""
 COMMIT=""
+BUILT_AT=""
 ASSET_DIR=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --kind) KIND="${2:-}"; shift 2 ;;
     --channel) CHANNEL="${2:-}"; shift 2 ;;
     --tag) TAG="${2:-}"; shift 2 ;;
     --version) VERSION="${2:-}"; shift 2 ;;
     --commit) COMMIT="${2:-}"; shift 2 ;;
+    --built-at) BUILT_AT="${2:-}"; shift 2 ;;
     --assets) ASSET_DIR="${2:-}"; shift 2 ;;
     *) usage; exit 2 ;;
   esac
 done
 
+case "$KIND" in
+  stable|dev|candidate) ;;
+  *) usage; exit 2 ;;
+esac
 case "$CHANNEL" in
   dev|stable) ;;
   *) usage; exit 2 ;;
 esac
-[[ -n "$TAG" && -n "$VERSION" && "$COMMIT" =~ ^[0-9a-f]{40}$ && -d "$ASSET_DIR" ]] || { usage; exit 2; }
+[[ -n "$TAG" && -n "$VERSION" && -n "$BUILT_AT" && "$COMMIT" =~ ^[0-9a-f]{40}$ && -d "$ASSET_DIR" ]] || { usage; exit 2; }
+[[ "$KIND" == "stable" && "$CHANNEL" == "stable" ]] || [[ "$KIND" != "stable" && "$CHANNEL" == "dev" ]] || { usage; exit 2; }
 
 expected=(
   atc-darwin-arm64.tar.gz
@@ -35,6 +44,7 @@ expected=(
   atc-linux-x64.tar.gz
   atc-macos-arm64.dmg
   checksums.txt
+  manifest.json
 )
 assets=()
 for name in "${expected[@]}"; do
@@ -47,7 +57,7 @@ done
 # workflow started. Later main pushes do not invalidate artifacts from that
 # snapshot. The rolling dev release, however, should never move backwards to an
 # obsolete build, so check its freshness immediately before updating dev.
-if [[ "$CHANNEL" == "dev" ]]; then
+if [[ "$KIND" == "dev" ]]; then
   REMOTE_MAIN="$(git ls-remote origin refs/heads/main | awk '{ print $1 }')"
   [[ -n "$REMOTE_MAIN" ]] || { echo "could not resolve origin/main" >&2; exit 1; }
   if [[ "$REMOTE_MAIN" != "$COMMIT" ]]; then
@@ -56,10 +66,26 @@ if [[ "$CHANNEL" == "dev" ]]; then
   fi
 fi
 
+if [[ "$KIND" == "candidate" ]]; then
+  [[ "$TAG" =~ ^dev-pr-([1-9][0-9]*)$ ]] || { echo "candidate releases must use a dev-pr-N tag" >&2; exit 1; }
+  PR_NUMBER="${BASH_REMATCH[1]}"
+  PR_STATE="$(gh pr view "$PR_NUMBER" --json state --jq .state 2>/dev/null || true)"
+  if [[ "$PR_STATE" != "OPEN" ]]; then
+    echo "skipping candidate build for closed PR #$PR_NUMBER"
+    exit 0
+  fi
+  REMOTE_PR_HEAD="$(gh pr view "$PR_NUMBER" --json headRefOid --jq .headRefOid 2>/dev/null || true)"
+  [[ -n "$REMOTE_PR_HEAD" ]] || { echo "could not resolve PR #$PR_NUMBER head" >&2; exit 1; }
+  if [[ "$REMOTE_PR_HEAD" != "$COMMIT" ]]; then
+    echo "skipping obsolete candidate build $COMMIT; PR #$PR_NUMBER is $REMOTE_PR_HEAD"
+    exit 0
+  fi
+fi
+
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-if [[ "$CHANNEL" == "stable" ]]; then
+if [[ "$KIND" == "stable" ]]; then
   [[ "$TAG" == "v$VERSION" ]] || { echo "stable tag/version mismatch: $TAG / $VERSION" >&2; exit 1; }
   git tag -a "$TAG" "$COMMIT" -m "Release $TAG"
   git push origin "$TAG"
@@ -67,13 +93,22 @@ if [[ "$CHANNEL" == "stable" ]]; then
   exit 0
 fi
 
-[[ "$TAG" == "dev" ]] || { echo "dev releases must use the rolling dev tag" >&2; exit 1; }
-git tag -f dev "$COMMIT"
-git push -f origin dev
-NOTES="$(printf 'Rolling whole-product build of commit %s.\n\nInstall or update the App Server:\n\n    curl -fsSL https://raw.githubusercontent.com/%s/main/install.sh | sh -s -- --channel dev\n\nInstalled builds update with `atc upgrade`.' "$COMMIT" "$GITHUB_REPOSITORY")"
-if gh release view dev >/dev/null 2>&1; then
-  gh release upload dev "${assets[@]}" --clobber
-  gh release edit dev --title "ATC dev ($VERSION)" --notes "$NOTES" --prerelease
+if [[ "$KIND" == "dev" ]]; then
+  [[ "$TAG" == "dev" ]] || { echo "rolling dev releases must use the dev tag" >&2; exit 1; }
+  TITLE="ATC Dev — ${BUILT_AT/T/ }"
+  TITLE="${TITLE%Z} UTC"
+  NOTES="$(printf 'Version: `%s`  \nCommit: `%s`\n\nInstall or update the App Server:\n\n    curl -fsSL https://raw.githubusercontent.com/%s/main/install.sh | sh -s -- --channel dev\n\nInstalled builds update with `atc upgrade`. The attached manifest records the exact component set.' "$VERSION" "$COMMIT" "$GITHUB_REPOSITORY")"
 else
-  gh release create dev "${assets[@]}" --title "ATC dev ($VERSION)" --notes "$NOTES" --prerelease --verify-tag
+  TITLE="ATC Dev Candidate — PR #${PR_NUMBER} — ${BUILT_AT/T/ }"
+  TITLE="${TITLE%Z} UTC"
+  NOTES="$(printf 'Version: `%s`  \nCommit: `%s`\n\nInstall the candidate App Server:\n\n    curl -fsSL https://raw.githubusercontent.com/%s/main/install.sh | sh -s -- --version %s\n\nThis candidate does not update automatically; rebuild or reinstall the PR candidate to test a newer revision. The attached manifest records the exact component set.' "$VERSION" "$COMMIT" "$GITHUB_REPOSITORY" "$TAG")"
+fi
+
+git tag -f "$TAG" "$COMMIT"
+git push -f origin "refs/tags/$TAG"
+if gh release view "$TAG" >/dev/null 2>&1; then
+  gh release upload "$TAG" "${assets[@]}" --clobber
+  gh release edit "$TAG" --title "$TITLE" --notes "$NOTES" --prerelease
+else
+  gh release create "$TAG" "${assets[@]}" --title "$TITLE" --notes "$NOTES" --prerelease --verify-tag
 fi

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -69,7 +69,8 @@ fi
 if [[ "$KIND" == "candidate" ]]; then
   [[ "$TAG" =~ ^dev-pr-([1-9][0-9]*)$ ]] || { echo "candidate releases must use a dev-pr-N tag" >&2; exit 1; }
   PR_NUMBER="${BASH_REMATCH[1]}"
-  PR_STATE="$(gh pr view "$PR_NUMBER" --json state --jq .state 2>/dev/null || true)"
+  PR_STATE="$(gh pr view "$PR_NUMBER" --json state --jq .state)" ||
+    { echo "could not resolve PR #$PR_NUMBER state" >&2; exit 1; }
   if [[ "$PR_STATE" != "OPEN" ]]; then
     echo "skipping candidate build for closed PR #$PR_NUMBER"
     exit 0

--- a/scripts/release-fingerprint.sh
+++ b/scripts/release-fingerprint.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Hashes every source input that can affect one distributable component. The
+# release manifest uses this content identity to reuse a previously signed or
+# compiled artifact without relying on path-filter guesses.
+set -euo pipefail
+
+usage() {
+  echo "usage: scripts/release-fingerprint.sh app-server|macos [COMMIT]" >&2
+}
+
+COMPONENT="${1:-}"
+COMMIT="${2:-HEAD}"
+case "$COMPONENT" in
+  app-server)
+    PATHS=(
+      app-server
+      mise.toml
+      .github/workflows/product-release.yml
+      scripts/package-app-server.sh
+      scripts/release-fingerprint.sh
+      scripts/release-plan.sh
+    )
+    ;;
+  macos)
+    PATHS=(
+      macos
+      packages
+      app-server/openapi.json
+      mise.toml
+      .github/workflows/product-release.yml
+      scripts/ExportOptions.DeveloperID.plist
+      scripts/prepare-xcode-openapi.sh
+      scripts/release-fingerprint.sh
+      scripts/release-macos.sh
+      scripts/release-plan.sh
+    )
+    ;;
+  *) usage; exit 2 ;;
+esac
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="${ATC_RELEASE_REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd -P)}"
+git -C "$REPO_ROOT" rev-parse --verify "${COMMIT}^{commit}" >/dev/null
+
+{
+  printf 'component %s\n' "$COMPONENT"
+  git -C "$REPO_ROOT" ls-tree -r "$COMMIT" -- "${PATHS[@]}"
+} | shasum -a 256 | awk '{ print $1 }'

--- a/scripts/release-fingerprint.sh
+++ b/scripts/release-fingerprint.sh
@@ -41,6 +41,9 @@ esac
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 REPO_ROOT="${ATC_RELEASE_REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd -P)}"
 git -C "$REPO_ROOT" rev-parse --verify "${COMMIT}^{commit}" >/dev/null
+for path in "${PATHS[@]}"; do
+  git -C "$REPO_ROOT" cat-file -e "$COMMIT:$path"
+done
 
 {
   printf 'component %s\n' "$COMPONENT"

--- a/scripts/release-plan.sh
+++ b/scripts/release-plan.sh
@@ -31,6 +31,10 @@ COMMIT="$(git -C "$REPO_ROOT" rev-parse HEAD)"
 SHORT_COMMIT="${COMMIT:0:8}"
 BUILD_NUMBER="$(git -C "$REPO_ROOT" rev-list --count HEAD)"
 BUILT_AT="${ATC_RELEASE_BUILT_AT:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+[[ "$BUILT_AT" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] || {
+  echo "invalid release timestamp: $BUILT_AT" >&2
+  exit 1
+}
 
 if [[ "$CHANNEL" == "stable" ]]; then
   NEXT_TAG="$(cd "$REPO_ROOT" && "$SCRIPT_DIR/next-version.sh" "$BUMP")"

--- a/scripts/release-plan.sh
+++ b/scripts/release-plan.sh
@@ -3,41 +3,56 @@
 set -euo pipefail
 
 usage() {
-  echo "usage: scripts/release-plan.sh dev|stable [patch|minor|major]" >&2
+  echo "usage: scripts/release-plan.sh stable [patch|minor|major] | dev [dev|dev-pr-N]" >&2
 }
 
 CHANNEL="${1:-}"
-BUMP="${2:-patch}"
 case "$CHANNEL" in
   dev|stable) ;;
   *) usage; exit 2 ;;
 esac
-case "$BUMP" in
-  patch|minor|major) ;;
-  *) usage; exit 2 ;;
-esac
-if [[ "$CHANNEL" == "dev" && $# -gt 1 ]]; then
-  usage
-  exit 2
+
+if [[ "$CHANNEL" == "stable" ]]; then
+  BUMP="${2:-patch}"
+  case "$BUMP" in
+    patch|minor|major) ;;
+    *) usage; exit 2 ;;
+  esac
+  [[ $# -le 2 ]] || { usage; exit 2; }
+else
+  TAG="${2:-dev}"
+  [[ "$TAG" == "dev" || "$TAG" =~ ^dev-pr-[1-9][0-9]*$ ]] || { usage; exit 2; }
+  [[ $# -le 2 ]] || { usage; exit 2; }
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 REPO_ROOT="${ATC_RELEASE_REPO_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd -P)}"
 COMMIT="$(git -C "$REPO_ROOT" rev-parse HEAD)"
-SHORT_COMMIT="${COMMIT:0:12}"
+SHORT_COMMIT="${COMMIT:0:8}"
 BUILD_NUMBER="$(git -C "$REPO_ROOT" rev-list --count HEAD)"
 BUILT_AT="${ATC_RELEASE_BUILT_AT:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
 
-NEXT_TAG="$(cd "$REPO_ROOT" && "$SCRIPT_DIR/next-version.sh" "$BUMP")"
-MARKETING_VERSION="${NEXT_TAG#v}"
 if [[ "$CHANNEL" == "stable" ]]; then
+  NEXT_TAG="$(cd "$REPO_ROOT" && "$SCRIPT_DIR/next-version.sh" "$BUMP")"
+  MARKETING_VERSION="${NEXT_TAG#v}"
   TAG="$NEXT_TAG"
   VERSION="$MARKETING_VERSION"
+  KIND="stable"
 else
-  TAG="dev"
-  VERSION="${MARKETING_VERSION}-dev.${BUILD_NUMBER}+${SHORT_COMMIT}"
+  YEAR="${BUILT_AT:0:4}"
+  MONTH="$((10#${BUILT_AT:5:2}))"
+  DAY="$((10#${BUILT_AT:8:2}))"
+  TIME="${BUILT_AT:11:2}${BUILT_AT:14:2}${BUILT_AT:17:2}"
+  MARKETING_VERSION="${YEAR}.${MONTH}.${DAY}"
+  VERSION="${MARKETING_VERSION}-dev.t${TIME}+${SHORT_COMMIT}"
+  if [[ "$TAG" == "dev" ]]; then
+    KIND="dev"
+  else
+    KIND="candidate"
+  fi
 fi
 
+printf 'kind=%s\n' "$KIND"
 printf 'channel=%s\n' "$CHANNEL"
 printf 'tag=%s\n' "$TAG"
 printf 'version=%s\n' "$VERSION"

--- a/scripts/release-test.sh
+++ b/scripts/release-test.sh
@@ -13,8 +13,26 @@ done
 git -C "$TEST_ROOT" init -q
 git -C "$TEST_ROOT" config user.name test
 git -C "$TEST_ROOT" config user.email test@example.com
-touch "$TEST_ROOT/file"
-git -C "$TEST_ROOT" add file
+mkdir -p \
+  "$TEST_ROOT/.github/workflows" \
+  "$TEST_ROOT/app-server" \
+  "$TEST_ROOT/macos" \
+  "$TEST_ROOT/packages" \
+  "$TEST_ROOT/scripts"
+touch \
+  "$TEST_ROOT/app-server/source.ts" \
+  "$TEST_ROOT/app-server/openapi.json" \
+  "$TEST_ROOT/macos/source.swift" \
+  "$TEST_ROOT/packages/source.swift" \
+  "$TEST_ROOT/mise.toml" \
+  "$TEST_ROOT/.github/workflows/product-release.yml" \
+  "$TEST_ROOT/scripts/ExportOptions.DeveloperID.plist" \
+  "$TEST_ROOT/scripts/package-app-server.sh" \
+  "$TEST_ROOT/scripts/prepare-xcode-openapi.sh" \
+  "$TEST_ROOT/scripts/release-fingerprint.sh" \
+  "$TEST_ROOT/scripts/release-macos.sh" \
+  "$TEST_ROOT/scripts/release-plan.sh"
+git -C "$TEST_ROOT" add .
 git -C "$TEST_ROOT" commit -qm initial
 git -C "$TEST_ROOT" tag v1.2.3
 git -C "$TEST_ROOT" commit --allow-empty -qm second
@@ -52,6 +70,17 @@ candidate="$(
 [[ "$(awk -F= '$1 == "tag" { print $2 }' <<< "$candidate")" == "dev-pr-214" ]]
 [[ "$(awk -F= '$1 == "version" { print $2 }' <<< "$candidate")" == "2026.8.15-dev.t070304+${commit:0:8}" ]]
 
+set +e
+invalid_plan_output="$(
+  ATC_RELEASE_REPO_ROOT="$TEST_ROOT" \
+    ATC_RELEASE_BUILT_AT="2026-08-15 07:03:04" \
+    "$SCRIPT_DIR/release-plan.sh" dev 2>&1
+)"
+invalid_plan_status=$?
+set -e
+[[ $invalid_plan_status -eq 1 ]]
+[[ "$invalid_plan_output" == *"invalid release timestamp"* ]]
+
 app_fingerprint="$(ATC_RELEASE_REPO_ROOT="$TEST_ROOT" "$SCRIPT_DIR/release-fingerprint.sh" app-server)"
 mac_fingerprint="$(ATC_RELEASE_REPO_ROOT="$TEST_ROOT" "$SCRIPT_DIR/release-fingerprint.sh" macos)"
 [[ "$app_fingerprint" =~ ^[0-9a-f]{64}$ && "$mac_fingerprint" =~ ^[0-9a-f]{64}$ ]]
@@ -77,14 +106,20 @@ manifest="$TEST_ROOT/manifest.json"
   --output "$manifest"
 jq -e '.schemaVersion == 1 and .release.tag == "dev" and .components.macos.reusedFrom == "dev"' "$manifest" >/dev/null
 
-selection="$($SCRIPT_DIR/select-release-components.sh "$app_fingerprint" "$mac_fingerprint" "$manifest")"
+selection="$("$SCRIPT_DIR/select-release-components.sh" "$app_fingerprint" "$mac_fingerprint" "$manifest")"
 [[ "$(awk -F= '$1 == "reuse_app_server" { print $2 }' <<< "$selection")" == "true" ]]
 [[ "$(awk -F= '$1 == "app_server_source_tag" { print $2 }' <<< "$selection")" == "dev" ]]
 [[ "$(awk -F= '$1 == "reuse_macos" { print $2 }' <<< "$selection")" == "true" ]]
 
-miss_selection="$($SCRIPT_DIR/select-release-components.sh "$(printf app | shasum -a 256 | awk '{ print $1 }')" "$(printf mac | shasum -a 256 | awk '{ print $1 }')" "$manifest")"
+miss_selection="$("$SCRIPT_DIR/select-release-components.sh" "$(printf app | shasum -a 256 | awk '{ print $1 }')" "$(printf mac | shasum -a 256 | awk '{ print $1 }')" "$manifest")"
 [[ "$(awk -F= '$1 == "reuse_app_server" { print $2 }' <<< "$miss_selection")" == "false" ]]
 [[ "$(awk -F= '$1 == "reuse_macos" { print $2 }' <<< "$miss_selection")" == "false" ]]
+
+unsafe_manifest="$TEST_ROOT/unsafe-manifest.json"
+jq '.components.appServer.version = "unsafe\noutput=true"' "$manifest" > "$unsafe_manifest"
+unsafe_selection="$("$SCRIPT_DIR/select-release-components.sh" "$app_fingerprint" "$mac_fingerprint" "$unsafe_manifest")"
+[[ "$(awk -F= '$1 == "reuse_app_server" { print $2 }' <<< "$unsafe_selection")" == "false" ]]
+[[ "$(awk -F= '$1 == "reuse_macos" { print $2 }' <<< "$unsafe_selection")" == "true" ]]
 
 mkdir -p "$TEST_ROOT/dist" "$TEST_ROOT/out"
 cp /bin/sh "$TEST_ROOT/dist/atc-darwin-arm64"
@@ -131,6 +166,100 @@ grep -Fqx "list-keychains -d user -s $TEST_ROOT/Login Keychain.keychain-db $TEST
 grep -Fqx "default-keychain -d user -s $TEST_ROOT/Login Keychain.keychain-db" "$security_log"
 grep -Fqx "delete-keychain $credential_dir/release.keychain-db" "$security_log"
 
+release_fake_bin="$TEST_ROOT/release-fake-bin"
+release_source="$TEST_ROOT/release-source"
+mkdir -p "$release_fake_bin" "$release_source"
+printf 'original asset\n' > "$release_source/atc-linux-x64.tar.gz"
+(
+  cd "$release_source"
+  shasum -a 256 atc-linux-x64.tar.gz > checksums.txt
+)
+printf 'tampered asset\n' > "$release_source/atc-linux-x64.tar.gz"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'if [[ "$1" == "release" && "$2" == "download" ]]; then' \
+  '  pattern=""' \
+  '  out=""' \
+  '  shift 2' \
+  '  while [[ $# -gt 0 ]]; do' \
+  '    case "$1" in' \
+  '      --pattern) pattern="$2"; shift 2 ;;' \
+  '      --dir) out="$2"; shift 2 ;;' \
+  '      *) shift ;;' \
+  '    esac' \
+  '  done' \
+  '  cp "$FAKE_RELEASE_SOURCE/$pattern" "$out/$pattern"' \
+  '  exit 0' \
+  'fi' \
+  'if [[ "$1" == "pr" && "$2" == "view" ]]; then' \
+  '  if [[ "$*" == *"--json state"* ]]; then' \
+  '    [[ "$FAKE_PR_STATE" != "ERROR" ]] || exit 1' \
+  '    printf '\''%s\n'\'' "$FAKE_PR_STATE"' \
+  '    exit 0' \
+  '  fi' \
+  '  if [[ "$*" == *"--json headRefOid"* ]]; then' \
+  '    printf '\''%s\n'\'' "$FAKE_PR_HEAD"' \
+  '    exit 0' \
+  '  fi' \
+  'fi' \
+  'exit 99' > "$release_fake_bin/gh"
+chmod +x "$release_fake_bin/gh"
+
+set +e
+reuse_output="$(
+  PATH="$release_fake_bin:$PATH" \
+    FAKE_RELEASE_SOURCE="$release_source" \
+    "$SCRIPT_DIR/reuse-release-assets.sh" \
+    --tag dev \
+    --out "$TEST_ROOT/reused-assets" \
+    --checksums checksums-reused.txt \
+    atc-linux-x64.tar.gz 2>&1
+)"
+reuse_status=$?
+set -e
+[[ $reuse_status -eq 1 ]]
+[[ "$reuse_output" == *"checksum mismatch"* ]]
+
+candidate_assets="$TEST_ROOT/candidate-assets"
+mkdir -p "$candidate_assets"
+touch \
+  "$candidate_assets/atc-darwin-arm64.tar.gz" \
+  "$candidate_assets/atc-darwin-x64.tar.gz" \
+  "$candidate_assets/atc-linux-arm64.tar.gz" \
+  "$candidate_assets/atc-linux-x64.tar.gz" \
+  "$candidate_assets/atc-macos-arm64.dmg" \
+  "$candidate_assets/checksums.txt" \
+  "$candidate_assets/manifest.json"
+
+candidate_publish() {
+  PATH="$release_fake_bin:$PATH" \
+    FAKE_PR_STATE="$1" \
+    FAKE_PR_HEAD="$2" \
+    "$SCRIPT_DIR/publish-release.sh" \
+    --kind candidate \
+    --channel dev \
+    --tag dev-pr-214 \
+    --version "2026.8.15-dev.t070304+${commit:0:8}" \
+    --commit "$commit" \
+    --built-at 2026-08-15T07:03:04Z \
+    --assets "$candidate_assets"
+}
+
+closed_output="$(candidate_publish CLOSED "$commit")"
+[[ "$closed_output" == *"skipping candidate build for closed PR #214"* ]]
+
+stale_head="0000000000000000000000000000000000000000"
+stale_output="$(candidate_publish OPEN "$stale_head")"
+[[ "$stale_output" == *"skipping obsolete candidate build $commit"* ]]
+
+set +e
+state_error_output="$(candidate_publish ERROR "$commit" 2>&1)"
+state_error_status=$?
+set -e
+[[ $state_error_status -eq 1 ]]
+[[ "$state_error_output" == *"could not resolve PR #214 state"* ]]
+
 set +e
 missing_value_output="$($SCRIPT_DIR/package-app-server.sh --dist 2>&1)"
 missing_value_status=$?
@@ -144,6 +273,13 @@ missing_value_status=$?
 set -e
 [[ $missing_value_status -eq 2 ]]
 [[ "$missing_value_output" == *"missing value for --channel"* ]]
+
+set +e
+missing_pr_output="$("$SCRIPT_DIR/dev-build.sh" --pr 2>&1)"
+missing_pr_status=$?
+set -e
+[[ $missing_pr_status -eq 2 ]]
+[[ "$missing_pr_output" == *"usage: mise run dev-build"* ]]
 
 set +e
 invalid_timestamp_output="$(

--- a/scripts/release-test.sh
+++ b/scripts/release-test.sh
@@ -25,6 +25,7 @@ stable="$(
     "$SCRIPT_DIR/release-plan.sh" stable minor
 )"
 [[ "$(awk -F= '$1 == "tag" { print $2 }' <<< "$stable")" == "v1.3.0" ]]
+[[ "$(awk -F= '$1 == "kind" { print $2 }' <<< "$stable")" == "stable" ]]
 [[ "$(awk -F= '$1 == "version" { print $2 }' <<< "$stable")" == "1.3.0" ]]
 [[ "$(awk -F= '$1 == "marketing_version" { print $2 }' <<< "$stable")" == "1.3.0" ]]
 [[ "$(awk -F= '$1 == "build_number" { print $2 }' <<< "$stable")" == "2" ]]
@@ -37,8 +38,53 @@ dev="$(
     "$SCRIPT_DIR/release-plan.sh" dev
 )"
 [[ "$(awk -F= '$1 == "tag" { print $2 }' <<< "$dev")" == "dev" ]]
-[[ "$(awk -F= '$1 == "version" { print $2 }' <<< "$dev")" == "1.2.4-dev.2+${commit:0:12}" ]]
+[[ "$(awk -F= '$1 == "kind" { print $2 }' <<< "$dev")" == "dev" ]]
+[[ "$(awk -F= '$1 == "version" { print $2 }' <<< "$dev")" == "2026.8.15-dev.t123456+${commit:0:8}" ]]
+[[ "$(awk -F= '$1 == "marketing_version" { print $2 }' <<< "$dev")" == "2026.8.15" ]]
 [[ "$(awk -F= '$1 == "commit" { print $2 }' <<< "$dev")" == "$commit" ]]
+
+candidate="$(
+  ATC_RELEASE_REPO_ROOT="$TEST_ROOT" \
+    ATC_RELEASE_BUILT_AT="2026-08-15T07:03:04Z" \
+    "$SCRIPT_DIR/release-plan.sh" dev dev-pr-214
+)"
+[[ "$(awk -F= '$1 == "kind" { print $2 }' <<< "$candidate")" == "candidate" ]]
+[[ "$(awk -F= '$1 == "tag" { print $2 }' <<< "$candidate")" == "dev-pr-214" ]]
+[[ "$(awk -F= '$1 == "version" { print $2 }' <<< "$candidate")" == "2026.8.15-dev.t070304+${commit:0:8}" ]]
+
+app_fingerprint="$(ATC_RELEASE_REPO_ROOT="$TEST_ROOT" "$SCRIPT_DIR/release-fingerprint.sh" app-server)"
+mac_fingerprint="$(ATC_RELEASE_REPO_ROOT="$TEST_ROOT" "$SCRIPT_DIR/release-fingerprint.sh" macos)"
+[[ "$app_fingerprint" =~ ^[0-9a-f]{64}$ && "$mac_fingerprint" =~ ^[0-9a-f]{64}$ ]]
+[[ "$app_fingerprint" != "$mac_fingerprint" ]]
+
+manifest="$TEST_ROOT/manifest.json"
+"$SCRIPT_DIR/write-release-manifest.sh" \
+  --kind dev \
+  --tag dev \
+  --version "2026.8.15-dev.t123456+${commit:0:8}" \
+  --commit "$commit" \
+  --built-at 2026-08-15T12:34:56Z \
+  --app-server-fingerprint "$app_fingerprint" \
+  --app-server-version "2026.8.15-dev.t123456+${commit:0:8}" \
+  --app-server-commit "$commit" \
+  --app-server-built-at 2026-08-15T12:34:56Z \
+  --app-server-reused-from "" \
+  --macos-fingerprint "$mac_fingerprint" \
+  --macos-version 2026.8.14-dev.t221030+deadbeef \
+  --macos-commit "$commit" \
+  --macos-built-at 2026-08-14T22:10:30Z \
+  --macos-reused-from dev \
+  --output "$manifest"
+jq -e '.schemaVersion == 1 and .release.tag == "dev" and .components.macos.reusedFrom == "dev"' "$manifest" >/dev/null
+
+selection="$($SCRIPT_DIR/select-release-components.sh "$app_fingerprint" "$mac_fingerprint" "$manifest")"
+[[ "$(awk -F= '$1 == "reuse_app_server" { print $2 }' <<< "$selection")" == "true" ]]
+[[ "$(awk -F= '$1 == "app_server_source_tag" { print $2 }' <<< "$selection")" == "dev" ]]
+[[ "$(awk -F= '$1 == "reuse_macos" { print $2 }' <<< "$selection")" == "true" ]]
+
+miss_selection="$($SCRIPT_DIR/select-release-components.sh "$(printf app | shasum -a 256 | awk '{ print $1 }')" "$(printf mac | shasum -a 256 | awk '{ print $1 }')" "$manifest")"
+[[ "$(awk -F= '$1 == "reuse_app_server" { print $2 }' <<< "$miss_selection")" == "false" ]]
+[[ "$(awk -F= '$1 == "reuse_macos" { print $2 }' <<< "$miss_selection")" == "false" ]]
 
 mkdir -p "$TEST_ROOT/dist" "$TEST_ROOT/out"
 cp /bin/sh "$TEST_ROOT/dist/atc-darwin-arm64"
@@ -223,7 +269,7 @@ while IFS= read -r action; do
     echo "release workflow action is not pinned to a full commit SHA: $action" >&2
     exit 1
   fi
-done < <(git -C "$REPO_ROOT" grep -hoE 'uses: [^ #]+' -- .github/workflows/product-release.yml)
+done < <(git -C "$REPO_ROOT" grep -hoE 'uses: [^ #]+' -- .github/workflows/product-*.yml)
 
 if git -C "$REPO_ROOT" grep -qE 'secrets\.ATC_APP_STORE_CONNECT_(KEY_ID|ISSUER_ID)' -- .github/workflows/product-release.yml; then
   echo "non-secret App Store Connect identifiers must be environment variables" >&2
@@ -239,7 +285,10 @@ if git -C "$REPO_ROOT" grep -qE 'ATC_NOTARY_KEY_' -- \
 fi
 
 git -C "$REPO_ROOT" grep -qE '^run-name:.*request_id' -- .github/workflows/product-release.yml
-git -C "$REPO_ROOT" grep -q 'request_id=' -- scripts/release.sh
+grep -q 'request_id=' "$REPO_ROOT/scripts/release.sh"
+grep -q 'Product Release \[stable:$REQUEST_ID\]' "$REPO_ROOT/scripts/release.sh"
+grep -q 'request_id=' "$REPO_ROOT/scripts/dev-build.sh"
+grep -q 'mode=candidate' "$REPO_ROOT/scripts/dev-build.sh"
 git -C "$REPO_ROOT" check-ignore -q --no-index AuthKey.p8
 git -C "$REPO_ROOT" check-ignore -q --no-index another-key.p8
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -23,7 +23,7 @@ gh auth status -h github.com >/dev/null 2>&1 || die "gh is not authenticated for
 
 WORKFLOW="product-release.yml"
 REQUEST_ID="$(printf '%s:%s:%s:%s' "$(date -u +%s)" "$$" "$RANDOM" "$RANDOM" | git hash-object --stdin)"
-RUN_TITLE="Product Release [$REQUEST_ID]"
+RUN_TITLE="Product Release [stable:$REQUEST_ID]"
 
 matching_run_id() {
   gh run list \
@@ -36,7 +36,7 @@ matching_run_id() {
     2>/dev/null | head -n 1 || true
 }
 
-gh workflow run "$WORKFLOW" --ref main -f release_type="$BUMP" -f request_id="$REQUEST_ID"
+gh workflow run "$WORKFLOW" --ref main -f mode=stable -f release_type="$BUMP" -f request_id="$REQUEST_ID"
 printf 'dispatched stable %s release from main\n' "$BUMP"
 
 RUN_ID=""

--- a/scripts/reuse-release-assets.sh
+++ b/scripts/reuse-release-assets.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Downloads immutable component assets from an existing rolling release and
+# verifies them against that release's checksums before handing them to a new
+# product assembly.
+set -euo pipefail
+
+usage() {
+  echo "usage: scripts/reuse-release-assets.sh --tag TAG --out DIR --checksums NAME ASSET [...]" >&2
+}
+
+TAG=""
+OUT=""
+CHECKSUMS=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag) TAG="${2:-}"; shift 2 ;;
+    --out) OUT="${2:-}"; shift 2 ;;
+    --checksums) CHECKSUMS="${2:-}"; shift 2 ;;
+    --) shift; break ;;
+    -*) usage; exit 2 ;;
+    *) break ;;
+  esac
+done
+
+[[ "$TAG" == "dev" || "$TAG" =~ ^dev-pr-[1-9][0-9]*$ ]] || { usage; exit 2; }
+[[ -n "$OUT" && -n "$CHECKSUMS" && "$CHECKSUMS" != */* && $# -gt 0 ]] || { usage; exit 2; }
+command -v gh >/dev/null 2>&1 || { echo "required command not found: gh" >&2; exit 1; }
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/atc-release-reuse.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+gh release download "$TAG" --pattern checksums.txt --dir "$TMP"
+mkdir -p "$OUT"
+
+assets=()
+for name in "$@"; do
+  [[ "$name" != */* ]] || { echo "asset name must be a basename: $name" >&2; exit 2; }
+  expected="$(awk -v file="$name" '{ candidate=$NF; sub(/^\*/, "", candidate); if (candidate == file) print $1 }' "$TMP/checksums.txt")"
+  [[ "$expected" =~ ^[0-9a-f]{64}$ ]] || { echo "checksums.txt does not include $name" >&2; exit 1; }
+  gh release download "$TAG" --pattern "$name" --dir "$TMP"
+  actual="$(shasum -a 256 "$TMP/$name" | awk '{ print $1 }')"
+  [[ "$actual" == "$expected" ]] || { echo "checksum mismatch for $name from $TAG" >&2; exit 1; }
+  cp "$TMP/$name" "$OUT/$name"
+  assets+=("$name")
+done
+
+(
+  cd "$OUT"
+  shasum -a 256 "${assets[@]}" > "$CHECKSUMS"
+)

--- a/scripts/select-release-components.sh
+++ b/scripts/select-release-components.sh
@@ -16,13 +16,14 @@ select_component() {
   local component="$1"
   local fingerprint="$2"
   local manifest tag
+  shift 2
   for manifest in "$@"; do
     [[ -f "$manifest" ]] || continue
     jq -e --arg component "$component" --arg fingerprint "$fingerprint" '
       .schemaVersion == 1 and
       .release.tag != null and
       .components[$component].fingerprint == $fingerprint and
-      (.components[$component].version | type == "string" and length > 0) and
+      (.components[$component].version | type == "string" and test("^[0-9A-Za-z.+-]+$")) and
       (.components[$component].commit | type == "string" and test("^[0-9a-f]{40}$")) and
       (.components[$component].builtAt | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))
     ' "$manifest" >/dev/null 2>&1 || continue

--- a/scripts/select-release-components.sh
+++ b/scripts/select-release-components.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Selects reusable component identities from newest-to-oldest manifests.
+# Missing, malformed, or stale manifests are cache misses, never failures.
+set -euo pipefail
+
+usage() {
+  echo "usage: scripts/select-release-components.sh APP_SERVER_FINGERPRINT MACOS_FINGERPRINT [MANIFEST ...]" >&2
+}
+
+APP_SERVER_FINGERPRINT="${1:-}"
+MACOS_FINGERPRINT="${2:-}"
+[[ "$APP_SERVER_FINGERPRINT" =~ ^[0-9a-f]{64}$ && "$MACOS_FINGERPRINT" =~ ^[0-9a-f]{64}$ ]] || { usage; exit 2; }
+shift 2
+
+select_component() {
+  local component="$1"
+  local fingerprint="$2"
+  local manifest tag
+  for manifest in "$@"; do
+    [[ -f "$manifest" ]] || continue
+    jq -e --arg component "$component" --arg fingerprint "$fingerprint" '
+      .schemaVersion == 1 and
+      .release.tag != null and
+      .components[$component].fingerprint == $fingerprint and
+      (.components[$component].version | type == "string" and length > 0) and
+      (.components[$component].commit | type == "string" and test("^[0-9a-f]{40}$")) and
+      (.components[$component].builtAt | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))
+    ' "$manifest" >/dev/null 2>&1 || continue
+    tag="$(jq -r '.release.tag // empty' "$manifest")"
+    [[ "$tag" == "dev" || "$tag" =~ ^dev-pr-[1-9][0-9]*$ ]] || continue
+    printf '%s\n' "$manifest"
+    return
+  done
+}
+
+emit_component() {
+  local output_name="$1"
+  local component="$2"
+  local fingerprint="$3"
+  shift 3
+  local manifest=""
+  manifest="$(select_component "$component" "$fingerprint" "$@" || true)"
+  if [[ -z "$manifest" ]]; then
+    printf 'reuse_%s=false\n' "$output_name"
+    return
+  fi
+  printf 'reuse_%s=true\n' "$output_name"
+  printf '%s_source_tag=%s\n' "$output_name" "$(jq -r '.release.tag' "$manifest")"
+  printf '%s_version=%s\n' "$output_name" "$(jq -r ".components.${component}.version" "$manifest")"
+  printf '%s_commit=%s\n' "$output_name" "$(jq -r ".components.${component}.commit" "$manifest")"
+  printf '%s_built_at=%s\n' "$output_name" "$(jq -r ".components.${component}.builtAt" "$manifest")"
+}
+
+emit_component app_server appServer "$APP_SERVER_FINGERPRINT" "$@"
+emit_component macos macos "$MACOS_FINGERPRINT" "$@"

--- a/scripts/write-release-manifest.sh
+++ b/scripts/write-release-manifest.sh
@@ -35,6 +35,13 @@ done
 
 case "$KIND" in stable|dev|candidate) ;; *) usage; exit 2 ;; esac
 [[ -n "$TAG" && -n "$VERSION" && -n "$OUTPUT" ]] || { usage; exit 2; }
+[[ -n "$APP_SERVER_VERSION" && -n "$MACOS_VERSION" ]] || { usage; exit 2; }
+for value in "$BUILT_AT" "$APP_SERVER_BUILT_AT" "$MACOS_BUILT_AT"; do
+  [[ "$value" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] || {
+    echo "invalid release timestamp: $value" >&2
+    exit 1
+  }
+done
 for value in "$COMMIT" "$APP_SERVER_COMMIT" "$MACOS_COMMIT"; do
   [[ "$value" =~ ^[0-9a-f]{40}$ ]] || { usage; exit 2; }
 done

--- a/scripts/write-release-manifest.sh
+++ b/scripts/write-release-manifest.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Writes the bill of materials for one product release set. Component identity
+# remains the identity embedded in the reused bytes, while release identity
+# describes the newly assembled and compatibility-tested set.
+set -euo pipefail
+
+usage() {
+  echo "usage: scripts/write-release-manifest.sh --kind KIND --tag TAG --version VERSION --commit SHA --built-at TIME --app-server-fingerprint SHA --app-server-version VERSION --app-server-commit SHA --app-server-built-at TIME --app-server-reused-from TAG --macos-fingerprint SHA --macos-version VERSION --macos-commit SHA --macos-built-at TIME --macos-reused-from TAG --output PATH" >&2
+}
+
+KIND="" TAG="" VERSION="" COMMIT="" BUILT_AT="" OUTPUT=""
+APP_SERVER_FINGERPRINT="" APP_SERVER_VERSION="" APP_SERVER_COMMIT="" APP_SERVER_BUILT_AT="" APP_SERVER_REUSED_FROM=""
+MACOS_FINGERPRINT="" MACOS_VERSION="" MACOS_COMMIT="" MACOS_BUILT_AT="" MACOS_REUSED_FROM=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --kind) KIND="${2:-}"; shift 2 ;;
+    --tag) TAG="${2:-}"; shift 2 ;;
+    --version) VERSION="${2:-}"; shift 2 ;;
+    --commit) COMMIT="${2:-}"; shift 2 ;;
+    --built-at) BUILT_AT="${2:-}"; shift 2 ;;
+    --app-server-fingerprint) APP_SERVER_FINGERPRINT="${2:-}"; shift 2 ;;
+    --app-server-version) APP_SERVER_VERSION="${2:-}"; shift 2 ;;
+    --app-server-commit) APP_SERVER_COMMIT="${2:-}"; shift 2 ;;
+    --app-server-built-at) APP_SERVER_BUILT_AT="${2:-}"; shift 2 ;;
+    --app-server-reused-from) APP_SERVER_REUSED_FROM="${2:-}"; shift 2 ;;
+    --macos-fingerprint) MACOS_FINGERPRINT="${2:-}"; shift 2 ;;
+    --macos-version) MACOS_VERSION="${2:-}"; shift 2 ;;
+    --macos-commit) MACOS_COMMIT="${2:-}"; shift 2 ;;
+    --macos-built-at) MACOS_BUILT_AT="${2:-}"; shift 2 ;;
+    --macos-reused-from) MACOS_REUSED_FROM="${2:-}"; shift 2 ;;
+    --output) OUTPUT="${2:-}"; shift 2 ;;
+    *) usage; exit 2 ;;
+  esac
+done
+
+case "$KIND" in stable|dev|candidate) ;; *) usage; exit 2 ;; esac
+[[ -n "$TAG" && -n "$VERSION" && -n "$OUTPUT" ]] || { usage; exit 2; }
+for value in "$COMMIT" "$APP_SERVER_COMMIT" "$MACOS_COMMIT"; do
+  [[ "$value" =~ ^[0-9a-f]{40}$ ]] || { usage; exit 2; }
+done
+for value in "$APP_SERVER_FINGERPRINT" "$MACOS_FINGERPRINT"; do
+  [[ "$value" =~ ^[0-9a-f]{64}$ ]] || { usage; exit 2; }
+done
+
+mkdir -p "$(dirname "$OUTPUT")"
+jq -n \
+  --arg kind "$KIND" --arg tag "$TAG" --arg version "$VERSION" \
+  --arg commit "$COMMIT" --arg builtAt "$BUILT_AT" \
+  --arg appFingerprint "$APP_SERVER_FINGERPRINT" --arg appVersion "$APP_SERVER_VERSION" \
+  --arg appCommit "$APP_SERVER_COMMIT" --arg appBuiltAt "$APP_SERVER_BUILT_AT" \
+  --arg appReusedFrom "$APP_SERVER_REUSED_FROM" \
+  --arg macFingerprint "$MACOS_FINGERPRINT" --arg macVersion "$MACOS_VERSION" \
+  --arg macCommit "$MACOS_COMMIT" --arg macBuiltAt "$MACOS_BUILT_AT" \
+  --arg macReusedFrom "$MACOS_REUSED_FROM" \
+  '{
+    schemaVersion: 1,
+    release: { kind: $kind, tag: $tag, version: $version, commit: $commit, builtAt: $builtAt },
+    components: {
+      appServer: {
+        fingerprint: $appFingerprint, version: $appVersion, commit: $appCommit,
+        builtAt: $appBuiltAt, reusedFrom: (if $appReusedFrom == "" then null else $appReusedFrom end)
+      },
+      macos: {
+        fingerprint: $macFingerprint, version: $macVersion, commit: $macCommit,
+        builtAt: $macBuiltAt, reusedFrom: (if $macReusedFrom == "" then null else $macReusedFrom end)
+      }
+    }
+  }' > "$OUTPUT"


### PR DESCRIPTION
## Summary

- version rolling development builds with UTC CalVer and expose the full build identity in the CLI and macOS About window
- add PR-scoped rolling `dev-pr-N` candidate releases and a single `mise run dev-build` entry point
- reuse checksum-verified App Server and macOS artifacts when their component fingerprints are unchanged
- publish a release manifest and automatically clean up candidate releases when a PR closes

## Why

Development releases previously inferred a future patch version, which made their identity misleading, and pre-merge testing required coordinating separate server and macOS builds. This gives every development build a clear timestamped identity while presenting one product release regardless of which component changed.

## Developer impact

Run `mise run dev-build` from a pull-request branch (or pass `-- --pr N`) to create or update that PR's candidate release. The workflow rebuilds only changed components, reuses verified existing artifacts for unchanged components, and publishes everything together under `dev-pr-N`. Merges to `main` continue updating the rolling `dev` release.

Stable releases remain SemVer and always rebuild all components.

## Validation

- `TMPDIR=/tmp mise run check`
- `xcodebuildmcp macos test` (293 tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added development candidate releases linked to pull requests.
  * Added automatic cleanup of candidate releases when pull requests close.
  * Added verified reuse of unchanged App Server and macOS components.
  * Added an “About atc” menu item showing the app version on macOS.
  * Added a command to dispatch and monitor development builds.

* **Improvements**
  * Release manifests now record component details and provenance.
  * Release planning, validation, and publishing now include stronger checks for candidate and stable releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->