### PR TITLE
Thread runtime: transcript persistence, turn loop, prompt queue, re-read (ATC-199)

### DIFF
--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -2684,7 +2684,7 @@
           },
           "error": {
             "type": "string",
-            "description": "Present iff failed."
+            "description": "Failure detail; only ever present when failed."
           },
           "promptId": {
             "type": "string",
@@ -3214,7 +3214,7 @@
             "items": {
               "$ref": "#/components/schemas/ThreadTurn"
             },
-            "description": "Every turn referenced by `items`."
+            "description": "Every turn referenced by `items`, plus any turn still running."
           },
           "seq": {
             "type": "integer",

--- a/app-server/src/agents/agentAdapter.ts
+++ b/app-server/src/agents/agentAdapter.ts
@@ -75,6 +75,10 @@ export const NESTED_SESSION_ENV_VARIABLES = [
  */
 export type AgentActivity = "idle" | "working" | "needs_input" | "unknown"
 
+/** Busy covers a pending request too: a turn parked on an approval is mid-turn. */
+export const isBusyActivity = (activity: AgentActivity): boolean =>
+  activity === "working" || activity === "needs_input"
+
 const ACTIVITY_PRECEDENCE: Record<AgentActivity, number> = {
   needs_input: 3,
   working: 2,
@@ -150,7 +154,7 @@ export type AgentSessionEvent =
 /**
  * One entry of the normalized writer feed. Turn ids are provider-native
  * where the provider has them (Codex) and adapter-minted where it does not
- * (Claude) — unique within the thread either way, since Threads persists
+ * (Claude) — unique within the thread either way, since the Thread runtime persists
  * them. `turnStarted` always precedes its `turnCompleted`; every item event
  * of a turn falls between the two. `textDelta` is live-only: it extends the
  * text of the `assistantText` / `reasoning` item whose `itemStarted` carried

--- a/app-server/src/agents/claudeAdapter.ts
+++ b/app-server/src/agents/claudeAdapter.ts
@@ -940,7 +940,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
       /**
        * Open a turn on the feed: turnStarted, then the user's prompt as the
        * turn's first item (the SDK never echoes it), then the input itself.
-       * Turn ids are uuids — Threads persists them, so a process-local
+       * Turn ids are uuids — the Thread runtime persists them, so a process-local
        * counter would collide with an earlier process's turns.
        */
       const beginTurn = (session: LiveSession, text: string): string => {

--- a/app-server/src/agents/claudeItems.ts
+++ b/app-server/src/agents/claudeItems.ts
@@ -24,7 +24,7 @@ import { fileChangeTitle, toolOutcome } from "./agentAdapter.ts"
 //     text and thinking blocks are keyed `${messageKey}:${blockIndex}` where
 //     the key is the API message id while streaming and the SDK message
 //     uuid otherwise. History ids therefore differ from live ids for text —
-//     accepted: Threads replaces its copy wholesale on a re-read.
+//     accepted: the Thread runtime replaces its copy wholesale on a re-read.
 //   - Tool names decide the item shape: Bash → command; Edit / Write /
 //     MultiEdit / NotebookEdit → fileChange; `mcp__<server>__<tool>` →
 //     mcpCall; everything else → toolCall. A tool_result completes its item;

--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -306,7 +306,7 @@ interface LiveSession {
   ownTurn: string | null
   /** The active turn's TOOL items by id (latest state), so an approval can
    * name its item and flip it to pending; cleared at turn end. Text items
-   * are never retained — Threads owns the transcript. */
+   * are never retained — the Thread runtime owns the transcript. */
   readonly toolItems: Map<string, ThreadItem>
   /** Parked requests by request id, closed with their turn. */
   readonly pendingRequests: Map<string, PendingRequest>
@@ -1132,7 +1132,7 @@ export const layer = Layer.effect(CodexAdapter)(
               emit(session, { type: "requestClosed", requestId })
             }),
         }
-        return { connection, unregister }
+        return { connection, session, unregister }
       })
 
     /**
@@ -1270,12 +1270,22 @@ export const layer = Layer.effect(CodexAdapter)(
             if (!samePath(decoded.thread.cwd, options.cwd)) {
               return yield* Effect.fail(identityMismatch("cwd", options.cwd, decoded.thread.cwd))
             }
-            const { connection } = yield* registerSession(
+            const { connection, session } = yield* registerSession(
               state,
               decoded.thread.id,
               options.cwd,
               decoded.thread.status,
             )
+            // A turn still running on the shared server (ours before a
+            // restart, or a TUI's) is the interrupt target this connection
+            // may name; thread/resume's turns say which it is.
+            const running = yield* CodexItems.decodeHistoryTurns(decoded.thread.turns ?? []).pipe(
+              Effect.map((turns) => turns.findLast((turn) => turn.status === "inProgress")),
+              Effect.orElseSucceed(() => undefined),
+            )
+            if (running !== undefined && session.activeTurn === null) {
+              session.activeTurn = running.id
+            }
             return connection
           }),
         ),

--- a/app-server/src/agents/codexItems.ts
+++ b/app-server/src/agents/codexItems.ts
@@ -22,7 +22,7 @@ import { fileChangeTitle, toolOutcome } from "./agentAdapter.ts"
 //     re-numbers items positionally (`item-1`, `item-2`, … — probed live
 //     2026-08-17 on 0.147) and omits some tool items (an `exec` custom tool
 //     call recorded in the rollout did not come back as a commandExecution).
-//     Threads therefore treats a re-read as a wholesale replacement, never a
+//     The Thread runtime therefore treats a re-read as a wholesale replacement, never a
 //     merge by id.
 //   - hookPrompt and the review-mode markers are deliberately not emitted;
 //     every other unknown or exotic item type surfaces as a `toolCall`

--- a/app-server/src/api/contract.ts
+++ b/app-server/src/api/contract.ts
@@ -382,7 +382,7 @@ export const ResourceChangedEvent = Schema.Struct({
 // --- The Thread runtime vocabulary (ATC-193) ---------------------------------
 //
 // Defined once, here, and reused verbatim by the AgentAdapter seam: adapters
-// emit these values, Threads persists them, and every client decodes them.
+// emit these values, the Thread runtime persists them, and every client decodes them.
 // Every union is `oneOf` over NAMED variants with one literal discriminant
 // (`type` / `kind`), so openapi.ts can stamp an OpenAPI discriminator and the
 // generated Swift client gets one enum per union instead of a struct of
@@ -538,7 +538,9 @@ export const ThreadTurn = Schema.Struct({
     description: "Provider turn id (Codex) or adapter-derived (Claude); unique within the thread.",
   }),
   status: ThreadTurnStatus,
-  error: Schema.optionalKey(Schema.String.annotate({ description: "Present iff failed." })),
+  error: Schema.optionalKey(
+    Schema.String.annotate({ description: "Failure detail; only ever present when failed." }),
+  ),
   promptId: Schema.optionalKey(
     Schema.String.annotate({
       description: "The queued prompt this turn ran, when ATC started it.",
@@ -674,7 +676,9 @@ export const QueuedPromptList = Schema.Array(QueuedPrompt).annotate({
 
 export const ThreadTranscript = Schema.Struct({
   items: Schema.Array(ThreadItem).annotate({ description: "Transcript order, oldest first." }),
-  turns: Schema.Array(ThreadTurn).annotate({ description: "Every turn referenced by `items`." }),
+  turns: Schema.Array(ThreadTurn).annotate({
+    description: "Every turn referenced by `items`, plus any turn still running.",
+  }),
   seq: Schema.Int.annotate({
     description: "The thread's change counter at the time of the read; subscribe with after=seq.",
   }),
@@ -993,6 +997,69 @@ export class ThreadBusy extends Schema.TaggedErrorClass<ThreadBusy>()(
     super({
       ...props,
       message: `thread ${props.threadId} is working; retry once the turn completes`,
+    })
+  }
+}
+
+/** Unknown or already-answered request id on the thread. */
+export class RequestNotFound extends Schema.TaggedErrorClass<RequestNotFound>()(
+  "RequestNotFound",
+  { threadId: Schema.String, requestId: Schema.String, message: errorMessage },
+  {
+    identifier: "RequestNotFound",
+    description:
+      "No pending request with the given id on this thread (unknown, or already answered).",
+    httpApiStatus: 404,
+  },
+) {
+  constructor(props: { readonly threadId: string; readonly requestId: string }) {
+    super({
+      ...props,
+      message: `thread ${props.threadId} has no pending request ${props.requestId}`,
+    })
+  }
+}
+
+/** The answer does not fit the request (kind mismatch, unknown question, non-option answer). */
+export class InvalidRequestAnswer extends Schema.TaggedErrorClass<InvalidRequestAnswer>()(
+  "InvalidRequestAnswer",
+  {
+    threadId: Schema.String,
+    requestId: Schema.String,
+    reason: Schema.String,
+    message: errorMessage,
+  },
+  {
+    identifier: "InvalidRequestAnswer",
+    description:
+      "The answer does not fit the pending request: kind mismatch, unknown question id, or a non-option answer to a question that is not freeform.",
+    httpApiStatus: 400,
+  },
+) {
+  constructor(props: {
+    readonly threadId: string
+    readonly requestId: string
+    readonly reason: string
+  }) {
+    super({ ...props, message: props.reason })
+  }
+}
+
+/** Unknown queued prompt id, or the prompt already started (it is a turn now). */
+export class QueuedPromptNotFound extends Schema.TaggedErrorClass<QueuedPromptNotFound>()(
+  "QueuedPromptNotFound",
+  { threadId: Schema.String, promptId: Schema.String, message: errorMessage },
+  {
+    identifier: "QueuedPromptNotFound",
+    description:
+      "No waiting prompt with the given id on this thread (unknown, or already started).",
+    httpApiStatus: 404,
+  },
+) {
+  constructor(props: { readonly threadId: string; readonly promptId: string }) {
+    super({
+      ...props,
+      message: `thread ${props.threadId} has no waiting prompt ${props.promptId}`,
     })
   }
 }

--- a/app-server/src/platform/migrations.ts
+++ b/app-server/src/platform/migrations.ts
@@ -89,4 +89,62 @@ export const migrations: Record<string, Effect.Effect<void, unknown, SqlClient.S
     yield* sql`ALTER TABLE threads ADD COLUMN last_finished_at TEXT`
     yield* sql`ALTER TABLE threads ADD COLUMN last_viewed_at TEXT`
   }),
+  // The Thread runtime's durable state (ATC-193): the normalized transcript
+  // copy — a projection of provider history, never the authority — and the
+  // prompt queue. `transcript_seq` is the thread's monotonic change counter
+  // (every item/turn write takes the next value into `updated_seq`; `ord`
+  // is the value taken at first insert, i.e. transcript order);
+  // `snapshot_version` bumps when a provider re-read replaces the copy and
+  // `snapshot_seq` records the seq that replacement took, so a subscriber
+  // rejoining from before it is told to refetch instead of replayed rows
+  // that no longer describe what was deleted.
+  // `item` is the ThreadItem JSON verbatim. `source` is internal
+  // (native | observed | history). Queue rows with a NULL started_turn_id
+  // are still waiting. CASCADE: a deleted thread takes its runtime state.
+  "0006_thread_runtime": Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+    yield* sql`ALTER TABLE threads ADD COLUMN transcript_seq INTEGER NOT NULL DEFAULT 0`
+    yield* sql`ALTER TABLE threads ADD COLUMN snapshot_version INTEGER NOT NULL DEFAULT 0`
+    yield* sql`ALTER TABLE threads ADD COLUMN snapshot_seq INTEGER NOT NULL DEFAULT 0`
+    yield* sql`
+      CREATE TABLE thread_turns (
+        thread_id TEXT NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+        turn_id TEXT NOT NULL,
+        ord INTEGER NOT NULL,
+        updated_seq INTEGER NOT NULL,
+        status TEXT NOT NULL CHECK (status IN ('running', 'completed', 'interrupted', 'failed')),
+        error TEXT,
+        prompt_id TEXT,
+        started_at TEXT,
+        ended_at TEXT,
+        source TEXT NOT NULL CHECK (source IN ('native', 'observed', 'history')),
+        PRIMARY KEY (thread_id, turn_id)
+      ) STRICT
+    `
+    yield* sql`
+      CREATE TABLE thread_items (
+        thread_id TEXT NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+        item_id TEXT NOT NULL,
+        turn_id TEXT NOT NULL,
+        ord INTEGER NOT NULL,
+        updated_seq INTEGER NOT NULL,
+        item TEXT NOT NULL,
+        PRIMARY KEY (thread_id, item_id)
+      ) STRICT
+    `
+    yield* sql`CREATE INDEX thread_items_thread_ord ON thread_items(thread_id, ord)`
+    // The replay query (`updated_seq > ?` per thread) on both tables.
+    yield* sql`CREATE INDEX thread_items_thread_seq ON thread_items(thread_id, updated_seq)`
+    yield* sql`CREATE INDEX thread_turns_thread_seq ON thread_turns(thread_id, updated_seq)`
+    yield* sql`
+      CREATE TABLE thread_queue (
+        id TEXT PRIMARY KEY,
+        thread_id TEXT NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+        prompt TEXT NOT NULL,
+        queued_at TEXT NOT NULL,
+        started_turn_id TEXT
+      ) STRICT
+    `
+    yield* sql`CREATE INDEX thread_queue_thread_id ON thread_queue(thread_id)`
+  }),
 }

--- a/app-server/src/server.ts
+++ b/app-server/src/server.ts
@@ -23,7 +23,9 @@ import * as Projects from "./projects/projects.ts"
 import * as TerminalRepository from "./terminals/terminalRepository.ts"
 import * as Terminals from "./terminals/terminals.ts"
 import * as ThreadRepository from "./threads/threadRepository.ts"
+import * as ThreadRuntime from "./threads/threadRuntime.ts"
 import * as Threads from "./threads/threads.ts"
+import * as TranscriptRepository from "./threads/transcriptRepository.ts"
 import * as Zmx from "./terminals/zmxAdapter.ts"
 
 // OpenAPI discovery (ATC-131): the contract-derived document at a stable
