### PR TITLE
Thread runtime API: endpoints, per-thread SSE, CLI, smoke gate (ATC-200)

### DIFF
--- a/app-server/mise.toml
+++ b/app-server/mise.toml
@@ -125,7 +125,7 @@ run = "ATC_COMPILED_TEST=1 bun --bun vitest run test/compiled.blackbox.test.ts"
 [tasks."test:smoke"]
 description = "Opt-in live provider smoke tests (requires Codex CLI and Claude Code credentials)"
 depends = ["build"]
-run = "ATC_SMOKE=1 bun --bun vitest run test/agents/provider.smoke.test.ts test/agents/codexAdapter.smoke.test.ts test/agents/claudeAdapter.smoke.test.ts test/agents/claudeTui.smoke.test.ts"
+run = "ATC_SMOKE=1 bun --bun vitest run test/agents/provider.smoke.test.ts test/agents/codexAdapter.smoke.test.ts test/agents/claudeAdapter.smoke.test.ts test/agents/claudeTui.smoke.test.ts test/threads/threadRuntime.smoke.test.ts"
 
 [tasks."test:zmx"]
 description = "Opt-in tests against the real installed zmx: adapter smoke and compiled restart recovery"

--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -1097,6 +1097,449 @@
         "description": "Open the thread's TUI terminal. Idempotent: a live linked terminal is returned as-is. Otherwise the provider TUI is launched in a new terminal — a confirmed session is relaunched against its exact persisted identity (ATC never adopts a different one), an unconfirmed one materializes a fresh provider session whose identity is established and persisted before this call returns. A provider that can be probed (Codex) fails fast when the persisted session no longer exists; one that cannot (Claude) launches blind — a successful open whose terminal dies within seconds is a state clients must expect and surface."
       }
     },
+    "/api/v1/threads/{threadId}/prompt": {
+      "post": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "promptThread",
+        "parameters": [
+          {
+            "name": "threadId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A prompt was admitted: it started a turn now, or waits in the queue.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PromptThreadResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No thread exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadNotFoundJsonEncoding"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The thread is archived; unarchive it first. | The thread's provider session cannot be driven as requested (resume failed, identity mismatch, or a concurrent writer). Fail-closed: no changed identity was adopted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ThreadArchivedJsonEncoding"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ProviderSessionConflictJsonEncoding"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The thread's agent provider cannot be used right now (not installed, not ready, or unreachable). Retryable once the cause is fixed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderUnavailableJsonEncoding"
+                }
+              }
+            }
+          }
+        },
+        "description": "Prompt the thread. Always admitted: an idle thread starts a turn at once (`turnId` present) and a busy one queues the prompt to run at the next idle (`turnId` absent) — there is no busy error and no lock between surfaces. The turn is server-owned: the client's connection never matters to it. When the prompt would start now and the provider refuses, it is un-admitted (the error means not accepted; nothing stays queued); a prompt queued behind others is admitted regardless. Follow the turn on the per-thread event stream.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PromptThreadRequest"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v1/threads/{threadId}/transcript": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "getThreadTranscript",
+        "parameters": [
+          {
+            "name": "threadId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "description": "Page older: return items before this item id (a cursor from a replaced copy reads as an empty page)."
+            },
+            "required": false
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d+$",
+              "description": "Most items to return, 1–200 (default 200)."
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ATC's normalized copy of the provider conversation — a rebuildable projection, never the authority.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadTranscript"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No thread exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadNotFoundJsonEncoding"
+                }
+              }
+            }
+          }
+        },
+        "description": "Read the thread's transcript: the newest `limit` items (or the page before `before`), oldest first, with every turn they reference and any running turn, plus the head `seq` to subscribe after and the `snapshotVersion`. The transcript is ATC's copy of the provider's conversation — a re-read from the provider replaces it wholesale (snapshotVersion bumps, `snapshot.invalidated` on the stream)."
+      }
+    },
+    "/api/v1/threads/{threadId}/events": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "subscribeThreadEvents",
+        "parameters": [
+          {
+            "name": "threadId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d+$",
+              "description": "Replay every durable change after this seq before going live; omit for live only."
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A data-only SSE byte stream. Each event is a single `data:` line whose payload is a JSON-encoded ThreadEvent (see that component schema); frames never carry `id:` or `event:` lines. Comment lines are protocol control, ignored by conforming SSE parsers: the stream opens with `: connected` (the resync handshake) and a `: heartbeat` follows roughly every 25 seconds. Example:\n\n```\n: connected\n\n: heartbeat\n\ndata: {\"type\":\"item.completed\",\"seq\":42,\"item\":{\"type\":\"assistantText\",\"id\":\"msg_1\",\"turnId\":\"turn_1\",\"text\":\"done\",\"complete\":true}}\n```",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadEventJsonEncoding"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No thread exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadNotFoundJsonEncoding"
+                }
+              }
+            }
+          }
+        },
+        "description": "Subscribe to one thread's live events (SSE): items as they start, stream (`text.delta`), update, and complete; turns; pending requests; the queue; and snapshot invalidations. Durable events carry `seq`; track the highest seen and reconnect with `after=<seq>` to replay every change you missed (current state per row, in seq order) — a rejoin from before a provider re-read gets `snapshot.invalidated` instead: refetch the transcript and resubscribe after its `seq`. Framed like /events (see that endpoint's response); a subscriber that falls too far behind is ended and should resubscribe with `after`."
+      }
+    },
+    "/api/v1/threads/{threadId}/interrupt": {
+      "post": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "interruptThread",
+        "parameters": [
+          {
+            "name": "threadId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "<No Content>"
+          },
+          "404": {
+            "description": "No thread exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadNotFoundJsonEncoding"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The thread's agent provider cannot be used right now (not installed, not ready, or unreachable). Retryable once the cause is fixed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderUnavailableJsonEncoding"
+                }
+              }
+            }
+          }
+        },
+        "description": "Interrupt the turn the server is driving (its `turn.completed` reads interrupted). A thread with no server-driven turn is a no-op — a turn a TUI drives is interrupted from the TUI — and queued prompts stay queued; they run at the next idle."
+      }
+    },
+    "/api/v1/threads/{threadId}/requests": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "listThreadRequests",
+        "parameters": [
+          {
+            "name": "threadId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The thread's pending requests, oldest first.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadRequestList"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No thread exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadNotFoundJsonEncoding"
+                }
+              }
+            }
+          }
+        },
+        "description": "List the thread's pending provider requests (approvals and questions). Requests park until answered — no timeout — and die with their turn."
+      }
+    },
+    "/api/v1/threads/{threadId}/requests/{requestId}/answer": {
+      "post": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "answerThreadRequest",
+        "parameters": [
+          {
+            "name": "threadId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "requestId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "<No Content>"
+          },
+          "400": {
+            "description": "The answer does not fit the pending request: kind mismatch, unknown question id, or a non-option answer to a question that is not freeform.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidRequestAnswerJsonEncoding"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No thread exists with the given id. | No pending request with the given id on this thread (unknown, or already answered).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ThreadNotFoundJsonEncoding"
+                    },
+                    {
+                      "$ref": "#/components/schemas/RequestNotFoundJsonEncoding"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The thread's agent provider cannot be used right now (not installed, not ready, or unreachable). Retryable once the cause is fixed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderUnavailableJsonEncoding"
+                }
+              }
+            }
+          }
+        },
+        "description": "Answer a pending request. The answer's `kind` must match the request's; question answers must cover every question with option labels (or freeform text where allowed). An answered or unknown request is 404.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ThreadRequestAnswer"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v1/threads/{threadId}/queue": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "listThreadQueue",
+        "parameters": [
+          {
+            "name": "threadId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Prompts still waiting, oldest first.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueuedPromptList"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No thread exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadNotFoundJsonEncoding"
+                }
+              }
+            }
+          }
+        },
+        "description": "List the prompts still waiting to run, oldest first."
+      }
+    },
+    "/api/v1/threads/{threadId}/queue/{promptId}": {
+      "delete": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "deleteQueuedPrompt",
+        "parameters": [
+          {
+            "name": "threadId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "promptId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "<No Content>"
+          },
+          "404": {
+            "description": "No thread exists with the given id. | No waiting prompt with the given id on this thread (unknown, or already started).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ThreadNotFoundJsonEncoding"
+                    },
+                    {
+                      "$ref": "#/components/schemas/QueuedPromptNotFoundJsonEncoding"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Withdraw a waiting prompt. A prompt that already started is a turn now (404); interrupt the thread instead."
+      }
+    },
     "/api/v1/agents": {
       "get": {
         "tags": [
@@ -1971,184 +2414,38 @@
         ],
         "additionalProperties": false
       },
-      "Agent": {
+      "PromptThreadRequest": {
         "type": "object",
         "properties": {
-          "id": {
-            "$ref": "#/components/schemas/AgentId"
-          },
-          "available": {
-            "type": "boolean",
-            "description": "Whether the agent's CLI is installed and resolvable right now."
-          },
-          "reason": {
+          "prompt": {
             "type": "string",
-            "description": "Actionable install-or-configure hint; absent when available."
-          },
-          "detectedVersion": {
-            "type": "string",
-            "description": "Installed CLI version, when it could be determined."
+            "minLength": 1,
+            "description": "The user's message."
           }
         },
         "required": [
-          "id",
-          "available"
+          "prompt"
         ],
         "additionalProperties": false,
-        "description": "A built-in agent provider: availability report, detected on demand and never persisted."
+        "description": "Payload for prompting a thread: text only (attachments are additive later)."
       },
-      "AgentList": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/Agent"
-        },
-        "description": "The built-in agent registry."
-      },
-      "AgentNotFoundJsonEncoding": {
+      "PromptThreadResponse": {
         "type": "object",
         "properties": {
-          "_tag": {
+          "promptId": {
             "type": "string",
-            "enum": [
-              "AgentNotFound"
-            ]
+            "description": "The admitted prompt's id."
           },
-          "agentId": {
-            "type": "string"
-          },
-          "message": {
+          "turnId": {
             "type": "string",
-            "description": "Human-readable diagnostic derived from the structured fields."
+            "description": "Present when the prompt started a turn at once; absent when it queued."
           }
         },
         "required": [
-          "_tag",
-          "agentId",
-          "message"
-        ],
-        "additionalProperties": false
-      },
-      "ResourceChangedEventJsonEncoding": {
-        "type": "string",
-        "contentMediaType": "application/json"
-      },
-      "DirectoryState": {
-        "type": "string",
-        "enum": [
-          "available",
-          "missing",
-          "inaccessible",
-          "not_directory",
-          "unknown"
-        ],
-        "description": "Tagged result of a demand-driven directory health check."
-      },
-      "FsCheckResponse": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "The checked path (canonicalized when the directory is available)."
-          },
-          "state": {
-            "$ref": "#/components/schemas/DirectoryState"
-          },
-          "checkedAt": {
-            "type": "string",
-            "description": "Check time.",
-            "format": "date-time"
-          },
-          "reason": {
-            "type": "string",
-            "description": "Why the state is not conclusive (e.g. \"timeout\" for unknown); absent otherwise."
-          }
-        },
-        "required": [
-          "path",
-          "state",
-          "checkedAt"
+          "promptId"
         ],
         "additionalProperties": false,
-        "description": "Result of a directory health check. Never persisted."
-      },
-      "FsListEntry": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Directory name within the listed directory."
-          },
-          "path": {
-            "type": "string",
-            "description": "Absolute path of the subdirectory (not symlink-resolved)."
-          }
-        },
-        "required": [
-          "name",
-          "path"
-        ],
-        "additionalProperties": false,
-        "description": "One subdirectory of a listed directory."
-      },
-      "FsListResponse": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string",
-            "description": "Canonical (symlink-resolved) absolute path of the listed directory."
-          },
-          "parent": {
-            "type": "string",
-            "description": "Parent directory of `path`; absent at the filesystem root."
-          },
-          "entries": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/FsListEntry"
-            },
-            "description": "Subdirectories only — non-recursive, dotfolders excluded, symlinks included when they resolve to directories, sorted case-insensitively by name."
-          }
-        },
-        "required": [
-          "path",
-          "entries"
-        ],
-        "additionalProperties": false,
-        "description": "A directory listing for the server-backed folder browser. Never persisted."
-      },
-      "ResourceChangedEvent": {
-        "type": "object",
-        "properties": {
-          "resource": {
-            "type": "string",
-            "enum": [
-              "project",
-              "thread",
-              "terminal"
-            ],
-            "description": "Which resource collection changed."
-          },
-          "id": {
-            "type": "string",
-            "description": "Id of the changed resource."
-          },
-          "change": {
-            "type": "string",
-            "enum": [
-              "created",
-              "updated",
-              "deleted"
-            ],
-            "description": "What happened. Every field-level transition (status, archive state, activity) is \"updated\"."
-          }
-        },
-        "required": [
-          "resource",
-          "id",
-          "change"
-        ],
-        "additionalProperties": false,
-        "description": "Thin invalidation event: names what changed, never carries resource state. Clients coalesce events and refetch through the corresponding GETs, which stay the single source of truth."
+        "description": "A prompt was admitted: it started a turn now, or waits in the queue."
       },
       "ThreadItemUserMessage": {
         "type": "object",
@@ -2590,78 +2887,6 @@
           }
         }
       },
