### PR TITLE
Auto-name threads whose first turn is native (ATC-202)

### DIFF
--- a/app-server/src/server.ts
+++ b/app-server/src/server.ts
@@ -23,6 +23,7 @@ import * as Projects from "./projects/projects.ts"
 import * as TerminalRepository from "./terminals/terminalRepository.ts"
 import * as Terminals from "./terminals/terminals.ts"
 import * as ThreadRepository from "./threads/threadRepository.ts"
+import * as ThreadNaming from "./threads/threadNaming.ts"
 import * as ThreadRuntime from "./threads/threadRuntime.ts"
 import * as Threads from "./threads/threads.ts"
 import * as TranscriptRepository from "./threads/transcriptRepository.ts"
@@ -131,10 +132,12 @@ export const production = (options: { readonly port: number; readonly hostname?:
     Layer.provideMerge(Tailscale.layer),
     // Projects sits above Threads (its delete cascades through them), which
     // sits above the ThreadRuntime (activity ledger, transcript, turns) and
-    // Terminals — each provide feeds everything composed so far.
+    // Terminals; ThreadNaming serves both Threads and the runtime — each
+    // provide feeds everything composed so far.
     Layer.provide(Projects.layer),
     Layer.provide(Threads.layer),
     Layer.provide([Terminals.layer, ThreadRuntime.layer]),
+    Layer.provide(ThreadNaming.layer),
     Layer.provide(AgentRegistry.layer),
     // Below Terminals (the deepest publisher) so one memoized Events instance
     // serves every domain service, the handlers, and the shutdown drain.

--- a/app-server/src/threads/threadNaming.ts
+++ b/app-server/src/threads/threadNaming.ts
@@ -1,0 +1,305 @@
+import { Context, Deferred, Duration, Effect, Fiber, Layer, Option } from "effect"
+import { AgentRegistry } from "../agents/agentRegistry.ts"
+import type { AgentActivity, AgentAdapter } from "../agents/agentAdapter.ts"
+import { isBusyActivity, sanitizeTitle } from "../agents/agentAdapter.ts"
+import { isAgentId } from "../api/contract.ts"
+import { Events } from "../events/events.ts"
+import { ThreadRepository } from "./threadRepository.ts"
+import type { ThreadRecord } from "./threadRepository.ts"
+
+// Thread auto-naming (ATC-155) and title refinement (ATC-190): one flow for
+// every surface (ATC-202). Whichever surface takes a thread's first turn —
+// a TUI observed by threads.ts or a native turn the ThreadRuntime drives —
+// feeds the same three signals here (the first user prompt, the ledger's
+// activity transitions, the end of the evidence feed) and the result is
+// indistinguishable. Invariants:
+//
+//   - Eligibility: naming opens for a thread only on a record that is
+//     unnamed AND unconfirmed — the terminal observation's record at
+//     subscription start, the runtime's record as adopted for the first
+//     native turn (before that turn confirms it). Retro-naming is a
+//     non-goal, so a confirmed record never opens naming. Once open, the
+//     per-thread state outlives the surface that opened it, and every later
+//     signal on that thread — from any surface — feeds the same state. That
+//     is what makes "named once" hold across surfaces (a native first turn
+//     followed by a TUI turn) and across the Codex prompt discovery that
+//     lags busy.
+//   - The refinement is bound to the provider session it was armed on: a
+//     turn end or feed end reported for another session is ignored. An
+//     unconfirmed thread re-materializes (a native prompt replaces the TUI's
+//     idle session), and the superseded session's observation ending must
+//     not spend the live turn's refinement.
+//   - Auto-naming: the first prompt forks one fire-and-forget title
+//     generation through the adapter seam (verbatim prompt + cwd). A
+//     creation-time or manual name always wins — checked before the
+//     generation call and enforced atomically by the guarded rename — and
+//     every failure leaves the fallback name, silently.
+//   - Refinement: at most ONE bounded refinement per thread, from the
+//     conversation the primary agent naturally produces
+//     (collectTitleContext). Armed by the first busy evidence, it fires at
+//     the refine delay or the busy→idle turn end, whichever comes first,
+//     with one catch-up at turn end when the early collect found nothing
+//     usable. The guarded rename binds the first-pass title as its expected
+//     value (the seed), so a manual rename racing the refinement wins
+//     atomically and the guard is self-verifying. Every failure is silent —
+//     a thread never ends up worse than its first-pass name, and its name
+//     visibly changes at most once after the instant one.
+//   - State is in-memory only, kept until the thread is archived or
+//     deleted so a late signal on a spent thread stays inert: a restart
+//     forfeits a pending refinement, never a name.
+
+export interface ThreadNamingOptions {
+  /** How far into a thread's first turn the title refinement fires when
+   * the turn has not ended yet (ATC-190). */
+  readonly titleRefineDelay?: Duration.Input
+}
+
+export class ThreadNaming extends Context.Service<
+  ThreadNaming,
+  {
+    /** A user prompt seen on the thread, from any surface: the first one on
+     * an eligible thread names it; every later one is ignored. */
+    readonly notePrompt: (record: ThreadRecord, prompt: string) => Effect.Effect<void>
+    /** An activity transition from the runtime's ledger: the first busy arms
+     * the refinement, the busy→idle drop is the turn's end. */
+    readonly noteActivity: (
+      record: ThreadRecord,
+      previous: AgentActivity | undefined,
+      activity: AgentActivity,
+    ) => Effect.Effect<void>
+    /** The evidence feed for the record's session ended (its observation
+     * closed, its run was abandoned): a refinement armed on that session
+     * stops waiting for a turn end that will never be reported. */
+    readonly noteFeedEnded: (record: ThreadRecord) => Effect.Effect<void>
+    /** Drop the thread's naming state (archive/delete): a pending
+     * refinement is interrupted. */
+    readonly release: (id: string) => Effect.Effect<void>
+  }
+>()("app-server/ThreadNaming") {}
+
+export const layerWith = (options: ThreadNamingOptions) =>
+  Layer.effect(ThreadNaming)(
+    Effect.gen(function* () {
+      const repository = yield* ThreadRepository
+      const registry = yield* AgentRegistry
+      const events = yield* Events
+      // Naming fibers outlive whatever fired them (a closed terminal, a
+      // finished turn) but not the server.
+      const serviceScope = yield* Effect.scope
+      const titleRefineDelay = options.titleRefineDelay ?? "30 seconds"
+
+      interface NamingState {
+        /** First observed user prompt (best-effort; Codex discovery can lag
+         * busy and even a short turn's idle edge). */
+        prompt: string | null
+        /** The adopted first-pass title — the refinement's write guard. */
+        seed: string | null
+        /** The one refinement, once armed by the first busy evidence, and
+         * the provider session it was armed on (its turn-end evidence must
+         * come from that session). */
+        refinement: {
+          readonly session: string | undefined
+          readonly fiber: Fiber.Fiber<void>
+        } | null
+        /** Resolved when the first prompt lands. */
+        readonly promptArrived: Deferred.Deferred<void>
+        /** Resolved at the first busy→idle edge, or when the feed ends. */
+        readonly turnEnded: Deferred.Deferred<void>
+      }
+      const states = new Map<string, NamingState>()
+
+      const adapterFor = (record: ThreadRecord): AgentAdapter | undefined =>
+        isAgentId(record.agentId) ? registry.adapterFor(record.agentId) : undefined
+
+      const isBusy = isBusyActivity
+
+      /** Existing state wins whatever the record says; a fresh one opens
+       * only on an eligible record (the header's rule). */
+      const stateFor = (record: ThreadRecord): NamingState | undefined => {
+        const existing = states.get(record.id)
+        if (existing !== undefined) return existing
+        if (record.name !== undefined || record.confirmedAt !== undefined) return undefined
+        const created: NamingState = {
+          prompt: null,
+          seed: null,
+          refinement: null,
+          promptArrived: Deferred.makeUnsafe<void>(),
+          turnEnded: Deferred.makeUnsafe<void>(),
+        }
+        states.set(record.id, created)
+        return created
+      }
+
+      /**
+       * The auto-naming transition (ATC-155): one title one-shot through
+       * the adapter seam, adopted only while the thread is still unnamed
+       * (pre-checked here, enforced atomically by the guarded rename).
+       * Every failure logs and leaves the fallback name — a missing title
+       * is never an error, so the effect itself cannot fail.
+       */
+      const generateThreadTitle = (
+        record: ThreadRecord,
+        prompt: string,
+        naming: NamingState,
+      ): Effect.Effect<void> =>
+        Effect.gen(function* () {
+          const adapter = adapterFor(record)
+          if (adapter === undefined) return
+          // A rename that landed since the prompt was captured makes the
+          // generation pointless — skip the provider call, not just the
+          // write (T3Code semantics).
+          const current = yield* repository.get(record.id)
+          if (Option.isNone(current) || current.value.name !== undefined) return
+          const raw = yield* adapter.generateTitle({
+            cwd: record.workingDirectory,
+            prompt,
+          })
+          const title = sanitizeTitle(raw)
+          if (title === null) return
+          const renamed = yield* repository.renameIfUnchanged(record.id, title, null)
+          if (Option.isNone(renamed)) return
+          naming.seed = title
+          yield* events.publish({ resource: "thread", id: record.id, change: "updated" })
+        }).pipe(
+          Effect.catch((error) =>
+            Effect.logDebug("thread auto-naming failed").pipe(
+              Effect.annotateLogs({ threadId: record.id, reason: error.message }),
+            ),
+          ),
+        )
+
+      /**
+       * One refinement attempt (ATC-190): pre-check the seed guard, collect
+       * context through the adapter seam, rerun the titler, and write
+       * through the seed-guarded rename. "noPrompt" and "noContext" report
+       * which evidence was still missing (the caller may retry once);
+       * every other outcome — success, guard mismatch, unusable title —
+       * spends the refinement.
+       */
+      const attemptRefineTitle = (
+        record: ThreadRecord,
+        naming: NamingState,
+      ): Effect.Effect<"done" | "noPrompt" | "noContext", never, never> =>
+        Effect.gen(function* () {
+          const adapter = adapterFor(record)
+          const providerSessionId = record.providerSessionId
+          if (adapter === undefined || providerSessionId === undefined) return "done" as const
+          const prompt = naming.prompt
+          if (prompt === null) return "noPrompt" as const
+          const current = yield* repository.get(record.id)
+          if (Option.isNone(current)) return "done" as const
+          // The seed check: any name the server did not seed (manual or
+          // creation-time) already won. Both null means the first pass
+          // adopted nothing (or is still in flight) — the refinement may
+          // still name the thread, guarded exactly the same way.
+          const name = current.value.name ?? null
+          if (name !== naming.seed) return "done" as const
+          const context = yield* adapter.collectTitleContext({
+            providerSessionId,
+            cwd: record.workingDirectory,
+          })
+          if (context === null) return "noContext" as const
+          const raw = yield* adapter.generateTitle({
+            cwd: record.workingDirectory,
+            prompt,
+            refine: { context, currentTitle: name },
+          })
+          const title = sanitizeTitle(raw)
+          // An unchanged title is the instructed no-churn outcome: no
+          // write, no publish, and the refinement is still spent.
+          if (title === null || title === name) return "done" as const
+          const renamed = yield* repository.renameIfUnchanged(record.id, title, name)
+          if (Option.isNone(renamed)) return "done" as const
+          yield* events.publish({ resource: "thread", id: record.id, change: "updated" })
+          return "done" as const
+        }).pipe(
+          Effect.catch((error) =>
+            Effect.logDebug("thread title refinement failed").pipe(
+              Effect.annotateLogs({ threadId: record.id, reason: error.message }),
+              Effect.as("done" as const),
+            ),
+          ),
+        )
+
+      /**
+       * The one bounded title refinement (ATC-190): wait for the refine
+       * delay or the turn's end — whichever comes first — attempt, and
+       * catch up at most once when evidence was still missing. Missing
+       * CONTEXT retries at turn end (it accrues over the turn) and gives
+       * up silently when the turn already ended. A missing PROMPT is
+       * different: Codex discovers it by polling and it can lag even a
+       * short turn's idle edge, so the catch-up waits for its arrival —
+       * bounded by the turn's end or one more refine delay, so the fiber
+       * always ends. After the catch-up the thread is spent for good.
+       */
+      const refineThreadTitle = (record: ThreadRecord, naming: NamingState): Effect.Effect<void> =>
+        Effect.gen(function* () {
+          const trigger = yield* Effect.raceFirst(
+            Effect.sleep(titleRefineDelay).pipe(Effect.as("delay" as const)),
+            Deferred.await(naming.turnEnded).pipe(Effect.as("turnEnd" as const)),
+          )
+          const outcome = yield* attemptRefineTitle(record, naming)
+          if (outcome === "done") return
+          if (outcome === "noContext" && trigger === "turnEnd") return
+          yield* outcome === "noContext"
+            ? Deferred.await(naming.turnEnded)
+            : Effect.raceFirst(
+                Deferred.await(naming.promptArrived),
+                trigger === "turnEnd"
+                  ? Effect.sleep(titleRefineDelay)
+                  : Deferred.await(naming.turnEnded),
+              )
+          yield* attemptRefineTitle(record, naming)
+        })
+
+      /** Only an armed refinement waits on the turn's end (ending it early
+       * would pre-empt one not yet armed), and only its own session's end
+       * counts (the header's binding rule). */
+      const endTurn = (record: ThreadRecord): void => {
+        const state = states.get(record.id)
+        if (state?.refinement === null || state?.refinement === undefined) return
+        if (state.refinement.session !== record.providerSessionId) return
+        Deferred.doneUnsafe(state.turnEnded, Effect.void)
+      }
+
+      return {
+        notePrompt: (record, prompt) =>
+          Effect.gen(function* () {
+            const naming = stateFor(record)
+            if (naming === undefined || naming.prompt !== null) return
+            naming.prompt = prompt
+            yield* generateThreadTitle(record, prompt, naming).pipe(Effect.forkIn(serviceScope))
+            Deferred.doneUnsafe(naming.promptArrived, Effect.void)
+          }),
+        noteActivity: (record, previous, activity) =>
+          Effect.gen(function* () {
+            if (isBusy(activity)) {
+              // Armed even before the prompt is known (Codex prompt
+              // discovery lags busy) — the attempt reads the state at
+              // fire time. The arming record is the refinement's: it
+              // carries the session the context is collected from.
+              const naming = stateFor(record)
+              if (naming === undefined || naming.refinement !== null) return
+              const fiber = yield* refineThreadTitle(record, naming).pipe(
+                Effect.forkIn(serviceScope),
+              )
+              naming.refinement = { session: record.providerSessionId, fiber }
+              return
+            }
+            if (previous !== undefined && isBusy(previous) && activity === "idle") {
+              endTurn(record)
+            }
+          }),
+        noteFeedEnded: (record) => Effect.sync(() => endTurn(record)),
+        release: (id) =>
+          Effect.gen(function* () {
+            const state = states.get(id)
+            if (state === undefined) return
+            states.delete(id)
+            if (state.refinement !== null) yield* Fiber.interrupt(state.refinement.fiber)
+          }),
+      }
+    }),
+  )
+
+export const layer = layerWith({})

--- a/app-server/src/threads/threadRuntime.ts
+++ b/app-server/src/threads/threadRuntime.ts
@@ -35,6 +35,7 @@ import {
   ThreadNotFound,
 } from "../api/contract.ts"
 import { Events } from "../events/events.ts"
+import { ThreadNaming } from "./threadNaming.ts"
 import { ThreadRepository } from "./threadRepository.ts"
 import type { ThreadRecord } from "./threadRepository.ts"
 import { TranscriptRepository } from "./transcriptRepository.ts"
@@ -79,7 +80,9 @@ export type QueuedPrompt = typeof Contract.QueuedPrompt.Type
 //     (unread, ATC-160), and every transition publishes the thread as
 //     updated. Turn end forces idle — the connection is released, so no
 //     later evidence can arrive on it. While the runtime drives a thread,
-//     its ledger entry is authoritative and never re-derived.
+//     its ledger entry is authoritative and never re-derived. The ledger
+//     also feeds ThreadNaming every busy/idle edge, whichever surface
+//     produced it (ATC-202).
 //   - Startup: threads with a running turn re-read history (their status
 //     is whatever the provider says); a turn still running on a shared
 //     provider server (Codex) is reattached and followed to its end, any
@@ -175,7 +178,8 @@ export class ThreadRuntime extends Context.Service<
       record: ThreadRecord,
       activity: AgentActivity,
     ) => Effect.Effect<{ readonly previous: AgentActivity | undefined }>
-    /** Drop the ledger entry (an observation ended). */
+    /** Drop the ledger entry (an observation ended) — unless the runtime is
+     * driving the thread, whose own evidence stays authoritative. */
     readonly clearActivity: (id: string) => Effect.Effect<void>
     /** Record an item observed on a TUI-driven session (the shared-server fan-out). */
     readonly recordObserved: (record: ThreadRecord, event: AgentItemEvent) => Effect.Effect<void>
@@ -194,6 +198,7 @@ export const layer = Layer.effect(ThreadRuntime)(
     const transcripts = yield* TranscriptRepository
     const registry = yield* AgentRegistry
     const events = yield* Events
+    const naming = yield* ThreadNaming
     // Runs and their drain fibers outlive their originating requests; they
     // live in the service scope so shutdown releases every connection.
     const serviceScope = yield* Effect.scope
@@ -333,6 +338,7 @@ export const layer = Layer.effect(ThreadRuntime)(
         if (previous !== undefined && isBusy(previous) && activity === "idle") {
           yield* repository.markFinished(record.id)
         }
+        yield* naming.noteActivity(record, previous, activity)
         if (previous !== activity) {
           yield* events.publish({ resource: "thread", id: record.id, change: "updated" })
         }
@@ -472,6 +478,7 @@ export const layer = Layer.effect(ThreadRuntime)(
         run.finished = true
         closeRequests(record.id, run)
         yield* noteActivity(record, "unknown")
+        yield* naming.noteFeedEnded(record)
         yield* Effect.logWarning("the turn's connection failed; re-reading provider history").pipe(
           Effect.annotateLogs({ threadId: record.id, turnId: run.turnId, reason }),
         )
@@ -583,6 +590,10 @@ export const layer = Layer.effect(ThreadRuntime)(
               exit._tag === "Failure" ? Scope.close(scope, Exit.void) : Effect.void,
             ),
           )
+          // The adopted record predates this turn's confirm (a fresh
+          // session is unconfirmed by construction), which is what makes a
+          // native first prompt eligible for naming (ATC-202).
+          yield* naming.notePrompt(started.record, next.value.prompt)
           const turnId = started.turn.turnId
           const turn: ThreadTurn = {
             id: turnId,
@@ -892,6 +903,7 @@ export const layer = Layer.effect(ThreadRuntime)(
       noteActivity,
       clearActivity: (id) =>
         Effect.sync(() => {
+          if (runs.has(id)) return
           liveActivity.delete(id)
           nativeBusy.delete(id)
         }),

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -1,6 +1,5 @@
 import {
   Context,
-  Deferred,
   Duration,
   Effect,
   Exit,
@@ -23,11 +22,7 @@ import type {
   AgentUnavailable,
   TuiLaunchSpec,
 } from "../agents/agentAdapter.ts"
-import {
-  isBusyActivity,
-  NESTED_SESSION_ENV_VARIABLES,
-  sanitizeTitle,
-} from "../agents/agentAdapter.ts"
+import { isBusyActivity, NESTED_SESSION_ENV_VARIABLES } from "../agents/agentAdapter.ts"
 import {
   isAgentId,
   ProviderSessionConflict,
@@ -50,6 +45,7 @@ import { Directories } from "../platform/directories.ts"
 import { ProjectRepository } from "../projects/projectRepository.ts"
 import { Terminals } from "../terminals/terminals.ts"
 import type { Terminal } from "../terminals/terminals.ts"
+import { ThreadNaming } from "./threadNaming.ts"
 import { ThreadRepository } from "./threadRepository.ts"
 import type { ThreadRecord } from "./threadRepository.ts"
 import { ThreadRuntime } from "./threadRuntime.ts"
@@ -99,24 +95,9 @@ export type Thread = typeof Contract.Thread.Type
 //     TUI-driven Codex thread) feed the runtime's transcript copy, and an
 //     observed busy→idle asks the runtime to re-read the provider's
 //     history — the copy for turns ATC did not drive.
-//   - Auto-naming (ATC-155): the first user prompt observed on a thread
-//     that was unnamed AND unconfirmed when its subscription started forks
-//     one fire-and-forget title generation through the adapter seam. A
-//     creation-time or manual name always wins — checked before the
-//     generation call and enforced atomically by the guarded rename — and
-//     every failure leaves the fallback name, silently.
-//   - Title refinement (ATC-190): each auto-name-eligible thread gets at
-//     most ONE bounded refinement, from the conversation the primary agent
-//     naturally produces (collectTitleContext). Armed by the first busy
-//     evidence on the subscription, it fires at the refine delay or the
-//     busy→idle turn end, whichever comes first, with one catch-up at turn
-//     end when the early collect found nothing usable. The guarded rename
-//     binds the first-pass title as its expected value (the seed), so a
-//     manual rename racing the refinement wins atomically and the guard is
-//     self-verifying; a restart between the passes loses the seed and the
-//     refinement simply does not happen. Every failure is silent — a
-//     thread never ends up worse than its first-pass name, and its name
-//     visibly changes at most once after the instant one.
+//   - Auto-naming lives in ThreadNaming (ATC-155/190/202); the drain feeds
+//     it observed user prompts and its feed's end, judged on the record at
+//     subscription start.
 //   - archived threads are never pinned: pin refuses archived records, and
 //     archive clears the pin in the same repository write so no client can
 //     observe or restore an archived pin.
@@ -146,9 +127,6 @@ export interface ThreadsOptions {
   /** Initial delay before the identity wait's first TUI-liveness check;
    * subsequent checks back off from it (see watchForEarlyDeath). */
   readonly launchWatchInterval?: Duration.Input
-  /** How far into a thread's first turn the title refinement fires when
-   * the turn has not ended yet (ATC-190). */
-  readonly titleRefineDelay?: Duration.Input
 }
 
 export class Threads extends Context.Service<
@@ -213,12 +191,12 @@ export const layerWith = (options: ThreadsOptions) =>
       const registry = yield* AgentRegistry
       const events = yield* Events
       const runtime = yield* ThreadRuntime
+      const naming = yield* ThreadNaming
       // Observation fibers outlive their originating requests; they live in
       // the service's own scope so shutdown reaps every subscription.
       const serviceScope = yield* Effect.scope
       const identityTimeout = options.identityTimeout ?? "30 seconds"
       const launchWatchInterval = options.launchWatchInterval ?? "500 millis"
-      const titleRefineDelay = options.titleRefineDelay ?? "30 seconds"
 
       /** The observed session per thread; the child scope closes it. */
       interface Observation {
@@ -262,147 +240,6 @@ export const layerWith = (options: ThreadsOptions) =>
         record.archivedAt === undefined &&
         record.lastFinishedAt !== undefined &&
         (record.lastViewedAt === undefined || record.lastViewedAt < record.lastFinishedAt)
-
-      /**
-       * Per-observation naming state (ATC-155/ATC-190), shared between the
-       * drain loop and the fire-and-forget naming fibers. In-memory only —
-       * a restart forfeits the pending refinement, never a name.
-       */
-      interface NamingState {
-        /** First observed user prompt (best-effort; Codex discovery can lag
-         * busy and even a short turn's idle edge). */
-        prompt: string | null
-        /** The adopted first-pass title — the refinement's write guard. */
-        seed: string | null
-        /** The one refinement fiber is armed (first busy evidence seen). */
-        armed: boolean
-        /** Resolved when the first prompt lands. */
-        readonly promptArrived: Deferred.Deferred<void>
-        /** Resolved at the first busy→idle edge, or when observation ends. */
-        readonly turnEnded: Deferred.Deferred<void>
-      }
-
-      /**
-       * The auto-naming transition (ATC-155): one title one-shot through
-       * the adapter seam, adopted only while the thread is still unnamed
-       * (pre-checked here, enforced atomically by the guarded rename).
-       * Every failure logs and leaves the fallback name — a missing title
-       * is never an error, so the effect itself cannot fail.
-       */
-      const generateThreadTitle = (
-        record: ThreadRecord,
-        prompt: string,
-        naming: NamingState,
-      ): Effect.Effect<void> =>
-        Effect.gen(function* () {
-          const adapter = adapterFor(record)
-          if (adapter === undefined) return
-          // A rename that landed since the prompt was captured makes the
-          // generation pointless — skip the provider call, not just the
-          // write (T3Code semantics).
-          const current = yield* repository.get(record.id)
-          if (Option.isNone(current) || current.value.name !== undefined) return
-          const raw = yield* adapter.generateTitle({
-            cwd: record.workingDirectory,
-            prompt,
-          })
-          const title = sanitizeTitle(raw)
-          if (title === null) return
-          const renamed = yield* repository.renameIfUnchanged(record.id, title, null)
-          if (Option.isNone(renamed)) return
-          naming.seed = title
-          yield* events.publish({ resource: "thread", id: record.id, change: "updated" })
-        }).pipe(
-          Effect.catch((error) =>
-            Effect.logDebug("thread auto-naming failed").pipe(
-              Effect.annotateLogs({ threadId: record.id, reason: error.message }),
-            ),
-          ),
-        )
-
-      /**
-       * One refinement attempt (ATC-190): pre-check the seed guard, collect
-       * context through the adapter seam, rerun the titler, and write
-       * through the seed-guarded rename. "noPrompt" and "noContext" report
-       * which evidence was still missing (the caller may retry once);
-       * every other outcome — success, guard mismatch, unusable title —
-       * spends the refinement.
-       */
-      const attemptRefineTitle = (
-        record: ThreadRecord,
-        naming: NamingState,
-      ): Effect.Effect<"done" | "noPrompt" | "noContext", never, never> =>
-        Effect.gen(function* () {
-          const adapter = adapterFor(record)
-          const providerSessionId = record.providerSessionId
-          if (adapter === undefined || providerSessionId === undefined) return "done" as const
-          const prompt = naming.prompt
-          if (prompt === null) return "noPrompt" as const
-          const current = yield* repository.get(record.id)
-          if (Option.isNone(current)) return "done" as const
-          // The seed check: any name the server did not seed (manual or
-          // creation-time) already won. Both null means the first pass
-          // adopted nothing (or is still in flight) — the refinement may
-          // still name the thread, guarded exactly the same way.
-          const name = current.value.name ?? null
-          if (name !== naming.seed) return "done" as const
-          const context = yield* adapter.collectTitleContext({
-            providerSessionId,
-            cwd: record.workingDirectory,
-          })
-          if (context === null) return "noContext" as const
-          const raw = yield* adapter.generateTitle({
-            cwd: record.workingDirectory,
-            prompt,
-            refine: { context, currentTitle: name },
-          })
-          const title = sanitizeTitle(raw)
-          // An unchanged title is the instructed no-churn outcome: no
-          // write, no publish, and the refinement is still spent.
-          if (title === null || title === name) return "done" as const
-          const renamed = yield* repository.renameIfUnchanged(record.id, title, name)
-          if (Option.isNone(renamed)) return "done" as const
-          yield* events.publish({ resource: "thread", id: record.id, change: "updated" })
-          return "done" as const
-        }).pipe(
-          Effect.catch((error) =>
-            Effect.logDebug("thread title refinement failed").pipe(
-              Effect.annotateLogs({ threadId: record.id, reason: error.message }),
-              Effect.as("done" as const),
-            ),
-          ),
-        )
-
-      /**
-       * The one bounded title refinement (ATC-190): wait for the refine
-       * delay or the turn's end — whichever comes first — attempt, and
-       * catch up at most once when evidence was still missing. Missing
-       * CONTEXT retries at turn end (it accrues over the turn) and gives
-       * up silently when the turn already ended. A missing PROMPT is
-       * different: Codex discovers it by polling and it can lag even a
-       * short turn's idle edge, so the catch-up waits for its arrival —
-       * bounded by the turn's end or one more refine delay, so the fiber
-       * always ends. After the catch-up the thread is spent for good.
-       */
-      const refineThreadTitle = (record: ThreadRecord, naming: NamingState): Effect.Effect<void> =>
-        Effect.gen(function* () {
-          const trigger = yield* Effect.raceFirst(
-            Effect.sleep(titleRefineDelay).pipe(Effect.as("delay" as const)),
-            Deferred.await(naming.turnEnded).pipe(Effect.as("turnEnd" as const)),
-          )
-          const outcome = yield* attemptRefineTitle(record, naming)
-          if (outcome === "done") return
-          if (outcome === "noContext" && trigger === "turnEnd") return
-          yield* outcome === "noContext"
-            ? Deferred.await(naming.turnEnded)
-            : Effect.raceFirst(
-                Deferred.await(naming.promptArrived),
-                trigger === "turnEnd"
-                  ? Effect.sleep(titleRefineDelay)
-                  : Deferred.await(naming.turnEnded),
-              )
-          yield* attemptRefineTitle(record, naming)
-        })
 
       /**
        * Start (once) the thread's normalized activity subscription. The
@@ -451,32 +288,11 @@ export const layerWith = (options: ThreadsOptions) =>
                 ),
                 Scope.provide(child),
               )
-            // Auto-name eligibility is fixed at subscription start: a name
-            // or a confirmed first turn already on the record rules the
-            // thread out (retro-naming is a non-goal), and the first prompt
-            // event spends the one attempt (`naming.prompt` set). The same
-            // eligibility governs the refinement (ATC-190).
-            const eligible = record.name === undefined && record.confirmedAt === undefined
-            const naming: NamingState = {
-              prompt: null,
-              seed: null,
-              armed: false,
-              promptArrived: Deferred.makeUnsafe<void>(),
-              turnEnded: Deferred.makeUnsafe<void>(),
-            }
             yield* stream.pipe(
               Stream.runForEach((event) =>
                 Effect.gen(function* () {
                   if (event.type === "userPrompt") {
-                    if (!eligible || naming.prompt !== null) return
-                    naming.prompt = event.text
-                    // Fire-and-forget in the SERVICE scope: the generation
-                    // outlives observation churn (a closed terminal) but
-                    // not the server.
-                    yield* generateThreadTitle(record, event.text, naming).pipe(
-                      Effect.forkIn(serviceScope),
-                    )
-                    Deferred.doneUnsafe(naming.promptArrived, Effect.void)
+                    yield* naming.notePrompt(record, event.text)
                     return
                   }
                   // Conversation items observed on the shared server feed
@@ -488,21 +304,11 @@ export const layerWith = (options: ThreadsOptions) =>
                   const activity = event.activity
                   // The ledger applies the confirm / finish / publish rules.
                   const { previous } = yield* runtime.noteActivity(record, activity)
-                  // The first busy evidence arms the one refinement fiber
-                  // (ATC-190), in the service scope for the same reason as
-                  // the generation above. Armed even before the prompt is
-                  // known (Codex prompt discovery lags busy) — the attempt
-                  // reads the state at fire time.
-                  if (eligible && !naming.armed && isBusy(activity)) {
-                    naming.armed = true
-                    yield* refineThreadTitle(record, naming).pipe(Effect.forkIn(serviceScope))
-                  }
-                  // The busy→idle drop is the turn's end: the refinement's
-                  // trigger, and — for a turn ATC did not drive — the moment
-                  // to re-read the provider's history (forked: the drain
-                  // must never wait on the provider).
+                  // The busy→idle drop is the turn's end — for a turn ATC
+                  // did not drive, the moment to re-read the provider's
+                  // history (forked: the drain must never wait on the
+                  // provider).
                   if (previous !== undefined && isBusy(previous) && activity === "idle") {
-                    Deferred.doneUnsafe(naming.turnEnded, Effect.void)
                     yield* runtime.observedIdle(record).pipe(Effect.forkIn(serviceScope))
                   }
                 }),
@@ -512,11 +318,7 @@ export const layerWith = (options: ThreadsOptions) =>
               // nor leak its child scope into the service scope. An ended
               // observation also ends the refinement's wait — its turn-end
               // evidence is gone, so the catch-up must not park forever.
-              Effect.ensuring(
-                Effect.sync(() => Deferred.doneUnsafe(naming.turnEnded, Effect.void)).pipe(
-                  Effect.andThen(releaseClaim),
-                ),
-              ),
+              Effect.ensuring(naming.noteFeedEnded(record).pipe(Effect.andThen(releaseClaim))),
               Effect.forkIn(child),
             )
           }).pipe(
@@ -942,6 +744,7 @@ export const layerWith = (options: ThreadsOptions) =>
                 .pipe(Effect.catchTag("TerminalNotFound", () => Effect.void))
             }
             yield* runtime.release(id)
+            yield* naming.release(id)
             const adapter = adapterFor(record)
             if (adapter !== undefined && record.providerSessionId !== undefined) {
               yield* adapter.releaseSession({
@@ -1056,6 +859,7 @@ export const layerWith = (options: ThreadsOptions) =>
               // observation. The provider conversation itself is untouched,
               // so unarchive + open resumes it exactly.
               yield* runtime.release(id)
+              yield* naming.release(id)
               const adapter = adapterFor(record)
               if (adapter !== undefined && record.providerSessionId !== undefined) {
                 yield* adapter.releaseSession({

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -24,6 +24,7 @@ import type { TerminalAdapter } from "../src/terminals/terminalAdapter.ts"
 import * as TerminalRepository from "../src/terminals/terminalRepository.ts"
 import * as Terminals from "../src/terminals/terminals.ts"
 import * as ThreadRepository from "../src/threads/threadRepository.ts"
+import * as ThreadNaming from "../src/threads/threadNaming.ts"
 import * as ThreadRuntime from "../src/threads/threadRuntime.ts"
 import * as TranscriptRepository from "../src/threads/transcriptRepository.ts"
 import * as Threads from "../src/threads/threads.ts"
@@ -102,7 +103,7 @@ export const testAppConfig = (overrides: Partial<AppConfig["Service"]>): Layer.L
  */
 export const makeTestServiceLayers = (
   dbFile = ":memory:",
-  threadsOptions: Threads.ThreadsOptions = {},
+  threadOptions: Threads.ThreadsOptions & ThreadNaming.ThreadNamingOptions = {},
   eventsOptions: Events.EventsOptions = {},
   configOverrides: Partial<AppConfig["Service"]> = {},
   tailscaleStatus: Tailscale.TailscaleStatus = { state: "disabled" },
@@ -155,9 +156,12 @@ export const makeTestServiceLayers = (
       Subprocess.layer.pipe(Layer.provide(BunServices.layer)),
     ]),
   )
-  const runtime = ThreadRuntime.layer.pipe(Layer.provide([services, registry, eventsLayer]))
-  const threads = Threads.layerWith(threadsOptions).pipe(
-    Layer.provide([services, terminals, registry, eventsLayer, runtime]),
+  const naming = ThreadNaming.layerWith(threadOptions).pipe(
+    Layer.provide([services, registry, eventsLayer]),
+  )
+  const runtime = ThreadRuntime.layer.pipe(Layer.provide([services, registry, eventsLayer, naming]))
+  const threads = Threads.layerWith(threadOptions).pipe(
+    Layer.provide([services, terminals, registry, eventsLayer, runtime, naming]),
   )
   return {
     fake,

--- a/app-server/test/threads/threadTitle.test.ts
+++ b/app-server/test/threads/threadTitle.test.ts
@@ -13,7 +13,8 @@ import { apiTestLayer, eventually, makeTestServiceLayers } from "../testLayers.t
 // Auto-naming (ATC-155) through the uniform seam contract: the first user
 // prompt observed on an unnamed, unconfirmed thread titles it via the
 // adapter's generateTitle one-shot, and a creation-time or manual name
-// always wins. All through the fake adapters — no provider knowledge.
+// always wins. A first turn driven natively (ATC-202) is named exactly the
+// same way. All through the fake adapters — no provider knowledge.
 
 const kit = makeTestServiceLayers()
 const TestLayer = apiTestLayer(kit)
@@ -40,6 +41,23 @@ const openedThread = (name?: string) =>
     const record = Option.getOrThrow(yield* repository.get(thread.id))
     return { client, threadId: thread.id, sessionId: record.providerSessionId ?? "" }
   })
+
+/** One unnamed thread with no terminal: its first turn will be native. */
+const nativeThread = Effect.gen(function* () {
+  const client = yield* HttpApiTest.groups(Api, ["v1"])
+  const repository = yield* ThreadRepository
+  const project = yield* client.v1.createProject({
+    payload: { name: `Title native ${Date.now()}`, defaultWorkingDirectory: realDir },
+  })
+  const thread = yield* client.v1.createThread({
+    payload: { projectId: project.id, agentId: "codex" },
+  })
+  /** The provider session the runtime adopted for the thread. */
+  const readSessionId = repository
+    .get(thread.id)
+    .pipe(Effect.map((record) => Option.getOrThrow(record).providerSessionId ?? ""))
+  return { client, threadId: thread.id, readSessionId }
+})
 
 describe("thread auto-naming", () => {
   it.live("titles an unnamed thread from its first prompt, once, and publishes", () =>
@@ -95,6 +113,96 @@ describe("thread auto-naming", () => {
         yield* client.v1.deleteThread({ params: { threadId } })
       }),
     ).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.live("titles a thread whose first turn is native from its prompt, once", () =>
+    Effect.gen(function* () {
+      const fake = kit.fakeAgents.codex
+      const { client, threadId, readSessionId } = yield* nativeThread
+      const requestsBefore = fake.titleRequests.length
+      fake.setTitle('  "Add dark mode to settings."  ')
+
+      const started = yield* client.v1.promptThread({
+        params: { threadId },
+        payload: { prompt: "please add dark mode to the settings page" },
+      })
+      assert.isString(started.turnId)
+      yield* eventually(
+        client.v1.getThread({ params: { threadId } }),
+        (read) => read.name === "Add dark mode to settings",
+      )
+      // The generation saw the thread's cwd and the verbatim prompt — the
+      // surface that started the thread is invisible in the request.
+      assert.deepStrictEqual(fake.titleRequests[requestsBefore], {
+        cwd: realDir,
+        prompt: "please add dark mode to the settings page",
+      })
+
+      // A later native prompt on the (now confirmed) thread never re-titles.
+      fake.completeTurn(yield* readSessionId, "completed")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId } }),
+        (read) => read.activityState === "idle",
+      )
+      const second = yield* client.v1.promptThread({
+        params: { threadId },
+        payload: { prompt: "now remove it again" },
+      })
+      assert.isString(second.turnId)
+      assert.strictEqual(fake.titleRequests.length, requestsBefore + 1)
+
+      fake.completeTurn(yield* readSessionId, "completed")
+      yield* client.v1.deleteThread({ params: { threadId } })
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.live("a native first turn followed by a TUI turn names the thread once, not twice", () =>
+    Effect.gen(function* () {
+      const fake = kit.fakeAgents.codex
+      const { client, threadId, readSessionId } = yield* nativeThread
+      const requestsBefore = fake.titleRequests.length
+      const contextsBefore = fake.contextRequests.length
+      fake.setTitle("Native first")
+
+      yield* client.v1.promptThread({
+        params: { threadId },
+        payload: { prompt: "first, natively" },
+      })
+      yield* eventually(
+        client.v1.getThread({ params: { threadId } }),
+        (read) => read.name === "Native first",
+      )
+      // The native turn ends: its one refinement collects (nothing usable
+      // here) and is spent.
+      const providerSessionId = yield* readSessionId
+      fake.completeTurn(providerSessionId, "completed")
+      yield* eventually(
+        Effect.sync(() => fake.contextRequests.length),
+        (count) => count === contextsBefore + 1,
+      )
+
+      // The second turn runs in the TUI over the same, now confirmed,
+      // session: neither its prompt nor its busy/idle edges may name or
+      // refine again.
+      yield* client.v1.openThreadTerminal({ params: { threadId } })
+      fake.emitUserPrompt(providerSessionId, "second, in the TUI")
+      fake.emitActivity(providerSessionId, "working")
+      fake.emitActivity(providerSessionId, "idle")
+      // Barrier: a later event observed proves the edges were consumed.
+      fake.emitActivity(providerSessionId, "working")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId } }),
+        (read) => read.activityState === "working",
+      )
+      assert.strictEqual(fake.titleRequests.length, requestsBefore + 1)
+      assert.strictEqual(fake.contextRequests.length, contextsBefore + 1)
+      assert.strictEqual(
+        (yield* client.v1.getThread({ params: { threadId } })).name,
+        "Native first",
+      )
+
+      yield* client.v1.deleteThread({ params: { threadId } })
+    }).pipe(Effect.provide(TestLayer)),
   )
 
   it.live("a creation-time name suppresses generation and refinement entirely", () =>

--- a/app-server/test/threads/threadTitleRefine.test.ts
+++ b/app-server/test/threads/threadTitleRefine.test.ts
@@ -121,6 +121,54 @@ describe("thread title refinement", () => {
     }).pipe(Effect.provide(SlowLayer)),
   )
 
+  it.live("a superseded session's observation ending never spends a native turn's refinement", () =>
+    Effect.gen(function* () {
+      const fake = slowKit.fakeAgents.codex
+      const repository = yield* ThreadRepository
+      // A TUI is open on an idle, unconfirmed session A (ATC-202's likely
+      // shape: opened in TUI, first prompt sent from Chat).
+      const { client, threadId, sessionId: sessionA } = yield* openedThread()
+      const contextsBefore = fake.contextRequests.length
+      // A's observation is live: its idle is what the thread reads.
+      fake.emitActivity(sessionA, "idle")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId } }),
+        (read) => read.activityState === "idle",
+      )
+
+      fake.setTitle("Native title")
+      const started = yield* client.v1.promptThread({
+        params: { threadId },
+        payload: { prompt: "first prompt, natively" },
+      })
+      assert.isString(started.turnId)
+      yield* eventually(
+        client.v1.getThread({ params: { threadId } }),
+        (read) => read.name === "Native title",
+      )
+      // The prompt re-materialized the thread as a fresh session B; the read
+      // above swapped the observation, ending A's feed. That end belongs to
+      // A — B's refinement, armed on B, must keep waiting for B's turn end.
+      const sessionB = Option.getOrThrow(yield* repository.get(threadId)).providerSessionId ?? ""
+      assert.notStrictEqual(sessionB, sessionA)
+      yield* eventually(
+        Effect.sync(() => fake.observerCount(sessionA)),
+        (count) => count === 0,
+      )
+
+      fake.setTitleContext(sessionB, "assistant: did the native work")
+      fake.setTitle("Native title refined")
+      fake.completeTurn(sessionB, "completed")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId } }),
+        (read) => read.name === "Native title refined",
+      )
+      assert.strictEqual(fake.contextRequests.length, contextsBefore + 1)
+
+      yield* client.v1.deleteThread({ params: { threadId } })
+    }).pipe(Effect.provide(SlowLayer)),
+  )
+
   it.live("an empty early collect gets exactly one catch-up at turn end", () =>
     Effect.gen(function* () {
       const fake = fastKit.fakeAgents.codex


### PR DESCRIPTION
Closes ATC-202 — https://linear.app/elevenideas/issue/ATC-202

## What

A thread whose first turn is driven natively (`POST /threads/:id/prompt`) is now auto-named and refined exactly like one whose first turn ran in its TUI. Same eligibility (unnamed AND unconfirmed when the first prompt is seen), same one-shot rules, same silent failures — the surface that started the thread is invisible in the result. This unblocks ATC-191 (Chat as the default view for new threads).

## How

- **New `threads/threadNaming.ts` (`ThreadNaming` service)** — the ATC-155/ATC-190 flow moved out of `threads.ts` verbatim (generation, refinement, seed-guarded rename), now with **per-thread** naming state instead of per-observation. Seams: `notePrompt` (a user prompt seen on any surface), `noteActivity` (busy/idle edges), `noteFeedEnded` (a session's observation closed / run abandoned), `release` (archive/delete: drop state, interrupt a pending refinement).
- **`threadRuntime.ts`** — the activity ledger (already the one place both the observation drain and native turns reach) forwards every transition to `ThreadNaming`, so the first busy arms the refinement and the busy→idle drop ends it for both paths. The native turn start reports its prompt on the adopted record — unconfirmed by construction for a fresh session, so eligibility is judged before the confirm; a resumed (confirmed) session is ineligible. `abandon` reports the feed's end. `clearActivity` now leaves the ledger alone while the runtime drives the thread (its header already promised that entry is authoritative; an observation swap mid-native-turn used to drop it).
- **`threads.ts`** — the observation drain now just reports observed prompts and its feed's end; archive/delete call `naming.release`. The arm/turn-end logic and `titleRefineDelay` option moved with the flow.
- **Layers** — `ThreadNaming` sits below `Threads` and `ThreadRuntime` in `server.ts` and `testLayers.ts` (one shared instance).

Per-thread state is what makes "named once" hold across surfaces: a native first turn followed by a TUI turn, or a Codex prompt discovered after busy, all feed the same entry. The refinement is **bound to the session it was armed on**: when a native prompt re-materializes an unconfirmed thread (TUI opened, nothing typed, first prompt from Chat), the superseded session's observation ending no longer spends the live turn's refinement — an adversarial review caught this; it's the likely ATC-191 shape.

## Tests

- `test/threads/threadTitle.test.ts`: native first prompt names the thread (verbatim prompt + cwd through the adapter seam) and a later native prompt never re-titles; native first turn + TUI second turn ⇒ named once, refined once.
- `test/threads/threadTitleRefine.test.ts`: a superseded session's observation ending never spends a native turn's refinement.

Each fails without its fix and passes with it. `mise run -C app-server check` is green (457 tests). No contract change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic thread titles for native conversations based on the initial prompt.
  * Added one-time title refinement using conversation context.
  * Preserves manually assigned or creation-time titles.
  * Publishes updated titles across supported surfaces.

* **Bug Fixes**
  * Prevented duplicate naming or refinement after subsequent activity.
  * Improved handling of incomplete context, abandoned conversations, and replaced sessions.
  * Ensured refinement occurs only after the relevant native conversation ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->