@@ -128,10 +130,12 @@ export const production = (options: { readonly port: number; readonly hostname?:
     // server-info handler and the optional trust allowlist read one instance.
     Layer.provideMerge(Tailscale.layer),
     // Projects sits above Threads (its delete cascades through them), which
-    // sits above Terminals — each provide feeds everything composed so far.
+    // sits above the ThreadRuntime (activity ledger, transcript, turns) and
+    // Terminals — each provide feeds everything composed so far.
     Layer.provide(Projects.layer),
     Layer.provide(Threads.layer),
-    Layer.provide([Terminals.layer, AgentRegistry.layer]),
+    Layer.provide([Terminals.layer, ThreadRuntime.layer]),
+    Layer.provide(AgentRegistry.layer),
     // Below Terminals (the deepest publisher) so one memoized Events instance
     // serves every domain service, the handlers, and the shutdown drain.
     Layer.provide(Events.layer),
@@ -141,6 +145,7 @@ export const production = (options: { readonly port: number; readonly hostname?:
       ProjectRepository.layer,
       TerminalRepository.layer,
       ThreadRepository.layer,
+      TranscriptRepository.layer,
       Directories.layer,
       Zmx.layer,
       ClaudeHooks.layer,

--- a/app-server/src/threads/threadRuntime.ts
+++ b/app-server/src/threads/threadRuntime.ts
@@ -1,0 +1,944 @@
+import {
+  Cause,
+  Context,
+  Effect,
+  Exit,
+  Layer,
+  Option,
+  Queue,
+  Scope,
+  Semaphore,
+  Stream,
+} from "effect"
+import { AgentRegistry } from "../agents/agentRegistry.ts"
+import { isBusyActivity } from "../agents/agentAdapter.ts"
+import type {
+  AgentActivity,
+  AgentAdapter,
+  AgentConnection,
+  AgentEvent,
+  AgentItemEvent,
+  AgentTurn,
+  ThreadRequest,
+  ThreadRequestAnswer,
+  ThreadTurn,
+} from "../agents/agentAdapter.ts"
+import type * as Contract from "../api/contract.ts"
+import {
+  InvalidRequestAnswer,
+  isAgentId,
+  ProviderSessionConflict,
+  ProviderUnavailable,
+  QueuedPromptNotFound,
+  RequestNotFound,
+  ThreadArchived,
+  ThreadNotFound,
+} from "../api/contract.ts"
+import { Events } from "../events/events.ts"
+import { ThreadRepository } from "./threadRepository.ts"
+import type { ThreadRecord } from "./threadRepository.ts"
+import { TranscriptRepository } from "./transcriptRepository.ts"
+import type { TranscriptChange, TurnSource } from "./transcriptRepository.ts"
+
+export type ThreadEvent = typeof Contract.ThreadEvent.Type
+export type ThreadTranscript = typeof Contract.ThreadTranscript.Type
+export type QueuedPrompt = typeof Contract.QueuedPrompt.Type
+
+// The Thread runtime (ATC-193): the server-owned run. It drives a thread's
+// conversation through the AgentAdapter seam with no Terminal involved —
+// prompts, the durable prompt queue, the turn loop, parked provider
+// requests, the transcript projection with its per-thread event stream, and
+// the live activity ledger every surface reads. Every surface (macOS, CLI,
+// Linear) is a client of this one service; nothing here is provider-
+// specific. Invariants:
+//
+//   - A prompt is admitted, always: it lands in the queue (durable), and if
+//     the thread is idle it starts a turn at once — the one exception being
+//     a provider that refuses that immediate start, which un-admits the
+//     prompt so the caller's error means "not accepted". A thread busy
+//     under a TUI (the ledger says so) queues the prompt and drains at the
+//     observed idle: no busy error, no lock between surfaces. A turn opens a
+//     writer connection, runs, and releases the connection at turn end —
+//     between turns a thread holds nothing, and client connections never
+//     matter to a run's lifetime. A run stays registered until its
+//     connection has closed, so the next prompt never races the writer.
+//   - The transcript copy is a projection of provider history, never the
+//     authority: `seq` (allocated by the repository) orders durable changes
+//     and replays them (subscribe after=seq); a re-read (`readHistory`)
+//     replaces the copy wholesale and bumps snapshotVersion — triggered at
+//     startup for threads mid-work and when a TUI-driven thread goes idle,
+//     never for a turn ATC drove itself. An empty history never replaces
+//     the copy (a swept Claude transcript keeps ATC's copy readable).
+//   - Provider requests park in memory until answered through
+//     `answerRequest`; they die with their turn or the process (a re-run
+//     turn re-asks). Answers are validated against the request here, so
+//     adapters only ever see well-formed answers.
+//   - The activity ledger is the one place live activity lives (the
+//     terminal-observation drain in threads.ts feeds it too): a first busy
+//     confirms the thread, a busy→idle drop stamps last_finished_at
+//     (unread, ATC-160), and every transition publishes the thread as
+//     updated. Turn end forces idle — the connection is released, so no
+//     later evidence can arrive on it. While the runtime drives a thread,
+//     its ledger entry is authoritative and never re-derived.
+//   - Startup: threads with a running turn re-read history (their status
+//     is whatever the provider says); a turn still running on a shared
+//     provider server (Codex) is reattached and followed to its end, any
+//     other still-running turn is marked interrupted; then queues drain.
+//     A provider that is unavailable at startup leaves prompts queued —
+//     the next prompt on that thread retries the drain.
+//   - Live-only events (text.delta, request.*, queue.updated) carry no seq
+//     and are never replayed; a replay re-sends changed rows as
+//     item.updated / turn.started|completed with the row's current state,
+//     in seq order. A subscriber rejoining from before the latest
+//     replacement gets snapshot.invalidated instead — the deleted rows
+//     cannot be replayed, so it refetches.
+//   - Recovery, prompt admission, run end, and release serialize per thread
+//     behind one start lock; threads still recovering at startup queue
+//     their prompts until recovery has settled them.
+
+/** The most items one transcript read returns. */
+const TRANSCRIPT_PAGE = 200
+
+/** Per-subscriber backlog; overflow ends the stream (resubscribe after=seq). */
+const SUBSCRIBER_CAPACITY = 512
+
+/** One live turn ATC drives (or follows, after a restart). */
+interface Run {
+  readonly turnId: string
+  readonly scope: Scope.Closeable
+  readonly connection: AgentConnection
+  readonly turn: AgentTurn
+  readonly requests: Map<string, ThreadRequest>
+  finished: boolean
+}
+
+export class ThreadRuntime extends Context.Service<
+  ThreadRuntime,
+  {
+    /** Admit a prompt; `turnId` present ⇒ it started at once, else queued. */
+    readonly prompt: (
+      id: string,
+      prompt: string,
+    ) => Effect.Effect<
+      { readonly promptId: string; readonly turnId?: string },
+      ThreadNotFound | ThreadArchived | ProviderUnavailable | ProviderSessionConflict
+    >
+    /** Interrupt the running turn; an idle thread is a no-op. Queued prompts stay. */
+    readonly interrupt: (id: string) => Effect.Effect<void, ThreadNotFound | ProviderUnavailable>
+    readonly listRequests: (
+      id: string,
+    ) => Effect.Effect<ReadonlyArray<ThreadRequest>, ThreadNotFound>
+    readonly answerRequest: (
+      id: string,
+      requestId: string,
+      answer: ThreadRequestAnswer,
+    ) => Effect.Effect<
+      void,
+      ThreadNotFound | RequestNotFound | InvalidRequestAnswer | ProviderUnavailable
+    >
+    readonly listQueue: (id: string) => Effect.Effect<ReadonlyArray<QueuedPrompt>, ThreadNotFound>
+    readonly deleteQueued: (
+      id: string,
+      promptId: string,
+    ) => Effect.Effect<void, ThreadNotFound | QueuedPromptNotFound>
+    /** A page of the transcript (newest `limit`, or the page before `before`). */
+    readonly transcript: (
+      id: string,
+      options?: { readonly before?: string | undefined; readonly limit?: number | undefined },
+    ) => Effect.Effect<ThreadTranscript, ThreadNotFound>
+    /**
+     * The per-thread event stream. With `after`, every durable change past
+     * that seq replays first (current row state), then live events follow;
+     * without it the stream is live only. Scoped: closing unsubscribes.
+     */
+    readonly subscribe: (
+      id: string,
+      after?: number | undefined,
+    ) => Effect.Effect<Stream.Stream<ThreadEvent>, ThreadNotFound, Scope.Scope>
+    /** Replace the copy with provider history (see the header's rules). No
+     * route calls this — the triggers are internal; it exists for tests
+     * and manual repair. */
+    readonly reread: (
+      id: string,
+    ) => Effect.Effect<void, ThreadNotFound | ProviderUnavailable | ProviderSessionConflict>
+
+    // --- The seams threads.ts consumes -------------------------------------
+
+    /** The ledger's current activity for a thread (undefined = no evidence). */
+    readonly activity: (id: string) => Effect.Effect<AgentActivity | undefined>
+    /** Whether the runtime currently drives (or follows) a turn on the thread. */
+    readonly isDriving: (id: string) => Effect.Effect<boolean>
+    /** Feed one activity observation through the ledger's rules (see header). */
+    readonly noteActivity: (
+      record: ThreadRecord,
+      activity: AgentActivity,
+    ) => Effect.Effect<{ readonly previous: AgentActivity | undefined }>
+    /** Drop the ledger entry (an observation ended). */
+    readonly clearActivity: (id: string) => Effect.Effect<void>
+    /** Record an item observed on a TUI-driven session (the shared-server fan-out). */
+    readonly recordObserved: (record: ThreadRecord, event: AgentItemEvent) => Effect.Effect<void>
+    /** The thread went idle under observation: re-read unless the busy was ours. */
+    readonly observedIdle: (record: ThreadRecord) => Effect.Effect<void>
+    /** Release the run and end the thread's event streams (archive/delete):
+     * the connection closes, its turn is recorded interrupted, and the
+     * provider keeps its own state. */
+    readonly release: (id: string) => Effect.Effect<void>
+  }
+>()("app-server/ThreadRuntime") {}
+
+export const layer = Layer.effect(ThreadRuntime)(
+  Effect.gen(function* () {
+    const repository = yield* ThreadRepository
+    const transcripts = yield* TranscriptRepository
+    const registry = yield* AgentRegistry
+    const events = yield* Events
+    // Runs and their drain fibers outlive their originating requests; they
+    // live in the service scope so shutdown releases every connection.
+    const serviceScope = yield* Effect.scope
+
+    const runs = new Map<string, Run>()
+    const hubs = new Map<string, Set<Queue.Queue<ThreadEvent, Cause.Done>>>()
+    const liveActivity = new Map<string, AgentActivity>()
+    // Threads the startup pass has not settled yet: their prompts wait.
+    const recovering = new Set(yield* transcripts.threadsNeedingAttention())
+    /** Threads whose latest busy spell was a native turn: the observed idle
+     * that ends it is not a TUI turn's end (observedIdle consumes the mark). */
+    const nativeBusy = new Set<string>()
+    /** Per-thread serialization of "is a run active → start the next prompt". */
+    const startLocks = new Map<string, Semaphore.Semaphore>()
+    const withStartLock =
+      (id: string) =>
+      <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+        Effect.suspend(() => {
+          const lock = startLocks.get(id) ?? Semaphore.makeUnsafe(1)
+          startLocks.set(id, lock)
+          return lock.withPermit(effect)
+        })
+
+    const adapterFor = (record: ThreadRecord): AgentAdapter | undefined =>
+      isAgentId(record.agentId) ? registry.adapterFor(record.agentId) : undefined
+
+    const requireAdapter = (record: ThreadRecord) =>
+      Effect.suspend(() => {
+        const adapter = adapterFor(record)
+        return adapter === undefined
+          ? Effect.fail(
+              new ProviderUnavailable({
+                agentId: record.agentId,
+                reason: `this build knows no agent "${record.agentId}"`,
+              }),
+            )
+          : Effect.succeed(adapter)
+      })
+
+    const isBusy = isBusyActivity
+
+    // --- Per-thread event hub -------------------------------------------------
+
+    const publish = (threadId: string, event: ThreadEvent): void => {
+      const subscribers = hubs.get(threadId)
+      if (subscribers === undefined) return
+      for (const queue of subscribers) {
+        if (Queue.offerUnsafe(queue, event)) continue
+        // A subscriber that stopped draining lost this event: end its
+        // stream so it resubscribes after=seq rather than reading a gap.
+        Queue.endUnsafe(queue)
+        subscribers.delete(queue)
+      }
+    }
+
+    // --- Transcript projection --------------------------------------------------
+
+    const recordItem = (threadId: string, event: AgentItemEvent): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        const seq = yield* transcripts.upsertItem(threadId, event.item)
+        const type =
+          event.type === "itemStarted"
+            ? "item.started"
+            : event.type === "itemUpdated"
+              ? "item.updated"
+              : "item.completed"
+        publish(threadId, { type, seq, item: event.item })
+      })
+
+    /** Upsert a turn and publish the row as it now stands (an update keeps
+     * the row's promptId/startedAt), so live events carry current state. */
+    const recordTurn = (
+      threadId: string,
+      turn: ThreadTurn,
+      source: TurnSource,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        const stored = yield* transcripts.upsertTurn(threadId, turn, source)
+        publish(threadId, {
+          type: stored.turn.status === "running" ? "turn.started" : "turn.completed",
+          seq: stored.seq,
+          turn: stored.turn,
+        })
+      })
+
+    const publishQueue = (threadId: string): Effect.Effect<void> =>
+      transcripts
+        .listWaiting(threadId)
+        .pipe(Effect.map((prompts) => publish(threadId, { type: "queue.updated", prompts })))
+
+    const replayEvent = (change: TranscriptChange): ThreadEvent =>
+      change.change.kind === "item"
+        ? { type: "item.updated", seq: change.seq, item: change.change.item }
+        : {
+            type: change.change.turn.status === "running" ? "turn.started" : "turn.completed",
+            seq: change.seq,
+            turn: change.change.turn,
+          }
+
+    /** Replace the copy with what the provider has; empty never wipes. */
+    const rereadRecord = (
+      record: ThreadRecord,
+    ): Effect.Effect<void, ProviderUnavailable | ProviderSessionConflict> =>
+      Effect.gen(function* () {
+        const adapter = yield* requireAdapter(record)
+        const providerSessionId = record.providerSessionId
+        if (providerSessionId === undefined) return
+        const history = yield* adapter
+          .readHistory({ providerSessionId, cwd: record.workingDirectory })
+          .pipe(Effect.mapError(mapAgentError(record)))
+        // Nothing to replace with is nothing to replace: a swept transcript
+        // keeps ATC's copy readable, and an empty copy stays quiet.
+        if (history.length === 0) return
+        const { seq, snapshotVersion } = yield* transcripts.replace(record.id, history)
+        publish(record.id, { type: "snapshot.invalidated", seq, snapshotVersion })
+        yield* events.publish({ resource: "thread", id: record.id, change: "updated" })
+      })
+
+    // --- Activity ledger ------------------------------------------------------------
+
+    const noteActivity = (
+      record: ThreadRecord,
+      activity: AgentActivity,
+    ): Effect.Effect<{ readonly previous: AgentActivity | undefined }> =>
+      Effect.gen(function* () {
+        const previous = liveActivity.get(record.id)
+        liveActivity.set(record.id, activity)
+        if (isBusy(activity)) {
+          if (runs.has(record.id)) nativeBusy.add(record.id)
+          else nativeBusy.delete(record.id)
+          // The first busy confirms (idempotent in the repository): a
+          // submitted prompt is durable provider history worth protecting.
+          if (previous === undefined || !isBusy(previous)) yield* repository.confirm(record.id)
+        }
+        // The busy→idle drop IS the turn-finished signal (ATC-160): stamp
+        // before publishing so the refetch already sees the thread unread.
+        if (previous !== undefined && isBusy(previous) && activity === "idle") {
+          yield* repository.markFinished(record.id)
+        }
+        if (previous !== activity) {
+          yield* events.publish({ resource: "thread", id: record.id, change: "updated" })
+        }
+        return { previous }
+      })
+
+    // --- The turn loop ---------------------------------------------------------------
+
+    const mapAgentError =
+      (record: ThreadRecord) => (error: { readonly _tag: string; readonly message: string }) =>
+        error._tag === "AgentUnavailable" || error._tag === "AgentProtocolError"
+          ? new ProviderUnavailable({ agentId: record.agentId, reason: error.message })
+          : new ProviderSessionConflict({ threadId: record.id, reason: error.message })
+
+    /** Close every parked request of a run (its turn ended). */
+    const closeRequests = (threadId: string, run: Run): void => {
+      for (const requestId of run.requests.keys())
+        publish(threadId, { type: "request.closed", requestId })
+      run.requests.clear()
+    }
+
+    /**
+     * The run's last act: close the connection, deregister only once it is
+     * closed (a prompt arriving meanwhile queues rather than racing the
+     * writer), then start the next queued prompt. Runs in the service scope
+     * — the callers sit on the run's own drain fiber, which the scope close
+     * interrupts.
+     */
+    const closeRun = (
+      record: ThreadRecord,
+      run: Run,
+      then: Effect.Effect<void>,
+    ): Effect.Effect<void> =>
+      Scope.close(run.scope, Exit.void).pipe(
+        Effect.andThen(
+          Effect.sync(() => {
+            if (runs.get(record.id) === run) runs.delete(record.id)
+          }),
+        ),
+        Effect.andThen(then),
+        Effect.andThen(startNextLogged(record.id)),
+        Effect.forkIn(serviceScope),
+      )
+
+    /**
+     * End a run: the turn row takes its outcome, parked requests close, the
+     * ledger drops to idle (the connection is going away — see the header),
+     * and the run closes.
+     */
+    const finish = (
+      record: ThreadRecord,
+      run: Run,
+      status: "completed" | "interrupted" | "failed",
+      detail?: string,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        if (run.finished) return
+        run.finished = true
+        closeRequests(record.id, run)
+        // The upsert keeps the row's promptId/startedAt (COALESCE).
+        yield* recordTurn(
+          record.id,
+          {
+            id: run.turnId,
+            status,
+            ...(status === "failed" && detail !== undefined ? { error: detail } : {}),
+            endedAt: new Date().toISOString(),
+          },
+          "native",
+        )
+        yield* noteActivity(record, "idle")
+        yield* closeRun(record, run, Effect.void)
+      })
+
+    const handleEvent = (
+      record: ThreadRecord,
+      run: Run,
+      event: AgentEvent,
+    ): Effect.Effect<void> => {
+      switch (event.type) {
+        case "activity":
+          // After the turn ended, lingering busy evidence on this feed (a
+          // subagent still winding down) must not re-busy a thread whose
+          // connection is closing — nothing on it would ever report idle.
+          return run.finished && isBusy(event.activity)
+            ? Effect.void
+            : noteActivity(record, event.activity).pipe(Effect.asVoid)
+        case "itemStarted":
+        case "itemUpdated":
+        case "itemCompleted":
+          return recordItem(record.id, event)
+        case "textDelta":
+          return Effect.sync(() =>
+            publish(record.id, { type: "text.delta", itemId: event.itemId, delta: event.delta }),
+          )
+        case "requestOpened":
+          return Effect.sync(() => {
+            run.requests.set(event.request.id, event.request)
+            publish(record.id, { type: "request.opened", request: event.request })
+          })
+        case "requestClosed":
+          return Effect.sync(() => {
+            if (!run.requests.delete(event.requestId)) return
+            publish(record.id, { type: "request.closed", requestId: event.requestId })
+          })
+        case "turnStarted":
+          // Another writer's turn on a connection we hold (a TUI mid-run):
+          // observed, not ours.
+          return event.turnId === run.turnId
+            ? Effect.void
+            : recordTurn(
+                record.id,
+                { id: event.turnId, status: "running", startedAt: new Date().toISOString() },
+                "observed",
+              )
+        case "turnCompleted":
+          return event.turnId === run.turnId
+            ? finish(record, run, event.outcome, event.detail)
+            : recordTurn(
+                record.id,
+                { id: event.turnId, status: event.outcome, endedAt: new Date().toISOString() },
+                "observed",
+              )
+      }
+    }
+
+    /**
+     * The feed died with no truthful turn end (transport loss): ATC no
+     * longer knows how the turn is doing — the provider may still be
+     * running it. Drop the run without guessing an outcome, and re-read the
+     * provider's history for the truth; a turn history still calls running
+     * is the startup pass's job if the provider stays unreachable.
+     */
+    const abandon = (record: ThreadRecord, run: Run, reason: string): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        if (run.finished) return
+        run.finished = true
+        closeRequests(record.id, run)
+        yield* noteActivity(record, "unknown")
+        yield* Effect.logWarning("the turn's connection failed; re-reading provider history").pipe(
+          Effect.annotateLogs({ threadId: record.id, turnId: run.turnId, reason }),
+        )
+        yield* closeRun(
+          record,
+          run,
+          rereadRecord(record).pipe(
+            Effect.catch((error) =>
+              Effect.logWarning("re-read after a failed connection failed").pipe(
+                Effect.annotateLogs({ threadId: record.id, reason: error.message }),
+              ),
+            ),
+          ),
+        )
+      })
+
+    /**
+     * Register a run and fork its drain. A feed that FAILS is abandoned
+     * (above); so is one that ENDS without a turn end while the run is
+     * still open — the provider dropped the session under us (a closed
+     * connection's drain is interrupted before its feed ends, so ATC's own
+     * closes never take this path).
+     */
+    const startRun = (record: ThreadRecord, run: Run): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        runs.set(record.id, run)
+        // The connection's snapshot seeds the ledger so a read racing the
+        // first feed event already sees what the provider says.
+        yield* noteActivity(record, yield* run.connection.activity)
+        yield* run.connection.events.pipe(
+          Stream.runForEach((event) => handleEvent(record, run, event)),
+          Effect.andThen(
+            Effect.suspend(() =>
+              run.finished
+                ? Effect.void
+                : abandon(record, run, "the feed ended without a turn end"),
+            ),
+          ),
+          Effect.catch((error) => abandon(record, run, error.message)),
+          Effect.forkIn(run.scope),
+        )
+      })
+
+    /**
+     * Start the oldest waiting prompt if the thread can take one: no run
+     * registered, not recovering, not archived, and not busy under another
+     * surface (the ledger's word — a TUI turn in progress queues us until
+     * the observed idle drains). A confirmed thread resumes its exact
+     * session; anything else creates a fresh one (the second `materialize`
+     * caller ATC-124 anticipated): identity is persisted — and confirmed,
+     * the prompt is durable provider history — before the run is
+     * registered. Under the per-thread start lock, with the record re-read
+     * inside it, so two prompts cannot both start and an archive or delete
+     * that won the lock first is honored.
+     */
+    const startNext = (
+      id: string,
+    ): Effect.Effect<
+      Option.Option<{ readonly promptId: string; readonly turnId: string }>,
+      ProviderUnavailable | ProviderSessionConflict
+    > =>
+      withStartLock(id)(
+        Effect.gen(function* () {
+          if (runs.has(id) || recovering.has(id)) return Option.none()
+          const found = yield* repository.get(id)
+          if (Option.isNone(found) || found.value.archivedAt !== undefined) return Option.none()
+          const record = found.value
+          if (isBusy(liveActivity.get(id) ?? "unknown")) return Option.none()
+          const next = yield* transcripts.peek(id)
+          if (Option.isNone(next)) return Option.none()
+          const adapter = yield* requireAdapter(record)
+          const scope = Scope.forkUnsafe(serviceScope)
+          const started = yield* Effect.gen(function* () {
+            const cwd = record.workingDirectory
+            if (record.providerSessionId !== undefined && record.confirmedAt !== undefined) {
+              const connection = yield* adapter.resumeSession({
+                providerSessionId: record.providerSessionId,
+                cwd,
+              })
+              const turn = yield* connection.startTurn(next.value.prompt)
+              return { connection, turn, record }
+            }
+            // Unconfirmed (none, or zero completed turns): a fresh session,
+            // as openTerminal's materialize does — there is no history to
+            // protect, and the superseded session's adapter resources go.
+            if (record.providerSessionId !== undefined) {
+              yield* adapter.releaseSession({
+                providerSessionId: record.providerSessionId,
+                providerMetadata: record.providerMetadata,
+              })
+            }
+            const session = yield* adapter.createSession({ cwd, input: next.value.prompt })
+            const still = yield* repository.get(record.id)
+            if (Option.isNone(still)) {
+              return yield* Effect.die(new Error(`thread ${record.id} vanished mid-prompt`))
+            }
+            const adopted = yield* repository.setProviderSession(
+              record.id,
+              session.connection.providerSessionId,
+              null,
+            )
+            yield* repository.confirm(record.id)
+            yield* events.publish({ resource: "thread", id: record.id, change: "updated" })
+            return { connection: session.connection, turn: session.turn, record: adopted }
+          }).pipe(
+            Scope.provide(scope),
+            Effect.mapError(mapAgentError(record)),
+            Effect.onExit((exit) =>
+              exit._tag === "Failure" ? Scope.close(scope, Exit.void) : Effect.void,
+            ),
+          )
+          const turnId = started.turn.turnId
+          const turn: ThreadTurn = {
+            id: turnId,
+            status: "running",
+            promptId: next.value.id,
+            startedAt: new Date().toISOString(),
+          }
+          // From here the connection is ours until the run owns it: no
+          // interruption (a dropped request) may land between the two, or
+          // the writer would stay open with nobody to close it.
+          yield* Effect.uninterruptible(
+            Effect.gen(function* () {
+              const seq = yield* transcripts.beginTurn(record.id, next.value.id, turn)
+              publish(record.id, { type: "turn.started", seq, turn })
+              yield* publishQueue(record.id)
+              yield* startRun(started.record, {
+                turnId,
+                scope,
+                connection: started.connection,
+                turn: started.turn,
+                requests: new Map(),
+                finished: false,
+              })
+            }).pipe(
+              Effect.onExit((exit) =>
+                exit._tag === "Failure" && !runs.has(record.id)
+                  ? Scope.close(scope, Exit.void)
+                  : Effect.void,
+              ),
+            ),
+          )
+          return Option.some({ promptId: next.value.id, turnId })
+        }),
+      )
+
+    /** The drain continuation: a provider failure leaves the prompt queued. */
+    const startNextLogged = (id: string): Effect.Effect<void> =>
+      startNext(id).pipe(
+        Effect.asVoid,
+        Effect.catch((error) =>
+          Effect.logWarning("the next queued prompt could not start; it stays queued").pipe(
+            Effect.annotateLogs({ threadId: id, reason: error.message }),
+          ),
+        ),
+      )
+
+    // --- Startup ---------------------------------------------------------------------
+
+    /**
+     * Follow a turn still running on a shared provider server after a
+     * restart: resume the session and drain its feed to the turn's end.
+     * A session that is already idle has nothing to follow — the copy is
+     * re-read once more, and a turn history still calls running is marked
+     * interrupted.
+     */
+    const reattach = (record: ThreadRecord, turn: ThreadTurn): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        const adapter = yield* requireAdapter(record)
+        const providerSessionId = record.providerSessionId
+        if (providerSessionId === undefined) return yield* markInterrupted(record, turn)
+        const scope = Scope.forkUnsafe(serviceScope)
+        const connection = yield* adapter
+          .resumeSession({ providerSessionId, cwd: record.workingDirectory })
+          .pipe(Scope.provide(scope))
+        if (!isBusy(yield* connection.activity)) {
+          yield* Scope.close(scope, Exit.void)
+          yield* rereadRecord(record)
+          const still = (yield* transcripts.runningTurns(record.id)).find(
+            (entry) => entry.id === turn.id,
+          )
+          if (still !== undefined) yield* markInterrupted(record, still)
+          return
+        }
+        yield* startRun(record, {
+          turnId: turn.id,
+          scope,
+          connection,
+          turn: { turnId: turn.id },
+          requests: new Map(),
+          finished: false,
+        })
+      }).pipe(
+        Effect.catch((error) =>
+          Effect.logWarning("could not reattach to a running turn; marking it interrupted").pipe(
+            Effect.annotateLogs({ threadId: record.id, turnId: turn.id, reason: error.message }),
+            Effect.andThen(markInterrupted(record, turn)),
+          ),
+        ),
+      )
+
+    const markInterrupted = (record: ThreadRecord, turn: ThreadTurn): Effect.Effect<void> =>
+      recordTurn(
+        record.id,
+        { ...turn, status: "interrupted", endedAt: new Date().toISOString() },
+        "native",
+      )
+
+    const recoverThread = (id: string): Effect.Effect<void> =>
+      withStartLock(id)(
+        Effect.gen(function* () {
+          const found = yield* repository.get(id)
+          if (Option.isNone(found)) return
+          const record = found.value
+          const running = yield* transcripts.runningTurns(id)
+          if (running.length === 0) return
+          yield* rereadRecord(record).pipe(
+            Effect.catch((error) =>
+              Effect.logWarning("startup re-read failed").pipe(
+                Effect.annotateLogs({ threadId: id, reason: error.message }),
+              ),
+            ),
+          )
+          const still = yield* transcripts.runningTurns(id)
+          const adapter = adapterFor(record)
+          for (const turn of still) {
+            // A shared provider server (the observation-outlives-TUI shape)
+            // keeps running our turn across ATC's restart; anything else
+            // died with the process.
+            yield* adapter?.observationOutlivesTui === true
+              ? reattach(record, turn)
+              : markInterrupted(record, turn)
+          }
+        }),
+      ).pipe(
+        // Settled (or given up): prompts may start, beginning with the
+        // ones that waited — outside the lock, which startNext takes.
+        Effect.ensuring(Effect.sync(() => recovering.delete(id))),
+        Effect.andThen(startNextLogged(id)),
+      )
+
+    yield* Effect.forEach([...recovering], recoverThread, { concurrency: 4 }).pipe(
+      Effect.catchCause((cause) =>
+        Effect.logWarning("startup thread recovery failed").pipe(
+          Effect.annotateLogs({ cause: Cause.pretty(cause) }),
+        ),
+      ),
+      Effect.forkScoped,
+    )
+
+    // --- Answer validation ---------------------------------------------------------------
+
+    const validateAnswer = (request: ThreadRequest, answer: ThreadRequestAnswer): string | null => {
+      if (request.kind !== answer.kind) return `the request expects a ${request.kind} answer`
+      if (request.kind !== "question" || answer.kind !== "question") return null
+      const known = new Map(request.questions.map((question) => [question.id, question]))
+      const missing = request.questions.find((question) => !(question.id in answer.answers))
+      if (missing !== undefined) return `question ${missing.id} needs an answer`
+      for (const [id, chosen] of Object.entries(answer.answers)) {
+        const question = known.get(id)
+        if (question === undefined) return `unknown question ${id}`
+        if (chosen.length === 0) return `question ${id} needs an answer`
+        if (!question.multiSelect && chosen.length > 1) return `question ${id} takes one answer`
+        if (!question.freeform) {
+          const labels = new Set(question.options.map((option) => option.label))
+          const stray = chosen.find((value) => !labels.has(value))
+          if (stray !== undefined) return `"${stray}" is not an option of question ${id}`
+        }
+      }
+      return null
+    }
+
+    return {
+      prompt: (id, prompt) =>
+        Effect.gen(function* () {
+          const record = yield* repository.require(id)
+          if (record.archivedAt !== undefined) {
+            return yield* Effect.fail(new ThreadArchived({ threadId: id }))
+          }
+          yield* requireAdapter(record)
+          // Whether THIS prompt is the one an immediate start would run.
+          const first = !runs.has(id) && Option.isNone(yield* transcripts.peek(id))
+          const queued = yield* transcripts.enqueue(id, prompt)
+          yield* publishQueue(id)
+          // The drain runs the OLDEST waiting prompt. When that is ours, a
+          // provider that refuses un-admits it (the caller's error means
+          // "not accepted"); an older prompt's failure just leaves ours
+          // queued behind it (logged).
+          const started = yield* startNext(id).pipe(
+            Effect.catch((error) =>
+              first
+                ? transcripts
+                    .deleteWaiting(id, queued.id)
+                    .pipe(Effect.andThen(publishQueue(id)), Effect.andThen(Effect.fail(error)))
+                : Effect.logWarning("an older queued prompt could not start; it stays queued").pipe(
+                    Effect.annotateLogs({ threadId: id, reason: error.message }),
+                    Effect.as(Option.none()),
+                  ),
+            ),
+          )
+          return Option.isSome(started) && started.value.promptId === queued.id
+            ? { promptId: queued.id, turnId: started.value.turnId }
+            : { promptId: queued.id }
+        }),
+      interrupt: (id) =>
+        Effect.gen(function* () {
+          const record = yield* repository.require(id)
+          const run = runs.get(id)
+          // No run, or one already ending: idle is the goal state.
+          if (run === undefined || run.finished) return
+          yield* run.connection.interrupt(run.turn).pipe(
+            // The turn ended on its own first: already the goal state.
+            Effect.catchTag("AgentConflict", () => Effect.void),
+            Effect.mapError(
+              (error) =>
+                new ProviderUnavailable({ agentId: record.agentId, reason: error.message }),
+            ),
+          )
+        }),
+      listRequests: (id) =>
+        repository.require(id).pipe(Effect.map(() => [...(runs.get(id)?.requests.values() ?? [])])),
+      answerRequest: (id, requestId, answer) =>
+        Effect.gen(function* () {
+          const record = yield* repository.require(id)
+          const run = runs.get(id)
+          const request = run?.requests.get(requestId)
+          if (run === undefined || request === undefined) {
+            return yield* Effect.fail(new RequestNotFound({ threadId: id, requestId }))
+          }
+          const reason = validateAnswer(request, answer)
+          if (reason !== null) {
+            return yield* Effect.fail(new InvalidRequestAnswer({ threadId: id, requestId, reason }))
+          }
+          yield* run.connection.respond(requestId, answer).pipe(
+            // Resolved elsewhere between our lookup and the answer.
+            Effect.catchTag("AgentConflict", () =>
+              Effect.fail(new RequestNotFound({ threadId: id, requestId })),
+            ),
+            Effect.catchTags({
+              AgentUnavailable: (error) =>
+                Effect.fail(
+                  new ProviderUnavailable({ agentId: record.agentId, reason: error.message }),
+                ),
+              AgentProtocolError: (error) =>
+                Effect.fail(
+                  new ProviderUnavailable({ agentId: record.agentId, reason: error.message }),
+                ),
+            }),
+          )
+        }),
+      listQueue: (id) => repository.require(id).pipe(Effect.andThen(transcripts.listWaiting(id))),
+      deleteQueued: (id, promptId) =>
+        withStartLock(id)(
+          Effect.gen(function* () {
+            yield* repository.require(id)
+            const removed = yield* transcripts.deleteWaiting(id, promptId)
+            if (!removed) {
+              return yield* Effect.fail(new QueuedPromptNotFound({ threadId: id, promptId }))
+            }
+            yield* publishQueue(id)
+          }),
+        ),
+      transcript: (id, options) =>
+        repository.require(id).pipe(
+          Effect.andThen(
+            transcripts.read(id, {
+              before: options?.before,
+              limit: Math.max(1, Math.min(options?.limit ?? TRANSCRIPT_PAGE, TRANSCRIPT_PAGE)),
+            }),
+          ),
+        ),
+      subscribe: (id, after) =>
+        Effect.gen(function* () {
+          yield* repository.require(id)
+          const queue = yield* Queue.make<ThreadEvent, Cause.Done>({
+            capacity: SUBSCRIBER_CAPACITY,
+          })
+          // Registered BEFORE the replay read: anything published in
+          // between waits in the queue, and the seq filter below drops
+          // what the replay already covered.
+          yield* Effect.acquireRelease(
+            Effect.sync(() => {
+              const set = hubs.get(id) ?? new Set()
+              set.add(queue)
+              hubs.set(id, set)
+            }),
+            () =>
+              Effect.sync(() => {
+                const set = hubs.get(id)
+                set?.delete(queue)
+                if (set?.size === 0) hubs.delete(id)
+                Queue.endUnsafe(queue)
+              }),
+          )
+          if (after === undefined) return Stream.fromQueue(queue)
+          const { changes, counters } = yield* transcripts.changesAfter(id, after)
+          // A copy replaced since `after`: what was deleted cannot be
+          // replayed, so the client is told to refetch instead.
+          const replay: ReadonlyArray<ThreadEvent> =
+            counters.snapshotSeq > after
+              ? [
+                  {
+                    type: "snapshot.invalidated",
+                    seq: counters.seq,
+                    snapshotVersion: counters.snapshotVersion,
+                  },
+                ]
+              : changes.map(replayEvent)
+          return Stream.concat(
+            Stream.fromIterable(replay),
+            Stream.fromQueue(queue).pipe(
+              Stream.filter((event) => !("seq" in event) || event.seq > counters.seq),
+            ),
+          )
+        }),
+      reread: (id) => repository.require(id).pipe(Effect.flatMap(rereadRecord)),
+      activity: (id) => Effect.sync(() => liveActivity.get(id)),
+      isDriving: (id) => Effect.sync(() => runs.has(id)),
+      noteActivity,
+      clearActivity: (id) =>
+        Effect.sync(() => {
+          liveActivity.delete(id)
+          nativeBusy.delete(id)
+        }),
+      // While the runtime drives, the writer feed already carries every
+      // item; the observer copy of the same fan-out would double it.
+      recordObserved: (record, event) =>
+        runs.has(record.id) ? Effect.void : recordItem(record.id, event),
+      observedIdle: (record) =>
+        Effect.gen(function* () {
+          if (runs.has(record.id)) return
+          // Our own turn's idle is not a TUI turn ending: the copy is live.
+          // A TUI turn's end is what the re-read is for — before the queue
+          // drains, so the new turn's live items survive it.
+          if (!nativeBusy.delete(record.id)) {
+            yield* rereadRecord(record).pipe(
+              Effect.catch((error) =>
+                Effect.logDebug("re-read after observed idle failed").pipe(
+                  Effect.annotateLogs({ threadId: record.id, reason: error.message }),
+                ),
+              ),
+            )
+          }
+          yield* startNextLogged(record.id)
+        }),
+      release: (id) =>
+        withStartLock(id)(
+          Effect.gen(function* () {
+            const run = runs.get(id)
+            liveActivity.delete(id)
+            nativeBusy.delete(id)
+            if (run !== undefined) {
+              run.finished = true
+              closeRequests(id, run)
+              // The turn is over as far as ATC is concerned — the row must
+              // not read running forever (nor pull the thread into every
+              // startup pass).
+              const found = yield* repository.get(id)
+              if (Option.isSome(found)) {
+                yield* markInterrupted(found.value, { id: run.turnId, status: "running" })
+              }
+              yield* Scope.close(run.scope, Exit.void)
+              runs.delete(id)
+            }
+            // Subscribers of a thread being put away or deleted are done.
+            for (const queue of hubs.get(id) ?? []) Queue.endUnsafe(queue)
+            hubs.delete(id)
+          }),
+        ),
+    }
+  }),
+)

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -23,7 +23,11 @@ import type {
   AgentUnavailable,
   TuiLaunchSpec,
 } from "../agents/agentAdapter.ts"