-      "ThreadEventItemStarted": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "item.started"
-            ]
-          },
-          "seq": {
-            "type": "integer",
-            "description": "Position of this durable change."
-          },
-          "item": {
-            "$ref": "#/components/schemas/ThreadItem"
-          }
-        },
-        "required": [
-          "type",
-          "seq",
-          "item"
-        ],
-        "additionalProperties": false
-      },
-      "ThreadEventItemUpdated": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "item.updated"
-            ]
-          },
-          "seq": {
-            "type": "integer",
-            "description": "Position of this durable change."
-          },
-          "item": {
-            "$ref": "#/components/schemas/ThreadItem"
-          }
-        },
-        "required": [
-          "type",
-          "seq",
-          "item"
-        ],
-        "additionalProperties": false
-      },
-      "ThreadEventItemCompleted": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "item.completed"
-            ]
-          },
-          "seq": {
-            "type": "integer",
-            "description": "Position of this durable change."
-          },
-          "item": {
-            "$ref": "#/components/schemas/ThreadItem"
-          }
-        },
-        "required": [
-          "type",
-          "seq",
-          "item"
-        ],
-        "additionalProperties": false
-      },
       "ThreadTurnStatus": {
         "type": "string",
         "enum": [
@@ -2708,77 +2933,49 @@
         "additionalProperties": false,
         "description": "One turn of the conversation."
       },
-      "ThreadEventTurnStarted": {
+      "ThreadTranscript": {
         "type": "object",
         "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "turn.started"
-            ]
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ThreadItem"
+            },
+            "description": "Transcript order, oldest first."
+          },
+          "turns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ThreadTurn"
+            },
+            "description": "Every turn referenced by `items`, plus any turn still running."
           },
           "seq": {
             "type": "integer",
-            "description": "Position of this durable change."
+            "description": "The thread's change counter at the time of the read; subscribe with after=seq."
           },
-          "turn": {
-            "$ref": "#/components/schemas/ThreadTurn"
-          }
-        },
-        "required": [
-          "type",
-          "seq",
-          "turn"
-        ],
-        "additionalProperties": false
-      },
-      "ThreadEventTurnCompleted": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "turn.completed"
-            ]
-          },
-          "seq": {
+          "snapshotVersion": {
             "type": "integer",
-            "description": "Position of this durable change."
+            "description": "Bumps whenever a provider re-read replaced the copy."
           },
-          "turn": {
-            "$ref": "#/components/schemas/ThreadTurn"
+          "hasMore": {
+            "type": "boolean",
+            "description": "Older items exist before the first one returned."
           }
         },
         "required": [
-          "type",
+          "items",
+          "turns",
           "seq",
-          "turn"
-        ],
-        "additionalProperties": false
-      },
-      "ThreadEventTextDelta": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "text.delta"
-            ]
-          },
-          "itemId": {
-            "type": "string"
-          },
-          "delta": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "itemId",
-          "delta"
+          "snapshotVersion",
+          "hasMore"
         ],
         "additionalProperties": false,
-        "description": "Live-only, never replayed: appends to a streaming assistantText or reasoning item."
+        "description": "ATC's normalized copy of the provider conversation — a rebuildable projection, never the authority."
+      },
+      "ThreadEventJsonEncoding": {
+        "type": "string",
+        "contentMediaType": "application/json"
       },
       "QuestionOption": {
         "type": "object",
@@ -3034,6 +3231,527 @@
           }
         }
       },
+      "ThreadRequestList": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/ThreadRequest"
+        },
+        "description": "The thread's pending requests, oldest first."
+      },
+      "ThreadRequestQuestionAnswer": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "question"
+            ]
+          },
+          "answers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "description": "Question id → chosen option labels (exactly one unless multiSelect), or one freeform string."
+          }
+        },
+        "required": [
+          "kind",
+          "answers"
+        ],
+        "additionalProperties": false
+      },
+      "ApprovalDecision": {
+        "type": "string",
+        "enum": [
+          "accept",
+          "acceptForSession",
+          "decline",
+          "cancel"
+        ],
+        "description": "cancel = decline and interrupt the turn."
+      },
+      "ThreadRequestApprovalAnswer": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "approval"
+            ]
+          },
+          "decision": {
+            "$ref": "#/components/schemas/ApprovalDecision"
+          }
+        },
+        "required": [
+          "kind",
+          "decision"
+        ],
+        "additionalProperties": false
+      },
+      "ThreadRequestAnswer": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ThreadRequestQuestionAnswer"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadRequestApprovalAnswer"
+          }
+        ],
+        "description": "The answer to a pending request; `kind` must match the request's.",
+        "discriminator": {
+          "propertyName": "kind",
+          "mapping": {
+            "question": "#/components/schemas/ThreadRequestQuestionAnswer",
+            "approval": "#/components/schemas/ThreadRequestApprovalAnswer"
+          }
+        }
+      },
+      "RequestNotFoundJsonEncoding": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": [
+              "RequestNotFound"
+            ]
+          },
+          "threadId": {
+            "type": "string"
+          },
+          "requestId": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic derived from the structured fields."
+          }
+        },
+        "required": [
+          "_tag",
+          "threadId",
+          "requestId",
+          "message"
+        ],
+        "additionalProperties": false
+      },
+      "InvalidRequestAnswerJsonEncoding": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": [
+              "InvalidRequestAnswer"
+            ]
+          },
+          "threadId": {
+            "type": "string"
+          },
+          "requestId": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic derived from the structured fields."
+          }
+        },
+        "required": [
+          "_tag",
+          "threadId",
+          "requestId",
+          "reason",
+          "message"
+        ],
+        "additionalProperties": false
+      },
+      "QueuedPrompt": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "prompt": {
+            "type": "string"
+          },
+          "queuedAt": {
+            "type": "string",
+            "description": "When the prompt was admitted.",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "prompt",
+          "queuedAt"
+        ],
+        "additionalProperties": false,
+        "description": "A prompt admitted while a turn was running; it runs at the next idle."
+      },
+      "QueuedPromptList": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/QueuedPrompt"
+        },
+        "description": "Prompts still waiting, oldest first."
+      },
+      "QueuedPromptNotFoundJsonEncoding": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": [
+              "QueuedPromptNotFound"
+            ]
+          },
+          "threadId": {
+            "type": "string"
+          },
+          "promptId": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic derived from the structured fields."
+          }
+        },
+        "required": [
+          "_tag",
+          "threadId",
+          "promptId",
+          "message"
+        ],
+        "additionalProperties": false
+      },
+      "Agent": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/AgentId"
+          },
+          "available": {
+            "type": "boolean",
+            "description": "Whether the agent's CLI is installed and resolvable right now."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Actionable install-or-configure hint; absent when available."
+          },
+          "detectedVersion": {
+            "type": "string",
+            "description": "Installed CLI version, when it could be determined."
+          }
+        },
+        "required": [
+          "id",
+          "available"
+        ],
+        "additionalProperties": false,
+        "description": "A built-in agent provider: availability report, detected on demand and never persisted."
+      },
+      "AgentList": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Agent"
+        },
+        "description": "The built-in agent registry."
+      },
+      "AgentNotFoundJsonEncoding": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": [
+              "AgentNotFound"
+            ]
+          },
+          "agentId": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic derived from the structured fields."
+          }
+        },
+        "required": [
+          "_tag",
+          "agentId",
+          "message"
+        ],
+        "additionalProperties": false
+      },
+      "ResourceChangedEventJsonEncoding": {
+        "type": "string",
+        "contentMediaType": "application/json"
+      },
+      "DirectoryState": {
+        "type": "string",
+        "enum": [
+          "available",
+          "missing",
+          "inaccessible",
+          "not_directory",
+          "unknown"
+        ],
+        "description": "Tagged result of a demand-driven directory health check."
+      },
+      "FsCheckResponse": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "The checked path (canonicalized when the directory is available)."
+          },
+          "state": {
+            "$ref": "#/components/schemas/DirectoryState"
+          },
+          "checkedAt": {
+            "type": "string",
+            "description": "Check time.",
+            "format": "date-time"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Why the state is not conclusive (e.g. \"timeout\" for unknown); absent otherwise."
+          }
+        },
+        "required": [
+          "path",
+          "state",
+          "checkedAt"
+        ],
+        "additionalProperties": false,
+        "description": "Result of a directory health check. Never persisted."
+      },
+      "FsListEntry": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Directory name within the listed directory."
+          },
+          "path": {
+            "type": "string",
+            "description": "Absolute path of the subdirectory (not symlink-resolved)."
+          }
+        },
+        "required": [
+          "name",
+          "path"
+        ],
+        "additionalProperties": false,
+        "description": "One subdirectory of a listed directory."
+      },
+      "FsListResponse": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Canonical (symlink-resolved) absolute path of the listed directory."
+          },
+          "parent": {
+            "type": "string",
+            "description": "Parent directory of `path`; absent at the filesystem root."
+          },
+          "entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FsListEntry"
+            },
+            "description": "Subdirectories only — non-recursive, dotfolders excluded, symlinks included when they resolve to directories, sorted case-insensitively by name."
+          }
+        },
+        "required": [
+          "path",
+          "entries"
+        ],
+        "additionalProperties": false,
+        "description": "A directory listing for the server-backed folder browser. Never persisted."
+      },
+      "ResourceChangedEvent": {
+        "type": "object",
+        "properties": {
+          "resource": {
+            "type": "string",
+            "enum": [
+              "project",
+              "thread",
+              "terminal"
+            ],
+            "description": "Which resource collection changed."
+          },
+          "id": {
+            "type": "string",
+            "description": "Id of the changed resource."
+          },
+          "change": {
+            "type": "string",
+            "enum": [
+              "created",
+              "updated",
+              "deleted"
+            ],
+            "description": "What happened. Every field-level transition (status, archive state, activity) is \"updated\"."
+          }
+        },
+        "required": [
+          "resource",
+          "id",
+          "change"
+        ],
+        "additionalProperties": false,
+        "description": "Thin invalidation event: names what changed, never carries resource state. Clients coalesce events and refetch through the corresponding GETs, which stay the single source of truth."
+      },
+      "ThreadEventItemStarted": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "item.started"
+            ]
+          },
+          "seq": {
+            "type": "integer",
+            "description": "Position of this durable change."
+          },
+          "item": {
+            "$ref": "#/components/schemas/ThreadItem"
+          }
+        },
+        "required": [
+          "type",
+          "seq",
+          "item"
+        ],
+        "additionalProperties": false
+      },
+      "ThreadEventItemUpdated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "item.updated"
+            ]
+          },
+          "seq": {
+            "type": "integer",
+            "description": "Position of this durable change."
+          },
+          "item": {
+            "$ref": "#/components/schemas/ThreadItem"
+          }
+        },
+        "required": [
+          "type",
+          "seq",
+          "item"
+        ],
+        "additionalProperties": false
+      },
+      "ThreadEventItemCompleted": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "item.completed"
+            ]
+          },
+          "seq": {
+            "type": "integer",
+            "description": "Position of this durable change."
+          },
+          "item": {
+            "$ref": "#/components/schemas/ThreadItem"
+          }
+        },
+        "required": [
+          "type",
+          "seq",
+          "item"
+        ],
+        "additionalProperties": false
+      },
+      "ThreadEventTurnStarted": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "turn.started"
+            ]
+          },
+          "seq": {
+            "type": "integer",
+            "description": "Position of this durable change."
+          },
+          "turn": {
+            "$ref": "#/components/schemas/ThreadTurn"
+          }
+        },
+        "required": [
+          "type",
+          "seq",
+          "turn"
+        ],
+        "additionalProperties": false
+      },
+      "ThreadEventTurnCompleted": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "turn.completed"
+            ]
+          },
+          "seq": {
+            "type": "integer",
+            "description": "Position of this durable change."
+          },
+          "turn": {
+            "$ref": "#/components/schemas/ThreadTurn"
+          }
+        },
+        "required": [
+          "type",
+          "seq",
+          "turn"
+        ],
+        "additionalProperties": false
+      },
+      "ThreadEventTextDelta": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "text.delta"
+            ]
+          },
+          "itemId": {
+            "type": "string"
+          },
+          "delta": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "itemId",
+          "delta"
+        ],
+        "additionalProperties": false,
+        "description": "Live-only, never replayed: appends to a streaming assistantText or reasoning item."
+      },
       "ThreadEventRequestOpened": {
         "type": "object",
         "properties": {
@@ -3073,36 +3791,6 @@
         ],
         "additionalProperties": false,
         "description": "Live-only."
-      },
-      "QueuedPrompt": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "prompt": {
-            "type": "string"
-          },
-          "queuedAt": {
-            "type": "string",
-            "description": "When the prompt was admitted.",
-            "format": "date-time"
-          }
-        },
-        "required": [
-          "id",
-          "prompt",
-          "queuedAt"
-        ],
-        "additionalProperties": false,
-        "description": "A prompt admitted while a turn was running; it runs at the next idle."
-      },
-      "QueuedPromptList": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/QueuedPrompt"
-        },
-        "description": "Prompts still waiting, oldest first."
       },
       "ThreadEventQueueUpdated": {
         "type": "object",
@@ -3196,119 +3884,6 @@
             "request.closed": "#/components/schemas/ThreadEventRequestClosed",
             "queue.updated": "#/components/schemas/ThreadEventQueueUpdated",
             "snapshot.invalidated": "#/components/schemas/ThreadEventSnapshotInvalidated"
-          }
-        }
-      },
-      "ThreadTranscript": {
-        "type": "object",
-        "properties": {
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ThreadItem"
-            },
-            "description": "Transcript order, oldest first."
-          },
-          "turns": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ThreadTurn"
-            },
-            "description": "Every turn referenced by `items`, plus any turn still running."
-          },
-          "seq": {
-            "type": "integer",
-            "description": "The thread's change counter at the time of the read; subscribe with after=seq."
-          },
-          "snapshotVersion": {
-            "type": "integer",
-            "description": "Bumps whenever a provider re-read replaced the copy."
-          },
-          "hasMore": {
-            "type": "boolean",
-            "description": "Older items exist before the first one returned."
-          }
-        },
-        "required": [
-          "items",
-          "turns",
-          "seq",
-          "snapshotVersion",
-          "hasMore"
-        ],
-        "additionalProperties": false,
-        "description": "ATC's normalized copy of the provider conversation — a rebuildable projection, never the authority."
-      },
-      "ThreadRequestQuestionAnswer": {
-        "type": "object",
-        "properties": {
-          "kind": {
-            "type": "string",
-            "enum": [
-              "question"
-            ]
-          },
-          "answers": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "description": "Question id → chosen option labels (exactly one unless multiSelect), or one freeform string."
-          }
-        },
-        "required": [
-          "kind",
-          "answers"
-        ],
-        "additionalProperties": false
-      },
-      "ApprovalDecision": {
-        "type": "string",
-        "enum": [
-          "accept",
-          "acceptForSession",
-          "decline",
-          "cancel"
-        ],
-        "description": "cancel = decline and interrupt the turn."
-      },
-      "ThreadRequestApprovalAnswer": {
-        "type": "object",
-        "properties": {
-          "kind": {
-            "type": "string",
-            "enum": [
-              "approval"
-            ]
-          },
-          "decision": {
-            "$ref": "#/components/schemas/ApprovalDecision"
-          }
-        },
-        "required": [
-          "kind",
-          "decision"
-        ],
-        "additionalProperties": false
-      },
-      "ThreadRequestAnswer": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/ThreadRequestQuestionAnswer"
-          },
-          {
-            "$ref": "#/components/schemas/ThreadRequestApprovalAnswer"
-          }
-        ],
-        "description": "The answer to a pending request; `kind` must match the request's.",
-        "discriminator": {
-          "propertyName": "kind",
-          "mapping": {
-            "question": "#/components/schemas/ThreadRequestQuestionAnswer",
-            "approval": "#/components/schemas/ThreadRequestApprovalAnswer"
           }
         }
       }

