### PR TITLE
Fix macOS release checksum reuse

### DIFF
--- a/.github/workflows/product-release.yml
+++ b/.github/workflows/product-release.yml
@@ -367,6 +367,9 @@ jobs:
             --built-at "${{ needs.plan.outputs.built_at }}" \
             --output out/atc-macos-arm64.dmg
 
+      - name: Checksum macOS asset
+        run: (cd out && shasum -a 256 atc-macos-arm64.dmg > checksums-macos.txt)
+
       - name: Remove ephemeral signing credentials
         if: always() && steps.signing.outcome != 'skipped'
         run: scripts/cleanup-macos-signing.sh
@@ -374,7 +377,9 @@ jobs:
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: product-release-assets-macos
-          path: out/atc-macos-arm64.dmg
+          path: |
+            out/atc-macos-arm64.dmg
+            out/checksums-macos.txt
           if-no-files-found: error
 
       - name: Upload macOS release failure logs

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -37,15 +37,15 @@ esac
 [[ -n "$TAG" && -n "$VERSION" && -n "$BUILT_AT" && "$COMMIT" =~ ^[0-9a-f]{40}$ && -d "$ASSET_DIR" ]] || { usage; exit 2; }
 [[ "$KIND" == "stable" && "$CHANNEL" == "stable" ]] || [[ "$KIND" != "stable" && "$CHANNEL" == "dev" ]] || { usage; exit 2; }
 
