### PR TITLE
Use one shared Codex app-server on the well-known control socket (ATC-196)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,10 +72,13 @@ server domain logic, and no tooling should enforce an API-to-CLI mapping.
 1. **Formatting above `app-server/`.** Only ever `mise run -C app-server fmt`.
    A bare `prettier --write .` from the repo root rewrites the read-only
    `repos/` clones and dozens of unrelated tracked files.
-2. **Touching the user's real zmx sessions.** `zmx` with no `ZMX_DIR` points at
-   the developer's own multiplexer, not ATC's. Always scope debugging to
-   `ZMX_DIR=~/.local/state/atc/terminals zmx list`, and never kill a session
-   you did not create.
+2. **Touching the user's real zmx sessions or Codex server.** `zmx` with no
+   `ZMX_DIR` points at the developer's own multiplexer, not ATC's. Always
+   scope debugging to `ZMX_DIR=~/.local/state/atc/terminals zmx list`, and
+   never kill a session you did not create. Likewise the `codex app-server`
+   on `~/.codex/app-server-control/` is shared with the Codex desktop app and
+   every terminal `codex`: never kill it, and test against a private
+   `CODEX_HOME`.
 3. **Editing generated output.** `app-server/openapi.json` is generated from
    the contract, and `packages/ATCKit/Sources/ATCAppServerAPI/openapi.json` is
    a symlink to it. The admin UI build (`app-server/web/build/`) and its embed

--- a/app-server/src/agents/agentAdapter.ts
+++ b/app-server/src/agents/agentAdapter.ts
@@ -710,14 +710,26 @@ export const readInstalledVersion = (
     // Bounded: a wedged binary must not hang a demand-driven registry read.
     Effect.timeoutOrElse({ duration: "5 seconds", orElse: () => Effect.succeed("") }),
     Effect.orElseSucceed(() => ""),
-    Effect.map(
-      (output) =>
-        output
-          .match(/(\d+)\.(\d+)\.(\d+)/)
-          ?.slice(1, 4)
-          .join(".") ?? null,
-    ),
+    Effect.map(parseVersion),
   )
+
+/** The first x.y.z in `text` (a --version line, a userAgent), else null. */
+export const parseVersion = (text: string): string | null =>
+  text
+    .match(/(\d+)\.(\d+)\.(\d+)/)
+    ?.slice(1, 4)
+    .join(".") ?? null
+
+/** Whether `installed` is below the `tested` x.y.z floor (component-wise). */
+export const versionIsOlder = (installed: string, tested: string): boolean => {
+  const left = installed.split(".").map(Number)
+  const right = tested.split(".").map(Number)
+  for (let index = 0; index < 3; index++) {
+    const difference = (left[index] ?? 0) - (right[index] ?? 0)
+    if (difference !== 0) return difference < 0
+  }
+  return false
+}
 
 /**
  * The shared version-drift rule (record + warn, never block), memoized to
@@ -750,13 +762,7 @@ export const makeVersionGate = (
           `could not determine the installed ${provider} version (tested against ${testedVersion})`,
         )
       }
-      // Components are small; packing keeps the comparison one expression.
-      const pack = (version: string) =>
-        version
-          .split(".")
-          .map(Number)
-          .reduce((total, part) => total * 1_000 + part, 0)
-      if (pack(installed) < pack(testedVersion)) {
+      if (versionIsOlder(installed, testedVersion)) {
         yield* Effect.logWarning(
           `installed ${provider} ${installed} is older than the tested ${testedVersion}; proceeding, but upgrade it if provider behavior misbehaves`,
         )

--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -34,22 +34,33 @@ import {
   emitAgentEvent,
   makeVersionGate,
   NESTED_SESSION_ENV_VARIABLES,
+  parseVersion,
   providerErrors,
   resolveProviderExecutable,
   samePath,
   titleInstruction,
+  versionIsOlder,
   withTitleTimeout,
 } from "./agentAdapter.ts"
 import * as BuildInfo from "../platform/buildInfo.ts"
 import * as CodexServer from "./codexServer.ts"
 import { AppConfig } from "../platform/config.ts"
 import * as Subprocess from "../platform/subprocess.ts"
+import * as UnixWebSocket from "../platform/unixWebSocket.ts"
 
-// The Codex AgentAdapter (ATC-123): one WebSocket JSON-RPC client of the
-// profile's supervised, detached app-server (codexServer.ts), multiplexing
-// every thread over that single shared connection — which is what makes
-// TUI-driven turns observable on our feed. Invariants beyond the seam's:
+// The Codex AgentAdapter (ATC-123): one JSON-RPC client of the machine's
+// shared Codex app-server (codexServer.ts adopts or starts it on Codex's
+// well-known unix control socket — ATC-196), multiplexing every thread
+// over that single held connection. Because every Codex client on the
+// machine — ATC-launched TUIs, plain `codex` in a terminal, the desktop app
+// over SSH — is a client of that same process, turns driven from any of
+// them are observable on our feed and no surface conflicts with another
+// for a thread's writer lock. Invariants beyond the seam's:
 //
+//   - The transport is a WebSocket over the unix socket (unixWebSocket.ts);
+//     ATC-launched TUIs are pointed at the same socket explicitly
+//     (`--remote unix://<path>`) so identity capture never depends on the
+//     TUI's own auto-join, which silently turns off under `-c` overrides.
 //   - One writer per thread is enforced HERE (the app-server would accept a
 //     concurrent second writer, and concurrent writers corrupt provider
 //     turn attribution — ATC-83 evidence).
@@ -70,8 +81,11 @@ import * as Subprocess from "../platform/subprocess.ts"
 //     per-id thread/read. Descendant bookkeeping is in-memory and pruned
 //     on teardown, root unobserve/unregister, and release.
 
-/** The codex-cli version this adapter was validated against (record + warn). */
-const CODEX_TESTED_VERSION = "0.146.0"
+/** The codex-cli version this adapter was validated against (record + warn).
+ * Gated twice: the CLI ATC resolves (TUI launches, title one-shots) and the
+ * running app-server (from `initialize`'s userAgent) — an adopted server
+ * can drift from the CLI. */
+const CODEX_TESTED_VERSION = "0.147.0"
 
 const REQUEST_TIMEOUT = "30 seconds"
 
@@ -118,6 +132,11 @@ const ThreadReply = Schema.Struct({
 })
 
 const TurnReply = Schema.Struct({ turn: Schema.Struct({ id: Schema.String }) })
+
+// initialize's userAgent carries the server's own version, e.g.
+// "codex_chatgpt_ios_remote/0.147.0 (Mac OS 26.5; arm64) ..." (probed live
+// 2026-08-15) — the only version evidence an adopted server offers.
+const InitializeReply = Schema.Struct({ userAgent: Schema.optional(Schema.String) })
 
 // The real thread/list reply is paginated: { data, nextCursor } (probe
 // evidence in experiments/provider-identity-resume, pinned generated schema