--- a/app-server/src/api/contract.ts
+++ b/app-server/src/api/contract.ts
@@ -1,4 +1,4 @@
-import { Schema } from "effect"
+import { Schema, SchemaTransformation } from "effect"
 import {
   HttpApi,
   HttpApiEndpoint,
@@ -70,6 +70,20 @@ export const AbsolutePath = Schema.String.check(
 /** A wire timestamp: RFC 3339 UTC with millisecond precision (`Date.toISOString()`). */
 const timestamp = (description: string) =>
   Schema.String.annotate({ format: "date-time", description })
+
+/** A decimal integer query parameter within [min, max] (query values are strings on the wire). */
+const integerParam = (description: string, min: number, max?: number) =>
+  Schema.String.check(Schema.isPattern(/^\d+$/, { description: "a decimal integer" }))
+    .annotate({ description })
+    .pipe(
+      Schema.decodeTo(
+        Schema.Int.check(
+          Schema.isGreaterThanOrEqualTo(min),
+          ...(max === undefined ? [] : [Schema.isLessThanOrEqualTo(max)]),
+        ),
+        SchemaTransformation.numberFromString,
+      ),
+    )
 
 export const ProjectName = Schema.NonEmptyString.annotate({
   description: "Human-readable project name.",
@@ -658,6 +672,25 @@ export const ThreadRequestAnswer = Schema.Union(
 ).annotate({
   identifier: "ThreadRequestAnswer",
   description: "The answer to a pending request; `kind` must match the request's.",
+})
+
+export const PromptThreadRequest = Schema.Struct({
+  prompt: Schema.NonEmptyString.annotate({ description: "The user's message." }),
+}).annotate({
+  identifier: "PromptThreadRequest",
+  description: "Payload for prompting a thread: text only (attachments are additive later).",
+})
+
+export const PromptThreadResponse = Schema.Struct({
+  promptId: Schema.String.annotate({ description: "The admitted prompt's id." }),
+  turnId: Schema.optionalKey(
+    Schema.String.annotate({
+      description: "Present when the prompt started a turn at once; absent when it queued.",
+    }),
+  ),
+}).annotate({
+  identifier: "PromptThreadResponse",
+  description: "A prompt was admitted: it started a turn now, or waits in the queue.",
 })
 
 export const QueuedPrompt = Schema.Struct({
@@ -1325,6 +1358,108 @@ export class V1 extends HttpApiGroup.make("v1")
         "Open the thread's TUI terminal. Idempotent: a live linked terminal is returned as-is. Otherwise the provider TUI is launched in a new terminal — a confirmed session is relaunched against its exact persisted identity (ATC never adopts a different one), an unconfirmed one materializes a fresh provider session whose identity is established and persisted before this call returns. " +
           "A provider that can be probed (Codex) fails fast when the persisted session no longer exists; one that cannot (Claude) launches blind — a successful open whose terminal dies within seconds is a state clients must expect and surface.",
       ),
+    // --- The Thread runtime (ATC-193): drive a thread with no Terminal ---
+    HttpApiEndpoint.post("promptThread", "/threads/:threadId/prompt", {
+      params: threadIdParam,
+      payload: PromptThreadRequest,
+      success: PromptThreadResponse,
+      error: [ThreadNotFound, ThreadArchived, ProviderUnavailable, ProviderSessionConflict],
+    })
+      .annotate(OpenApi.Identifier, "promptThread")
+      .annotate(
+        OpenApi.Description,
+        "Prompt the thread. Always admitted: an idle thread starts a turn at once (`turnId` present) and a busy one queues the prompt to run at the next idle (`turnId` absent) — there is no busy error and no lock between surfaces. " +
+          "The turn is server-owned: the client's connection never matters to it. When the prompt would start now and the provider refuses, it is un-admitted (the error means not accepted; nothing stays queued); a prompt queued behind others is admitted regardless. Follow the turn on the per-thread event stream.",
+      ),
+    HttpApiEndpoint.get("getThreadTranscript", "/threads/:threadId/transcript", {
+      params: threadIdParam,
+      query: {
+        before: Schema.optionalKey(
+          Schema.String.annotate({
+            description:
+              "Page older: return items before this item id (a cursor from a replaced copy reads as an empty page).",
+          }),
+        ),
+        limit: Schema.optionalKey(
+          integerParam("Most items to return, 1–200 (default 200).", 1, 200),
+        ),
+      },
+      success: ThreadTranscript,
+      error: ThreadNotFound,
+    })
+      .annotate(OpenApi.Identifier, "getThreadTranscript")
+      .annotate(
+        OpenApi.Description,
+        "Read the thread's transcript: the newest `limit` items (or the page before `before`), oldest first, with every turn they reference and any running turn, plus the head `seq` to subscribe after and the `snapshotVersion`. " +
+          "The transcript is ATC's copy of the provider's conversation — a re-read from the provider replaces it wholesale (snapshotVersion bumps, `snapshot.invalidated` on the stream).",
+      ),
+    HttpApiEndpoint.get("subscribeThreadEvents", "/threads/:threadId/events", {
+      params: threadIdParam,
+      query: {
+        after: Schema.optionalKey(
+          integerParam(
+            "Replay every durable change after this seq before going live; omit for live only.",
+            0,
+          ),
+        ),
+      },
+      success: HttpApiSchema.StreamSse({ data: ThreadEvent }),
+      error: ThreadNotFound,
+    })
+      .annotate(OpenApi.Identifier, "subscribeThreadEvents")
+      // The generated 200 documents StreamSse's frame envelope; openapi.ts
+      // replaces it with the data-only wire shape (see subscribeEvents).
+      .annotate(
+        OpenApi.Description,
+        "Subscribe to one thread's live events (SSE): items as they start, stream (`text.delta`), update, and complete; turns; pending requests; the queue; and snapshot invalidations. " +
+          "Durable events carry `seq`; track the highest seen and reconnect with `after=<seq>` to replay every change you missed (current state per row, in seq order) — a rejoin from before a provider re-read gets `snapshot.invalidated` instead: refetch the transcript and resubscribe after its `seq`. " +
+          "Framed like /events (see that endpoint's response); a subscriber that falls too far behind is ended and should resubscribe with `after`.",
+      ),
+    HttpApiEndpoint.post("interruptThread", "/threads/:threadId/interrupt", {
+      params: threadIdParam,
+      error: [ThreadNotFound, ProviderUnavailable],
+    })
+      .annotate(OpenApi.Identifier, "interruptThread")
+      .annotate(
+        OpenApi.Description,
+        "Interrupt the turn the server is driving (its `turn.completed` reads interrupted). A thread with no server-driven turn is a no-op — a turn a TUI drives is interrupted from the TUI — and queued prompts stay queued; they run at the next idle.",
+      ),
+    HttpApiEndpoint.get("listThreadRequests", "/threads/:threadId/requests", {
+      params: threadIdParam,
+      success: ThreadRequestList,
+      error: ThreadNotFound,
+    })
+      .annotate(OpenApi.Identifier, "listThreadRequests")
+      .annotate(
+        OpenApi.Description,
+        "List the thread's pending provider requests (approvals and questions). Requests park until answered — no timeout — and die with their turn.",
+      ),
+    HttpApiEndpoint.post("answerThreadRequest", "/threads/:threadId/requests/:requestId/answer", {
+      params: { threadId: Schema.String, requestId: Schema.String },
+      payload: ThreadRequestAnswer,
+      error: [ThreadNotFound, RequestNotFound, InvalidRequestAnswer, ProviderUnavailable],
+    })
+      .annotate(OpenApi.Identifier, "answerThreadRequest")
+      .annotate(
+        OpenApi.Description,
+        "Answer a pending request. The answer's `kind` must match the request's; question answers must cover every question with option labels (or freeform text where allowed). An answered or unknown request is 404.",
+      ),
+    HttpApiEndpoint.get("listThreadQueue", "/threads/:threadId/queue", {
+      params: threadIdParam,
+      success: QueuedPromptList,
+      error: ThreadNotFound,
+    })
+      .annotate(OpenApi.Identifier, "listThreadQueue")
+      .annotate(OpenApi.Description, "List the prompts still waiting to run, oldest first."),
+    HttpApiEndpoint.delete("deleteQueuedPrompt", "/threads/:threadId/queue/:promptId", {
+      params: { threadId: Schema.String, promptId: Schema.String },
+      error: [ThreadNotFound, QueuedPromptNotFound],
+    })
+      .annotate(OpenApi.Identifier, "deleteQueuedPrompt")
+      .annotate(
+        OpenApi.Description,
+        "Withdraw a waiting prompt. A prompt that already started is a turn now (404); interrupt the thread instead.",
+      ),
     HttpApiEndpoint.get("listAgents", "/agents", { success: AgentList })
       .annotate(OpenApi.Identifier, "listAgents")
       .annotate(
@@ -1344,7 +1479,7 @@ export class V1 extends HttpApiGroup.make("v1")
       .annotate(OpenApi.Identifier, "subscribeEvents")
       // The generated 200 for this endpoint documents StreamSse's decoded
       // frame envelope, not the data-only bytes the server actually emits —
-      // openapi.ts (withDataOnlySseResponse) replaces it with the wire-true
+      // openapi.ts (withDataOnlySseResponses) replaces it with the wire-true
       // shape, and openapi.test.ts pins that documented shape to the bytes.
       .annotate(
         OpenApi.Description,

--- a/app-server/src/api/handlers.ts
+++ b/app-server/src/api/handlers.ts
@@ -1,7 +1,7 @@
 import { Effect, Schema, Stream } from "effect"
 import { HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
-import { Api, ResourceChangedEvent } from "./contract.ts"
+import { Api, ResourceChangedEvent, ThreadEvent } from "./contract.ts"
 import { AgentRegistry } from "../agents/agentRegistry.ts"
 import { Events, HEARTBEAT } from "../events/events.ts"
 import { BuildInfo } from "../platform/buildInfo.ts"
@@ -10,10 +10,24 @@ import * as Tailscale from "../platform/tailscale.ts"
 import { Projects } from "../projects/projects.ts"
 import { attachTerminal } from "../terminals/terminalAttach.ts"
 import { Terminals } from "../terminals/terminals.ts"
+import { ThreadRuntime } from "../threads/threadRuntime.ts"
 import { Threads } from "../threads/threads.ts"
 
 /** One SSE frame per contract event: the exact wire shape StreamSse encodes. */
 const encodeEventJson = Schema.encodeEffect(Schema.fromJsonString(ResourceChangedEvent))
+const encodeThreadEventJson = Schema.encodeEffect(Schema.fromJsonString(ThreadEvent))
+
+/**
+ * The data-only SSE response both stream endpoints share: an opening
+ * `: connected` comment (see subscribeEvents below for why), then `data:`
+ * frames, with heartbeat ticks as comments. `frames` already carries the
+ * heartbeat marker interleaved (both feeds ride the Events heartbeat).
+ */
+const sseResponse = (frames: Stream.Stream<string, unknown>) =>
+  HttpServerResponse.stream(
+    Stream.concat(Stream.succeed(": connected\n\n"), frames).pipe(Stream.encodeText, Stream.orDie),
+    { contentType: "text/event-stream" },
+  )
 
 /**
  * Implements the /api/v1 contract. App construction only — no listener, and
@@ -29,6 +43,7 @@ export const V1Handlers = HttpApiBuilder.group(
     const directories = yield* Directories
     const terminals = yield* Terminals
     const threads = yield* Threads
+    const runtime = yield* ThreadRuntime
     const agents = yield* AgentRegistry
     const events = yield* Events
     // Attach bridges outlive their originating requests (Bun aborts the
@@ -85,6 +100,21 @@ export const V1Handlers = HttpApiBuilder.group(
         .handle("markThreadViewed", ({ params }) => threads.markViewed(params.threadId))
         .handle("deleteThread", ({ params }) => threads.delete(params.threadId))
         .handle("openThreadTerminal", ({ params }) => threads.openTerminal(params.threadId))
+        .handle("promptThread", ({ params, payload }) =>
+          runtime.prompt(params.threadId, payload.prompt),
+        )
+        .handle("getThreadTranscript", ({ params, query }) =>
+          runtime.transcript(params.threadId, { before: query.before, limit: query.limit }),
+        )
+        .handle("interruptThread", ({ params }) => runtime.interrupt(params.threadId))
+        .handle("listThreadRequests", ({ params }) => runtime.listRequests(params.threadId))
+        .handle("answerThreadRequest", ({ params, payload }) =>
+          runtime.answerRequest(params.threadId, params.requestId, payload),
+        )
+        .handle("listThreadQueue", ({ params }) => runtime.listQueue(params.threadId))
+        .handle("deleteQueuedPrompt", ({ params }) =>
+          runtime.deleteQueued(params.threadId, params.promptId),
+        )
         .handle("listAgents", () => agents.list())
         .handle("getAgent", ({ params }) => agents.get(params.agentId))
         // handleRaw instead of the typed handler for one reason: this stream
@@ -110,13 +140,28 @@ export const V1Handlers = HttpApiBuilder.group(
                   : Effect.map(encodeEventJson(item), (json) => `data: ${json}\n\n`),
               ),
             )
-            return HttpServerResponse.stream(
-              Stream.concat(Stream.succeed(": connected\n\n"), encoded).pipe(
-                Stream.encodeText,
-                Stream.orDie,
+            return sseResponse(encoded)
+          }),
+        )
+        // The per-thread stream (ATC-193), framed exactly like /events. Its
+        // heartbeat and its shutdown ordering come from the Events service's
+        // heartbeat-only feed: it ends when Events closes
+        // (drainEventsBeforeStop), which ends this response before the
+        // listener's bounded stop — the same guarantee /events has.
+        .handleRaw("subscribeThreadEvents", ({ params, query }) =>
+          Effect.gen(function* () {
+            const feed = yield* runtime.subscribe(params.threadId, query.after)
+            const heartbeats = yield* events.heartbeats()
+            const encoded = Stream.merge(
+              feed.pipe(
+                Stream.mapEffect((event) =>
+                  Effect.map(encodeThreadEventJson(event), (json) => `data: ${json}\n\n`),
+                ),
               ),
-              { contentType: "text/event-stream" },
+              heartbeats.pipe(Stream.map(() => ": heartbeat\n\n")),
+              { haltStrategy: "either" },
             )
+            return sseResponse(encoded)
           }),
         )
         .handleRaw("attachTerminal", attachTerminal({ terminals, bridgeScope }))

--- a/app-server/src/api/openapi.ts
+++ b/app-server/src/api/openapi.ts
@@ -145,55 +145,70 @@ const withDiscriminators = (document: ReturnType<typeof OpenApi.fromApi>) => {
   } as ReturnType<typeof OpenApi.fromApi>
 }
 
+/** The endpoints that stream data-only SSE, with their per-frame payload. */
+const SSE_ENDPOINTS = [
+  {
+    path: "/api/v1/events",
+    payload: "ResourceChangedEvent",
+    example: 'data: {"resource":"thread","id":"0198aaf1","change":"updated"}',
+  },
+  {
+    path: "/api/v1/threads/{threadId}/events",
+    payload: "ThreadEvent",
+    example:
+      'data: {"type":"item.completed","seq":42,"item":{"type":"assistantText","id":"msg_1","turnId":"turn_1","text":"done","complete":true}}',
+  },
+] as const
+
 /**
- * Replace the generated `/events` 200 with the shape that actually crosses
- * the wire. The generator documents StreamSse's decoded frame envelope
- * ({id, event, data}, all required), but the server emits data-only frames
- * (`data: <json>`) plus `: connected` / `: heartbeat` comment lines — a
- * strict decoder generated from the envelope would reject every real frame.
- * The replacement declares the per-frame data payload (the JSON-encoded
- * ResourceChangedEvent string) and states the full framing protocol in the
+ * Replace each SSE endpoint's generated 200 with the shape that actually
+ * crosses the wire. The generator documents StreamSse's decoded frame
+ * envelope ({id, event, data}, all required), but the server emits data-only
+ * frames (`data: <json>`) plus `: connected` / `: heartbeat` comment lines —
+ * a strict decoder generated from the envelope would reject every real
+ * frame. The replacement declares the per-frame data payload (the
+ * JSON-encoded event string) and states the full framing protocol in the
  * response description; openapi.test.ts pins this documented shape to the
- * emitted bytes. The guard fails generation loudly if the endpoint moves.
+ * emitted bytes. The guard fails generation loudly if an endpoint moves.
  */
-const withDataOnlySseResponse = (document: ReturnType<typeof OpenApi.fromApi>) => {
-  const paths = document.paths as Record<string, { get?: { responses?: Record<string, unknown> } }>
-  const operation = paths["/api/v1/events"]?.get
-  if (operation?.responses?.["200"] === undefined) {
-    throw new Error("no GET /api/v1/events 200 response to replace; did the endpoint move?")
-  }
-  const response = {
-    description:
-      "A data-only SSE byte stream. Each event is a single `data:` line whose payload is a " +
-      "JSON-encoded ResourceChangedEvent (see that component schema); frames never carry `id:` " +
-      "or `event:` lines. Comment lines are protocol control, ignored by conforming SSE " +
-      "parsers: the stream opens with `: connected` (the resync handshake) and a `: heartbeat` " +
-      "follows roughly every 25 seconds. Example:\n\n" +
-      "```\n" +
-      ": connected\n\n" +
-      ": heartbeat\n\n" +
-      'data: {"resource":"thread","id":"0198aaf1","change":"updated"}\n' +
-      "```",
-    content: {
-      "text/event-stream": {
-        schema: { $ref: "#/components/schemas/ResourceChangedEventJsonEncoding" },
+const withDataOnlySseResponses = (document: ReturnType<typeof OpenApi.fromApi>) => {
+  const paths = { ...document.paths } as Record<
+    string,
+    { get?: { responses?: Record<string, unknown> } }
+  >
+  for (const endpoint of SSE_ENDPOINTS) {
+    const operation = paths[endpoint.path]?.get
+    if (operation?.responses?.["200"] === undefined) {
+      throw new Error(`no GET ${endpoint.path} 200 response to replace; did the endpoint move?`)
+    }
+    const response = {
+      description:
+        "A data-only SSE byte stream. Each event is a single `data:` line whose payload is a " +
+        `JSON-encoded ${endpoint.payload} (see that component schema); frames never carry \`id:\` ` +
+        "or `event:` lines. Comment lines are protocol control, ignored by conforming SSE " +
+        "parsers: the stream opens with `: connected` (the resync handshake) and a `: heartbeat` " +
+        "follows roughly every 25 seconds. Example:\n\n" +
+        "```\n" +
+        ": connected\n\n" +
+        ": heartbeat\n\n" +
+        `${endpoint.example}\n` +
+        "```",
+      content: {
+        "text/event-stream": {
+          schema: { $ref: `#/components/schemas/${endpoint.payload}JsonEncoding` },
+        },
       },
-    },
+    }
+    paths[endpoint.path] = {
+      ...paths[endpoint.path],
+      get: { ...operation, responses: { ...operation.responses, "200": response } },
+    }
   }
-  return {
-    ...document,
-    paths: {
-      ...paths,
-      "/api/v1/events": {
-        ...paths["/api/v1/events"],
-        get: { ...operation, responses: { ...operation.responses, "200": response } },
-      },
-    },
-  } as unknown as ReturnType<typeof OpenApi.fromApi>
+  return { ...document, paths } as unknown as ReturnType<typeof OpenApi.fromApi>
 }
 
 export const openApiDocument = hoistSingleAllOf(
-  withDiscriminators(withDataOnlySseResponse(withVocabularyComponents(OpenApi.fromApi(Api)))),
+  withDiscriminators(withDataOnlySseResponses(withVocabularyComponents(OpenApi.fromApi(Api)))),
 ) as ReturnType<typeof OpenApi.fromApi>
 
 /**

--- a/app-server/src/cli/threads.ts
+++ b/app-server/src/cli/threads.ts
@@ -1,14 +1,30 @@
-import { Effect } from "effect"
+import { Console, Effect, Option, Schema, Stream } from "effect"
 import { Argument, Command, Flag } from "effect/unstable/cli"
 import * as path from "node:path"
+import type * as Contract from "../api/contract.ts"
 import { AGENT_IDS } from "../api/contract.ts"
 import * as Cli from "./cli.ts"
 import { attachAndReport } from "./terminals.ts"
 
 // The `atc thread` command group: thin client commands over the contract,
-// plus `thread open` — open-terminal + raw attach, the one command here
-// with local TTY behavior. Threads are the primary unit of work, so they
-// get the full named set (ATC-124).
+// plus the commands that earn a name by local TTY or streaming behavior —
+// `thread open` (open-terminal + raw attach) and the runtime set (ATC-193):
+// `prompt --follow` / `follow` stream the per-thread events as JSON lines
+// until the turn ends (or forever); `answer` composes a request answer from
+// flags. Threads are the primary unit of work, so they get the full named
+// set (ATC-124); everything else stays `atc api`.
+
+type ThreadEvent = typeof Contract.ThreadEvent.Type
+
+/** Print each event as one JSON line; stop when `done` says so (or the stream ends). */
+const printEvents = (
+  events: Stream.Stream<ThreadEvent, unknown>,
+  done: (event: ThreadEvent) => boolean = () => false,
+) =>
+  events.pipe(
+    Stream.takeUntil(done),
+    Stream.runForEach((event) => Console.log(JSON.stringify(event))),
+  )
 
 const threadIdArgument = Argument.string("thread-id")
 
@@ -110,6 +126,161 @@ const threadDelete = Cli.clientCommand(
     ),
 )
 
+const threadPrompt = Command.make(
+  "prompt",
+  {
+    threadId: threadIdArgument,
+    text: Argument.string("text"),
+    follow: Flag.boolean("follow").pipe(
+      Flag.withDescription("Stream the thread's events (JSON lines) until this prompt's turn ends"),
+    ),
+  },
+  ({ threadId, text, follow }) =>
+    Cli.withClient("thread prompt", (client) =>
+      Effect.gen(function* () {
+        // Subscribe BEFORE prompting so no event of the turn is missed.
+        const events = follow
+          ? yield* client.v1.subscribeThreadEvents({ params: { threadId }, query: {} })
+          : undefined
+        const admitted = yield* client.v1.promptThread({
+          params: { threadId },
+          payload: { prompt: text },
+        })
+        // Without --follow the admission is the result; with it, stdout is
+        // a pure ThreadEvent stream (the turn.started event names the
+        // prompt) that ends when this prompt's turn does.
+        if (events === undefined) return yield* Console.log(JSON.stringify(admitted))
+        yield* printEvents(
+          events,
+          (event) =>
+            event.type === "turn.completed" &&
+            (event.turn.id === admitted.turnId || event.turn.promptId === admitted.promptId),
+        )
+      }),
+    ),
+).pipe(
+  Command.withDescription(
+    "Prompt the thread (queued if a turn is running); --follow streams the thread's events (JSON lines) until this prompt's turn ends",
+  ),
+)
+
+const threadFollow = Command.make(
+  "follow",
+  {
+    threadId: threadIdArgument,
+    after: Flag.optional(
+      Flag.integer("after").pipe(
+        Flag.withDescription("Replay every durable change after this seq before going live"),
+      ),
+    ),
+  },
+  ({ threadId, after }) =>
+    Cli.withClient("thread follow", (client) =>
+      Effect.gen(function* () {
+        const events = yield* client.v1.subscribeThreadEvents({
+          params: { threadId },
+          query: Cli.optionalKey("after", after),
+        })
+        yield* printEvents(events)
+      }),
+    ),
+).pipe(Command.withDescription("Stream the thread's events as JSON lines (Ctrl-C to stop)"))
+
+const threadInterrupt = Cli.clientCommand(
+  "thread interrupt",
+  "Interrupt the running turn (queued prompts stay queued)",
+  { threadId: threadIdArgument },
+  (client, { threadId }) => client.v1.interruptThread({ params: { threadId } }),
+)
+
+const threadTranscript = Cli.clientCommand(
+  "thread transcript",
+  "Read the thread's transcript (newest page; --before pages older)",
+  {
+    threadId: threadIdArgument,
+    limit: Flag.optional(Flag.integer("limit").pipe(Flag.withDescription("Most items to return"))),
+    before: Flag.optional(
+      Flag.string("before").pipe(Flag.withDescription("Return items before this item id")),
+    ),
+  },
+  (client, { threadId, limit, before }) =>
+    client.v1.getThreadTranscript({
+      params: { threadId },
+      query: { ...Cli.optionalKey("limit", limit), ...Cli.optionalKey("before", before) },
+    }),
+)
+
+const threadRequests = Cli.clientCommand(
+  "thread requests",
+  "List the thread's pending provider requests (approvals and questions)",
+  { threadId: threadIdArgument },
+  (client, { threadId }) => client.v1.listThreadRequests({ params: { threadId } }),
+)
+
+const DECISIONS = ["accept", "acceptForSession", "decline", "cancel"] as const
+
+const decodeAnswers = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(Schema.Record(Schema.String, Schema.Array(Schema.String))),
+)
+
+const threadAnswer = Command.make(
+  "answer",
+  {
+    threadId: threadIdArgument,
+    requestId: Argument.string("request-id"),
+    decision: Flag.optional(
+      Flag.choice("decision", DECISIONS).pipe(
+        Flag.withDescription(
+          "Approval decision (cancel = decline and interrupt the turn); exclusive with --answers",
+        ),
+      ),
+    ),
+    answers: Flag.optional(
+      Flag.string("answers").pipe(
+        Flag.withDescription(
+          'Question answers as JSON, question id → chosen labels or freeform text ({"q0":["blue"]}); "-" reads the JSON from stdin (use it for secret answers, which must never sit in argv)',
+        ),
+      ),
+    ),
+  },
+  ({ threadId, requestId, decision, answers }) =>
+    Cli.withClient("thread answer", (client) =>
+      Effect.gen(function* () {
+        if (Option.isSome(decision) === Option.isSome(answers)) {
+          return yield* Effect.fail(new Error("pass exactly one of --decision or --answers"))
+        }
+        if (Option.isSome(decision)) {
+          return yield* client.v1.answerThreadRequest({
+            params: { threadId, requestId },
+            payload: { kind: "approval", decision: decision.value },
+          })
+        }
+        const raw = Option.getOrElse(answers, () => "-")
+        const json = raw === "-" ? yield* Effect.promise(() => Bun.stdin.text()) : raw
+        const decoded = yield* decodeAnswers(json).pipe(
+          Effect.mapError(
+            (error) => new Error(`--answers must be a JSON object: ${error.message}`),
+          ),
+        )
+        yield* client.v1.answerThreadRequest({
+          params: { threadId, requestId },
+          payload: { kind: "question", answers: decoded },
+        })
+      }),
+    ),
+).pipe(
+  Command.withDescription(
+    "Answer a pending request: --decision for an approval, --answers (JSON, or - for stdin) for a question",
+  ),
+)
+
+const threadQueue = Cli.clientCommand(
+  "thread queue",
+  "List the prompts still waiting to run, oldest first",
+  { threadId: threadIdArgument },
+  (client, { threadId }) => client.v1.listThreadQueue({ params: { threadId } }),
+)
+
 export const thread = Command.make("thread").pipe(
   Command.withDescription("Manage durable agent threads (the primary unit of work)"),
   Command.withSubcommands([
@@ -118,6 +289,13 @@ export const thread = Command.make("thread").pipe(
     threadCreate,
     threadUpdate,
     threadOpen,
+    threadPrompt,
+    threadFollow,
+    threadInterrupt,
+    threadTranscript,
+    threadRequests,
+    threadAnswer,
+    threadQueue,
     threadArchive,
     threadUnarchive,
     threadDelete,

--- a/app-server/src/events/events.ts
+++ b/app-server/src/events/events.ts
@@ -28,6 +28,8 @@ export type ResourceChangedEvent = typeof Contract.ResourceChangedEvent.Type
 //     down at ~60s), clients get a liveness signal for half-open sockets,
 //     and a dead subscriber is torn down by its failing write instead of
 //     holding a queue until overflow. No per-subscriber timers, no polling.
+//     Streams that ride another feed (the per-thread event stream) take the
+//     same ticks through heartbeats(), and end with close() like the rest.
 //   - close() (also the layer finalizer) ends every subscriber stream
 //     cleanly. server.ts sequences it to release BEFORE the HTTP listener's
 //     bounded graceful stop — an open SSE response would otherwise hold the
@@ -61,6 +63,12 @@ export class Events extends Context.Service<
     readonly subscribe: <E = never>(options?: {
       readonly reconcile?: Effect.Effect<unknown, E> | undefined
     }) => Effect.Effect<Stream.Stream<ResourceChangedEvent | Heartbeat>, E>
+    /**
+     * The heartbeat ticks alone — for streams that ride another feed but
+     * want the shared keepalive and the same shutdown (`close` ends these
+     * too). Resource events never enter these queues.
+     */
+    readonly heartbeats: () => Effect.Effect<Stream.Stream<Heartbeat>>
     /** Currently registered subscribers. Exists for tests and diagnostics. */
     readonly subscriberCount: () => Effect.Effect<number>
     /** End every subscriber stream, current and future. Idempotent. */
@@ -82,13 +90,16 @@ export const layerWith = (options: EventsOptions) =>
       const capacity = options.subscriberCapacity ?? 128
       const heartbeatInterval = options.heartbeatInterval ?? "25 seconds"
       const subscribers = new Set<Queue.Queue<ResourceChangedEvent | Heartbeat, Cause.Done>>()
+      const heartbeatOnly = new Set<Queue.Queue<Heartbeat, Cause.Done>>()
       let closed = false
 
       const close = () =>
         Effect.sync(() => {
           closed = true
           for (const queue of subscribers) Queue.endUnsafe(queue)
+          for (const queue of heartbeatOnly) Queue.endUnsafe(queue)
           subscribers.clear()
+          heartbeatOnly.clear()
         })
 
       // Belt and braces: the server drains explicitly before the listener
@@ -107,8 +118,17 @@ export const layerWith = (options: EventsOptions) =>
         }
       }
 
+      const tick = (): void => {
+        offer(HEARTBEAT)
+        for (const queue of heartbeatOnly) {
+          if (Queue.offerUnsafe(queue, HEARTBEAT)) continue
+          Queue.endUnsafe(queue)
+          heartbeatOnly.delete(queue)
+        }
+      }
+
       // The one shared timer; the layer scope reaps it on release.
-      yield* Effect.sync(() => offer(HEARTBEAT)).pipe(
+      yield* Effect.sync(tick).pipe(
         Effect.delay(heartbeatInterval),
         Effect.forever,
         Effect.forkScoped,
@@ -129,6 +149,20 @@ export const layerWith = (options: EventsOptions) =>
             }
             return Stream.fromQueue(queue).pipe(
               Stream.ensuring(Effect.sync(() => subscribers.delete(queue))),
+            )
+          }),
+        heartbeats: () =>
+          Effect.gen(function* () {
+            // A few ticks of slack: a consumer that cannot drain one tick
+            // in a heartbeat period is gone anyway.
+            const queue = yield* Queue.make<Heartbeat, Cause.Done>({ capacity: 4 })
+            if (closed) {
+              yield* Queue.end(queue)
+            } else {
+              heartbeatOnly.add(queue)
+            }
+            return Stream.fromQueue(queue).pipe(
+              Stream.ensuring(Effect.sync(() => heartbeatOnly.delete(queue))),
             )
           }),
         subscriberCount: () => Effect.sync(() => subscribers.size),

--- a/app-server/src/threads/threadRuntime.ts
+++ b/app-server/src/threads/threadRuntime.ts
@@ -96,7 +96,7 @@ export type QueuedPrompt = typeof Contract.QueuedPrompt.Type
 //     behind one start lock; threads still recovering at startup queue
 //     their prompts until recovery has settled them.
 
-/** The most items one transcript read returns. */
+/** The default transcript page (the contract caps requests at the same size). */
 const TRANSCRIPT_PAGE = 200
 
 /** Per-subscriber backlog; overflow ends the stream (resubscribe after=seq). */
@@ -141,7 +141,8 @@ export class ThreadRuntime extends Context.Service<
       id: string,
       promptId: string,
     ) => Effect.Effect<void, ThreadNotFound | QueuedPromptNotFound>
-    /** A page of the transcript (newest `limit`, or the page before `before`). */
+    /** A page of the transcript (newest `limit`, default 200 — the contract
+     * bounds it; or the page before `before`). */
     readonly transcript: (
       id: string,
       options?: { readonly before?: string | undefined; readonly limit?: number | undefined },
@@ -149,12 +150,13 @@ export class ThreadRuntime extends Context.Service<
     /**
      * The per-thread event stream. With `after`, every durable change past
      * that seq replays first (current row state), then live events follow;
-     * without it the stream is live only. Scoped: closing unsubscribes.
+     * without it the stream is live only. Registered eagerly (a publish
+     * after this returns is delivered); the stream's end unsubscribes.
      */
     readonly subscribe: (
       id: string,
       after?: number | undefined,
-    ) => Effect.Effect<Stream.Stream<ThreadEvent>, ThreadNotFound, Scope.Scope>
+    ) => Effect.Effect<Stream.Stream<ThreadEvent>, ThreadNotFound>
     /** Replace the copy with provider history (see the header's rules). No
      * route calls this — the triggers are internal; it exists for tests
      * and manual repair. */
@@ -837,7 +839,7 @@ export const layer = Layer.effect(ThreadRuntime)(
           Effect.andThen(
             transcripts.read(id, {
               before: options?.before,
-              limit: Math.max(1, Math.min(options?.limit ?? TRANSCRIPT_PAGE, TRANSCRIPT_PAGE)),
+              limit: options?.limit ?? TRANSCRIPT_PAGE,
             }),
           ),
         ),
@@ -849,23 +851,22 @@ export const layer = Layer.effect(ThreadRuntime)(
           })
           // Registered BEFORE the replay read: anything published in
           // between waits in the queue, and the seq filter below drops
-          // what the replay already covered.
-          yield* Effect.acquireRelease(
-            Effect.sync(() => {
-              const set = hubs.get(id) ?? new Set()
-              set.add(queue)
-              hubs.set(id, set)
-            }),
-            () =>
-              Effect.sync(() => {
-                const set = hubs.get(id)
-                set?.delete(queue)
-                if (set?.size === 0) hubs.delete(id)
-                Queue.endUnsafe(queue)
-              }),
-          )
-          if (after === undefined) return Stream.fromQueue(queue)
-          const { changes, counters } = yield* transcripts.changesAfter(id, after)
+          // what the replay already covered. A stream that never runs
+          // self-heals the way Events' do: its queue fills and publish
+          // drops it.
+          const set = hubs.get(id) ?? new Set()
+          set.add(queue)
+          hubs.set(id, set)
+          const unsubscribe = Effect.sync(() => {
+            set.delete(queue)
+            if (set.size === 0 && hubs.get(id) === set) hubs.delete(id)
+            Queue.endUnsafe(queue)
+          })
+          if (after === undefined) return Stream.fromQueue(queue).pipe(Stream.ensuring(unsubscribe))
+          // A replay read that dies must not strand the registration.
+          const { changes, counters } = yield* transcripts
+            .changesAfter(id, after)
+            .pipe(Effect.onExit((exit) => (exit._tag === "Failure" ? unsubscribe : Effect.void)))
           // A copy replaced since `after`: what was deleted cannot be
           // replayed, so the client is told to refetch instead.
           const replay: ReadonlyArray<ThreadEvent> =
@@ -883,7 +884,7 @@ export const layer = Layer.effect(ThreadRuntime)(
             Stream.fromQueue(queue).pipe(
               Stream.filter((event) => !("seq" in event) || event.seq > counters.seq),
             ),
-          )
+          ).pipe(Stream.ensuring(unsubscribe))
         }),
       reread: (id) => repository.require(id).pipe(Effect.flatMap(rereadRecord)),
       activity: (id) => Effect.sync(() => liveActivity.get(id)),

--- a/app-server/test/api/openapi.test.ts
+++ b/app-server/test/api/openapi.test.ts
@@ -181,6 +181,14 @@ describe("openapi document vs runtime", () => {
       "/api/v1/threads/{threadId}/unpin",
       "/api/v1/threads/{threadId}/viewed",
       "/api/v1/threads/{threadId}/terminal",
+      "/api/v1/threads/{threadId}/prompt",
+      "/api/v1/threads/{threadId}/transcript",
+      "/api/v1/threads/{threadId}/events",
+      "/api/v1/threads/{threadId}/interrupt",
+      "/api/v1/threads/{threadId}/requests",
+      "/api/v1/threads/{threadId}/requests/{requestId}/answer",
+      "/api/v1/threads/{threadId}/queue",
+      "/api/v1/threads/{threadId}/queue/{promptId}",
       "/api/v1/agents",
       "/api/v1/agents/{agentId}",
       "/api/v1/events",
@@ -545,6 +553,244 @@ describe("openapi document vs runtime", () => {
         message: "no agent with id nope",
       })
     }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
+  )
+
+  // The Thread runtime routes (ATC-193): documented shapes against the raw
+  // wire, over the fake adapter (TestRepositoryLayers).
+  it.effect("thread prompt / queue / interrupt document and return their payloads", () =>
+    Effect.gen(function* () {
+      const client = yield* rawClient
+      const project = yield* client.post("http://127.0.0.1/api/v1/projects", {
+        body: HttpBody.jsonUnsafe({ name: "Runtime Docs", defaultWorkingDirectory: "/tmp" }),
+      })
+      const projectBody = (yield* project.json) as { id: string }
+      const created = yield* client.post("http://127.0.0.1/api/v1/threads", {
+        body: HttpBody.jsonUnsafe({ projectId: projectBody.id, agentId: "codex" }),
+      })
+      const thread = (yield* created.json) as { id: string }
+      const base = `http://127.0.0.1/api/v1/threads/${thread.id}`
+
+      const prompted = yield* client.post(`${base}/prompt`, {
+        body: HttpBody.jsonUnsafe({ prompt: "hello" }),
+      })
+      assert.strictEqual(prompted.status, 200)
+      const promptBody = (yield* prompted.json) as { promptId: string; turnId?: string }
+      assert.isString(promptBody.promptId)
+      assert.isString(promptBody.turnId)
+      assert.deepStrictEqual(
+        operation(`/api/v1/threads/{threadId}/prompt`, "post").responses["200"]!.content[
+          "application/json"
+        ]!.schema,
+        { $ref: "#/components/schemas/PromptThreadResponse" },
+      )
+      assert.sameMembers(Object.keys(componentSchema("PromptThreadResponse").properties), [
+        "promptId",
+        "turnId",
+      ])
+      // A second prompt queues (the fake turn is still running).
+      const queued = yield* client.post(`${base}/prompt`, {
+        body: HttpBody.jsonUnsafe({ prompt: "later" }),
+      })
+      const queuedBody = (yield* queued.json) as { promptId: string; turnId?: string }
+      assert.isUndefined(queuedBody.turnId)
+      const list = yield* client.get(`${base}/queue`)
+      assert.strictEqual(list.status, 200)
+      const listBody = (yield* list.json) as Array<{ id: string; prompt: string; queuedAt: string }>
+      assert.deepStrictEqual(
+        listBody.map((entry) => [entry.id, entry.prompt]),
+        [[queuedBody.promptId, "later"]],
+      )
+      assert.deepStrictEqual(
+        operation(`/api/v1/threads/{threadId}/queue`).responses["200"]!.content["application/json"]!
+          .schema,
+        { $ref: "#/components/schemas/QueuedPromptList" },
+      )
+      const removed = yield* client.del(`${base}/queue/${queuedBody.promptId}`)
+      assert.strictEqual(removed.status, 204)
+      const gone = yield* client.del(`${base}/queue/${queuedBody.promptId}`)
+      assert.strictEqual(gone.status, 404)
+      // Two 404s share the status: the thread, or the prompt.
+      assert.deepStrictEqual(
+        operation(`/api/v1/threads/{threadId}/queue/{promptId}`, "delete").responses["404"]!
+          .content["application/json"]!.schema as unknown,
+        {
+          anyOf: [
+            { $ref: "#/components/schemas/ThreadNotFoundJsonEncoding" },
+            { $ref: "#/components/schemas/QueuedPromptNotFoundJsonEncoding" },
+          ],
+        },
+      )
+      const interrupted = yield* client.post(`${base}/interrupt`, { body: HttpBody.empty })
+      assert.strictEqual(interrupted.status, 204)
+      const requests = yield* client.get(`${base}/requests`)
+      assert.strictEqual(requests.status, 200)
+      assert.deepStrictEqual(yield* requests.json, [])
+      assert.deepStrictEqual(
+        operation(`/api/v1/threads/{threadId}/requests`).responses["200"]!.content[
+          "application/json"
+        ]!.schema,
+        { $ref: "#/components/schemas/ThreadRequestList" },
+      )
+      const unanswered = yield* client.post(`${base}/requests/nope/answer`, {
+        body: HttpBody.jsonUnsafe({ kind: "approval", decision: "accept" }),
+      })
+      assert.strictEqual(unanswered.status, 404)
+      assert.deepStrictEqual(yield* unanswered.json, {
+        _tag: "RequestNotFound",
+        threadId: thread.id,
+        requestId: "nope",
+        message: `thread ${thread.id} has no pending request nope`,
+      })
+      assert.deepStrictEqual(
+        operation(`/api/v1/threads/{threadId}/requests/{requestId}/answer`, "post").responses[
+          "400"
+        ]!.content["application/json"]!.schema,
+        { $ref: "#/components/schemas/InvalidRequestAnswerJsonEncoding" },
+      )
+      const transcript = yield* client.get(`${base}/transcript?limit=5`)
+      assert.strictEqual(transcript.status, 200)
+      const transcriptBody = (yield* transcript.json) as {
+        items: Array<{ type: string }>
+        turns: Array<{ id: string; status: string }>
+        seq: number
+        snapshotVersion: number
+        hasMore: boolean
+      }
+      assert.deepStrictEqual(
+        transcriptBody.turns.map((turn) => turn.status),
+        ["interrupted"],
+      )
+      assert.isNumber(transcriptBody.seq)
+      assert.strictEqual(transcriptBody.snapshotVersion, 0)
+      assert.isFalse(transcriptBody.hasMore)
+      assert.deepStrictEqual(
+        operation(`/api/v1/threads/{threadId}/transcript`).responses["200"]!.content[
+          "application/json"
+        ]!.schema,
+        { $ref: "#/components/schemas/ThreadTranscript" },
+      )
+      assert.sameMembers(Object.keys(componentSchema("ThreadTranscript").properties), [
+        "items",
+        "turns",
+        "seq",
+        "snapshotVersion",
+        "hasMore",
+      ])
+    }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
+  )
+
+  it.live("GET /api/v1/threads/{threadId}/events: the documented SSE shape matches the bytes", () =>
+    Effect.gen(function* () {
+      const content = operation("/api/v1/threads/{threadId}/events").responses["200"]!.content[
+        "text/event-stream"
+      ]!
+      assert.deepStrictEqual(content.schema as unknown, {
+        $ref: "#/components/schemas/ThreadEventJsonEncoding",
+      })
+      const description = (
+        operation("/api/v1/threads/{threadId}/events").responses["200"]! as unknown as {
+          description: string
+        }
+      ).description
+      for (const token of [": connected", ": heartbeat", "`data:`", "ThreadEvent"]) {
+        assert.include(description, token)
+      }
+      // The event union is a discriminated component with one variant per
+      // event type — what generated clients decode the frames into.
+      const event = componentSchema("ThreadEvent") as unknown as {
+        oneOf: Array<{ $ref: string }>
+        discriminator: { propertyName: string; mapping: Record<string, string> }
+      }
+      assert.strictEqual(event.discriminator.propertyName, "type")
+      assert.sameMembers(Object.keys(event.discriminator.mapping), [
+        "item.started",
+        "item.updated",
+        "item.completed",
+        "turn.started",
+        "turn.completed",
+        "text.delta",
+        "request.opened",
+        "request.closed",
+        "queue.updated",
+        "snapshot.invalidated",
+      ])
+
+      const { base } = yield* startServer(
+        Server.layer({ port: 0 }).pipe(Layer.provide([TestBuildInfoLayer, TestRepositoryLayers])),
+      )
+      const json = <A>(response: Promise<Response>) => response.then((r) => r.json() as Promise<A>)
+      const project = yield* Effect.promise(() =>
+        json<{ id: string }>(
+          fetch(`${base}/api/v1/projects`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ name: "ThreadSse", defaultWorkingDirectory: "/tmp" }),
+          }),
+        ),
+      )
+      const thread = yield* Effect.promise(() =>
+        json<{ id: string }>(
+          fetch(`${base}/api/v1/threads`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ projectId: project.id, agentId: "codex" }),
+          }),
+        ),
+      )
+      const response = yield* Effect.promise(() =>
+        fetch(`${base}/api/v1/threads/${thread.id}/events`, {
+          headers: { accept: "text/event-stream" },
+        }),
+      )
+      assert.match(response.headers.get("content-type") ?? "", /^text\/event-stream/)
+      const reader = response.body!.getReader()
+      const opening = yield* Effect.promise(() => reader.read())
+      // A prefix, not the whole chunk: the transport may batch a frame in.
+      const openingText = new TextDecoder().decode(opening.value)
+      assert.isTrue(
+        openingText.startsWith(": connected\n\n"),
+        `expected the connected comment first, got ${JSON.stringify(openingText)}`,
+      )
+
+      yield* Effect.promise(() =>
+        fetch(`${base}/api/v1/threads/${thread.id}/prompt`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ prompt: "stream me" }),
+        }),
+      )
+      // Frames arrive as bare `data:` lines; the first durable one is the
+      // queue update, then the turn start with its seq. Bounded: a missing
+      // frame must fail naming what was seen, not hang on heartbeats.
+      let text = openingText
+      yield* Effect.promise(async () => {
+        while (!text.includes('"type":"turn.started"')) {
+          const chunk = await reader.read()
+          if (chunk.done) break
+          text += new TextDecoder().decode(chunk.value)
+        }
+      }).pipe(
+        Effect.timeoutOrElse({
+          duration: "10 seconds",
+          orElse: () => Effect.die(new Error(`no turn.started frame within 10s; saw: ${text}`)),
+        }),
+      )
+      const frames = text.split("\n\n").filter((frame) => frame.startsWith("data: "))
+      const parsed = frames.map(
+        (frame) =>
+          JSON.parse(frame.slice("data: ".length)) as {
+            type: string
+            seq?: number
+          },
+      )
+      assert.strictEqual(parsed[0]?.type, "queue.updated")
+      assert.isUndefined(parsed[0]?.seq)
+      const started = parsed.find((event) => event.type === "turn.started")
+      assert.isNumber(started?.seq)
+      assert.isFalse(text.includes("\nid:"))
+      assert.isFalse(text.includes("\nevent:"))
+      yield* Effect.promise(() => reader.cancel())
+    }),
   )
 
   // it.live: real socket I/O — the point is pinning the *documented* frame