-expected=(
+checksummed=(
   atc-darwin-arm64.tar.gz
   atc-darwin-x64.tar.gz
   atc-linux-arm64.tar.gz
   atc-linux-x64.tar.gz
   atc-macos-arm64.dmg
-  checksums.txt
   manifest.json
 )
+expected=("${checksummed[@]}" checksums.txt)
 assets=()
 for name in "${expected[@]}"; do
   path="$ASSET_DIR/$name"
@@ -82,6 +82,13 @@ if [[ "$KIND" == "candidate" ]]; then
     exit 0
   fi
 fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+"$SCRIPT_DIR/verify-release-assets.sh" \
+  --exact \
+  "$ASSET_DIR/checksums.txt" \
+  "$ASSET_DIR" \
+  "${checksummed[@]}"
 
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/scripts/release-test.sh
+++ b/scripts/release-test.sh
@@ -135,10 +135,23 @@ chmod +x "$TEST_ROOT/dist/atc-darwin-arm64" "$TEST_ROOT/dist/atc-linux-x64"
   --out "$TEST_ROOT/out" \
   --checksums checksums-linux.txt \
   linux-x64
+printf 'macOS disk image\n' > "$TEST_ROOT/out/atc-macos-arm64.dmg"
+(
+  cd "$TEST_ROOT/out"
+  shasum -a 256 atc-macos-arm64.dmg > checksums-macos.txt
+)
 "$SCRIPT_DIR/merge-checksums.sh" "$TEST_ROOT/out"
-[[ "$(wc -l < "$TEST_ROOT/out/checksums.txt" | tr -d ' ')" == "2" ]]
+[[ "$(wc -l < "$TEST_ROOT/out/checksums.txt" | tr -d ' ')" == "3" ]]
 tar -tzf "$TEST_ROOT/out/atc-darwin-arm64.tar.gz" | grep -qx atc
 tar -tzf "$TEST_ROOT/out/atc-linux-x64.tar.gz" | grep -qx atc
+grep -q '  atc-macos-arm64.dmg$' "$TEST_ROOT/out/checksums.txt"
+"$SCRIPT_DIR/verify-release-assets.sh" \
+  --exact \
+  "$TEST_ROOT/out/checksums.txt" \
+  "$TEST_ROOT/out" \
+  atc-darwin-arm64.tar.gz \
+  atc-linux-x64.tar.gz \
+  atc-macos-arm64.dmg
 
 credential_dir="$TEST_ROOT/runner-temp/atc-release-credentials"
 fake_bin="$TEST_ROOT/fake-bin"
@@ -204,7 +217,11 @@ printf '%s\n' \
   '  fi' \
   'fi' \
   'exit 99' > "$release_fake_bin/gh"
-chmod +x "$release_fake_bin/gh"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'echo "unexpected git command: $*" >&2' \
+  'exit 99' > "$release_fake_bin/git"
+chmod +x "$release_fake_bin/gh" "$release_fake_bin/git"
 
 set +e
 reuse_output="$(
@@ -259,6 +276,22 @@ state_error_status=$?
 set -e
 [[ $state_error_status -eq 1 ]]
 [[ "$state_error_output" == *"could not resolve PR #214 state"* ]]
+
+(
+  cd "$candidate_assets"
+  shasum -a 256 \
+    atc-darwin-arm64.tar.gz \
+    atc-darwin-x64.tar.gz \
+    atc-linux-arm64.tar.gz \
+    atc-linux-x64.tar.gz \
+    manifest.json > checksums.txt
+)
+set +e
+incomplete_checksums_output="$(candidate_publish OPEN "$commit" 2>&1)"
+incomplete_checksums_status=$?
+set -e
+[[ $incomplete_checksums_status -eq 1 ]]
+[[ "$incomplete_checksums_output" == *"does not include exactly one valid checksum for atc-macos-arm64.dmg"* ]]
 
 set +e
 missing_value_output="$($SCRIPT_DIR/package-app-server.sh --dist 2>&1)"
@@ -421,6 +454,8 @@ if git -C "$REPO_ROOT" grep -qE 'ATC_NOTARY_KEY_' -- \
 fi
 
 git -C "$REPO_ROOT" grep -qE '^run-name:.*request_id' -- .github/workflows/product-release.yml
+git -C "$REPO_ROOT" grep -qF 'shasum -a 256 atc-macos-arm64.dmg > checksums-macos.txt' -- .github/workflows/product-release.yml
+git -C "$REPO_ROOT" grep -qF 'out/checksums-macos.txt' -- .github/workflows/product-release.yml
 grep -q 'request_id=' "$REPO_ROOT/scripts/release.sh"
 grep -q 'Product Release \[stable:$REQUEST_ID\]' "$REPO_ROOT/scripts/release.sh"
 grep -q 'request_id=' "$REPO_ROOT/scripts/dev-build.sh"

--- a/scripts/reuse-release-assets.sh
+++ b/scripts/reuse-release-assets.sh
@@ -26,6 +26,7 @@ done
 [[ -n "$OUT" && -n "$CHECKSUMS" && "$CHECKSUMS" != */* && $# -gt 0 ]] || { usage; exit 2; }
 command -v gh >/dev/null 2>&1 || { echo "required command not found: gh" >&2; exit 1; }
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/atc-release-reuse.XXXXXX")"
 trap 'rm -rf "$TMP"' EXIT
 gh release download "$TAG" --pattern checksums.txt --dir "$TMP"
@@ -34,13 +35,13 @@ mkdir -p "$OUT"
 assets=()
 for name in "$@"; do
   [[ "$name" != */* ]] || { echo "asset name must be a basename: $name" >&2; exit 2; }
-  expected="$(awk -v file="$name" '{ candidate=$NF; sub(/^\*/, "", candidate); if (candidate == file) print $1 }' "$TMP/checksums.txt")"
-  [[ "$expected" =~ ^[0-9a-f]{64}$ ]] || { echo "checksums.txt does not include $name" >&2; exit 1; }
   gh release download "$TAG" --pattern "$name" --dir "$TMP"
-  actual="$(shasum -a 256 "$TMP/$name" | awk '{ print $1 }')"
-  [[ "$actual" == "$expected" ]] || { echo "checksum mismatch for $name from $TAG" >&2; exit 1; }
-  cp "$TMP/$name" "$OUT/$name"
   assets+=("$name")
+done
+
+"$SCRIPT_DIR/verify-release-assets.sh" "$TMP/checksums.txt" "$TMP" "${assets[@]}"
+for name in "${assets[@]}"; do
+  cp "$TMP/$name" "$OUT/$name"
 done
 
 (

--- a/scripts/verify-release-assets.sh
+++ b/scripts/verify-release-assets.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Verifies named release assets against one checksum file. Reuse may validate a
+# component subset; publication uses --exact to require one canonical entry for
+# every asset in the final product set and no extras.
+set -euo pipefail
+
+usage() {
+  echo "usage: scripts/verify-release-assets.sh [--exact] CHECKSUMS ASSET_DIR ASSET [...]" >&2
+}
+
+EXACT=false
+if [[ "${1:-}" == "--exact" ]]; then
+  EXACT=true
+  shift
+fi
+
+CHECKSUMS="${1:-}"
+ASSET_DIR="${2:-}"
+[[ -f "$CHECKSUMS" && -d "$ASSET_DIR" && $# -gt 2 ]] || { usage; exit 2; }
+shift 2
+EXPECTED_COUNT=$#
+
+for name in "$@"; do
+  [[ -n "$name" && "$name" != */* ]] || { echo "asset name must be a basename: $name" >&2; exit 2; }
+  path="$ASSET_DIR/$name"
+  [[ -f "$path" ]] || { echo "missing release asset: $path" >&2; exit 1; }
+  expected="$(awk -v file="$name" '{ candidate=$NF; sub(/^\*/, "", candidate); if (candidate == file) print $1 }' "$CHECKSUMS")"
+  [[ "$expected" =~ ^[0-9a-f]{64}$ ]] || { echo "$(basename "$CHECKSUMS") does not include exactly one valid checksum for $name" >&2; exit 1; }
+  actual="$(shasum -a 256 "$path" | awk '{ print $1 }')"
+  [[ "$actual" == "$expected" ]] || { echo "checksum mismatch for $name" >&2; exit 1; }
+done
+
+if [[ "$EXACT" == "true" ]]; then
+  ENTRY_COUNT="$(awk 'NF { count++ } END { print count + 0 }' "$CHECKSUMS")"
+  [[ "$ENTRY_COUNT" -eq "$EXPECTED_COUNT" ]] || {
+    echo "$(basename "$CHECKSUMS") contains unexpected checksum entries" >&2
+    exit 1
+  }
+fi


### PR DESCRIPTION
## Summary

- generate and upload a checksum fragment alongside freshly built macOS DMGs
- share checksum verification between component reuse and final publication
- reject incomplete, duplicate, extra, or mismatched checksum entries before mutating a release
- cover complete product assembly and the missing-DMG checksum regression

## Root cause

[Product Release run 31944486467](https://github.com/jeremytondo/atc/actions/runs/31944486467) selected the existing macOS DMG for reuse, then failed with:

> `checksums.txt does not include atc-macos-arm64.dmg`

The previous rolling release contained the DMG and declared it in its manifest, but the macOS build had never emitted a checksum fragment. The assembled `checksums.txt` therefore covered only App Server archives and the manifest.

## Impact

The next main build will rebuild macOS because this workflow change alters its source fingerprint. It will publish a complete checksum set and repair the rolling `dev` release without manual deletion. Future publication is blocked unless every expected release asset is covered exactly once and its checksum matches.

## Validation

- `mise run release:check`
- `TMPDIR=/tmp mise run check` (including all 293 macOS tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS release downloads now include a SHA-256 checksum file alongside the disk image.
  * Release assets are verified together before being published or reused.
  * Checksum validation detects missing, unexpected, unsafe, or modified assets.

* **Bug Fixes**
  * Improved protection against publishing incomplete or corrupted release packages.
  * Release testing now covers macOS disk-image checksums and exact asset verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->