-import { NESTED_SESSION_ENV_VARIABLES, sanitizeTitle } from "../agents/agentAdapter.ts"
+import {
+  isBusyActivity,
+  NESTED_SESSION_ENV_VARIABLES,
+  sanitizeTitle,
+} from "../agents/agentAdapter.ts"
 import {
   isAgentId,
   ProviderSessionConflict,
@@ -48,6 +52,7 @@ import { Terminals } from "../terminals/terminals.ts"
 import type { Terminal } from "../terminals/terminals.ts"
 import { ThreadRepository } from "./threadRepository.ts"
 import type { ThreadRecord } from "./threadRepository.ts"
+import { ThreadRuntime } from "./threadRuntime.ts"
 
 export type Thread = typeof Contract.Thread.Type
 
@@ -68,30 +73,32 @@ export type Thread = typeof Contract.Thread.Type
 //     (concurrent opens conflict). Confirmed sessions reopen their exact
 //     id; unconfirmed ones re-materialize with fresh identity — there is
 //     no history to protect yet.
-//   - The writer rule is a WRITE SEAT, not a terminal check (ATC-124
-//     surface-agnostic follow-up): the live-linked-terminal check above IS
-//     the V1 seat check, because a TUI terminal is the only holder that
-//     can exist yet. Native mode adds the second holder type — the
-//     adapter connection — here, so "open a TUI while native drives" and
-//     "prompt natively while a TUI is live" become the same conflict;
-//     nothing ever binds a Thread to one surface (sequential cross-surface
-//     alternation stays supported).
+//   - No lock between surfaces (ATC-193): a TUI may open while the runtime
+//     drives a turn and a prompt may arrive while a TUI is live — the
+//     provider taking one turn at a time is its own affair, and the only
+//     guard is the in-progress state plus the queue. Nothing binds a Thread
+//     to one surface.
 //   - workingDirectory is validated, canonicalized, and immutable.
-//   - activityState is in-memory evidence from the one normalized status
-//     feed, never persisted; `unknown` when there is no evidence, and a
-//     busy state whose driver (the seat holder: the linked terminal in
-//     V1, the adapter connection in native mode) is gone re-derives
-//     demand-driven from the adapter's reconciliation check on read. The
-//     confirmed marker is persisted at the FIRST busy signal observed on
-//     the feed — a submitted prompt is already durable provider history
-//     worth protecting, and writing at onset (not busy→idle) keeps the
-//     marker across a restart or observer gap mid-first-turn — the same
-//     signal for every provider.
+//   - activityState is in-memory evidence, never persisted, and lives in
+//     the ThreadRuntime's activity ledger — fed by the terminal-observation
+//     drain here and by native turns there, one set of rules (first busy
+//     confirms, busy→idle stamps the finish, every transition publishes).
+//     `unknown` when there is no evidence; a busy state whose driver is
+//     gone re-derives demand-driven from the adapter's reconciliation
+//     check on read, unless the runtime is driving the thread (its
+//     evidence is authoritative) or a shared-server observation still
+//     covers it. The confirmed marker is persisted at the FIRST busy signal
+//     — a submitted prompt is already durable provider history worth
+//     protecting — the same signal for every provider.
 //   - The unread overlay (ATC-160) is derived, never stored as a flag:
 //     last_finished_at is stamped at the observed busy→idle drop — the
-//     drain loop and the driver-gone re-derivation alike — last_viewed_at
-//     by markViewed, and archived rows are never unread. The activity
+//     ledger and the driver-gone re-derivation alike — last_viewed_at by
+//     markViewed, and archived rows are never unread. The activity
 //     vocabulary is untouched; "Done" is client-side display translation.
+//   - Observed conversation items (the shared-server fan-out on a
+//     TUI-driven Codex thread) feed the runtime's transcript copy, and an
+//     observed busy→idle asks the runtime to re-read the provider's
+//     history — the copy for turns ATC did not drive.
 //   - Auto-naming (ATC-155): the first user prompt observed on a thread
 //     that was unnamed AND unconfirmed when its subscription started forks
 //     one fire-and-forget title generation through the adapter seam. A
@@ -205,6 +212,7 @@ export const layerWith = (options: ThreadsOptions) =>
       const terminals = yield* Terminals
       const registry = yield* AgentRegistry
       const events = yield* Events
+      const runtime = yield* ThreadRuntime
       // Observation fibers outlive their originating requests; they live in
       // the service's own scope so shutdown reaps every subscription.
       const serviceScope = yield* Effect.scope
@@ -212,10 +220,6 @@ export const layerWith = (options: ThreadsOptions) =>
       const launchWatchInterval = options.launchWatchInterval ?? "500 millis"
       const titleRefineDelay = options.titleRefineDelay ?? "30 seconds"
 
-      // Live activity evidence by thread id, fed by the per-session
-      // subscriptions below. In-memory only — restart resets to no
-      // evidence, and reads re-derive on demand.
-      const liveActivity = new Map<string, AgentActivity>()
       /** The observed session per thread; the child scope closes it. */
       interface Observation {
         readonly providerSessionId: string
@@ -242,8 +246,7 @@ export const layerWith = (options: ThreadsOptions) =>
       const adapterFor = (record: ThreadRecord): AgentAdapter | undefined =>
         isAgentId(record.agentId) ? registry.adapterFor(record.agentId) : undefined
 
-      const isBusy = (activity: AgentActivity): boolean =>
-        activity === "working" || activity === "needs_input"
+      const isBusy = isBusyActivity
 
       /**
        * The unread overlay (ATC-160): a finish no client has viewed yet.
@@ -448,7 +451,6 @@ export const layerWith = (options: ThreadsOptions) =>
                 ),
                 Scope.provide(child),
               )
-            let confirmed = record.confirmedAt !== undefined
             // Auto-name eligibility is fixed at subscription start: a name
             // or a confirmed first turn already on the record rules the
             // thread out (retro-naming is a non-goal), and the first prompt
@@ -477,16 +479,15 @@ export const layerWith = (options: ThreadsOptions) =>
                     Deferred.doneUnsafe(naming.promptArrived, Effect.void)
                     return
                   }
-                  // Item events feed the transcript copy (ATC-193, the
-                  // Threads runtime PR); the activity subscription ignores them.
-                  if (event.type !== "activity") return
-                  const activity = event.activity
-                  const previous = liveActivity.get(record.id)
-                  liveActivity.set(record.id, activity)
-                  if (!confirmed && isBusy(activity)) {
-                    confirmed = true
-                    yield* repository.confirm(record.id)
+                  // Conversation items observed on the shared server feed
+                  // the runtime's transcript copy (ATC-193).
+                  if (event.type !== "activity") {
+                    yield* runtime.recordObserved(record, event)
+                    return
                   }
+                  const activity = event.activity
+                  // The ledger applies the confirm / finish / publish rules.
+                  const { previous } = yield* runtime.noteActivity(record, activity)
                   // The first busy evidence arms the one refinement fiber
                   // (ATC-190), in the service scope for the same reason as
                   // the generation above. Armed even before the prompt is
@@ -496,17 +497,13 @@ export const layerWith = (options: ThreadsOptions) =>
                     naming.armed = true
                     yield* refineThreadTitle(record, naming).pipe(Effect.forkIn(serviceScope))
                   }
-                  // The busy→idle drop IS the turn-finished signal (ATC-160):
-                  // stamp before publishing so the refetch the event triggers
-                  // already sees the thread unread.
+                  // The busy→idle drop is the turn's end: the refinement's
+                  // trigger, and — for a turn ATC did not drive — the moment
+                  // to re-read the provider's history (forked: the drain
+                  // must never wait on the provider).
                   if (previous !== undefined && isBusy(previous) && activity === "idle") {
-                    yield* repository.markFinished(record.id)
                     Deferred.doneUnsafe(naming.turnEnded, Effect.void)
-                  }
-                  // One publish covers both the activity transition and the
-                  // confirm write above (which only happens on a transition).
-                  if (previous !== activity) {
-                    yield* events.publish({ resource: "thread", id: record.id, change: "updated" })
+                    yield* runtime.observedIdle(record).pipe(Effect.forkIn(serviceScope))
                   }
                 }),
               ),
@@ -532,7 +529,7 @@ export const layerWith = (options: ThreadsOptions) =>
 
       const unobserve = (threadId: string): Effect.Effect<void> =>
         Effect.gen(function* () {
-          liveActivity.delete(threadId)
+          yield* runtime.clearActivity(threadId)
           const observation = observed.get(threadId)
           if (observation === undefined) return
           observed.delete(threadId)
@@ -555,8 +552,10 @@ export const layerWith = (options: ThreadsOptions) =>
       ): Effect.Effect<{ readonly activity: AgentActivity; readonly record: ThreadRecord }> =>
         Effect.gen(function* () {
           if (record.providerSessionId === undefined) return { activity: "idle" as const, record }
-          const live = liveActivity.get(record.id) ?? "unknown"
+          const live = (yield* runtime.activity(record.id)) ?? "unknown"
           if (!isBusy(live) || linked !== undefined) return { activity: live, record }
+          // The runtime's own turn is the evidence — never re-derived.
+          if (yield* runtime.isDriving(record.id)) return { activity: live, record }
           const adapter = adapterFor(record)
           // A live observation whose feed outlives the TUI (shared-server
           // providers) is already authoritative — it drives liveActivity —
@@ -578,28 +577,23 @@ export const layerWith = (options: ThreadsOptions) =>
               : yield* adapter
                   .checkSession({ providerSessionId })
                   .pipe(Effect.orElseSucceed(() => "unknown" as const))
-          liveActivity.set(record.id, checked)
-          // A finish discovered on read stamps too (the busy snapshot was
-          // real evidence and the check says the turn is over), and the
-          // record is re-read so the discovering response itself presents
-          // the thread unread — never a stale `unread: false` racing the
-          // publish-triggered refetch.
+          // The ledger stamps a finish discovered here (the busy snapshot
+          // was real evidence and the check says the turn is over) and
+          // publishes the change to every subscriber. Loop-safe: the busy
+          // snapshot is gone, so the next event-triggered read returns at
+          // the short-circuit above without publishing. The record is
+          // re-read so the discovering response itself presents the thread
+          // unread — never a stale `unread: false` racing the refetch.
+          yield* runtime.noteActivity(record, checked)
+          if (checked === "idle") {
+            // A turn ended under observation, discovered here: the same
+            // moment the drain loop reports (re-read, drain the queue).
+            yield* runtime.observedIdle(record).pipe(Effect.forkIn(serviceScope))
+          }
           const current =
             checked === "idle"
-              ? yield* repository
-                  .markFinished(record.id)
-                  .pipe(
-                    Effect.andThen(repository.get(record.id)),
-                    Effect.map(Option.getOrElse(() => record)),
-                  )
+              ? yield* repository.get(record.id).pipe(Effect.map(Option.getOrElse(() => record)))
               : record
-          // Other subscribers must hear about the re-derived state too, not
-          // just the client whose read triggered it. Loop-safe: the busy
-          // snapshot is gone, so the next event-triggered read returns at
-          // the short-circuit above without publishing.
-          if (checked !== live) {
-            yield* events.publish({ resource: "thread", id: record.id, change: "updated" })
-          }
           return { activity: checked, record: current }
         })
 
@@ -947,6 +941,7 @@ export const layerWith = (options: ThreadsOptions) =>
                 .delete(linked.id)
                 .pipe(Effect.catchTag("TerminalNotFound", () => Effect.void))
             }
+            yield* runtime.release(id)
             const adapter = adapterFor(record)
             if (adapter !== undefined && record.providerSessionId !== undefined) {
               yield* adapter.releaseSession({
@@ -1060,6 +1055,7 @@ export const layerWith = (options: ThreadsOptions) =>
               // hook plumbing; the next tuiLaunch recreates it) and stop
               // observation. The provider conversation itself is untouched,
               // so unarchive + open resumes it exactly.
+              yield* runtime.release(id)
               const adapter = adapterFor(record)
               if (adapter !== undefined && record.providerSessionId !== undefined) {
                 yield* adapter.releaseSession({

--- a/app-server/src/threads/transcriptRepository.ts
+++ b/app-server/src/threads/transcriptRepository.ts
@@ -1,0 +1,571 @@
+import { Context, Effect, Layer, Option, Schema } from "effect"
+import { SqlClient, SqlSchema } from "effect/unstable/sql"
+import type * as Contract from "../api/contract.ts"
+import { ThreadItem, ThreadTurn } from "../api/contract.ts"
+import type { HistoryTurn } from "../agents/agentAdapter.ts"
+
+// The Thread runtime's repository (ATC-193): the only module that speaks SQL
+// for the transcript copy (thread_items, thread_turns), the prompt queue
+// (thread_queue), and the two runtime counters on threads
+// (transcript_seq, snapshot_version). Invariants:
+//
+//   - `seq` is allocated HERE, atomically with the write it stamps: every
+//     item or turn upsert bumps threads.transcript_seq inside one
+//     transaction and records the new value as the row's updated_seq. A
+//     row's `ord` is the seq it was first inserted at, so transcript order
+//     is `ORDER BY ord` and never changes on update.
+//   - Items are stored as the ThreadItem JSON verbatim, encoded and decoded
+//     through the contract schema — an unreadable row is a defect (a
+//     schema this build cannot decode), never a silent skip.
+//   - Reads that pair rows with the head seq (`read`, `changesAfter`) run
+//     in one transaction too: a write landing between the row query and
+//     the counter read would otherwise be missing from the rows yet covered
+//     by the head — a permanent gap for a subscriber filtering on it.
+//   - `replace` is the re-read: everything goes, the history lands with
+//     fresh ords, snapshot_version bumps, and snapshot_seq records the seq
+//     the replacement took — one transaction, so a concurrent reader sees
+//     the old copy or the new one, never a mix.
+//   - Queue rows start oldest-first: `beginTurn` stamps started_turn_id and
+//     inserts the running turn atomically, and a started prompt is no
+//     longer waiting (deleteWaiting refuses it).
+
+export type ThreadTurnRecord = typeof ThreadTurn.Type
+export type ThreadItemRecord = typeof ThreadItem.Type
+export type QueuedPromptRecord = typeof Contract.QueuedPrompt.Type
+export type TurnSource = "native" | "observed" | "history"
+
+/** One replayable change: the row's current state at the seq that last touched it. */
+export interface TranscriptChange {
+  readonly seq: number
+  readonly change:
+    | { readonly kind: "item"; readonly item: ThreadItemRecord }
+    | { readonly kind: "turn"; readonly turn: ThreadTurnRecord }
+}
+
+const encodeItem = Schema.encodeSync(Schema.fromJsonString(ThreadItem))
+const decodeItem = Schema.decodeUnknownSync(Schema.fromJsonString(ThreadItem))
+
+const TurnRow = Schema.Struct({
+  thread_id: Schema.String,
+  turn_id: Schema.String,
+  ord: Schema.Number,
+  updated_seq: Schema.Number,
+  status: Schema.Literals(["running", "completed", "interrupted", "failed"]),
+  error: Schema.NullOr(Schema.String),
+  prompt_id: Schema.NullOr(Schema.String),
+  started_at: Schema.NullOr(Schema.String),
+  ended_at: Schema.NullOr(Schema.String),
+  source: Schema.Literals(["native", "observed", "history"]),
+})
+
+const ItemRow = Schema.Struct({
+  thread_id: Schema.String,
+  item_id: Schema.String,
+  turn_id: Schema.String,
+  ord: Schema.Number,
+  updated_seq: Schema.Number,
+  item: Schema.String,
+})
+
+const QueueRow = Schema.Struct({
+  id: Schema.String,
+  thread_id: Schema.String,
+  prompt: Schema.String,
+  queued_at: Schema.String,
+  started_turn_id: Schema.NullOr(Schema.String),
+})
+
+const CountersRow = Schema.Struct({
+  transcript_seq: Schema.Number,
+  snapshot_version: Schema.Number,
+  snapshot_seq: Schema.Number,
+})
+
+const toTurn = (row: typeof TurnRow.Type): ThreadTurnRecord => ({
+  id: row.turn_id,
+  status: row.status,
+  ...(row.error !== null ? { error: row.error } : {}),
+  ...(row.prompt_id !== null ? { promptId: row.prompt_id } : {}),
+  ...(row.started_at !== null ? { startedAt: row.started_at } : {}),
+  ...(row.ended_at !== null ? { endedAt: row.ended_at } : {}),
+})
+
+const toQueued = (row: typeof QueueRow.Type): QueuedPromptRecord => ({
+  id: row.id,
+  prompt: row.prompt,
+  queuedAt: row.queued_at,
+})
+
+export interface TranscriptPage {
+  readonly items: ReadonlyArray<ThreadItemRecord>
+  readonly turns: ReadonlyArray<ThreadTurnRecord>
+  readonly seq: number
+  readonly snapshotVersion: number
+  readonly hasMore: boolean
+}
+
+/** The thread's runtime counters (see the header). */
+export interface TranscriptCounters {
+  readonly seq: number
+  readonly snapshotVersion: number
+  /** The seq the latest `replace` took (0 = the copy was never replaced). */
+  readonly snapshotSeq: number
+}
+
+export class TranscriptRepository extends Context.Service<
+  TranscriptRepository,
+  {
+    /** Insert or update one item (upsert by id); returns the seq it took. */
+    readonly upsertItem: (threadId: string, item: ThreadItemRecord) => Effect.Effect<number>
+    /** Insert or update one turn (upsert by id); returns the seq it took and
+     * the row as it now stands (an update keeps promptId/startedAt). */
+    readonly upsertTurn: (
+      threadId: string,
+      turn: ThreadTurnRecord,
+      source: TurnSource,
+    ) => Effect.Effect<{ readonly seq: number; readonly turn: ThreadTurnRecord }>
+    /** Start a queued prompt as a turn: stamp the queue row and insert the
+     * running turn atomically; returns the seq the turn took. */
+    readonly beginTurn: (
+      threadId: string,
+      promptId: string,
+      turn: ThreadTurnRecord,
+    ) => Effect.Effect<number>
+    /** Every turn of the thread with status running, oldest first. */
+    readonly runningTurns: (threadId: string) => Effect.Effect<ReadonlyArray<ThreadTurnRecord>>
+    /** Thread ids holding a running turn or a waiting prompt (the startup pass). */
+    readonly threadsNeedingAttention: () => Effect.Effect<ReadonlyArray<string>>
+    /**
+     * A page of the transcript: the newest `limit` items (or the `limit`
+     * items before `before`), oldest first, with every turn they reference
+     * (and any running turn), the head seq, and the snapshot version. An
+     * unknown `before` — a cursor from a replaced copy — reads as an empty
+     * page: the client sees the new snapshotVersion and starts over.
+     */
+    readonly read: (
+      threadId: string,
+      options: { readonly before?: string | undefined; readonly limit: number },
+    ) => Effect.Effect<TranscriptPage>
+    /** Every row changed after `after`, in seq order, plus the counters. */
+    readonly changesAfter: (
+      threadId: string,
+      after: number,
+    ) => Effect.Effect<{
+      readonly changes: ReadonlyArray<TranscriptChange>
+      readonly counters: TranscriptCounters
+    }>
+    readonly counters: (threadId: string) => Effect.Effect<TranscriptCounters>
+    /** Replace the whole copy with provider history (see the header). */
+    readonly replace: (
+      threadId: string,
+      history: ReadonlyArray<HistoryTurn>,
+    ) => Effect.Effect<TranscriptCounters>
+    /** Admit a prompt to the queue. */
+    readonly enqueue: (threadId: string, prompt: string) => Effect.Effect<QueuedPromptRecord>
+    /** Prompts still waiting, oldest first. */
+    readonly listWaiting: (threadId: string) => Effect.Effect<ReadonlyArray<QueuedPromptRecord>>
+    /** The oldest waiting prompt (None when nothing waits). */
+    readonly peek: (threadId: string) => Effect.Effect<Option.Option<QueuedPromptRecord>>
+    /** Remove a WAITING prompt; false when unknown or already started. */
+    readonly deleteWaiting: (threadId: string, promptId: string) => Effect.Effect<boolean>
+  }
+>()("app-server/TranscriptRepository") {}
+
+// Database failures are defects, not domain errors (the threads repository rule).
+export const layer = Layer.effect(TranscriptRepository)(
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+
+    const nextSeqRows = SqlSchema.findAll({
+      Request: Schema.String,
+      Result: Schema.Struct({ transcript_seq: Schema.Number }),
+      execute: (threadId) => sql`
+        UPDATE threads SET transcript_seq = transcript_seq + 1
+        WHERE id = ${threadId}
+        RETURNING transcript_seq
+      `,
+    })
+
+    /** Allocate the thread's next seq; a vanished thread is a defect (callers hold the record). */
+    const nextSeq = (threadId: string) =>
+      nextSeqRows(threadId).pipe(
+        Effect.flatMap((rows) =>
+          rows[0] === undefined
+            ? Effect.die(new Error(`nextSeq: thread ${threadId} vanished`))
+            : Effect.succeed(rows[0].transcript_seq),
+        ),
+      )
+
+    const upsertItemRow = SqlSchema.void({
+      Request: ItemRow,
+      execute: (row) => sql`
+        INSERT INTO thread_items ${sql.insert(row)}
+        ON CONFLICT (thread_id, item_id) DO UPDATE SET
+          turn_id = excluded.turn_id,
+          updated_seq = excluded.updated_seq,
+          item = excluded.item
+      `,
+    })
+
+    const upsertTurnRows = SqlSchema.findAll({
+      Request: TurnRow,
+      Result: TurnRow,
+      execute: (row) => sql`
+        INSERT INTO thread_turns ${sql.insert(row)}
+        ON CONFLICT (thread_id, turn_id) DO UPDATE SET
+          updated_seq = excluded.updated_seq,
+          status = excluded.status,
+          error = excluded.error,
+          prompt_id = COALESCE(excluded.prompt_id, thread_turns.prompt_id),
+          started_at = COALESCE(excluded.started_at, thread_turns.started_at),
+          ended_at = excluded.ended_at,
+          source = excluded.source
+        RETURNING *
+      `,
+    })
+
+    const turnRows = SqlSchema.findAll({
+      Request: Schema.String,
+      Result: TurnRow,
+      execute: (threadId) =>
+        sql`SELECT * FROM thread_turns WHERE thread_id = ${threadId} ORDER BY ord ASC`,
+    })
+
+    const runningTurnRows = SqlSchema.findAll({
+      Request: Schema.String,
+      Result: TurnRow,
+      execute: (threadId) => sql`
+        SELECT * FROM thread_turns
+        WHERE thread_id = ${threadId} AND status = 'running'
+        ORDER BY ord ASC
+      `,
+    })
+
+    const attentionRows = SqlSchema.findAll({
+      Request: Schema.Void,
+      Result: Schema.Struct({ thread_id: Schema.String }),
+      execute: () => sql`
+        SELECT DISTINCT thread_id FROM (
+          SELECT thread_id FROM thread_turns WHERE status = 'running'
+          UNION
+          SELECT thread_id FROM thread_queue WHERE started_turn_id IS NULL
+        )
+      `,
+    })
+
+    // The newest `limit` items, or the `limit` before an ord — fetched
+    // newest-first (LIMIT + 1 to learn hasMore) and reversed in code.
+    const itemPageRows = SqlSchema.findAll({
+      Request: Schema.Struct({
+        thread_id: Schema.String,
+        before_ord: Schema.NullOr(Schema.Number),
+        limit: Schema.Number,
+      }),
+      Result: ItemRow,
+      execute: (request) =>
+        request.before_ord === null
+          ? sql`
+              SELECT * FROM thread_items WHERE thread_id = ${request.thread_id}
+              ORDER BY ord DESC LIMIT ${request.limit}
+            `
+          : sql`
+              SELECT * FROM thread_items
+              WHERE thread_id = ${request.thread_id} AND ord < ${request.before_ord}
+              ORDER BY ord DESC LIMIT ${request.limit}
+            `,
+    })
+
+    const itemOrdRows = SqlSchema.findAll({
+      Request: Schema.Struct({ thread_id: Schema.String, item_id: Schema.String }),
+      Result: Schema.Struct({ ord: Schema.Number }),
+      execute: (request) => sql`
+        SELECT ord FROM thread_items
+        WHERE thread_id = ${request.thread_id} AND item_id = ${request.item_id}
+      `,
+    })
+
+    const changedItemRows = SqlSchema.findAll({
+      Request: Schema.Struct({ thread_id: Schema.String, after: Schema.Number }),
+      Result: ItemRow,
+      execute: (request) => sql`
+        SELECT * FROM thread_items
+        WHERE thread_id = ${request.thread_id} AND updated_seq > ${request.after}
+        ORDER BY ord ASC
+      `,
+    })
+
+    const changedTurnRows = SqlSchema.findAll({
+      Request: Schema.Struct({ thread_id: Schema.String, after: Schema.Number }),
+      Result: TurnRow,
+      execute: (request) => sql`
+        SELECT * FROM thread_turns
+        WHERE thread_id = ${request.thread_id} AND updated_seq > ${request.after}
+        ORDER BY ord ASC
+      `,
+    })
+
+    const countersRows = SqlSchema.findAll({
+      Request: Schema.String,
+      Result: CountersRow,
+      execute: (threadId) => sql`
+        SELECT transcript_seq, snapshot_version, snapshot_seq FROM threads WHERE id = ${threadId}
+      `,
+    })
+
+    // The replacement itself takes a seq (the invalidation's position) and
+    // records it as snapshot_seq.
+    const bumpSnapshotRows = SqlSchema.findAll({
+      Request: Schema.String,
+      Result: CountersRow,
+      execute: (threadId) => sql`
+        UPDATE threads SET
+          transcript_seq = transcript_seq + 1,
+          snapshot_version = snapshot_version + 1,
+          snapshot_seq = transcript_seq + 1
+        WHERE id = ${threadId}
+        RETURNING transcript_seq, snapshot_version, snapshot_seq
+      `,
+    })
+
+    const clearItems = SqlSchema.void({
+      Request: Schema.String,
+      execute: (threadId) => sql`DELETE FROM thread_items WHERE thread_id = ${threadId}`,
+    })
+    const clearTurns = SqlSchema.void({
+      Request: Schema.String,
+      execute: (threadId) => sql`DELETE FROM thread_turns WHERE thread_id = ${threadId}`,
+    })
+
+    const insertQueueRow = SqlSchema.void({
+      Request: QueueRow,
+      execute: (row) => sql`INSERT INTO thread_queue ${sql.insert(row)}`,
+    })
+
+    const waitingRows = SqlSchema.findAll({
+      Request: Schema.String,
+      Result: QueueRow,
+      execute: (threadId) => sql`
+        SELECT * FROM thread_queue
+        WHERE thread_id = ${threadId} AND started_turn_id IS NULL
+        ORDER BY queued_at ASC, id ASC
+      `,
+    })
+
+    const markStartedRows = SqlSchema.void({
+      Request: Schema.Struct({ id: Schema.String, turn_id: Schema.String }),
+      execute: (request) =>
+        sql`UPDATE thread_queue SET started_turn_id = ${request.turn_id} WHERE id = ${request.id}`,
+    })
+
+    const deleteWaitingRows = SqlSchema.findAll({
+      Request: Schema.Struct({ thread_id: Schema.String, id: Schema.String }),
+      Result: Schema.Struct({ id: Schema.String }),
+      execute: (request) => sql`
+        DELETE FROM thread_queue
+        WHERE thread_id = ${request.thread_id} AND id = ${request.id} AND started_turn_id IS NULL
+        RETURNING id
+      `,
+    })
+
+    const turnRow = (
+      threadId: string,
+      turn: ThreadTurnRecord,
+      seq: number,
+      source: TurnSource,
+    ): typeof TurnRow.Type => ({
+      thread_id: threadId,
+      turn_id: turn.id,
+      ord: seq,
+      updated_seq: seq,
+      status: turn.status,
+      error: turn.error ?? null,
+      prompt_id: turn.promptId ?? null,
+      started_at: turn.startedAt ?? null,
+      ended_at: turn.endedAt ?? null,
+      source,
+    })
+
+    const itemRow = (
+      threadId: string,
+      item: ThreadItemRecord,
+      seq: number,
+    ): typeof ItemRow.Type => ({
+      thread_id: threadId,
+      item_id: item.id,
+      turn_id: item.turnId,
+      ord: seq,
+      updated_seq: seq,
+      item: encodeItem(item),
+    })
+
+    const upsertItem = (threadId: string, item: ThreadItemRecord) =>
+      sql.withTransaction(
+        Effect.gen(function* () {
+          const seq = yield* nextSeq(threadId)
+          yield* upsertItemRow(itemRow(threadId, item, seq))
+          return seq
+        }),
+      )
+
+    const upsertTurn = (threadId: string, turn: ThreadTurnRecord, source: TurnSource) =>
+      sql.withTransaction(
+        Effect.gen(function* () {
+          const seq = yield* nextSeq(threadId)
+          const rows = yield* upsertTurnRows(turnRow(threadId, turn, seq, source))
+          if (rows[0] === undefined) {
+            return yield* Effect.die(new Error(`upsertTurn: no row returned for ${turn.id}`))
+          }
+          return { seq, turn: toTurn(rows[0]) }
+        }),
+      )
+
+    const beginTurn = (threadId: string, promptId: string, turn: ThreadTurnRecord) =>
+      sql.withTransaction(
+        Effect.gen(function* () {
+          yield* markStartedRows({ id: promptId, turn_id: turn.id })
+          const seq = yield* nextSeq(threadId)
+          yield* upsertTurnRows(turnRow(threadId, turn, seq, "native"))
+          return seq
+        }),
+      )
+
+    const toCounters = (row: typeof CountersRow.Type | undefined): TranscriptCounters => ({
+      seq: row?.transcript_seq ?? 0,
+      snapshotVersion: row?.snapshot_version ?? 0,
+      snapshotSeq: row?.snapshot_seq ?? 0,
+    })
+
+    const counters = (threadId: string) =>
+      countersRows(threadId).pipe(Effect.map((rows) => toCounters(rows[0])))
+
+    return {
+      upsertItem: (threadId, item) => upsertItem(threadId, item).pipe(Effect.orDie),
+      upsertTurn: (threadId, turn, source) => upsertTurn(threadId, turn, source).pipe(Effect.orDie),
+      beginTurn: (threadId, promptId, turn) =>
+        beginTurn(threadId, promptId, turn).pipe(Effect.orDie),
+      runningTurns: (threadId) =>
+        runningTurnRows(threadId).pipe(
+          Effect.map((rows) => rows.map(toTurn)),
+          Effect.orDie,
+        ),
+      threadsNeedingAttention: () =>
+        attentionRows().pipe(
+          Effect.map((rows) => rows.map((row) => row.thread_id)),
+          Effect.orDie,
+        ),
+      read: (threadId, options) =>
+        sql
+          .withTransaction(
+            Effect.gen(function* () {
+              const cursor =
+                options.before === undefined
+                  ? undefined
+                  : (yield* itemOrdRows({ thread_id: threadId, item_id: options.before }))[0]
+              const head = yield* counters(threadId)
+              if (options.before !== undefined && cursor === undefined) {
+                return {
+                  items: [],
+                  turns: [],
+                  hasMore: false,
+                  seq: head.seq,
+                  snapshotVersion: head.snapshotVersion,
+                }
+              }
+              const rows = yield* itemPageRows({
+                thread_id: threadId,
+                before_ord: cursor?.ord ?? null,
+                limit: options.limit + 1,
+              })
+              const hasMore = rows.length > options.limit
+              const page = rows.slice(0, options.limit).toReversed()
+              const items = page.map((row) => decodeItem(row.item))
+              const turnIds = new Set(page.map((row) => row.turn_id))
+              // Every turn the page references, plus a running turn that has
+              // no item yet — it is current state a client must show.
+              const turns = (yield* turnRows(threadId)).filter(
+                (row) => turnIds.has(row.turn_id) || row.status === "running",
+              )
+              return {
+                items,
+                turns: turns.map(toTurn),
+                hasMore,
+                seq: head.seq,
+                snapshotVersion: head.snapshotVersion,
+              }
+            }),
+          )
+          .pipe(Effect.orDie),
+      changesAfter: (threadId, after) =>
+        sql
+          .withTransaction(
+            Effect.gen(function* () {
+              const items = yield* changedItemRows({ thread_id: threadId, after })
+              const turns = yield* changedTurnRows({ thread_id: threadId, after })
+              // Seq order, not transcript order: a client resumes from the
+              // highest seq it saw, so nothing may follow a higher seq.
+              const changes: Array<TranscriptChange> = [
+                ...turns.map((row) => ({
+                  seq: row.updated_seq,
+                  change: { kind: "turn" as const, turn: toTurn(row) },
+                })),
+                ...items.map((row) => ({
+                  seq: row.updated_seq,
+                  change: { kind: "item" as const, item: decodeItem(row.item) },
+                })),
+              ].toSorted((left, right) => left.seq - right.seq)
+              return { changes, counters: yield* counters(threadId) }
+            }),
+          )
+          .pipe(Effect.orDie),
+      counters: (threadId) => counters(threadId).pipe(Effect.orDie),
+      replace: (threadId, history) =>
+        sql
+          .withTransaction(
+            Effect.gen(function* () {
+              yield* clearItems(threadId)
+              yield* clearTurns(threadId)
+              for (const entry of history) {
+                const turnSeq = yield* nextSeq(threadId)
+                yield* upsertTurnRows(turnRow(threadId, entry.turn, turnSeq, "history"))
+                for (const item of entry.items) {
+                  const itemSeq = yield* nextSeq(threadId)
+                  yield* upsertItemRow(itemRow(threadId, item, itemSeq))
+                }
+              }
+              const rows = yield* bumpSnapshotRows(threadId)
+              if (rows[0] === undefined) {
+                return yield* Effect.die(new Error(`replace: thread ${threadId} vanished`))
+              }
+              return toCounters(rows[0])
+            }),
+          )
+          .pipe(Effect.orDie),
+      enqueue: (threadId, prompt) =>
+        Effect.suspend(() => {
+          const row: typeof QueueRow.Type = {
+            id: Bun.randomUUIDv7(),
+            thread_id: threadId,
+            prompt,
+            queued_at: new Date().toISOString(),
+            started_turn_id: null,
+          }
+          return insertQueueRow(row).pipe(Effect.as(toQueued(row)))
+        }).pipe(Effect.orDie),
+      listWaiting: (threadId) =>
+        waitingRows(threadId).pipe(
+          Effect.map((rows) => rows.map(toQueued)),
+          Effect.orDie,
+        ),
+      peek: (threadId) =>
+        waitingRows(threadId).pipe(
+          Effect.map((rows) => Option.fromNullishOr(rows[0]).pipe(Option.map(toQueued))),
+          Effect.orDie,
+        ),
+      deleteWaiting: (threadId, promptId) =>
+        deleteWaitingRows({ thread_id: threadId, id: promptId }).pipe(
+          Effect.map((rows) => rows.length > 0),
+          Effect.orDie,
+        ),
+    }
+  }),
+)