--- a/app-server/test/api/threadEvents.test.ts
+++ b/app-server/test/api/threadEvents.test.ts
@@ -1,0 +1,155 @@
+import { assert, describe, it } from "@effect/vitest"
+import { BunServices } from "@effect/platform-bun"
+import { Effect, Layer } from "effect"
+import * as Server from "../../src/server.ts"
+import { TestBuildInfoLayer } from "../testBuildInfo.ts"
+import { makeTestServiceLayers, startServer, TEST_AUTH_TOKEN } from "../testLayers.ts"
+
+// The multi-client, remote-client proof (ATC-193): two independent clients
+// attached to one thread's event stream — one a plain loopback client, one
+// the shape of a remote client (a non-loopback Host plus the bearer token,
+// the same rule localTrust.test.ts pins) — see the same events in the same
+// order, and a prompt sent from either shows up in both. Real listener: the
+// trust guard and the SSE framing sit on the HTTP layer.
+
+/**
+ * Read `data:` frames off an SSE response until `until` matches one —
+ * bounded, so a missing frame fails naming what arrived instead of hanging
+ * on heartbeats.
+ */
+const readFrames = async (
+  response: Response,
+  until: (frame: Record<string, unknown>) => boolean,
+  deadlineMillis = 10_000,
+): Promise<Array<Record<string, unknown>>> => {
+  const reader = response.body!.getReader()
+  const decoder = new TextDecoder()
+  let text = ""
+  const frames: Array<Record<string, unknown>> = []
+  const deadline = Date.now() + deadlineMillis
+  for (;;) {
+    const remaining = deadline - Date.now()
+    if (remaining <= 0) {
+      await reader.cancel()
+      throw new Error(`no matching frame within ${deadlineMillis}ms; saw ${JSON.stringify(frames)}`)
+    }
+    const chunk = await Promise.race([
+      reader.read(),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error(`SSE read stalled; saw ${JSON.stringify(frames)}`)),
+          remaining,
+        ),
+      ),
+    ])
+    if (chunk.done) break
+    text += decoder.decode(chunk.value, { stream: true })
+    // Stop at the matching frame itself, whatever else the chunk carried.
+    let end = text.indexOf("\n\n")
+    let stop = false
+    while (end >= 0 && !stop) {
+      const raw = text.slice(0, end)
+      text = text.slice(end + 2)
+      if (raw.startsWith("data: ")) {
+        const frame = JSON.parse(raw.slice("data: ".length)) as Record<string, unknown>
+        frames.push(frame)
+        stop = until(frame)
+      }
+      end = text.indexOf("\n\n")
+    }
+    if (stop) break
+  }
+  await reader.cancel()
+  return frames
+}
+
+describe("thread event stream: two clients, one remote", () => {
+  it.live("both clients see the same events in the same order, whoever prompted", () =>
+    Effect.gen(function* () {
+      const kit = makeTestServiceLayers()
+      const { base: local } = yield* startServer(
+        Server.layer({ port: 0 }).pipe(Layer.provide([TestBuildInfoLayer, kit.layer])),
+      )
+      const port = new URL(local).port
+      const remoteHeaders = {
+        Host: `workstation.tailnet:${port}`,
+        Authorization: `Bearer ${TEST_AUTH_TOKEN}`,
+      }
+      const json = <A>(response: Promise<Response>) => response.then((r) => r.json() as Promise<A>)
+      const post = (path: string, body: unknown, headers: Record<string, string> = {}) =>
+        fetch(`${local}${path}`, {
+          method: "POST",
+          headers: { "content-type": "application/json", ...headers },
+          body: JSON.stringify(body),
+        })
+
+      const project = yield* Effect.promise(() =>
+        json<{ id: string }>(
+          post("/api/v1/projects", { name: "TwoClients", defaultWorkingDirectory: "/tmp" }),
+        ),
+      )
+      const thread = yield* Effect.promise(() =>
+        json<{ id: string }>(post("/api/v1/threads", { projectId: project.id, agentId: "codex" })),
+      )
+      const eventsPath = `${local}/api/v1/threads/${thread.id}/events`
+
+      // A remote client without the token is refused; with it, it streams.
+      const refused = yield* Effect.promise(() =>
+        fetch(eventsPath, { headers: { Host: `workstation.tailnet:${port}` } }),
+      )
+      assert.strictEqual(refused.status, 403)
+      const [localStream, remoteStream] = yield* Effect.promise(() =>
+        Promise.all([
+          fetch(eventsPath, { headers: { accept: "text/event-stream" } }),
+          fetch(eventsPath, { headers: { accept: "text/event-stream", ...remoteHeaders } }),
+        ]),
+      )
+      assert.strictEqual(localStream.status, 200)
+      assert.strictEqual(remoteStream.status, 200)
+
+      // The remote client prompts; the local one prompts again (queued).
+      const first = yield* Effect.promise(() =>
+        json<{ promptId: string; turnId?: string }>(
+          post(`/api/v1/threads/${thread.id}/prompt`, { prompt: "from remote" }, remoteHeaders),
+        ),
+      )
+      assert.isString(first.turnId)
+      const second = yield* Effect.promise(() =>
+        json<{ promptId: string; turnId?: string }>(
+          post(`/api/v1/threads/${thread.id}/prompt`, { prompt: "from local" }),
+        ),
+      )
+      assert.isUndefined(second.turnId)
+      // The fake provider finishes the first turn; the queued prompt runs.
+      const session = [...kit.fakeAgents.codex.sessions.values()].find((entry) =>
+        entry.inputs.includes("from remote"),
+      )
+      assert.isDefined(session, "the fake adapter recorded no session for the remote prompt")
+      kit.fakeAgents.codex.completeTurn(session.providerSessionId, "completed")
+
+      const untilSecondTurn = (frame: Record<string, unknown>) =>
+        frame["type"] === "turn.started" &&
+        (frame["turn"] as { promptId?: string }).promptId === second.promptId
+      const [localFrames, remoteFrames] = yield* Effect.promise(() =>
+        Promise.all([
+          readFrames(localStream, untilSecondTurn),
+          readFrames(remoteStream, untilSecondTurn),
+        ]),
+      )
+      // Identical, in order — the server-side copy is the one conversation.
+      assert.deepStrictEqual(localFrames, remoteFrames)
+      const types = localFrames.map((frame) => frame["type"])
+      assert.include(types, "turn.started")
+      assert.include(types, "turn.completed")
+      assert.include(types, "item.completed")
+      assert.strictEqual(types.filter((type) => type === "turn.started").length, 2)
+      const seqs = localFrames.flatMap((frame) =>
+        typeof frame["seq"] === "number" ? [frame["seq"]] : [],
+      )
+      assert.deepStrictEqual(
+        seqs,
+        seqs.toSorted((left, right) => left - right),
+      )
+    }).pipe(Effect.scoped, Effect.provide(BunServices.layer)),
+  )
+})