@@ -252,7 +271,7 @@ interface PendingReply {
 }
 
 interface ClientState {
-  readonly socket: WebSocket
+  readonly socket: UnixWebSocket.Connection
   readonly pending: Map<number, PendingReply>
   nextId: number
   alive: boolean
@@ -741,39 +760,40 @@ export const layer = Layer.effect(CodexAdapter)(
       CODEX_TESTED_VERSION,
     )
 
-    const openSocket = (url: string): Effect.Effect<ClientState, AgentUnavailable> =>
+    const openSocket = (socketPath: string): Effect.Effect<ClientState, AgentUnavailable> =>
       Effect.callback<ClientState, AgentUnavailable>((resume) => {
-        const socket = new WebSocket(url)
+        const socket = UnixWebSocket.open(socketPath)
         const state: ClientState = { socket, pending: new Map(), nextId: 1, alive: true }
         socket.onopen = () => resume(Effect.succeed(state))
-        socket.onerror = () => {
-          teardown(state, "connection failed")
-          resume(Effect.fail(unavailable(`could not connect to ${url}`)))
+        // Before open this is the connect failure; after, a lost connection.
+        socket.onclose = (reason) => {
+          teardown(state, `the codex app-server connection closed: ${reason}`)
+          resume(Effect.fail(unavailable(`could not connect to ${socketPath}: ${reason}`)))
         }
-        socket.onclose = () => teardown(state, "the codex app-server connection closed")
-        socket.onmessage = (event) => dispatch(state, String(event.data))
+        socket.onmessage = (text) => dispatch(state, text)
         return Effect.sync(() => {
           if (current !== state) teardown(state, "connection attempt interrupted")
         })
       }).pipe(
         Effect.timeoutOrElse({
           duration: "5 seconds",
-          orElse: () => Effect.fail(unavailable(`timed out connecting to ${url}`)),
+          orElse: () => Effect.fail(unavailable(`timed out connecting to ${socketPath}`)),
         }),
       )
 
     const connect = Effect.gen(function* () {
       yield* versionCheck
       const info = yield* codexServer.ensure()
-      const state = yield* openSocket(info.url)
+      const state = yield* openSocket(info.socketPath)
       // A failed or interrupted handshake must close this socket: a
       // half-open connection would double-deliver broadcasts and, on its
       // eventual death, could not be told apart from the live one.
-      yield* request(state, "initialize", {
+      const reply = yield* request(state, "initialize", {
         clientInfo: { name: "atc", title: "ATC App Server", version: build.version },
         capabilities: null,
       }).pipe(
         Effect.mapError(rpcToProtocol),
+        Effect.flatMap((reply) => decodeReply(InitializeReply, reply)),
         Effect.onExit((exit) =>
           Effect.sync(() => {
             if (exit._tag === "Failure") teardown(state, "the handshake failed")
@@ -782,6 +802,14 @@ export const layer = Layer.effect(CodexAdapter)(
       )
       state.socket.send(JSON.stringify({ method: "initialized", params: {} }))
       current = state
+      // The shared server may be older than the CLI ATC resolved (adopted
+      // from another client): record + warn, never block.
+      const serverVersion = parseVersion(reply.userAgent ?? "")
+      if (serverVersion !== null && versionIsOlder(serverVersion, CODEX_TESTED_VERSION)) {
+        yield* Effect.logWarning(
+          `the shared codex app-server is ${serverVersion}, older than the tested ${CODEX_TESTED_VERSION}; proceeding, but restart it on a newer codex if provider behavior misbehaves`,
+        )
+      }
       return state
     })
 
@@ -1115,7 +1143,13 @@ export const layer = Layer.effect(CodexAdapter)(
           const info = yield* codexServer.ensure()
           return {
             launchSpec: {
-              command: [executable, "resume", "--remote", info.url, options.providerSessionId],
+              command: [
+                executable,
+                "resume",
+                "--remote",
+                `unix://${info.socketPath}`,
+                options.providerSessionId,
+              ],
               env: {},
             },
           }
@@ -1157,7 +1191,7 @@ export const layer = Layer.effect(CodexAdapter)(
             // the new thread with ITS process cwd and the capture's cwd match
             // below can never adopt the thread (observed on codex 0.146.0).
             launchSpec: {
-              command: [executable, "--cd", options.cwd, "--remote", info.url],
+              command: [executable, "--cd", options.cwd, "--remote", `unix://${info.socketPath}`],
               env: {},
             },
             identity: Deferred.await(gate),

--- a/app-server/src/agents/codexServer.ts
+++ b/app-server/src/agents/codexServer.ts
@@ -17,47 +17,64 @@ import { providerErrors, resolveProviderExecutable } from "./agentAdapter.ts"
 import type { AgentUnavailable } from "./agentAdapter.ts"
 import { AppConfig } from "../platform/config.ts"
 import * as Subprocess from "../platform/subprocess.ts"
+import * as UnixWebSocket from "../platform/unixWebSocket.ts"
 
-// Supervision for the single long-lived `codex app-server` per ATC profile
-// (ATC-123). Invariants that are invisible from the call sites:
+// Supervision of the ONE shared `codex app-server` per CODEX_HOME (ATC-196),
+// reached on Codex's well-known control socket
+// ($CODEX_HOME/app-server-control/app-server-control.sock) — the address
+// every Codex client on the machine meets at: the desktop/mobile apps over
+// SSH, plain `codex` invocations (which auto-join a live server), and ATC.
+// Invariants that are invisible from the call sites:
 //
-//   - The server is spawned DETACHED (reparented through an intermediate sh,
-//     zmx-style) because a live `codex resume --remote` TUI dies the moment
-//     its app-server dies, with no reconnect loop. A scoped child would kill
-//     every attached TUI on every ATC restart — so ATC shutdown deliberately
-//     leaves the server running, and boot re-adopts it from the persisted
-//     identity file + /readyz. Adopt-or-replace, never accumulate.
-//   - Exactly one server per profile, always ATC's own `--listen` listener —
-//     never the machine-wide `codex app-server proxy` daemon (externally
-//     owned; observed held by the Codex desktop integration).
+//   - Adopt-or-start. Whatever answers the socket is adopted as-is; ATC
+//     starts `codex app-server --listen unix://` only when nothing answers,
+//     and never runs an app-server on any other address. A private server
+//     splits the thread store — one process may write a thread at a time,
+//     and live events reach only clients of the same process — which is
+//     exactly the failure this module exists to prevent.
+//   - Ownership boundary. ATC never kills, replaces, or signals a server it
+//     did not start, and never invokes `codex app-server daemon *` (the
+//     managed daemon/updater). It replaces only its own recorded pid, and
+//     only once that pid is dead or has stopped answering. A codex upgrade
+//     therefore takes effect on the next start after the USER stops the
+//     server — never implicitly.
+//   - The server ATC starts is spawned DETACHED (reparented through an
+//     intermediate sh, zmx-style) because a `codex resume --remote` TUI
+//     dies the moment its app-server dies, with no reconnect loop. So ATC
+//     shutdown deliberately leaves the server running, and the next boot
+//     adopts it from the socket like any other client would.
 //   - A persisted pid is only trusted (and only ever signaled) after its
 //     command line still looks like an app-server: pids get recycled, and
 //     SIGKILLing a stranger is worse than leaking a server.
-//   - `stop` is the only intentional-kill path. The exit watcher restarts a
-//     server that died underneath us (with backoff); interrupting the
-//     watcher (layer shutdown) never touches the process itself.
+//   - "Answers" means accepts a WebSocket handshake. The adapter's
+//     `initialize` right after is what actually gates use; the probe only
+//     decides whether a start is needed.
+//   - `stop` is the only intentional-kill path and only ever targets our
+//     own recorded pid. The exit watcher restarts our own dead server (a
+//     server that appeared on the socket meanwhile is adopted, never
+//     replaced); interrupting the watcher never touches the process.
 
-/** Persisted identity of the detached server, in stateDir. */
+/** Persisted identity of the server ATC started, in stateDir. */
 const ServerIdentity = Schema.Struct({
   pid: Schema.Number,
-  port: Schema.Number,
   startedAt: Schema.String,
 })
 
 export interface CodexServerInfo {
-  readonly pid: number
-  readonly port: number
-  /** JSON-RPC WebSocket endpoint (also the TUI `--remote` endpoint). */
-  readonly url: string
+  /** The well-known control socket every Codex client on the machine shares. */
+  readonly socketPath: string
+  /** The pid of the server ATC started, or null when a foreign server was adopted. */
+  readonly pid: number | null
 }
 
 export interface CodexServerOptions {
-  /** Readiness window for a freshly spawned server. */
+  /** How long a freshly started server may take to answer. */
   readonly readyTimeout?: Duration.Input
   /**
-   * Readiness window when adopting an already-running pid. Deliberately
-   * generous by default: concluding a live server is dead kills every
-   * attached TUI, so patience is the cheaper error.
+   * How long our own already-running server may take to answer again
+   * before it is replaced. Deliberately generous by default: concluding a
+   * live server is dead kills every attached TUI, so patience is the
+   * cheaper error.
    */
   readonly adoptTimeout?: Duration.Input
   /** Exit-watcher poll interval. */
@@ -71,15 +88,15 @@ export class CodexServer extends Context.Service<
   CodexServer,
   {
     /**
-     * The profile's ready app-server: adopt the persisted one when it is
-     * alive and answers /readyz, replace it otherwise, spawn fresh when
-     * there is none. Serialized — concurrent callers get the same server.
+     * The shared app-server: adopt whatever answers the well-known socket,
+     * else start one (detached). Serialized — concurrent callers get the
+     * same answer.
      */
     readonly ensure: () => Effect.Effect<CodexServerInfo, AgentUnavailable>
     /**
-     * Intentionally stop the detached server and clear its identity. Live
-     * TUIs attached to it will exit — callers own that decision. Stopping
-     * an already-stopped server succeeds.
+     * Intentionally stop the server ATC started and clear its identity;
+     * a foreign server is left alone. Live TUIs attached to it will exit —
+     * callers own that decision. Stopping nothing succeeds.
      */
     readonly stop: () => Effect.Effect<void, AgentUnavailable>
   }
@@ -87,48 +104,27 @@ export class CodexServer extends Context.Service<
 
 const { unavailable } = providerErrors("codex")
 
-/** Readiness-gate failure that must stop the retry loop: the pid is gone. */
+/** Readiness-wait outcome that must stop polling: the pid is gone. */
 class ServerExited extends Schema.TaggedErrorClass<ServerExited>()("ServerExited", {
   pid: Schema.Number,
 }) {}
 
-const infoFor = (pid: number, port: number): CodexServerInfo => ({
-  pid,
-  port,
-  url: `ws://127.0.0.1:${port}`,
-})
+/** Codex's hardcoded control socket location under its home directory. */
+export const controlSocketPath = (codexHome: string): string =>
+  path.join(codexHome, "app-server-control", "app-server-control.sock")
 
-/** An OS-assigned free loopback port; the tiny claim race is acceptable. */
-const freePort = Effect.try({
-  try: () => {
-    const listener = Bun.listen({
-      hostname: "127.0.0.1",
-      port: 0,
-      socket: { data: () => {} },
-    })
-    const port = listener.port
-    listener.stop(true)
-    return port
-  },
-  catch: (error) => unavailable(`could not allocate a listen port: ${error}`),
-})
-
-/** One /readyz probe; any failure (refused, non-2xx, >1s) is "not ready". */
-const probeReady = (port: number): Effect.Effect<void, AgentUnavailable> =>
-  Effect.tryPromise({
-    try: (signal) => fetch(`http://127.0.0.1:${port}/readyz`, { signal }),
-    catch: () => unavailable(`not answering /readyz on port ${port}`),
-  }).pipe(
-    Effect.timeoutOrElse({
-      duration: "1 second",
-      orElse: () => Effect.fail(unavailable(`/readyz probe timed out on port ${port}`)),
-    }),
-    Effect.flatMap((response) =>
-      response.ok
-        ? Effect.void
-        : Effect.fail(unavailable(`/readyz answered ${response.status} on port ${port}`)),
-    ),
-  )
+/** One handshake probe: whether something completes a WebSocket upgrade. */
+const probeSocket = (socketPath: string): Effect.Effect<boolean> =>
+  Effect.callback<boolean>((resume) => {
+    const socket = UnixWebSocket.open(socketPath)
+    // Resume before closing: close() reports onclose synchronously.
+    socket.onopen = () => {
+      resume(Effect.succeed(true))
+      socket.close()
+    }
+    socket.onclose = () => resume(Effect.succeed(false))
+    return Effect.sync(() => socket.close())
+  }).pipe(Effect.timeoutOrElse({ duration: "1 second", orElse: () => Effect.succeed(false) }))
 
 /** SIGTERM → bounded wait → SIGKILL → verified gone. Absent pid succeeds. */
 const terminate = (pid: number): Effect.Effect<void, AgentUnavailable> =>
@@ -154,12 +150,18 @@ export const layerWith = (options: CodexServerOptions) =>
       const config = yield* AppConfig
       const subprocess = yield* Subprocess.Subprocess
       const fs = yield* FileSystem.FileSystem
+      const socketPath = controlSocketPath(config.codexHome)
       const identityFile = path.join(config.stateDir, "codex-app-server.json")
       const logFile = path.join(config.stateDir, "codex-app-server.log")
       const readyTimeout = options.readyTimeout ?? "15 seconds"
       const adoptTimeout = options.adoptTimeout ?? "10 seconds"
       const watchInterval = options.watchInterval ?? "1 second"
-      const readySchedule = Schedule.exponential("100 millis").pipe(Schedule.jittered)
+      // Capped backoff: a real server takes a second or two to bind, and an
+      // uncapped exponential would leave whole seconds on the table.
+      const readySchedule = Schedule.min([
+        Schedule.exponential("100 millis"),
+        Schedule.spaced("1 second"),
+      ]).pipe(Schedule.jittered)
 
       const current = yield* Ref.make<CodexServerInfo | null>(null)
       const lock = yield* Semaphore.make(1)
@@ -172,13 +174,7 @@ export const layerWith = (options: CodexServerOptions) =>
       const isOurServer = (pid: number) =>
         Subprocess.processHasArgvToken(subprocess, pid, "app-server")
 
-      /** Terminate `pid` only if it is provably still our server. */
-      const terminateOurs = (pid: number) =>
-        Effect.gen(function* () {
-          if (yield* isOurServer(pid)) yield* terminate(pid)
-        })
-
-      /** Last log lines, for actionable spawn/readiness diagnostics. */
+      /** Last log lines, for actionable start/readiness diagnostics. */
       const logTail = fs.readFileString(logFile).pipe(
         Effect.map((text) => {
           const lines = text.trimEnd().split("\n").slice(-10).join("\n")
@@ -188,15 +184,18 @@ export const layerWith = (options: CodexServerOptions) =>
       )
 
       /**
-       * Poll /readyz until ready, the window elapses, or the pid dies —
-       * a dead pid fails immediately instead of burning the whole window
-       * (the lock is held while this runs).
+       * Poll the socket until it answers, the window elapses, or `pid`
+       * dies — a dead pid fails immediately instead of burning the whole
+       * window (the lock is held while this runs).
        */
-      const awaitReady = (pid: number, port: number, window: Duration.Input) =>
+      const awaitAnswer = (pid: number, window: Duration.Input) =>
         Effect.suspend((): Effect.Effect<void, AgentUnavailable | ServerExited> =>
-          Subprocess.isProcessAlive(pid)
-            ? probeReady(port)
-            : Effect.fail(new ServerExited({ pid })),
+          Effect.gen(function* () {
+            if (yield* probeSocket(socketPath)) return
+            return yield* Subprocess.isProcessAlive(pid)
+              ? Effect.fail(unavailable("not answering yet"))
+              : Effect.fail(new ServerExited({ pid }))
+          }),
         ).pipe(
           Effect.retry({
             schedule: readySchedule,
@@ -204,18 +203,13 @@ export const layerWith = (options: CodexServerOptions) =>
           }),
           Effect.timeoutOrElse({
             duration: window,
-            orElse: () => Effect.fail(unavailable(`gave up waiting for /readyz on port ${port}`)),
+            orElse: () =>
+              Effect.fail(
+                unavailable(
+                  `not answering on ${socketPath} within ${Duration.format(Duration.fromInputUnsafe(window))}`,
+                ),
+              ),
           }),
-          Effect.catch((error) =>
-            Effect.gen(function* () {
-              const tail = yield* logTail
-              const cause =
-                error._tag === "ServerExited"
-                  ? `process ${pid} exited before becoming ready`
-                  : `not ready within ${Duration.format(Duration.fromInputUnsafe(window))} on port ${port}`
-              return yield* Effect.fail(unavailable(cause + tail))
-            }),
-          ),
         )
 
       const readIdentity = fs.readFileString(identityFile).pipe(
@@ -224,15 +218,15 @@ export const layerWith = (options: CodexServerOptions) =>
         ),
         Effect.flatMap((json) => Schema.decodeUnknownEffect(ServerIdentity)(json)),
         Effect.map(Option.some),
-        // Absent or corrupt identity is "no server" — replaced, never trusted.
+        // Absent or corrupt identity is "no server of ours" — never trusted.
         Effect.orElseSucceed(() => Option.none<typeof ServerIdentity.Type>()),
       )
 
-      const writeIdentity = (pid: number, port: number) =>
+      const writeIdentity = (pid: number) =>
         fs
           .writeFileString(
             identityFile,
-            JSON.stringify({ pid, port, startedAt: new Date().toISOString() }, null, 2),
+            JSON.stringify({ pid, startedAt: new Date().toISOString() }, null, 2),
           )
           .pipe(
             Effect.mapError((error) => unavailable(`could not persist identity: ${error.message}`)),
@@ -240,13 +234,28 @@ export const layerWith = (options: CodexServerOptions) =>
 
       const clearIdentity = fs.remove(identityFile).pipe(Effect.ignore)
 
+      /**
+       * Who serves an answering socket: our recorded pid when it is alive
+       * and still an app-server, otherwise a foreign server (and a stale
+       * identity of ours is cleared).
+       */
+      const claimAnswering = Effect.gen(function* () {
+        const persisted = yield* readIdentity
+        if (Option.isSome(persisted) && (yield* isOurServer(persisted.value.pid))) {
+          return { socketPath, pid: persisted.value.pid }
+        }
+        yield* clearIdentity
+        return { socketPath, pid: null }
+      })
+
       // Detached spawn, zmx-style: an intermediate sh backgrounds the server
       // (reparenting it away from ATC, stdin from /dev/null so it can never
       // see EOF when ATC exits) and echoes the server's pid. The sh itself
-      // is a normal scoped child that exits immediately.
+      // is a normal scoped child that exits immediately. `--listen unix://`
+      // with no path binds Codex's well-known socket for the CODEX_HOME the
+      // server inherits — the derivation stays codex's.
       const spawnDetached = Effect.gen(function* () {
         const executable = yield* resolveProviderExecutable("codex", config.codexExecutable)
-        const port = yield* freePort
         yield* fs
           .makeDirectory(config.stateDir, { recursive: true })
           .pipe(
@@ -258,14 +267,14 @@ export const layerWith = (options: CodexServerOptions) =>
               executable: "/bin/sh",
               args: [
                 "-c",
-                `nohup "$1" app-server --listen "$2" >"$3" 2>&1 </dev/null & echo $!`,
+                `nohup "$1" app-server --listen unix:// >"$2" 2>&1 </dev/null & echo $!`,
                 "sh",
                 executable,
-                `ws://127.0.0.1:${port}`,
                 logFile,
               ],
               env: {},
-              // The server needs the user's full environment (auth state).
+              // The server needs the user's full environment (auth state,
+              // CODEX_HOME).
               extendEnv: true,
               // A fixed, neutral cwd: the detached server outlives ATC, and
               // codex uses the server's cwd as the default for threads whose
@@ -286,10 +295,39 @@ export const layerWith = (options: CodexServerOptions) =>
         }
         // From here the detached server exists: any non-success exit —
         // identity write failure, readiness failure, interruption — must
-        // reap it, or "never accumulate" is broken.
-        yield* Effect.gen(function* () {
-          yield* writeIdentity(pid, port)
-          yield* awaitReady(pid, port, readyTimeout)
+        // reap it, or ATC could accumulate servers of its own. (If a
+        // foreign server binds the socket while our child is still
+        // starting, the answer seen here may be the foreign one's while our
+        // child has not yet exited "already in use"; the identity then
+        // briefly names that pid, and the exit watcher reconciles on its
+        // next tick by adopting the winner.)
+        const outcome = yield* Effect.gen(function* () {
+          yield* writeIdentity(pid)
+          return yield* awaitAnswer(pid, readyTimeout).pipe(
+            // Answering while our child is already gone: another server
+            // took the socket and ours exited "already in use".
+            Effect.map(() =>
+              Subprocess.isProcessAlive(pid) ? ("started" as const) : ("raced" as const),
+            ),
+            Effect.catchTag("ServerExited", () =>
+              Effect.gen(function* () {
+                // Our child exited: either it lost the start race to
+                // another client's server (codex exits "already in use"),
+                // which we then adopt, or it failed outright.
+                if (yield* probeSocket(socketPath)) return "raced" as const
+                const tail = yield* logTail
+                return yield* Effect.fail(
+                  unavailable(`process ${pid} exited before answering on ${socketPath}` + tail),
+                )
+              }),
+            ),
+            Effect.catchTag("AgentUnavailable", (error) =>
+              Effect.gen(function* () {
+                const tail = yield* logTail
+                return yield* Effect.fail(unavailable(error.reason + tail))
+              }),
+            ),
+          )
         }).pipe(
           Effect.onExit((exit) =>
             exit._tag === "Failure"
@@ -297,28 +335,39 @@ export const layerWith = (options: CodexServerOptions) =>
               : Effect.void,
           ),
         )
-        yield* Effect.logInfo("codex app-server started").pipe(Effect.annotateLogs({ pid, port }))
-        return infoFor(pid, port)
+        if (outcome === "raced") {
+          yield* clearIdentity
+          yield* Effect.logInfo("codex app-server adopted (another client started it first)")
+          return { socketPath, pid: null }
+        }
+        yield* Effect.logInfo("codex app-server started").pipe(
+          Effect.annotateLogs({ pid, socketPath }),
+        )
+        return { socketPath, pid }
       })
 
-      // Adopt-or-replace against the persisted identity, then spawn fresh if
-      // nothing was adoptable. Callers hold the lock.
+      // Adopt whatever answers; else wait for (or replace) our own recorded
+      // server; else start one. Callers hold the lock.
       const acquire = Effect.gen(function* () {
+        if (yield* probeSocket(socketPath)) {
+          const info = yield* claimAnswering
+          yield* Effect.logInfo(
+            info.pid === null ? "codex app-server adopted" : "codex app-server re-adopted",
+          ).pipe(Effect.annotateLogs({ socketPath, pid: info.pid }))
+          return info
+        }
         const persisted = yield* readIdentity
         if (Option.isSome(persisted)) {
-          const { pid, port } = persisted.value
+          const { pid } = persisted.value
           if (yield* isOurServer(pid)) {
-            const adopted = yield* awaitReady(pid, port, adoptTimeout).pipe(
+            // Ours, alive, silent: it may still be starting up. Wait, and
+            // only then replace it — replacing our own server is within
+            // the ownership boundary; a foreign one never gets here.
+            const answered = yield* awaitAnswer(pid, adoptTimeout).pipe(
               Effect.as(true),
               Effect.orElseSucceed(() => false),
             )
-            if (adopted) {
-              yield* Effect.logInfo("codex app-server adopted").pipe(
-                Effect.annotateLogs({ pid, port }),
-              )
-              return infoFor(pid, port)
-            }
-            // Alive but not answering: replace it rather than accumulate.
+            if (answered) return { socketPath, pid }
             yield* terminate(pid)
           }
           yield* clearIdentity
@@ -329,12 +378,13 @@ export const layerWith = (options: CodexServerOptions) =>
       const watchLoop: Effect.Effect<void> = Effect.gen(function* () {
         while (true) {
           const info = yield* Ref.get(current)
-          if (info === null) return
+          // Only a server we started is ours to watch and restart.
+          if (info === null || info.pid === null) return
           if (Subprocess.isProcessAlive(info.pid)) {
             yield* Effect.sleep(watchInterval)
             continue
           }
-          yield* Effect.logWarning("codex app-server exited unexpectedly; restarting").pipe(
+          yield* Effect.logWarning("codex app-server exited unexpectedly; recovering").pipe(
             Effect.annotateLogs({ pid: info.pid }),
           )
           yield* Ref.set(current, null)
@@ -371,15 +421,11 @@ export const layerWith = (options: CodexServerOptions) =>
           .withPermits(1)(
             Effect.gen(function* () {
               const cached = yield* Ref.get(current)
-              if (cached !== null && Subprocess.isProcessAlive(cached.pid)) {
-                const stillReady = yield* probeReady(cached.port).pipe(
-                  Effect.as(true),
-                  Effect.orElseSucceed(() => false),
-                )
-                // Not ready ≠ dead: acquire re-probes within adoptTimeout
-                // before concluding anything drastic.
-                if (stillReady) return cached
-              }
+              const ownAlive =
+                cached !== null && (cached.pid === null || Subprocess.isProcessAlive(cached.pid))
+              // Not answering ≠ dead: acquire re-probes within adoptTimeout
+              // before concluding anything drastic.
+              if (ownAlive && (yield* probeSocket(socketPath))) return cached
               yield* Ref.set(current, null)
               const info = yield* acquire
               yield* Ref.set(current, info)
@@ -396,13 +442,15 @@ export const layerWith = (options: CodexServerOptions) =>
             Effect.gen(function* () {
               // Cache and file normally agree; if they diverged (another
               // process rewrote the file), reap both — an unrecorded server
-              // would be unadoptable forever.
+              // of ours would be unadoptable forever.
               const cached = yield* Ref.get(current)
               const persisted = yield* readIdentity
               const pids = new Set<number>()
-              if (cached !== null) pids.add(cached.pid)
+              if (cached !== null && cached.pid !== null) pids.add(cached.pid)
               if (Option.isSome(persisted)) pids.add(persisted.value.pid)
-              for (const pid of pids) yield* terminateOurs(pid)
+              for (const pid of pids) {
+                if (yield* isOurServer(pid)) yield* terminate(pid)
+              }
               yield* clearIdentity
               yield* Ref.set(current, null)
             }),

--- a/app-server/src/platform/config.ts
+++ b/app-server/src/platform/config.ts
@@ -18,7 +18,9 @@ import { DEFAULT_PORT } from "../api/contract.ts"
 //                                             terminals/ (zmx sockets)
 //
 // ATC_CONFIG overrides the config file path; ATC_DATA_DIR the data directory.
-// The TOML format never leaks past this module.
+// CODEX_HOME (codex's own variable, default ~/.codex) is read as-is so ATC
+// finds the same shared Codex app-server socket every other Codex client
+// does. The TOML format never leaks past this module.
 
 /** Environment shape consumed by the pipeline; tests inject their own. */
 export type Env = Record<string, string | undefined>
@@ -99,6 +101,13 @@ export class AppConfig extends Context.Service<
     readonly tailscaleExecutable: string
     /** Codex CLI executable: an absolute path, or a name resolved on PATH. */
     readonly codexExecutable: string
+    /**
+     * The Codex home directory exactly as codex itself resolves it
+     * (CODEX_HOME, else ~/.codex). Environment only — it is codex's
+     * variable, not ATC's, and ATC must agree with every other Codex client
+     * on the machine: the shared app-server control socket lives under it.
+     */
+    readonly codexHome: string
     /** Claude Code executable: an absolute path, or a name resolved on PATH. */
     readonly claudeExecutable: string
     /**
@@ -327,6 +336,7 @@ export const load = (
       "state directory",
       "XDG_STATE_HOME",
     )
+    const home = nonEmpty(env["HOME"]) ?? os.homedir()
     return {
       port: settings.port,
       bind: settings.bind,
@@ -335,7 +345,7 @@ export const load = (
       context,
       logLevel: settings.logLevel,
       configFile,
-      home: nonEmpty(env["HOME"]) ?? os.homedir(),
+      home,
       dataDir,
       stateDir,
       dbFile: path.join(dataDir, "atc.db"),
@@ -345,6 +355,7 @@ export const load = (
       zmxExecutable: settings.zmxExecutable,
       tailscaleExecutable: settings.tailscaleExecutable,
       codexExecutable: settings.codexExecutable,
+      codexHome: nonEmpty(env["CODEX_HOME"]) ?? path.join(home, ".codex"),
       claudeExecutable: settings.claudeExecutable,
       terminalSocketDir: path.join(stateDir, "terminals"),
     }

--- a/app-server/src/platform/unixWebSocket.ts
+++ b/app-server/src/platform/unixWebSocket.ts
@@ -1,0 +1,304 @@
+// A minimal RFC 6455 WebSocket client over a unix domain socket (ATC-196).
+// Bun's global `WebSocket` only dials TCP, while the codex app-server's
+// supported local transport is a WebSocket served on its unix control
+// socket, so this module speaks the protocol itself: the Upgrade handshake,
+// masked text frames out, fragment reassembly in, ping/pong, and the close
+// handshake. Nothing more — no extensions, no subprotocols, and binary
+// payloads are handed over decoded as text (a JSON-RPC peer never sends
+// any). The surface mirrors the browser WebSocket so a caller can swap one
+// for the other: construct, assign handlers synchronously, then wait for
+// `onopen`. Nothing fires before the caller's current task ends — the
+// connect is deferred a microtask to guarantee it.
+
+const GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+const OPCODE_CONTINUATION = 0x0
+const OPCODE_TEXT = 0x1
+const OPCODE_CLOSE = 0x8
+const OPCODE_PING = 0x9
+const OPCODE_PONG = 0xa
+/** Bound on one incoming message; a header past it is a protocol failure. */
+const MAX_MESSAGE_BYTES = 256 * 1024 * 1024
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+export interface Connection {
+  /** The handshake completed; `send` is live from here. */
+  onopen: (() => void) | null
+  /** One complete text message (fragments already reassembled). */
+  onmessage: ((text: string) => void) | null
+  /**
+   * The connection is gone — refused, handshake rejected, peer closed, socket
+   * error, or a local `close()`. Fires exactly once, before or after
+   * `onopen`; `reason` is a short human-readable cause.
+   */
+  onclose: ((reason: string) => void) | null
+  /** Queue one text message; silently dropped once the connection is gone. */
+  readonly send: (text: string) => void
+  /**
+   * Close: the closing handshake when open (onclose follows once the peer
+   * echoes, bounded), an immediate release otherwise. Idempotent.
+   */
+  readonly close: () => void
+}
+
+/** Encode one client frame: FIN set, masked as RFC 6455 requires of clients. */
+const encodeFrame = (opcode: number, payload: Uint8Array): Uint8Array => {
+  const length = payload.length
+  const header =
+    length < 126
+      ? [0x80 | opcode, 0x80 | length]
+      : length < 65_536
+        ? [0x80 | opcode, 0x80 | 126, length >>> 8, length & 0xff]
+        : [
+            0x80 | opcode,
+            0x80 | 127,
+            0,
+            0,
+            0,
+            0,
+            (length >>> 24) & 0xff,
+            (length >>> 16) & 0xff,
+            (length >>> 8) & 0xff,
+            length & 0xff,
+          ]
+  const mask = crypto.getRandomValues(new Uint8Array(4))
+  const frame = new Uint8Array(header.length + 4 + length)
+  frame.set(header, 0)
+  frame.set(mask, header.length)
+  const offset = header.length + 4
+  for (let index = 0; index < length; index++) {
+    frame[offset + index] = payload[index]! ^ mask[index & 3]!
+  }
+  return frame
+}
+
+const concat = (left: Uint8Array, right: Uint8Array): Uint8Array => {
+  if (left.length === 0) return right
+  const joined = new Uint8Array(left.length + right.length)
+  joined.set(left, 0)
+  joined.set(right, left.length)
+  return joined
+}
+
+/**
+ * Open a WebSocket connection to the server listening on `socketPath`. The
+ * connection is returned immediately; assign handlers before yielding to
+ * the event loop.
+ */
+export const open = (socketPath: string): Connection => {
+  const key = btoa(String.fromCharCode(...crypto.getRandomValues(new Uint8Array(16))))
+  const expectedAccept = new Bun.CryptoHasher("sha1").update(key + GUID).digest("base64")
+
+  let socket: Bun.Socket<undefined> | null = null
+  let handshaken = false
+  let closing = false
+  let finished = false
+  let closeTimer: ReturnType<typeof setTimeout> | null = null
+  let buffered: Uint8Array = new Uint8Array(0)
+  // Reassembly of a fragmented message: the first fragment's opcode and
+  // the payload so far.
+  let fragmentOpcode: number | null = null
+  let fragments: Uint8Array = new Uint8Array(0)
+  // Bytes the kernel would not take yet, flushed on `drain`.
+  const backlog: Array<Uint8Array> = []
+
+  const connection: Connection = {
+    onopen: null,
+    onmessage: null,
+    onclose: null,
+    send: (text) => {
+      if (handshaken && !closing) write(encodeFrame(OPCODE_TEXT, encoder.encode(text)))
+    },
+    close: () => {
+      if (finished || closing) return
+      if (socket === null || !handshaken) {
+        finish("closed")
+        return
+      }
+      // The closing handshake: send close, let the peer echo it (or the
+      // socket drop) before ending — a FIN right behind our close frame
+      // reads as an abnormal closure to the peer. Bounded: a peer that
+      // never echoes is cut off.
+      closing = true
+      write(encodeFrame(OPCODE_CLOSE, new Uint8Array(0)))
+      closeTimer = setTimeout(() => finish("closed"), 1_000)
+    },
+  }
+
+  const finish = (reason: string): void => {
+    if (finished) return
+    finished = true
+    if (closeTimer !== null) clearTimeout(closeTimer)
+    // FIN goes out behind whatever is still queued (a close echo, say) —
+    // bounded, since a stalled peer may never drain it. A socket that never
+    // connected has nothing to end and is terminated on arrival below.
+    if (backlog.length === 0) socket?.end()
+    else setTimeout(() => socket?.terminate(), 1_000)
+    connection.onclose?.(reason)
+  }
+
+  /** Raw bytes to the peer, queued past what the kernel takes at once. */
+  const write = (bytes: Uint8Array): void => {
+    if (finished || socket === null) return
+    if (backlog.length > 0) {
+      backlog.push(bytes)
+      return
+    }
+    const written = socket.write(bytes)
+    if (written < bytes.length) backlog.push(bytes.subarray(Math.max(written, 0)))
+  }
+
+  const drain = (): void => {
+    while (backlog.length > 0) {
+      if (socket === null) return
+      const next = backlog[0]!
+      const written = socket.write(next)
+      if (written < next.length) {
+        backlog[0] = next.subarray(Math.max(written, 0))
+        return
+      }
+      backlog.shift()
+    }
+    if (finished) socket?.end()
+  }
+
+  const deliver = (opcode: number, payload: Uint8Array): void => {
+    if (opcode === OPCODE_TEXT || opcode === OPCODE_CONTINUATION) {
+      connection.onmessage?.(decoder.decode(payload))
+      return
+    }
+    if (opcode === OPCODE_PING) {
+      write(encodeFrame(OPCODE_PONG, payload))
+      return
+    }
+    if (opcode === OPCODE_CLOSE) {
+      // Their echo of our close completes our handshake; their own close
+      // is echoed so they can complete theirs. Either way we are done.
+      if (closing) {
+        finish("closed")
+        return
+      }
+      write(encodeFrame(OPCODE_CLOSE, payload.subarray(0, 2)))
+      const code = payload.length >= 2 ? (payload[0]! << 8) | payload[1]! : null
+      finish(code === null ? "closed by peer" : `closed by peer (${code})`)
+    }
+    // Pong and reserved opcodes carry nothing for us.
+  }
+
+  /** Consume every complete frame in `buffered`; partial frames wait. */
+  const parseFrames = (): void => {
+    while (buffered.length >= 2) {
+      // A close frame mid-buffer ends parsing; whatever follows is noise.
+      if (finished) return
+      const fin = (buffered[0]! & 0x80) !== 0
+      const opcode = buffered[0]! & 0x0f
+      const masked = (buffered[1]! & 0x80) !== 0
+      let length = buffered[1]! & 0x7f
+      let offset = 2
+      if (length === 126) {
+        if (buffered.length < 4) return
+        length = (buffered[2]! << 8) | buffered[3]!
+        offset = 4
+      } else if (length === 127) {
+        if (buffered.length < 10) return
+        const high =
+          ((buffered[2]! << 24) >>> 0) + ((buffered[3]! << 16) | (buffered[4]! << 8) | buffered[5]!)
+        const low =
+          ((buffered[6]! << 24) >>> 0) + ((buffered[7]! << 16) | (buffered[8]! << 8) | buffered[9]!)
+        length = high * 2 ** 32 + low
+        offset = 10
+      }
+      // A length no JSON-RPC peer would send (or a corrupt header) is a
+      // protocol failure, never a buffer to wait for.
+      if (fragments.length + length > MAX_MESSAGE_BYTES) {
+        finish(`protocol error: frame of ${length} bytes exceeds the limit`)
+        return
+      }
+      const maskOffset = offset
+      if (masked) offset += 4
+      if (buffered.length < offset + length) return
+      const payload = buffered.slice(offset, offset + length)
+      if (masked) {
+        for (let index = 0; index < length; index++) {
+          payload[index] = payload[index]! ^ buffered[maskOffset + (index & 3)]!
+        }
+      }
+      buffered = buffered.subarray(offset + length)
+      // Control frames may interleave fragments; data frames reassemble.
+      if (opcode >= 0x8) {
+        deliver(opcode, payload)
+        continue
+      }
+      if (opcode !== OPCODE_CONTINUATION) fragmentOpcode = opcode
+      fragments = concat(fragments, payload)
+      if (!fin) continue
+      const message = fragments
+      const messageOpcode = fragmentOpcode ?? opcode
+      fragments = new Uint8Array(0)
+      fragmentOpcode = null
+      deliver(messageOpcode, message)
+    }
+  }
+
+  const completeHandshake = (): void => {
+    const text = decoder.decode(buffered)
+    const end = text.indexOf("\r\n\r\n")
+    if (end < 0) return
+    const head = text.slice(0, end)
+    // The head is ASCII: its character count is its byte count.
+    buffered = buffered.subarray(end + 4)
+    const [statusLine = "", ...headerLines] = head.split("\r\n")
+    const accept = headerLines
+      .map((line) => line.split(/:\s*/, 2))
+      .find(([name]) => name?.toLowerCase() === "sec-websocket-accept")?.[1]
+      ?.trim()
+    if (!statusLine.startsWith("HTTP/1.1 101") || accept !== expectedAccept) {
+      finish(`handshake rejected: ${statusLine || "no HTTP status line"}`)
+      return
+    }
+    handshaken = true
+    connection.onopen?.()
+    parseFrames()
+  }
+
+  // Deferred one microtask: an immediate failure (no such socket) would
+  // otherwise report `connectError` synchronously inside connect(), before
+  // the caller has assigned its handlers.
+  queueMicrotask(() => {
+    if (finished) return
+    Bun.connect<undefined>({
+      unix: socketPath,
+      socket: {
+        open: (opened) => {
+          if (finished) {
+            opened.terminate()
+            return
+          }
+          socket = opened
+          write(
+            encoder.encode(
+              `GET / HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n` +
+                `Sec-WebSocket-Version: 13\r\nSec-WebSocket-Key: ${key}\r\n\r\n`,
+            ),
+          )
+        },
+        data: (_, chunk) => {
+          if (finished) return
+          buffered = concat(buffered, new Uint8Array(chunk))
+          if (!handshaken) completeHandshake()
+          else parseFrames()
+        },
+        drain: () => drain(),
+        close: () => finish("connection closed"),
+        end: () => finish("connection closed by peer"),
+        error: (_, error) => finish(`socket error: ${error.message}`),
+        connectError: (_, error) => finish(`connect failed: ${error.message}`),
+      },
+    }).catch((error: unknown) => {
+      finish(`connect failed: ${error instanceof Error ? error.message : String(error)}`)
+    })
+  })
+
+  return connection
+}

--- a/app-server/test/agents/agentAdapter.test.ts
+++ b/app-server/test/agents/agentAdapter.test.ts
@@ -5,8 +5,10 @@ import {
   aggregateActivity,
   buildTitleContext,
   makeVersionGate,
+  parseVersion,
   sanitizeTitle,
   titleInstruction,
+  versionIsOlder,
 } from "../../src/agents/agentAdapter.ts"
 import type { Subprocess } from "../../src/platform/subprocess.ts"
 import { makeFakeAgentAdapter } from "./fakeAgentAdapter.ts"
@@ -329,6 +331,21 @@ const untilSpawns = (fake: { spawns: () => number }, count: number) =>
       yield* Effect.yieldNow
     }
   })
+
+describe("version helpers", () => {
+  it("parse the first x.y.z and compare floors", () => {
+    assert.strictEqual(parseVersion("codex-cli 0.147.0"), "0.147.0")
+    assert.strictEqual(
+      parseVersion("codex_chatgpt_ios_remote/0.147.0 (Mac OS 26.5.2; arm64)"),
+      "0.147.0",
+    )
+    assert.isNull(parseVersion("unknown"))
+    assert.isTrue(versionIsOlder("0.146.0", "0.147.0"))
+    assert.isFalse(versionIsOlder("0.147.0", "0.147.0"))
+    assert.isFalse(versionIsOlder("1.0.0", "0.147.0"))
+    assert.isTrue(versionIsOlder("0.146.1000", "0.147.0"))
+  })
+})
 
 describe("makeVersionGate", () => {
   it.effect("single-flight: concurrent callers share one version read, memoized after", () =>

--- a/app-server/test/agents/agentTestKit.ts
+++ b/app-server/test/agents/agentTestKit.ts
@@ -1,7 +1,6 @@
 import { BunServices } from "@effect/platform-bun"
 import { Duration, Effect, Layer, Stream } from "effect"
 import * as fs from "node:fs"
-import * as os from "node:os"
 import * as path from "node:path"
 import { fileURLToPath } from "node:url"
 import type { AgentEvent } from "../../src/agents/agentAdapter.ts"
@@ -10,6 +9,7 @@ import * as ClaudeHooks from "../../src/agents/claudeHooks.ts"
 import * as CodexAdapter from "../../src/agents/codexAdapter.ts"
 import * as CodexServer from "../../src/agents/codexServer.ts"
 import * as Subprocess from "../../src/platform/subprocess.ts"
+import * as UnixWebSocket from "../../src/platform/unixWebSocket.ts"
 import { trackTempDir } from "../blackbox.ts"
 import { eventually, testAppConfig } from "../testLayers.ts"
 import { TestBuildInfoLayer } from "../testBuildInfo.ts"
@@ -26,16 +26,25 @@ const fakeCodexFixture = fileURLToPath(
 /**
  * A per-test fake-codex sandbox: the wrapper script is the configured codex
  * executable, per-test fixture configuration is baked into it, and the
- * fixture records its pid for reap assertions.
+ * fixture records its pid for reap assertions. Its CODEX_HOME is a private
+ * directory (baked into the wrapper AND settled into AppConfig, as one
+ * environment would in production), so the well-known socket the fixture
+ * binds and ATC dials is the sandbox's own — never the developer's. The
+ * base lives under /tmp, short enough for the unix socket-path budget.
  */
 export const makeCodexSandbox = (vars: Record<string, string> = {}) => {
-  const base = trackTempDir(fs.mkdtempSync(path.join(os.tmpdir(), "atc-codex-")))
+  const base = trackTempDir(fs.mkdtempSync("/tmp/atc-codex-"))
   const stateDir = path.join(base, "state")
+  const codexHome = path.join(base, "codex")
   const cwd = path.join(base, "work")
   fs.mkdirSync(cwd, { recursive: true })
   const pidFile = path.join(base, "fixture.pid")
   const wrapper = path.join(base, "fake-codex")
-  const assignments = Object.entries({ FAKE_CODEX_PID_FILE: pidFile, ...vars })
+  const assignments = Object.entries({
+    FAKE_CODEX_PID_FILE: pidFile,
+    CODEX_HOME: codexHome,
+    ...vars,
+  })
     .map(([key, value]) => `${key}='${value}'`)
     .join(" ")
   fs.writeFileSync(
@@ -46,34 +55,47 @@ export const makeCodexSandbox = (vars: Record<string, string> = {}) => {
   return {
     base,
     stateDir,
+    codexHome,
+    socketPath: CodexServer.controlSocketPath(codexHome),
     cwd,
     wrapper,
     pidFile,
+    /** The argv the most recently launched listener saw. */
+    listenRecord: path.join(base, "listen-record.json"),
     identityFile: path.join(stateDir, "codex-app-server.json"),
   }
 }
 
+export interface CodexSandbox {
+  readonly stateDir: string
+  readonly codexHome: string
+  readonly wrapper: string
+}
+
 /** The platform stack under every codex supervision/adapter test. */
-const codexPlatform = (sandbox: { readonly stateDir: string; readonly wrapper: string }) =>
+const codexPlatform = (sandbox: CodexSandbox) =>
   Layer.mergeAll(
     Subprocess.layer.pipe(Layer.provide(BunServices.layer)),
-    testAppConfig({ codexExecutable: sandbox.wrapper, stateDir: sandbox.stateDir }),
+    testAppConfig({
+      codexExecutable: sandbox.wrapper,
+      codexHome: sandbox.codexHome,
+      stateDir: sandbox.stateDir,
+    }),
     TestBuildInfoLayer,
     BunServices.layer,
   )
 
 /** The supervision module over a sandbox wrapper (codexServer tests). */
 export const codexServerLayer = (
-  sandbox: { readonly stateDir: string; readonly wrapper: string },
+  sandbox: CodexSandbox,
   options: CodexServer.CodexServerOptions = {},
 ): Layer.Layer<CodexServer.CodexServer, unknown> =>
   CodexServer.layerWith(options).pipe(Layer.provide(codexPlatform(sandbox)))
 
 /** Adapter + supervision over a sandbox wrapper (codexAdapter tests). */
-export const codexAdapterLayer = (sandbox: {
-  readonly stateDir: string
-  readonly wrapper: string
-}): Layer.Layer<CodexAdapter.CodexAdapter | CodexServer.CodexServer, unknown> => {
+export const codexAdapterLayer = (
+  sandbox: CodexSandbox,
+): Layer.Layer<CodexAdapter.CodexAdapter | CodexServer.CodexServer, unknown> => {
   const platform = codexPlatform(sandbox)
   // `server` appears twice in the graph but is memoized to one instance.
   const server = CodexServer.layerWith({}).pipe(Layer.provide(platform))
@@ -121,4 +143,62 @@ export const waitForAgentEvent = (
     Effect.sync(() => sink),
     (events) => events.some(predicate),
     { attempts: options?.attempts ?? 200, interval: options?.interval ?? "25 millis" },
+  )
+
+/**
+ * A second client of the shared fake app-server — the TUI stand-in in
+ * adapter tests. Scoped: closing the scope closes the connection.
+ */
+export interface ExternalClient {
+  readonly send: (frame: unknown) => void
+  /** One JSON-RPC request; resolves with its `result` (empty when absent). */
+  readonly request: (
+    id: number,
+    method: string,
+    params: unknown,
+  ) => Effect.Effect<Record<string, unknown>>
+  /** `thread/start` for `cwd`, resolving with the new thread id. */
+  readonly startThread: (id: number, cwd: string) => Effect.Effect<string>
+  readonly close: () => void
+}
+
+export const openExternal = (socketPath: string) =>
+  Effect.acquireRelease(
+    Effect.callback<ExternalClient>((resume) => {
+      const socket = UnixWebSocket.open(socketPath)
+      const pending = new Map<number, (reply: Effect.Effect<Record<string, unknown>>) => void>()
+      socket.onmessage = (text) => {
+        const message = JSON.parse(text) as { id?: number; result?: unknown }
+        if (message.id === undefined) return
+        const waiter = pending.get(message.id)
+        if (waiter === undefined) return
+        pending.delete(message.id)
+        waiter(Effect.succeed((message.result ?? {}) as Record<string, unknown>))
+      }
+      const request = (id: number, method: string, params: unknown) =>
+        Effect.callback<Record<string, unknown>>((resumeRequest) => {
+          pending.set(id, resumeRequest)
+          socket.send(JSON.stringify({ id, method, params }))
+          return Effect.sync(() => pending.delete(id))
+        })
+      const client: ExternalClient = {
+        send: (frame) => socket.send(JSON.stringify(frame)),
+        request,
+        startThread: (id, cwd) =>
+          request(id, "thread/start", { cwd }).pipe(
+            Effect.map((result) => (result["thread"] as { id: string }).id),
+          ),
+        close: () => socket.close(),
+      }
+      socket.onopen = () => resume(Effect.succeed(client))
+      // A closed socket fails the open AND every request still waiting —
+      // a test must fail, never hang, when the fake server goes away.
+      socket.onclose = (reason) => {
+        const failure = Effect.die(new Error(`external client: ${reason}`))
+        resume(failure)
+        for (const waiter of pending.values()) waiter(failure)
+        pending.clear()
+      }
+    }),
+    (client) => Effect.sync(() => client.close()),
   )

--- a/app-server/test/agents/codexAdapter.test.ts
+++ b/app-server/test/agents/codexAdapter.test.ts
@@ -6,20 +6,23 @@ import * as CodexAdapter from "../../src/agents/codexAdapter.ts"
 import * as CodexServer from "../../src/agents/codexServer.ts"
 import { eventually } from "../testLayers.ts"
 import {
+  type CodexSandbox,
   codexAdapterLayer,
   collectAgentEvents,
   makeCodexSandbox,
+  openExternal,
   waitForAgentEvent,
 } from "./agentTestKit.ts"
 
 // Codex adapter tests against the fake app-server fixture, through the real
-// supervision module (ensure → detached fixture → WebSocket → adapter). All
-// it.live: real processes, sockets, and clock. Each test block ends with
-// CodexServer.stop() via `withAdapter` so no detached fixture leaks.
+// supervision module (ensure → detached fixture on the sandbox's well-known
+// unix socket → WebSocket → adapter). All it.live: real processes, sockets,
+// and clock. Each test block ends with CodexServer.stop() via `withAdapter`
+// so no detached fixture leaks.
 
 /** Run `use` with the adapter, then always stop the detached server. */
 const withAdapter = (
-  sandbox: { readonly stateDir: string; readonly wrapper: string },
+  sandbox: CodexSandbox,
   use: (adapter: CodexAdapter.CodexAdapter["Service"]) => Effect.Effect<void, unknown, never>,
 ) =>
   Effect.gen(function* () {
@@ -280,23 +283,15 @@ describe("CodexAdapter", () => {
 
               // A second client of the same shared server (the TUI stand-in)
               // drives a turn on the same thread.
-              const identity = JSON.parse(
-                fs.readFileSync(path.join(sandbox.stateDir, "codex-app-server.json"), "utf8"),
-              ) as { port: number }
-              const external = new WebSocket(`ws://127.0.0.1:${identity.port}`)
-              yield* Effect.callback<void>((resume) => {
-                external.onopen = () => resume(Effect.void)
+              const external = yield* openExternal(sandbox.socketPath)
+              external.send({
+                id: 1,
+                method: "turn/start",
+                params: {
+                  threadId: connection.providerSessionId,
+                  input: [{ type: "text", text: "external turn" }],
+                },
               })
-              external.send(
-                JSON.stringify({
-                  id: 1,
-                  method: "turn/start",
-                  params: {
-                    threadId: connection.providerSessionId,
-                    input: [{ type: "text", text: "external turn" }],
-                  },
-                }),
-              )
               yield* waitForAgentEvent(
                 sink,
                 (event) =>
@@ -304,7 +299,6 @@ describe("CodexAdapter", () => {
                   event.turnId !== turn.turnId &&
                   event.outcome === "completed",
               )
-              external.close()
             }),
           ),
         )
@@ -332,9 +326,12 @@ describe("CodexAdapter", () => {
               providerMetadata: undefined,
             })
             assert.strictEqual(launchSpec.command[0], sandbox.wrapper)
-            assert.deepStrictEqual(launchSpec.command.slice(1, 3), ["resume", "--remote"])
-            assert.match(launchSpec.command[3] ?? "", /^ws:\/\/127\.0\.0\.1:\d+$/)
-            assert.strictEqual(launchSpec.command[4], sessionId)
+            assert.deepStrictEqual(launchSpec.command.slice(1), [
+              "resume",
+              "--remote",
+              `unix://${sandbox.socketPath}`,
+              sessionId,
+            ])
 
             // A session codex no longer has (pruned/deleted history) fails
             // the probe closed instead of launching a TUI that dies in the
@@ -382,33 +379,6 @@ describe("CodexAdapter", () => {
 // thread/list reconciliation check — the TUI stand-in is a second WebSocket
 // client of the same shared fake app-server.
 describe("CodexAdapter TUI session plumbing", () => {
-  const openExternal = (url: string) =>
-    Effect.acquireRelease(
-      Effect.callback<WebSocket>((resume) => {
-        const socket = new WebSocket(url)
-        socket.onopen = () => resume(Effect.succeed(socket))
-      }),
-      (socket) => Effect.sync(() => socket.close()),
-    )
-
-  const externalRequest = (socket: WebSocket, id: number, method: string, params: unknown) =>
-    Effect.callback<Record<string, unknown>>((resume) => {
-      const listener = (event: MessageEvent) => {
-        const message = JSON.parse(String(event.data)) as { id?: number; result?: unknown }
-        if (message.id === id) {
-          socket.removeEventListener("message", listener)
-          resume(Effect.succeed((message.result ?? {}) as Record<string, unknown>))
-        }
-      }
-      socket.addEventListener("message", listener)
-      socket.send(JSON.stringify({ id, method, params }))
-    })
-
-  const startExternalThread = (socket: WebSocket, id: number, cwd: string) =>
-    externalRequest(socket, id, "thread/start", { cwd }).pipe(
-      Effect.map((result) => (result["thread"] as { id: string }).id),
-    )
-
   const waitForActivity = (sink: Array<string>, wanted: string) =>
     eventually(
       Effect.sync(() => sink),
@@ -429,13 +399,16 @@ describe("CodexAdapter TUI session plumbing", () => {
               // --cd pins the thread's cwd server-side: the remote TUI does
               // not forward its own working directory (codex 0.146.0).
               assert.deepStrictEqual(prepared.launchSpec.command.slice(1, 3), ["--cd", sandbox.cwd])
-              assert.strictEqual(prepared.launchSpec.command[3], "--remote")
-              const url = prepared.launchSpec.command[4] ?? ""
-              assert.match(url, /^ws:\/\/127\.0\.0\.1:\d+$/)
+              // The TUI is pointed at the shared server's well-known socket
+              // explicitly — never left to its own auto-join.
+              assert.deepStrictEqual(prepared.launchSpec.command.slice(3), [
+                "--remote",
+                `unix://${sandbox.socketPath}`,
+              ])
 
               // The launched TUI stand-in bootstraps a thread in the cwd.
-              const external = yield* openExternal(url)
-              const threadId = yield* startExternalThread(external, 1, sandbox.cwd)
+              const external = yield* openExternal(sandbox.socketPath)
+              const threadId = yield* external.startThread(1, sandbox.cwd)
               const identity = yield* prepared.identity
               assert.strictEqual(identity.providerSessionId, threadId)
               assert.strictEqual(identity.cwd, sandbox.cwd)
@@ -457,11 +430,10 @@ describe("CodexAdapter TUI session plumbing", () => {
           Effect.scoped(
             Effect.gen(function* () {
               const prepared = yield* adapter.prepareTuiSession({ cwd: sandbox.cwd })
-              const url = prepared.launchSpec.command[4] ?? ""
-              const external = yield* openExternal(url)
+              const external = yield* openExternal(sandbox.socketPath)
               // Another client's thread in a different cwd is not ours.
-              const foreignId = yield* startExternalThread(external, 1, otherCwd)
-              const matchingId = yield* startExternalThread(external, 2, sandbox.cwd)
+              const foreignId = yield* external.startThread(1, otherCwd)
+              const matchingId = yield* external.startThread(2, sandbox.cwd)
               const identity = yield* prepared.identity
               assert.notStrictEqual(identity.providerSessionId, foreignId)
               assert.strictEqual(identity.providerSessionId, matchingId)
@@ -483,11 +455,8 @@ describe("CodexAdapter TUI session plumbing", () => {
               // Arm the shared connection, then drive a thread externally.
               const activity = yield* adapter.checkSession({ providerSessionId: "none" })
               assert.strictEqual(activity, "unknown")
-              const identity = JSON.parse(
-                fs.readFileSync(path.join(sandbox.stateDir, "codex-app-server.json"), "utf8"),
-              ) as { port: number }
-              const external = yield* openExternal(`ws://127.0.0.1:${identity.port}`)
-              const threadId = yield* startExternalThread(external, 1, sandbox.cwd)
+              const external = yield* openExternal(sandbox.socketPath)
+              const threadId = yield* external.startThread(1, sandbox.cwd)
 
               const stream = yield* adapter.observeSession({
                 providerSessionId: threadId,
@@ -503,7 +472,7 @@ describe("CodexAdapter TUI session plumbing", () => {
                 Effect.ignore,
                 Effect.forkScoped,
               )
-              yield* externalRequest(external, 2, "turn/start", {
+              yield* external.request(2, "turn/start", {
                 threadId,
                 input: [{ type: "text", text: "external turn" }],
               })
@@ -532,11 +501,8 @@ describe("CodexAdapter TUI session plumbing", () => {
                 yield* adapter.checkSession({ providerSessionId: "none" }),
                 "unknown",
               )
-              const identity = JSON.parse(
-                fs.readFileSync(path.join(sandbox.stateDir, "codex-app-server.json"), "utf8"),
-              ) as { port: number }
-              const external = yield* openExternal(`ws://127.0.0.1:${identity.port}`)
-              const threadId = yield* startExternalThread(external, 1, sandbox.cwd)
+              const external = yield* openExternal(sandbox.socketPath)
+              const threadId = yield* external.startThread(1, sandbox.cwd)
               const stream = yield* adapter.observeSession({
                 providerSessionId: threadId,
                 providerMetadata: undefined,
@@ -551,7 +517,7 @@ describe("CodexAdapter TUI session plumbing", () => {
                 Effect.ignore,
                 Effect.forkScoped,
               )
-              yield* externalRequest(external, 2, "turn/start", {
+              yield* external.request(2, "turn/start", {
                 threadId,
                 input: [{ type: "text", text: "please add dark mode" }],
               })
@@ -559,7 +525,7 @@ describe("CodexAdapter TUI session plumbing", () => {
               yield* waitForActivity(sink, "idle")
               // A second turn's busy transition re-reads nothing: the first
               // prompt was already emitted, exactly once.
-              yield* externalRequest(external, 3, "turn/start", {
+              yield* external.request(3, "turn/start", {
                 threadId,
                 input: [{ type: "text", text: "second message" }],
               })
@@ -630,11 +596,8 @@ describe("CodexAdapter TUI session plumbing", () => {
                 yield* adapter.checkSession({ providerSessionId: "none" }),
                 "unknown",
               )
-              const identity = JSON.parse(
-                fs.readFileSync(path.join(sandbox.stateDir, "codex-app-server.json"), "utf8"),
-              ) as { port: number }
-              const external = yield* openExternal(`ws://127.0.0.1:${identity.port}`)
-              const threadId = yield* startExternalThread(external, 1, sandbox.cwd)
+              const external = yield* openExternal(sandbox.socketPath)
+              const threadId = yield* external.startThread(1, sandbox.cwd)
               const stream = yield* adapter.observeSession({
                 providerSessionId: threadId,
                 providerMetadata: undefined,
@@ -649,7 +612,7 @@ describe("CodexAdapter TUI session plumbing", () => {
                 Effect.ignore,
                 Effect.forkScoped,
               )
-              yield* externalRequest(external, 2, "turn/start", {
+              yield* external.request(2, "turn/start", {
                 threadId,
                 input: [{ type: "text", text: "slow read" }],
               })
@@ -687,11 +650,8 @@ describe("CodexAdapter TUI session plumbing", () => {
                 yield* adapter.checkSession({ providerSessionId: "none" }),
                 "unknown",
               )
-              const identity = JSON.parse(
-                fs.readFileSync(path.join(sandbox.stateDir, "codex-app-server.json"), "utf8"),
-              ) as { port: number }
-              const external = yield* openExternal(`ws://127.0.0.1:${identity.port}`)
-              const threadId = yield* startExternalThread(external, 1, sandbox.cwd)
+              const external = yield* openExternal(sandbox.socketPath)
+              const threadId = yield* external.startThread(1, sandbox.cwd)
               const stream = yield* adapter.observeSession({
                 providerSessionId: threadId,
                 providerMetadata: undefined,
@@ -706,7 +666,7 @@ describe("CodexAdapter TUI session plumbing", () => {
                 Effect.ignore,
                 Effect.forkScoped,
               )
-              yield* externalRequest(external, 2, "turn/start", {
+              yield* external.request(2, "turn/start", {
                 threadId,
                 input: [{ type: "text", text: "late preview" }],
               })
@@ -754,16 +714,13 @@ describe("CodexAdapter TUI session plumbing", () => {
               yield* adapter.checkSession({ providerSessionId: "missing" }),
               "unknown",
             )
-            const identity = JSON.parse(
-              fs.readFileSync(path.join(sandbox.stateDir, "codex-app-server.json"), "utf8"),
-            ) as { port: number }
             // The fake serves one thread per page, so the second thread only
             // appears after following nextCursor.
             const laterPage = yield* Effect.scoped(
               Effect.gen(function* () {
-                const socket = yield* openExternal(`ws://127.0.0.1:${identity.port}`)
-                yield* startExternalThread(socket, 1, sandbox.cwd)
-                return yield* startExternalThread(socket, 2, sandbox.cwd)
+                const socket = yield* openExternal(sandbox.socketPath)
+                yield* socket.startThread(1, sandbox.cwd)
+                return yield* socket.startThread(2, sandbox.cwd)
               }),
             )
             assert.strictEqual(
@@ -780,8 +737,8 @@ describe("CodexAdapter TUI session plumbing", () => {
             // tuiLaunch must not fail it closed as deleted.
             yield* Effect.scoped(
               Effect.gen(function* () {
-                const socket = yield* openExternal(`ws://127.0.0.1:${identity.port}`)
-                yield* externalRequest(socket, 3, "thread/archive", { threadId: laterPage })
+                const socket = yield* openExternal(sandbox.socketPath)
+                yield* socket.request(3, "thread/archive", { threadId: laterPage })
               }),
             )
             assert.strictEqual(
@@ -806,40 +763,11 @@ describe("CodexAdapter TUI session plumbing", () => {
 // the parent, child thread/status/changed broadcasts, no thread/started,
 // no thread/list entry, and loaded/list + thread/read for reconciliation.
 describe("CodexAdapter descendant aggregation", () => {
-  const openExternal = (url: string) =>
-    Effect.acquireRelease(
-      Effect.callback<WebSocket>((resume) => {
-        const socket = new WebSocket(url)
-        socket.onopen = () => resume(Effect.succeed(socket))
-      }),
-      (socket) => Effect.sync(() => socket.close()),
-    )
-
-  const externalRequest = (socket: WebSocket, id: number, method: string, params: unknown) =>
-    Effect.callback<Record<string, unknown>>((resume) => {
-      const listener = (event: MessageEvent) => {
-        const message = JSON.parse(String(event.data)) as { id?: number; result?: unknown }
-        if (message.id === id) {
-          socket.removeEventListener("message", listener)
-          resume(Effect.succeed((message.result ?? {}) as Record<string, unknown>))
-        }
-      }
-      socket.addEventListener("message", listener)
-      socket.send(JSON.stringify({ id, method, params }))
-    })
-
-  const fixtureUrl = (sandbox: { readonly stateDir: string }) => {
-    const identity = JSON.parse(
-      fs.readFileSync(path.join(sandbox.stateDir, "codex-app-server.json"), "utf8"),
-    ) as { port: number }
-    return `ws://127.0.0.1:${identity.port}`
-  }
-
-  const finishChild = (sandbox: { readonly stateDir: string }, childId: string) =>
+  const finishChild = (sandbox: { readonly socketPath: string }, childId: string) =>
     Effect.scoped(
       Effect.gen(function* () {
-        const socket = yield* openExternal(fixtureUrl(sandbox))
-        yield* externalRequest(socket, 900, "test/child/finish", { threadId: childId })
+        const socket = yield* openExternal(sandbox.socketPath)
+        yield* socket.request(900, "test/child/finish", { threadId: childId })
       }),
     )
 
@@ -921,11 +849,11 @@ describe("CodexAdapter descendant aggregation", () => {
             Effect.gen(function* () {
               // Force the shared connection (and fixture) up.
               yield* adapter.checkSession({ providerSessionId: "missing" })
-              const url = fixtureUrl(sandbox)
+              const url = sandbox.socketPath
               const rootId = yield* Effect.scoped(
                 Effect.gen(function* () {
                   const socket = yield* openExternal(url)
-                  const started = yield* externalRequest(socket, 1, "thread/start", {
+                  const started = yield* socket.request(1, "thread/start", {
                     cwd: sandbox.cwd,
                   })
                   return (started["thread"] as { id: string }).id
@@ -948,7 +876,7 @@ describe("CodexAdapter descendant aggregation", () => {
               yield* Effect.scoped(
                 Effect.gen(function* () {
                   const socket = yield* openExternal(url)
-                  yield* externalRequest(socket, 2, "turn/start", {
+                  yield* socket.request(2, "turn/start", {
                     threadId: rootId,
                     input: [{ type: "text", text: "SPAWN from tui" }],
                   })
@@ -979,16 +907,16 @@ describe("CodexAdapter descendant aggregation", () => {
         yield* withAdapter(sandbox, (adapter) =>
           Effect.gen(function* () {
             yield* adapter.checkSession({ providerSessionId: "missing" })
-            const url = fixtureUrl(sandbox)
+            const url = sandbox.socketPath
             const spawn = (input: string) =>
               Effect.scoped(
                 Effect.gen(function* () {
                   const socket = yield* openExternal(url)
-                  const started = yield* externalRequest(socket, 1, "thread/start", {
+                  const started = yield* socket.request(1, "thread/start", {
                     cwd: sandbox.cwd,
                   })
                   const rootId = (started["thread"] as { id: string }).id
-                  yield* externalRequest(socket, 2, "turn/start", {
+                  yield* socket.request(2, "turn/start", {
                     threadId: rootId,
                     input: [{ type: "text", text: input }],
                   })
@@ -1040,8 +968,8 @@ describe("CodexAdapter descendant aggregation", () => {
               // ...then the child finishes and unloads without a broadcast.
               yield* Effect.scoped(
                 Effect.gen(function* () {
-                  const socket = yield* openExternal(fixtureUrl(sandbox))
-                  yield* externalRequest(socket, 901, "test/child/vanish", {
+                  const socket = yield* openExternal(sandbox.socketPath)
+                  yield* socket.request(901, "test/child/vanish", {
                     threadId: `${connection.providerSessionId}-child-1`,
                   })
                 }),
@@ -1073,11 +1001,11 @@ describe("CodexAdapter descendant aggregation", () => {
             Effect.scoped(
               Effect.gen(function* () {
                 yield* adapter.checkSession({ providerSessionId: "missing" })
-                const url = fixtureUrl(sandbox)
+                const url = sandbox.socketPath
                 const rootId = yield* Effect.scoped(
                   Effect.gen(function* () {
                     const socket = yield* openExternal(url)
-                    const started = yield* externalRequest(socket, 1, "thread/start", {
+                    const started = yield* socket.request(1, "thread/start", {
                       cwd: sandbox.cwd,
                     })
                     return (started["thread"] as { id: string }).id
@@ -1101,7 +1029,7 @@ describe("CodexAdapter descendant aggregation", () => {
                 yield* Effect.scoped(
                   Effect.gen(function* () {
                     const socket = yield* openExternal(url)
-                    yield* externalRequest(socket, 2, "turn/start", {
+                    yield* socket.request(2, "turn/start", {
                       threadId: rootId,
                       input: [{ type: "text", text: "SPAWN then die" }],
                     })

--- a/app-server/test/agents/codexServer.test.ts
+++ b/app-server/test/agents/codexServer.test.ts
@@ -1,16 +1,17 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Effect } from "effect"
 import * as fs from "node:fs"
+import * as path from "node:path"
 import { fileURLToPath } from "node:url"
 import * as CodexServer from "../../src/agents/codexServer.ts"
 import * as Subprocess from "../../src/platform/subprocess.ts"
-import { freePort } from "../blackbox.ts"
+import { eventually } from "../testLayers.ts"
 import { codexServerLayer, makeCodexSandbox } from "./agentTestKit.ts"
 
 // Supervision tests against the fake-codex-listener fixture (a Bun script
-// that binds the requested --listen port and answers /readyz). All tests are
-// it.live: they spawn real detached processes and need the real clock for
-// readiness retries. Every path ends in stop() so no detached fixture
+// that serves the well-known unix socket under its CODEX_HOME). All tests
+// are it.live: they spawn real detached processes and need the real clock
+// for readiness retries. Every path ends in stop() so no detached fixture
 // outlives its test; the fixture's TTL self-exit is the backstop.
 
 const fixturePath = fileURLToPath(new URL("../fixtures/fake-codex-listener.ts", import.meta.url))
@@ -19,51 +20,174 @@ const fixturePath = fileURLToPath(new URL("../fixtures/fake-codex-listener.ts", 
 const fixturePid = (sandbox: { readonly pidFile: string }): number =>
   Number.parseInt(fs.readFileSync(sandbox.pidFile, "utf8"), 10)
 
-const readIdentity = (identityFile: string): { pid: number; port: number } =>
-  JSON.parse(fs.readFileSync(identityFile, "utf8")) as { pid: number; port: number }
+const readIdentity = (identityFile: string): { pid: number } =>
+  JSON.parse(fs.readFileSync(identityFile, "utf8")) as { pid: number }
 
-/** Poll a real condition; assertion-bounded, never a bare sleep. */
-const waitFor = (what: string, check: () => boolean, attempts = 200) =>
-  Effect.gen(function* () {
-    for (let attempt = 0; !check(); attempt++) {
-      assert.isBelow(attempt, attempts, `never observed: ${what}`)
-      yield* Effect.sleep("50 millis")
-    }
+/**
+ * A server ATC did not start: the fixture launched by hand on the sandbox's
+ * well-known socket (no pid file, so a later ATC spawn would be visible).
+ */
+const spawnForeign = (
+  sandbox: { readonly codexHome: string },
+  env: Record<string, string> = {},
+  args: ReadonlyArray<string> = ["app-server", "--listen", "unix://"],
+) =>
+  Bun.spawn([process.execPath, fixturePath, ...args], {
+    env: { ...process.env, CODEX_HOME: sandbox.codexHome, ...env },
   })
+
+/** Poll a real condition; never a bare sleep. */
+const waitFor = (check: () => boolean) =>
+  eventually(Effect.sync(check), (ok) => ok, { attempts: 200, interval: "50 millis" })
 
 describe("CodexServer", () => {
   it.live(
-    "spawns detached, persists identity, adopts from a fresh service, and stops",
+    "starts detached on the well-known socket, persists identity, re-adopts, and stops",
     () =>
       Effect.gen(function* () {
         const sandbox = makeCodexSandbox()
 
-        // First service instance spawns the server.
+        // First service instance starts the server.
         const first = yield* Effect.gen(function* () {
           const codex = yield* CodexServer.CodexServer
           return yield* codex.ensure()
         }).pipe(Effect.provide(codexServerLayer(sandbox)))
-        assert.isTrue(Subprocess.isProcessAlive(first.pid))
-        assert.strictEqual(first.url, `ws://127.0.0.1:${first.port}`)
-        const persisted = readIdentity(sandbox.identityFile)
-        assert.strictEqual(persisted.pid, first.pid)
-        assert.strictEqual(persisted.port, first.port)
+        assert.strictEqual(first.socketPath, sandbox.socketPath)
+        assert.isNotNull(first.pid)
+        assert.isTrue(Subprocess.isProcessAlive(first.pid!))
+        assert.strictEqual(readIdentity(sandbox.identityFile).pid, first.pid)
+        // Exactly the well-known socket, never any other address.
+        const record = JSON.parse(fs.readFileSync(sandbox.listenRecord, "utf8")) as {
+          argv: ReadonlyArray<string>
+        }
+        assert.deepStrictEqual(record.argv, ["app-server", "--listen", "unix://"])
 
         // The first service's layer scope is closed now — the detached
         // server must have survived it (the whole point of detaching).
-        assert.isTrue(Subprocess.isProcessAlive(first.pid))
+        assert.isTrue(Subprocess.isProcessAlive(first.pid!))
 
-        // A fresh service instance adopts the same server instead of
-        // spawning a second one, then stop() reaps it and clears identity.
+        // A fresh service instance adopts the same server as its own
+        // instead of starting a second one, then stop() reaps it.
         yield* Effect.gen(function* () {
           const codex = yield* CodexServer.CodexServer
           const adopted = yield* codex.ensure()
           assert.strictEqual(adopted.pid, first.pid)
-          assert.strictEqual(adopted.port, first.port)
           yield* codex.stop()
         }).pipe(Effect.provide(codexServerLayer(sandbox)))
-        assert.isTrue(yield* Subprocess.waitForProcessExit(first.pid))
+        assert.isTrue(yield* Subprocess.waitForProcessExit(first.pid!))
         assert.isFalse(fs.existsSync(sandbox.identityFile))
+      }),
+    30_000,
+  )
+
+  it.live(
+    "adopts a live foreign server without starting or signaling anything",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        const foreign = spawnForeign(sandbox)
+        try {
+          yield* waitFor(() => fs.existsSync(sandbox.socketPath))
+          yield* Effect.gen(function* () {
+            const codex = yield* CodexServer.CodexServer
+            const info = yield* codex.ensure()
+            assert.isNull(info.pid)
+            assert.strictEqual(info.socketPath, sandbox.socketPath)
+            // Nothing of ours: no spawn, no identity — and a second ensure
+            // still starts nothing.
+            assert.isFalse(fs.existsSync(sandbox.pidFile))
+            assert.isFalse(fs.existsSync(sandbox.identityFile))
+            assert.isNull((yield* codex.ensure()).pid)
+            assert.isFalse(fs.existsSync(sandbox.pidFile))
+            // stop() only ever targets a server we started.
+            yield* codex.stop()
+            assert.isTrue(Subprocess.isProcessAlive(foreign.pid))
+          }).pipe(Effect.provide(codexServerLayer(sandbox)))
+          assert.isTrue(Subprocess.isProcessAlive(foreign.pid))
+        } finally {
+          foreign.kill()
+        }
+      }),
+    30_000,
+  )
+
+  it.live(
+    "a foreign server that goes away is replaced by our own on next use",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        const foreign = spawnForeign(sandbox)
+        try {
+          yield* waitFor(() => fs.existsSync(sandbox.socketPath))
+          yield* Effect.gen(function* () {
+            const codex = yield* CodexServer.CodexServer
+            assert.isNull((yield* codex.ensure()).pid)
+            foreign.kill()
+            assert.isTrue(yield* Subprocess.waitForProcessExit(foreign.pid))
+            // The socket is dead: nothing to adopt, so ATC starts its own —
+            // rebinding over the stale socket file the foreign one left.
+            const own = yield* codex.ensure()
+            assert.isNotNull(own.pid)
+            assert.isTrue(Subprocess.isProcessAlive(own.pid!))
+            // The watcher was idle while a foreign server was adopted; it
+            // is armed again now that a server of ours exists.
+            process.kill(own.pid!, "SIGKILL")
+            yield* waitFor(() => {
+              if (!fs.existsSync(sandbox.identityFile)) return false
+              const identity = readIdentity(sandbox.identityFile)
+              return identity.pid !== own.pid && Subprocess.isProcessAlive(identity.pid)
+            })
+            yield* codex.stop()
+          }).pipe(Effect.provide(codexServerLayer(sandbox, { watchInterval: "50 millis" })))
+        } finally {
+          foreign.kill()
+        }
+      }),
+    30_000,
+  )
+
+  it.live(
+    "losing the start race adopts the winner instead of failing",
+    () =>
+      Effect.gen(function* () {
+        // Between ATC's probe (nothing answers) and its child's bind, a
+        // foreign server takes the socket: codex then exits "already in
+        // use". Modeled deterministically by a wrapper that starts the
+        // foreign server, waits for it, and only then runs "our" child.
+        const sandbox = makeCodexSandbox()
+        const foreignPidFile = path.join(sandbox.base, "foreign-fixture.pid")
+        fs.writeFileSync(
+          sandbox.wrapper,
+          [
+            "#!/bin/sh",
+            `CODEX_HOME='${sandbox.codexHome}' FAKE_CODEX_PID_FILE='${foreignPidFile}' ` +
+              `"${process.execPath}" "${fixturePath}" app-server --listen unix:// &`,
+            `while [ ! -S '${sandbox.socketPath}' ]; do sleep 0.05; done`,
+            `CODEX_HOME='${sandbox.codexHome}' FAKE_CODEX_PID_FILE='${sandbox.pidFile}' ` +
+              `exec "${process.execPath}" "${fixturePath}" "$@"`,
+            "",
+          ].join("\n"),
+        )
+        try {
+          yield* Effect.gen(function* () {
+            const codex = yield* CodexServer.CodexServer
+            yield* codex.ensure()
+            // Our child lost and exited; the winner is untouched. If the
+            // socket answered before our child had exited (or even started),
+            // the first answer may briefly have named our pid — the watcher
+            // reconciles.
+            yield* waitFor(() => fs.existsSync(sandbox.pidFile))
+            assert.isTrue(yield* Subprocess.waitForProcessExit(fixturePid(sandbox)))
+            yield* waitFor(() => !fs.existsSync(sandbox.identityFile))
+            assert.isNull((yield* codex.ensure()).pid)
+            yield* codex.stop()
+            assert.isTrue(Subprocess.isProcessAlive(fixturePid({ pidFile: foreignPidFile })))
+          }).pipe(Effect.provide(codexServerLayer(sandbox, { watchInterval: "50 millis" })))
+        } finally {
+          if (fs.existsSync(foreignPidFile)) {
+            process.kill(fixturePid({ pidFile: foreignPidFile }), "SIGKILL")
+          }
+        }
       }),
     30_000,
   )
@@ -78,13 +202,13 @@ describe("CodexServer", () => {
         fs.mkdirSync(sandbox.stateDir, { recursive: true })
         fs.writeFileSync(
           sandbox.identityFile,
-          JSON.stringify({ pid: gone.pid ?? 999999, port: 1, startedAt: "then" }),
+          JSON.stringify({ pid: gone.pid ?? 999999, startedAt: "then" }),
         )
         yield* Effect.gen(function* () {
           const codex = yield* CodexServer.CodexServer
           const info = yield* codex.ensure()
-          assert.isTrue(Subprocess.isProcessAlive(info.pid))
-          assert.notStrictEqual(info.port, 1)
+          assert.isNotNull(info.pid)
+          assert.isTrue(Subprocess.isProcessAlive(info.pid!))
           yield* codex.stop()
         }).pipe(Effect.provide(codexServerLayer(sandbox)))
       }),
@@ -92,29 +216,26 @@ describe("CodexServer", () => {
   )
 
   it.live(
-    "replaces an alive-but-unready server (adopt-or-replace, never accumulate)",
+    "replaces our own alive-but-silent server (never a foreign one)",
     () =>
       Effect.gen(function* () {
         const sandbox = makeCodexSandbox()
-        // A live process that IS an app-server by command line but never
-        // becomes ready: the never-ready fixture launched by hand.
-        const stalePort = yield* Effect.promise(() => freePort())
-        const stale = Bun.spawn(
-          [process.execPath, fixturePath, "app-server", "--listen", `ws://127.0.0.1:${stalePort}`],
-          { env: { ...process.env, FAKE_CODEX_MODE: "never-ready" } },
-        )
+        // A live process that IS an app-server by command line and IS
+        // recorded as ours, but never binds: the never-ready fixture.
+        const stale = spawnForeign(sandbox, { FAKE_CODEX_MODE: "never-ready" })
         try {
           fs.mkdirSync(sandbox.stateDir, { recursive: true })
           fs.writeFileSync(
             sandbox.identityFile,
-            JSON.stringify({ pid: stale.pid, port: stalePort, startedAt: "then" }),
+            JSON.stringify({ pid: stale.pid, startedAt: "then" }),
           )
           yield* Effect.gen(function* () {
             const codex = yield* CodexServer.CodexServer
             const info = yield* codex.ensure()
-            // The stale claimant was killed; the new server is ready.
+            // The silent claimant was ours, so it was replaced.
             assert.isTrue(yield* Subprocess.waitForProcessExit(stale.pid))
-            assert.isTrue(Subprocess.isProcessAlive(info.pid))
+            assert.isNotNull(info.pid)
+            assert.isTrue(Subprocess.isProcessAlive(info.pid!))
             yield* codex.stop()
           }).pipe(Effect.provide(codexServerLayer(sandbox, { adoptTimeout: "500 millis" })))
         } finally {
@@ -139,13 +260,13 @@ describe("CodexServer", () => {
           fs.mkdirSync(sandbox.stateDir, { recursive: true })
           fs.writeFileSync(
             sandbox.identityFile,
-            JSON.stringify({ pid: bystander.pid, port: 1, startedAt: "then" }),
+            JSON.stringify({ pid: bystander.pid, startedAt: "then" }),
           )
           yield* Effect.gen(function* () {
             const codex = yield* CodexServer.CodexServer
             const info = yield* codex.ensure()
-            // A fresh server was spawned and the bystander was left alone.
-            assert.isTrue(Subprocess.isProcessAlive(info.pid))
+            // A fresh server was started and the bystander was left alone.
+            assert.isTrue(Subprocess.isProcessAlive(info.pid!))
             assert.isTrue(Subprocess.isProcessAlive(bystander.pid))
             yield* codex.stop()
           }).pipe(Effect.provide(codexServerLayer(sandbox)))
@@ -158,7 +279,7 @@ describe("CodexServer", () => {
   )
 
   it.live(
-    "a server that never becomes ready is reaped and reported actionably",
+    "a server that never answers is reaped and reported actionably",
     () =>
       Effect.gen(function* () {
         const sandbox = makeCodexSandbox({ FAKE_CODEX_MODE: "never-ready" })
@@ -166,8 +287,9 @@ describe("CodexServer", () => {
           const codex = yield* CodexServer.CodexServer
           return yield* Effect.flip(codex.ensure())
         }).pipe(Effect.provide(codexServerLayer(sandbox, { readyTimeout: "700 millis" })))
-        assert.include(failure.message, "not ready")
-        // The failed spawn was cleaned up: no identity, no stray process.
+        assert.include(failure.message, "not answering")
+        assert.include(failure.message, sandbox.socketPath)
+        // The failed start was cleaned up: no identity, no stray process.
         assert.isFalse(fs.existsSync(sandbox.identityFile))
         assert.isTrue(yield* Subprocess.waitForProcessExit(fixturePid(sandbox)))
       }),
@@ -175,21 +297,44 @@ describe("CodexServer", () => {
   )
 
   it.live(
-    "a missing executable is one actionable diagnostic",
+    "a start that exits early reports the child's output",
     () =>
       Effect.gen(function* () {
         const sandbox = makeCodexSandbox()
+        fs.writeFileSync(
+          sandbox.wrapper,
+          `#!/bin/sh\necho "fake codex: cannot start" >&2\nexit 3\n`,
+        )
         const failure = yield* Effect.gen(function* () {
           const codex = yield* CodexServer.CodexServer
           return yield* Effect.flip(codex.ensure())
-        }).pipe(
-          Effect.provide(
-            codexServerLayer({
-              stateDir: sandbox.stateDir,
-              wrapper: "atc-test-definitely-not-codex",
-            }),
-          ),
-        )
+        }).pipe(Effect.provide(codexServerLayer(sandbox)))
+        assert.include(failure.message, "exited before answering")
+        assert.include(failure.message, "fake codex: cannot start")
+        assert.isFalse(fs.existsSync(sandbox.identityFile))
+      }),
+    30_000,
+  )
+
+  it.live(
+    "a missing executable is one actionable diagnostic, and building the layer touches nothing",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        const layer = codexServerLayer({
+          stateDir: sandbox.stateDir,
+          codexHome: sandbox.codexHome,
+          wrapper: "atc-test-definitely-not-codex",
+        })
+        // Codex is only consulted on first use: an ATC without codex boots.
+        yield* Effect.gen(function* () {
+          yield* CodexServer.CodexServer
+          assert.isFalse(fs.existsSync(sandbox.socketPath))
+        }).pipe(Effect.provide(layer))
+        const failure = yield* Effect.gen(function* () {
+          const codex = yield* CodexServer.CodexServer
+          return yield* Effect.flip(codex.ensure())
+        }).pipe(Effect.provide(layer))
         assert.include(failure.message, "install the Codex CLI")
         assert.include(failure.message, "ATC_CODEX_EXECUTABLE")
       }),
@@ -197,15 +342,15 @@ describe("CodexServer", () => {
   )
 
   it.live(
-    "the exit watcher restarts a server that died underneath us",
+    "the exit watcher restarts our own server that died underneath us",
     () =>
       Effect.gen(function* () {
         const sandbox = makeCodexSandbox()
         yield* Effect.gen(function* () {
           const codex = yield* CodexServer.CodexServer
           const info = yield* codex.ensure()
-          process.kill(info.pid, "SIGKILL")
-          yield* waitFor("watcher restarted the server with a new live pid", () => {
+          process.kill(info.pid!, "SIGKILL")
+          yield* waitFor(() => {
             if (!fs.existsSync(sandbox.identityFile)) return false
             const identity = readIdentity(sandbox.identityFile)
             return identity.pid !== info.pid && Subprocess.isProcessAlive(identity.pid)
@@ -217,4 +362,13 @@ describe("CodexServer", () => {
       }),
     30_000,
   )
+})
+
+describe("CodexServer.controlSocketPath", () => {
+  it("is codex's hardcoded location under the codex home", () => {
+    assert.strictEqual(
+      CodexServer.controlSocketPath("/home/u/.codex"),
+      path.join("/home/u/.codex", "app-server-control", "app-server-control.sock"),
+    )
+  })
 })

--- a/app-server/test/blackbox.ts
+++ b/app-server/test/blackbox.ts
@@ -35,8 +35,8 @@ process.on("exit", cleanupTempDirs)
 export const makeShortSocketDir = (): string => trackTempDir(mkdtempSync("/tmp/atc-zs-"))
 
 /**
- * Environment pointing every settled location (config, data, state) away
- * from the real user locations on the machine running the tests. The state
+ * Environment pointing every settled location (config, data, state, Codex
+ * home) away from the real user locations on the machine running the tests. The state
  * home gets its own short /tmp path rather than living under `dir`: the
  * terminal socket directory lives under it and must fit the unix
  * socket-path budget. Read the location back from the returned env when a
@@ -54,6 +54,9 @@ export const isolatedEnv = (dir: string, extra: Record<string, string> = {}) => 
   XDG_CONFIG_HOME: `${dir}/config`,
   XDG_DATA_HOME: `${dir}/data`,
   XDG_STATE_HOME: trackTempDir(mkdtempSync("/tmp/atc-st-")),
+  // A private Codex home: the shared app-server socket under the real one
+  // belongs to the developer's Codex clients.
+  CODEX_HOME: `${dir}/codex`,
   ...extra,
 })
 

--- a/app-server/test/fixtures/fake-codex-listener.ts
+++ b/app-server/test/fixtures/fake-codex-listener.ts
@@ -1,8 +1,11 @@
-// Fixture stand-in for `codex app-server --listen ws://127.0.0.1:<port>`:
-// binds the requested port, answers /readyz, and speaks the JSON-RPC subset
-// the codex adapter uses (initialize, thread/start, thread/resume,
-// turn/start, turn/interrupt, thread/unsubscribe), broadcasting
-// notifications to every connected socket like the real shared app-server.
+// Fixture stand-in for `codex app-server --listen unix://`: serves a
+// WebSocket on Codex's well-known control socket under CODEX_HOME and
+// speaks the JSON-RPC subset the codex adapter uses
+// (initialize, thread/start, thread/resume, turn/start, turn/interrupt,
+// thread/unsubscribe), broadcasting notifications to every connected
+// socket like the real shared app-server. Like the real server it exits
+// "already in use" when a live server answers the socket, and rebinds
+// over a stale socket file that nothing answers.
 //
 // Turn behavior is keyed off the input text: containing "HANG" leaves the
 // turn active until interrupted; containing "APPROVAL" first round-trips an
@@ -17,10 +20,13 @@
 // "test/child/finish" request completes a child.
 //
 // Env switches (baked into the wrapper script by tests):
-//   FAKE_CODEX_MODE       "ok" (default) | "never-ready" (503 /readyz)
+//   FAKE_CODEX_MODE       "ok" (default) | "never-ready" (alive, never binds)
 //   FAKE_CODEX_WRONG_CWD  "start" | "resume" — lie about cwd in that reply
-//   FAKE_CODEX_VERSION    printed for `--version` (default 0.146.0)
-//   FAKE_CODEX_PID_FILE   record this pid for reap assertions
+//   FAKE_CODEX_VERSION    printed for `--version` and carried in initialize's
+//                         userAgent (default 0.147.0)
+//   FAKE_CODEX_PID_FILE   record this pid for reap assertions; the listener
+//                         argv lands next to it (listen-record.json) so
+//                         tests can pin the launch shape
 //   FAKE_CODEX_TTL_MS     self-exit backstop (default 120s) so a test that
 //                         fails to stop() a detached fixture cannot leak it
 //   FAKE_CODEX_READ_DELAY_MS  delay root thread/read replies, so tests can
@@ -31,8 +37,11 @@
 //                         flush lag), so tests can prove the ATC-155
 //                         discovery loop lands mid-turn
 
+import { existsSync, mkdirSync, rmSync } from "node:fs"
+import * as path from "node:path"
+
 if (process.argv.includes("--version")) {
-  console.log(`codex-cli ${process.env["FAKE_CODEX_VERSION"] ?? "0.146.0"}`)
+  console.log(`codex-cli ${process.env["FAKE_CODEX_VERSION"] ?? "0.147.0"}`)
   process.exit(0)
 }
 
@@ -78,18 +87,58 @@ if (process.argv.includes("exec")) {
   process.exit(0)
 }
 
-const listenArg = process.argv.find((arg) => arg.startsWith("ws://"))
-if (listenArg === undefined) {
-  console.error("fake-codex-listener: no ws:// listen argument")
-  process.exit(64)
-}
-const port = Number.parseInt(new URL(listenArg).port, 10)
+const listenIndex = process.argv.indexOf("--listen")
+const listenArg = listenIndex >= 0 ? process.argv[listenIndex + 1] : undefined
 const mode = process.env["FAKE_CODEX_MODE"] ?? "ok"
 const wrongCwd = process.env["FAKE_CODEX_WRONG_CWD"]
+const version = process.env["FAKE_CODEX_VERSION"] ?? "0.147.0"
 const ttl = Number.parseInt(process.env["FAKE_CODEX_TTL_MS"] ?? "120000", 10)
 const pidFile = process.env["FAKE_CODEX_PID_FILE"]
 if (pidFile !== undefined && pidFile !== "") {
   await Bun.write(pidFile, String(process.pid))
+  await Bun.write(
+    path.join(path.dirname(pidFile), "listen-record.json"),
+    JSON.stringify({ argv: process.argv.slice(2) }),
+  )
+}
+setTimeout(() => process.exit(0), ttl)
+
+// Bare `unix://` — the one shape ATC starts — binds the well-known socket
+// under CODEX_HOME (~/.codex by default), the same derivation as codex.
+if (listenArg !== "unix://") {
+  console.error("fake-codex-listener: expected --listen unix://")
+  process.exit(64)
+}
+const codexHome =
+  process.env["CODEX_HOME"] !== undefined && process.env["CODEX_HOME"] !== ""
+    ? process.env["CODEX_HOME"]
+    : `${process.env["HOME"]}/.codex`
+const socketPath = `${codexHome}/app-server-control/app-server-control.sock`
+
+// A wedged server: alive, never binds.
+if (mode === "never-ready") await new Promise(() => {})
+
+// The real server's startup rule: a live server answering the socket means
+// "already in use"; a stale socket file that nothing answers is rebound.
+mkdirSync(path.dirname(socketPath), { recursive: true })
+if (existsSync(socketPath)) {
+  const answers = await Bun.connect({
+    unix: socketPath,
+    socket: {
+      data() {},
+      open(socket) {
+        socket.end()
+      },
+    },
+  }).then(
+    () => true,
+    () => false,
+  )
+  if (answers) {
+    console.error("app-server control socket is already in use")
+    process.exit(1)
+  }
+  rmSync(socketPath, { force: true })
 }
 
 interface Thread {
@@ -181,7 +230,7 @@ const handle = (
   const params = message.params ?? {}
   switch (message.method) {
     case "initialize":
-      return respond({ userAgent: "fake-codex-app-server" })
+      return respond({ userAgent: `fake-codex-app-server/${version}` })
     case "initialized":
       return
     case "thread/start": {
@@ -387,15 +436,8 @@ const handle = (
 }
 
 Bun.serve({
-  hostname: "127.0.0.1",
-  port,
+  unix: socketPath,
   fetch(request, server) {
-    const url = new URL(request.url)
-    if (url.pathname === "/readyz") {
-      return mode === "ok"
-        ? new Response("ok", { status: 200 })
-        : new Response("not ready", { status: 503 })
-    }
     if (server.upgrade(request)) return undefined
     return new Response("not found", { status: 404 })
   },
@@ -411,5 +453,3 @@ Bun.serve({
     },
   },
 })
-
-setTimeout(() => process.exit(0), ttl)

--- a/app-server/test/platform/config.test.ts
+++ b/app-server/test/platform/config.test.ts
@@ -48,11 +48,22 @@ describe("configuration", () => {
       assert.strictEqual(config.zmxExecutable, "zmx")
       assert.strictEqual(config.tailscaleExecutable, "tailscale")
       assert.strictEqual(config.codexExecutable, "codex")
+      assert.strictEqual(config.codexHome, join(home, ".codex"))
       assert.strictEqual(config.claudeExecutable, "claude")
       assert.strictEqual(
         config.terminalSocketDir,
         join(home, ".local", "state", "atc", "terminals"),
       )
+    }),
+  )
+
+  it.effect("codexHome follows codex's own CODEX_HOME variable", () =>
+    Effect.gen(function* () {
+      const config = yield* load({ CODEX_HOME: "/opt/codex-home" })
+      assert.strictEqual(config.codexHome, "/opt/codex-home")
+      // Empty means unset, like every other environment value.
+      const unset = yield* load({ CODEX_HOME: "" })
+      assert.strictEqual(unset.codexHome, join(home, ".codex"))
     }),
   )
 

--- a/app-server/test/platform/unixWebSocket.test.ts
+++ b/app-server/test/platform/unixWebSocket.test.ts
@@ -1,0 +1,215 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import * as path from "node:path"
+import * as UnixWebSocket from "../../src/platform/unixWebSocket.ts"
+import { makeShortSocketDir } from "../blackbox.ts"
+import { eventually } from "../testLayers.ts"
+
+// The hand-rolled WebSocket client, two ways: against Bun's own server over
+// a unix socket (every frame-length encoding, ping/pong, server-initiated
+// close, refusal), and against a raw byte peer that emits exact frames —
+// fragmentation with an interleaved ping split across chunk boundaries, a
+// masked server frame, and a corrupt length header — the protocol surface
+// no cooperative server would exercise.
+
+const serve = (socketPath: string) =>
+  Effect.acquireRelease(
+    Effect.sync(() =>
+      Bun.serve({
+        unix: socketPath,
+        fetch: (request, server) =>
+          server.upgrade(request) ? undefined : new Response("nope", { status: 400 }),
+        websocket: {
+          message(ws, message) {
+            const text = String(message)
+            if (text === "PING") ws.ping("hello")
+            else if (text === "CLOSE") ws.close(4000, "bye")
+            else ws.send(text)
+          },
+        },
+      }),
+    ),
+    // Not awaited: Bun's stop() promise never settles once the server has
+    // closed a websocket itself (observed on 1.3.14).
+    (server) => Effect.sync(() => void server.stop(true)),
+  )
+
+interface Client {
+  readonly connection: UnixWebSocket.Connection
+  readonly received: Array<string>
+  readonly closed: Array<string>
+}
+
+const openClient = (socketPath: string): Effect.Effect<Client> =>
+  Effect.callback<Client>((resume) => {
+    const connection = UnixWebSocket.open(socketPath)
+    const received: Array<string> = []
+    const closed: Array<string> = []
+    connection.onmessage = (text) => received.push(text)
+    connection.onclose = (reason) => closed.push(reason)
+    connection.onopen = () => resume(Effect.succeed({ connection, received, closed }))
+    return Effect.sync(() => connection.close())
+  })
+
+const waitUntil = (check: () => boolean) =>
+  eventually(Effect.sync(check), (ok) => ok, { attempts: 200, interval: "10 millis" })
+
+describe("UnixWebSocket", () => {
+  it.live("round-trips every frame length class and answers pings", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const socketPath = path.join(makeShortSocketDir(), "ws.sock")
+        yield* serve(socketPath)
+        const client = yield* openClient(socketPath)
+        const messages = ["tiny", "x".repeat(200), "y".repeat(70_000)]
+        for (const message of messages) client.connection.send(message)
+        yield* waitUntil(() => client.received.length === messages.length)
+        assert.deepStrictEqual(client.received, messages)
+        // A ping is answered transparently; the connection stays usable.
+        client.connection.send("PING")
+        client.connection.send("after ping")
+        yield* waitUntil(() => client.received.includes("after ping"))
+        assert.deepStrictEqual(client.closed, [])
+        client.connection.close()
+        // The closing handshake completes with the peer's echo.
+        yield* waitUntil(() => client.closed.length > 0)
+        assert.deepStrictEqual(client.closed, ["closed"])
+      }),
+    ),
+  )
+
+  it.live("a server-initiated close is reported once with its code", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const socketPath = path.join(makeShortSocketDir(), "ws.sock")
+        yield* serve(socketPath)
+        const client = yield* openClient(socketPath)
+        client.connection.send("CLOSE")
+        yield* waitUntil(() => client.closed.length > 0)
+        assert.deepStrictEqual(client.closed, ["closed by peer (4000)"])
+        // Later local closes are no-ops.
+        client.connection.close()
+        assert.strictEqual(client.closed.length, 1)
+      }),
+    ),
+  )
+
+  it.live("nothing listening is one close before open", () =>
+    Effect.gen(function* () {
+      const socketPath = path.join(makeShortSocketDir(), "absent.sock")
+      const reason = yield* Effect.callback<string>((resume) => {
+        const connection = UnixWebSocket.open(socketPath)
+        connection.onopen = () => resume(Effect.succeed("opened?!"))
+        connection.onclose = (reason) => resume(Effect.succeed(reason))
+      })
+      assert.include(reason, "connect failed")
+    }),
+  )
+})
+
+// A raw peer: completes the upgrade by hand, then writes exact frame bytes
+// in the chunks the test dictates and records what the client sends back.
+describe("UnixWebSocket against a raw peer", () => {
+  const ACCEPT_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+  const decoder = new TextDecoder()
+  const encoder = new TextEncoder()
+
+  /** Serve `socketPath`; `script` gets the accepted socket after the upgrade. */
+  const rawPeer = (
+    socketPath: string,
+    script: (peer: Bun.Socket<undefined>) => void,
+    inbound: Array<Uint8Array>,
+  ) =>
+    Effect.acquireRelease(
+      Effect.sync(() =>
+        Bun.listen<undefined>({
+          unix: socketPath,
+          socket: {
+            data(peer, chunk) {
+              const bytes = new Uint8Array(chunk)
+              const head = decoder.decode(bytes)
+              if (!head.startsWith("GET ")) {
+                inbound.push(bytes)
+                return
+              }
+              const key = /Sec-WebSocket-Key: (.+)\r\n/.exec(head)?.[1] ?? ""
+              const accept = new Bun.CryptoHasher("sha1").update(key + ACCEPT_GUID).digest("base64")
+              peer.write(
+                `HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n` +
+                  `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
+              )
+              script(peer)
+            },
+          },
+        }),
+      ),
+      (listener) => Effect.sync(() => listener.stop(true)),
+    )
+
+  /** An unmasked server frame (the normal server→client shape). */
+  const frame = (fin: boolean, opcode: number, payload: string): Uint8Array =>
+    new Uint8Array([(fin ? 0x80 : 0) | opcode, payload.length, ...encoder.encode(payload)])
+
+  it.live("reassembles fragments split across chunks around an interleaved ping", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const socketPath = path.join(makeShortSocketDir(), "raw.sock")
+        const inbound: Array<Uint8Array> = []
+        yield* rawPeer(
+          socketPath,
+          (peer) => {
+            // Frame boundaries and chunk boundaries deliberately disagree.
+            const bytes = new Uint8Array([
+              ...frame(false, 0x1, "hel"),
+              ...frame(true, 0x9, "p"),
+              ...frame(true, 0x0, "lo"),
+            ])
+            peer.write(bytes.subarray(0, 4))
+            setTimeout(() => peer.write(bytes.subarray(4, 9)), 20)
+            setTimeout(() => peer.write(bytes.subarray(9)), 40)
+          },
+          inbound,
+        )
+        const client = yield* openClient(socketPath)
+        yield* waitUntil(() => client.received.length > 0)
+        assert.deepStrictEqual(client.received, ["hello"])
+        // The pong (opcode 0xa, masked, one byte) went back for the ping.
+        const pong = inbound.find((bytes) => (bytes[0]! & 0x0f) === 0xa)
+        assert.isDefined(pong)
+        assert.strictEqual(pong![1]!, 0x80 | 1)
+        assert.deepStrictEqual(client.closed, [])
+      }),
+    ),
+  )
+
+  it.live("a masked frame is unmasked; a corrupt length is a protocol failure, never a hang", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const socketPath = path.join(makeShortSocketDir(), "raw.sock")
+        yield* rawPeer(
+          socketPath,
+          (peer) => {
+            const masked = new Uint8Array([
+              0x81,
+              0x80 | 2,
+              1,
+              2,
+              3,
+              4,
+              "o".charCodeAt(0) ^ 1,
+              "k".charCodeAt(0) ^ 2,
+            ])
+            peer.write(masked)
+            // A 64-bit length with the reserved high bit set.
+            peer.write(new Uint8Array([0x81, 0x7f, 0x80, 0, 0, 0, 0, 0, 0, 0]))
+          },
+          [],
+        )
+        const client = yield* openClient(socketPath)
+        yield* waitUntil(() => client.closed.length > 0)
+        assert.deepStrictEqual(client.received, ["ok"])
+        assert.match(client.closed[0]!, /^protocol error/)
+      }),
+    ),
+  )
+})

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -83,6 +83,7 @@ export const testAppConfig = (overrides: Partial<AppConfig["Service"]>): Layer.L
     zmxExecutable: "zmx",
     tailscaleExecutable: "tailscale",
     codexExecutable: "codex",
+    codexHome: "/tmp/atc-codex-home",
     claudeExecutable: "claude",
     terminalSocketDir: "/tmp/atc-sockets",
     ...overrides,


### PR DESCRIPTION
Closes ATC-196.

## What

ATC becomes a client of **one shared Codex app-server per `CODEX_HOME`** on Codex's well-known control socket (`$CODEX_HOME/app-server-control/app-server-control.sock`) instead of running a private detached `codex app-server --listen ws://127.0.0.1:<port>`.

- **Adopt-or-start** (`codexServer.ts`): probe the socket (WebSocket handshake); connect to and use whatever answers; start `codex app-server --listen unix://` detached only when nothing answers. Losing the start race to another client's server adopts the winner. Exactly the well-known socket, never any other address.
- **Ownership boundary**: ATC never kills or restarts a server it did not start (it *uses* it); it replaces only its own recorded pid, and only once dead or silent past a bounded wait. `stop()` targets only our pid. The exit watcher restarts only our own dead server and re-probes first (a server that appeared meanwhile is adopted). `codex app-server daemon *` is never invoked.
- **Transport** (`platform/unixWebSocket.ts`, new): a small RFC 6455 client over `Bun.connect({unix})` — Bun's `WebSocket` cannot dial unix sockets, and `codex app-server proxy` turned out to be a raw byte tunnel (the client still speaks WebSocket). Handshake, masking, 16/64-bit lengths with a size cap, fragment reassembly, ping/pong, bounded close handshake, write backpressure. Browser-shaped surface so `codexAdapter.ts` swaps one for the other.
- **Adapter** (`codexAdapter.ts`): same connection/teardown/session logic over the new transport; TUI launches pass `--remote unix://<path>` explicitly; the *running* server's version (from `initialize`'s `userAgent`) is gated alongside the CLI's; `CODEX_TESTED_VERSION` → 0.147.0.
- **Config**: `AppConfig.codexHome` (`CODEX_HOME`, else `~/.codex`; environment only, it's codex's variable) — ATC finds the same socket every other Codex client does.
- **No legacy compatibility machinery** (review decision): nothing sweeps pre-196 private servers. A recorded pid of ours that is alive but silent is replaced after the adopt window, so a stale legacy identity file self-heals; untracked orphans are the user's to stop.
- Tests: `codexServer.test.ts` rewritten (adopt foreign without signaling, start when absent, no double start, lost start race, own-death restart vs foreign death, silent-own replacement, recycled pid, early-exit diagnostic with child output, launch shape); adapter tests moved to the unix socket with a shared external-client helper; new `unixWebSocket.test.ts` (Bun server + a raw byte peer for fragmentation/ping/masked/corrupt-length). Blackbox `isolatedEnv` now isolates `CODEX_HOME`.

## Verified live (this machine, codex 0.147.0)

- Adopted the desktop/SSH-started server on the real socket (`initialize` → `codex_chatgpt_ios_remote/0.147.0`) and walked the real thread list over the new transport.
- `codex --cd … --remote unix:///Users/…/app-server-control.sock` attaches and renders the TUI.

Not verified here (needs the laptop): Codex desktop app over SSH resuming an ATC thread while an ATC-*started* server owns the socket (probe #1 in the issue).

## Review notes

Two adversarial Codex reviews (correctness, simplicity) ran on the diff before opening; CodeRabbit reviewed the PR. Adopted: 64-bit-length validation + message-size cap, handshake and close echo through the backpressure path, bounded close (timer cleared on echo; FIN behind a stalled backlog is terminated), component-wise version compare, raw-peer protocol tests, fake external client fails pending requests on close, fixture/test trims, and — per Jeremy — dropping the legacy sweep entirely rather than adding ownership tracking for obsolete servers. Declined: startedAt-based pid verification and socket-ownership checks beyond the argv guard (pre-existing design; the only kill path is our own recorded pid), and making ATC refuse to boot on a relative `CODEX_HOME` (Codex trouble must not affect ATC startup).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Codex app-server connections now use a shared Unix socket for more reliable communication.
  - Automatically adopts available servers and recovers from stale or competing server processes.
  - Added Codex version detection with warnings for outdated servers.
  - Added support for configuring a dedicated Codex home directory.

- **Bug Fixes**
  - Improved startup, readiness checks, cleanup, and recovery behavior for Codex servers.
  - Prevented test environments from using shared developer configuration or sockets.

- **Documentation**
  - Expanded guidance on using private Codex environments and safely managing sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->