### PR TITLE
Fix Tailscale discovery and startup diagnostics

### DIFF
--- a/app-server/src/cli/serve.ts
+++ b/app-server/src/cli/serve.ts
@@ -150,6 +150,28 @@ const signal = (pid: number, name: "SIGTERM" | "SIGKILL") =>
     }
   })
 
+/** Stop a detached child whose start cannot be completed, then remove only
+ * the pidfile still proven to belong to it. Cleanup never masks the failure
+ * that made the start incomplete. */
+const cleanupFailedStart = (
+  fs: FileSystem.FileSystem,
+  pid: number,
+  pidFile: string,
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    yield* signal(pid, "SIGTERM")
+    const exited = yield* waitForProcessExit(pid, { attempts: 50, interval: "100 millis" })
+    const stopped = exited
+      ? true
+      : yield* signal(pid, "SIGKILL").pipe(
+          Effect.andThen(waitForProcessExit(pid, { attempts: 20, interval: "100 millis" })),
+        )
+    const current = yield* readPidRecord(fs, pidFile)
+    if (stopped && current?.pid === pid) {
+      yield* fs.remove(pidFile).pipe(Effect.ignore)
+    }
+  })
+
 export const start = Command.make("start", { port, bind, tailscale }, ({ port, bind, tailscale }) =>
   Effect.gen(function* () {
     const config = yield* AppConfig
@@ -211,6 +233,11 @@ export const start = Command.make("start", { port, bind, tailscale }, ({ port, b
       .pipe(Effect.tapError(() => fs.remove(startupErrorFile).pipe(Effect.ignore)))
     yield* encodePidRecord({ pid, port: effective.port, bind: effective.bind }).pipe(
       Effect.flatMap((json) => fs.writeFileString(effective.pidFile, json)),
+      Effect.tapError(() =>
+        cleanupFailedStart(fs, pid, effective.pidFile).pipe(
+          Effect.andThen(fs.remove(startupErrorFile).pipe(Effect.ignore)),
+        ),
+      ),
     )
     // A child that already exited can never become healthy. Race its exit
     // against the health deadline so boot failures surface immediately.
@@ -221,15 +248,7 @@ export const start = Command.make("start", { port, bind, tailscale }, ({ port, b
     if (!healthy) {
       // Success is only ever reported for a healthy server, so the spawned
       // child is stopped rather than left as an orphan no `stop` can reach.
-      yield* signal(pid, "SIGTERM")
-      yield* waitForProcessExit(pid, { attempts: 50, interval: "100 millis" })
-      // Concurrent starts are not serialized; remove the pidfile only while
-      // it still records OUR child, so a racing start's healthy server is
-      // never made invisible by this cleanup.
-      const current = yield* readPidRecord(fs, effective.pidFile)
-      if (current?.pid === pid) {
-        yield* fs.remove(effective.pidFile).pipe(Effect.ignore)
-      }
+      yield* cleanupFailedStart(fs, pid, effective.pidFile)
       const diagnostic = yield* readStartupDiagnostic(fs, startupErrorFile)
       yield* fs.remove(startupErrorFile).pipe(Effect.ignore)
       return yield* Cli.failReported(

--- a/app-server/src/cli/serve.ts
+++ b/app-server/src/cli/serve.ts
@@ -13,6 +13,7 @@ import {
 } from "../platform/subprocess.ts"
 import * as Server from "../server.ts"
 import * as Cli from "./cli.ts"
+import { randomUUID } from "node:crypto"
 
 // Running the service: `serve` is the foreground primitive (what a
 // supervisor owns, and what `start` spawns); `start`/`stop`/`status` are the
@@ -120,6 +121,24 @@ const readPidRecord = (fs: FileSystem.FileSystem, file: string) =>
     Effect.catch(() => Effect.succeed(undefined)),
   )
 
+/** Prefer the child's one-line CLI diagnostic; otherwise retain a bounded
+ * stderr tail for unexpected startup failures. */
+const startupDiagnostic = (text: string): string | undefined => {
+  const lines = text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "")
+  const reported = lines.findLast((line) => line.startsWith("atc serve:"))
+  const detail = reported ?? lines.slice(-5).join(" ")
+  return detail === "" ? undefined : detail.slice(0, 2_000)
+}
+
+const readStartupDiagnostic = (fs: FileSystem.FileSystem, file: string) =>
+  fs.readFileString(file).pipe(
+    Effect.map(startupDiagnostic),
+    Effect.catch(() => Effect.succeed(undefined)),
+  )
+
 const signal = (pid: number, name: "SIGTERM" | "SIGKILL") =>
   Effect.sync(() => {
     // A process that exits between the liveness check and the signal is
@@ -177,19 +196,27 @@ export const start = Command.make("start", { port, bind, tailscale }, ({ port, b
       effective.bind,
       ...(effective.tailscale ? ["--tailscale"] : []),
     ]
-    const pid = yield* subprocess.spawnDetached(
-      build.commit === "dev"
-        ? { executable: process.execPath, args: [process.argv[1] ?? "src/main.ts", ...serveArgs] }
-        : { executable: process.execPath, args: serveArgs },
-    )
     yield* fs.makeDirectory(config.stateDir, { recursive: true })
+    const startupErrorFile = `${config.stateDir}/.start-${randomUUID()}.stderr`
+    const pid = yield* subprocess
+      .spawnDetached(
+        build.commit === "dev"
+          ? {
+              executable: process.execPath,
+              args: [process.argv[1] ?? "src/main.ts", ...serveArgs],
+              stderrFile: startupErrorFile,
+            }
+          : { executable: process.execPath, args: serveArgs, stderrFile: startupErrorFile },
+      )
+      .pipe(Effect.tapError(() => fs.remove(startupErrorFile).pipe(Effect.ignore)))
     yield* encodePidRecord({ pid, port: effective.port, bind: effective.bind }).pipe(
       Effect.flatMap((json) => fs.writeFileString(effective.pidFile, json)),
     )
-    const healthy = yield* Cli.pollUntil(
-      15_000,
-      150,
-      Cli.probeHealth(probeHost, effective.port, 1_000, token),
+    // A child that already exited can never become healthy. Race its exit
+    // against the health deadline so boot failures surface immediately.
+    const healthy = yield* Effect.raceFirst(
+      Cli.pollUntil(15_000, 150, Cli.probeHealth(probeHost, effective.port, 1_000, token)),
+      waitForProcessExit(pid, { attempts: 300, interval: "50 millis" }).pipe(Effect.as(false)),
     )
     if (!healthy) {
       // Success is only ever reported for a healthy server, so the spawned
@@ -203,10 +230,15 @@ export const start = Command.make("start", { port, bind, tailscale }, ({ port, b
       if (current?.pid === pid) {
         yield* fs.remove(effective.pidFile).pipe(Effect.ignore)
       }
+      const diagnostic = yield* readStartupDiagnostic(fs, startupErrorFile)
+      yield* fs.remove(startupErrorFile).pipe(Effect.ignore)
       return yield* Cli.failReported(
-        `atc start: the server did not become healthy within 15s (stopped pid ${pid}); logs: ${effective.logFile}`,
+        diagnostic === undefined
+          ? `atc start: the server did not become healthy within 15s (stopped pid ${pid}); logs: ${effective.logFile}`
+          : `atc start: the server failed to start: ${diagnostic}`,
       )
     }
+    yield* fs.remove(startupErrorFile).pipe(Effect.ignore)
     yield* Console.log(
       `started atc app server (pid ${pid}) on http://${Server.hostForUrl(effective.bind)}:${effective.port} (logs: ${effective.logFile})`,
     )

--- a/app-server/src/platform/subprocess.ts
+++ b/app-server/src/platform/subprocess.ts
@@ -14,6 +14,7 @@ import {
 import * as Poll from "./poll.ts"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { spawn as nodeSpawn } from "node:child_process"
+import { closeSync, openSync } from "node:fs"
 
 // The generic subprocess seam: how the App Server launches and supervises
 // child processes. Children are acquired in Scopes, so closing the scope —
@@ -125,12 +126,15 @@ export class Subprocess extends Context.Service<
     /**
      * The one deliberate exception to scope ownership: spawn a child meant
      * to OUTLIVE this process (`atc start`'s background server). Detached
-     * session, stdio ignored, environment inherited; returns the pid. The
-     * caller owns liveness from here — nothing supervises the child.
+     * session, environment inherited, stdout ignored, and stderr optionally
+     * redirected for startup diagnostics; returns the pid. The caller owns
+     * liveness from here — nothing supervises the child.
      */
     readonly spawnDetached: (spec: {
       readonly executable: string
       readonly args?: ReadonlyArray<string>
+      /** Optional file receiving the detached child's stderr. */
+      readonly stderrFile?: string
     }) => Effect.Effect<number, SubprocessError>
   }
 >()("app-server/Subprocess") {}
@@ -459,22 +463,29 @@ const spawnPty = Effect.fnUntraced(function* (spec: PtySpawnSpec) {
 const spawnDetached = (spec: {
   readonly executable: string
   readonly args?: ReadonlyArray<string>
+  readonly stderrFile?: string
 }) =>
   Effect.try({
     try: () => {
-      const child = nodeSpawn(spec.executable, [...(spec.args ?? [])], {
-        detached: true,
-        stdio: "ignore",
-      })
-      // An EventEmitter with no error listener re-throws asynchronously and
-      // would crash this process; the missing-pid check below is the actual
-      // fast-fail, and anything later is the caller's bounded-wait problem.
-      child.on("error", () => {})
-      if (child.pid === undefined) {
-        throw new Error("the child reported no pid")
+      const stderr =
+        spec.stderrFile === undefined ? undefined : openSync(spec.stderrFile, "wx", 0o600)
+      try {
+        const child = nodeSpawn(spec.executable, [...(spec.args ?? [])], {
+          detached: true,
+          stdio: ["ignore", "ignore", stderr ?? "ignore"],
+        })
+        // An EventEmitter with no error listener re-throws asynchronously and
+        // would crash this process; the missing-pid check below is the actual
+        // fast-fail, and anything later is the caller's bounded-wait problem.
+        child.on("error", () => {})
+        if (child.pid === undefined) {
+          throw new Error("the child reported no pid")
+        }
+        child.unref()
+        return child.pid
+      } finally {
+        if (stderr !== undefined) closeSync(stderr)
       }
-      child.unref()
-      return child.pid
     },
     catch: (error) =>
       new SubprocessError({

--- a/app-server/src/platform/tailscale.ts
+++ b/app-server/src/platform/tailscale.ts
@@ -43,6 +43,26 @@ const StatusOutput = Schema.Struct({
 const decodeStatus = Schema.decodeEffect(Schema.fromJsonString(StatusOutput))
 const STATUS_TIMEOUT: Duration.Input = "10 seconds"
 const SERVE_READY_TIMEOUT: Duration.Input = "15 seconds"
+const MACOS_APP_EXECUTABLE = "/Applications/Tailscale.app/Contents/MacOS/Tailscale"
+
+/** Default discovery follows Tailscale's supported installation shapes:
+ * normal PATH lookup everywhere, then the CLI bundled in the macOS app. A
+ * custom configured name/path is exact user intent and gets no fallback. */
+export const executableCandidates = (
+  configured: string,
+  platform: typeof process.platform,
+): ReadonlyArray<string> =>
+  configured === "tailscale" && platform === "darwin"
+    ? [configured, MACOS_APP_EXECUTABLE]
+    : [configured]
+
+const resolveExecutable = (configured: string): string | null => {
+  for (const candidate of executableCandidates(configured, process.platform)) {
+    const resolved = Subprocess.resolveExecutable(candidate)
+    if (resolved !== null && existsSync(resolved)) return resolved
+  }
+  return null
+}
 
 const failed = (reason: string) => new AttemptFailed({ reason })
 
@@ -69,7 +89,9 @@ const runStatus = (
     const child = yield* subprocess.spawn({
       executable,
       args: ["status", "--json"],
-      env: {},
+      // The macOS app and CLI are one executable. Tailscale otherwise guesses
+      // which mode to enter from shell variables that services need not have.
+      env: { TAILSCALE_BE_CLI: "1" },
       extendEnv: true,
     })
     yield* child.endInput
@@ -121,7 +143,7 @@ const superviseServe = (
     const child = yield* subprocess.spawn({
       executable,
       args: ["serve", `--https=${port}`, `localhost:${port}`],
-      env: {},
+      env: { TAILSCALE_BE_CLI: "1" },
       extendEnv: true,
     })
     yield* child.endInput
@@ -198,12 +220,15 @@ export const layer = Layer.effect(Tailscale)(
 
     const subprocess = yield* Subprocess.Subprocess
     const configured = config.tailscaleExecutable
-    const executable = Subprocess.resolveExecutable(configured)
-    if (executable === null || !existsSync(executable)) {
+    const executable = resolveExecutable(configured)
+    if (executable === null) {
+      const tried = executableCandidates(configured, process.platform)
       return yield* Effect.fail(
         new TailscaleConfigError({
           reason:
-            `tailscale executable "${configured}" not found; install Tailscale or set ` +
+            `tailscale executable "${configured}" not found` +
+            (tried.length > 1 ? ` (also tried ${tried.slice(1).join(", ")})` : "") +
+            "; install Tailscale or set " +
             "tailscaleExecutable in config.toml / ATC_TAILSCALE_EXECUTABLE",
         }),
       )

--- a/app-server/test/agents/codexServer.test.ts
+++ b/app-server/test/agents/codexServer.test.ts
@@ -23,6 +23,15 @@ const fixturePid = (sandbox: { readonly pidFile: string }): number =>
 const readIdentity = (identityFile: string): { pid: number } =>
   JSON.parse(fs.readFileSync(identityFile, "utf8")) as { pid: number }
 
+/** A writer may have created or truncated the file between poll attempts. */
+const readIdentityIfReady = (identityFile: string): { pid: number } | undefined => {
+  try {
+    return readIdentity(identityFile)
+  } catch {
+    return undefined
+  }
+}
+
 /**
  * A server ATC did not start: the fixture launched by hand on the sandbox's
  * well-known socket (no pid file, so a later ATC spawn would be visible).
@@ -133,8 +142,8 @@ describe("CodexServer", () => {
             // is armed again now that a server of ours exists.
             process.kill(own.pid!, "SIGKILL")
             yield* waitFor(() => {
-              if (!fs.existsSync(sandbox.identityFile)) return false
-              const identity = readIdentity(sandbox.identityFile)
+              const identity = readIdentityIfReady(sandbox.identityFile)
+              if (identity === undefined) return false
               return identity.pid !== own.pid && Subprocess.isProcessAlive(identity.pid)
             })
             yield* codex.stop()
@@ -351,8 +360,8 @@ describe("CodexServer", () => {
           const info = yield* codex.ensure()
           process.kill(info.pid!, "SIGKILL")
           yield* waitFor(() => {
-            if (!fs.existsSync(sandbox.identityFile)) return false
-            const identity = readIdentity(sandbox.identityFile)
+            const identity = readIdentityIfReady(sandbox.identityFile)
+            if (identity === undefined) return false
             return identity.pid !== info.pid && Subprocess.isProcessAlive(identity.pid)
           })
           const replacement = yield* codex.ensure()

--- a/app-server/test/cli/startStopStatus.blackbox.test.ts
+++ b/app-server/test/cli/startStopStatus.blackbox.test.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterAll, describe, expect, test } from "vitest"
@@ -184,6 +192,24 @@ describe("atc start / stop / status (black box)", () => {
     )
     expect(started.stderr).not.toContain("did not become healthy within 15s")
     expect(existsSync(failedPidFile)).toBe(false)
+  }, 30_000)
+
+  test("start stops the detached server when its pidfile cannot be persisted", async () => {
+    const failedEnv = isolatedEnv(join(scratch, "failed-pid-write"), {
+      ATC_ZMX_EXECUTABLE: sandbox.wrapper,
+    })
+    const failedCli = (...args: Array<string>) =>
+      runCli([process.execPath, "src/main.ts"], args, appServerRoot, failedEnv)
+    const stateDir = join(failedEnv.XDG_STATE_HOME, "atc")
+    // A directory at the pidfile path makes the post-spawn write fail without
+    // making the state directory unavailable to the startup stderr capture.
+    mkdirSync(join(stateDir, "atc.pid"), { recursive: true })
+    const port = await freePort()
+
+    const started = await failedCli("start", "--port", String(port))
+    expect(started.exitCode).not.toBe(0)
+    await expect(fetch(`http://127.0.0.1:${port}/api/v1/health`)).rejects.toThrow()
+    expect(readdirSync(stateDir).filter((name) => name.startsWith(".start-"))).toEqual([])
   }, 30_000)
 
   test("start threads --tailscale through serve and status reports the verified URL", async () => {

--- a/app-server/test/cli/startStopStatus.blackbox.test.ts
+++ b/app-server/test/cli/startStopStatus.blackbox.test.ts
@@ -167,6 +167,25 @@ describe("atc start / stop / status (black box)", () => {
     expect(stopped.exitCode).toBe(0)
   }, 60_000)
 
+  test("start surfaces a detached server's actionable boot failure", async () => {
+    const failedEnv = isolatedEnv(join(scratch, "failed-start"), {
+      ATC_ZMX_EXECUTABLE: sandbox.wrapper,
+      ATC_TAILSCALE_EXECUTABLE: "/definitely/missing/tailscale",
+    })
+    const failedCli = (...args: Array<string>) =>
+      runCli([process.execPath, "src/main.ts"], args, appServerRoot, failedEnv)
+    const failedPidFile = join(failedEnv.XDG_STATE_HOME, "atc", "atc.pid")
+    const port = await freePort()
+
+    const started = await failedCli("start", "--port", String(port), "--tailscale")
+    expect(started.exitCode).not.toBe(0)
+    expect(started.stderr).toContain(
+      'atc start: the server failed to start: atc serve: tailscale executable "/definitely/missing/tailscale" not found',
+    )
+    expect(started.stderr).not.toContain("did not become healthy within 15s")
+    expect(existsSync(failedPidFile)).toBe(false)
+  }, 30_000)
+
   test("start threads --tailscale through serve and status reports the verified URL", async () => {
     const tailscaleSandbox = makeFakeTailscaleSandbox()
     const tailscaleEnv = isolatedEnv(join(scratch, "tailscale"), {

--- a/app-server/test/cli/startStopStatus.blackbox.test.ts
+++ b/app-server/test/cli/startStopStatus.blackbox.test.ts
@@ -201,13 +201,17 @@ describe("atc start / stop / status (black box)", () => {
     const failedCli = (...args: Array<string>) =>
       runCli([process.execPath, "src/main.ts"], args, appServerRoot, failedEnv)
     const stateDir = join(failedEnv.XDG_STATE_HOME, "atc")
+    const failedPidFile = join(stateDir, "atc.pid")
     // A directory at the pidfile path makes the post-spawn write fail without
     // making the state directory unavailable to the startup stderr capture.
-    mkdirSync(join(stateDir, "atc.pid"), { recursive: true })
+    mkdirSync(failedPidFile, { recursive: true })
     const port = await freePort()
 
     const started = await failedCli("start", "--port", String(port))
     expect(started.exitCode).not.toBe(0)
+    expect(started.stderr).toContain(
+      `atc start: BadResource: FileSystem.writeFile (${failedPidFile})`,
+    )
     await expect(fetch(`http://127.0.0.1:${port}/api/v1/health`)).rejects.toThrow()
     expect(readdirSync(stateDir).filter((name) => name.startsWith(".start-"))).toEqual([])
   }, 30_000)

--- a/app-server/test/fixtures/fake-tailscale.ts
+++ b/app-server/test/fixtures/fake-tailscale.ts
@@ -13,6 +13,10 @@ if (stateDir === undefined) {
   console.error("fake-tailscale: FAKE_TAILSCALE_STATE is not set")
   process.exit(2)
 }
+if (process.env["TAILSCALE_BE_CLI"] !== "1") {
+  console.error("fake-tailscale: TAILSCALE_BE_CLI is not set to 1")
+  process.exit(2)
+}
 fs.mkdirSync(stateDir, { recursive: true })
 
 const setting = (name: string, fallback: string): string => {

--- a/app-server/test/platform/tailscale.test.ts
+++ b/app-server/test/platform/tailscale.test.ts
@@ -15,6 +15,17 @@ const layerFor = (executable: string, port = 8443) =>
   )
 
 describe("Tailscale supervisor", () => {
+  it("falls back to the documented macOS app CLI only for the default executable", () => {
+    assert.deepStrictEqual(Tailscale.executableCandidates("tailscale", "darwin"), [
+      "tailscale",
+      "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+    ])
+    assert.deepStrictEqual(Tailscale.executableCandidates("tailscale", "linux"), ["tailscale"])
+    assert.deepStrictEqual(Tailscale.executableCandidates("custom-tailscale", "darwin"), [
+      "custom-tailscale",
+    ])
+  })
+
   it.live("verifies a healthy foreground Serve child and reports its URL", () => {
     const sandbox = makeFakeTailscaleSandbox()
     return Effect.gen(function* () {


### PR DESCRIPTION
## Summary

- discover the documented Tailscale app-bundled CLI on macOS when `tailscale` is not on `PATH`
- force scripted macOS invocations into CLI mode with `TAILSCALE_BE_CLI=1`
- capture detached server startup stderr and surface actionable boot failures immediately
- clean up temporary startup diagnostics and PID state on both success and failure
- add unit and black-box regression coverage

## Root cause

ATC only resolved a bare `tailscale` executable through `PATH`, while macOS App Store installations expose the CLI at `/Applications/Tailscale.app/Contents/MacOS/Tailscale`. The shared macOS app/CLI executable also infers its mode from shell environment variables unless callers explicitly force CLI mode.

Separately, `atc start` launched its detached `atc serve` child with ignored stderr. When that child failed during layer construction, the parent could observe only an unhealthy port, waited for the full health deadline, and reported a generic timeout pointing to a log that did not contain the boot error.

## Impact

macOS users can use Tailscale exposure without separately installing a PATH launcher. Failed background starts now return the child’s specific one-line diagnostic and clean up promptly instead of waiting 15 seconds.

Explicit executable overrides remain authoritative, and Linux continues to use normal PATH resolution.

## Validation

- `mise run -C app-server check`
- 407 tests passed, 10 skipped
- lint, strict typecheck, formatting, OpenAPI drift, admin asset, and Svelte checks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved startup diagnostics for background servers by reporting actionable boot errors instead of generic health-check timeouts.
  - Added macOS support for discovering the bundled Tailscale application executable.
  - Improved validation and error reporting when Tailscale cannot be found.

- **Bug Fixes**
  - Ensured temporary diagnostic files are cleaned up after startup succeeds or fails.
  - Improved reliability when launching detached server processes.
  - Improved cleanup of failed servers and stale pidfiles.
  - Reduced transient errors while detecting newly started processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->