--- a/app-server/test/cli/cli.blackbox.test.ts
+++ b/app-server/test/cli/cli.blackbox.test.ts
@@ -368,6 +368,19 @@ describe("atc thread (black box)", () => {
     const fetched = await cli(["thread", "get", thread.id])
     expect(JSON.parse(fetched.stdout)).toEqual(thread)
 
+    // The runtime read commands (ATC-193) work on a thread nobody has
+    // prompted: an empty transcript at seq 0, nothing queued, nothing asked.
+    const transcript = await cli(["thread", "transcript", thread.id, "--limit", "5"])
+    expect(JSON.parse(transcript.stdout)).toEqual({
+      items: [],
+      turns: [],
+      seq: 0,
+      snapshotVersion: 0,
+      hasMore: false,
+    })
+    expect(JSON.parse((await cli(["thread", "queue", thread.id])).stdout)).toEqual([])
+    expect(JSON.parse((await cli(["thread", "requests", thread.id])).stdout)).toEqual([])
+
     const updated = await cli(["thread", "update", thread.id, "--name", "Renamed"])
     expect((JSON.parse(updated.stdout) as { name: string }).name).toBe("Renamed")
 

--- a/app-server/test/threads/threadRuntime.smoke.test.ts
+++ b/app-server/test/threads/threadRuntime.smoke.test.ts
@@ -1,0 +1,83 @@
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, test } from "vitest"
+import { appServerRoot, runCli, trackTempDir } from "../blackbox.ts"
+import { withFakeZmxServer } from "../testLayers.ts"
+
+// Live Thread runtime smoke (opt-in: mise run test:smoke): the whole stack
+// against real Claude Code — a real `atc serve` from source, `atc thread
+// prompt --follow` streaming the turn to its end, then the transcript and
+// the queue read back through the CLI. Needs an installed, authenticated
+// Claude Code; runs one real (cheap) turn from a directory outside any
+// repository. Codex is exercised at the adapter level (codexAdapter.smoke);
+// the runtime is provider-neutral above the seam.
+
+const enabled = process.env["ATC_SMOKE"] === "1"
+
+describe.skipIf(!enabled)("live thread runtime smoke (opt-in)", () => {
+  test("prompt --follow runs a real Claude turn end to end; the transcript reads back", async () => {
+    const cwd = trackTempDir(mkdtempSync(join(tmpdir(), "atc-runtime-smoke-")))
+    await withFakeZmxServer(async (server) => {
+      const cli = (args: ReadonlyArray<string>) =>
+        runCli([process.execPath, "src/main.ts"], args, appServerRoot, server.env)
+      const project = JSON.parse(
+        (await cli(["project", "create", "--name", "Smoke", "--directory", cwd])).stdout,
+      ) as { id: string }
+      const thread = JSON.parse(
+        (
+          await cli([
+            "thread",
+            "create",
+            "--project",
+            project.id,
+            "--agent",
+            "claude-code",
+            "--directory",
+            cwd,
+          ])
+        ).stdout,
+      ) as { id: string }
+
+      const followed = await cli([
+        "thread",
+        "prompt",
+        thread.id,
+        "Reply with exactly: SMOKE-OK",
+        "--follow",
+      ])
+      // Real Claude Code may print provider notices on stderr; the exit
+      // code is the verdict (stderr rides along in the failure message).
+      expect(followed.exitCode, followed.stderr).toBe(0)
+      const events = followed.stdout
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line)) as Array<{
+        type: string
+        item?: { type: string; text?: string }
+      }>
+      expect(events[0]?.type).toBe("queue.updated")
+      expect(events.at(-1)?.type).toBe("turn.completed")
+      // The prompt landed as the turn's first item; the reply streamed and
+      // completed with the requested text.
+      expect(events.some((event) => event.item?.type === "userMessage")).toBe(true)
+      expect(events.some((event) => event.type === "text.delta")).toBe(true)
+      expect(
+        events.some(
+          (event) =>
+            event.type === "item.completed" &&
+            event.item?.type === "assistantText" &&
+            (event.item.text ?? "").includes("SMOKE-OK"),
+        ),
+      ).toBe(true)
+
+      const transcript = JSON.parse((await cli(["thread", "transcript", thread.id])).stdout) as {
+        items: Array<{ type: string }>
+        turns: Array<{ status: string }>
+      }
+      expect(transcript.turns.map((turn) => turn.status)).toEqual(["completed"])
+      expect(transcript.items[0]?.type).toBe("userMessage")
+      expect(JSON.parse((await cli(["thread", "queue", thread.id])).stdout)).toEqual([])
+    })
+  }, 240_000)
+})

