### PR TITLE
Thread runtime vocabulary and adapter seam extensions (ATC-198)

### DIFF
--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -2149,6 +2149,1168 @@
         ],
         "additionalProperties": false,
         "description": "Thin invalidation event: names what changed, never carries resource state. Clients coalesce events and refetch through the corresponding GETs, which stay the single source of truth."
+      },
+      "ThreadItemUserMessage": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "userMessage"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "Item id, unique within the thread."
+          },
+          "turnId": {
+            "type": "string",
+            "description": "The turn this item belongs to."
+          },
+          "parentItemId": {
+            "type": "string",
+            "description": "The enclosing item when this work happened inside a subagent or nested tool; absent at top level."
+          },
+          "providerMetadata": {},
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "turnId",
+          "text"
+        ],
+        "additionalProperties": false,
+        "description": "A user prompt (text only)."
+      },
+      "ThreadItemAssistantText": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "assistantText"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "Item id, unique within the thread."
+          },
+          "turnId": {
+            "type": "string",
+            "description": "The turn this item belongs to."
+          },
+          "parentItemId": {
+            "type": "string",
+            "description": "The enclosing item when this work happened inside a subagent or nested tool; absent at top level."
+          },
+          "providerMetadata": {},
+          "text": {
+            "type": "string"
+          },
+          "complete": {
+            "type": "boolean",
+            "description": "False while the text is still streaming (text.delta events extend it)."
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "turnId",
+          "text",
+          "complete"
+        ],
+        "additionalProperties": false,
+        "description": "Assistant message text."
+      },
+      "ThreadItemReasoning": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "reasoning"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "Item id, unique within the thread."
+          },
+          "turnId": {
+            "type": "string",
+            "description": "The turn this item belongs to."
+          },
+          "parentItemId": {
+            "type": "string",
+            "description": "The enclosing item when this work happened inside a subagent or nested tool; absent at top level."
+          },
+          "providerMetadata": {},
+          "text": {
+            "type": "string"
+          },
+          "complete": {
+            "type": "boolean",
+            "description": "False while the text is still streaming (text.delta events extend it)."
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "turnId",
+          "text",
+          "complete"
+        ],
+        "additionalProperties": false,
+        "description": "Model reasoning (summary) text."
+      },
+      "ToolStatus": {
+        "type": "string",
+        "enum": [
+          "pending",
+          "running",
+          "completed",
+          "error"
+        ],
+        "description": "Lifecycle of a tool item: pending (not executing yet — typically awaiting approval), running, completed, or error."
+      },
+      "ThreadItemCommand": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "command"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "Item id, unique within the thread."
+          },
+          "turnId": {
+            "type": "string",
+            "description": "The turn this item belongs to."
+          },
+          "parentItemId": {
+            "type": "string",
+            "description": "The enclosing item when this work happened inside a subagent or nested tool; absent at top level."
+          },
+          "providerMetadata": {},
+          "title": {
+            "type": "string",
+            "description": "Adapter-rendered one-liner for list rows (\"bun test\", \"Edit threads.ts\")."
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolStatus"
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable failure; present iff status is error (a declined approval is \"declined\")."
+          },
+          "command": {
+            "type": "string"
+          },
+          "cwd": {
+            "type": "string"
+          },
+          "output": {
+            "type": "string",
+            "description": "Aggregated stdout/stderr."
+          },
+          "exitCode": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "turnId",
+          "title",
+          "status",
+          "command"
+        ],
+        "additionalProperties": false,
+        "description": "A shell command the agent ran."
+      },
+      "FileChange": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Path of the changed file."
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "add",
+              "update",
+              "delete"
+            ]
+          },
+          "diff": {
+            "type": "string",
+            "description": "Unified diff, when the provider supplies one."
+          }
+        },
+        "required": [
+          "path",
+          "kind"
+        ],
+        "additionalProperties": false,
+        "description": "One file touched by a change."
+      },
+      "ThreadItemFileChange": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "fileChange"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "Item id, unique within the thread."
+          },
+          "turnId": {
+            "type": "string",
+            "description": "The turn this item belongs to."
+          },
+          "parentItemId": {
+            "type": "string",
+            "description": "The enclosing item when this work happened inside a subagent or nested tool; absent at top level."
+          },
+          "providerMetadata": {},
+          "title": {
+            "type": "string",
+            "description": "Adapter-rendered one-liner for list rows (\"bun test\", \"Edit threads.ts\")."
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolStatus"
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable failure; present iff status is error (a declined approval is \"declined\")."
+          },
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileChange"
+            }
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "turnId",
+          "title",
+          "status",
+          "changes"
+        ],
+        "additionalProperties": false,
+        "description": "Files the agent changed."
+      },
+      "ThreadItemMcpCall": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "mcpCall"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "Item id, unique within the thread."
+          },
+          "turnId": {
+            "type": "string",
+            "description": "The turn this item belongs to."
+          },
+          "parentItemId": {
+            "type": "string",
+            "description": "The enclosing item when this work happened inside a subagent or nested tool; absent at top level."
+          },
+          "providerMetadata": {},
+          "title": {
+            "type": "string",
+            "description": "Adapter-rendered one-liner for list rows (\"bun test\", \"Edit threads.ts\")."
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolStatus"
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable failure; present iff status is error (a declined approval is \"declined\")."
+          },
+          "server": {
+            "type": "string"
+          },
+          "tool": {
+            "type": "string"
+          },
+          "arguments": {},
+          "result": {}
+        },
+        "required": [
+          "type",
+          "id",
+          "turnId",
+          "title",
+          "status",
+          "server",
+          "tool",
+          "arguments"
+        ],
+        "additionalProperties": false,
+        "description": "An MCP tool call."
+      },
+      "ThreadItemToolCall": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "toolCall"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "Item id, unique within the thread."
+          },
+          "turnId": {
+            "type": "string",
+            "description": "The turn this item belongs to."
+          },
+          "parentItemId": {
+            "type": "string",
+            "description": "The enclosing item when this work happened inside a subagent or nested tool; absent at top level."
+          },
+          "providerMetadata": {},
+          "title": {
+            "type": "string",
+            "description": "Adapter-rendered one-liner for list rows (\"bun test\", \"Edit threads.ts\")."
+          },
+          "status": {
+            "$ref": "#/components/schemas/ToolStatus"
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable failure; present iff status is error (a declined approval is \"declined\")."
+          },
+          "name": {
+            "type": "string"
+          },
+          "input": {},
+          "output": {}
+        },
+        "required": [
+          "type",
+          "id",
+          "turnId",
+          "title",
+          "status",
+          "name",
+          "input"
+        ],
+        "additionalProperties": false,
+        "description": "Any other tool call (file reads, searches, subagents, web fetches, …)."
+      },
+      "ThreadItemCompaction": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "compaction"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "Item id, unique within the thread."
+          },
+          "turnId": {
+            "type": "string",
+            "description": "The turn this item belongs to."
+          },
+          "parentItemId": {
+            "type": "string",
+            "description": "The enclosing item when this work happened inside a subagent or nested tool; absent at top level."
+          },
+          "providerMetadata": {}
+        },
+        "required": [
+          "type",
+          "id",
+          "turnId"
+        ],
+        "additionalProperties": false,
+        "description": "Marker: the provider compacted the conversation context here."
+      },
+      "ThreadItem": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ThreadItemUserMessage"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadItemAssistantText"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadItemReasoning"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadItemCommand"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadItemFileChange"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadItemMcpCall"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadItemToolCall"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadItemCompaction"
+          }
+        ],
+        "description": "One normalized transcript item, discriminated by `type`.",
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "userMessage": "#/components/schemas/ThreadItemUserMessage",
+            "assistantText": "#/components/schemas/ThreadItemAssistantText",
+            "reasoning": "#/components/schemas/ThreadItemReasoning",
+            "command": "#/components/schemas/ThreadItemCommand",
+            "fileChange": "#/components/schemas/ThreadItemFileChange",
+            "mcpCall": "#/components/schemas/ThreadItemMcpCall",
+            "toolCall": "#/components/schemas/ThreadItemToolCall",
+            "compaction": "#/components/schemas/ThreadItemCompaction"
+          }
+        }
+      },
+      "ThreadEventItemStarted": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "item.started"
+            ]
+          },
+          "seq": {
+            "type": "integer",
+            "description": "Position of this durable change."
+          },
+          "item": {
+            "$ref": "#/components/schemas/ThreadItem"
+          }
+        },
+        "required": [
+          "type",
+          "seq",
+          "item"
+        ],
+        "additionalProperties": false
+      },
+      "ThreadEventItemUpdated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "item.updated"
+            ]
+          },
+          "seq": {
+            "type": "integer",
+            "description": "Position of this durable change."
+          },
+          "item": {
+            "$ref": "#/components/schemas/ThreadItem"
+          }
+        },
+        "required": [
+          "type",
+          "seq",
+          "item"
+        ],
+        "additionalProperties": false
+      },
+      "ThreadEventItemCompleted": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "item.completed"
+            ]
+          },
+          "seq": {
+            "type": "integer",
+            "description": "Position of this durable change."
+          },
+          "item": {
+            "$ref": "#/components/schemas/ThreadItem"
+          }
+        },
+        "required": [
+          "type",
+          "seq",
+          "item"
+        ],
+        "additionalProperties": false
+      },
+      "ThreadTurnStatus": {
+        "type": "string",
+        "enum": [
+          "running",
+          "completed",
+          "interrupted",
+          "failed"
+        ],
+        "description": "Lifecycle of one turn."
+      },
+      "ThreadTurn": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Provider turn id (Codex) or adapter-derived (Claude); unique within the thread."
+          },
+          "status": {
+            "$ref": "#/components/schemas/ThreadTurnStatus"
+          },
+          "error": {
+            "type": "string",
+            "description": "Present iff failed."
+          },
+          "promptId": {
+            "type": "string",
+            "description": "The queued prompt this turn ran, when ATC started it."
+          },
+          "startedAt": {
+            "type": "string",
+            "description": "Turn start; history re-reads may lack it.",
+            "format": "date-time"
+          },
+          "endedAt": {
+            "type": "string",
+            "description": "Turn end; absent while running.",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "status"
+        ],
+        "additionalProperties": false,
+        "description": "One turn of the conversation."
+      },
+      "ThreadEventTurnStarted": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "turn.started"
+            ]
+          },
+          "seq": {
+            "type": "integer",
+            "description": "Position of this durable change."
+          },
+          "turn": {
+            "$ref": "#/components/schemas/ThreadTurn"
+          }
+        },
+        "required": [
+          "type",
+          "seq",
+          "turn"
+        ],
+        "additionalProperties": false
+      },
+      "ThreadEventTurnCompleted": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "turn.completed"
+            ]
+          },
+          "seq": {
+            "type": "integer",
+            "description": "Position of this durable change."
+          },
+          "turn": {
+            "$ref": "#/components/schemas/ThreadTurn"
+          }
+        },
+        "required": [
+          "type",
+          "seq",
+          "turn"
+        ],
+        "additionalProperties": false
+      },
+      "ThreadEventTextDelta": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "text.delta"
+            ]
+          },
+          "itemId": {
+            "type": "string"
+          },
+          "delta": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "itemId",
+          "delta"
+        ],
+        "additionalProperties": false,
+        "description": "Live-only, never replayed: appends to a streaming assistantText or reasoning item."
+      },
+      "QuestionOption": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "label",
+          "description"
+        ],
+        "additionalProperties": false
+      },
+      "Question": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Question id, the key of the answer."
+          },
+          "header": {
+            "type": "string"
+          },
+          "question": {
+            "type": "string"
+          },
+          "options": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QuestionOption"
+            }
+          },
+          "multiSelect": {
+            "type": "boolean"
+          },
+          "freeform": {
+            "type": "boolean",
+            "description": "A typed answer that is not one of the options is accepted."
+          },
+          "secret": {
+            "type": "boolean",
+            "description": "The answer is sensitive (a credential): mask it while typing and never echo it."
+          }
+        },
+        "required": [
+          "id",
+          "header",
+          "question",
+          "options",
+          "multiSelect",
+          "freeform",
+          "secret"
+        ],
+        "additionalProperties": false,
+        "description": "One question the agent asked the user."
+      },
+      "ThreadRequestQuestion": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "question"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "Request id; answer it through the API."
+          },
+          "turnId": {
+            "type": "string"
+          },
+          "itemId": {
+            "type": "string",
+            "description": "The item awaiting this request, when known."
+          },
+          "openedAt": {
+            "type": "string",
+            "description": "When the provider opened the request.",
+            "format": "date-time"
+          },
+          "questions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Question"
+            }
+          }
+        },
+        "required": [
+          "kind",
+          "id",
+          "turnId",
+          "openedAt",
+          "questions"
+        ],
+        "additionalProperties": false,
+        "description": "The agent asked questions."
+      },
+      "ApprovalSubjectCommand": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "command"
+            ]
+          },
+          "command": {
+            "type": "string"
+          },
+          "cwd": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "command"
+        ],
+        "additionalProperties": false
+      },
+      "ApprovalSubjectFileChange": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "fileChange"
+            ]
+          },
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileChange"
+            }
+          }
+        },
+        "required": [
+          "type",
+          "changes"
+        ],
+        "additionalProperties": false
+      },
+      "ApprovalSubjectTool": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "tool"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "input": {}
+        },
+        "required": [
+          "type",
+          "name",
+          "input"
+        ],
+        "additionalProperties": false
+      },
+      "ApprovalSubject": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ApprovalSubjectCommand"
+          },
+          {
+            "$ref": "#/components/schemas/ApprovalSubjectFileChange"
+          },
+          {
+            "$ref": "#/components/schemas/ApprovalSubjectTool"
+          }
+        ],
+        "description": "What the agent is asking permission for, discriminated by `type`.",
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "command": "#/components/schemas/ApprovalSubjectCommand",
+            "fileChange": "#/components/schemas/ApprovalSubjectFileChange",
+            "tool": "#/components/schemas/ApprovalSubjectTool"
+          }
+        }
+      },
+      "ThreadRequestApproval": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "approval"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "Request id; answer it through the API."
+          },
+          "turnId": {
+            "type": "string"
+          },
+          "itemId": {
+            "type": "string",
+            "description": "The item awaiting this request, when known."
+          },
+          "openedAt": {
+            "type": "string",
+            "description": "When the provider opened the request.",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string",
+            "description": "One-line prompt to show the user."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Why approval is needed."
+          },
+          "subject": {
+            "$ref": "#/components/schemas/ApprovalSubject"
+          }
+        },
+        "required": [
+          "kind",
+          "id",
+          "turnId",
+          "openedAt",
+          "title",
+          "subject"
+        ],
+        "additionalProperties": false,
+        "description": "The agent asked for approval."
+      },
+      "ThreadRequest": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ThreadRequestQuestion"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadRequestApproval"
+          }
+        ],
+        "description": "A pending provider request parked until answered — live state, not a transcript item; discriminated by `kind`.",
+        "discriminator": {
+          "propertyName": "kind",
+          "mapping": {
+            "question": "#/components/schemas/ThreadRequestQuestion",
+            "approval": "#/components/schemas/ThreadRequestApproval"
+          }
+        }
+      },
+      "ThreadEventRequestOpened": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "request.opened"
+            ]
+          },
+          "request": {
+            "$ref": "#/components/schemas/ThreadRequest"
+          }
+        },
+        "required": [
+          "type",
+          "request"
+        ],
+        "additionalProperties": false,
+        "description": "Live-only."
+      },
+      "ThreadEventRequestClosed": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "request.closed"
+            ]
+          },
+          "requestId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "requestId"
+        ],
+        "additionalProperties": false,
+        "description": "Live-only."
+      },
+      "QueuedPrompt": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "prompt": {
+            "type": "string"
+          },
+          "queuedAt": {
+            "type": "string",
+            "description": "When the prompt was admitted.",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "prompt",
+          "queuedAt"
+        ],
+        "additionalProperties": false,
+        "description": "A prompt admitted while a turn was running; it runs at the next idle."
+      },
+      "QueuedPromptList": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/QueuedPrompt"
+        },
+        "description": "Prompts still waiting, oldest first."
+      },
+      "ThreadEventQueueUpdated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "queue.updated"
+            ]
+          },
+          "prompts": {
+            "$ref": "#/components/schemas/QueuedPromptList"
+          }
+        },
+        "required": [
+          "type",
+          "prompts"
+        ],
+        "additionalProperties": false,
+        "description": "Live-only: the full queue, every time it changes."
+      },
+      "ThreadEventSnapshotInvalidated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "snapshot.invalidated"
+            ]
+          },
+          "seq": {
+            "type": "integer",
+            "description": "Position of this durable change."
+          },
+          "snapshotVersion": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "type",
+          "seq",
+          "snapshotVersion"
+        ],
+        "additionalProperties": false,
+        "description": "A provider re-read replaced the copy: refetch the transcript and resubscribe after `seq`."
+      },
+      "ThreadEvent": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ThreadEventItemStarted"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadEventItemUpdated"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadEventItemCompleted"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadEventTurnStarted"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadEventTurnCompleted"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadEventTextDelta"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadEventRequestOpened"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadEventRequestClosed"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadEventQueueUpdated"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadEventSnapshotInvalidated"
+          }
+        ],
+        "description": "One per-thread stream event, discriminated by `type`. Durable events carry `seq` and replay on reconnect (after=seq); live-only events do not.",
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "item.started": "#/components/schemas/ThreadEventItemStarted",
+            "item.updated": "#/components/schemas/ThreadEventItemUpdated",
+            "item.completed": "#/components/schemas/ThreadEventItemCompleted",
+            "turn.started": "#/components/schemas/ThreadEventTurnStarted",
+            "turn.completed": "#/components/schemas/ThreadEventTurnCompleted",
+            "text.delta": "#/components/schemas/ThreadEventTextDelta",
+            "request.opened": "#/components/schemas/ThreadEventRequestOpened",
+            "request.closed": "#/components/schemas/ThreadEventRequestClosed",
+            "queue.updated": "#/components/schemas/ThreadEventQueueUpdated",
+            "snapshot.invalidated": "#/components/schemas/ThreadEventSnapshotInvalidated"
+          }
+        }
+      },
+      "ThreadTranscript": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ThreadItem"
+            },
+            "description": "Transcript order, oldest first."
+          },
+          "turns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ThreadTurn"
+            },
+            "description": "Every turn referenced by `items`."
+          },
+          "seq": {
+            "type": "integer",
+            "description": "The thread's change counter at the time of the read; subscribe with after=seq."
+          },
+          "snapshotVersion": {
+            "type": "integer",
+            "description": "Bumps whenever a provider re-read replaced the copy."
+          },
+          "hasMore": {
+            "type": "boolean",
+            "description": "Older items exist before the first one returned."
+          }
+        },
+        "required": [
+          "items",
+          "turns",
+          "seq",
+          "snapshotVersion",
+          "hasMore"
+        ],
+        "additionalProperties": false,
+        "description": "ATC's normalized copy of the provider conversation — a rebuildable projection, never the authority."
+      },
+      "ThreadRequestQuestionAnswer": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "question"
+            ]
+          },
+          "answers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "description": "Question id → chosen option labels (exactly one unless multiSelect), or one freeform string."
+          }
+        },
+        "required": [
+          "kind",
+          "answers"
+        ],
+        "additionalProperties": false
+      },
+      "ApprovalDecision": {
+        "type": "string",
+        "enum": [
+          "accept",
+          "acceptForSession",
+          "decline",
+          "cancel"
+        ],
+        "description": "cancel = decline and interrupt the turn."
+      },
+      "ThreadRequestApprovalAnswer": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "approval"
+            ]
+          },
+          "decision": {
+            "$ref": "#/components/schemas/ApprovalDecision"
+          }
+        },
+        "required": [
+          "kind",
+          "decision"
+        ],
+        "additionalProperties": false
+      },
+      "ThreadRequestAnswer": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ThreadRequestQuestionAnswer"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadRequestApprovalAnswer"
+          }
+        ],
+        "description": "The answer to a pending request; `kind` must match the request's.",
+        "discriminator": {
+          "propertyName": "kind",
+          "mapping": {
+            "question": "#/components/schemas/ThreadRequestQuestionAnswer",
+            "approval": "#/components/schemas/ThreadRequestApprovalAnswer"
+          }
+        }
       }
     },
     "securitySchemes": {

--- a/app-server/src/agents/agentAdapter.ts
+++ b/app-server/src/agents/agentAdapter.ts
@@ -1,7 +1,9 @@
 import { Cause, Duration, Effect, Queue, Schema, Semaphore, Stream } from "effect"
 import type { Scope } from "effect"
 import { existsSync, realpathSync } from "node:fs"
+import { basename } from "node:path"
 import type { AgentId } from "../api/contract.ts"
+import type * as Contract from "../api/contract.ts"
 import type { Subprocess } from "../platform/subprocess.ts"
 import { resolveExecutable } from "../platform/subprocess.ts"
 
@@ -19,9 +21,18 @@ import { resolveExecutable } from "../platform/subprocess.ts"
 //     writers; observation never opens a second writer.
 //   - Status is derived from structured provider events only — never from
 //     transcript or terminal-output parsing.
-//   - Responding to provider requests (approvals, questions) is native-mode
-//     work: adapters surface `requestOpened` and answer the provider
-//     conservatively (reject) so a turn can never hang on ATC.
+//   - Conversation content crosses the seam in the ONE contract vocabulary
+//     (ThreadItem / ThreadTurn / ThreadRequest, contract.ts — ATC-193):
+//     an adapter's job is provider wire shape → those types, full stop.
+//     There is no seam-private content vocabulary and no mapping layer
+//     above the adapters. Item ids are the provider's stable ids where it
+//     has them, otherwise adapter-derived, unique within a thread, and
+//     never minted above the seam.
+//   - Provider requests (approvals, questions) are surfaced as
+//     `requestOpened` and PARKED until `respond` answers them — no timeout,
+//     no auto-reject; the request dies with its turn (closed on
+//     turnCompleted) or its connection. Requests raised for a turn another
+//     writer started are never ours to answer.
 //
 // The fake adapter for tests lives in test/agents/fakeAgentAdapter.ts; per-provider
 // service tags live with their adapters (codexAdapter.ts, claudeAdapter.ts).
@@ -93,27 +104,59 @@ export const aggregateActivity = (
 
 export type AgentTurnOutcome = "completed" | "interrupted" | "failed"
 
+/** The contract vocabulary as the seam speaks it (see the header). */
+export type ThreadItem = typeof Contract.ThreadItem.Type
+export type ThreadTurn = typeof Contract.ThreadTurn.Type
+export type ThreadRequest = typeof Contract.ThreadRequest.Type
+export type ThreadRequestAnswer = typeof Contract.ThreadRequestAnswer.Type
+export type ApprovalSubject = typeof Contract.ApprovalSubject.Type
+export type FileChange = typeof Contract.FileChange.Type
+export type ToolStatus = typeof Contract.ToolStatus.Type
+
+/** One turn of provider history, as `readHistory` returns it. */
+export interface HistoryTurn {
+  readonly turn: ThreadTurn
+  readonly items: ReadonlyArray<ThreadItem>
+}
+
+/**
+ * The item lifecycle events shared by both feeds: `itemStarted` opens an
+ * item (a streaming text item arrives with `complete: false`), `itemUpdated`
+ * re-sends the whole item after a change (a tool flipping to pending, output
+ * landing), `itemCompleted` carries its final state. Every event carries the
+ * FULL item — consumers upsert by id and never patch.
+ */
+export type AgentItemEvent =
+  | { readonly type: "itemStarted"; readonly item: ThreadItem }
+  | { readonly type: "itemUpdated"; readonly item: ThreadItem }
+  | { readonly type: "itemCompleted"; readonly item: ThreadItem }
+
 /**
  * One entry of a TUI-driven session's observation feed (observeSession).
  * `userPrompt` is best-effort evidence of a user prompt submitted to the
  * session — adapters emit at least the session's first prompt when their
  * evidence source carries it (Claude: the UserPromptSubmit webhook; Codex:
  * a demand-driven thread/read of the session's preview), and consumers
- * must tolerate duplicates, later prompts, and absence.
+ * must tolerate duplicates, later prompts, and absence. Item events arrive
+ * only from a provider whose shared server fans conversation items out to
+ * passive observers (Codex); a hooks-fed observation (Claude) is
+ * activity-only and its turns reach ATC through `readHistory`.
  */
 export type AgentSessionEvent =
   | { readonly type: "activity"; readonly activity: AgentActivity }
   | { readonly type: "userPrompt"; readonly text: string }
-
-export type AgentRequestKind = "approval" | "question"
+  | AgentItemEvent
 
 /**
- * One entry of the normalized status feed. Turn and request ids are
- * adapter-scoped correlation ids — provider-native where the provider has
- * them (Codex), adapter-minted and process-local where it does not
- * (Claude); never persist them as durable identity. `turnStarted` always
- * precedes its `turnCompleted`. Raw provider events stay inside the
- * adapters (logged there for diagnostics, never re-parsed above the seam).
+ * One entry of the normalized writer feed. Turn ids are provider-native
+ * where the provider has them (Codex) and adapter-minted where it does not
+ * (Claude) — unique within the thread either way, since Threads persists
+ * them. `turnStarted` always precedes its `turnCompleted`; every item event
+ * of a turn falls between the two. `textDelta` is live-only: it extends the
+ * text of the `assistantText` / `reasoning` item whose `itemStarted` carried
+ * `complete: false`, and is never persisted or replayed. Raw provider events
+ * stay inside the adapters (logged there for diagnostics, never re-parsed
+ * above the seam).
  */
 export type AgentEvent =
   | { readonly type: "activity"; readonly activity: AgentActivity }
@@ -125,7 +168,9 @@ export type AgentEvent =
       /** Human-readable failure/interrupt detail, for diagnostics only. */
       readonly detail?: string
     }
-  | { readonly type: "requestOpened"; readonly requestId: string; readonly kind: AgentRequestKind }
+  | AgentItemEvent
+  | { readonly type: "textDelta"; readonly itemId: string; readonly delta: string }
+  | { readonly type: "requestOpened"; readonly request: ThreadRequest }
   | { readonly type: "requestClosed"; readonly requestId: string }
 
 /** Correlation handle for exactly one turn — interrupt targets this turn. */
@@ -210,6 +255,17 @@ export interface AgentConnection {
    */
   readonly interrupt: (
     turn: AgentTurn,
+  ) => Effect.Effect<void, AgentConflict | AgentUnavailable | AgentProtocolError>
+  /**
+   * Answer a parked provider request (Codex: reply on the JSON-RPC request;
+   * Claude: resolve the parked `canUseTool`). The answer's `kind` must
+   * match the request's. Success means the provider took the answer; the
+   * feed's `requestClosed` follows. An unknown, already-answered, or
+   * mismatched request is `AgentConflict`.
+   */
+  readonly respond: (
+    requestId: string,
+    answer: ThreadRequestAnswer,
   ) => Effect.Effect<void, AgentConflict | AgentUnavailable | AgentProtocolError>
 }
 
@@ -368,6 +424,22 @@ export interface AgentAdapter {
     readonly cwd: string
   }) => Effect.Effect<string | null>
   /**
+   * The provider's own record of the session's conversation, normalized:
+   * every turn with its items, oldest first. Codex reads `thread/resume`
+   * (side-effect free on a loaded thread; it also loads the thread, which
+   * the read path needs); Claude reads `getSessionMessages` and groups it
+   * into turns at each top-level user message. Never opens a writer, never
+   * starts a turn. Threads uses it to REPLACE its copy wholesale — item ids
+   * here need not match the ids the same turns carried live.
+   */
+  readonly readHistory: (options: {
+    readonly providerSessionId: string
+    readonly cwd: string
+  }) => Effect.Effect<
+    ReadonlyArray<HistoryTurn>,
+    AgentUnavailable | AgentResumeFailed | AgentProtocolError
+  >
+  /**
    * Demand-driven reconciliation: the provider's current word on the
    * session's activity, `unknown` when it offers no evidence. Never
    * guesses; failures are the retryable AgentUnavailable.
@@ -468,7 +540,49 @@ export const providerErrors = (provider: AgentProvider) => {
     staleTurn: (turnId: string) => conflict(`turn ${turnId} is not the active turn`),
     writerConnected: (providerSessionId: string) =>
       conflict(`a writer is already connected to ${providerSessionId}`),
+    unknownRequest: (requestId: string) => conflict(`request ${requestId} is not pending`),
+    answerKindMismatch: (requestId: string, expected: string) =>
+      conflict(`request ${requestId} expects a ${expected} answer`),
   }
+}
+
+/** The shared tool-status rule: a declined approval is an error, and every
+ * error carries a human-readable reason (`toolFields` in the contract). */
+export const toolOutcome = (
+  status: "pending" | "running" | "completed" | "declined",
+  failure: string | null,
+): { readonly status: ToolStatus; readonly error?: string } => {
+  if (status === "declined") return { status: "error", error: "declined" }
+  if (failure !== null) return { status: "error", error: failure }
+  return { status }
+}
+
+/** The shared fileChange title rule: one verb for the batch, the file name
+ * for a single change, a count beyond that. */
+export const fileChangeTitle = (changes: ReadonlyArray<FileChange>): string => {
+  const kinds = new Set(changes.map((change) => change.kind))
+  const verb =
+    kinds.size === 1 && kinds.has("add")
+      ? "Create"
+      : kinds.size === 1 && kinds.has("delete")
+        ? "Delete"
+        : "Edit"
+  if (changes.length === 1) return `${verb} ${basename(changes[0]!.path)}`
+  return `${verb} ${changes.length} files`
+}
+
+/**
+ * The pending ↔ running flip a parked approval performs on its tool item:
+ * the re-sent item, or null when there is nothing to change (not a tool
+ * item, already there, or past those states).
+ */
+export const withToolStatus = (
+  item: ThreadItem,
+  status: "pending" | "running",
+): ThreadItem | null => {
+  if (!("status" in item) || item.status === status) return null
+  if (item.status !== "pending" && item.status !== "running") return null
+  return { ...item, status }
 }
 
 /** Bound on one title one-shot (ATC-155); a hung child/query is cut here. */