--- a/app-server/test/agents/fakeAgentAdapter.ts
+++ b/app-server/test/agents/fakeAgentAdapter.ts
@@ -47,6 +47,9 @@ export interface FakeAgentAdapter {
   readonly setUnavailable: (reason: string | null) => void
   /** Insert a resumable session directly (no createSession). */
   readonly seed: (providerSessionId: string, cwd: string) => FakeAgentSession
+  /** Make the next resume of `providerSessionId` find turn `turnId` still
+   * running (working) — a shared provider server across an ATC restart. */
+  readonly seedRunningTurn: (providerSessionId: string, turnId: string) => void
   /** Complete the active turn of `providerSessionId` with `outcome`. */
   readonly completeTurn: (providerSessionId: string, outcome: AgentTurnOutcome) => void
   /** Open a stock provider request (an approval, or a one-question ask)
@@ -137,6 +140,7 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
   const connections = new Map<string, LiveConnection>()
   const observers = new Map<string, Set<Queue.Queue<AgentSessionEvent, Cause.Done>>>()
   const checkActivity = new Map<string, AgentActivity>()
+  const runningOnResume = new Map<string, string>()
   const histories = new Map<string, ReadonlyArray<HistoryTurn>>()
   const historyReads: Array<string> = []
   const answers: FakeAgentAdapter["answers"] = []
@@ -158,6 +162,7 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
   let unavailableReason: string | null = null
   let nextSessionId = 1
   let nextTurnId = 1
+  const instance = crypto.randomUUID().slice(0, 8)
   let nextRequestId = 1
 
   const requireAvailable = Effect.suspend(() =>
@@ -194,10 +199,12 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
         )
       }
       const events = yield* Queue.make<AgentEvent, Cause.Done>()
+      const running = runningOnResume.get(session.providerSessionId) ?? null
+      runningOnResume.delete(session.providerSessionId)
       const live: LiveConnection = {
         events,
-        activity: "idle",
-        activeTurn: null,
+        activity: running === null ? "idle" : "working",
+        activeTurn: running,
         closed: false,
         openRequests: new Map(),
       }
@@ -231,9 +238,17 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
             )
           }
           session.inputs.push(input)
-          const turnId = `fake-turn-${nextTurnId++}`
+          // Unique across fake instances: turn ids are persisted, and a
+          // "restarted" fake must not collide with the previous one's turns.
+          const turnId = `fake-turn-${nextTurnId++}-${instance}`
           live.activeTurn = turnId
           emit(live, { type: "turnStarted", turnId })
+          // Both real adapters put the prompt on the feed as the turn's
+          // first item (Codex via the fan-out, Claude explicitly).
+          emit(live, {
+            type: "itemCompleted",
+            item: { type: "userMessage", id: `${turnId}:prompt`, turnId, text: input },
+          })
           setActivity(live, "working")
           return { turnId }
         })
@@ -478,6 +493,9 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
       const session: FakeAgentSession = { providerSessionId, cwd, inputs: [] }
       sessions.set(providerSessionId, session)
       return session
+    },
+    seedRunningTurn: (providerSessionId, turnId) => {
+      runningOnResume.set(providerSessionId, turnId)
     },
     completeTurn: (providerSessionId, outcome) => finishTurn(providerSessionId, outcome),
     openRequest: (providerSessionId, kind) => {

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -24,6 +24,8 @@ import type { TerminalAdapter } from "../src/terminals/terminalAdapter.ts"
 import * as TerminalRepository from "../src/terminals/terminalRepository.ts"
 import * as Terminals from "../src/terminals/terminals.ts"
 import * as ThreadRepository from "../src/threads/threadRepository.ts"
+import * as ThreadRuntime from "../src/threads/threadRuntime.ts"
+import * as TranscriptRepository from "../src/threads/transcriptRepository.ts"
 import * as Threads from "../src/threads/threads.ts"
 import * as Zmx from "../src/terminals/zmxAdapter.ts"
 import { V1Handlers } from "../src/api/handlers.ts"
@@ -112,6 +114,8 @@ export const makeTestServiceLayers = (
     | Layer.Success<ServiceLayer>
     | Terminals.Terminals
     | Threads.Threads
+    | ThreadRuntime.ThreadRuntime
+    | TranscriptRepository.TranscriptRepository
     | Projects.Projects
     | AgentRegistry.AgentRegistry
     | Events.Events
@@ -133,6 +137,7 @@ export const makeTestServiceLayers = (
     ProjectRepository.layer,
     TerminalRepository.layer,
     ThreadRepository.layer,
+    TranscriptRepository.layer,
   ).pipe(Layer.provide(Persistence.layerFile(dbFile)))
   const services = Layer.mergeAll(
     base,
@@ -150,8 +155,9 @@ export const makeTestServiceLayers = (
       Subprocess.layer.pipe(Layer.provide(BunServices.layer)),
     ]),
   )
+  const runtime = ThreadRuntime.layer.pipe(Layer.provide([services, registry, eventsLayer]))
   const threads = Threads.layerWith(threadsOptions).pipe(
-    Layer.provide([services, terminals, registry, eventsLayer]),
+    Layer.provide([services, terminals, registry, eventsLayer, runtime]),
   )
   return {
     fake,
@@ -164,6 +170,7 @@ export const makeTestServiceLayers = (
       eventsLayer,
       TestAuthTokenLayer,
       Layer.succeed(Tailscale.Tailscale)({ status: Effect.succeed(tailscaleStatus) }),
+      runtime,
       threads,
       Projects.layer.pipe(Layer.provide([services, terminals, threads, eventsLayer])),
     ),

--- a/app-server/test/threads/threadRuntime.test.ts
+++ b/app-server/test/threads/threadRuntime.test.ts
@@ -1,0 +1,707 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Stream } from "effect"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll } from "vitest"
+import type { ThreadEvent } from "../../src/threads/threadRuntime.ts"
+import { ThreadRuntime } from "../../src/threads/threadRuntime.ts"
+import { ThreadRepository } from "../../src/threads/threadRepository.ts"
+import { TranscriptRepository } from "../../src/threads/transcriptRepository.ts"
+import { Threads } from "../../src/threads/threads.ts"
+import { Projects } from "../../src/projects/projects.ts"
+import { eventually, makeTestServiceLayers } from "../testLayers.ts"
+
+// The Thread runtime (ATC-193) against the fake adapter and the uniform
+// seam contract only: prompt → items → completion, queueing, interrupt,
+// parked requests, the transcript and its replayable stream, re-reads, and
+// restart recovery. Nothing here knows a provider.
+
+const scratch = mkdtempSync(join(tmpdir(), "atc-runtime-test-"))
+afterAll(() => rmSync(scratch, { recursive: true, force: true }))
+
+/** Collect a thread's events in the background (scoped). */
+const collectEvents = (runtime: ThreadRuntime["Service"], id: string, after?: number) =>
+  Effect.gen(function* () {
+    const stream = yield* runtime.subscribe(id, after)
+    const sink: Array<ThreadEvent> = []
+    yield* stream.pipe(
+      Stream.runForEach((event) => Effect.sync(() => sink.push(event))),
+      Effect.forkScoped,
+    )
+    return sink
+  })
+
+const waitFor = <A>(read: Effect.Effect<A>, predicate: (value: A) => boolean) =>
+  eventually(read, predicate, { attempts: 400, interval: "10 millis" })
+
+const seqs = (events: ReadonlyArray<ThreadEvent>): Array<number> =>
+  events.flatMap((event) => ("seq" in event ? [event.seq] : []))
+
+describe("ThreadRuntime", () => {
+  const kit = makeTestServiceLayers()
+  const fake = kit.fakeAgents.codex
+
+  const newThread = Effect.gen(function* () {
+    const projects = yield* Projects
+    const threads = yield* Threads
+    const project = yield* projects.create({ name: "Runtime", defaultWorkingDirectory: scratch })
+    return yield* threads.create({ projectId: project.id, agentId: "codex" })
+  })
+
+  it.live("a first prompt creates the session, streams items, and completes the turn", () =>
+    Effect.gen(function* () {
+      const runtime = yield* ThreadRuntime
+      const threads = yield* Threads
+      const thread = yield* newThread
+      const events = yield* collectEvents(runtime, thread.id)
+
+      const started = yield* runtime.prompt(thread.id, "hello")
+      assert.isString(started.turnId)
+      const turnId = started.turnId ?? ""
+      // A fresh session was created with the prompt, and identity persisted
+      // (and confirmed: the prompt is durable provider history).
+      const session = [...fake.sessions.values()].find((entry) => entry.inputs.includes("hello"))
+      assert.isDefined(session)
+      const record = yield* Effect.flatMap(ThreadRepository, (repo) => repo.require(thread.id))
+      assert.strictEqual(record.providerSessionId, session?.providerSessionId)
+      assert.isString(record.confirmedAt)
+      // The thread reads as working while the runtime drives it.
+      yield* waitFor(
+        threads.get(thread.id).pipe(Effect.orDie),
+        (current) => current.activityState === "working",
+      )
+
+      // The adapter streams a reply.
+      const providerSessionId = session?.providerSessionId ?? ""
+      fake.emitItem(providerSessionId, "itemStarted", {
+        type: "assistantText",
+        id: "a1",
+        turnId,
+        text: "",
+        complete: false,
+      })
+      fake.emitTextDelta(providerSessionId, "a1", "hi ")
+      fake.emitTextDelta(providerSessionId, "a1", "there")
+      fake.emitItem(providerSessionId, "itemCompleted", {
+        type: "assistantText",
+        id: "a1",
+        turnId,
+        text: "hi there",
+        complete: true,
+      })
+      fake.completeTurn(providerSessionId, "completed")
+
+      yield* waitFor(
+        Effect.sync(() => events),
+        (list) => list.some((event) => event.type === "turn.completed"),
+      )
+      assert.deepStrictEqual(
+        events.map((event) => event.type),
+        [
+          "queue.updated",
+          "turn.started",
+          "queue.updated",
+          "item.completed",
+          "item.started",
+          "text.delta",
+          "text.delta",
+          "item.completed",
+          "turn.completed",
+        ],
+      )
+      // Durable events carry strictly increasing seqs; live-only ones none.
+      const durable = seqs(events)
+      assert.deepStrictEqual(
+        durable,
+        durable.toSorted((left, right) => left - right),
+      )
+      assert.strictEqual(new Set(durable).size, durable.length)
+
+      const transcript = yield* runtime.transcript(thread.id)
+      assert.deepStrictEqual(
+        transcript.items.map((item) => [item.type, item.id]),
+        [
+          ["userMessage", `${turnId}:prompt`],
+          ["assistantText", "a1"],
+        ],
+      )
+      assert.strictEqual(transcript.turns.length, 1)
+      assert.strictEqual(transcript.turns[0]?.status, "completed")
+      assert.strictEqual(transcript.turns[0]?.promptId, started.promptId)
+      assert.isString(transcript.turns[0]?.endedAt)
+      assert.strictEqual(transcript.seq, durable[durable.length - 1])
+      assert.isFalse(transcript.hasMore)
+      // The turn's end is idle, and — no client viewed it — unread.
+      const after = yield* threads.get(thread.id)
+      assert.strictEqual(after.activityState, "idle")
+      assert.isTrue(after.unread)
+      assert.isFalse(yield* runtime.isDriving(thread.id))
+    }).pipe(Effect.scoped, Effect.provide(kit.layer)),
+  )
+
+  it.live(
+    "a prompt during a turn queues and runs at the next idle; interrupt keeps the queue",
+    () =>
+      Effect.gen(function* () {
+        const runtime = yield* ThreadRuntime
+        const thread = yield* newThread
+        const events = yield* collectEvents(runtime, thread.id)
+        const first = yield* runtime.prompt(thread.id, "one")
+        const providerSessionId =
+          [...fake.sessions.values()].find((entry) => entry.inputs.includes("one"))
+            ?.providerSessionId ?? ""
+
+        const second = yield* runtime.prompt(thread.id, "two")
+        assert.isUndefined(second.turnId)
+        const queued = yield* runtime.listQueue(thread.id)
+        assert.deepStrictEqual(
+          queued.map((entry) => [entry.id, entry.prompt]),
+          [[second.promptId, "two"]],
+        )
+        // A started prompt is a turn now — it cannot be deleted from the queue.
+        const gone = yield* Effect.flip(runtime.deleteQueued(thread.id, first.promptId))
+        assert.strictEqual(gone._tag, "QueuedPromptNotFound")
+
+        // Interrupt ends the current turn (interrupted) and the queue proceeds.
+        yield* runtime.interrupt(thread.id)
+        yield* waitFor(
+          Effect.sync(() => events),
+          (list) =>
+            list.some(
+              (event) => event.type === "turn.completed" && event.turn.status === "interrupted",
+            ),
+        )
+        yield* waitFor(
+          Effect.sync(() => fake.sessions.get(providerSessionId)?.inputs ?? []),
+          (inputs) => inputs.length === 2,
+        )
+        assert.deepStrictEqual(fake.sessions.get(providerSessionId)?.inputs, ["one", "two"])
+        assert.deepStrictEqual(yield* runtime.listQueue(thread.id), [])
+        // The queue events show the admission and the drain.
+        const queueSizes = () =>
+          events.flatMap((event) => (event.type === "queue.updated" ? [event.prompts.length] : []))
+        yield* waitFor(Effect.sync(queueSizes), (sizes) => sizes.length === 4)
+        assert.deepStrictEqual(queueSizes(), [1, 0, 1, 0])
+        // The second turn resumed the exact session and runs the queued prompt.
+        const transcript = yield* runtime.transcript(thread.id)
+        assert.deepStrictEqual(
+          transcript.turns.map((turn) => [turn.status, turn.promptId]),
+          [
+            ["interrupted", first.promptId],
+            ["running", second.promptId],
+          ],
+        )
+        // An idle interrupt after the second turn ends is a no-op.
+        fake.completeTurn(providerSessionId, "completed")
+        yield* waitFor(
+          Effect.sync(() => events),
+          (list) => list.filter((event) => event.type === "turn.completed").length === 2,
+        )
+        yield* runtime.interrupt(thread.id)
+        // A waiting prompt can be withdrawn.
+        const third = yield* runtime.prompt(thread.id, "three")
+        assert.isString(third.turnId)
+        const fourth = yield* runtime.prompt(thread.id, "four")
+        yield* runtime.deleteQueued(thread.id, fourth.promptId)
+        assert.deepStrictEqual(yield* runtime.listQueue(thread.id), [])
+        fake.completeTurn(providerSessionId, "completed")
+      }).pipe(Effect.scoped, Effect.provide(kit.layer)),
+  )
+
+  it.live("provider requests park until answered; answers are validated", () =>
+    Effect.gen(function* () {
+      const runtime = yield* ThreadRuntime
+      const threads = yield* Threads
+      const thread = yield* newThread
+      const events = yield* collectEvents(runtime, thread.id)
+      yield* runtime.prompt(thread.id, "ask")
+      const providerSessionId =
+        [...fake.sessions.values()].find((entry) => entry.inputs.includes("ask"))
+          ?.providerSessionId ?? ""
+      const requestId = fake.openRequest(providerSessionId, "question")
+      yield* waitFor(
+        Effect.sync(() => events),
+        (list) => list.some((event) => event.type === "request.opened"),
+      )
+      const pending = yield* runtime.listRequests(thread.id)
+      assert.deepStrictEqual(
+        pending.map((request) => [request.id, request.kind]),
+        [[requestId, "question"]],
+      )
+      yield* waitFor(
+        threads.get(thread.id).pipe(Effect.orDie),
+        (current) => current.activityState === "needs_input",
+      )
+
+      const mismatch = yield* Effect.flip(
+        runtime.answerRequest(thread.id, requestId, { kind: "approval", decision: "accept" }),
+      )
+      assert.strictEqual(mismatch._tag, "InvalidRequestAnswer")
+      const unknownQuestion = yield* Effect.flip(
+        runtime.answerRequest(thread.id, requestId, { kind: "question", answers: { q9: ["A"] } }),
+      )
+      assert.strictEqual(unknownQuestion._tag, "InvalidRequestAnswer")
+      const notAnOption = yield* Effect.flip(
+        runtime.answerRequest(thread.id, requestId, {
+          kind: "question",
+          answers: { q0: ["Z"] },
+        }),
+      )
+      assert.strictEqual(notAnOption._tag, "InvalidRequestAnswer")
+      const missing = yield* Effect.flip(
+        runtime.answerRequest(thread.id, "nope", { kind: "question", answers: { q0: ["A"] } }),
+      )
+      assert.strictEqual(missing._tag, "RequestNotFound")
+      const unanswered = yield* Effect.flip(
+        runtime.answerRequest(thread.id, requestId, { kind: "question", answers: {} }),
+      )
+      assert.strictEqual(unanswered._tag, "InvalidRequestAnswer")
+
+      yield* runtime.answerRequest(thread.id, requestId, {
+        kind: "question",
+        answers: { q0: ["B"] },
+      })
+      assert.deepStrictEqual(fake.answers.at(-1), {
+        requestId,
+        answer: { kind: "question", answers: { q0: ["B"] } },
+      })
+      yield* waitFor(
+        Effect.sync(() => events),
+        (list) => list.some((event) => event.type === "request.closed"),
+      )
+      assert.deepStrictEqual(yield* runtime.listRequests(thread.id), [])
+      const again = yield* Effect.flip(
+        runtime.answerRequest(thread.id, requestId, { kind: "question", answers: { q0: ["A"] } }),
+      )
+      assert.strictEqual(again._tag, "RequestNotFound")
+      // Requests die with their turn.
+      const second = fake.openRequest(providerSessionId, "approval")
+      fake.completeTurn(providerSessionId, "completed")
+      yield* waitFor(
+        Effect.sync(() => events),
+        (list) =>
+          list.some((event) => event.type === "request.closed" && event.requestId === second),
+      )
+      assert.deepStrictEqual(yield* runtime.listRequests(thread.id), [])
+    }).pipe(Effect.scoped, Effect.provide(kit.layer)),
+  )
+
+  it.live("subscribing after a seq replays every later change, then goes live", () =>
+    Effect.gen(function* () {
+      const runtime = yield* ThreadRuntime
+      const thread = yield* newThread
+      const live = yield* collectEvents(runtime, thread.id)
+      const started = yield* runtime.prompt(thread.id, "replay me")
+      const turnId = started.turnId ?? ""
+      const providerSessionId =
+        [...fake.sessions.values()].find((entry) => entry.inputs.includes("replay me"))
+          ?.providerSessionId ?? ""
+      fake.emitItem(providerSessionId, "itemCompleted", {
+        type: "assistantText",
+        id: "r1",
+        turnId,
+        text: "one",
+        complete: true,
+      })
+      yield* waitFor(
+        Effect.sync(() => live),
+        (list) => list.some((event) => event.type === "item.completed" && event.item.id === "r1"),
+      )
+      // Rejoin after the prompt item's seq: the reply and its turn replay
+      // with their current state, then a live change follows.
+      const promptSeq = live.find(
+        (event) => event.type === "item.completed" && event.item.type === "userMessage",
+      )
+      const after = promptSeq !== undefined && "seq" in promptSeq ? promptSeq.seq : -1
+      const rejoined = yield* collectEvents(runtime, thread.id, after)
+      yield* waitFor(
+        Effect.sync(() => rejoined),
+        (list) => list.length >= 1,
+      )
+      assert.deepStrictEqual(
+        rejoined.map((event) => [event.type, "seq" in event ? event.seq > after : null]),
+        [["item.updated", true]],
+      )
+      fake.completeTurn(providerSessionId, "completed")
+      yield* waitFor(
+        Effect.sync(() => rejoined),
+        (list) => list.some((event) => event.type === "turn.completed"),
+      )
+      // Everything after `after` — replayed and live — arrives once, in order.
+      const heads = seqs(rejoined)
+      assert.deepStrictEqual(
+        heads,
+        heads.toSorted((left, right) => left - right),
+      )
+      assert.strictEqual(new Set(heads).size, heads.length)
+      assert.isTrue(heads.every((seq) => seq > after))
+
+      // Paging: newest-first pages walk back with `before`.
+      const page = yield* runtime.transcript(thread.id, { limit: 1 })
+      assert.deepStrictEqual(
+        page.items.map((item) => item.id),
+        ["r1"],
+      )
+      assert.isTrue(page.hasMore)
+      const older = yield* runtime.transcript(thread.id, { limit: 1, before: "r1" })
+      assert.deepStrictEqual(
+        older.items.map((item) => item.type),
+        ["userMessage"],
+      )
+      assert.isFalse(older.hasMore)
+    }).pipe(Effect.scoped, Effect.provide(kit.layer)),
+  )
+
+  it.live(
+    "replay follows seq order, and a rejoin from before a replacement is told to refetch",
+    () =>
+      Effect.gen(function* () {
+        const runtime = yield* ThreadRuntime
+        const transcripts = yield* TranscriptRepository
+        const thread = yield* newThread
+        const started = yield* runtime.prompt(thread.id, "order")
+        const turnId = started.turnId ?? ""
+        const providerSessionId =
+          [...fake.sessions.values()].find((entry) => entry.inputs.includes("order"))
+            ?.providerSessionId ?? ""
+        // Two items, then the OLDER one is updated: its seq is now the newest.
+        fake.emitItem(providerSessionId, "itemStarted", {
+          type: "assistantText",
+          id: "o1",
+          turnId,
+          text: "",
+          complete: false,
+        })
+        fake.emitItem(providerSessionId, "itemCompleted", {
+          type: "assistantText",
+          id: "o2",
+          turnId,
+          text: "second",
+          complete: true,
+        })
+        fake.emitItem(providerSessionId, "itemCompleted", {
+          type: "assistantText",
+          id: "o1",
+          turnId,
+          text: "first, finished late",
+          complete: true,
+        })
+        yield* waitFor(transcripts.counters(thread.id), (counters) => counters.seq >= 5)
+        const rejoined = yield* collectEvents(runtime, thread.id, 0)
+        yield* waitFor(
+          Effect.sync(() => rejoined),
+          (list) => list.length >= 4,
+        )
+        const replayed = seqs(rejoined)
+        assert.deepStrictEqual(
+          replayed,
+          replayed.toSorted((left, right) => left - right),
+        )
+        // The late update of o1 replays after o2, at its own (higher) seq.
+        const ids = rejoined.flatMap((event) =>
+          event.type === "item.updated" ? [event.item.id] : [],
+        )
+        assert.deepStrictEqual(ids.slice(-2), ["o2", "o1"])
+
+        // A replacement in between: a client that left before it must refetch.
+        const before = yield* transcripts.counters(thread.id)
+        fake.completeTurn(providerSessionId, "completed")
+        fake.setHistory(providerSessionId, [
+          {
+            turn: { id: "h-turn", status: "completed" },
+            items: [{ type: "userMessage", id: "h1", turnId: "h-turn", text: "order" }],
+          },
+        ])
+        yield* runtime.reread(thread.id)
+        const late = yield* collectEvents(runtime, thread.id, before.seq)
+        yield* waitFor(
+          Effect.sync(() => late),
+          (list) => list.length >= 1,
+        )
+        const first = late[0]
+        assert.isTrue(
+          first?.type === "snapshot.invalidated" &&
+            first.snapshotVersion === 1 &&
+            first.seq > before.seq,
+        )
+        // A cursor from the replaced copy reads as an empty page (the client
+        // sees the new snapshotVersion and restarts).
+        const stale = yield* runtime.transcript(thread.id, { before: "o2", limit: 10 })
+        assert.deepStrictEqual(stale.items, [])
+        assert.isFalse(stale.hasMore)
+        assert.strictEqual(stale.snapshotVersion, 1)
+      }).pipe(Effect.scoped, Effect.provide(kit.layer)),
+  )
+
+  it.live("a prompt during a TUI-driven turn queues and drains at the observed idle", () =>
+    Effect.gen(function* () {
+      const runtime = yield* ThreadRuntime
+      const thread = yield* newThread
+      // A confirmed thread whose session the provider knows.
+      const seeded = fake.seed(`tui-${crypto.randomUUID()}`, thread.workingDirectory)
+      const repo = yield* ThreadRepository
+      const record = yield* repo.setProviderSession(thread.id, seeded.providerSessionId, null)
+      yield* repo.confirm(record.id)
+      const confirmed = yield* repo.require(record.id)
+      // The TUI is mid-turn: the observation drain reports busy.
+      yield* runtime.noteActivity(confirmed, "working")
+      const queued = yield* runtime.prompt(thread.id, "after the tui")
+      assert.isUndefined(queued.turnId)
+      assert.deepStrictEqual(seeded.inputs, [])
+      assert.deepStrictEqual(
+        (yield* runtime.listQueue(thread.id)).map((entry) => entry.prompt),
+        ["after the tui"],
+      )
+      // The TUI turn ends: re-read, then the queued prompt runs.
+      fake.setHistory(seeded.providerSessionId, [
+        {
+          turn: { id: "tui-turn", status: "completed" },
+          items: [{ type: "userMessage", id: "t1", turnId: "tui-turn", text: "typed in the tui" }],
+        },
+      ])
+      yield* runtime.noteActivity(confirmed, "idle")
+      yield* runtime.observedIdle(confirmed)
+      yield* waitFor(
+        Effect.sync(() => seeded.inputs),
+        (inputs) => inputs.length === 1,
+      )
+      assert.deepStrictEqual(seeded.inputs, ["after the tui"])
+      const transcript = yield* runtime.transcript(thread.id)
+      // The re-read landed first (the TUI's turn), then the native turn.
+      assert.deepStrictEqual(
+        transcript.turns.map((turn) => [turn.id === "tui-turn" ? "tui" : "native", turn.status]),
+        [
+          ["tui", "completed"],
+          ["native", "running"],
+        ],
+      )
+      assert.strictEqual(transcript.snapshotVersion, 1)
+      fake.completeTurn(seeded.providerSessionId, "completed")
+    }).pipe(Effect.scoped, Effect.provide(kit.layer)),
+  )
+
+  it.live("a re-read replaces the copy, bumps the snapshot, and never wipes on empty history", () =>
+    Effect.gen(function* () {
+      const runtime = yield* ThreadRuntime
+      const thread = yield* newThread
+      const events = yield* collectEvents(runtime, thread.id)
+      const started = yield* runtime.prompt(thread.id, "history")
+      const providerSessionId =
+        [...fake.sessions.values()].find((entry) => entry.inputs.includes("history"))
+          ?.providerSessionId ?? ""
+      fake.completeTurn(providerSessionId, "completed")
+      yield* waitFor(
+        Effect.sync(() => events),
+        (list) => list.some((event) => event.type === "turn.completed"),
+      )
+      const before = yield* runtime.transcript(thread.id)
+      assert.strictEqual(before.snapshotVersion, 0)
+
+      // Empty history: the copy stays.
+      yield* runtime.reread(thread.id)
+      const kept = yield* runtime.transcript(thread.id)
+      assert.strictEqual(kept.snapshotVersion, 0)
+      assert.strictEqual(kept.items.length, 1)
+
+      fake.setHistory(providerSessionId, [
+        {
+          turn: { id: "h-turn", status: "completed" },
+          items: [
+            { type: "userMessage", id: "h1", turnId: "h-turn", text: "history" },
+            { type: "assistantText", id: "h2", turnId: "h-turn", text: "done", complete: true },
+          ],
+        },
+      ])
+      yield* runtime.reread(thread.id)
+      const replaced = yield* runtime.transcript(thread.id)
+      assert.strictEqual(replaced.snapshotVersion, 1)
+      assert.deepStrictEqual(
+        replaced.items.map((item) => item.id),
+        ["h1", "h2"],
+      )
+      assert.deepStrictEqual(
+        replaced.turns.map((turn) => turn.id),
+        ["h-turn"],
+      )
+      assert.isTrue(replaced.seq > before.seq)
+      yield* waitFor(
+        Effect.sync(() => events),
+        (list) => list.some((event) => event.type === "snapshot.invalidated"),
+      )
+      const invalidated = events.find((event) => event.type === "snapshot.invalidated")
+      assert.isTrue(
+        invalidated?.type === "snapshot.invalidated" &&
+          invalidated.snapshotVersion === 1 &&
+          invalidated.seq === replaced.seq,
+      )
+      assert.isString(started.turnId)
+    }).pipe(Effect.scoped, Effect.provide(kit.layer)),
+  )
+
+  it.live("a provider that refuses the immediate start un-admits the prompt", () =>
+    Effect.gen(function* () {
+      const runtime = yield* ThreadRuntime
+      const thread = yield* newThread
+      fake.setUnavailable("provider down")
+      const failure = yield* Effect.flip(runtime.prompt(thread.id, "nothing")).pipe(
+        Effect.ensuring(Effect.sync(() => fake.setUnavailable(null))),
+      )
+      assert.strictEqual(failure._tag, "ProviderUnavailable")
+      assert.deepStrictEqual(yield* runtime.listQueue(thread.id), [])
+      assert.isFalse(yield* runtime.isDriving(thread.id))
+    }).pipe(Effect.scoped, Effect.provide(kit.layer)),
+  )
+
+  it.live("archive refuses mid-turn; delete releases the run", () =>
+    Effect.gen(function* () {
+      const runtime = yield* ThreadRuntime
+      const threads = yield* Threads
+      const thread = yield* newThread
+      yield* runtime.prompt(thread.id, "busy")
+      const providerSessionId =
+        [...fake.sessions.values()].find((entry) => entry.inputs.includes("busy"))
+          ?.providerSessionId ?? ""
+      const busy = yield* Effect.flip(threads.archive(thread.id))
+      assert.strictEqual(busy._tag, "ThreadBusy")
+      yield* threads.delete(thread.id)
+      assert.isFalse(yield* runtime.isDriving(thread.id))
+      // The fake connection was closed with the run: no writer remains.
+      const resumed = yield* Effect.scoped(
+        fake.adapter.resumeSession({ providerSessionId, cwd: thread.workingDirectory }),
+      )
+      assert.strictEqual(resumed.providerSessionId, providerSessionId)
+    }).pipe(Effect.scoped, Effect.provide(kit.layer)),
+  )
+})
+
+describe("ThreadRuntime restart", () => {
+  it.live("a turn still running on a shared provider server is reattached and followed", () =>
+    Effect.gen(function* () {
+      const dbFile = join(scratch, `reattach-${crypto.randomUUID()}.db`)
+      const first = makeTestServiceLayers(dbFile)
+      const { threadId, providerSessionId, turnId, workingDirectory } = yield* Effect.gen(
+        function* () {
+          const runtime = yield* ThreadRuntime
+          const projects = yield* Projects
+          const threads = yield* Threads
+          const project = yield* projects.create({
+            name: "Reattach",
+            defaultWorkingDirectory: scratch,
+          })
+          const thread = yield* threads.create({ projectId: project.id, agentId: "codex" })
+          const started = yield* runtime.prompt(thread.id, "long running")
+          yield* runtime.prompt(thread.id, "afterwards")
+          yield* waitFor(
+            runtime.transcript(thread.id).pipe(Effect.orDie),
+            (transcript) => transcript.items.length === 1,
+          )
+          const session = [...first.fakeAgents.codex.sessions.values()].find((entry) =>
+            entry.inputs.includes("long running"),
+          )
+          return {
+            threadId: thread.id,
+            providerSessionId: session?.providerSessionId ?? "",
+            turnId: started.turnId ?? "",
+            workingDirectory: thread.workingDirectory,
+          }
+        },
+      ).pipe(Effect.scoped, Effect.provide(first.layer))
+
+      // The provider still runs the turn when ATC comes back.
+      const second = makeTestServiceLayers(dbFile)
+      const fake = second.fakeAgents.codex
+      fake.seed(providerSessionId, workingDirectory)
+      fake.seedRunningTurn(providerSessionId, turnId)
+      yield* Effect.gen(function* () {
+        const runtime = yield* ThreadRuntime
+        const threads = yield* Threads
+        // Reattached: the run is registered, the thread reads working, the
+        // queued prompt waits.
+        yield* waitFor(runtime.isDriving(threadId), (driving) => driving)
+        yield* waitFor(
+          threads.get(threadId).pipe(Effect.orDie),
+          (current) => current.activityState === "working",
+        )
+        assert.deepStrictEqual(
+          (yield* runtime.listQueue(threadId)).map((entry) => entry.prompt),
+          ["afterwards"],
+        )
+        // The turn ends on the provider: followed to completion, then the
+        // queue drains onto the same session.
+        fake.completeTurn(providerSessionId, "completed")
+        yield* waitFor(
+          Effect.sync(() => fake.sessions.get(providerSessionId)?.inputs ?? []),
+          (inputs) => inputs.length === 1,
+        )
+        assert.deepStrictEqual(fake.sessions.get(providerSessionId)?.inputs, ["afterwards"])
+        const transcript = yield* runtime.transcript(threadId)
+        assert.deepStrictEqual(
+          transcript.turns.map((turn) => [turn.id === turnId ? "reattached" : "next", turn.status]),
+          [
+            ["reattached", "completed"],
+            ["next", "running"],
+          ],
+        )
+      }).pipe(Effect.scoped, Effect.provide(second.layer))
+    }),
+  )
+
+  it.live("a running turn is marked interrupted and the queue drains after a restart", () =>
+    Effect.gen(function* () {
+      const dbFile = join(scratch, `restart-${crypto.randomUUID()}.db`)
+      const first = makeTestServiceLayers(dbFile)
+      // Session 1: a turn is running and a second prompt waits.
+      const { threadId, providerSessionId, workingDirectory } = yield* Effect.gen(function* () {
+        const runtime = yield* ThreadRuntime
+        const projects = yield* Projects
+        const threads = yield* Threads
+        const project = yield* projects.create({
+          name: "Restart",
+          defaultWorkingDirectory: scratch,
+        })
+        const thread = yield* threads.create({ projectId: project.id, agentId: "codex" })
+        yield* runtime.prompt(thread.id, "before restart")
+        yield* runtime.prompt(thread.id, "after restart")
+        // The prompt item has landed before the "crash".
+        yield* waitFor(
+          runtime.transcript(thread.id).pipe(Effect.orDie),
+          (transcript) => transcript.items.length === 1,
+        )
+        const session = [...first.fakeAgents.codex.sessions.values()].find((entry) =>
+          entry.inputs.includes("before restart"),
+        )
+        return {
+          threadId: thread.id,
+          providerSessionId: session?.providerSessionId ?? "",
+          workingDirectory: thread.workingDirectory,
+        }
+      }).pipe(Effect.scoped, Effect.provide(first.layer))
+
+      // Session 2 over the same database: the provider knows the session
+      // (seeded) but no turn is running there any more.
+      const second = makeTestServiceLayers(dbFile)
+      second.fakeAgents.codex.seed(providerSessionId, workingDirectory)
+      yield* Effect.gen(function* () {
+        const runtime = yield* ThreadRuntime
+        yield* waitFor(
+          runtime.transcript(threadId).pipe(Effect.orDie),
+          (transcript) =>
+            transcript.turns.some((turn) => turn.status === "interrupted") &&
+            transcript.turns.some((turn) => turn.status === "running"),
+        )
+        const transcript = yield* runtime.transcript(threadId)
+        assert.deepStrictEqual(
+          transcript.turns.map((turn) => turn.status),
+          ["interrupted", "running"],
+        )
+        // The queued prompt drained into the new turn on the exact session.
+        assert.deepStrictEqual(second.fakeAgents.codex.sessions.get(providerSessionId)?.inputs, [
+          "after restart",
+        ])
+        assert.deepStrictEqual(yield* runtime.listQueue(threadId), [])
+        assert.isTrue(yield* runtime.isDriving(threadId))
+      }).pipe(Effect.scoped, Effect.provide(second.layer))
+    }),
+  )
+})


### PR DESCRIPTION
PR 2 of 3 for ATC-193 (server-side Thread runtime). Sub-issue: ATC-199. **Stacked on #205** (base = its branch); ATC-200 (endpoints + CLI) follows.

## What

- **Migration `0006_thread_runtime`** (append-only): `thread_items`, `thread_turns`, `thread_queue`, and `threads.transcript_seq / snapshot_version / snapshot_seq`.
- **`TranscriptRepository`** (`threads/transcriptRepository.ts`): the only SQL for the transcript copy, the queue, and the counters. `seq` is allocated atomically with each write (`updated_seq`; `ord` = first-insert seq → transcript order); reads that pair rows with the head run in one transaction; `replace` (a provider re-read) swaps the copy wholesale, bumps `snapshot_version` and stamps `snapshot_seq`; `beginTurn` stamps the queue row and inserts the running turn atomically.
- **`ThreadRuntime`** (`threads/threadRuntime.ts`): prompt admission + the durable queue; the turn loop over the AgentAdapter seam (resume the exact session, or create one for an unconfirmed thread — the second `materialize` caller ATC-124 anticipated); the connection feed → item upserts → per-thread events; turn end → next queued prompt; interrupt; parked provider requests with validated answers; transcript reads (paged); the per-thread event stream with `after=seq` replay (seq-ordered; a rejoin from before a replacement gets `snapshot.invalidated`); provider re-reads (startup, TUI-driven idle, failed connection); the live activity ledger both evidence sources feed (first busy confirms, busy→idle stamps unread, transitions publish); startup recovery (re-read → reattach on a shared provider server or mark interrupted → drain).
- **`threads.ts`** consumes the ledger for `activityState`/`unread`, feeds observed Codex items into the copy, asks for a re-read + drain at an observed idle, and releases the run on archive/delete. No lock between surfaces: a prompt during a TUI-driven turn queues and runs at the observed idle.
- Contract gains the tagged errors `RequestNotFound`, `InvalidRequestAnswer`, `QueuedPromptNotFound` (routes come in PR 3; `openapi.json` unchanged).
- Tests: `test/threads/threadRuntime.test.ts` on the fake adapter — prompt→items→completion, queue/interrupt, requests + validation, seq-ordered replay + rejoin across a replacement, re-read rules, prompt behind a TUI turn, un-admit on provider refusal, archive/delete, and restart recovery on a file DB.

## Decisions worth knowing

- **Admission is the success boundary, with one exception**: a provider that refuses the *immediate* start un-admits the prompt so the caller's error means "not accepted" (no duplicate on retry). An older queued prompt's failure leaves the new one queued (logged).
- **A run stays registered until its connection has closed**; a prompt arriving at turn end queues rather than racing the writer.
- **A feed that fails (transport loss) is abandoned without guessing an outcome**: the copy is re-read from the provider; a feed that ends because ATC closed it (release, shutdown) records nothing — startup recovery reads the truth.
- **An empty history never replaces the copy** (a swept Claude transcript keeps ATC's copy readable).
- **Codex re-read replaces wholesale**: history item ids are positional and can omit some tool items (recorded in PR 1), so re-reads only run for turns ATC did not drive.

## Verification

`mise run -C app-server check` (450 tests). Two adversarial Codex reviews (correctness, simplicity) run and acted on.

https://claude.ai/code/session_01YA92SLZgoV2UGJuSHSm19n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable conversation transcripts with pagination, replay, and live updates.
  * Added prompt queueing, interruption, request handling, and recovery across restarts.
  * Improved activity tracking and provider session management for more reliable thread execution.
  * Added clearer handling for missing requests, invalid answers, and unavailable queued prompts.

* **Bug Fixes**
  * Prevented identifier collisions when agent sessions restart.
  * Improved transcript consistency and refresh behavior after turns complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->