--- a/macos/ATC/PreviewSupport/PreviewAppServerClient.swift
+++ b/macos/ATC/PreviewSupport/PreviewAppServerClient.swift
@@ -458,6 +458,54 @@ import OpenAPIRuntime
 
         // MARK: - Agents
 
+        // MARK: - Thread runtime (ATC-193) — previews show an idle, empty runtime.
+
+        func promptThread(_ input: Operations.PromptThread.Input) async throws -> Operations.PromptThread.Output {
+            .ok(.init(body: .json(.init(promptId: "0192f4c0-0000-7000-8000-000000000001", turnId: nil))))
+        }
+
+        func getThreadTranscript(
+            _ input: Operations.GetThreadTranscript.Input
+        ) async throws -> Operations.GetThreadTranscript.Output {
+            .ok(.init(body: .json(.init(items: [], turns: [], seq: 0, snapshotVersion: 0, hasMore: false))))
+        }
+
+        func subscribeThreadEvents(
+            _ input: Operations.SubscribeThreadEvents.Input
+        ) async throws -> Operations.SubscribeThreadEvents.Output {
+            .ok(.init(body: .textEventStream(HTTPBody(": connected\n\n"))))
+        }
+
+        func interruptThread(_ input: Operations.InterruptThread.Input) async throws
+            -> Operations.InterruptThread.Output
+        {
+            .noContent(.init())
+        }
+
+        func listThreadRequests(
+            _ input: Operations.ListThreadRequests.Input
+        ) async throws -> Operations.ListThreadRequests.Output {
+            .ok(.init(body: .json([])))
+        }
+
+        func answerThreadRequest(
+            _ input: Operations.AnswerThreadRequest.Input
+        ) async throws -> Operations.AnswerThreadRequest.Output {
+            .noContent(.init())
+        }
+
+        func listThreadQueue(_ input: Operations.ListThreadQueue.Input) async throws
+            -> Operations.ListThreadQueue.Output
+        {
+            .ok(.init(body: .json([])))
+        }
+
+        func deleteQueuedPrompt(
+            _ input: Operations.DeleteQueuedPrompt.Input
+        ) async throws -> Operations.DeleteQueuedPrompt.Output {
+            .noContent(.init())
+        }
+
         func listAgents(_ input: Operations.ListAgents.Input) async throws -> Operations.ListAgents.Output {
             .ok(.init(body: .json(agents)))
         }