--- a/app-server/src/agents/claudeAdapter.ts
+++ b/app-server/src/agents/claudeAdapter.ts
@@ -3,6 +3,8 @@ import type {
   HookCallbackMatcher,
   HookEvent,
   Options,
+  PermissionResult,
+  PermissionUpdate,
   SDKMessage,
   SDKUserMessage,
   SessionMessage,
@@ -31,6 +33,8 @@ import type {
   AgentProtocolError,
   AgentSessionEvent,
   AgentUnavailable,
+  ThreadItem,
+  ThreadRequest,
 } from "./agentAdapter.ts"
 import {
   AgentResumeFailed,
@@ -43,9 +47,11 @@ import {
   samePath,
   titleInstruction,
   withTitleTimeout,
+  withToolStatus,
 } from "./agentAdapter.ts"
 import * as path from "node:path"
 import * as ClaudeHooks from "./claudeHooks.ts"
+import * as ClaudeItems from "./claudeItems.ts"
 import { AppConfig } from "../platform/config.ts"
 import * as Subprocess from "../platform/subprocess.ts"
 
@@ -85,6 +91,20 @@ import * as Subprocess from "../platform/subprocess.ts"
 //     spawns the claude child itself (not via Subprocess) and the child
 //     env is built from process.env directly — the SDK owns that process,
 //     and the env must carry the user's credentials verbatim.
+//   - Conversation items (ATC-193): the query runs with
+//     includePartialMessages, so assistant text and thinking stream as
+//     content blocks — itemStarted at content_block_start (keyed by the API
+//     message id + block index), textDelta per delta, itemCompleted at
+//     content_block_stop; the SDK's per-block `assistant` messages are then
+//     used only for tool_use blocks (a message whose id never streamed still
+//     yields its text from them). tool_result user messages complete the
+//     tool items; the mapping itself is claudeItems.ts. The user's own prompt
+//     is emitted at startTurn (the SDK never echoes it): the one item this
+//     adapter keys itself, `${turnId}:prompt`.
+//   - canUseTool callbacks PARK (the promise stays pending) as
+//     ThreadRequests until `respond` resolves them; a turn's end or the
+//     session's close resolves any survivor with a deny so the SDK child
+//     never waits on a request nothing will answer.
 //   - One writer per session id, enforced here. Webhook hook activity is
 //     NOT bridged into these feeds: a TUI-driven session has no adapter
 //     connection by definition, and while ATC drives, the same vocabulary
@@ -129,6 +149,8 @@ const {
   turnStillActive,
   staleTurn,
   writerConnected,
+  unknownRequest,
+  answerKindMismatch,
 } = providerErrors("claude")
 
 /**
@@ -229,6 +251,22 @@ const transcriptLines = (messages: ReadonlyArray<SessionMessage>): Array<string>
 
 type GateError = AgentResumeFailed | AgentIdentityMismatch | AgentProtocolError
 
+/** A parked canUseTool: what the SDK asked, and how to answer it. */
+interface PendingRequest {
+  readonly request: ThreadRequest
+  readonly input: Record<string, unknown>
+  readonly suggestions: ReadonlyArray<PermissionUpdate>
+  readonly resolve: (result: PermissionResult) => void
+}
+
+/** One API message being streamed (per root/subagent lane): its id and the
+ * text/thinking blocks opened so far, by block index. */
+interface StreamingMessage {
+  readonly messageId: string
+  readonly parentItemId: string | null
+  readonly blocks: Map<number, ThreadItem>
+}
+
 interface LiveSession {
   /** The id resume promised (null for create — any id is acceptable). */
   readonly expectedSessionId: string | null
@@ -245,6 +283,17 @@ interface LiveSession {
   activity: AgentActivity
   activeTurn: string | null
   interruptRequested: boolean
+  /** The active turn's TOOL items by id (latest state): a tool_result or
+   * approval flip needs the item it completes. Text is never retained. */
+  readonly toolItems: Map<string, ThreadItem>
+  /** In-flight streamed messages by lane (parent_tool_use_id, "" = root). */
+  readonly streaming: Map<string, StreamingMessage>
+  /** API message ids whose text arrived through the stream — their
+   * `assistant` messages contribute tool_use blocks only. */
+  readonly streamedMessages: Set<string>
+  /** tool_use ids whose canUseTool landed before the tool_use block. */
+  readonly pendingTools: Set<string>
+  readonly pendingRequests: Map<string, PendingRequest>
   closed: boolean
   /** The session itself ended (terminal turn, transport, failed
    * verification) — as opposed to the caller closing its handle. */
@@ -264,7 +313,6 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
 
       /** Live sessions by verified (and, for resumes, expected) session id. */
       const sessions = new Map<string, LiveSession>()
-      let nextTurn = 1
 
       const emit = (session: LiveSession, event: AgentEvent): void =>
         emitAgentEvent(session.queue, event, protocolError)
@@ -281,8 +329,64 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
         }
       }
 
+      /** Publish an item on the feed; tool items are also retained. */
+      const emitItem = (
+        session: LiveSession,
+        type: "itemStarted" | "itemUpdated" | "itemCompleted",
+        item: ThreadItem,
+      ): void => {
+        if ("status" in item) session.toolItems.set(item.id, item)
+        emit(session, { type, item })
+      }
+
+      /** Flip a tool item pending ↔ running around its approval. */
+      const restatusItem = (
+        session: LiveSession,
+        itemId: string,
+        status: "pending" | "running",
+      ): void => {
+        const item = session.toolItems.get(itemId)
+        const updated = item === undefined ? null : withToolStatus(item, status)
+        if (updated !== null) emitItem(session, "itemUpdated", updated)
+      }
+
+      /** Answer every parked request with a deny and close it (turn end,
+       * session close): the SDK child must never wait on a request nothing
+       * will answer. */
+      const closePendingRequests = (session: LiveSession, reason: string): void => {
+        for (const [requestId, pending] of session.pendingRequests) {
+          pending.resolve({ behavior: "deny", message: reason })
+          emit(session, { type: "requestClosed", requestId })
+        }
+        session.pendingRequests.clear()
+        session.pendingTools.clear()
+      }
+
+      /** Complete every block still streaming (a lane replaced mid-block, or
+       * a turn cut short): a `complete: false` item must never outlive the
+       * evidence that could finish it. */
+      const flushStreaming = (session: LiveSession): void => {
+        for (const streaming of session.streaming.values()) {
+          for (const block of streaming.blocks.values()) {
+            if (block.type === "assistantText" || block.type === "reasoning") {
+              emitItem(session, "itemCompleted", { ...block, complete: true })
+            }
+          }
+        }
+        session.streaming.clear()
+      }
+
+      /** A turn ended: its parked requests and item bookkeeping go with it. */
+      const endTurnState = (session: LiveSession): void => {
+        closePendingRequests(session, "the turn ended")
+        flushStreaming(session)
+        session.toolItems.clear()
+        session.streamedMessages.clear()
+      }
+
       const closeSession = (session: LiveSession, failure?: AgentProtocolError): void => {
         if (session.closed) return
+        closePendingRequests(session, "the session closed")
         session.closed = true
         dropFromRegistry(session)
         if (failure !== undefined) {
@@ -302,8 +406,162 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
         closeSession(session, protocolError(error.message))
       }
 
+      const handleStreamEvent = (
+        session: LiveSession,
+        message: { readonly event: unknown; readonly parent_tool_use_id: string | null },
+      ): void => {
+        const turnId = session.activeTurn
+        if (turnId === null) return
+        const lane = message.parent_tool_use_id ?? ""
+        const event = message.event as {
+          readonly type?: unknown
+          readonly index?: unknown
+          readonly message?: { readonly id?: unknown }
+          readonly content_block?: { readonly type?: unknown }
+          readonly delta?: {
+            readonly type?: unknown
+            readonly text?: unknown
+            readonly thinking?: unknown
+          }
+        }
+        if (event.type === "message_start" && typeof event.message?.id === "string") {
+          // A lane replaced mid-block completes what it still had open.
+          const previous = session.streaming.get(lane)
+          if (previous !== undefined) {
+            for (const block of previous.blocks.values()) {
+              if (block.type === "assistantText" || block.type === "reasoning") {
+                emitItem(session, "itemCompleted", { ...block, complete: true })
+              }
+            }
+          }
+          session.streaming.set(lane, {
+            messageId: event.message.id,
+            parentItemId: message.parent_tool_use_id,
+            blocks: new Map(),
+          })
+          session.streamedMessages.add(event.message.id)
+          return
+        }
+        const streaming = session.streaming.get(lane)
+        if (streaming === undefined || typeof event.index !== "number") return
+        if (event.type === "content_block_start") {
+          const kind = event.content_block?.type
+          if (kind !== "text" && kind !== "thinking") return
+          const item = ClaudeItems.textItem(
+            `${streaming.messageId}:${event.index}`,
+            turnId,
+            kind,
+            "",
+            false,
+            streaming.parentItemId,
+          )
+          streaming.blocks.set(event.index, item)
+          emitItem(session, "itemStarted", item)
+          return
+        }
+        const block = streaming.blocks.get(event.index)
+        if (block === undefined || (block.type !== "assistantText" && block.type !== "reasoning")) {
+          return
+        }
+        if (event.type === "content_block_delta") {
+          const delta =
+            event.delta?.type === "text_delta" && typeof event.delta.text === "string"
+              ? event.delta.text
+              : event.delta?.type === "thinking_delta" && typeof event.delta.thinking === "string"
+                ? event.delta.thinking
+                : null
+          if (delta === null) return
+          streaming.blocks.set(event.index, { ...block, text: block.text + delta })
+          emit(session, { type: "textDelta", itemId: block.id, delta })
+          return
+        }
+        if (event.type === "content_block_stop") {
+          streaming.blocks.delete(event.index)
+          emitItem(session, "itemCompleted", { ...block, complete: true })
+        }
+      }
+
+      const handleAssistantMessage = (
+        session: LiveSession,
+        message: {
+          readonly uuid: string
+          readonly message: { readonly id?: unknown; readonly content?: unknown }
+          readonly parent_tool_use_id: string | null
+        },
+      ): void => {
+        const turnId = session.activeTurn
+        if (turnId === null) return
+        const streamed =
+          typeof message.message.id === "string" && session.streamedMessages.has(message.message.id)
+        ClaudeItems.contentBlocks(message.message.content).forEach((block, index) => {
+          if (block.type === "tool_use") {
+            const pending = session.pendingTools.delete(block.id)
+            emitItem(
+              session,
+              "itemStarted",
+              ClaudeItems.toolItem(
+                block,
+                turnId,
+                message.parent_tool_use_id,
+                pending ? "pending" : "running",
+              ),
+            )
+            return
+          }
+          if (streamed || block.type === "tool_result") return
+          // Already complete: one event, like a history item.
+          emitItem(
+            session,
+            "itemCompleted",
+            ClaudeItems.textItem(
+              `${message.uuid}:${index}`,
+              turnId,
+              block.type,
+              block.type === "text" ? block.text : block.thinking,
+              true,
+              message.parent_tool_use_id,
+            ),
+          )
+        })
+      }
+
+      const handleUserMessage = (
+        session: LiveSession,
+        message: {
+          readonly message: { readonly content?: unknown }
+          readonly tool_use_result?: unknown
+        },
+      ): void => {
+        for (const block of ClaudeItems.contentBlocks(message.message.content)) {
+          if (block.type !== "tool_result") continue
+          const item = session.toolItems.get(block.tool_use_id)
+          if (item === undefined) continue
+          emitItem(
+            session,
+            "itemCompleted",
+            ClaudeItems.completeToolItem(item, block, message.tool_use_result),
+          )
+        }
+      }
+
       const handleMessage = (session: LiveSession, message: SDKMessage): void => {
         if (session.closed) return
+        if (message.type === "stream_event") return handleStreamEvent(session, message)
+        if (message.type === "assistant") return handleAssistantMessage(session, message)
+        if (message.type === "user") return handleUserMessage(session, message)
+        if (message.type === "system" && message.subtype === "compact_boundary") {
+          const turnId = session.activeTurn
+          const uuid = (message as { uuid?: unknown }).uuid
+          if (turnId !== null && typeof uuid === "string") {
+            emitItem(session, "itemCompleted", {
+              type: "compaction",
+              id: uuid,
+              turnId,
+              providerMetadata: { claude: message.compact_metadata },
+            })
+          }
+          return
+        }
         if (message.type === "system" && message.subtype === "init") {
           if (
             session.expectedSessionId !== null &&
@@ -374,6 +632,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
           const turnId = session.activeTurn
           session.activeTurn = null
           session.interruptRequested = false
+          endTurnState(session)
           if (turnId !== null) {
             emit(
               session,
@@ -422,6 +681,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
               }
               const turnId = session.activeTurn
               session.activeTurn = null
+              endTurnState(session)
               if (turnId !== null) {
                 emit(session, {
                   type: "turnCompleted",
@@ -440,22 +700,36 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
 
       const makeCanUseTool =
         (session: LiveSession): CanUseTool =>
-        (toolName, _input, options) => {
-          // Activity is NOT touched here: requires_action state events carry
-          // that truthfully, and a synchronous needs_input/working round
-          // trip would clobber overlapping callbacks once responses become
-          // asynchronous (ATC-124).
-          if (!session.closed) {
-            const requestId = options.requestId
-            const kind = toolName === "AskUserQuestion" ? "question" : "approval"
-            emit(session, { type: "requestOpened", requestId, kind })
-            emit(session, { type: "requestClosed", requestId })
-          }
-          return Promise.resolve({
-            behavior: "deny",
-            message: "atc does not answer provider requests yet (native-mode work)",
+        (toolName, input, options) =>
+          new Promise<PermissionResult>((resolve) => {
+            // Activity is NOT touched here: requires_action state events
+            // carry that truthfully. The request parks until `respond`
+            // resolves it, or the turn/session ends (closePendingRequests).
+            if (session.closed || session.activeTurn === null) {
+              resolve({ behavior: "deny", message: "no turn is accepting requests" })
+              return
+            }
+            const request = ClaudeItems.mapRequest(
+              toolName,
+              input,
+              options,
+              session.activeTurn,
+              new Date().toISOString(),
+            )
+            session.pendingRequests.set(options.requestId, {
+              request,
+              input,
+              suggestions: options.suggestions ?? [],
+              resolve,
+            })
+            // The tool_use block may land before or after its permission ask.
+            if (session.toolItems.has(options.toolUseID)) {
+              restatusItem(session, options.toolUseID, "pending")
+            } else {
+              session.pendingTools.add(options.toolUseID)
+            }
+            emit(session, { type: "requestOpened", request })
           })
-        }
 
       const makeHooks = (
         session: LiveSession,
@@ -596,6 +870,11 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
             activity: "unknown",
             activeTurn: null,
             interruptRequested: false,
+            toolItems: new Map(),
+            streaming: new Map(),
+            streamedMessages: new Set(),
+            pendingTools: new Set(),
+            pendingRequests: new Map(),
             closed: false,
             over: false,
           }
@@ -631,6 +910,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
               settingSources: [],
               permissionMode: "default",
               persistSession: true,
+              includePartialMessages: true,
               canUseTool: makeCanUseTool(session),
               hooks: makeHooks(session),
             },
@@ -654,6 +934,44 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
                 closeSession(session, error)
                 return error
               }).pipe(Effect.flatMap(Effect.fail)),
+          }),
+        )
+
+      /**
+       * Open a turn on the feed: turnStarted, then the user's prompt as the
+       * turn's first item (the SDK never echoes it), then the input itself.
+       * Turn ids are uuids — Threads persists them, so a process-local
+       * counter would collide with an earlier process's turns.
+       */
+      const beginTurn = (session: LiveSession, text: string): string => {
+        const turnId = `claude-turn-${crypto.randomUUID()}`
+        session.activeTurn = turnId
+        // Emitted before anything can await: the consume fiber may deliver
+        // this turn's result on the very next microtask, and turnStarted
+        // must precede turnCompleted on the feed.
+        emit(session, { type: "turnStarted", turnId })
+        emitItem(session, "itemCompleted", {
+          type: "userMessage",
+          id: `${turnId}:prompt`,
+          turnId,
+          text,
+        })
+        session.pushInput(text)
+        return turnId
+      }
+
+      /** The bounded getSessionMessages read behind both transcript readers. */
+      const readTranscript = (
+        providerSessionId: string,
+        cwd: string,
+      ): Effect.Effect<ReadonlyArray<SessionMessage>, string> =>
+        Effect.tryPromise({
+          try: () => sessionMessagesFn(providerSessionId, { dir: cwd }),
+          catch: (error) => (error instanceof Error ? error.message : String(error)),
+        }).pipe(
+          Effect.timeoutOrElse({
+            duration: "10 seconds",
+            orElse: () => Effect.fail("the transcript read timed out"),
           }),
         )
 
@@ -682,13 +1000,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
               if (session.activeTurn !== null) {
                 return yield* Effect.fail(turnStillActive(session.activeTurn))
               }
-              const turnId = `claude-turn-${nextTurn++}`
-              session.activeTurn = turnId
-              // Emitted before anything can await: the consume fiber may
-              // deliver this turn's result on the very next microtask, and
-              // turnStarted must precede turnCompleted on the feed.
-              emit(session, { type: "turnStarted", turnId })
-              session.pushInput(text)
+              const turnId = beginTurn(session, text)
               if (session.sessionId === null) {
                 // First turn after a resume: this is where the deferred
                 // identity verification lands (see the module header).
@@ -722,6 +1034,36 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
                 ),
               )
             }),
+          respond: (requestId, answer) =>
+            Effect.gen(function* () {
+              yield* requireOpen
+              const pending = session.pendingRequests.get(requestId)
+              if (pending === undefined) return yield* Effect.fail(unknownRequest(requestId))
+              if (pending.request.kind !== answer.kind) {
+                return yield* Effect.fail(answerKindMismatch(requestId, pending.request.kind))
+              }
+              session.pendingRequests.delete(requestId)
+              // A cancel is a deny that also interrupts; the SDK carries the
+              // interrupt, and the outcome must read as interrupted.
+              if (answer.kind === "approval" && answer.decision === "cancel") {
+                session.interruptRequested = true
+              }
+              pending.resolve(
+                ClaudeItems.permissionResult(
+                  pending.request,
+                  answer,
+                  pending.input,
+                  pending.suggestions,
+                ),
+              )
+              if (pending.request.itemId !== undefined) {
+                // Answered before its tool_use block landed: the block must
+                // not start pending against a request that is already gone.
+                session.pendingTools.delete(pending.request.itemId)
+                restatusItem(session, pending.request.itemId, "running")
+              }
+              emit(session, { type: "requestClosed", requestId })
+            }),
         }
       }
 
@@ -731,10 +1073,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
         createSession: (options) =>
           Effect.gen(function* () {
             const session = yield* openSession({ cwd: options.cwd })
-            const turnId = `claude-turn-${nextTurn++}`
-            session.activeTurn = turnId
-            emit(session, { type: "turnStarted", turnId })
-            session.pushInput(options.input)
+            const turnId = beginTurn(session, options.input)
             // A create has no expected id, so AgentResumeFailed cannot
             // happen here — same rule as the codex adapter.
             yield* awaitVerified(session).pipe(
@@ -904,14 +1243,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
         // contract: any read failure — a hung read included, hence the
         // bound — is debug-logged and reads as "nothing usable".
         collectTitleContext: (options) =>
-          Effect.tryPromise({
-            try: () => sessionMessagesFn(options.providerSessionId, { dir: options.cwd }),
-            catch: (error) => (error instanceof Error ? error.message : String(error)),
-          }).pipe(
-            Effect.timeoutOrElse({
-              duration: "10 seconds",
-              orElse: () => Effect.fail("the transcript read timed out"),
-            }),
+          readTranscript(options.providerSessionId, options.cwd).pipe(
             Effect.map(transcriptLines),
             Effect.map(buildTitleContext),
             Effect.catch((reason) =>
@@ -923,6 +1255,14 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
                 Effect.as(null),
               ),
             ),
+          ),
+        // The same read, normalized (claudeItems.ts). An unknown session
+        // reads as empty — the SDK cannot tell "no such session" from "no
+        // messages yet"; only a failing read is an error.
+        readHistory: (options) =>
+          readTranscript(options.providerSessionId, options.cwd).pipe(
+            Effect.map(ClaudeItems.mapHistory),
+            Effect.mapError((reason) => protocolError(`the transcript read failed: ${reason}`)),
           ),
         // Claude offers no cheap truthful liveness query for a session it
         // is not driving; the domain's linked-terminal liveness carries

--- a/app-server/src/agents/claudeItems.ts
+++ b/app-server/src/agents/claudeItems.ts
@@ -1,0 +1,474 @@
+import type {
+  PermissionResult,
+  PermissionUpdate,
+  SessionMessage,
+} from "@anthropic-ai/claude-agent-sdk"
+import { Option, Schema } from "effect"
+import * as path from "node:path"
+import type {
+  ApprovalSubject,
+  FileChange,
+  HistoryTurn,
+  ThreadItem,
+  ThreadRequest,
+  ThreadRequestAnswer,
+} from "./agentAdapter.ts"
+import { fileChangeTitle, toolOutcome } from "./agentAdapter.ts"
+
+// Claude Agent SDK shapes → the contract vocabulary (ATC-193): pure functions
+// over assistant/user message content blocks, `canUseTool` callbacks, and
+// `getSessionMessages` history. No SDK calls, no state — claudeAdapter.ts
+// owns those. Invariants:
+//
+//   - Tool items are keyed by the tool_use id (stable live and in history);
+//     text and thinking blocks are keyed `${messageKey}:${blockIndex}` where
+//     the key is the API message id while streaming and the SDK message
+//     uuid otherwise. History ids therefore differ from live ids for text —
+//     accepted: Threads replaces its copy wholesale on a re-read.
+//   - Tool names decide the item shape: Bash → command; Edit / Write /
+//     MultiEdit / NotebookEdit → fileChange; `mcp__<server>__<tool>` →
+//     mcpCall; everything else → toolCall. A tool_result completes its item;
+//     `tool_use_result` (live only — history drops it) supplies the Write
+//     create-vs-update kind and the structured patch rendered as a diff.
+//   - History is grouped into turns at each top-level user message that
+//     carries text (tool_result-only and synthetic messages never open a
+//     turn); the turn id is that message's uuid. A turn whose tool_use never
+//     got a result reads as interrupted. getSessionMessages exposes system
+//     entries without their subtype (probed 2026-08-17, SDK 0.3.220), so
+//     compaction markers come only from the live compact_boundary message.
+//   - AskUserQuestion is a question request whose answers go back through
+//     `updatedInput.answers` keyed by question text (what the tool expects);
+//     every other canUseTool is an approval answered allow/deny, with
+//     `acceptForSession` returning the SDK's own session-scoped suggestions.
+
+const FILE_TOOLS = new Set(["Edit", "Write", "MultiEdit", "NotebookEdit"])
+const MCP_PREFIX = /^mcp__([^_]+(?:_[^_]+)*)__(.+)$/
+
+const TextBlock = Schema.Struct({ type: Schema.Literal("text"), text: Schema.String })
+const ThinkingBlock = Schema.Struct({ type: Schema.Literal("thinking"), thinking: Schema.String })
+const ToolUseBlock = Schema.Struct({
+  type: Schema.Literal("tool_use"),
+  id: Schema.String,
+  name: Schema.String,
+  input: Schema.Unknown,
+})
+const ToolResultBlock = Schema.Struct({
+  type: Schema.Literal("tool_result"),
+  tool_use_id: Schema.String,
+  content: Schema.optional(Schema.Unknown),
+  is_error: Schema.optional(Schema.Boolean),
+})
+const ContentBlock = Schema.Union([TextBlock, ThinkingBlock, ToolUseBlock, ToolResultBlock])
+type ContentBlock = typeof ContentBlock.Type
+const decodeBlock = Schema.decodeUnknownOption(ContentBlock)
+
+/** The recognized blocks of a message `content` (string content is one text block). */
+export const contentBlocks = (content: unknown): Array<ContentBlock> => {
+  if (typeof content === "string") return content === "" ? [] : [{ type: "text", text: content }]
+  if (!Array.isArray(content)) return []
+  return content.flatMap((raw) => Option.toArray(decodeBlock(raw)))
+}
+
+/** Plain text of a tool_result `content` (string, or text blocks joined). */
+const resultText = (content: unknown): string => {
+  if (typeof content === "string") return content
+  if (!Array.isArray(content)) return ""
+  return content
+    .flatMap((block) => {
+      const candidate = block as { type?: unknown; text?: unknown }
+      return candidate.type === "text" && typeof candidate.text === "string" ? [candidate.text] : []
+    })
+    .join("\n")
+}
+
+const record = (value: unknown): Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+
+const stringField = (input: Record<string, unknown>, key: string): string | undefined => {
+  const value = input[key]
+  return typeof value === "string" ? value : undefined
+}
+
+/** A one-line title for any tool call, from the fields users recognize. */
+export const toolTitle = (name: string, input: Record<string, unknown>): string => {
+  const file = stringField(input, "file_path") ?? stringField(input, "notebook_path")
+  switch (name) {
+    case "Bash":
+      return (stringField(input, "command") ?? "").split("\n")[0]?.trim() || "Bash"
+    case "Read":
+    case "Edit":
+    case "Write":
+    case "MultiEdit":
+    case "NotebookEdit":
+      return file === undefined ? name : `${name} ${path.basename(file)}`
+    case "Glob":
+    case "Grep":
+      return stringField(input, "pattern") === undefined ? name : `${name} ${input["pattern"]}`
+    case "Task":
+    case "Agent":
+      return stringField(input, "description") ?? name
+    case "WebFetch":
+    case "WebSearch":
+      return stringField(input, "url") ?? stringField(input, "query") ?? name
+    default: {
+      const mcp = MCP_PREFIX.exec(name)
+      return mcp === null ? name : `${mcp[1]} · ${mcp[2]}`
+    }
+  }
+}
+
+const fileChangesFor = (input: Record<string, unknown>): Array<FileChange> => {
+  const file = stringField(input, "file_path") ?? stringField(input, "notebook_path")
+  // Write overwrites as readily as it creates; the tool result says which
+  // (`type: "create"`), so until it lands every change is an "update".
+  return file === undefined ? [] : [{ path: file, kind: "update" }]
+}
+
+/**
+ * The item a tool_use block opens. `pending` marks a call whose permission
+ * request is already parked (canUseTool can land before the block).
+ */
+export const toolItem = (
+  block: { readonly id: string; readonly name: string; readonly input: unknown },
+  turnId: string,
+  parentItemId: string | null,
+  status: "pending" | "running",
+): ThreadItem => {
+  const input = record(block.input)
+  const common = {
+    id: block.id,
+    turnId,
+    ...(parentItemId !== null ? { parentItemId } : {}),
+    title: toolTitle(block.name, input),
+    ...toolOutcome(status, null),
+  }
+  if (block.name === "Bash") {
+    const cwd = stringField(input, "cwd")
+    return {
+      type: "command",
+      ...common,
+      command: stringField(input, "command") ?? "",
+      ...(cwd !== undefined ? { cwd } : {}),
+    }
+  }
+  if (FILE_TOOLS.has(block.name)) {
+    const changes = fileChangesFor(input)
+    return {
+      type: "fileChange",
+      ...common,
+      title: changes.length === 0 ? common.title : fileChangeTitle(changes),
+      changes,
+    }
+  }
+  const mcp = MCP_PREFIX.exec(block.name)
+  if (mcp !== null) {
+    return { type: "mcpCall", ...common, server: mcp[1]!, tool: mcp[2]!, arguments: block.input }
+  }
+  return { type: "toolCall", ...common, name: block.name, input: block.input }
+}
+
+// A structured patch is the `diff` library's hunk list; rendered back to
+// unified-diff hunks so clients get one diff format from both providers.
+const StructuredPatch = Schema.Array(
+  Schema.Struct({
+    oldStart: Schema.Number,
+    oldLines: Schema.Number,
+    newStart: Schema.Number,
+    newLines: Schema.Number,
+    lines: Schema.Array(Schema.String),
+  }),
+)
+const decodeStructuredPatch = Schema.decodeUnknownOption(StructuredPatch)
+
+const renderPatch = (patch: typeof StructuredPatch.Type): string =>
+  patch
+    .map(
+      (hunk) =>
+        `@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@\n` +
+        hunk.lines.join("\n"),
+    )
+    .join("\n")
+
+/**
+ * Complete a tool item from its tool_result block plus the SDK's structured
+ * `tool_use_result` (absent in history). Unknown item shapes pass through
+ * with only their status updated.
+ */
+export const completeToolItem = (
+  item: ThreadItem,
+  result: { readonly content?: unknown; readonly is_error?: boolean | undefined },
+  toolUseResult: unknown,
+): ThreadItem => {
+  const text = resultText(result.content)
+  const failed = result.is_error === true
+  const lifecycle = toolOutcome("completed", failed ? text || "tool failed" : null)
+  switch (item.type) {
+    case "command":
+      return { ...item, ...lifecycle, ...(text !== "" ? { output: text } : {}) }
+    case "fileChange": {
+      const structured = record(toolUseResult)
+      const patch = decodeStructuredPatch(structured["structuredPatch"])
+      const diff =
+        Option.isSome(patch) && patch.value.length > 0 ? renderPatch(patch.value) : undefined
+      const changes: Array<FileChange> = item.changes.map((change) => ({
+        ...change,
+        ...(structured["type"] === "create" ? { kind: "add" as const } : {}),
+        ...(diff !== undefined ? { diff } : {}),
+      }))
+      return { ...item, ...lifecycle, changes, title: fileChangeTitle(changes) }
+    }
+    case "mcpCall":
+      return {
+        ...item,
+        ...lifecycle,
+        ...(result.content !== undefined ? { result: result.content } : {}),
+      }
+    case "toolCall":
+      return {
+        ...item,
+        ...lifecycle,
+        ...(toolUseResult !== undefined
+          ? { output: toolUseResult }
+          : text !== ""
+            ? { output: text }
+            : {}),
+      }
+    default:
+      return item
+  }
+}
+
+/** A text or thinking item; streaming items start with `complete: false`. */
+export const textItem = (
+  id: string,
+  turnId: string,
+  kind: "text" | "thinking",
+  text: string,
+  complete: boolean,
+  parentItemId: string | null,
+): ThreadItem => ({
+  type: kind === "text" ? "assistantText" : "reasoning",
+  id,
+  turnId,
+  ...(parentItemId !== null ? { parentItemId } : {}),
+  text,
+  complete,
+})
+
+// --- Requests ---------------------------------------------------------------
+
+const AskUserQuestionInput = Schema.Struct({
+  questions: Schema.Array(
+    Schema.Struct({
+      question: Schema.String,
+      header: Schema.optional(Schema.String),
+      options: Schema.optional(
+        Schema.Array(
+          Schema.Struct({ label: Schema.String, description: Schema.optional(Schema.String) }),
+        ),
+      ),
+      multiSelect: Schema.optional(Schema.Boolean),
+    }),
+  ),
+})
+const decodeAskUserQuestion = Schema.decodeUnknownOption(AskUserQuestionInput)
+
+/** The canUseTool callback options the mapping reads (a subset of the SDK's). */
+interface PermissionContext {
+  readonly requestId: string
+  readonly toolUseID: string
+  readonly title?: string | undefined
+  readonly decisionReason?: string | undefined
+}
+
+/** Normalize one canUseTool call into a ThreadRequest. */
+export const mapRequest = (
+  toolName: string,
+  input: Record<string, unknown>,
+  context: PermissionContext,
+  turnId: string,
+  openedAt: string,
+): ThreadRequest => {
+  const common = { id: context.requestId, turnId, itemId: context.toolUseID, openedAt }
+  if (toolName === "AskUserQuestion") {
+    const decoded = decodeAskUserQuestion(input)
+    const questions = Option.isSome(decoded) ? decoded.value.questions : []
+    return {
+      kind: "question",
+      ...common,
+      // Question ids are minted from position; the answer maps them back to
+      // the question text the tool keys its answers by.
+      questions: questions.map((question, index) => ({
+        id: `q${index}`,
+        header: question.header ?? "",
+        question: question.question,
+        options: (question.options ?? []).map((option) => ({
+          label: option.label,
+          description: option.description ?? "",
+        })),
+        multiSelect: question.multiSelect ?? false,
+        freeform: true,
+        secret: false,
+      })),
+    }
+  }
+  const subject: ApprovalSubject =
+    toolName === "Bash"
+      ? {
+          type: "command",
+          command: stringField(input, "command") ?? "",
+          ...(stringField(input, "cwd") !== undefined ? { cwd: stringField(input, "cwd")! } : {}),
+        }
+      : FILE_TOOLS.has(toolName)
+        ? { type: "fileChange", changes: fileChangesFor(input) }
+        : { type: "tool", name: toolName, input }
+  return {
+    kind: "approval",
+    ...common,
+    title: context.title ?? toolTitle(toolName, input),
+    ...(context.decisionReason !== undefined ? { reason: context.decisionReason } : {}),
+    subject,
+  }
+}
+
+/** The PermissionResult that answers `request` — kinds already matched. */
+export const permissionResult = (
+  request: ThreadRequest,
+  answer: ThreadRequestAnswer,
+  input: Record<string, unknown>,
+  suggestions: ReadonlyArray<PermissionUpdate>,
+): PermissionResult => {
+  if (answer.kind === "question" && request.kind === "question") {
+    const answers = Object.fromEntries(
+      request.questions.flatMap((question) => {
+        const chosen = answer.answers[question.id]
+        return chosen === undefined ? [] : [[question.question, chosen.join(", ")]]
+      }),
+    )
+    return { behavior: "allow", updatedInput: { ...input, answers } }
+  }
+  if (answer.kind !== "approval") return { behavior: "deny", message: "declined" }
+  switch (answer.decision) {
+    case "accept":
+      return { behavior: "allow" }
+    case "acceptForSession": {
+      const updatedPermissions: Array<PermissionUpdate> =
+        suggestions.length > 0
+          ? [...suggestions]
+          : request.kind === "approval" && request.subject.type === "tool"
+            ? [
+                {
+                  type: "addRules",
+                  rules: [{ toolName: request.subject.name }],
+                  behavior: "allow",
+                  destination: "session",
+                },
+              ]
+            : []
+      return { behavior: "allow", updatedPermissions }
+    }
+    case "decline":
+      return { behavior: "deny", message: "declined" }
+    case "cancel":
+      return { behavior: "deny", message: "cancelled", interrupt: true }
+  }
+}
+
+// --- History ----------------------------------------------------------------
+
+/** The user-text test that opens a turn: string content, or a text block. */
+const userText = (content: unknown): string | null => {
+  const blocks = contentBlocks(content)
+  const texts = blocks.flatMap((block) => (block.type === "text" ? [block.text] : []))
+  return texts.length === 0 ? null : texts.join("\n")
+}
+
+const messageTimestamp = (message: SessionMessage): string | undefined => {
+  const value = (message as { timestamp?: unknown }).timestamp
+  return typeof value === "string" ? value : undefined
+}
+
+/** getSessionMessages output → HistoryTurn[] (see the header's grouping rule). */
+export const mapHistory = (messages: ReadonlyArray<SessionMessage>): ReadonlyArray<HistoryTurn> => {
+  interface OpenTurn {
+    readonly id: string
+    readonly startedAt: string | undefined
+    endedAt: string | undefined
+    readonly items: Array<ThreadItem>
+    readonly tools: Map<string, number>
+  }
+  const turns: Array<OpenTurn> = []
+  let current: OpenTurn | null = null
+  for (const message of messages) {
+    if (message.parent_tool_use_id !== null) continue
+    const content = (message.message as { content?: unknown } | null)?.content
+    const stamp = messageTimestamp(message)
+    if (message.type === "user") {
+      const text = userText(content)
+      if (text !== null) {
+        current = {
+          id: message.uuid,
+          startedAt: stamp,
+          endedAt: stamp,
+          items: [],
+          tools: new Map(),
+        }
+        turns.push(current)
+        current.items.push({
+          type: "userMessage",
+          id: `${message.uuid}:0`,
+          turnId: current.id,
+          text,
+        })
+      }
+      if (current === null) continue
+      current.endedAt = stamp ?? current.endedAt
+      for (const block of contentBlocks(content)) {
+        if (block.type !== "tool_result") continue
+        const index = current.tools.get(block.tool_use_id)
+        if (index === undefined) continue
+        current.items[index] = completeToolItem(current.items[index]!, block, undefined)
+      }
+      continue
+    }
+    if (message.type !== "assistant" || current === null) continue
+    current.endedAt = stamp ?? current.endedAt
+    contentBlocks(content).forEach((block, index) => {
+      if (current === null) return
+      const id = `${message.uuid}:${index}`
+      switch (block.type) {
+        case "text":
+          current.items.push(textItem(id, current.id, "text", block.text, true, null))
+          return
+        case "thinking":
+          current.items.push(textItem(id, current.id, "thinking", block.thinking, true, null))
+          return
+        case "tool_use":
+          current.tools.set(block.id, current.items.length)
+          current.items.push(toolItem(block, current.id, null, "running"))
+          return
+        default:
+          return
+      }
+    })
+  }
+  return turns.map((turn) => {
+    // A tool call that never got its result is a turn cut short.
+    const unfinished = turn.items.some((item) => "status" in item && item.status === "running")
+    return {
+      turn: {
+        id: turn.id,
+        status: unfinished ? "interrupted" : "completed",
+        ...(turn.startedAt !== undefined ? { startedAt: turn.startedAt } : {}),
+        ...(turn.endedAt !== undefined ? { endedAt: turn.endedAt } : {}),
+      },
+      items: turn.items.map((item) =>
+        "status" in item && item.status === "running"
+          ? { ...item, ...toolOutcome("completed", "no result recorded") }
+          : item,
+      ),
+    }
+  })
+}

--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -22,10 +22,13 @@ import type {
   AgentConnection,
   AgentEvent,
   AgentIdentityMismatch,
+  AgentItemEvent,
   AgentProtocolError,
   AgentSessionEvent,
   AgentUnavailable,
   EstablishedIdentity,
+  ThreadItem,
+  ThreadRequest,
 } from "./agentAdapter.ts"
 import {
   AgentResumeFailed,
@@ -41,8 +44,10 @@ import {
   titleInstruction,
   versionIsOlder,
   withTitleTimeout,
+  withToolStatus,
 } from "./agentAdapter.ts"
 import * as BuildInfo from "../platform/buildInfo.ts"
+import * as CodexItems from "./codexItems.ts"
 import * as CodexServer from "./codexServer.ts"
 import { AppConfig } from "../platform/config.ts"
 import * as Subprocess from "../platform/subprocess.ts"
@@ -64,9 +69,18 @@ import * as UnixWebSocket from "../platform/unixWebSocket.ts"
 //   - One writer per thread is enforced HERE (the app-server would accept a
 //     concurrent second writer, and concurrent writers corrupt provider
 //     turn attribution — ATC-83 evidence).
-//   - Server-initiated requests (approvals, questions) are surfaced on the
-//     feed and answered with an immediate JSON-RPC rejection — never left
-//     hanging. Real responses are ATC-124 work.
+//   - Server-initiated requests for OUR turns are parked (the JSON-RPC
+//     request stays open) and surfaced as ThreadRequests; `respond` replies
+//     on them (ATC-193). Requests of kinds the seam does not surface
+//     (permissions, MCP elicitation, tool calls) keep an immediate JSON-RPC
+//     rejection so a turn can never hang on ATC. Requests raised for a turn
+//     another writer started are never answered here.
+//   - Conversation items ride the fan-out for every thread (item/started,
+//     item/completed — probed 2026-08-10, ATC-190): a writer session's feed
+//     carries them normalized (codexItems.ts) plus text deltas; observers of
+//     TUI-driven threads get the same item events. Deltas follow the
+//     agentMessage / plan / reasoning-summary streams and always resolve to
+//     the full text on item/completed.
 //   - A lost server connection fails every live session's feed loudly; the
 //     next create/resume reconnects. Sessions never survive their socket.
 //   - Wire shapes stay private to this module; raw events are logged at
@@ -115,6 +129,8 @@ const {
   turnStillActive,
   staleTurn,
   writerConnected,
+  unknownRequest,
+  answerKindMismatch,
 } = providerErrors("codex")
 
 /** A JSON-RPC error response — mapped per call site (resume vs the rest). */
@@ -128,6 +144,8 @@ const ThreadReply = Schema.Struct({
     id: Schema.String,
     cwd: Schema.String,
     status: Schema.optional(Schema.Unknown),
+    // Populated on thread/resume only (generated schema): the history read.
+    turns: Schema.optional(Schema.Unknown),
   }),
 })
 
@@ -204,6 +222,30 @@ const messageItemText = (item: typeof MessageItemNotification.Type.item): string
   (item.content ?? [])
     .flatMap((block) => (block.type === "text" && block.text !== undefined ? [block.text] : []))
     .join("\n")
+// item/started and item/completed carry the item plus its turn; the raw
+// item is normalized by codexItems.ts (unknown types skip there).
+const ItemNotification = Schema.Struct({
+  threadId: Schema.String,
+  turnId: Schema.String,
+  item: Schema.Unknown,
+})
+// The text streams the seam forwards as deltas (see the header).
+const TextDeltaNotification = Schema.Struct({
+  threadId: Schema.String,
+  itemId: Schema.String,
+  delta: Schema.String,
+})
+const TEXT_DELTA_METHODS = new Set([
+  "item/agentMessage/delta",
+  "item/plan/delta",
+  "item/reasoning/summaryTextDelta",
+])
+// serverRequest/resolved: a request answered or cleared elsewhere (another
+// client, or lifecycle cleanup such as an interrupted turn).
+const RequestResolvedNotification = Schema.Struct({
+  threadId: Schema.String,
+  requestId: Schema.Union([Schema.String, Schema.Number]),
+})
 const StatusChangedNotification = Schema.Struct({
   threadId: Schema.String,
   status: Schema.optional(Schema.Unknown),
@@ -228,6 +270,9 @@ const ThreadStartedNotification = Schema.Struct({
 })
 const decodeSubAgentActivity = Schema.decodeUnknownOption(SubAgentActivityNotification)
 const decodeMessageItem = Schema.decodeUnknownOption(MessageItemNotification)
+const decodeItemNotification = Schema.decodeUnknownOption(ItemNotification)
+const decodeTextDelta = Schema.decodeUnknownOption(TextDeltaNotification)
+const decodeRequestResolved = Schema.decodeUnknownOption(RequestResolvedNotification)
 const decodeStatusChanged = Schema.decodeUnknownOption(StatusChangedNotification)
 const decodeTurnStarted = Schema.decodeUnknownOption(TurnStartedNotification)
 const decodeTurnCompleted = Schema.decodeUnknownOption(TurnCompletedNotification)
@@ -244,9 +289,10 @@ const statusToActivity = (status: unknown): AgentActivity => {
     : "working"
 }
 
-const SERVER_REQUEST_KINDS: Record<string, "approval" | "question"> = {
-  "item/commandExecution/requestApproval": "approval",
-  "item/tool/requestUserInput": "question",
+/** A parked server request: the JSON-RPC id to reply on plus its normalized shape. */
+interface PendingRequest {
+  readonly rpcId: number | string
+  readonly request: ThreadRequest
 }
 
 interface LiveSession {
@@ -258,6 +304,12 @@ interface LiveSession {
   /** The turn THIS client started, if any — the only one whose provider
    * requests we may answer. */
   ownTurn: string | null
+  /** The active turn's TOOL items by id (latest state), so an approval can
+   * name its item and flip it to pending; cleared at turn end. Text items
+   * are never retained — Threads owns the transcript. */
+  readonly toolItems: Map<string, ThreadItem>
+  /** Parked requests by request id, closed with their turn. */
+  readonly pendingRequests: Map<string, PendingRequest>
   /** Set when the transport died underneath the session (vs. caller close). */
   failed: boolean
 }
@@ -313,6 +365,15 @@ const decodeReply = <S extends Schema.Top>(schema: S, reply: unknown) =>
   Schema.decodeUnknownEffect(schema)(reply).pipe(
     Effect.mapError((error) => protocolError(`unexpected reply shape: ${error.message}`)),
   )
+
+/** thread/resume's error mapping: the server's invalid-request code on an
+ * unknown thread id is the fail-closed AgentResumeFailed. */
+const resumeError =
+  (providerSessionId: string) =>
+  (error: RpcError | AgentProtocolError): AgentResumeFailed | AgentProtocolError =>
+    error._tag === "RpcError" && error.code === -32600
+      ? new AgentResumeFailed({ provider: "codex", providerSessionId, reason: error.text })
+      : rpcToProtocol(error)
 
 /** The passive seam's error mapping: an RPC failure is "unavailable". */
 const rpcToUnavailable = (error: RpcError | AgentProtocolError): AgentUnavailable =>
@@ -406,10 +467,11 @@ export const layer = Layer.effect(CodexAdapter)(
     // All live writer sessions, keyed by thread id. They always belong to
     // `current`; a connection teardown fails and clears every one of them.
     const sessions = new Map<string, LiveSession>()
-    // Passive per-thread activity observers (TUI-driven sessions). Unlike
-    // sessions they survive reconnects: the map is adapter-level, and a new
-    // connection's broadcasts route to the same queues.
-    const observers = new Map<string, Set<Queue.Queue<AgentActivity, Cause.Done>>>()
+    // Passive per-thread observers (TUI-driven sessions): activity plus the
+    // fan-out's item events. Unlike sessions they survive reconnects: the
+    // map is adapter-level, and a new connection's broadcasts route to the
+    // same queues.
+    const observers = new Map<string, Set<Queue.Queue<AgentSessionEvent, Cause.Done>>>()
 
     // Descendant bookkeeping (ATC-158): each thread's own last-broadcast
     // status, the child→parent links learned from subAgentActivity items
@@ -472,15 +534,19 @@ export const layer = Layer.effect(CodexAdapter)(
 
     /** Publish the root's current aggregate to its observers and (deduped)
      * writer-session feed. */
+    /** Deliver one event to a thread's observers. Overflow ends the
+     * observation: dropping intermediate transitions would be silent
+     * evidence loss (the first busy drives the confirm marker), while an
+     * ended feed makes the consumer re-observe and re-derive. */
+    const observe = (threadId: string, event: AgentSessionEvent): void => {
+      for (const queue of observers.get(threadId) ?? []) {
+        if (!Queue.offerUnsafe(queue, event)) Queue.endUnsafe(queue)
+      }
+    }
+
     const emitAggregate = (rootId: string): void => {
       const aggregate = aggregateFor(rootId)
-      for (const queue of observers.get(rootId) ?? []) {
-        // Overflow ends the observation: dropping intermediate transitions
-        // would be silent evidence loss (the first busy drives the confirm
-        // marker), while an ended feed makes the consumer re-observe and
-        // re-derive.
-        if (!Queue.offerUnsafe(queue, aggregate)) Queue.endUnsafe(queue)
-      }
+      observe(rootId, { type: "activity", activity: aggregate })
       const session = sessions.get(rootId)
       if (session !== undefined && aggregate !== session.activity) {
         session.activity = aggregate
@@ -579,10 +645,8 @@ export const layer = Layer.effect(CodexAdapter)(
         // Observers outlive the socket, but their evidence just died with
         // it: tell them honestly rather than letting the last busy state
         // sit stale while the provider moves on unheard (ATC-158).
-        for (const set of observers.values()) {
-          for (const queue of set) {
-            if (!Queue.offerUnsafe(queue, "unknown")) Queue.endUnsafe(queue)
-          }
+        for (const threadId of observers.keys()) {
+          observe(threadId, { type: "activity", activity: "unknown" })
         }
         // An armed capture fails closed with the connection: the caller
         // abandons the launch and retries rather than adopting anything
@@ -595,6 +659,19 @@ export const layer = Layer.effect(CodexAdapter)(
       state.socket.close()
     }
 
+    /** Flip a tool item pending ↔ running around its approval. */
+    const restatusItem = (
+      session: LiveSession,
+      itemId: string | undefined,
+      status: "pending" | "running",
+    ): void => {
+      const item = itemId === undefined ? undefined : session.toolItems.get(itemId)
+      const updated = item === undefined ? null : withToolStatus(item, status)
+      if (updated === null) return
+      session.toolItems.set(updated.id, updated)
+      emit(session, { type: "itemUpdated", item: updated })
+    }
+
     const handleServerRequest = (
       state: ClientState,
       message: {
@@ -603,30 +680,44 @@ export const layer = Layer.effect(CodexAdapter)(
         params: Record<string, unknown> | undefined
       },
     ): void => {
-      const kind = SERVER_REQUEST_KINDS[message.method]
       const threadId = message.params?.["threadId"]
       const turnId = message.params?.["turnId"]
       const session = typeof threadId === "string" ? sessions.get(threadId) : undefined
       // Only answer requests for turns THIS client started: a shared-server
       // request belonging to another writer (a TUI's approval prompt) is
-      // never ours to reject. Requests for our turns are surfaced, then
-      // answered with an immediate rejection — never left hanging. Real
-      // responses are ATC-124.
+      // never ours to answer or reject.
       if (session === undefined || session.ownTurn !== turnId) return
-      if (kind !== undefined) {
-        const requestId = String(message.id)
-        emit(session, { type: "requestOpened", requestId, kind })
+      const requestId = String(message.id)
+      const itemId = message.params?.["itemId"]
+      const request = CodexItems.mapRequest(
+        message.method,
+        requestId,
+        message.params,
+        typeof itemId === "string" ? session.toolItems.get(itemId) : undefined,
+        new Date().toISOString(),
+      )
+      if (request === null) {
+        // Not a kind the seam surfaces (yet): the conservative reject, so
+        // the turn proceeds instead of hanging on ATC.
+        state.socket.send(
+          JSON.stringify({
+            id: message.id,
+            error: { code: -32601, message: "atc does not answer this kind of provider request" },
+          }),
+        )
+        return
+      }
+      session.pendingRequests.set(requestId, { rpcId: message.id, request })
+      restatusItem(session, request.itemId, "pending")
+      emit(session, { type: "requestOpened", request })
+    }
+
+    /** Close every parked request of a session (its turn ended). */
+    const closePendingRequests = (session: LiveSession): void => {
+      for (const requestId of session.pendingRequests.keys()) {
         emit(session, { type: "requestClosed", requestId })
       }
-      state.socket.send(
-        JSON.stringify({
-          id: message.id,
-          error: {
-            code: -32601,
-            message: "atc does not answer provider requests yet (native-mode work)",
-          },
-        }),
-      )
+      session.pendingRequests.clear()
     }
 
     const handleNotification = (message: {
@@ -643,10 +734,8 @@ export const layer = Layer.effect(CodexAdapter)(
         if (Option.isSome(subAgent)) {
           registerDescendant(subAgent.value.threadId, subAgent.value.item.agentThreadId)
           emitAggregate(resolveRoot(subAgent.value.threadId))
-          return
         }
-        // Completed conversation items feed the title-context retention;
-        // anything else stays the deliberate silent skip.
+        // Completed conversation items feed the title-context retention.
         if (message.method === "item/completed") {
           const item = decodeMessageItem(params)
           if (Option.isSome(item)) {
@@ -657,6 +746,46 @@ export const layer = Layer.effect(CodexAdapter)(
             )
           }
         }
+        // The normalized item reaches the thread's writer feed and its
+        // observers alike; an item type the seam does not carry, or a
+        // drifted shape, is the deliberate silent skip.
+        const decoded = decodeItemNotification(params)
+        if (Option.isNone(decoded)) return
+        const phase = message.method === "item/started" ? "started" : "completed"
+        const item = CodexItems.mapItem(decoded.value.item, decoded.value.turnId, phase)
+        if (item === null) return
+        const event: AgentItemEvent =
+          phase === "started" ? { type: "itemStarted", item } : { type: "itemCompleted", item }
+        const session = sessions.get(decoded.value.threadId)
+        if (session !== undefined) {
+          if ("status" in item) session.toolItems.set(item.id, item)
+          emit(session, event)
+        }
+        observe(decoded.value.threadId, event)
+        return
+      }
+      if (message.method === "serverRequest/resolved") {
+        // Resolved elsewhere (another client answered, or the turn's
+        // cleanup cleared it): the parked request is gone, and a later
+        // respond is the conflict it should be.
+        const decoded = decodeRequestResolved(params)
+        if (Option.isNone(decoded)) return
+        const session = sessions.get(decoded.value.threadId)
+        const requestId = String(decoded.value.requestId)
+        if (session === undefined || !session.pendingRequests.delete(requestId)) return
+        emit(session, { type: "requestClosed", requestId })
+        return
+      }
+      if (TEXT_DELTA_METHODS.has(message.method)) {
+        const decoded = decodeTextDelta(params)
+        if (Option.isNone(decoded)) return
+        const session = sessions.get(decoded.value.threadId)
+        if (session === undefined) return
+        emit(session, {
+          type: "textDelta",
+          itemId: decoded.value.itemId,
+          delta: decoded.value.delta,
+        })
         return
       }
       // Coarse status fans out for EVERY thread on the shared server
@@ -690,7 +819,13 @@ export const layer = Layer.effect(CodexAdapter)(
         if (session === undefined) return
         const { id: turnId, status } = decoded.value.turn
         if (session.activeTurn === turnId) session.activeTurn = null
-        if (session.ownTurn === turnId) session.ownTurn = null
+        if (session.ownTurn === turnId) {
+          session.ownTurn = null
+          // Requests die with their turn (an interrupted turn drops its
+          // parked approvals); a re-run turn re-asks.
+          closePendingRequests(session)
+        }
+        session.toolItems.clear()
         const outcome =
           status === "completed" ? "completed" : status === "interrupted" ? "interrupted" : "failed"
         emit(
@@ -701,7 +836,7 @@ export const layer = Layer.effect(CodexAdapter)(
         )
         return
       }
-      // Item deltas, token usage, MCP startup noise: not status facts.
+      // Output deltas, token usage, MCP startup noise: not facts the seam carries.
     }
 
     const dispatch = (state: ClientState, raw: string): void => {
@@ -874,6 +1009,8 @@ export const layer = Layer.effect(CodexAdapter)(
           activity: "unknown",
           activeTurn: null,
           ownTurn: null,
+          toolItems: new Map(),
+          pendingRequests: new Map(),
           failed: false,
         }
         const unregister = (): void => {
@@ -882,6 +1019,21 @@ export const layer = Layer.effect(CodexAdapter)(
           pruneRoot(threadId)
           Queue.endUnsafe(queue)
           if (state.alive) {
+            // Requests parked on a closing connection get the conservative
+            // reject: nothing will answer them, and an unanswered request
+            // would park the provider's turn forever.
+            for (const pending of session.pendingRequests.values()) {
+              state.socket.send(
+                JSON.stringify({
+                  id: pending.rpcId,
+                  error: {
+                    code: -32601,
+                    message: "atc closed the connection with the request pending",
+                  },
+                }),
+              )
+            }
+            session.pendingRequests.clear()
             state.socket.send(
               JSON.stringify({
                 id: state.nextId++,
@@ -962,6 +1114,22 @@ export const layer = Layer.effect(CodexAdapter)(
                   error._tag === "RpcError" ? conflict(error.text) : error,
                 ),
               )
+            }),
+          respond: (requestId, answer) =>
+            Effect.gen(function* () {
+              yield* requireLive
+              const pending = session.pendingRequests.get(requestId)
+              if (pending === undefined) return yield* Effect.fail(unknownRequest(requestId))
+              if (pending.request.kind !== answer.kind) {
+                return yield* Effect.fail(answerKindMismatch(requestId, pending.request.kind))
+              }
+              session.pendingRequests.delete(requestId)
+              state.socket.send(
+                JSON.stringify({ id: pending.rpcId, result: CodexItems.answerResult(answer) }),
+              )
+              // The item resumes (or ends declined — item/completed says so).
+              restatusItem(session, pending.request.itemId, "running")
+              emit(session, { type: "requestClosed", requestId })
             }),
         }
         return { connection, unregister }
@@ -1092,17 +1260,7 @@ export const layer = Layer.effect(CodexAdapter)(
             const reply = yield* request(state, "thread/resume", {
               threadId: options.providerSessionId,
               cwd: options.cwd,
-            }).pipe(
-              Effect.mapError((error) =>
-                error._tag === "RpcError" && error.code === -32600
-                  ? new AgentResumeFailed({
-                      provider: "codex",
-                      providerSessionId: options.providerSessionId,
-                      reason: error.text,
-                    })
-                  : rpcToProtocol(error),
-              ),
-            )
+            }).pipe(Effect.mapError(resumeError(options.providerSessionId)))
             const decoded = yield* decodeReply(ThreadReply, reply)
             if (decoded.thread.id !== options.providerSessionId) {
               return yield* Effect.fail(
@@ -1201,9 +1359,9 @@ export const layer = Layer.effect(CodexAdapter)(
         Effect.gen(function* () {
           // Ensure the shared connection exists — it is the evidence source.
           yield* getClientRetryable
-          // Bounded (overflow ends the feed — see emitAggregate); a
-          // 16-deep undrained backlog means the observer is gone.
-          const queue = yield* Queue.make<AgentActivity, Cause.Done>({ capacity: 16 })
+          // Bounded (overflow ends the feed — see observe); items arrive in
+          // bursts, so the backlog is sized for a turn's worth of them.
+          const queue = yield* Queue.make<AgentSessionEvent, Cause.Done>({ capacity: 256 })
           // Observer registration and its finalizer land atomically
           // (acquireRelease — ATC-167 M4).
           yield* Effect.acquireRelease(
@@ -1285,21 +1443,24 @@ export const layer = Layer.effect(CodexAdapter)(
               }),
             ),
           )
-          const activityEvents = Stream.fromQueue(queue).pipe(
-            Stream.mapEffect((activity): Effect.Effect<AgentSessionEvent> =>
+          const observedEvents = Stream.fromQueue(queue).pipe(
+            Stream.tap((event) =>
               Effect.gen(function* () {
                 // Any provider-evidenced transition can carry the news that
                 // history exists; `unknown` is the teardown signal, where a
                 // read could only fail and burn the attempt.
-                if (promptPhase === "pending" && activity !== "unknown") {
+                if (
+                  event.type === "activity" &&
+                  promptPhase === "pending" &&
+                  event.activity !== "unknown"
+                ) {
                   promptPhase = "reading"
                   yield* discoverPrompt.pipe(Effect.forkIn(scope))
                 }
-                return { type: "activity", activity }
               }),
             ),
           )
-          return Stream.merge(activityEvents, Stream.fromQueue(promptQueue))
+          return Stream.merge(observedEvents, Stream.fromQueue(promptQueue))
         }),
       generateTitle: (options) =>
         Effect.scoped(
@@ -1384,6 +1545,30 @@ export const layer = Layer.effect(CodexAdapter)(
         ),
       collectTitleContext: (options) =>
         Effect.sync(() => recentMessages.get(options.providerSessionId) ?? null),
+      readHistory: (options) =>
+        Effect.gen(function* () {
+          const state = yield* getClient
+          // thread/resume returns full typed turns[].items[] and is
+          // side-effect free on an already-loaded thread (probed
+          // 2026-08-17). It loads the thread when needed — which the read
+          // needs anyway — and never opens a writer or starts a turn.
+          const reply = yield* request(state, "thread/resume", {
+            threadId: options.providerSessionId,
+            cwd: options.cwd,
+          }).pipe(Effect.mapError(resumeError(options.providerSessionId)))
+          const decoded = yield* decodeReply(ThreadReply, reply)
+          if (decoded.thread.id !== options.providerSessionId) {
+            return yield* Effect.fail(
+              protocolError(
+                `thread/resume answered for ${decoded.thread.id}, not ${options.providerSessionId}`,
+              ),
+            )
+          }
+          const turns = yield* CodexItems.decodeHistoryTurns(decoded.thread.turns ?? []).pipe(
+            Effect.mapError((error) => protocolError(`unexpected turns shape: ${error.message}`)),
+          )
+          return CodexItems.mapHistory(turns)
+        }),
       checkSession: (options) =>
         Effect.gen(function* () {
           const state = yield* getClientRetryable

--- a/app-server/src/agents/codexItems.ts
+++ b/app-server/src/agents/codexItems.ts
@@ -1,0 +1,411 @@
+import { Option, Schema } from "effect"
+import * as path from "node:path"
+import type {
+  HistoryTurn,
+  ThreadItem,
+  ThreadRequest,
+  ThreadRequestAnswer,
+  ThreadTurn,
+} from "./agentAdapter.ts"
+import { fileChangeTitle, toolOutcome } from "./agentAdapter.ts"
+
+// Codex wire shapes → the contract vocabulary (ATC-193): pure functions over
+// the codex 0.147 app-server protocol (`ThreadItem` from item/started,
+// item/completed, and thread/resume turns; the item/* server requests). No
+// transport, no state — codexAdapter.ts owns those. Every decoder is
+// tolerant: an unrecognized or drifted payload is a silent skip (null), the
+// same rule the adapter applies to every unknown notification, so a new
+// Codex item type can never break a feed. Invariants:
+//
+//   - Item ids are Codex's own (`item.id`), turn ids the Codex turn id.
+//     Live ids are the provider's message/exec ids; thread/resume history
+//     re-numbers items positionally (`item-1`, `item-2`, … — probed live
+//     2026-08-17 on 0.147) and omits some tool items (an `exec` custom tool
+//     call recorded in the rollout did not come back as a commandExecution).
+//     Threads therefore treats a re-read as a wholesale replacement, never a
+//     merge by id.
+//   - hookPrompt and the review-mode markers are deliberately not emitted;
+//     every other unknown or exotic item type surfaces as a `toolCall`
+//     named after the Codex type, so nothing the agent did disappears.
+//   - Reasoning text is the SUMMARY (joined); raw reasoning content rides
+//     providerMetadata. Live deltas therefore follow summaryTextDelta only.
+
+const nullable = <S extends Schema.Top>(schema: S) => Schema.optional(Schema.NullOr(schema))
+
+const ToolStatus = Schema.Literals(["inProgress", "completed", "failed", "declined"])
+
+const codexToolStatus = (
+  status: typeof ToolStatus.Type,
+  failure: string | null,
+): ReturnType<typeof toolOutcome> =>
+  toolOutcome(
+    status === "inProgress" ? "running" : status === "declined" ? "declined" : "completed",
+    status === "failed" ? (failure ?? "failed") : failure,
+  )
+
+const ItemBase = Schema.Struct({ type: Schema.String, id: Schema.String })
+const decodeItemBase = Schema.decodeUnknownOption(ItemBase)
+
+const UserMessage = Schema.Struct({
+  content: Schema.Array(
+    Schema.Struct({ type: Schema.String, text: Schema.optional(Schema.String) }),
+  ),
+})
+const AgentMessage = Schema.Struct({ text: Schema.String, phase: nullable(Schema.String) })
+const Plan = Schema.Struct({ text: Schema.String })
+const Reasoning = Schema.Struct({
+  summary: Schema.Array(Schema.String),
+  content: Schema.Array(Schema.String),
+})
+const CommandExecution = Schema.Struct({
+  command: Schema.String,
+  cwd: nullable(Schema.String),
+  status: ToolStatus,
+  aggregatedOutput: nullable(Schema.String),
+  exitCode: nullable(Schema.Number),
+  durationMs: nullable(Schema.Number),
+})
+const FileChange = Schema.Struct({
+  changes: Schema.Array(
+    Schema.Struct({
+      path: Schema.String,
+      kind: Schema.Struct({ type: Schema.Literals(["add", "delete", "update"]) }),
+      diff: nullable(Schema.String),
+    }),
+  ),
+  status: ToolStatus,
+})
+const McpToolCall = Schema.Struct({
+  server: Schema.String,
+  tool: Schema.String,
+  status: ToolStatus,
+  arguments: Schema.Unknown,
+  result: Schema.optional(Schema.Unknown),
+  error: nullable(Schema.Struct({ message: Schema.String })),
+})
+// The rest of the tool-like items share only an optional lifecycle status;
+// their remaining fields become the toolCall input verbatim.
+const GenericTool = Schema.Struct({ status: Schema.optional(Schema.Unknown) })
+
+const decoders = {
+  userMessage: Schema.decodeUnknownOption(UserMessage),
+  agentMessage: Schema.decodeUnknownOption(AgentMessage),
+  plan: Schema.decodeUnknownOption(Plan),
+  reasoning: Schema.decodeUnknownOption(Reasoning),
+  commandExecution: Schema.decodeUnknownOption(CommandExecution),
+  fileChange: Schema.decodeUnknownOption(FileChange),
+  mcpToolCall: Schema.decodeUnknownOption(McpToolCall),
+  generic: Schema.decodeUnknownOption(GenericTool),
+}
+
+const NOT_EMITTED = new Set(["hookPrompt", "enteredReviewMode", "exitedReviewMode"])
+
+/** Item lifecycle phase the notification carries; history reads are final. */
+type Phase = "started" | "completed"
+
+/** A short display title for the exotic tool-like items. */
+const genericTitle = (type: string, input: Record<string, unknown>): string => {
+  switch (type) {
+    case "webSearch":
+      return typeof input["query"] === "string" ? `Search: ${input["query"]}` : "Web search"
+    case "imageView":
+      return typeof input["path"] === "string"
+        ? `View ${path.basename(input["path"])}`
+        : "View image"
+    case "subAgentActivity":
+      return typeof input["kind"] === "string" ? `Subagent ${input["kind"]}` : "Subagent"
+    case "collabAgentToolCall":
+      return typeof input["tool"] === "string" ? `Agent ${input["tool"]}` : "Agent"
+    case "dynamicToolCall":
+      return typeof input["tool"] === "string" ? input["tool"] : type
+    default:
+      return type
+  }
+}
+
+/**
+ * Normalize one Codex item. `phase` decides the lifecycle of items that
+ * carry no status of their own (text completes with the notification;
+ * status-less tools run until completed).
+ */
+export const mapItem = (raw: unknown, turnId: string, phase: Phase): ThreadItem | null => {
+  const base = decodeItemBase(raw)
+  if (Option.isNone(base) || NOT_EMITTED.has(base.value.type)) return null
+  const { id, type } = base.value
+  const common = { id, turnId }
+  switch (type) {
+    case "userMessage": {
+      const decoded = decoders.userMessage(raw)
+      if (Option.isNone(decoded)) return null
+      const text = decoded.value.content
+        .flatMap((block) => (block.type === "text" && block.text !== undefined ? [block.text] : []))
+        .join("\n")
+      return { type: "userMessage", ...common, text }
+    }
+    case "agentMessage": {
+      const decoded = decoders.agentMessage(raw)
+      if (Option.isNone(decoded)) return null
+      const phaseTag = decoded.value.phase
+      return {
+        type: "assistantText",
+        ...common,
+        text: decoded.value.text,
+        complete: phase === "completed",
+        ...(typeof phaseTag === "string"
+          ? { providerMetadata: { codex: { phase: phaseTag } } }
+          : {}),
+      }
+    }
+    case "plan": {
+      const decoded = decoders.plan(raw)
+      if (Option.isNone(decoded)) return null
+      return {
+        type: "assistantText",
+        ...common,
+        text: decoded.value.text,
+        complete: phase === "completed",
+        providerMetadata: { codex: { plan: true } },
+      }
+    }
+    case "reasoning": {
+      const decoded = decoders.reasoning(raw)
+      if (Option.isNone(decoded)) return null
+      const { summary, content } = decoded.value
+      return {
+        type: "reasoning",
+        ...common,
+        text: (summary.length > 0 ? summary : content).join("\n\n"),
+        complete: phase === "completed",
+        ...(content.length > 0 && summary.length > 0
+          ? { providerMetadata: { codex: { content } } }
+          : {}),
+      }
+    }
+    case "commandExecution": {
+      const decoded = decoders.commandExecution(raw)
+      if (Option.isNone(decoded)) return null
+      const value = decoded.value
+      const output = value.aggregatedOutput ?? undefined
+      return {
+        type: "command",
+        ...common,
+        title: value.command.split("\n")[0]?.trim() ?? value.command,
+        ...codexToolStatus(value.status, null),
+        command: value.command,
+        ...(typeof value.cwd === "string" ? { cwd: value.cwd } : {}),
+        ...(output !== undefined ? { output } : {}),
+        ...(typeof value.exitCode === "number" ? { exitCode: value.exitCode } : {}),
+        ...(typeof value.durationMs === "number"
+          ? { providerMetadata: { codex: { durationMs: value.durationMs } } }
+          : {}),
+      }
+    }
+    case "fileChange": {
+      const decoded = decoders.fileChange(raw)
+      if (Option.isNone(decoded)) return null
+      const changes = decoded.value.changes.map((change) => ({
+        path: change.path,
+        kind: change.kind.type,
+        ...(typeof change.diff === "string" ? { diff: change.diff } : {}),
+      }))
+      return {
+        type: "fileChange",
+        ...common,
+        title: fileChangeTitle(changes),
+        ...codexToolStatus(decoded.value.status, null),
+        changes,
+      }
+    }
+    case "mcpToolCall": {
+      const decoded = decoders.mcpToolCall(raw)
+      if (Option.isNone(decoded)) return null
+      const value = decoded.value
+      return {
+        type: "mcpCall",
+        ...common,
+        title: `${value.server} · ${value.tool}`,
+        ...codexToolStatus(value.status, value.error?.message ?? null),
+        server: value.server,
+        tool: value.tool,
+        arguments: value.arguments,
+        ...(value.result !== undefined && value.result !== null ? { result: value.result } : {}),
+      }
+    }
+    case "contextCompaction":
+      return { type: "compaction", ...common }
+    default: {
+      const decoded = decoders.generic(raw)
+      if (Option.isNone(decoded)) return null
+      const { type: _type, id: _id, status, ...input } = raw as Record<string, unknown>
+      const known = Schema.decodeUnknownOption(ToolStatus)(status)
+      const lifecycle = Option.isSome(known)
+        ? codexToolStatus(known.value, null)
+        : toolOutcome(phase === "completed" ? "completed" : "running", null)
+      return {
+        type: "toolCall",
+        ...common,
+        title: genericTitle(type, input),
+        ...lifecycle,
+        name: type,
+        input,
+      }
+    }
+  }
+}
+
+// --- Server requests -------------------------------------------------------
+
+const RequestParams = Schema.Struct({
+  turnId: Schema.String,
+  itemId: Schema.optional(Schema.String),
+})
+const CommandApproval = Schema.Struct({
+  command: nullable(Schema.String),
+  cwd: nullable(Schema.String),
+  reason: nullable(Schema.String),
+})
+const FileChangeApproval = Schema.Struct({ reason: nullable(Schema.String) })
+const UserInput = Schema.Struct({
+  questions: Schema.Array(
+    Schema.Struct({
+      id: Schema.String,
+      header: Schema.String,
+      question: Schema.String,
+      isOther: Schema.Boolean,
+      isSecret: Schema.Boolean,
+      options: nullable(
+        Schema.Array(Schema.Struct({ label: Schema.String, description: Schema.String })),
+      ),
+    }),
+  ),
+})
+const decodeRequestParams = Schema.decodeUnknownOption(RequestParams)
+const decodeCommandApproval = Schema.decodeUnknownOption(CommandApproval)
+const decodeFileChangeApproval = Schema.decodeUnknownOption(FileChangeApproval)
+const decodeUserInput = Schema.decodeUnknownOption(UserInput)
+
+/**
+ * Normalize one server request into a ThreadRequest, or null for a method
+ * the seam does not surface (permissions, MCP elicitation, tool calls —
+ * those keep the adapter's conservative reject). `pendingItem` is the live
+ * item the request names, when the adapter has it: a fileChange approval
+ * carries no changes of its own, so the pending item supplies them.
+ */
+export const mapRequest = (
+  method: string,
+  requestId: string,
+  params: unknown,
+  pendingItem: ThreadItem | undefined,
+  openedAt: string,
+): ThreadRequest | null => {
+  const base = decodeRequestParams(params)
+  if (Option.isNone(base)) return null
+  const common = {
+    id: requestId,
+    turnId: base.value.turnId,
+    ...(base.value.itemId !== undefined ? { itemId: base.value.itemId } : {}),
+    openedAt,
+  }
+  switch (method) {
+    case "item/commandExecution/requestApproval": {
+      const decoded = decodeCommandApproval(params)
+      if (Option.isNone(decoded)) return null
+      const command =
+        decoded.value.command ??
+        (pendingItem?.type === "command" ? pendingItem.command : undefined) ??
+        ""
+      const cwd =
+        decoded.value.cwd ?? (pendingItem?.type === "command" ? pendingItem.cwd : undefined)
+      return {
+        kind: "approval",
+        ...common,
+        title: command === "" ? "Run a command" : (command.split("\n")[0]?.trim() ?? command),
+        ...(typeof decoded.value.reason === "string" ? { reason: decoded.value.reason } : {}),
+        subject: { type: "command", command, ...(cwd !== undefined ? { cwd } : {}) },
+      }
+    }
+    case "item/fileChange/requestApproval": {
+      const decoded = decodeFileChangeApproval(params)
+      if (Option.isNone(decoded)) return null
+      const changes = pendingItem?.type === "fileChange" ? pendingItem.changes : []
+      return {
+        kind: "approval",
+        ...common,
+        title: changes.length === 0 ? "Apply file changes" : fileChangeTitle(changes),
+        ...(typeof decoded.value.reason === "string" ? { reason: decoded.value.reason } : {}),
+        subject: { type: "fileChange", changes },
+      }
+    }
+    case "item/tool/requestUserInput": {
+      const decoded = decodeUserInput(params)
+      if (Option.isNone(decoded)) return null
+      return {
+        kind: "question",
+        ...common,
+        questions: decoded.value.questions.map((question) => ({
+          id: question.id,
+          header: question.header,
+          question: question.question,
+          options: question.options ?? [],
+          multiSelect: false,
+          // No options at all means a typed answer is the only answer.
+          freeform: question.isOther || question.options === null || question.options === undefined,
+          secret: question.isSecret,
+        })),
+      }
+    }
+    default:
+      return null
+  }
+}
+
+/** The JSON-RPC `result` that answers `request` — kinds already matched. */
+export const answerResult = (answer: ThreadRequestAnswer): unknown =>
+  answer.kind === "approval"
+    ? { decision: answer.decision }
+    : {
+        answers: Object.fromEntries(
+          Object.entries(answer.answers).map(([id, answers]) => [id, { answers }]),
+        ),
+      }
+
+// --- History ---------------------------------------------------------------
+
+const HistoryTurns = Schema.Array(
+  Schema.Struct({
+    id: Schema.String,
+    items: Schema.Array(Schema.Unknown),
+    status: Schema.Literals(["inProgress", "completed", "interrupted", "failed"]),
+    error: nullable(Schema.Struct({ message: Schema.String })),
+    startedAt: nullable(Schema.Number),
+    completedAt: nullable(Schema.Number),
+  }),
+)
+export const decodeHistoryTurns = Schema.decodeUnknownEffect(HistoryTurns)
+
+/** Codex stamps turns in unix seconds; the wire wants ISO. */
+const isoTimestamp = (value: number | null | undefined): string | undefined =>
+  typeof value === "number" && Number.isFinite(value)
+    ? new Date(value * 1000).toISOString()
+    : undefined
+
+/** thread/resume turns → HistoryTurn[] (unix-second stamps become ISO). */
+export const mapHistory = (turns: typeof HistoryTurns.Type): ReadonlyArray<HistoryTurn> =>
+  turns.map((turn) => {
+    const startedAt = isoTimestamp(turn.startedAt)
+    const endedAt = isoTimestamp(turn.completedAt)
+    const status: ThreadTurn["status"] = turn.status === "inProgress" ? "running" : turn.status
+    return {
+      turn: {
+        id: turn.id,
+        status,
+        ...(status === "failed" && turn.error ? { error: turn.error.message } : {}),
+        ...(startedAt !== undefined ? { startedAt } : {}),
+        ...(endedAt !== undefined ? { endedAt } : {}),
+      },
+      items: turn.items.flatMap((raw) => {
+        const item = mapItem(raw, turn.id, "completed")
+        return item === null ? [] : [item]
+      }),
+    }
+  })

--- a/app-server/src/api/contract.ts
+++ b/app-server/src/api/contract.ts
@@ -379,6 +379,400 @@ export const ResourceChangedEvent = Schema.Struct({
     "Thin invalidation event: names what changed, never carries resource state. Clients coalesce events and refetch through the corresponding GETs, which stay the single source of truth.",
 })
 
+// --- The Thread runtime vocabulary (ATC-193) ---------------------------------
+//
+// Defined once, here, and reused verbatim by the AgentAdapter seam: adapters
+// emit these values, Threads persists them, and every client decodes them.
+// Every union is `oneOf` over NAMED variants with one literal discriminant
+// (`type` / `kind`), so openapi.ts can stamp an OpenAPI discriminator and the
+// generated Swift client gets one enum per union instead of a struct of
+// optionals. Optional fields are absent keys, never null (see
+// UpdateProjectRequest).
+
+export const FileChange = Schema.Struct({
+  path: Schema.String.annotate({ description: "Path of the changed file." }),
+  kind: Schema.Literals(["add", "update", "delete"]),
+  diff: Schema.optionalKey(
+    Schema.String.annotate({ description: "Unified diff, when the provider supplies one." }),
+  ),
+}).annotate({ identifier: "FileChange", description: "One file touched by a change." })
+
+export const ToolStatus = Schema.Literals(["pending", "running", "completed", "error"]).annotate({
+  identifier: "ToolStatus",
+  description:
+    "Lifecycle of a tool item: pending (not executing yet — typically awaiting approval), running, completed, or error.",
+})
+
+// `id` is the provider's own item id when it has a stable one (Codex item id,
+// Claude tool_use id), otherwise adapter-derived — unique within a thread,
+// never ATC-minted. Items carry no position: transcript order is array order,
+// live items append at the tail, and an update re-sends the whole item
+// (upsert by id).
+const threadItemBase = {
+  id: Schema.String.annotate({ description: "Item id, unique within the thread." }),
+  turnId: Schema.String.annotate({ description: "The turn this item belongs to." }),
+  parentItemId: Schema.optionalKey(
+    Schema.String.annotate({
+      description:
+        "The enclosing item when this work happened inside a subagent or nested tool; absent at top level.",
+    }),
+  ),
+  providerMetadata: Schema.optionalKey(
+    Schema.Unknown.annotate({
+      description:
+        "Opaque provider-namespaced JSON (e.g. { codex: { phase } }). Clients never branch on it.",
+    }),
+  ),
+}
+
+const toolFields = {
+  title: Schema.String.annotate({
+    description: 'Adapter-rendered one-liner for list rows ("bun test", "Edit threads.ts").',
+  }),
+  status: ToolStatus,
+  error: Schema.optionalKey(
+    Schema.String.annotate({
+      description:
+        'Human-readable failure; present iff status is error (a declined approval is "declined").',
+    }),
+  ),
+}
+
+export const ThreadItemUserMessage = Schema.Struct({
+  type: Schema.Literal("userMessage"),
+  ...threadItemBase,
+  text: Schema.String,
+}).annotate({ identifier: "ThreadItemUserMessage", description: "A user prompt (text only)." })
+
+export const ThreadItemAssistantText = Schema.Struct({
+  type: Schema.Literal("assistantText"),
+  ...threadItemBase,
+  text: Schema.String,
+  complete: Schema.Boolean.annotate({
+    description: "False while the text is still streaming (text.delta events extend it).",
+  }),
+}).annotate({ identifier: "ThreadItemAssistantText", description: "Assistant message text." })
+
+export const ThreadItemReasoning = Schema.Struct({
+  type: Schema.Literal("reasoning"),
+  ...threadItemBase,
+  text: Schema.String,
+  complete: Schema.Boolean.annotate({
+    description: "False while the text is still streaming (text.delta events extend it).",
+  }),
+}).annotate({ identifier: "ThreadItemReasoning", description: "Model reasoning (summary) text." })
+
+export const ThreadItemCommand = Schema.Struct({
+  type: Schema.Literal("command"),
+  ...threadItemBase,
+  ...toolFields,
+  command: Schema.String,
+  cwd: Schema.optionalKey(Schema.String),
+  output: Schema.optionalKey(Schema.String.annotate({ description: "Aggregated stdout/stderr." })),
+  exitCode: Schema.optionalKey(Schema.Int),
+}).annotate({ identifier: "ThreadItemCommand", description: "A shell command the agent ran." })
+
+export const ThreadItemFileChange = Schema.Struct({
+  type: Schema.Literal("fileChange"),
+  ...threadItemBase,
+  ...toolFields,
+  changes: Schema.Array(FileChange),
+}).annotate({ identifier: "ThreadItemFileChange", description: "Files the agent changed." })
+
+export const ThreadItemMcpCall = Schema.Struct({
+  type: Schema.Literal("mcpCall"),
+  ...threadItemBase,
+  ...toolFields,
+  server: Schema.String,
+  tool: Schema.String,
+  arguments: Schema.Unknown,
+  result: Schema.optionalKey(Schema.Unknown),
+}).annotate({ identifier: "ThreadItemMcpCall", description: "An MCP tool call." })
+
+export const ThreadItemToolCall = Schema.Struct({
+  type: Schema.Literal("toolCall"),
+  ...threadItemBase,
+  ...toolFields,
+  name: Schema.String,
+  input: Schema.Unknown,
+  output: Schema.optionalKey(Schema.Unknown),
+}).annotate({
+  identifier: "ThreadItemToolCall",
+  description: "Any other tool call (file reads, searches, subagents, web fetches, …).",
+})
+
+export const ThreadItemCompaction = Schema.Struct({
+  type: Schema.Literal("compaction"),
+  ...threadItemBase,
+}).annotate({
+  identifier: "ThreadItemCompaction",
+  description: "Marker: the provider compacted the conversation context here.",
+})
+
+export const ThreadItem = Schema.Union(
+  [
+    ThreadItemUserMessage,
+    ThreadItemAssistantText,
+    ThreadItemReasoning,
+    ThreadItemCommand,
+    ThreadItemFileChange,
+    ThreadItemMcpCall,
+    ThreadItemToolCall,
+    ThreadItemCompaction,
+  ],
+  { mode: "oneOf" },
+).annotate({
+  identifier: "ThreadItem",
+  description: "One normalized transcript item, discriminated by `type`.",
+})
+
+export const ThreadTurnStatus = Schema.Literals([
+  "running",
+  "completed",
+  "interrupted",
+  "failed",
+]).annotate({ identifier: "ThreadTurnStatus", description: "Lifecycle of one turn." })
+
+export const ThreadTurn = Schema.Struct({
+  id: Schema.String.annotate({
+    description: "Provider turn id (Codex) or adapter-derived (Claude); unique within the thread.",
+  }),
+  status: ThreadTurnStatus,
+  error: Schema.optionalKey(Schema.String.annotate({ description: "Present iff failed." })),
+  promptId: Schema.optionalKey(
+    Schema.String.annotate({
+      description: "The queued prompt this turn ran, when ATC started it.",
+    }),
+  ),
+  startedAt: Schema.optionalKey(timestamp("Turn start; history re-reads may lack it.")),
+  endedAt: Schema.optionalKey(timestamp("Turn end; absent while running.")),
+}).annotate({ identifier: "ThreadTurn", description: "One turn of the conversation." })
+
+export const Question = Schema.Struct({
+  id: Schema.String.annotate({ description: "Question id, the key of the answer." }),
+  header: Schema.String,
+  question: Schema.String,
+  options: Schema.Array(
+    Schema.Struct({ label: Schema.String, description: Schema.String }).annotate({
+      identifier: "QuestionOption",
+    }),
+  ),
+  multiSelect: Schema.Boolean,
+  freeform: Schema.Boolean.annotate({
+    description: "A typed answer that is not one of the options is accepted.",
+  }),
+  secret: Schema.Boolean.annotate({
+    description: "The answer is sensitive (a credential): mask it while typing and never echo it.",
+  }),
+}).annotate({ identifier: "Question", description: "One question the agent asked the user." })
+
+export const ApprovalSubjectCommand = Schema.Struct({
+  type: Schema.Literal("command"),
+  command: Schema.String,
+  cwd: Schema.optionalKey(Schema.String),
+}).annotate({ identifier: "ApprovalSubjectCommand" })
+
+export const ApprovalSubjectFileChange = Schema.Struct({
+  type: Schema.Literal("fileChange"),
+  changes: Schema.Array(FileChange),
+}).annotate({ identifier: "ApprovalSubjectFileChange" })
+
+export const ApprovalSubjectTool = Schema.Struct({
+  type: Schema.Literal("tool"),
+  name: Schema.String,
+  input: Schema.Unknown,
+}).annotate({ identifier: "ApprovalSubjectTool" })
+
+export const ApprovalSubject = Schema.Union(
+  [ApprovalSubjectCommand, ApprovalSubjectFileChange, ApprovalSubjectTool],
+  { mode: "oneOf" },
+).annotate({
+  identifier: "ApprovalSubject",
+  description: "What the agent is asking permission for, discriminated by `type`.",
+})
+
+const threadRequestBase = {
+  id: Schema.String.annotate({ description: "Request id; answer it through the API." }),
+  turnId: Schema.String,
+  itemId: Schema.optionalKey(
+    Schema.String.annotate({ description: "The item awaiting this request, when known." }),
+  ),
+  openedAt: timestamp("When the provider opened the request."),
+}
+
+export const ThreadRequestQuestion = Schema.Struct({
+  kind: Schema.Literal("question"),
+  ...threadRequestBase,
+  questions: Schema.Array(Question),
+}).annotate({ identifier: "ThreadRequestQuestion", description: "The agent asked questions." })
+
+export const ThreadRequestApproval = Schema.Struct({
+  kind: Schema.Literal("approval"),
+  ...threadRequestBase,
+  title: Schema.String.annotate({ description: "One-line prompt to show the user." }),
+  reason: Schema.optionalKey(Schema.String.annotate({ description: "Why approval is needed." })),
+  subject: ApprovalSubject,
+}).annotate({ identifier: "ThreadRequestApproval", description: "The agent asked for approval." })
+
+export const ThreadRequest = Schema.Union([ThreadRequestQuestion, ThreadRequestApproval], {
+  mode: "oneOf",
+}).annotate({
+  identifier: "ThreadRequest",
+  description:
+    "A pending provider request parked until answered — live state, not a transcript item; discriminated by `kind`.",
+})
+
+export const ThreadRequestList = Schema.Array(ThreadRequest).annotate({
+  identifier: "ThreadRequestList",
+  description: "The thread's pending requests, oldest first.",
+})
+
+export const ThreadRequestQuestionAnswer = Schema.Struct({
+  kind: Schema.Literal("question"),
+  answers: Schema.Record(Schema.String, Schema.Array(Schema.String)).annotate({
+    description:
+      "Question id → chosen option labels (exactly one unless multiSelect), or one freeform string.",
+  }),
+}).annotate({ identifier: "ThreadRequestQuestionAnswer" })
+
+export const ApprovalDecision = Schema.Literals([
+  "accept",
+  "acceptForSession",
+  "decline",
+  "cancel",
+]).annotate({
+  identifier: "ApprovalDecision",
+  description: "cancel = decline and interrupt the turn.",
+})
+
+export const ThreadRequestApprovalAnswer = Schema.Struct({
+  kind: Schema.Literal("approval"),
+  decision: ApprovalDecision,
+}).annotate({ identifier: "ThreadRequestApprovalAnswer" })
+
+export const ThreadRequestAnswer = Schema.Union(
+  [ThreadRequestQuestionAnswer, ThreadRequestApprovalAnswer],
+  { mode: "oneOf" },
+).annotate({
+  identifier: "ThreadRequestAnswer",
+  description: "The answer to a pending request; `kind` must match the request's.",
+})
+
+export const QueuedPrompt = Schema.Struct({
+  id: Schema.String,
+  prompt: Schema.String,
+  queuedAt: timestamp("When the prompt was admitted."),
+}).annotate({
+  identifier: "QueuedPrompt",
+  description: "A prompt admitted while a turn was running; it runs at the next idle.",
+})
+
+export const QueuedPromptList = Schema.Array(QueuedPrompt).annotate({
+  identifier: "QueuedPromptList",
+  description: "Prompts still waiting, oldest first.",
+})
+
+export const ThreadTranscript = Schema.Struct({
+  items: Schema.Array(ThreadItem).annotate({ description: "Transcript order, oldest first." }),
+  turns: Schema.Array(ThreadTurn).annotate({ description: "Every turn referenced by `items`." }),
+  seq: Schema.Int.annotate({
+    description: "The thread's change counter at the time of the read; subscribe with after=seq.",
+  }),
+  snapshotVersion: Schema.Int.annotate({
+    description: "Bumps whenever a provider re-read replaced the copy.",
+  }),
+  hasMore: Schema.Boolean.annotate({
+    description: "Older items exist before the first one returned.",
+  }),
+}).annotate({
+  identifier: "ThreadTranscript",
+  description:
+    "ATC's normalized copy of the provider conversation — a rebuildable projection, never the authority.",
+})
+
+// `seq` is the thread's monotonic change counter: every durable change takes
+// the next value and it appears only on durable events (and as the head of a
+// transcript). Live-only events carry none and are never replayed.
+const seq = Schema.Int.annotate({ description: "Position of this durable change." })
+
+export const ThreadEventItemStarted = Schema.Struct({
+  type: Schema.Literal("item.started"),
+  seq,
+  item: ThreadItem,
+}).annotate({ identifier: "ThreadEventItemStarted" })
+export const ThreadEventItemUpdated = Schema.Struct({
+  type: Schema.Literal("item.updated"),
+  seq,
+  item: ThreadItem,
+}).annotate({ identifier: "ThreadEventItemUpdated" })
+export const ThreadEventItemCompleted = Schema.Struct({
+  type: Schema.Literal("item.completed"),
+  seq,
+  item: ThreadItem,
+}).annotate({ identifier: "ThreadEventItemCompleted" })
+export const ThreadEventTurnStarted = Schema.Struct({
+  type: Schema.Literal("turn.started"),
+  seq,
+  turn: ThreadTurn,
+}).annotate({ identifier: "ThreadEventTurnStarted" })
+export const ThreadEventTurnCompleted = Schema.Struct({
+  type: Schema.Literal("turn.completed"),
+  seq,
+  turn: ThreadTurn,
+}).annotate({ identifier: "ThreadEventTurnCompleted" })
+export const ThreadEventTextDelta = Schema.Struct({
+  type: Schema.Literal("text.delta"),
+  itemId: Schema.String,
+  delta: Schema.String,
+}).annotate({
+  identifier: "ThreadEventTextDelta",
+  description: "Live-only, never replayed: appends to a streaming assistantText or reasoning item.",
+})
+export const ThreadEventRequestOpened = Schema.Struct({
+  type: Schema.Literal("request.opened"),
+  request: ThreadRequest,
+}).annotate({ identifier: "ThreadEventRequestOpened", description: "Live-only." })
+export const ThreadEventRequestClosed = Schema.Struct({
+  type: Schema.Literal("request.closed"),
+  requestId: Schema.String,
+}).annotate({ identifier: "ThreadEventRequestClosed", description: "Live-only." })
+export const ThreadEventQueueUpdated = Schema.Struct({
+  type: Schema.Literal("queue.updated"),
+  prompts: QueuedPromptList,
+}).annotate({
+  identifier: "ThreadEventQueueUpdated",
+  description: "Live-only: the full queue, every time it changes.",
+})
+export const ThreadEventSnapshotInvalidated = Schema.Struct({
+  type: Schema.Literal("snapshot.invalidated"),
+  seq,
+  snapshotVersion: Schema.Int,
+}).annotate({
+  identifier: "ThreadEventSnapshotInvalidated",
+  description:
+    "A provider re-read replaced the copy: refetch the transcript and resubscribe after `seq`.",
+})
+
+export const ThreadEvent = Schema.Union(
+  [
+    ThreadEventItemStarted,
+    ThreadEventItemUpdated,
+    ThreadEventItemCompleted,
+    ThreadEventTurnStarted,
+    ThreadEventTurnCompleted,
+    ThreadEventTextDelta,
+    ThreadEventRequestOpened,
+    ThreadEventRequestClosed,
+    ThreadEventQueueUpdated,
+    ThreadEventSnapshotInvalidated,
+  ],
+  { mode: "oneOf" },
+).annotate({
+  identifier: "ThreadEvent",
+  description:
+    "One per-thread stream event, discriminated by `type`. Durable events carry `seq` and replay on reconnect (after=seq); live-only events do not.",
+})
+
 // Every error carries a required `message` field ON THE WIRE, computed from
 // the structured fields by the class's own constructor — the one place each
 // message rule lives. Construction sites never pass it, every consumer (the

--- a/app-server/src/api/openapi.ts
+++ b/app-server/src/api/openapi.ts
@@ -1,6 +1,12 @@
-import { Schema } from "effect"
+import { JsonSchema, Schema } from "effect"
 import { OpenApi } from "effect/unstable/httpapi"
-import { Api, ResourceChangedEvent } from "./contract.ts"
+import {
+  Api,
+  ResourceChangedEvent,
+  ThreadEvent,
+  ThreadRequestAnswer,
+  ThreadTranscript,
+} from "./contract.ts"
 
 // The OpenAPI document derived from the contract. This module is pure — no
 // server, no side effects — so generation works anywhere the contract compiles.
@@ -38,38 +44,104 @@ const hoistSingleAllOf = (node: unknown): unknown => {
 }
 
 /**
- * Emit the SSE payload schema as an ordinary component. Data-mode `StreamSse`
- * documents its payload as the JSON-encoded string that crosses the wire
- * inside each `data:` line (`ResourceChangedEventJsonEncoding`), which the
- * pinned Swift generator can only render as a `String` typealias — leaving
- * Swift clients no generated type to decode that JSON into. The added plain
- * component fills that gap. Both guards below fail generation loudly rather
- * than emit a silently broken document: a nested named schema would carry a
- * dangling `#/$defs/` ref, and a same-named component from the contract
- * would be clobbered.
+ * The schemas documented as components even though no endpoint (yet) names
+ * them directly: the SSE payloads, which data-mode `StreamSse` documents only
+ * as the JSON-encoded string crossing the wire inside each `data:` line
+ * (`ResourceChangedEventJsonEncoding`) — a `String` typealias in the pinned
+ * Swift generator, leaving clients no type to decode into — and the Thread
+ * runtime vocabulary (ATC-193), whose types clients build against ahead of
+ * the routes that carry them.
  */
-const withSsePayloadComponents = (document: ReturnType<typeof OpenApi.fromApi>) => {
-  const { definitions } = Schema.toJsonSchemaDocument(ResourceChangedEvent)
-  const names = Object.keys(definitions)
-  if (names.length !== 1) {
-    throw new Error(
-      `the SSE payload schema must stay flat (no nested named schemas); got components ${names.join(", ")}`,
-    )
-  }
-  if ("ResourceChangedEvent" in document.components.schemas) {
-    throw new Error(
-      "the document already has a ResourceChangedEvent component; refusing to overwrite it",
-    )
+const VOCABULARY_SCHEMAS = [
+  ResourceChangedEvent,
+  ThreadEvent,
+  ThreadTranscript,
+  ThreadRequestAnswer,
+]
+
+/**
+ * Add `VOCABULARY_SCHEMAS` — each with every named schema it references —
+ * as ordinary components. Refs are rewritten to `#/components/schemas/…`
+ * through the same conversion the API document itself uses, so a schema
+ * that is ALSO reachable from an endpoint lands byte-identical; only a
+ * same-named component with different content is a collision, and that
+ * fails generation loudly rather than emitting a silently broken document.
+ */
+const withVocabularyComponents = (document: ReturnType<typeof OpenApi.fromApi>) => {
+  const schemas: Record<string, unknown> = { ...document.components.schemas }
+  for (const schema of VOCABULARY_SCHEMAS) {
+    const draft = Schema.toJsonSchemaDocument(schema)
+    const converted = JsonSchema.toMultiDocumentOpenApi3_1({
+      dialect: "draft-2020-12",
+      schemas: [draft.schema],
+      definitions: draft.definitions,
+    })
+    for (const [name, definition] of Object.entries(converted.definitions)) {
+      const existing = schemas[name]
+      if (existing !== undefined && JSON.stringify(existing) !== JSON.stringify(definition)) {
+        throw new Error(
+          `the document already has a different ${name} component; refusing to overwrite it`,
+        )
+      }
+      schemas[name] = definition
+    }
   }
   return {
     ...document,
-    components: {
-      ...document.components,
-      schemas: {
-        ...document.components.schemas,
-        ResourceChangedEvent: definitions["ResourceChangedEvent"],
-      },
-    },
+    components: { ...document.components, schemas },
+  } as ReturnType<typeof OpenApi.fromApi>
+}
+
+/**
+ * Stamp an OpenAPI `discriminator` on every component that is a `oneOf` of
+ * `$ref`s whose targets all pin the same single-valued literal property
+ * (`type`, `kind`, …). Effect renders tagged unions as plain `oneOf`; the
+ * pinned Swift generator turns a bare `oneOf` into positional `case1/case2`
+ * enums, and with a discriminator into one enum case per named variant.
+ * Applied to components only — inline unions never occur in this contract,
+ * and a schema the rule does not match is left exactly as generated.
+ */
+const withDiscriminators = (document: ReturnType<typeof OpenApi.fromApi>) => {
+  const schemas = document.components.schemas as Record<string, Record<string, unknown>>
+  const literalOf = (ref: string, key: string): string | undefined => {
+    const target = schemas[ref.replace("#/components/schemas/", "")]
+    const property = (target?.["properties"] as Record<string, unknown> | undefined)?.[key] as
+      { const?: unknown; enum?: ReadonlyArray<unknown> } | undefined
+    if (property === undefined) return undefined
+    if (typeof property.const === "string") return property.const
+    if (Array.isArray(property.enum) && property.enum.length === 1) {
+      return typeof property.enum[0] === "string" ? property.enum[0] : undefined
+    }
+    return undefined
+  }
+  const stamped = Object.fromEntries(
+    Object.entries(schemas).map(([name, schema]) => {
+      const oneOf = schema["oneOf"]
+      if (
+        !Array.isArray(oneOf) ||
+        oneOf.length === 0 ||
+        !oneOf.every((member) => typeof (member as { $ref?: unknown }).$ref === "string")
+      ) {
+        return [name, schema]
+      }
+      const refs = (oneOf as ReadonlyArray<{ $ref: string }>).map((member) => member.$ref)
+      for (const key of ["type", "kind"]) {
+        const mapping = Object.fromEntries(
+          refs.flatMap((ref) => {
+            const value = literalOf(ref, key)
+            return value === undefined ? [] : [[value, ref]]
+          }),
+        )
+        if (Object.keys(mapping).length === refs.length) {
+          return [name, { ...schema, discriminator: { propertyName: key, mapping } }]
+        }
+      }
+      return [name, schema]
+    }),
+  )
+  return {
+    ...document,
+    components: { ...document.components, schemas: stamped },
   } as ReturnType<typeof OpenApi.fromApi>
 }
 
@@ -121,7 +193,7 @@ const withDataOnlySseResponse = (document: ReturnType<typeof OpenApi.fromApi>) =
 }
 
 export const openApiDocument = hoistSingleAllOf(
-  withDataOnlySseResponse(withSsePayloadComponents(OpenApi.fromApi(Api))),
+  withDiscriminators(withDataOnlySseResponse(withVocabularyComponents(OpenApi.fromApi(Api)))),
 ) as ReturnType<typeof OpenApi.fromApi>
 
 /**

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -477,6 +477,9 @@ export const layerWith = (options: ThreadsOptions) =>
                     Deferred.doneUnsafe(naming.promptArrived, Effect.void)
                     return
                   }
+                  // Item events feed the transcript copy (ATC-193, the
+                  // Threads runtime PR); the activity subscription ignores them.
+                  if (event.type !== "activity") return
                   const activity = event.activity
                   const previous = liveActivity.get(record.id)
                   liveActivity.set(record.id, activity)

--- a/app-server/test/agents/agentAdapter.test.ts
+++ b/app-server/test/agents/agentAdapter.test.ts
@@ -268,12 +268,58 @@ describe("AgentAdapter seam semantics (fake adapter)", () => {
       const requestId = fake.openRequest(connection.providerSessionId, "approval")
       yield* waitForEvent(
         sink,
-        (event) => event.type === "requestOpened" && event.requestId === requestId,
+        (event) => event.type === "requestOpened" && event.request.id === requestId,
       )
       assert.strictEqual(yield* connection.activity, "needs_input")
       fake.closeRequest(connection.providerSessionId, requestId)
       assert.strictEqual(yield* connection.activity, "working")
     }).pipe(Effect.scoped),
+  )
+
+  it.effect("respond answers a parked request; unknown or mismatched answers conflict", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeAgentAdapter()
+      const { connection } = yield* fake.adapter.createSession({ cwd: "/work", input: "ask me" })
+      const sink = yield* collectEvents(connection.events)
+      const requestId = fake.openRequest(connection.providerSessionId, "question")
+      yield* waitForEvent(sink, (event) => event.type === "requestOpened")
+      const mismatch = yield* Effect.flip(
+        connection.respond(requestId, { kind: "approval", decision: "accept" }),
+      )
+      assert.strictEqual(mismatch._tag, "AgentConflict")
+      yield* connection.respond(requestId, { kind: "question", answers: { q0: ["A"] } })
+      yield* waitForEvent(
+        sink,
+        (event) => event.type === "requestClosed" && event.requestId === requestId,
+      )
+      assert.deepStrictEqual(fake.answers, [
+        { requestId, answer: { kind: "question", answers: { q0: ["A"] } } },
+      ])
+      const gone = yield* Effect.flip(
+        connection.respond(requestId, { kind: "question", answers: { q0: ["A"] } }),
+      )
+      assert.strictEqual(gone._tag, "AgentConflict")
+    }).pipe(Effect.scoped),
+  )
+
+  it.effect("readHistory returns the scripted turns and records the read", () =>
+    Effect.gen(function* () {
+      const fake = makeFakeAgentAdapter()
+      fake.seed("s1", "/work")
+      assert.deepStrictEqual(
+        yield* fake.adapter.readHistory({ providerSessionId: "s1", cwd: "/work" }),
+        [],
+      )
+      fake.setHistory("s1", [
+        {
+          turn: { id: "t1", status: "completed" },
+          items: [{ type: "userMessage", id: "u1", turnId: "t1", text: "hi" }],
+        },
+      ])
+      const history = yield* fake.adapter.readHistory({ providerSessionId: "s1", cwd: "/work" })
+      assert.strictEqual(history[0]?.items[0]?.type, "userMessage")
+      assert.deepStrictEqual(fake.historyReads, ["s1", "s1"])
+    }),
   )
 
   it.effect("unavailability is injected everywhere", () =>

--- a/app-server/test/agents/claudeAdapter.test.ts
+++ b/app-server/test/agents/claudeAdapter.test.ts
@@ -229,7 +229,7 @@ describe("ClaudeAdapter", () => {
     }),
   )
 
-  it.live("permission callbacks surface as request events and are denied", () =>
+  it.live("permission callbacks park as approval requests until answered", () =>
     Effect.gen(function* () {
       const cwd = workDir()
       const { fake, layer } = adapterStack()
@@ -242,18 +242,251 @@ describe("ClaudeAdapter", () => {
               input: "needs PERMISSION for a tool",
             })
             const sink = yield* collectAgentEvents(connection.events)
+            yield* waitForAgentEvent(sink, (event) => event.type === "requestOpened")
+            const opened = sink.find((event) => event.type === "requestOpened")
+            if (opened?.type !== "requestOpened" || opened.request.kind !== "approval") {
+              return assert.fail("expected an approval request")
+            }
+            // The SDK's pre-rendered title and reason ride the request; the
+            // Bash input becomes a command subject naming the tool item.
+            assert.strictEqual(opened.request.title, "Claude wants to run pwd")
+            assert.strictEqual(opened.request.reason, "outside the allow list")
+            assert.deepStrictEqual(opened.request.subject, { type: "command", command: "pwd" })
+            assert.strictEqual(opened.request.itemId, "fake-tool-use-1")
+            // The tool item is pending while its approval parks (whether the
+            // ask or the tool_use block landed first) — nothing has been
+            // denied yet.
             yield* waitForAgentEvent(
               sink,
-              (event) => event.type === "requestOpened" && event.kind === "approval",
+              (event) =>
+                (event.type === "itemStarted" || event.type === "itemUpdated") &&
+                event.item.id === "fake-tool-use-1" &&
+                event.item.type === "command" &&
+                event.item.status === "pending",
             )
+            assert.deepStrictEqual(fake.decisions, [])
+            assert.isTrue(
+              sink.some((event) => event.type === "activity" && event.activity === "needs_input"),
+            )
+            yield* connection.respond(opened.request.id, { kind: "approval", decision: "accept" })
             yield* waitForAgentEvent(sink, (event) => event.type === "requestClosed")
             yield* waitForAgentEvent(
               sink,
               (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
             )
-            assert.deepStrictEqual(fake.denials, [{ toolName: "Bash", behavior: "deny" }])
+            assert.deepStrictEqual(fake.decisions, [
+              { toolName: "Bash", result: { behavior: "allow" } },
+            ])
+            // Accepted: the command ran and its result completed the item.
+            const completed = sink.find(
+              (event) => event.type === "itemCompleted" && event.item.id === "fake-tool-use-1",
+            )
             assert.isTrue(
-              sink.some((event) => event.type === "activity" && event.activity === "needs_input"),
+              completed?.type === "itemCompleted" &&
+                completed.item.type === "command" &&
+                completed.item.status === "completed" &&
+                completed.item.output === "/work",
+            )
+            // Answered requests are gone: a second answer is a conflict.
+            const again = yield* Effect.flip(
+              connection.respond(opened.request.id, { kind: "approval", decision: "accept" }),
+            )
+            assert.strictEqual(again._tag, "AgentConflict")
+          }),
+        )
+      }).pipe(Effect.provide(layer))
+    }),
+  )
+
+  it.live("a declined approval fails the tool item; a cancel interrupts the turn", () =>
+    Effect.gen(function* () {
+      const cwd = workDir()
+      const { fake, layer } = adapterStack()
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const { connection, turn } = yield* adapter.createSession({
+              cwd,
+              input: "needs PERMISSION for a tool",
+            })
+            const sink = yield* collectAgentEvents(connection.events)
+            yield* waitForAgentEvent(sink, (event) => event.type === "requestOpened")
+            const opened = sink.find((event) => event.type === "requestOpened")
+            if (opened?.type !== "requestOpened") return assert.fail("expected a request")
+            // Kind mismatch is a conflict, and leaves the request parked.
+            const mismatch = yield* Effect.flip(
+              connection.respond(opened.request.id, { kind: "question", answers: {} }),
+            )
+            assert.strictEqual(mismatch._tag, "AgentConflict")
+            yield* connection.respond(opened.request.id, { kind: "approval", decision: "decline" })
+            yield* waitForAgentEvent(
+              sink,
+              (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
+            )
+            assert.deepStrictEqual(fake.decisions, [
+              { toolName: "Bash", result: { behavior: "deny", message: "declined" } },
+            ])
+            const completed = sink.find(
+              (event) => event.type === "itemCompleted" && event.item.id === "fake-tool-use-1",
+            )
+            assert.isTrue(
+              completed?.type === "itemCompleted" &&
+                completed.item.type === "command" &&
+                completed.item.status === "error",
+            )
+          }),
+        )
+        // cancel = deny + interrupt: the turn ends interrupted (and, Claude
+        // being Claude, the connection with it).
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const { connection, turn } = yield* adapter.createSession({
+              cwd,
+              input: "needs PERMISSION again",
+            })
+            const sink = yield* collectAgentEvents(connection.events)
+            yield* waitForAgentEvent(sink, (event) => event.type === "requestOpened")
+            const opened = sink.find((event) => event.type === "requestOpened")
+            if (opened?.type !== "requestOpened") return assert.fail("expected a request")
+            yield* connection.respond(opened.request.id, { kind: "approval", decision: "cancel" })
+            yield* waitForAgentEvent(
+              sink,
+              (event) =>
+                event.type === "turnCompleted" &&
+                event.turnId === turn.turnId &&
+                event.outcome === "interrupted",
+            )
+          }),
+        )
+      }).pipe(Effect.provide(layer))
+    }),
+  )
+
+  it.live("assistant text streams as content blocks; the per-block echo never duplicates it", () =>
+    Effect.gen(function* () {
+      const cwd = workDir()
+      const { layer } = adapterStack()
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const { connection, turn } = yield* adapter.createSession({
+              cwd,
+              input: "STREAM please",
+            })
+            const sink = yield* collectAgentEvents(connection.events)
+            yield* waitForAgentEvent(
+              sink,
+              (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
+            )
+            const items = sink.flatMap((event) =>
+              event.type === "itemStarted" ||
+              event.type === "itemCompleted" ||
+              event.type === "textDelta"
+                ? [event]
+                : [],
+            )
+            // The prompt is the turn's first item, keyed by the turn.
+            assert.deepStrictEqual(items[0], {
+              type: "itemCompleted",
+              item: {
+                type: "userMessage",
+                id: `${turn.turnId}:prompt`,
+                turnId: turn.turnId,
+                text: "STREAM please",
+              },
+            })
+            // Then the streamed block: keyed by API message id + block index.
+            assert.deepStrictEqual(items.slice(1), [
+              {
+                type: "itemStarted",
+                item: {
+                  type: "assistantText",
+                  id: "msg_fake_1:0",
+                  turnId: turn.turnId,
+                  text: "",
+                  complete: false,
+                },
+              },
+              { type: "textDelta", itemId: "msg_fake_1:0", delta: "fake: " },
+              { type: "textDelta", itemId: "msg_fake_1:0", delta: "STREAM please" },
+              {
+                type: "itemCompleted",
+                item: {
+                  type: "assistantText",
+                  id: "msg_fake_1:0",
+                  turnId: turn.turnId,
+                  text: "fake: STREAM please",
+                  complete: true,
+                },
+              },
+            ])
+          }),
+        )
+      }).pipe(Effect.provide(layer))
+    }),
+  )
+
+  it.live("tool_use blocks open tool items and their results complete them", () =>
+    Effect.gen(function* () {
+      const cwd = workDir()
+      const { layer } = adapterStack()
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const { connection, turn } = yield* adapter.createSession({
+              cwd,
+              input: "use a TOOL",
+            })
+            const sink = yield* collectAgentEvents(connection.events)
+            yield* waitForAgentEvent(
+              sink,
+              (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
+            )
+            const tool = sink.flatMap((event) =>
+              (event.type === "itemStarted" || event.type === "itemCompleted") &&
+              event.item.id === "toolu_fake_read"
+                ? [event]
+                : [],
+            )
+            assert.deepStrictEqual(tool, [
+              {
+                type: "itemStarted",
+                item: {
+                  type: "toolCall",
+                  id: "toolu_fake_read",
+                  turnId: turn.turnId,
+                  title: "Read notes.md",
+                  status: "running",
+                  name: "Read",
+                  input: { file_path: "/work/notes.md" },
+                },
+              },
+              {
+                type: "itemCompleted",
+                item: {
+                  type: "toolCall",
+                  id: "toolu_fake_read",
+                  turnId: turn.turnId,
+                  title: "Read notes.md",
+                  status: "completed",
+                  name: "Read",
+                  input: { file_path: "/work/notes.md" },
+                  output: { file: { filePath: "/work/notes.md", content: "hello" } },
+                },
+              },
+            ])
+            // The un-streamed final text still lands, keyed by its message uuid.
+            const text = sink.find(
+              (event) => event.type === "itemCompleted" && event.item.type === "assistantText",
+            )
+            assert.isTrue(
+              text?.type === "itemCompleted" &&
+                text.item.type === "assistantText" &&
+                text.item.text === "fake: use a TOOL" &&
+                text.item.complete,
             )
           }),
         )
@@ -406,7 +639,7 @@ describe("ClaudeAdapter", () => {
     }),
   )
 
-  it.live("AskUserQuestion surfaces as a question, not an approval", () =>
+  it.live("AskUserQuestion surfaces as a question; answers go back keyed by question text", () =>
     Effect.gen(function* () {
       const cwd = workDir()
       const { fake, layer } = adapterStack()
@@ -421,14 +654,54 @@ describe("ClaudeAdapter", () => {
             const sink = yield* collectAgentEvents(connection.events)
             yield* waitForAgentEvent(
               sink,
-              (event) => event.type === "requestOpened" && event.kind === "question",
+              (event) => event.type === "requestOpened" && event.request.kind === "question",
             )
+            const opened = sink.find((event) => event.type === "requestOpened")
+            if (opened?.type !== "requestOpened" || opened.request.kind !== "question") {
+              return assert.fail("expected a question request")
+            }
+            assert.deepStrictEqual(
+              opened.request.questions.map((question) => [
+                question.id,
+                question.header,
+                question.options.map((option) => option.label),
+                question.freeform,
+              ]),
+              [
+                ["q0", "Color", ["red", "blue"], true],
+                ["q1", "Notes", [], true],
+              ],
+            )
+            yield* connection.respond(opened.request.id, {
+              kind: "question",
+              answers: { q0: ["blue"], q1: ["ship it"] },
+            })
             yield* waitForAgentEvent(
               sink,
               (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
             )
-            assert.deepStrictEqual(fake.denials, [
-              { toolName: "AskUserQuestion", behavior: "deny" },
+            assert.deepStrictEqual(fake.decisions, [
+              {
+                toolName: "AskUserQuestion",
+                result: {
+                  behavior: "allow",
+                  updatedInput: {
+                    questions: [
+                      {
+                        question: "Which color?",
+                        header: "Color",
+                        options: [
+                          { label: "red", description: "warm" },
+                          { label: "blue", description: "cool" },
+                        ],
+                        multiSelect: false,
+                      },
+                      { question: "Any notes?", header: "Notes", options: [], multiSelect: false },
+                    ],
+                    answers: { "Which color?": "blue", "Any notes?": "ship it" },
+                  },
+                },
+              },
             ])
           }),
         )
@@ -530,7 +803,13 @@ describe("ClaudeAdapter TUI session plumbing", () => {
       yield* stream.pipe(
         Stream.runForEach((event) =>
           Effect.sync(() =>
-            sink.push(event.type === "activity" ? event.activity : `prompt:${event.text}`),
+            sink.push(
+              event.type === "activity"
+                ? event.activity
+                : event.type === "userPrompt"
+                  ? `prompt:${event.text}`
+                  : `item:${event.item.type}`,
+            ),
           ),
         ),
         Effect.ignore,
@@ -929,6 +1208,50 @@ describe("ClaudeAdapter collectTitleContext", () => {
         assert.deepStrictEqual(calls, [{ sessionId: "context-session", dir: "/work" }])
       }).pipe(Effect.provide(layer))
     }),
+  )
+
+  it.live(
+    "readHistory normalizes the transcript into turns; a failed read is a protocol error",
+    () =>
+      Effect.gen(function* () {
+        const calls: Array<{ sessionId: string; dir: string | undefined }> = []
+        const layer = claudeAdapterLayer({
+          sessionMessagesFn: (sessionId, options) => {
+            calls.push({ sessionId, dir: options?.dir })
+            if (sessionId === "gone-session") return Promise.reject(new Error("no transcript"))
+            return Promise.resolve([
+              transcriptMessage("user", "hello"),
+              transcriptMessage("assistant", [
+                { type: "tool_use", id: "t1", name: "Bash", input: { command: "ls" } },
+              ]),
+              transcriptMessage("user", [
+                { type: "tool_result", tool_use_id: "t1", content: "a b" },
+              ]),
+              transcriptMessage("assistant", "two files"),
+            ])
+          },
+        })
+        yield* Effect.gen(function* () {
+          const adapter = yield* ClaudeAdapter.ClaudeAdapter
+          const history = yield* adapter.readHistory({
+            providerSessionId: "context-session",
+            cwd: "/work",
+          })
+          assert.deepStrictEqual(calls, [{ sessionId: "context-session", dir: "/work" }])
+          assert.strictEqual(history.length, 1)
+          assert.deepStrictEqual(
+            history[0]?.items.map((item) => item.type),
+            ["userMessage", "command", "assistantText"],
+          )
+          const command = history[0]?.items[1]
+          assert.isTrue(command?.type === "command" && command.output === "a b")
+          assert.strictEqual(history[0]?.turn.status, "completed")
+          const failure = yield* Effect.flip(
+            adapter.readHistory({ providerSessionId: "gone-session", cwd: "/work" }),
+          )
+          assert.strictEqual(failure._tag, "AgentProtocolError")
+        }).pipe(Effect.provide(layer))
+      }),
   )
 
   it.live("a failed or empty transcript read is silently no context", () =>

--- a/app-server/test/agents/claudeHooks.test.ts
+++ b/app-server/test/agents/claudeHooks.test.ts
@@ -170,7 +170,7 @@ describe("claude hook webhook delivery", () => {
         const prompts: Array<string> = []
         yield* hooks.subscribe((sessionId, event) => {
           if (event.type === "activity") seen.push({ sessionId, activity: event.activity })
-          else prompts.push(event.text)
+          if (event.type === "userPrompt") prompts.push(event.text)
         })
         const secret = yield* hooks.registerSecret(RECORDED_SESSION)
 

--- a/app-server/test/agents/claudeItems.test.ts
+++ b/app-server/test/agents/claudeItems.test.ts
@@ -1,0 +1,358 @@
+import type { SessionMessage } from "@anthropic-ai/claude-agent-sdk"
+import { assert, describe, it } from "@effect/vitest"
+import * as ClaudeItems from "../../src/agents/claudeItems.ts"
+
+// The Claude SDK shape → vocabulary mapping table (ATC-193). Pure functions:
+// no fixture query, no SDK.
+
+const turnId = "claude-turn-1"
+const openedAt = "2026-08-17T00:00:00.000Z"
+
+describe("ClaudeItems.toolItem / completeToolItem", () => {
+  it("Bash is a command; its result is the output", () => {
+    const item = ClaudeItems.toolItem(
+      { id: "tu1", name: "Bash", input: { command: "bun test\n# more", cwd: "/w" } },
+      turnId,
+      null,
+      "running",
+    )
+    assert.deepStrictEqual(item, {
+      type: "command",
+      id: "tu1",
+      turnId,
+      title: "bun test",
+      status: "running",
+      command: "bun test\n# more",
+      cwd: "/w",
+    })
+    if (item.type !== "command") return assert.fail("expected a command")
+    assert.deepStrictEqual(ClaudeItems.completeToolItem(item, { content: "ok\n" }, undefined), {
+      ...item,
+      status: "completed" as const,
+      output: "ok\n",
+    })
+    assert.deepStrictEqual(
+      ClaudeItems.completeToolItem(item, { content: "boom", is_error: true }, undefined),
+      { ...item, status: "error" as const, error: "boom", output: "boom" },
+    )
+  })
+
+  it("edit tools are fileChanges; the structured result supplies kind and diff", () => {
+    const item = ClaudeItems.toolItem(
+      { id: "tu2", name: "Write", input: { file_path: "/w/new.ts", content: "x" } },
+      turnId,
+      "parent-tool",
+      "pending",
+    )
+    assert.deepStrictEqual(item, {
+      type: "fileChange",
+      id: "tu2",
+      turnId,
+      parentItemId: "parent-tool",
+      title: "Edit new.ts",
+      status: "pending",
+      changes: [{ path: "/w/new.ts", kind: "update" }],
+    })
+    if (item.type !== "fileChange") return assert.fail("expected a fileChange")
+    const completed = ClaudeItems.completeToolItem(
+      item,
+      { content: "File created successfully" },
+      {
+        type: "create",
+        filePath: "/w/new.ts",
+        content: "x",
+        structuredPatch: [{ oldStart: 0, oldLines: 0, newStart: 1, newLines: 1, lines: ["+x"] }],
+      },
+    )
+    assert.deepStrictEqual(completed, {
+      ...item,
+      status: "completed" as const,
+      title: "Create new.ts",
+      changes: [{ path: "/w/new.ts", kind: "add", diff: "@@ -0,0 +1,1 @@\n+x" }],
+    })
+    // Without a structured result (history) the change keeps its safe kind.
+    const plain = ClaudeItems.completeToolItem(item, { content: "ok" }, undefined)
+    assert.deepStrictEqual(plain.type === "fileChange" ? plain.changes : [], [
+      { path: "/w/new.ts", kind: "update" },
+    ])
+  })
+
+  it("mcp__server__tool is an mcpCall; anything else is a titled toolCall", () => {
+    const mcp = ClaudeItems.toolItem(
+      { id: "tu3", name: "mcp__linear-server__get_issue", input: { id: "ATC-1" } },
+      turnId,
+      null,
+      "running",
+    )
+    assert.deepStrictEqual(mcp, {
+      type: "mcpCall",
+      id: "tu3",
+      turnId,
+      title: "linear-server · get_issue",
+      status: "running",
+      server: "linear-server",
+      tool: "get_issue",
+      arguments: { id: "ATC-1" },
+    })
+    if (mcp.type !== "mcpCall") return assert.fail("expected an mcpCall")
+    assert.deepStrictEqual(
+      ClaudeItems.completeToolItem(mcp, { content: [{ type: "text", text: "{}" }] }, undefined),
+      { ...mcp, status: "completed" as const, result: [{ type: "text", text: "{}" }] },
+    )
+    const read = ClaudeItems.toolItem(
+      { id: "tu4", name: "Read", input: { file_path: "/w/a.ts" } },
+      turnId,
+      null,
+      "running",
+    )
+    assert.strictEqual(read.type === "toolCall" ? read.title : "", "Read a.ts")
+    const task = ClaudeItems.toolItem(
+      { id: "tu5", name: "Task", input: { description: "survey tests", prompt: "…" } },
+      turnId,
+      null,
+      "running",
+    )
+    assert.strictEqual(task.type === "toolCall" ? task.title : "", "survey tests")
+    // The structured output wins over the text content when present.
+    const done = ClaudeItems.completeToolItem(read, { content: "text" }, { file: { content: "x" } })
+    assert.deepStrictEqual(done.type === "toolCall" ? done.output : undefined, {
+      file: { content: "x" },
+    })
+  })
+})
+
+describe("ClaudeItems.mapRequest / permissionResult", () => {
+  const context = { requestId: "req-1", toolUseID: "tu-1" }
+
+  it("Bash asks are command approvals; edit tools fileChange; others tool", () => {
+    assert.deepStrictEqual(
+      ClaudeItems.mapRequest(
+        "Bash",
+        { command: "rm x" },
+        { ...context, title: "Claude wants to run rm x", decisionReason: "not allowed" },
+        turnId,
+        openedAt,
+      ),
+      {
+        kind: "approval",
+        id: "req-1",
+        turnId,
+        itemId: "tu-1",
+        openedAt,
+        title: "Claude wants to run rm x",
+        reason: "not allowed",
+        subject: { type: "command", command: "rm x" },
+      },
+    )
+    const edit = ClaudeItems.mapRequest("Edit", { file_path: "/w/a.ts" }, context, turnId, openedAt)
+    assert.deepStrictEqual(edit.kind === "approval" ? edit.subject : undefined, {
+      type: "fileChange",
+      changes: [{ path: "/w/a.ts", kind: "update" }],
+    })
+    assert.strictEqual(edit.kind === "approval" ? edit.title : "", "Edit a.ts")
+    const fetch = ClaudeItems.mapRequest(
+      "WebFetch",
+      { url: "https://x" },
+      context,
+      turnId,
+      openedAt,
+    )
+    assert.deepStrictEqual(fetch.kind === "approval" ? fetch.subject : undefined, {
+      type: "tool",
+      name: "WebFetch",
+      input: { url: "https://x" },
+    })
+  })
+
+  it("decisions map onto PermissionResults; session grants reuse the SDK's suggestions", () => {
+    const request = ClaudeItems.mapRequest(
+      "WebFetch",
+      { url: "https://x" },
+      context,
+      turnId,
+      openedAt,
+    )
+    const decide = (
+      decision: "accept" | "acceptForSession" | "decline" | "cancel",
+      suggestions = [],
+    ) =>
+      ClaudeItems.permissionResult(
+        request,
+        { kind: "approval", decision },
+        { url: "https://x" },
+        suggestions,
+      )
+    assert.deepStrictEqual(decide("accept"), { behavior: "allow" })
+    assert.deepStrictEqual(decide("decline"), { behavior: "deny", message: "declined" })
+    assert.deepStrictEqual(decide("cancel"), {
+      behavior: "deny",
+      message: "cancelled",
+      interrupt: true,
+    })
+    assert.deepStrictEqual(decide("acceptForSession"), {
+      behavior: "allow",
+      updatedPermissions: [
+        {
+          type: "addRules",
+          rules: [{ toolName: "WebFetch" }],
+          behavior: "allow",
+          destination: "session",
+        },
+      ],
+    })
+    const suggestion = {
+      type: "addRules" as const,
+      rules: [{ toolName: "WebFetch", ruleContent: "domain:x" }],
+      behavior: "allow" as const,
+      destination: "session" as const,
+    }
+    assert.deepStrictEqual(
+      ClaudeItems.permissionResult(
+        request,
+        { kind: "approval", decision: "acceptForSession" },
+        {},
+        [suggestion],
+      ),
+      { behavior: "allow", updatedPermissions: [suggestion] },
+    )
+  })
+
+  it("AskUserQuestion is a question; answers return keyed by question text", () => {
+    const input = {
+      questions: [
+        {
+          question: "Which?",
+          header: "Pick",
+          options: [{ label: "a", description: "A" }, { label: "b" }],
+          multiSelect: true,
+        },
+      ],
+    }
+    const request = ClaudeItems.mapRequest("AskUserQuestion", input, context, turnId, openedAt)
+    assert.deepStrictEqual(request, {
+      kind: "question",
+      id: "req-1",
+      turnId,
+      itemId: "tu-1",
+      openedAt,
+      questions: [
+        {
+          id: "q0",
+          header: "Pick",
+          question: "Which?",
+          options: [
+            { label: "a", description: "A" },
+            { label: "b", description: "" },
+          ],
+          multiSelect: true,
+          freeform: true,
+          secret: false,
+        },
+      ],
+    })
+    assert.deepStrictEqual(
+      ClaudeItems.permissionResult(
+        request,
+        { kind: "question", answers: { q0: ["a", "b"] } },
+        input,
+        [],
+      ),
+      { behavior: "allow", updatedInput: { ...input, answers: { "Which?": "a, b" } } },
+    )
+  })
+})
+
+describe("ClaudeItems.mapHistory", () => {
+  const message = (
+    type: "user" | "assistant" | "system",
+    content: unknown,
+    uuid: string,
+    extra: Partial<SessionMessage> & { timestamp?: string } = {},
+  ): SessionMessage =>
+    ({
+      type,
+      uuid,
+      session_id: "s",
+      message: { role: type, content },
+      parent_tool_use_id: null,
+      parent_agent_id: null,
+      ...extra,
+    }) as SessionMessage
+
+  it("groups at each user text message, links tool results, and reads incomplete turns as interrupted", () => {
+    const history = ClaudeItems.mapHistory([
+      message("user", "first prompt", "u1", { timestamp: "2026-08-17T10:00:00.000Z" }),
+      message("assistant", [{ type: "thinking", thinking: "hmm" }], "a1", {
+        timestamp: "2026-08-17T10:00:01.000Z",
+      }),
+      message(
+        "assistant",
+        [{ type: "tool_use", id: "t1", name: "Read", input: { file_path: "/w/x" } }],
+        "a2",
+      ),
+      message("user", [{ type: "tool_result", tool_use_id: "t1", content: "contents" }], "u2"),
+      message("assistant", [{ type: "text", text: "done" }], "a3", {
+        timestamp: "2026-08-17T10:00:05.000Z",
+      }),
+      // A subagent's message never reaches the top-level transcript.
+      message("assistant", [{ type: "text", text: "nested" }], "a4", { parent_tool_use_id: "t1" }),
+      message("system", undefined, "sys1"),
+      message("user", [{ type: "text", text: "second prompt" }], "u3"),
+      message(
+        "assistant",
+        [{ type: "tool_use", id: "t2", name: "Bash", input: { command: "ls" } }],
+        "a5",
+      ),
+    ])
+    assert.deepStrictEqual(history, [
+      {
+        turn: {
+          id: "u1",
+          status: "completed",
+          startedAt: "2026-08-17T10:00:00.000Z",
+          endedAt: "2026-08-17T10:00:05.000Z",
+        },
+        items: [
+          { type: "userMessage", id: "u1:0", turnId: "u1", text: "first prompt" },
+          { type: "reasoning", id: "a1:0", turnId: "u1", text: "hmm", complete: true },
+          {
+            type: "toolCall",
+            id: "t1",
+            turnId: "u1",
+            title: "Read x",
+            status: "completed",
+            name: "Read",
+            input: { file_path: "/w/x" },
+            output: "contents",
+          },
+          { type: "assistantText", id: "a3:0", turnId: "u1", text: "done", complete: true },
+        ],
+      },
+      {
+        turn: { id: "u3", status: "interrupted" },
+        items: [
+          { type: "userMessage", id: "u3:0", turnId: "u3", text: "second prompt" },
+          {
+            type: "command",
+            id: "t2",
+            turnId: "u3",
+            title: "ls",
+            status: "error",
+            error: "no result recorded",
+            command: "ls",
+          },
+        ],
+      },
+    ])
+  })
+
+  it("an empty or result-only transcript yields no turns", () => {
+    assert.deepStrictEqual(ClaudeItems.mapHistory([]), [])
+    assert.deepStrictEqual(
+      ClaudeItems.mapHistory([
+        message("user", [{ type: "tool_result", tool_use_id: "t9", content: "x" }], "u9"),
+      ]),
+      [],
+    )
+  })
+})

--- a/app-server/test/agents/codexAdapter.test.ts
+++ b/app-server/test/agents/codexAdapter.test.ts
@@ -2,6 +2,7 @@ import { assert, describe, it } from "@effect/vitest"
 import { Effect, Stream } from "effect"
 import * as fs from "node:fs"
 import * as path from "node:path"
+import type { AgentSessionEvent } from "../../src/agents/agentAdapter.ts"
 import * as CodexAdapter from "../../src/agents/codexAdapter.ts"
 import * as CodexServer from "../../src/agents/codexServer.ts"
 import { eventually } from "../testLayers.ts"
@@ -231,7 +232,7 @@ describe("CodexAdapter", () => {
   )
 
   it.live(
-    "provider approval requests surface on the feed and are auto-rejected",
+    "provider approval requests park on the feed until answered on the JSON-RPC request",
     () =>
       Effect.gen(function* () {
         const sandbox = makeCodexSandbox()
@@ -245,16 +246,127 @@ describe("CodexAdapter", () => {
               const sink = yield* collectAgentEvents(connection.events)
               yield* waitForAgentEvent(sink, (event) => event.type === "requestOpened")
               const opened = sink.find((event) => event.type === "requestOpened")
-              assert.strictEqual(opened?.type === "requestOpened" ? opened.kind : "", "approval")
+              if (opened?.type !== "requestOpened" || opened.request.kind !== "approval") {
+                return assert.fail("expected an approval request")
+              }
+              // The command, cwd, and reason ride the request; it names the
+              // pending commandExecution item, which flips to pending.
+              assert.deepStrictEqual(opened.request.subject, {
+                type: "command",
+                command: "/bin/sh -c pwd",
+                cwd: sandbox.cwd,
+              })
+              assert.strictEqual(opened.request.reason, "needs network")
+              assert.strictEqual(opened.request.turnId, turn.turnId)
+              const itemId = opened.request.itemId
+              assert.isString(itemId)
+              yield* waitForAgentEvent(
+                sink,
+                (event) =>
+                  event.type === "itemUpdated" &&
+                  event.item.id === itemId &&
+                  event.item.type === "command" &&
+                  event.item.status === "pending",
+              )
+              // needs_input was truthfully reported while the request parks.
+              yield* waitForAgentEvent(
+                sink,
+                (event) => event.type === "activity" && event.activity === "needs_input",
+              )
+              assert.isFalse(sink.some((event) => event.type === "turnCompleted"))
+              yield* connection.respond(opened.request.id, { kind: "approval", decision: "accept" })
               yield* waitForAgentEvent(sink, (event) => event.type === "requestClosed")
-              // The reject unblocks the fixture, so the turn still completes.
               yield* waitForAgentEvent(
                 sink,
                 (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
               )
-              // needs_input was truthfully reported while the request hung.
+              const completed = sink.find(
+                (event) => event.type === "itemCompleted" && event.item.id === itemId,
+              )
               assert.isTrue(
-                sink.some((event) => event.type === "activity" && event.activity === "needs_input"),
+                completed?.type === "itemCompleted" &&
+                  completed.item.type === "command" &&
+                  completed.item.status === "completed" &&
+                  completed.item.exitCode === 0,
+              )
+              const again = yield* Effect.flip(
+                connection.respond(opened.request.id, { kind: "approval", decision: "accept" }),
+              )
+              assert.strictEqual(again._tag, "AgentConflict")
+            }),
+          ),
+        )
+      }),
+    30_000,
+  )
+
+  it.live(
+    "a declined approval ends the item declined; questions answer by id",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.scoped(
+            Effect.gen(function* () {
+              const { connection, turn } = yield* adapter.createSession({
+                cwd: sandbox.cwd,
+                input: "needs APPROVAL for this",
+              })
+              const sink = yield* collectAgentEvents(connection.events)
+              yield* waitForAgentEvent(sink, (event) => event.type === "requestOpened")
+              const opened = sink.find((event) => event.type === "requestOpened")
+              if (opened?.type !== "requestOpened") return assert.fail("expected a request")
+              yield* connection.respond(opened.request.id, {
+                kind: "approval",
+                decision: "decline",
+              })
+              yield* waitForAgentEvent(
+                sink,
+                (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
+              )
+              const declined = sink.find(
+                (event) =>
+                  event.type === "itemCompleted" &&
+                  event.item.id === opened.request.itemId &&
+                  event.item.type === "command" &&
+                  event.item.status === "error" &&
+                  event.item.error === "declined",
+              )
+              assert.isDefined(declined)
+
+              // A question round trip: answers keyed by the question id reach
+              // the provider (the fixture echoes them back as its reply).
+              const asked = yield* connection.startTurn("QUESTION time")
+              yield* waitForAgentEvent(
+                sink,
+                (event) => event.type === "requestOpened" && event.request.kind === "question",
+              )
+              const question = sink.findLast((event) => event.type === "requestOpened")
+              if (question?.type !== "requestOpened" || question.request.kind !== "question") {
+                return assert.fail("expected a question request")
+              }
+              assert.deepStrictEqual(
+                question.request.questions.map((entry) => [entry.id, entry.freeform]),
+                [["color", false]],
+              )
+              yield* connection.respond(question.request.id, {
+                kind: "question",
+                answers: { color: ["blue"] },
+              })
+              yield* waitForAgentEvent(
+                sink,
+                (event) => event.type === "turnCompleted" && event.turnId === asked.turnId,
+              )
+              const echo = sink.find(
+                (event) =>
+                  event.type === "itemCompleted" &&
+                  event.item.type === "assistantText" &&
+                  event.item.text.startsWith("answers:"),
+              )
+              assert.isTrue(
+                echo?.type === "itemCompleted" &&
+                  echo.item.type === "assistantText" &&
+                  echo.item.text === 'answers: {"color":{"answers":["blue"]}}',
               )
             }),
           ),
@@ -351,6 +463,121 @@ describe("CodexAdapter", () => {
   )
 
   it.live(
+    "agent text streams: itemStarted, deltas, itemCompleted — after the user's message item",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.scoped(
+            Effect.gen(function* () {
+              const { connection, turn } = yield* adapter.createSession({
+                cwd: sandbox.cwd,
+                input: "STREAM me",
+              })
+              const sink = yield* collectAgentEvents(connection.events)
+              yield* waitForAgentEvent(
+                sink,
+                (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
+              )
+              const items = sink.flatMap((event) =>
+                event.type === "itemStarted" ||
+                event.type === "itemCompleted" ||
+                event.type === "textDelta"
+                  ? [event]
+                  : [],
+              )
+              const first = items[0]
+              assert.isTrue(
+                first?.type === "itemCompleted" &&
+                  first.item.type === "userMessage" &&
+                  first.item.text === "STREAM me" &&
+                  first.item.turnId === turn.turnId,
+              )
+              const started = items[1]
+              if (started?.type !== "itemStarted" || started.item.type !== "assistantText") {
+                return assert.fail("expected the streamed agent message to start")
+              }
+              assert.strictEqual(started.item.complete, false)
+              assert.deepStrictEqual(
+                items.slice(2, 4).map((event) => (event.type === "textDelta" ? event : null)),
+                [
+                  { type: "textDelta", itemId: started.item.id, delta: "fake: " },
+                  { type: "textDelta", itemId: started.item.id, delta: "STREAM me" },
+                ],
+              )
+              const completed = items[4]
+              assert.isTrue(
+                completed?.type === "itemCompleted" &&
+                  completed.item.type === "assistantText" &&
+                  completed.item.id === started.item.id &&
+                  completed.item.complete &&
+                  completed.item.text === "fake: STREAM me",
+              )
+            }),
+          ),
+        )
+      }),
+    30_000,
+  )
+
+  it.live(
+    "readHistory returns thread/resume's turns and items; an unknown id fails closed",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.gen(function* () {
+            const threadId = yield* Effect.scoped(
+              Effect.gen(function* () {
+                const { connection, turn } = yield* adapter.createSession({
+                  cwd: sandbox.cwd,
+                  input: "run a COMMAND",
+                })
+                const sink = yield* collectAgentEvents(connection.events)
+                yield* waitForAgentEvent(
+                  sink,
+                  (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
+                )
+                return connection.providerSessionId
+              }),
+            )
+            const history = yield* adapter.readHistory({
+              providerSessionId: threadId,
+              cwd: sandbox.cwd,
+            })
+            assert.strictEqual(history.length, 1)
+            const [entry] = history
+            assert.strictEqual(entry?.turn.status, "completed")
+            assert.isString(entry?.turn.startedAt)
+            assert.isString(entry?.turn.endedAt)
+            assert.deepStrictEqual(
+              entry?.items.map((item) => [item.type, item.turnId === entry.turn.id]),
+              [
+                ["userMessage", true],
+                ["command", true],
+                ["assistantText", true],
+              ],
+            )
+            const command = entry?.items[1]
+            assert.isTrue(
+              command?.type === "command" &&
+                command.status === "completed" &&
+                command.exitCode === 0,
+            )
+            const failure = yield* Effect.flip(
+              adapter.readHistory({
+                providerSessionId: "00000000-0000-7000-8000-000000000000",
+                cwd: sandbox.cwd,
+              }),
+            )
+            assert.strictEqual(failure._tag, "AgentResumeFailed")
+          }),
+        )
+      }),
+    30_000,
+  )
+
+  it.live(
     "an older installed codex warns but still works",
     () =>
       Effect.gen(function* () {
@@ -420,6 +647,58 @@ describe("CodexAdapter TUI session plumbing", () => {
   )
 
   it.live(
+    "observers of a TUI-driven thread receive its conversation items",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.scoped(
+            Effect.gen(function* () {
+              // Any passive call brings the shared server up for the stand-in.
+              yield* adapter.checkSession({ providerSessionId: "warm-up" })
+              const external = yield* openExternal(sandbox.socketPath)
+              const threadId = yield* external.startThread(1, sandbox.cwd)
+              const stream = yield* adapter.observeSession({
+                providerSessionId: threadId,
+                providerMetadata: undefined,
+              })
+              const sink: Array<AgentSessionEvent> = []
+              yield* stream.pipe(
+                Stream.runForEach((event) => Effect.sync(() => sink.push(event))),
+                Effect.forkScoped,
+              )
+              // The TUI stand-in drives a turn; the fan-out carries its items.
+              yield* external.request(2, "turn/start", {
+                threadId,
+                input: [{ type: "text", text: "from the tui" }],
+              })
+              yield* eventually(
+                Effect.sync(() => sink),
+                (entries) =>
+                  entries.some(
+                    (event) =>
+                      event.type === "itemCompleted" && event.item.type === "assistantText",
+                  ),
+                { attempts: 200, interval: "25 millis" },
+              )
+              const items = sink.flatMap((event) =>
+                event.type === "itemCompleted" ? [event.item] : [],
+              )
+              assert.deepStrictEqual(
+                items.map((item) => [item.type, item.type === "userMessage" ? item.text : ""]),
+                [
+                  ["userMessage", "from the tui"],
+                  ["assistantText", ""],
+                ],
+              )
+            }),
+          ),
+        )
+      }),
+    30_000,
+  )
+
+  it.live(
     "capture ignores foreign-cwd threads and adopts the matching one",
     () =>
       Effect.gen(function* () {
@@ -466,7 +745,13 @@ describe("CodexAdapter TUI session plumbing", () => {
               yield* stream.pipe(
                 Stream.runForEach((event) =>
                   Effect.sync(() =>
-                    sink.push(event.type === "activity" ? event.activity : `prompt:${event.text}`),
+                    sink.push(
+                      event.type === "activity"
+                        ? event.activity
+                        : event.type === "userPrompt"
+                          ? `prompt:${event.text}`
+                          : `item:${event.item.type}`,
+                    ),
                   ),
                 ),
                 Effect.ignore,
@@ -511,7 +796,13 @@ describe("CodexAdapter TUI session plumbing", () => {
               yield* stream.pipe(
                 Stream.runForEach((event) =>
                   Effect.sync(() =>
-                    sink.push(event.type === "activity" ? event.activity : `prompt:${event.text}`),
+                    sink.push(
+                      event.type === "activity"
+                        ? event.activity
+                        : event.type === "userPrompt"
+                          ? `prompt:${event.text}`
+                          : `item:${event.item.type}`,
+                    ),
                   ),
                 ),
                 Effect.ignore,
@@ -606,7 +897,13 @@ describe("CodexAdapter TUI session plumbing", () => {
               yield* stream.pipe(
                 Stream.runForEach((event) =>
                   Effect.sync(() =>
-                    sink.push(event.type === "activity" ? event.activity : `prompt:${event.text}`),
+                    sink.push(
+                      event.type === "activity"
+                        ? event.activity
+                        : event.type === "userPrompt"
+                          ? `prompt:${event.text}`
+                          : `item:${event.item.type}`,
+                    ),
                   ),
                 ),
                 Effect.ignore,
@@ -660,7 +957,13 @@ describe("CodexAdapter TUI session plumbing", () => {
               yield* stream.pipe(
                 Stream.runForEach((event) =>
                   Effect.sync(() =>
-                    sink.push(event.type === "activity" ? event.activity : `prompt:${event.text}`),
+                    sink.push(
+                      event.type === "activity"
+                        ? event.activity
+                        : event.type === "userPrompt"
+                          ? `prompt:${event.text}`
+                          : `item:${event.item.type}`,
+                    ),
                   ),
                 ),
                 Effect.ignore,
@@ -675,7 +978,7 @@ describe("CodexAdapter TUI session plumbing", () => {
               // No transition after idle exists to re-arm discovery — the
               // in-fiber retry alone delivered the prompt.
               assert.deepStrictEqual(
-                sink.filter((entry) => !entry.startsWith("prompt:")),
+                sink.filter((entry) => !entry.startsWith("prompt:") && !entry.startsWith("item:")),
                 ["working", "idle"],
               )
             }),
@@ -867,7 +1170,13 @@ describe("CodexAdapter descendant aggregation", () => {
               yield* stream.pipe(
                 Stream.runForEach((event) =>
                   Effect.sync(() =>
-                    sink.push(event.type === "activity" ? event.activity : `prompt:${event.text}`),
+                    sink.push(
+                      event.type === "activity"
+                        ? event.activity
+                        : event.type === "userPrompt"
+                          ? `prompt:${event.text}`
+                          : `item:${event.item.type}`,
+                    ),
                   ),
                 ),
                 Effect.forkScoped,
@@ -1020,7 +1329,11 @@ describe("CodexAdapter descendant aggregation", () => {
                   Stream.runForEach((event) =>
                     Effect.sync(() =>
                       sink.push(
-                        event.type === "activity" ? event.activity : `prompt:${event.text}`,
+                        event.type === "activity"
+                          ? event.activity
+                          : event.type === "userPrompt"
+                            ? `prompt:${event.text}`
+                            : `item:${event.item.type}`,
                       ),
                     ),
                   ),

--- a/app-server/test/agents/codexItems.test.ts
+++ b/app-server/test/agents/codexItems.test.ts
@@ -1,0 +1,521 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import * as CodexItems from "../../src/agents/codexItems.ts"
+
+// The Codex wire-shape → vocabulary mapping table (ATC-193), pinned against
+// the codex 0.147 generated protocol shapes. Pure functions: no fixture.
+
+const turnId = "turn-1"
+
+describe("CodexItems.mapItem", () => {
+  it("userMessage joins its text inputs and skips non-text inputs", () => {
+    const item = CodexItems.mapItem(
+      {
+        type: "userMessage",
+        id: "u1",
+        clientId: null,
+        content: [
+          { type: "text", text: "hello", text_elements: [] },
+          { type: "image", url: "data:…" },
+          { type: "text", text: "world", text_elements: [] },
+        ],
+      },
+      turnId,
+      "completed",
+    )
+    assert.deepStrictEqual(item, { type: "userMessage", id: "u1", turnId, text: "hello\nworld" })
+  })
+
+  it("agentMessage streams (started = incomplete) and carries its phase as provider metadata", () => {
+    const started = CodexItems.mapItem(
+      { type: "agentMessage", id: "a1", text: "", phase: null, memoryCitation: null },
+      turnId,
+      "started",
+    )
+    assert.deepStrictEqual(started, {
+      type: "assistantText",
+      id: "a1",
+      turnId,
+      text: "",
+      complete: false,
+    })
+    const completed = CodexItems.mapItem(
+      { type: "agentMessage", id: "a1", text: "done", phase: "final_answer", memoryCitation: null },
+      turnId,
+      "completed",
+    )
+    assert.deepStrictEqual(completed, {
+      type: "assistantText",
+      id: "a1",
+      turnId,
+      text: "done",
+      complete: true,
+      providerMetadata: { codex: { phase: "final_answer" } },
+    })
+  })
+
+  it("plan is assistant text marked as a plan", () => {
+    assert.deepStrictEqual(
+      CodexItems.mapItem({ type: "plan", id: "p1", text: "1. do" }, turnId, "completed"),
+      {
+        type: "assistantText",
+        id: "p1",
+        turnId,
+        text: "1. do",
+        complete: true,
+        providerMetadata: { codex: { plan: true } },
+      },
+    )
+  })
+
+  it("reasoning shows the summary and keeps raw content as metadata; raw-only falls back", () => {
+    assert.deepStrictEqual(
+      CodexItems.mapItem(
+        { type: "reasoning", id: "r1", summary: ["first", "second"], content: ["raw"] },
+        turnId,
+        "completed",
+      ),
+      {
+        type: "reasoning",
+        id: "r1",
+        turnId,
+        text: "first\n\nsecond",
+        complete: true,
+        providerMetadata: { codex: { content: ["raw"] } },
+      },
+    )
+    assert.deepStrictEqual(
+      CodexItems.mapItem(
+        { type: "reasoning", id: "r2", summary: [], content: ["raw"] },
+        turnId,
+        "started",
+      ),
+      { type: "reasoning", id: "r2", turnId, text: "raw", complete: false },
+    )
+  })
+
+  it("commandExecution maps status, output, exit code, and duration", () => {
+    const base = {
+      type: "commandExecution",
+      id: "c1",
+      pluginId: null,
+      scriptPath: null,
+      command: "bun test\n--filter x",
+      cwd: "/work",
+      processId: null,
+      source: "agent",
+      commandActions: [],
+      aggregatedOutput: null,
+      exitCode: null,
+      durationMs: null,
+    }
+    assert.deepStrictEqual(
+      CodexItems.mapItem({ ...base, status: "inProgress" }, turnId, "started"),
+      {
+        type: "command",
+        id: "c1",
+        turnId,
+        title: "bun test",
+        status: "running",
+        command: "bun test\n--filter x",
+        cwd: "/work",
+      },
+    )
+    assert.deepStrictEqual(
+      CodexItems.mapItem(
+        { ...base, status: "completed", aggregatedOutput: "ok\n", exitCode: 0, durationMs: 40 },
+        turnId,
+        "completed",
+      ),
+      {
+        type: "command",
+        id: "c1",
+        turnId,
+        title: "bun test",
+        status: "completed",
+        command: "bun test\n--filter x",
+        cwd: "/work",
+        output: "ok\n",
+        exitCode: 0,
+        providerMetadata: { codex: { durationMs: 40 } },
+      },
+    )
+    const declined = CodexItems.mapItem({ ...base, status: "declined" }, turnId, "completed")
+    assert.strictEqual(declined?.type === "command" ? declined.status : "", "error")
+    assert.strictEqual(declined?.type === "command" ? declined.error : "", "declined")
+    const failed = CodexItems.mapItem(
+      { ...base, status: "failed", exitCode: 1 },
+      turnId,
+      "completed",
+    )
+    assert.strictEqual(failed?.type === "command" ? failed.error : "", "failed")
+  })
+
+  it("fileChange maps kinds 1:1, keeps diffs, and titles by verb and count", () => {
+    const item = CodexItems.mapItem(
+      {
+        type: "fileChange",
+        id: "f1",
+        status: "completed",
+        changes: [
+          { path: "/w/a.ts", kind: { type: "update", move_path: null }, diff: "@@ -1 +1 @@" },
+          { path: "/w/b.ts", kind: { type: "add" }, diff: "+new" },
+        ],
+      },
+      turnId,
+      "completed",
+    )
+    assert.deepStrictEqual(item, {
+      type: "fileChange",
+      id: "f1",
+      turnId,
+      title: "Edit 2 files",
+      status: "completed",
+      changes: [
+        { path: "/w/a.ts", kind: "update", diff: "@@ -1 +1 @@" },
+        { path: "/w/b.ts", kind: "add", diff: "+new" },
+      ],
+    })
+    const single = CodexItems.mapItem(
+      {
+        type: "fileChange",
+        id: "f2",
+        status: "inProgress",
+        changes: [{ path: "/w/new.ts", kind: { type: "add" }, diff: "+x" }],
+      },
+      turnId,
+      "started",
+    )
+    assert.strictEqual(single?.type === "fileChange" ? single.title : "", "Create new.ts")
+  })
+
+  it("mcpToolCall carries server, tool, arguments, result, and error", () => {
+    const item = CodexItems.mapItem(
+      {
+        type: "mcpToolCall",
+        id: "m1",
+        server: "linear",
+        tool: "get_issue",
+        status: "failed",
+        arguments: { id: "ATC-1" },
+        appContext: null,
+        pluginId: null,
+        readOnlyHint: null,
+        result: null,
+        error: { message: "boom" },
+        durationMs: null,
+      },
+      turnId,
+      "completed",
+    )
+    assert.deepStrictEqual(item, {
+      type: "mcpCall",
+      id: "m1",
+      turnId,
+      title: "linear · get_issue",
+      status: "error",
+      error: "boom",
+      server: "linear",
+      tool: "get_issue",
+      arguments: { id: "ATC-1" },
+    })
+    const ok = CodexItems.mapItem(
+      {
+        type: "mcpToolCall",
+        id: "m2",
+        server: "linear",
+        tool: "get_issue",
+        status: "completed",
+        arguments: {},
+        result: { content: [{ type: "text", text: "…" }], structuredContent: null, _meta: null },
+        error: null,
+      },
+      turnId,
+      "completed",
+    )
+    assert.deepStrictEqual(ok?.type === "mcpCall" ? ok.result : undefined, {
+      content: [{ type: "text", text: "…" }],
+      structuredContent: null,
+      _meta: null,
+    })
+  })
+
+  it("every other tool-like item is a toolCall named after the codex type", () => {
+    const search = CodexItems.mapItem(
+      { type: "webSearch", id: "w1", query: "effect v4", action: null, results: null },
+      turnId,
+      "completed",
+    )
+    assert.deepStrictEqual(search, {
+      type: "toolCall",
+      id: "w1",
+      turnId,
+      title: "Search: effect v4",
+      status: "completed",
+      name: "webSearch",
+      input: { query: "effect v4", action: null, results: null },
+    })
+    const dynamic = CodexItems.mapItem(
+      {
+        type: "dynamicToolCall",
+        id: "d1",
+        namespace: null,
+        tool: "lint",
+        arguments: { fix: true },
+        status: "inProgress",
+        contentItems: null,
+        success: null,
+        durationMs: null,
+      },
+      turnId,
+      "started",
+    )
+    assert.strictEqual(dynamic?.type === "toolCall" ? dynamic.status : "", "running")
+    assert.strictEqual(dynamic?.type === "toolCall" ? dynamic.title : "", "lint")
+    const sub = CodexItems.mapItem(
+      {
+        type: "subAgentActivity",
+        id: "s1",
+        kind: "started",
+        agentThreadId: "child",
+        agentPath: "/r/c",
+      },
+      turnId,
+      "started",
+    )
+    assert.strictEqual(sub?.type === "toolCall" ? sub.title : "", "Subagent started")
+    // A type this build has never heard of still surfaces.
+    const novel = CodexItems.mapItem(
+      { type: "holographicCall", id: "h1", foo: 1 },
+      turnId,
+      "completed",
+    )
+    assert.deepStrictEqual(novel, {
+      type: "toolCall",
+      id: "h1",
+      turnId,
+      title: "holographicCall",
+      status: "completed",
+      name: "holographicCall",
+      input: { foo: 1 },
+    })
+  })
+
+  it("compaction is a marker; hookPrompt and review markers are not emitted; junk is skipped", () => {
+    assert.deepStrictEqual(
+      CodexItems.mapItem({ type: "contextCompaction", id: "k1" }, turnId, "completed"),
+      { type: "compaction", id: "k1", turnId },
+    )
+    assert.isNull(
+      CodexItems.mapItem({ type: "hookPrompt", id: "h", fragments: [] }, turnId, "completed"),
+    )
+    assert.isNull(
+      CodexItems.mapItem({ type: "enteredReviewMode", id: "e", review: "" }, turnId, "completed"),
+    )
+    assert.isNull(CodexItems.mapItem({ type: "agentMessage" }, turnId, "completed"))
+    assert.isNull(CodexItems.mapItem("nonsense", turnId, "completed"))
+  })
+})
+
+describe("CodexItems.mapRequest / answerResult", () => {
+  const openedAt = "2026-08-17T00:00:00.000Z"
+
+  it("command approvals carry the command, cwd, and reason", () => {
+    const request = CodexItems.mapRequest(
+      "item/commandExecution/requestApproval",
+      "7",
+      {
+        threadId: "t",
+        turnId,
+        itemId: "c1",
+        startedAtMs: 1,
+        approvalId: null,
+        environmentId: null,
+        reason: "network",
+        command: "curl x",
+        cwd: "/w",
+      },
+      undefined,
+      openedAt,
+    )
+    assert.deepStrictEqual(request, {
+      kind: "approval",
+      id: "7",
+      turnId,
+      itemId: "c1",
+      openedAt,
+      title: "curl x",
+      reason: "network",
+      subject: { type: "command", command: "curl x", cwd: "/w" },
+    })
+    assert.deepStrictEqual(
+      CodexItems.answerResult({ kind: "approval", decision: "acceptForSession" }),
+      { decision: "acceptForSession" },
+    )
+  })
+
+  it("fileChange approvals take their changes from the pending item", () => {
+    const pending = CodexItems.mapItem(
+      {
+        type: "fileChange",
+        id: "f1",
+        status: "inProgress",
+        changes: [{ path: "/w/a.ts", kind: { type: "update", move_path: null }, diff: "d" }],
+      },
+      turnId,
+      "started",
+    )
+    const request = CodexItems.mapRequest(
+      "item/fileChange/requestApproval",
+      "8",
+      { threadId: "t", turnId, itemId: "f1", startedAtMs: 1, reason: null },
+      pending ?? undefined,
+      openedAt,
+    )
+    assert.deepStrictEqual(request, {
+      kind: "approval",
+      id: "8",
+      turnId,
+      itemId: "f1",
+      openedAt,
+      title: "Edit a.ts",
+      subject: { type: "fileChange", changes: [{ path: "/w/a.ts", kind: "update", diff: "d" }] },
+    })
+  })
+
+  it("requestUserInput becomes a question with freeform where the provider allows it", () => {
+    const request = CodexItems.mapRequest(
+      "item/tool/requestUserInput",
+      "9",
+      {
+        threadId: "t",
+        turnId,
+        itemId: "q1",
+        isBlocking: true,
+        autoResolutionMs: null,
+        questions: [
+          {
+            id: "color",
+            header: "Color",
+            question: "Which?",
+            isOther: true,
+            isSecret: false,
+            options: [{ label: "red", description: "warm" }],
+          },
+          {
+            id: "note",
+            header: "Note",
+            question: "Notes?",
+            isOther: false,
+            isSecret: true,
+            options: null,
+          },
+        ],
+      },
+      undefined,
+      openedAt,
+    )
+    assert.deepStrictEqual(request, {
+      kind: "question",
+      id: "9",
+      turnId,
+      itemId: "q1",
+      openedAt,
+      questions: [
+        {
+          id: "color",
+          header: "Color",
+          question: "Which?",
+          options: [{ label: "red", description: "warm" }],
+          multiSelect: false,
+          freeform: true,
+          secret: false,
+        },
+        {
+          id: "note",
+          header: "Note",
+          question: "Notes?",
+          options: [],
+          multiSelect: false,
+          freeform: true,
+          secret: true,
+        },
+      ],
+    })
+    assert.deepStrictEqual(
+      CodexItems.answerResult({ kind: "question", answers: { color: ["red"], note: ["fine"] } }),
+      { answers: { color: { answers: ["red"] }, note: { answers: ["fine"] } } },
+    )
+  })
+
+  it("unsurfaced request kinds and malformed params are null", () => {
+    assert.isNull(
+      CodexItems.mapRequest(
+        "item/permissions/requestApproval",
+        "1",
+        { threadId: "t", turnId },
+        undefined,
+        openedAt,
+      ),
+    )
+    assert.isNull(CodexItems.mapRequest("item/tool/requestUserInput", "1", {}, undefined, openedAt))
+  })
+})
+
+describe("CodexItems.mapHistory", () => {
+  it.effect("thread/resume turns become HistoryTurns with ISO stamps and mapped items", () =>
+    Effect.gen(function* () {
+      const turns = yield* CodexItems.decodeHistoryTurns([
+        {
+          id: "t1",
+          status: "completed",
+          error: null,
+          startedAt: 1_700_000_000,
+          completedAt: 1_700_000_010,
+          items: [
+            {
+              type: "userMessage",
+              id: "u",
+              clientId: null,
+              content: [{ type: "text", text: "hi", text_elements: [] }],
+            },
+            { type: "hookPrompt", id: "h", fragments: [] },
+            { type: "agentMessage", id: "a", text: "hello", phase: null, memoryCitation: null },
+          ],
+        },
+        {
+          id: "t2",
+          status: "failed",
+          error: { message: "quota" },
+          startedAt: null,
+          completedAt: null,
+          items: [],
+        },
+        {
+          id: "t3",
+          status: "inProgress",
+          error: null,
+          startedAt: null,
+          completedAt: null,
+          items: [],
+        },
+      ])
+      assert.deepStrictEqual(CodexItems.mapHistory(turns), [
+        {
+          turn: {
+            id: "t1",
+            status: "completed",
+            startedAt: "2023-11-14T22:13:20.000Z",
+            endedAt: "2023-11-14T22:13:30.000Z",
+          },
+          items: [
+            { type: "userMessage", id: "u", turnId: "t1", text: "hi" },
+            { type: "assistantText", id: "a", turnId: "t1", text: "hello", complete: true },
+          ],
+        },
+        { turn: { id: "t2", status: "failed", error: "quota" }, items: [] },
+        { turn: { id: "t3", status: "running" }, items: [] },
+      ])
+    }),
+  )
+})

--- a/app-server/test/agents/fakeAgentAdapter.ts
+++ b/app-server/test/agents/fakeAgentAdapter.ts
@@ -4,10 +4,13 @@ import type {
   AgentAdapter,
   AgentConnection,
   AgentEvent,
-  AgentRequestKind,
   AgentSessionEvent,
   AgentTurn,
   AgentTurnOutcome,
+  HistoryTurn,
+  ThreadItem,
+  ThreadRequest,
+  ThreadRequestAnswer,
 } from "../../src/agents/agentAdapter.ts"
 import {
   AgentConflict,
@@ -21,8 +24,9 @@ import {
 // same observable semantics the real adapters must hold — create and resume
 // are distinct, resume fails closed on unknown ids and mismatched cwd, one
 // active writer per session, one active turn per connection, stale interrupt
-// targets rejected — plus controls to script turn outcomes and provider
-// requests and switches to inject unavailability.
+// targets rejected, provider requests parked until answered — plus controls
+// to script turn outcomes, items, requests, and history, and switches to
+// inject unavailability.
 //
 // It models the EAGER-verification, connection-survives-failed-turns flavor
 // (Codex). Claude differs on both axes (verification at first turn,
@@ -45,10 +49,25 @@ export interface FakeAgentAdapter {
   readonly seed: (providerSessionId: string, cwd: string) => FakeAgentSession
   /** Complete the active turn of `providerSessionId` with `outcome`. */
   readonly completeTurn: (providerSessionId: string, outcome: AgentTurnOutcome) => void
-  /** Open a provider request on the active turn; activity → needs_input. */
-  readonly openRequest: (providerSessionId: string, kind: AgentRequestKind) => string
-  /** Close a previously opened request; activity → working. */
+  /** Open a stock provider request (an approval, or a one-question ask)
+   * on the active turn; activity → needs_input. */
+  readonly openRequest: (providerSessionId: string, kind: "approval" | "question") => string
+  /** Close a previously opened request without an answer; activity → working. */
   readonly closeRequest: (providerSessionId: string, requestId: string) => void
+  /** Answers `respond` delivered, in order. */
+  readonly answers: Array<{ requestId: string; answer: ThreadRequestAnswer }>
+  /** Push one item event onto the active connection's feed. */
+  readonly emitItem: (
+    providerSessionId: string,
+    phase: "itemStarted" | "itemUpdated" | "itemCompleted",
+    item: ThreadItem,
+  ) => void
+  /** Push one text delta onto the active connection's feed. */
+  readonly emitTextDelta: (providerSessionId: string, itemId: string, delta: string) => void
+  /** Script what readHistory returns for a session (default []). */
+  readonly setHistory: (providerSessionId: string, turns: ReadonlyArray<HistoryTurn>) => void
+  /** readHistory calls (providerSessionIds), in order. */
+  readonly historyReads: Array<string>
   /** While set, prepared identities wait on a gate; unsetting releases any
    * waiter (so a hung identity can resolve late, after the test acted). */
   readonly setIdentityHangs: (hangs: boolean) => void
@@ -109,7 +128,7 @@ interface LiveConnection {
   activity: AgentActivity
   activeTurn: string | null
   closed: boolean
-  readonly openRequests: Set<string>
+  readonly openRequests: Map<string, ThreadRequest>
 }
 
 export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): FakeAgentAdapter => {
@@ -118,6 +137,9 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
   const connections = new Map<string, LiveConnection>()
   const observers = new Map<string, Set<Queue.Queue<AgentSessionEvent, Cause.Done>>>()
   const checkActivity = new Map<string, AgentActivity>()
+  const histories = new Map<string, ReadonlyArray<HistoryTurn>>()
+  const historyReads: Array<string> = []
+  const answers: FakeAgentAdapter["answers"] = []
   const prunedSessions = new Set<string>()
   const prepared: FakeAgentAdapter["prepared"] = []
   const released: FakeAgentAdapter["released"] = []
@@ -177,7 +199,7 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
         activity: "idle",
         activeTurn: null,
         closed: false,
-        openRequests: new Set(),
+        openRequests: new Map(),
       }
       connections.set(session.providerSessionId, live)
       yield* Effect.addFinalizer(() =>
@@ -240,6 +262,32 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
             }
             finishTurn(session.providerSessionId, "interrupted")
           }),
+        respond: (requestId, answer) =>
+          Effect.gen(function* () {
+            yield* requireAvailable
+            yield* requireOpen
+            const request = live.openRequests.get(requestId)
+            if (request === undefined) {
+              return yield* Effect.fail(
+                new AgentConflict({
+                  provider: "codex",
+                  reason: `request ${requestId} is not pending`,
+                }),
+              )
+            }
+            if (request.kind !== answer.kind) {
+              return yield* Effect.fail(
+                new AgentConflict({
+                  provider: "codex",
+                  reason: `request ${requestId} expects a ${request.kind} answer`,
+                }),
+              )
+            }
+            answers.push({ requestId, answer })
+            live.openRequests.delete(requestId)
+            emit(live, { type: "requestClosed", requestId })
+            setActivity(live, "working")
+          }),
       }
       return connection
     })
@@ -251,7 +299,7 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
     }
     const turnId = live.activeTurn
     live.activeTurn = null
-    for (const requestId of live.openRequests) {
+    for (const requestId of live.openRequests.keys()) {
       emit(live, { type: "requestClosed", requestId })
     }
     live.openRequests.clear()
@@ -390,6 +438,12 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
         contextRequests.push(options.providerSessionId)
         return titleContexts.get(options.providerSessionId) ?? null
       }),
+    readHistory: (options) =>
+      Effect.gen(function* () {
+        yield* requireAvailable
+        historyReads.push(options.providerSessionId)
+        return histories.get(options.providerSessionId) ?? []
+      }),
     checkSession: (options) =>
       Effect.gen(function* () {
         checkCalls.push(options.providerSessionId)
@@ -429,11 +483,48 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
     openRequest: (providerSessionId, kind) => {
       const live = requireLive(providerSessionId)
       const requestId = `fake-request-${nextRequestId++}`
-      live.openRequests.add(requestId)
-      emit(live, { type: "requestOpened", requestId, kind })
+      const base = {
+        id: requestId,
+        turnId: live.activeTurn ?? "",
+        openedAt: new Date().toISOString(),
+      }
+      const request: ThreadRequest =
+        kind === "approval"
+          ? { kind, ...base, title: "pwd", subject: { type: "command", command: "pwd" } }
+          : {
+              kind,
+              ...base,
+              questions: [
+                {
+                  id: "q0",
+                  header: "Choice",
+                  question: "Which one?",
+                  options: [
+                    { label: "A", description: "first" },
+                    { label: "B", description: "second" },
+                  ],
+                  multiSelect: false,
+                  freeform: false,
+                  secret: false,
+                },
+              ],
+            }
+      live.openRequests.set(requestId, request)
+      emit(live, { type: "requestOpened", request })
       setActivity(live, "needs_input")
       return requestId
     },
+    answers,
+    emitItem: (providerSessionId, phase, item) => {
+      emit(requireLive(providerSessionId), { type: phase, item })
+    },
+    emitTextDelta: (providerSessionId, itemId, delta) => {
+      emit(requireLive(providerSessionId), { type: "textDelta", itemId, delta })
+    },
+    setHistory: (providerSessionId, turns) => {
+      histories.set(providerSessionId, turns)
+    },
+    historyReads,
     closeRequest: (providerSessionId, requestId) => {
       const live = requireLive(providerSessionId)
       if (!live.openRequests.delete(requestId)) {

--- a/app-server/test/agents/fakeClaudeQuery.ts
+++ b/app-server/test/agents/fakeClaudeQuery.ts
@@ -7,9 +7,18 @@ import type { ClaudeQueryFn } from "../../src/agents/claudeAdapter.ts"
 // the load-bearing timing fact), and mimics the SDK's throw-after-error-
 // result iterator behavior. Turn behavior keys off the input text:
 //   "HANG"       — stays running until interrupt()
-//   "PERMISSION" — invokes canUseTool (Bash) before finishing
-//   "ASK"        — invokes canUseTool (AskUserQuestion) before finishing
+//   "PERMISSION" — emits a Bash tool_use block, then invokes canUseTool for
+//                  it and AWAITS the answer (the adapter parks it): allow
+//                  runs the tool (tool_result), deny fails it (is_error)
+//   "ASK"        — invokes canUseTool (AskUserQuestion) with two questions
+//                  and awaits the answer
+//   "STREAM"     — streams the reply as stream_event frames (message_start,
+//                  content_block_start/delta/stop, message_stop) before the
+//                  per-block `assistant` message with the same message id
+//   "TOOL"       — emits a Read tool_use block and its tool_result
 //   "FAILTURN"   — ends with error_max_turns, then the iterator throws
+// Every successful turn ends with a per-block `assistant` text message
+// (`fake: <text>`) before its result, like the SDK's own output.
 
 export interface FakeClaudeQueryOptions {
   /** session_id for created sessions (resumes echo the resume id). */
@@ -29,8 +38,8 @@ export interface FakeClaudeQueryOptions {
 
 export interface FakeClaudeQuery {
   readonly queryFn: ClaudeQueryFn
-  /** Deny results canUseTool handed back, for assertions. */
-  readonly denials: Array<{ toolName: string; behavior: string }>
+  /** PermissionResults canUseTool handed back, for assertions. */
+  readonly decisions: Array<{ toolName: string; result: unknown }>
   /** Interrupt calls observed. */
   readonly interrupts: Array<string>
   /**
@@ -42,7 +51,8 @@ export interface FakeClaudeQuery {
 }
 
 export const makeFakeClaudeQuery = (options: FakeClaudeQueryOptions = {}): FakeClaudeQuery => {
-  const denials: FakeClaudeQuery["denials"] = []
+  const decisions: FakeClaudeQuery["decisions"] = []
+  let nextMessage = 1
   const interrupts: Array<string> = []
   let lastFire: ((eventName: string, payload?: Record<string, unknown>) => Promise<void>) | null =
     null
@@ -92,6 +102,25 @@ export const makeFakeClaudeQuery = (options: FakeClaudeQueryOptions = {}): FakeC
       }
     }
     lastFire = fireHook
+    /** One per-block assistant message, like the SDK emits (uuid + API message id). */
+    const assistant = (messageId: string, block: Record<string, unknown>): void => {
+      push({
+        type: "assistant",
+        uuid: crypto.randomUUID(),
+        session_id: sessionId,
+        parent_tool_use_id: null,
+        message: { id: messageId, type: "message", role: "assistant", content: [block] },
+      })
+    }
+    const streamEvent = (event: Record<string, unknown>): void => {
+      push({
+        type: "stream_event",
+        uuid: crypto.randomUUID(),
+        session_id: sessionId,
+        parent_tool_use_id: null,
+        event,
+      })
+    }
     const initOnce = (() => {
       let sent = false
       return () => {
@@ -123,20 +152,108 @@ export const makeFakeClaudeQuery = (options: FakeClaudeQueryOptions = {}): FakeC
       if (hangs) hanging = text
       await fireHook("UserPromptSubmit")
       if (hangs) return
-      if (text.includes("PERMISSION") || text.includes("ASK")) {
-        const toolName = text.includes("ASK") ? "AskUserQuestion" : "Bash"
-        state("requires_action")
-        const result = await args.options.canUseTool?.(
-          toolName,
-          { command: "pwd" },
-          {
-            signal: new AbortController().signal,
-            requestId: "fake-request-1",
-            toolUseID: "fake-tool-use-1",
+      const messageId = `msg_fake_${nextMessage++}`
+      if (text.includes("STREAM")) {
+        const reply = `fake: ${text}`
+        streamEvent({ type: "message_start", message: { id: messageId, role: "assistant" } })
+        streamEvent({
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "text", text: "" },
+        })
+        for (const delta of ["fake: ", text]) {
+          streamEvent({
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "text_delta", text: delta },
+          })
+        }
+        streamEvent({ type: "content_block_stop", index: 0 })
+        streamEvent({ type: "message_stop" })
+        assistant(messageId, { type: "text", text: reply })
+      }
+      if (text.includes("TOOL")) {
+        assistant(messageId, {
+          type: "tool_use",
+          id: "toolu_fake_read",
+          name: "Read",
+          input: { file_path: "/work/notes.md" },
+        })
+        push({
+          type: "user",
+          uuid: crypto.randomUUID(),
+          session_id: sessionId,
+          parent_tool_use_id: null,
+          message: {
+            role: "user",
+            content: [{ type: "tool_result", tool_use_id: "toolu_fake_read", content: "hello" }],
           },
-        )
-        denials.push({ toolName, behavior: (result as { behavior: string }).behavior })
+          tool_use_result: { file: { filePath: "/work/notes.md", content: "hello" } },
+        })
+      }
+      if (text.includes("PERMISSION") || text.includes("ASK")) {
+        const ask = text.includes("ASK")
+        const toolName = ask ? "AskUserQuestion" : "Bash"
+        const input = ask
+          ? {
+              questions: [
+                {
+                  question: "Which color?",
+                  header: "Color",
+                  options: [
+                    { label: "red", description: "warm" },
+                    { label: "blue", description: "cool" },
+                  ],
+                  multiSelect: false,
+                },
+                { question: "Any notes?", header: "Notes", options: [], multiSelect: false },
+              ],
+            }
+          : { command: "pwd" }
+        if (!ask)
+          assistant(messageId, { type: "tool_use", id: "fake-tool-use-1", name: toolName, input })
+        state("requires_action")
+        const result = await args.options.canUseTool?.(toolName, input, {
+          signal: new AbortController().signal,
+          requestId: "fake-request-1",
+          toolUseID: "fake-tool-use-1",
+          ...(ask
+            ? {}
+            : { title: "Claude wants to run pwd", decisionReason: "outside the allow list" }),
+        })
+        decisions.push({ toolName, result })
         state("running")
+        const denied = (result as { behavior?: string } | null)?.behavior !== "allow"
+        if (!ask) {
+          push({
+            type: "user",
+            uuid: crypto.randomUUID(),
+            session_id: sessionId,
+            parent_tool_use_id: null,
+            message: {
+              role: "user",
+              content: [
+                {
+                  type: "tool_result",
+                  tool_use_id: "fake-tool-use-1",
+                  content: denied ? "permission denied" : "/work",
+                  is_error: denied,
+                },
+              ],
+            },
+          })
+        }
+        if ((result as { interrupt?: boolean } | null)?.interrupt === true) {
+          push({
+            type: "result",
+            subtype: "error_during_execution",
+            session_id: sessionId,
+            is_error: true,
+            errors: ["aborted_streaming"],
+          })
+          finish()
+          return
+        }
       }
       if (text.includes("FAILTURN")) {
         push({
@@ -151,6 +268,7 @@ export const makeFakeClaudeQuery = (options: FakeClaudeQueryOptions = {}): FakeC
         return
       }
       await fireHook("Stop")
+      if (!text.includes("STREAM")) assistant(messageId, { type: "text", text: `fake: ${text}` })
       push({
         type: "result",
         subtype: "success",
@@ -216,7 +334,7 @@ export const makeFakeClaudeQuery = (options: FakeClaudeQueryOptions = {}): FakeC
 
   return {
     queryFn,
-    denials,
+    decisions,
     interrupts,
     fireHook: (eventName, payload) => {
       if (lastFire === null) throw new Error("no query started yet")

--- a/app-server/test/fixtures/fake-codex-listener.ts
+++ b/app-server/test/fixtures/fake-codex-listener.ts
@@ -8,8 +8,16 @@
 // over a stale socket file that nothing answers.
 //
 // Turn behavior is keyed off the input text: containing "HANG" leaves the
-// turn active until interrupted; containing "APPROVAL" first round-trips an
-// item/commandExecution/requestApproval server request; containing "SPAWN"
+// turn active until interrupted; containing "APPROVAL" runs a
+// commandExecution item that first round-trips an
+// item/commandExecution/requestApproval server request (the decision
+// completes or declines the item); "QUESTION" round-trips an
+// item/tool/requestUserInput and echoes the answers back as the agent
+// message; "STREAM" streams the agent message as item/agentMessage/delta
+// frames between item/started and item/completed; "COMMAND" runs a
+// completed commandExecution item; every turn broadcasts its userMessage and
+// agentMessage items and records them on the turn for thread/resume;
+// containing "SPAWN"
 // creates a descendant thread (`<threadId>-child-N`) that stays active
 // after the parent's turn completes — mirroring the probed real behavior
 // (experiments/subagent-activity): a subAgentActivity item on the parent
@@ -141,10 +149,19 @@ if (existsSync(socketPath)) {
   rmSync(socketPath, { force: true })
 }
 
+interface Turn {
+  readonly id: string
+  status: string
+  readonly items: Array<Record<string, unknown>>
+  readonly startedAt: number
+  completedAt: number | null
+  error: { message: string } | null
+}
+
 interface Thread {
   readonly id: string
   readonly cwd: string
-  readonly turns: Array<{ id: string; status: string }>
+  readonly turns: Array<Turn>
   // "Usually the first user message in the thread, if available" — set at
   // the first turn/start, like the real rollout history (ATC-155).
   preview: string
@@ -163,7 +180,7 @@ const threads = new Map<string, Thread>()
 const children = new Map<string, Child>()
 const sockets = new Set<import("bun").ServerWebSocket<unknown>>()
 const hangingTurns = new Set<string>()
-const pendingServerRequests = new Map<number, () => void>()
+const pendingServerRequests = new Map<number, (reply: unknown) => void>()
 let nextServerRequestId = 1000
 
 const broadcast = (method: string, params: unknown) => {
@@ -188,18 +205,39 @@ const childStatus = (child: Child) =>
 
 const settleTurn = (thread: Thread, turnId: string, status: string) => {
   const turn = thread.turns.find((entry) => entry.id === turnId)
-  if (turn !== undefined) turn.status = status
+  if (turn === undefined) return
+  turn.status = status
+  turn.completedAt = Math.floor(Date.now() / 1000)
+}
+
+/** Broadcast one item lifecycle notification; completed items land on the
+ * turn's history (what thread/resume replays). */
+const emitItem = (
+  thread: Thread,
+  turnId: string,
+  phase: "started" | "completed",
+  item: Record<string, unknown>,
+) => {
+  broadcast(`item/${phase}`, { threadId: thread.id, turnId, item })
+  if (phase === "completed") thread.turns.find((entry) => entry.id === turnId)?.items.push(item)
+}
+
+const agentMessage = (text: string) => ({
+  id: crypto.randomUUID(),
+  type: "agentMessage",
+  text,
+  phase: null,
+})
+
+const endTurn = (thread: Thread, turnId: string, status: "completed" | "interrupted") => {
+  broadcast("thread/status/changed", { threadId: thread.id, status: { type: "idle" } })
+  settleTurn(thread, turnId, status)
+  broadcast("turn/completed", { threadId: thread.id, turn: { id: turnId, status } })
 }
 
 const finishTurn = (thread: Thread, turnId: string, text: string) => {
-  broadcast("item/completed", {
-    threadId: thread.id,
-    turnId,
-    item: { id: crypto.randomUUID(), type: "agentMessage", text: `fake: ${text}` },
-  })
-  broadcast("thread/status/changed", { threadId: thread.id, status: { type: "idle" } })
-  settleTurn(thread, turnId, "completed")
-  broadcast("turn/completed", { threadId: thread.id, turn: { id: turnId, status: "completed" } })
+  emitItem(thread, turnId, "completed", agentMessage(`fake: ${text}`))
+  endTurn(thread, turnId, "completed")
 }
 
 const handle = (
@@ -216,13 +254,13 @@ const handle = (
   const respondError = (code: number, text: string) =>
     socket.send(JSON.stringify({ id: message.id, error: { code, message: text } }))
 
-  // Responses to our server requests (approval round trip): any answer,
-  // result or error, unblocks the pending turn.
+  // Responses to our server requests (approval/question round trips): any
+  // answer, result or error, unblocks the pending turn with its payload.
   if (message.method === undefined && message.id !== undefined) {
     const pending = pendingServerRequests.get(message.id)
     if (pending !== undefined) {
       pendingServerRequests.delete(message.id)
-      pending()
+      pending(message.result)
     }
     return
   }
@@ -255,7 +293,20 @@ const handle = (
         return respondError(-32600, `no rollout found for thread id ${threadId}`)
       }
       const reported = wrongCwd === "resume" ? `${thread.cwd}-wrong` : thread.cwd
-      return respond({ thread: threadShape(thread, reported) })
+      // Like the real reply, thread/resume carries the full turn history.
+      return respond({
+        thread: {
+          ...threadShape(thread, reported),
+          turns: thread.turns.map((turn) => ({
+            id: turn.id,
+            items: turn.items,
+            status: turn.status,
+            error: turn.error,
+            startedAt: turn.startedAt,
+            completedAt: turn.completedAt,
+          })),
+        },
+      })
     }
     case "thread/unsubscribe":
       return respond({ status: "unsubscribed" })
@@ -349,7 +400,14 @@ const handle = (
       const input = params["input"] as Array<{ text?: string }> | undefined
       const text = input?.[0]?.text ?? ""
       const turnId = crypto.randomUUID()
-      thread.turns.push({ id: turnId, status: "inProgress" })
+      thread.turns.push({
+        id: turnId,
+        status: "inProgress",
+        items: [],
+        startedAt: Math.floor(Date.now() / 1000),
+        completedAt: null,
+        error: null,
+      })
       if (thread.preview === "") {
         thread.preview = text
         const flushLag = Number.parseInt(process.env["FAKE_CODEX_PREVIEW_DELAY_MS"] ?? "0", 10)
@@ -364,14 +422,82 @@ const handle = (
       // The real server broadcasts the turn's input back as a completed
       // userMessage item — content text blocks, unlike agentMessage's
       // top-level text — the retention evidence for title refinement.
-      broadcast("item/completed", {
-        threadId,
-        turnId,
-        item: { id: crypto.randomUUID(), type: "userMessage", content: [{ type: "text", text }] },
+      emitItem(thread, turnId, "completed", {
+        id: crypto.randomUUID(),
+        type: "userMessage",
+        content: [{ type: "text", text, text_elements: [] }],
       })
       if (text.includes("HANG")) {
         hangingTurns.add(threadId)
         return
+      }
+      if (text.includes("STREAM")) {
+        const item = agentMessage("")
+        emitItem(thread, turnId, "started", item)
+        for (const delta of ["fake: ", text]) {
+          broadcast("item/agentMessage/delta", { threadId, turnId, itemId: item.id, delta })
+        }
+        emitItem(thread, turnId, "completed", { ...item, text: `fake: ${text}` })
+        return endTurn(thread, turnId, "completed")
+      }
+      if (text.includes("COMMAND")) {
+        const item = {
+          id: crypto.randomUUID(),
+          type: "commandExecution",
+          command: "pwd",
+          cwd: thread.cwd,
+          status: "inProgress",
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        }
+        emitItem(thread, turnId, "started", item)
+        emitItem(thread, turnId, "completed", {
+          ...item,
+          status: "completed",
+          aggregatedOutput: `${thread.cwd}\n`,
+          exitCode: 0,
+          durationMs: 12,
+        })
+        return finishTurn(thread, turnId, text)
+      }
+      if (text.includes("QUESTION")) {
+        const requestId = nextServerRequestId++
+        pendingServerRequests.set(requestId, (reply) => {
+          const answers = (reply as { answers?: unknown } | undefined)?.answers ?? "rejected"
+          emitItem(thread, turnId, "completed", agentMessage(`answers: ${JSON.stringify(answers)}`))
+          endTurn(thread, turnId, "completed")
+        })
+        socket.send(
+          JSON.stringify({
+            id: requestId,
+            method: "item/tool/requestUserInput",
+            params: {
+              threadId,
+              turnId,
+              itemId: crypto.randomUUID(),
+              questions: [
+                {
+                  id: "color",
+                  header: "Color",
+                  question: "Which color?",
+                  isOther: false,
+                  isSecret: false,
+                  options: [
+                    { label: "red", description: "warm" },
+                    { label: "blue", description: "cool" },
+                  ],
+                },
+              ],
+              isBlocking: true,
+              autoResolutionMs: null,
+            },
+          }),
+        )
+        return broadcast("thread/status/changed", {
+          threadId,
+          status: { type: "active", activeFlags: ["waitingOnUserInput"] },
+        })
       }
       if (text.includes("SPAWN")) {
         const childId = `${threadId}-child-${children.size + 1}`
@@ -397,19 +523,51 @@ const handle = (
         return finishTurn(thread, turnId, text)
       }
       if (text.includes("APPROVAL")) {
+        const item = {
+          id: crypto.randomUUID(),
+          type: "commandExecution",
+          command: "/bin/sh -c pwd",
+          cwd: thread.cwd,
+          status: "inProgress",
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        }
+        emitItem(thread, turnId, "started", item)
         const requestId = nextServerRequestId++
-        pendingServerRequests.set(requestId, () => {
+        pendingServerRequests.set(requestId, (reply) => {
+          const decision = (reply as { decision?: unknown } | undefined)?.decision
           broadcast("thread/status/changed", {
             threadId,
             status: { type: "active", activeFlags: [] },
           })
-          finishTurn(thread, turnId, text)
+          if (decision === "accept" || decision === "acceptForSession") {
+            emitItem(thread, turnId, "completed", {
+              ...item,
+              status: "completed",
+              aggregatedOutput: `${thread.cwd}\n`,
+              exitCode: 0,
+              durationMs: 8,
+            })
+            return finishTurn(thread, turnId, text)
+          }
+          emitItem(thread, turnId, "completed", { ...item, status: "declined" })
+          return decision === "cancel"
+            ? endTurn(thread, turnId, "interrupted")
+            : finishTurn(thread, turnId, text)
         })
         socket.send(
           JSON.stringify({
             id: requestId,
             method: "item/commandExecution/requestApproval",
-            params: { threadId, turnId, command: "/bin/sh -c pwd", cwd: thread.cwd },
+            params: {
+              threadId,
+              turnId,
+              itemId: item.id,
+              command: item.command,
+              cwd: thread.cwd,
+              reason: "needs network",
+            },
           }),
         )
         return broadcast("thread/status/changed", {


### PR DESCRIPTION
PR 1 of 3 for ATC-193 (server-side Thread runtime). Sub-issue: ATC-198. Stacked: ATC-199 (persistence + Threads turn loop) and ATC-200 (endpoints + CLI) build on this branch.

## What

- **Vocabulary defined once in `contract.ts`**: `ThreadItem` (8 variants), `FileChange`, `ToolStatus`, `ThreadTurn`, `Question` / `ApprovalSubject` / `ThreadRequest` / `ThreadRequestAnswer`, `QueuedPrompt`, `ThreadTranscript`, `ThreadEvent`. Types only — no routes yet.
- **OpenAPI**: `openapi.ts` now documents a list of vocabulary schemas as components (generalizing the SSE-payload mechanism, with all nested named schemas and a collision guard) and stamps an OpenAPI `discriminator` on every `oneOf`-of-`$ref` component whose variants pin a single-valued literal — the pinned Swift generator then emits one enum case per named variant (verified: `kit:test` builds and passes). `openapi.json` gains the components.
- **Seam (`agentAdapter.ts`)**: `AgentEvent` gains `itemStarted | itemUpdated | itemCompleted { item }` and `textDelta`; `requestOpened` carries a full `ThreadRequest`; `AgentConnection.respond(requestId, answer)`; `AgentAdapter.readHistory`; Codex observations (`AgentSessionEvent`) carry the item events. Requests are now **parked until answered** (previously auto-rejected).
- **Codex** (`codexItems.ts` + `codexAdapter.ts`): item/started|completed → items on the writer feed and observers; `item/agentMessage/delta`, `item/plan/delta`, `item/reasoning/summaryTextDelta` → text deltas; approvals/questions parked and replied on the JSON-RPC request; `serverRequest/resolved` closes requests resolved elsewhere; a closing connection rejects still-parked requests (never leaves the provider's turn hung); `thread/resume` turns → `readHistory`.
- **Claude** (`claudeItems.ts` + `claudeAdapter.ts`): `includePartialMessages` on; text/thinking stream as content blocks (`${apiMessageId}:${index}`), tool_use blocks open tool items, tool_result completes them (with `tool_use_result` supplying Write create-vs-update and structured patches as unified diffs); `canUseTool` parks as a `ThreadRequest` and resolves from `respond` (`acceptForSession` returns the SDK's own session-scoped suggestions; AskUserQuestion answers go back through `updatedInput.answers` keyed by question text); `getSessionMessages` → `readHistory` grouped into turns at each top-level user message. Claude turn ids are now uuids (persistable).
- Fake adapter and both fixtures speak the same vocabulary; new pure mapping-table tests (`codexItems.test.ts`, `claudeItems.test.ts`) plus live-flow tests for streaming, respond, history, and observers.

## Probed facts worth knowing (recorded in module headers)

- Codex `thread/resume` re-numbers history items positionally (`item-1`, `item-2`, …) and, on 0.147, omitted an `exec` custom tool call that the rollout does record — so a re-read is a wholesale replacement, never a merge by id (as the design already assumed).
- Claude's `getSessionMessages` returns system entries without their subtype (SDK 0.3.220), so compaction markers come only from the live `compact_boundary` message; and history carries no `tool_use_result`, so historical fileChanges keep the safe `update` kind and no diff.
- The Codex smoke test (`test:smoke`) fails in this environment for a pre-existing reason (it spawns a server that binds `~/.codex` while dialing a private home); the real feed was validated with a one-off probe against the shared server instead (user message → streamed agent text with deltas → command item with output → history read).

## Verification

`mise run -C app-server check` (440 tests), `mise run kit:test`, `mise run app-server:openapi` (no drift). Two adversarial Codex reviews (correctness, simplicity) were run and acted on.

https://claude.ai/code/session_01YA92SLZgoV2UGJuSHSm19n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a unified thread transcript format for messages, reasoning, tool activity, file changes, MCP calls, compaction, and turn status.
  - Added live updates for streamed text, item lifecycle changes, approvals, questions, queued prompts, and transcript snapshots.
  - Added interactive responses to agent approvals and questions.
  - Added normalized conversation history across supported agent providers.
  - Expanded API documentation with thread and event schemas.

- **Bug Fixes**
  - Improved handling of pending requests, completed tools, interrupted turns, reconnects, and session cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->