--- a/macos/ATCTests/ScriptableAppServerClient.swift
+++ b/macos/ATCTests/ScriptableAppServerClient.swift
@@ -645,6 +645,56 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
         throw StubUnimplemented("subscribeEvents")
     }
 
+    // MARK: - Thread runtime (ATC-193): no macOS client yet (ATC-191)
+
+    func promptThread(_ input: Operations.PromptThread.Input) async throws
+        -> Operations.PromptThread.Output
+    {
+        throw StubUnimplemented("promptThread")
+    }
+
+    func getThreadTranscript(_ input: Operations.GetThreadTranscript.Input) async throws
+        -> Operations.GetThreadTranscript.Output
+    {
+        throw StubUnimplemented("getThreadTranscript")
+    }
+
+    func subscribeThreadEvents(_ input: Operations.SubscribeThreadEvents.Input) async throws
+        -> Operations.SubscribeThreadEvents.Output
+    {
+        throw StubUnimplemented("subscribeThreadEvents")
+    }
+
+    func interruptThread(_ input: Operations.InterruptThread.Input) async throws
+        -> Operations.InterruptThread.Output
+    {
+        throw StubUnimplemented("interruptThread")
+    }
+
+    func listThreadRequests(_ input: Operations.ListThreadRequests.Input) async throws
+        -> Operations.ListThreadRequests.Output
+    {
+        throw StubUnimplemented("listThreadRequests")
+    }
+
+    func answerThreadRequest(_ input: Operations.AnswerThreadRequest.Input) async throws
+        -> Operations.AnswerThreadRequest.Output
+    {
+        throw StubUnimplemented("answerThreadRequest")
+    }
+
+    func listThreadQueue(_ input: Operations.ListThreadQueue.Input) async throws
+        -> Operations.ListThreadQueue.Output
+    {
+        throw StubUnimplemented("listThreadQueue")
+    }
+
+    func deleteQueuedPrompt(_ input: Operations.DeleteQueuedPrompt.Input) async throws
+        -> Operations.DeleteQueuedPrompt.Output
+    {
+        throw StubUnimplemented("deleteQueuedPrompt")
+    }
+
     // MARK: - Private
 
     private func gate() async throws {


### PR DESCRIPTION
PR 3 of 3 for ATC-193 (server-side Thread runtime). Sub-issue: ATC-200. **Stacked on #206** (base = its branch), which is stacked on #205.

## What

- **Contract** (`contract.ts`): `promptThread`, `getThreadTranscript` (`before`, `limit` 1–200), `subscribeThreadEvents` (`after=seq`), `interruptThread`, `listThreadRequests`, `answerThreadRequest`, `listThreadQueue`, `deleteQueuedPrompt`, plus `PromptThreadRequest`/`PromptThreadResponse`. Query integers are strict decimal strings on the wire (`integerParam`). Operation ids pinned; `openapi.json` regenerated (`contract:check` green: TS + Swift client, 45 kit tests).
- **Handlers**: pure delegation to `ThreadRuntime`; one shared data-only SSE response. The per-thread stream rides a new heartbeat-only `Events.heartbeats()` feed (no coupling to the resource-event queues) and ends when `Events` closes — the same shutdown ordering `/events` has.
- **OpenAPI** (`openapi.ts`): the SSE response rewrite is table-driven over both stream endpoints (`ThreadEventJsonEncoding` documented as the frame payload; `ThreadEvent` is a discriminated `oneOf`).
- **CLI** (`atc thread …`): `prompt <id> <text> [--follow]` (follow mode = a pure `ThreadEvent` JSON-lines stream until this prompt's turn ends; subscribe-before-prompt so nothing is missed), `follow <id> [--after N]`, `interrupt`, `transcript [--limit] [--before]`, `requests`, `answer <id> <requestId> --decision … | --answers <json|->` (mutually exclusive; `-` reads stdin so secret answers never sit in argv), `queue`. Everything else stays `atc api`.
- **Tests**: openapi cases for every new path + the per-thread SSE bytes pin; `test/api/threadEvents.test.ts` — the two-client proof on a real listener (one plain loopback, one with a non-loopback `Host` + bearer token) seeing identical, seq-ordered event streams with a prompt from either; CLI black-box reads; and an **opt-in full-stack smoke** (`test:smoke`): real `atc serve` + `atc thread prompt --follow` against real Claude Code — run locally, passes (~5s).

## Deviations from the issue's table (all additive)

- `promptThread` errors omit `DirectoryUnavailable`/`DirectoryCheckTimedOut` (the runtime never checks directories at prompt time); `interruptThread` and `answerThreadRequest` add `ProviderUnavailable` (a provider that refuses the control call).
- No `reread` route: re-reads are internal triggers (startup, observed idle, failed connection).

- **macOS**: the two Swift `APIProtocol` conformers (`PreviewAppServerClient`, `ScriptableAppServerClient`) gained stubs for the eight new operations so the app builds; no macOS UI (ATC-191).

## Verification

`mise run -C app-server check` (453 tests), `mise run kit:test`, `mise run app-server:openapi` (no drift), the opt-in smoke. Two adversarial Codex reviews (correctness, simplicity) run and acted on.

https://claude.ai/code/session_01YA92SLZgoV2UGJuSHSm19n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added thread prompting with streamed events, transcript retrieval, interruption, and live event following.
  - Added management for pending approval or question requests, including answering and validation.
  - Added thread queue inspection and queued-prompt deletion.
  - Expanded the thread CLI with commands for prompting, transcripts, events, interruptions, requests, and queues.
  - Improved event streaming with heartbeats, replay support, and consistent SSE responses.
- **Bug Fixes**
  - Improved subscription cleanup and event delivery reliability during disconnects and shutdowns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->