### PR TITLE
macOS Chat mode: native thread transcript, composer, requests, queue (ATC-191)

### DIFF
--- a/macos/ATC/AppCommands.swift
+++ b/macos/ATC/AppCommands.swift
@@ -54,6 +54,7 @@ struct AppCommands: Commands {
 
         CommandGroup(after: .sidebar) {
             commandButton(.toggleSidebar)
+            commandButton(.toggleThreadViewMode)
             commandButton(.showDashboard)
             commandButton(.refresh, appScoped: true)
             commandButton(.toggleCommandPalette)

--- a/macos/ATC/AppModel.swift
+++ b/macos/ATC/AppModel.swift
@@ -1,4 +1,5 @@
 import ATCAppServerAPI
+import ATCAppServerTransport
 import Foundation
 import OSLog
 import Observation
@@ -39,6 +40,13 @@ struct WindowNavigationSnapshot: Equatable {
     let connections: [Connection]
 }
 
+/// How a window shows a Thread: its native transcript and composer (Chat)
+/// or its provider TUI in the linked Terminal (TUI). One at a time.
+enum ThreadViewMode: Equatable, Sendable {
+    case chat
+    case tui
+}
+
 /// Root domain model: owns the Connection list and one `ConnectionRuntime`
 /// per Connection, plus the terminal-controller registry that keeps attach
 /// WebSockets and Ghostty surfaces alive across navigation.
@@ -46,6 +54,13 @@ struct WindowNavigationSnapshot: Equatable {
 final class AppModel {
     let connections: ConnectionsStore
     private(set) var runtimes: [ConnectionRuntime] = []
+
+    /// The remembered Chat/TUI mode per thread, for this app session only —
+    /// app-level so every window on one thread agrees. Chat is the default
+    /// for any thread with no remembered mode, without exception: the
+    /// transcript is there either way because the server re-reads provider
+    /// history.
+    private(set) var threadViewModes: [ThreadRef: ThreadViewMode] = [:]
 
     /// Live terminal attaches by composite ref. Connections and surfaces
     /// stay alive here while the user switches around the sidebar, bounded
@@ -68,7 +83,8 @@ final class AppModel {
     private let clientFactory: (ConnectionRecord, URL) -> any APIProtocol
     private let terminalControllerFactory: (String, ConnectionRuntime) -> TerminalSessionController
     private let terminalRecoveryMonitor: TerminalRecoveryMonitor
-    private let eventStreamFactory: ConnectionRuntime.EventStreamFactory?
+    private let eventStreamFactory: ConnectionRuntime.EventStreamFactory
+    private let threadEventStreamFactory: ConnectionRuntime.ThreadEventStreamFactory
 
     /// The default (real Keychain-backed) construction path defers loading
     /// and runtime building to `start()` so launch never blocks the first
@@ -99,6 +115,7 @@ final class AppModel {
         terminalControllerFactory: ((String, ConnectionRuntime) -> TerminalSessionController)? = nil,
         terminalRecoveryMonitor: TerminalRecoveryMonitor? = nil,
         eventStreamFactory: ConnectionRuntime.EventStreamFactory? = nil,
+        threadEventStreamFactory: ConnectionRuntime.ThreadEventStreamFactory? = nil,
         threadNotifier: ThreadNotifier? = nil,
         attachmentBudget: Int = 12
     ) {
@@ -129,7 +146,10 @@ final class AppModel {
                 )
             }
         self.terminalRecoveryMonitor = terminalRecoveryMonitor ?? TerminalRecoveryMonitor()
-        self.eventStreamFactory = eventStreamFactory
+        self.eventStreamFactory =
+            eventStreamFactory ?? { ResourceEventStream.live(baseURL: $0, headers: $1) }
+        self.threadEventStreamFactory =
+            threadEventStreamFactory ?? { ThreadEventStream.live(baseURL: $0, threadId: $1, headers: $2, after: $3) }
         if !needsDeferredStart {
             for record in self.connections.connections {
                 if let runtime = makeRuntime(record) {
@@ -232,6 +252,20 @@ final class AppModel {
 
     func thread(for ref: ThreadRef) -> ATCThread? {
         runtime(id: ref.connectionID)?.threads.thread(id: ref.threadID)
+    }
+
+    func viewMode(for ref: ThreadRef) -> ThreadViewMode {
+        threadViewModes[ref] ?? .chat
+    }
+
+    /// Remembers the mode and re-opens the thread in every window showing
+    /// it: TUI runs the idempotent terminal open, Chat needs nothing opened
+    /// (each window's `openThread` decides).
+    func setViewMode(_ mode: ThreadViewMode, for ref: ThreadRef) {
+        threadViewModes[ref] = mode
+        for window in windowReconcilers.compactMap(\.value) where window.selectedThread == ref {
+            Task { await window.openThread(ref, in: self, reveal: false) }
+        }
     }
 
     func terminal(for ref: TerminalRef) -> Terminal? {
@@ -361,17 +395,20 @@ final class AppModel {
 
     // MARK: - Thread and terminal opening
 
+    /// Every thread open (Chat or TUI) reports here first: any open
+    /// supersedes a parked banner click — once the user navigates on their
+    /// own, a click still waiting on an unreachable server must not replay
+    /// later and yank their selection. (The click's own open passes
+    /// harmlessly — the slot was cleared when it was honored.)
+    func noteThreadOpened() {
+        pendingNotificationThread = nil
+    }
+
     /// Idempotently opens the thread's TUI terminal on the server, then
     /// attaches (or reuses) its controller. Returns the terminal ref the
     /// window should display.
     @discardableResult
     func openThread(_ ref: ThreadRef, retentionContext: TerminalRetentionContext = .empty) async throws -> TerminalRef {
-        // Every thread open funnels through here, so any open supersedes a
-        // parked banner click: once the user navigates on their own, a click
-        // still waiting on an unreachable server must not replay later and
-        // yank their selection. (The click's own open passes harmlessly —
-        // the slot was cleared when it was honored.)
-        pendingNotificationThread = nil
         guard let runtime = runtime(id: ref.connectionID) else {
             throw AppServerUnavailable()
         }
@@ -498,17 +535,13 @@ final class AppModel {
             logger.error("skipping connection \(record.id) — unparseable URL \(record.urlString)")
             return nil
         }
-        let runtime: ConnectionRuntime
-        if let eventStreamFactory {
-            runtime = ConnectionRuntime(
-                record: record,
-                client: clientFactory(record, url),
-                baseURL: url,
-                eventStreamFactory: eventStreamFactory
-            )
-        } else {
-            runtime = ConnectionRuntime(record: record, client: clientFactory(record, url), baseURL: url)
-        }
+        let runtime = ConnectionRuntime(
+            record: record,
+            client: clientFactory(record, url),
+            baseURL: url,
+            eventStreamFactory: eventStreamFactory,
+            threadEventStreamFactory: threadEventStreamFactory
+        )
         runtime.start()
         return runtime
     }

--- a/macos/ATC/AppServer/ServerModels.swift
+++ b/macos/ATC/AppServer/ServerModels.swift
@@ -14,6 +14,14 @@ typealias Agent = Components.Schemas.Agent
 typealias AgentID = Components.Schemas.AgentId
 typealias ThreadActivityState = Components.Schemas.ThreadActivityState
 typealias TerminalStatus = Components.Schemas.TerminalStatus
+typealias ThreadItem = Components.Schemas.ThreadItem
+typealias ThreadTurn = Components.Schemas.ThreadTurn
+typealias ThreadRequest = Components.Schemas.ThreadRequest
+typealias ThreadRequestAnswer = Components.Schemas.ThreadRequestAnswer
+typealias QueuedPrompt = Components.Schemas.QueuedPrompt
+typealias ThreadEvent = Components.Schemas.ThreadEvent
+typealias ThreadTranscriptPage = Components.Schemas.ThreadTranscript
+typealias ToolStatus = Components.Schemas.ToolStatus
 
 extension AgentID {
     var displayName: String {
@@ -106,4 +114,68 @@ extension Terminal {
     }
 
     var isLive: Bool { status == .live }
+}
+
+extension ThreadItem {
+    /// Item id, unique within the thread — the upsert key.
+    var id: String { head.id }
+    var turnId: String { head.turnId }
+    /// The enclosing item when this work happened inside a subagent or
+    /// nested tool; absent at top level.
+    var parentItemId: String? { head.parentItemId }
+
+    /// The fields every item variant carries, read through one switch.
+    private var head: (id: String, turnId: String, parentItemId: String?) {
+        switch self {
+        case .userMessage(let item): (item.id, item.turnId, item.parentItemId)
+        case .assistantText(let item): (item.id, item.turnId, item.parentItemId)
+        case .reasoning(let item): (item.id, item.turnId, item.parentItemId)
+        case .command(let item): (item.id, item.turnId, item.parentItemId)
+        case .fileChange(let item): (item.id, item.turnId, item.parentItemId)
+        case .mcpCall(let item): (item.id, item.turnId, item.parentItemId)
+        case .toolCall(let item): (item.id, item.turnId, item.parentItemId)
+        case .compaction(let item): (item.id, item.turnId, item.parentItemId)
+        }
+    }
+
+    /// Extends a still-streaming text item (`text.delta`). A completed item
+    /// already holds its whole text (a delta replayed behind the page that
+    /// completed it must not double it); other items ignore deltas.
+    mutating func appendText(_ delta: String) {
+        switch self {
+        case .assistantText(var item) where !item.complete:
+            item.text += delta
+            self = .assistantText(item)
+        case .reasoning(var item) where !item.complete:
+            item.text += delta
+            self = .reasoning(item)
+        case .assistantText, .reasoning, .userMessage, .command, .fileChange, .mcpCall, .toolCall, .compaction:
+            break
+        }
+    }
+}
+
+extension ThreadRequest {
+    var id: String {
+        switch self {
+        case .question(let request): request.id
+        case .approval(let request): request.id
+        }
+    }
+}
+
+extension ThreadEvent {
+    /// The durable position of this change; nil for live-only events (text
+    /// deltas, requests, the queue), which are never replayed.
+    var seq: Int? {
+        switch self {
+        case .item_started(let event): event.seq
+        case .item_updated(let event): event.seq
+        case .item_completed(let event): event.seq
+        case .turn_started(let event): event.seq
+        case .turn_completed(let event): event.seq
+        case .snapshot_invalidated(let event): event.seq
+        case .text_delta, .request_opened, .request_closed, .queue_updated: nil
+        }
+    }
 }

--- a/macos/ATC/Commands/CommandID.swift
+++ b/macos/ATC/Commands/CommandID.swift
@@ -5,6 +5,7 @@ enum CommandID: String, CaseIterable, Sendable {
     case searchTerminals = "view.search-terminals"
     case showDashboard = "view.show-dashboard"
     case newThread = "thread.new"
+    case toggleThreadViewMode = "thread.toggle-view-mode"
     case newTerminal = "terminal.new"
     case newProject = "project.new"
     case refresh = "data.refresh"

--- a/macos/ATC/Commands/CommandRegistry.swift
+++ b/macos/ATC/Commands/CommandRegistry.swift
@@ -30,6 +30,7 @@ struct CommandDescriptor {
 enum CommandRegistry {
     private static let connectionUnavailable = "Requires a reachable Connection"
     private static let projectContextUnavailable = "Requires an open Project"
+    private static let threadUnavailable = "Requires an open Thread"
     private static let dialogUnavailable = "Not available while a dialog is open"
     private static let paletteOpenUnavailable = "Not available while the Command Palette is open"
 
@@ -90,6 +91,17 @@ enum CommandRegistry {
                 title: "New Thread",
                 availability: anyConnectionAvailability,
                 perform: { $0.windowState.presentNewThread() }
+            )
+        case .toggleThreadViewMode:
+            CommandDescriptor(
+                id: id,
+                title: "Toggle Chat/TUI",
+                availability: {
+                    $0.windowState.selectedThread == nil
+                        ? .unavailable(reason: threadUnavailable)
+                        : .available
+                },
+                perform: { $0.windowState.toggleViewMode(in: $0.appModel) }
             )
         case .newTerminal:
             CommandDescriptor(

--- a/macos/ATC/Commands/KeyboardMonitorHost.swift
+++ b/macos/ATC/Commands/KeyboardMonitorHost.swift
@@ -245,7 +245,7 @@ struct KeyboardRoutingContainer<Content: View>: View {
                 KeyboardMonitorHost(
                     router: router,
                     onDeactivate: { windowState.commandPalettePresentation = nil },
-                    focusFallback: { windowState.requestTerminalFocus() }
+                    focusFallback: { windowState.requestContentFocus() }
                 )
             )
             .onChange(of: configStore.configuration.keymap.generation, initial: true) {

--- a/macos/ATC/Commands/Keymap.swift
+++ b/macos/ATC/Commands/Keymap.swift
@@ -19,6 +19,7 @@ enum Keymap {
         ("cmd+shift+p", .toggleCommandPalette),
         ("cmd+d", .showDashboard), ("leader>d", .showDashboard),
         ("cmd+n", .newThread), ("leader>n", .newThread),
+        ("leader>c", .toggleThreadViewMode),
         ("cmd+r", .refresh), ("leader>r", .refresh),
         ("cmd+t", .newTerminal),
         ("cmd+shift+n", .newProject),

--- a/macos/ATC/ConnectionRuntime.swift
+++ b/macos/ATC/ConnectionRuntime.swift
@@ -1,6 +1,7 @@
 // Everything the app runs for one configured Connection: one contract
-// client, four stores, and the SSE event loop that keeps them current.
-// AppModel builds and tears these down as the Connection list changes.
+// client, four stores, the SSE event loop that keeps them current, and one
+// Chat model per thread any window is showing in Chat. AppModel builds and
+// tears these down as the Connection list changes.
 //
 // Liveness model (no polling): the resource-change stream drives refreshes.
 // Every `.connected` refetches all lists — the server guarantees the
@@ -9,6 +10,11 @@
 // refetched per named collection (thread and terminal listings are priced —
 // they consult the multiplexer). Reachability derives from the stream plus
 // refresh outcomes; an unreachable Connection keeps its last-loaded data.
+//
+// Chat models are held by count: `acquireChat` on display, `releaseChat`
+// when a window stops showing the thread in Chat. Two windows on one thread
+// share one model (one transcript copy, one per-thread stream); the last
+// release stops it. `stop()` stops them all.
 
 import ATCAppServerAPI
 import ATCAppServerTransport
@@ -41,6 +47,9 @@ struct ProjectRef: Hashable, Sendable, Identifiable {
 @Observable
 final class ConnectionRuntime: Identifiable {
     typealias EventStreamFactory = (URL, [String: String]) -> AsyncStream<ResourceEventStream.Event>
+    /// (base URL, thread id, headers, resume cursor) → the per-thread stream.
+    typealias ThreadEventStreamFactory =
+        (URL, String, [String: String], @escaping @Sendable () -> Int?) -> AsyncStream<ThreadEventStream.Event>
 
     /// The record this runtime was built from. Name-only edits update it in
     /// place; URL/token edits rebuild the whole runtime instead.
@@ -61,7 +70,9 @@ final class ConnectionRuntime: Identifiable {
     private(set) var reachability: Reachability = .unknown
 
     private let eventStreamFactory: (URL, [String: String]) -> AsyncStream<ResourceEventStream.Event>
+    private let threadEventStreamFactory: ThreadEventStreamFactory
     private var eventTask: Task<Void, Never>?
+    private var chats: [String: (model: ThreadChatModel, holds: Int)] = [:]
     private var firstContactTask: Task<Void, Never>?
     /// Whether the SSE stream is currently open. `.connected` requires it:
     /// without the stream no invalidations flow, so a green dot would lie
@@ -79,6 +90,9 @@ final class ConnectionRuntime: Identifiable {
         baseURL: URL,
         eventStreamFactory: @escaping (URL, [String: String]) -> AsyncStream<ResourceEventStream.Event> = {
             ResourceEventStream.live(baseURL: $0, headers: $1)
+        },
+        threadEventStreamFactory: @escaping ThreadEventStreamFactory = {
+            ThreadEventStream.live(baseURL: $0, threadId: $1, headers: $2, after: $3)
         }
     ) {
         self.record = record
@@ -89,6 +103,7 @@ final class ConnectionRuntime: Identifiable {
             ? [:]
             : ["Authorization": "Bearer \(record.token)"]
         self.eventStreamFactory = eventStreamFactory
+        self.threadEventStreamFactory = threadEventStreamFactory
         projects = ProjectsStore(client: client)
         threads = ThreadsStore(client: client)
         terminals = TerminalsStore(client: client)
@@ -140,6 +155,40 @@ final class ConnectionRuntime: Identifiable {
         coalesceTask = nil
         pendingResources = []
         streamOpen = false
+        for entry in chats.values {
+            entry.model.stop()
+        }
+        chats = [:]
+    }
+
+    // MARK: - Chat models
+
+    /// The thread's Chat model, started on first acquire. Every acquire is
+    /// paired with a `releaseChat`.
+    func acquireChat(threadID: String) -> ThreadChatModel {
+        if let entry = chats[threadID] {
+            chats[threadID] = (entry.model, entry.holds + 1)
+            return entry.model
+        }
+        let makeStream = threadEventStreamFactory
+        let (baseURL, headers) = (baseURL, transportHeaders)
+        let model = ThreadChatModel(threadID: threadID, client: client) { after in
+            makeStream(baseURL, threadID, headers, after)
+        }
+        chats[threadID] = (model, 1)
+        model.start()
+        return model
+    }
+
+    /// The last release stops the stream and drops the copy.
+    func releaseChat(threadID: String) {
+        guard let entry = chats[threadID] else { return }
+        if entry.holds > 1 {
+            chats[threadID] = (entry.model, entry.holds - 1)
+            return
+        }
+        entry.model.stop()
+        chats[threadID] = nil
     }
 
     /// One combined refresh of all four stores; the Connection is reachable

--- a/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
+++ b/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
@@ -65,7 +65,7 @@ struct CommandPaletteView: View {
                 shouldRestoreCapturedResponder: {
                     responderRestoration.shouldRestoreCapturedResponder
                 },
-                fallback: { windowState.requestTerminalFocus() }
+                fallback: { windowState.requestContentFocus() }
             )
         )
         .onAppear { resetSelection(for: rows, presentation: presentation) }

--- a/macos/ATC/Features/Terminal/TerminalPane.swift
+++ b/macos/ATC/Features/Terminal/TerminalPane.swift
@@ -37,30 +37,30 @@ struct TerminalStatusBanner: View {
     var body: some View {
         switch controller.phase {
         case .connecting:
-            banner {
+            FloatingBanner {
                 ProgressView().controlSize(.small)
                 Text("Connecting…")
             }
         case .connected:
             EmptyView()
         case .reconnecting:
-            banner {
+            FloatingBanner {
                 ProgressView().controlSize(.small)
                 Text("Reconnecting…")
             }
         case .ended(.terminalEnded):
-            banner {
+            FloatingBanner {
                 Image(systemName: "checkmark.circle")
                 Text("Terminal ended")
             }
         case .ended(.rejected(let statusCode)):
-            banner {
+            FloatingBanner {
                 Image(systemName: "exclamationmark.triangle")
                 Text("Attach refused (\(statusCode))")
                 Button("Reconnect") { controller.reconnect() }
             }
         case .ended(.retryable):
-            banner {
+            FloatingBanner {
                 Image(systemName: "wifi.exclamationmark")
                 Text("Connection lost")
                 Button("Reconnect") { controller.reconnect() }
@@ -69,21 +69,11 @@ struct TerminalStatusBanner: View {
             // No production path renders this today (disconnects also drop
             // the controller); the branch exists for a future user-facing
             // detach and to keep the switch exhaustive.
-            banner {
+            FloatingBanner {
                 Image(systemName: "cable.connector.slash")
                 Text("Disconnected")
                 Button("Reconnect") { controller.reconnect() }
             }
         }
-    }
-
-    private func banner(@ViewBuilder content: () -> some View) -> some View {
-        HStack(spacing: Spacing.sm, content: content)
-            .padding(.horizontal, Spacing.md)
-            .padding(.vertical, Spacing.sm)
-            // Floating overlay on Liquid Glass, like the toolbar controls.
-            .glassEffect()
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-            .padding(.top, Spacing.lg)
     }
 }

--- a/macos/ATC/Features/Threads/Chat/ChatComposer.swift
+++ b/macos/ATC/Features/Threads/Chat/ChatComposer.swift
@@ -1,0 +1,111 @@
+// The prompt composer pinned under the transcript, shaped like the Codex
+// desktop composer: one rounded card, the text growing from a single line
+// to a few, and a round send button in the corner. Return sends,
+// Shift-Return inserts a newline. Send is never disabled while connected —
+// the server admits every prompt (idle starts a turn, busy queues it) — and
+// a refused prompt keeps its text with the server's message inline. Stop
+// shows only while the server is driving a turn.
+
+import SwiftUI
+
+struct ChatComposer: View {
+    @Binding var text: String
+    let isSending: Bool
+    let showsStop: Bool
+    let error: String?
+    /// Advances whenever the window wants the composer focused.
+    let focusRequest: UInt
+    let send: () -> Void
+    let stop: () -> Void
+
+    @FocusState private var isFocused: Bool
+    @State private var editorHeight: CGFloat = 24
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            if let error {
+                Label(error, systemImage: "exclamationmark.triangle")
+                    .font(.callout)
+                    .foregroundStyle(.orange)
+                    .textSelection(.enabled)
+            }
+            VStack(alignment: .leading, spacing: Spacing.sm) {
+                editor
+                HStack(spacing: Spacing.sm) {
+                    Spacer()
+                    if showsStop {
+                        Button(action: stop) {
+                            Label("Stop", systemImage: "stop.fill")
+                                .labelStyle(.titleAndIcon)
+                                .font(.callout.weight(.medium))
+                        }
+                        .buttonStyle(.plain)
+                        .padding(.horizontal, Spacing.md)
+                        .padding(.vertical, Spacing.xs)
+                        .background(Surface.raised, in: Capsule())
+                        .help("Stop the running turn")
+                    }
+                    Button(action: send) {
+                        Image(systemName: "arrow.up")
+                            .font(.body.weight(.bold))
+                            .frame(width: 30, height: 30)
+                            .foregroundStyle(canSend ? Color.black : Color.secondary)
+                            .background(canSend ? Color.white : Surface.raised, in: Circle())
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!canSend)
+                    .help("Send (Return)")
+                    .accessibilityLabel("Send message")
+                }
+            }
+            .padding(Spacing.md)
+            .background(Surface.raised, in: RoundedRectangle(cornerRadius: Radius.card + Spacing.xs))
+            .overlay(RoundedRectangle(cornerRadius: Radius.card + Spacing.xs).strokeBorder(Surface.chipBorder))
+        }
+        .onAppear { isFocused = true }
+        .onChange(of: focusRequest) { _, _ in isFocused = true }
+    }
+
+    /// A TextEditor sized by the text behind it: it grows with the message
+    /// from one line to a few, then scrolls. TextEditor claims every point
+    /// it is offered, so its height is pinned to the measured text.
+    private var editor: some View {
+        ZStack(alignment: .topLeading) {
+            Text(text.isEmpty ? " " : text)
+                .font(.body)
+                .lineLimit(1...8)
+                .padding(.vertical, Spacing.xs)
+                .padding(.horizontal, Spacing.xs + 1)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .hidden()
+                .onGeometryChange(for: CGFloat.self) {
+                    $0.size.height
+                } action: {
+                    editorHeight = $0
+                }
+            TextEditor(text: $text)
+                .font(.body)
+                .scrollContentBackground(.hidden)
+                .scrollIndicators(.never)
+                .focused($isFocused)
+                .frame(height: editorHeight)
+                .onKeyPress(.return, phases: .down) { press in
+                    guard !press.modifiers.contains(.shift) else { return .ignored }
+                    guard canSend else { return .handled }
+                    send()
+                    return .handled
+                }
+            if text.isEmpty {
+                Text("Message the agent…")
+                    .foregroundStyle(.tertiary)
+                    .padding(.vertical, Spacing.xs)
+                    .padding(.horizontal, Spacing.xs + 1)
+                    .allowsHitTesting(false)
+            }
+        }
+    }
+
+    private var canSend: Bool {
+        !isSending && !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}

--- a/macos/ATC/Features/Threads/Chat/ChatItemRows.swift
+++ b/macos/ATC/Features/Threads/Chat/ChatItemRows.swift
@@ -1,0 +1,225 @@
+// One view per transcript row kind. The visual model is the Codex desktop
+// app: left-aligned assistant text with no bubbles, the user's prompt on a
+// raised card, and compact tool rows — one line of adapter `title` + status —
+// that disclose monospaced detail. Fidelity is deliberately "rows +
+// expandable detail"; polish is a later issue.
+
+import ATCAppServerAPI
+import SwiftUI
+
+struct ChatRowView: View {
+    let row: ChatRow
+
+    var body: some View {
+        switch row {
+        case .item(let node):
+            ChatItemView(node: node)
+        case .turnEnded(let turn):
+            ChatTurnEndedRow(turn: turn)
+        }
+    }
+}
+
+struct ChatItemView: View {
+    let node: ChatNode
+
+    private var item: ThreadItem { node.item }
+    private var children: [ChatNode] { node.children }
+
+    var body: some View {
+        // Tool rows keep their nested items inside the disclosure; anything
+        // else shows them right below.
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            content
+            if !children.isEmpty, !isToolRow {
+                NestedItems(children: children)
+            }
+        }
+    }
+
+    private var isToolRow: Bool {
+        switch item {
+        case .command, .fileChange, .mcpCall, .toolCall: true
+        case .userMessage, .assistantText, .reasoning, .compaction: false
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch item {
+        case .userMessage(let message):
+            MarkdownText(text: message.text)
+                .padding(Spacing.md)
+                .background(Surface.raised, in: RoundedRectangle(cornerRadius: Radius.chip))
+        case .assistantText(let text):
+            MarkdownText(text: text.text)
+        case .reasoning(let reasoning):
+            ChatThinkingRow(text: reasoning.text)
+        case .command(let command):
+            ChatToolRow(
+                title: command.title, status: command.status, error: command.error, children: children
+            ) {
+                DetailSection(title: command.cwd.map { "$ \(command.command)  (\($0))" } ?? "$ \(command.command)") {
+                    if let output = command.output, !output.isEmpty {
+                        DetailBlock(text: output)
+                    }
+                    if let exitCode = command.exitCode {
+                        Text("exit \(exitCode)")
+                            .font(.caption.monospaced())
+                            .foregroundStyle(exitCode == 0 ? Color.secondary : Color.red)
+                    }
+                }
+            }
+        case .fileChange(let change):
+            ChatToolRow(title: change.title, status: change.status, error: change.error, children: children) {
+                ForEach(Array(change.changes.enumerated()), id: \.offset) { _, file in
+                    DetailSection(title: "\(file.kind.rawValue) \(file.path)") {
+                        if let diff = file.diff, !diff.isEmpty {
+                            DetailBlock(text: diff)
+                        }
+                    }
+                }
+            }
+        case .mcpCall(let call):
+            ChatToolRow(title: call.title, status: call.status, error: call.error, children: children) {
+                DetailSection(title: "\(call.server) · \(call.tool) — arguments") {
+                    DetailBlock(text: PrettyJSON.string(call.arguments))
+                }
+                if let result = call.result {
+                    DetailSection(title: "Result") { DetailBlock(text: PrettyJSON.string(result)) }
+                }
+            }
+        case .toolCall(let call):
+            ChatToolRow(title: call.title, status: call.status, error: call.error, children: children) {
+                DetailSection(title: "\(call.name) — input") {
+                    DetailBlock(text: PrettyJSON.string(call.input))
+                }
+                if let output = call.output {
+                    DetailSection(title: "Output") { DetailBlock(text: PrettyJSON.string(output)) }
+                }
+            }
+        case .compaction:
+            HStack(spacing: Spacing.sm) {
+                Rectangle().fill(Surface.chipBorder).frame(height: 1)
+                Text("Context compacted")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .fixedSize()
+                Rectangle().fill(Surface.chipBorder).frame(height: 1)
+            }
+            .padding(.vertical, Spacing.xs)
+        }
+    }
+}
+
+/// Reasoning collapses to a "Thinking" line; the text streams while
+/// collapsed and is there when the user opens it.
+private struct ChatThinkingRow: View {
+    let text: String
+    @State private var isExpanded = false
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $isExpanded) {
+            MarkdownText(text: text)
+                .foregroundStyle(.secondary)
+                .padding(.top, Spacing.xs)
+        } label: {
+            Label("Thinking", systemImage: "brain")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+/// A tool item: adapter title + status, disclosing detail and any nested
+/// items (subagent or nested-tool work) beneath it.
+private struct ChatToolRow<Detail: View>: View {
+    let title: String
+    let status: ToolStatus
+    let error: String?
+    let children: [ChatNode]
+    @ViewBuilder let detail: () -> Detail
+    @State private var isExpanded = false
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $isExpanded) {
+            VStack(alignment: .leading, spacing: Spacing.sm) {
+                detail()
+                if let error {
+                    Label(error, systemImage: "exclamationmark.triangle")
+                        .font(.callout)
+                        .foregroundStyle(.red)
+                        .textSelection(.enabled)
+                }
+                if !children.isEmpty {
+                    NestedItems(children: children)
+                }
+            }
+            .padding(.top, Spacing.xs)
+        } label: {
+            HStack(spacing: Spacing.sm) {
+                statusIndicator
+                    .frame(width: 14)
+                Text(title)
+                    .font(.callout.monospaced())
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                if !children.isEmpty {
+                    Text("\(children.count)")
+                        .font(.caption2.weight(.semibold))
+                        .padding(.horizontal, Spacing.xs)
+                        .padding(.vertical, 2)
+                        .background(Surface.raised, in: Capsule())
+                }
+            }
+            .foregroundStyle(status == .error ? Color.red : Color.primary)
+        }
+    }
+
+    @ViewBuilder
+    private var statusIndicator: some View {
+        switch status {
+        case .pending:
+            Image(systemName: "clock").foregroundStyle(.secondary)
+        case .running:
+            ProgressView().controlSize(.mini)
+        case .completed:
+            Image(systemName: "checkmark").foregroundStyle(.secondary)
+        case .error:
+            Image(systemName: "xmark").foregroundStyle(.red)
+        }
+    }
+}
+
+/// Items that happened inside another (subagent / nested-tool work), set
+/// in from the row that spawned them.
+private struct NestedItems: View {
+    let children: [ChatNode]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            ForEach(children) { child in
+                ChatItemView(node: child)
+            }
+        }
+        .padding(.leading, Spacing.md)
+        .overlay(alignment: .leading) {
+            Rectangle().fill(Surface.chipBorder).frame(width: 1)
+        }
+    }
+}
+
+/// The one visible turn boundary: a turn that failed or was interrupted.
+private struct ChatTurnEndedRow: View {
+    let turn: ThreadTurn
+
+    var body: some View {
+        HStack(spacing: Spacing.sm) {
+            Image(systemName: turn.status == .failed ? "exclamationmark.triangle" : "stop.circle")
+            Text(turn.status == .failed ? (turn.error ?? "Turn failed") : "Interrupted")
+                .textSelection(.enabled)
+        }
+        .font(.callout)
+        .foregroundStyle(turn.status == .failed ? Color.red : Color.secondary)
+    }
+}

--- a/macos/ATC/Features/Threads/Chat/ChatQueueStrip.swift
+++ b/macos/ATC/Features/Threads/Chat/ChatQueueStrip.swift
@@ -1,0 +1,38 @@
+// Prompts admitted while a turn was running, waiting for the next idle: a
+// compact strip above the composer, one row per queued prompt with ✕ to
+// withdraw it. Queued prompts are live state, never transcript items.
+
+import ATCAppServerAPI
+import SwiftUI
+
+struct ChatQueueStrip: View {
+    let prompts: [QueuedPrompt]
+    let withdraw: (QueuedPrompt) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            ForEach(prompts, id: \.id) { prompt in
+                HStack(spacing: Spacing.sm) {
+                    Image(systemName: "clock")
+                        .foregroundStyle(.secondary)
+                    Text(prompt.prompt)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    Spacer(minLength: 0)
+                    Button {
+                        withdraw(prompt)
+                    } label: {
+                        Image(systemName: "xmark")
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    .help("Withdraw this prompt")
+                }
+                .font(.callout)
+                .padding(.horizontal, Spacing.md)
+                .padding(.vertical, Spacing.xs)
+                .background(Surface.raised, in: RoundedRectangle(cornerRadius: Radius.chip))
+            }
+        }
+    }
+}

--- a/macos/ATC/Features/Threads/Chat/ChatRequestCard.swift
+++ b/macos/ATC/Features/Threads/Chat/ChatRequestCard.swift
@@ -1,0 +1,175 @@
+// A pending provider request (question or approval) as a card above the
+// composer. Answers go straight to the server; the card disappears when the
+// stream reports the request closed — by this client or any other.
+
+import ATCAppServerAPI
+import SwiftUI
+
+struct ChatRequestCard: View {
+    let request: ThreadRequest
+    let answer: (ThreadRequestAnswer) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.md) {
+            switch request {
+            case .question(let question):
+                QuestionRequestContent(request: question, answer: answer)
+            case .approval(let approval):
+                ApprovalRequestContent(request: approval, answer: answer)
+            }
+        }
+        .padding(Spacing.lg)
+        .background(Surface.card, in: RoundedRectangle(cornerRadius: Radius.card))
+        .overlay(RoundedRectangle(cornerRadius: Radius.card).strokeBorder(Surface.cardBorder))
+    }
+}
+
+private struct QuestionRequestContent: View {
+    let request: Components.Schemas.ThreadRequestQuestion
+    let answer: (ThreadRequestAnswer) -> Void
+    /// Chosen labels per question id (freeform text counts as one label).
+    @State private var chosen: [String: [String]] = [:]
+    @State private var freeform: [String: String] = [:]
+
+    var body: some View {
+        ForEach(request.questions, id: \.id) { question in
+            VStack(alignment: .leading, spacing: Spacing.sm) {
+                if !question.header.isEmpty {
+                    Text(question.header).font(.headline)
+                }
+                MarkdownText(text: question.question)
+                ForEach(Array(question.options.enumerated()), id: \.offset) { _, option in
+                    optionButton(question, option)
+                }
+                if question.freeform {
+                    freeformField(question)
+                }
+            }
+        }
+        HStack {
+            Spacer()
+            // No default action on purpose: Return belongs to the composer,
+            // and several cards can be up at once.
+            Button("Answer") {
+                answer(.question(.init(kind: .question, answers: .init(additionalProperties: answers))))
+            }
+            .disabled(!isComplete)
+        }
+    }
+
+    private func optionButton(_ question: Components.Schemas.Question, _ option: Components.Schemas.QuestionOption)
+        -> some View
+    {
+        let selected = chosen[question.id, default: []].contains(option.label)
+        return Button {
+            select(option.label, for: question)
+        } label: {
+            HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
+                Image(systemName: selected ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(selected ? Color.accentColor : .secondary)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(option.label)
+                    if !option.description.isEmpty {
+                        Text(option.description).font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func select(_ label: String, for question: Components.Schemas.Question) {
+        freeform[question.id] = nil
+        guard question.multiSelect else {
+            chosen[question.id] = [label]
+            return
+        }
+        var labels = chosen[question.id, default: []]
+        if let index = labels.firstIndex(of: label) {
+            labels.remove(at: index)
+        } else {
+            labels.append(label)
+        }
+        chosen[question.id] = labels
+    }
+
+    @ViewBuilder
+    private func freeformField(_ question: Components.Schemas.Question) -> some View {
+        let binding = Binding(
+            get: { freeform[question.id] ?? "" },
+            set: { text in
+                freeform[question.id] = text
+                // Typing an answer replaces any picked option.
+                if !text.isEmpty { chosen[question.id] = nil }
+            }
+        )
+        if question.secret {
+            SecureField("Type an answer", text: binding)
+        } else {
+            TextField("Type an answer", text: binding, axis: .vertical)
+                .lineLimit(1...4)
+        }
+    }
+
+    /// Every question has at least one label or some freeform text.
+    private var isComplete: Bool {
+        request.questions.allSatisfy { !answers[$0.id, default: []].isEmpty }
+    }
+
+    private var answers: [String: [String]] {
+        var answers: [String: [String]] = [:]
+        for question in request.questions {
+            let text = freeform[question.id]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let labels = chosen[question.id] ?? []
+            answers[question.id] = text.isEmpty ? labels : [text]
+        }
+        return answers
+    }
+}
+
+private struct ApprovalRequestContent: View {
+    let request: Components.Schemas.ThreadRequestApproval
+    let answer: (ThreadRequestAnswer) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            Text(request.title).font(.headline)
+            if let reason = request.reason, !reason.isEmpty {
+                Text(reason).font(.callout).foregroundStyle(.secondary)
+            }
+        }
+        subject
+        HStack(spacing: Spacing.sm) {
+            Button("Allow") { decide(.accept) }
+            Button("Allow for Session") { decide(.acceptForSession) }
+            Spacer()
+            Button("Deny") { decide(.decline) }
+            Button("Deny & Stop", role: .destructive) { decide(.cancel) }
+        }
+    }
+
+    @ViewBuilder
+    private var subject: some View {
+        switch request.subject {
+        case .command(let command):
+            DetailBlock(text: command.cwd.map { "$ \(command.command)\n(\($0))" } ?? "$ \(command.command)")
+        case .fileChange(let change):
+            VStack(alignment: .leading, spacing: Spacing.xs) {
+                ForEach(Array(change.changes.enumerated()), id: \.offset) { _, file in
+                    Text("\(file.kind.rawValue) \(file.path)")
+                        .font(.callout.monospaced())
+                }
+            }
+        case .tool(let tool):
+            DetailSection(title: tool.name) {
+                DetailBlock(text: PrettyJSON.string(tool.input))
+            }
+        }
+    }
+
+    private func decide(_ decision: Components.Schemas.ApprovalDecision) {
+        answer(.approval(.init(kind: .approval, decision: decision)))
+    }
+}

--- a/macos/ATC/Features/Threads/Chat/ChatRows.swift
+++ b/macos/ATC/Features/Threads/Chat/ChatRows.swift
@@ -1,0 +1,58 @@
+// The transcript as rows: what the Chat list actually renders. Items nest
+// under their `parentItemId` (subagent / nested-tool work shows under the
+// row that spawned it), and a turn that failed or was interrupted gets one
+// marker after its last item — the only place a turn boundary is visible.
+// Pure so the shape can be tested without views.
+
+import ATCAppServerAPI
+import Foundation
+
+/// One transcript item with the items nested under it, to any depth.
+struct ChatNode: Identifiable, Equatable {
+    let item: ThreadItem
+    let children: [ChatNode]
+
+    var id: String { item.id }
+}
+
+enum ChatRow: Identifiable, Equatable {
+    case item(ChatNode)
+    /// A turn that ended abnormally, placed after its last item.
+    case turnEnded(ThreadTurn)
+
+    var id: String {
+        switch self {
+        case .item(let node): "item:\(node.id)"
+        case .turnEnded(let turn): "turn:\(turn.id)"
+        }
+    }
+}
+
+extension ChatTranscript {
+    var rows: [ChatRow] {
+        let ids = Set(items.map(\.id))
+        var children: [String: [ThreadItem]] = [:]
+        var topLevel: [ThreadItem] = []
+        for item in items {
+            // A parent that isn't on this page (older) leaves the child at
+            // top level rather than dropping it.
+            if let parent = item.parentItemId, ids.contains(parent) {
+                children[parent, default: []].append(item)
+                continue
+            }
+            topLevel.append(item)
+        }
+        func node(_ item: ThreadItem) -> ChatNode {
+            ChatNode(item: item, children: (children[item.id] ?? []).map(node))
+        }
+        var rows: [ChatRow] = topLevel.map { .item(node($0)) }
+        for turn in turns where turn.status == .failed || turn.status == .interrupted {
+            let last = rows.lastIndex { row in
+                guard case .item(let node) = row else { return false }
+                return node.item.turnId == turn.id
+            }
+            rows.insert(.turnEnded(turn), at: last.map { $0 + 1 } ?? rows.endIndex)
+        }
+        return rows
+    }
+}

--- a/macos/ATC/Features/Threads/Chat/ChatText.swift
+++ b/macos/ATC/Features/Threads/Chat/ChatText.swift
@@ -1,0 +1,69 @@
+// Text rendering shared by the Chat rows: inline markdown for message text,
+// and monospaced detail blocks (command output, diffs, JSON) for the
+// expandable tool rows. Deliberately small — rendered code blocks and
+// syntax-highlighted diffs are a later issue.
+
+import ATCAppServerAPI
+import OpenAPIRuntime
+import SwiftUI
+
+/// Message text with inline markdown (emphasis, code spans, links); block
+/// structure is kept as plain paragraphs. Text that fails to parse renders
+/// verbatim.
+struct MarkdownText: View {
+    let text: String
+
+    var body: some View {
+        Text(attributed)
+            .textSelection(.enabled)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var attributed: AttributedString {
+        (try? AttributedString(
+            markdown: text,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        )) ?? AttributedString(text)
+    }
+}
+
+/// A monospaced detail block: selectable, wrapping, on a raised surface.
+struct DetailBlock: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.callout.monospaced())
+            .textSelection(.enabled)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(Spacing.sm)
+            .background(Surface.card, in: RoundedRectangle(cornerRadius: Radius.control))
+    }
+}
+
+/// A labelled detail block (e.g. "Arguments", "Output").
+struct DetailSection<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            content()
+        }
+    }
+}
+
+enum PrettyJSON {
+    /// Any provider JSON (tool input/output, MCP arguments/result) as
+    /// indented text; a value that cannot be re-encoded reads as `null`.
+    static func string(_ value: OpenAPIValueContainer?) -> String {
+        guard let value else { return "null" }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        guard let data = try? encoder.encode(value) else { return "null" }
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/macos/ATC/Features/Threads/Chat/ChatTranscript.swift
+++ b/macos/ATC/Features/Threads/Chat/ChatTranscript.swift
@@ -1,0 +1,142 @@
+// The Chat view's copy of one thread's runtime state, and the pure reducer
+// that keeps it current from the per-thread event stream. Everything here
+// is synchronous and value-typed so the merge rules can be tested without a
+// server; `ThreadChatModel` owns the I/O around it.
+//
+// Merge rules (from the contract, `ThreadEvent` / `ThreadTranscript`):
+// - Items carry no position: transcript order is array order, a known id is
+//   replaced in place (an update re-sends the whole item), an unknown id
+//   appends at the tail. Turns upsert the same way.
+// - `seq` is the highest durable change applied. A durable event at or
+//   below it is already reflected — by the page it was read into or by a
+//   later change — and is dropped, so a live event that overtakes a
+//   transcript read can never roll a row back.
+// - `text.delta` is live-only and extends the named item; a delta for an
+//   item never seen is dropped (its `item.completed` carries the whole text).
+// - `snapshot.invalidated` means a provider re-read replaced the copy: the
+//   caller must refetch (`apply` says so); nothing here can repair it, and
+//   it does not move `seq` — only a page that actually landed may, so a
+//   reconnect before the refetch succeeds is answered with the invalidation
+//   again instead of silently resuming a dead copy.
+// - Every page names the `snapshotVersion` it was read from; an older page
+//   from a copy that has since been replaced is discarded.
+// - Requests and the queue are live state, never transcript rows: the
+//   queue is replaced wholesale on every `queue.updated`; requests open and
+//   close by id.
+
+import ATCAppServerAPI
+import Foundation
+
+struct ChatTranscript: Equatable {
+    private(set) var items: [ThreadItem] = []
+    private(set) var turns: [ThreadTurn] = []
+    private(set) var requests: [ThreadRequest] = []
+    private(set) var queue: [QueuedPrompt] = []
+    /// The highest durable `seq` applied; subscribe `after` it.
+    private(set) var seq: Int?
+    /// The provider copy the loaded pages came from.
+    private(set) var snapshotVersion: Int?
+    /// Older items exist before `items.first`.
+    private(set) var hasMore = false
+    /// A transcript page has been read at least once.
+    private(set) var isLoaded = false
+
+    /// The turn the server is driving right now, if any.
+    var runningTurn: ThreadTurn? {
+        turns.last { $0.status == .running }
+    }
+
+    func turn(id: String) -> ThreadTurn? {
+        turns.first { $0.id == id }
+    }
+
+    /// Replaces the copy with the newest page (first load, or after a
+    /// snapshot invalidation).
+    mutating func load(_ page: ThreadTranscriptPage) {
+        items = page.items
+        turns = page.turns
+        seq = page.seq
+        snapshotVersion = page.snapshotVersion
+        hasMore = page.hasMore
+        isLoaded = true
+    }
+
+    /// Prepends an older page (`before` the first item). Its turns merge;
+    /// its `seq` is not newer than what is already applied. A page from a
+    /// copy that was replaced meanwhile is discarded.
+    mutating func prependOlder(_ page: ThreadTranscriptPage) {
+        guard page.snapshotVersion == snapshotVersion else { return }
+        let knownItems = Set(items.map(\.id))
+        let knownTurns = Set(turns.map(\.id))
+        items = page.items.filter { !knownItems.contains($0.id) } + items
+        turns = page.turns.filter { !knownTurns.contains($0.id) } + turns
+        hasMore = page.hasMore
+    }
+
+    mutating func replaceRequests(_ requests: [ThreadRequest]) {
+        self.requests = requests
+    }
+
+    mutating func replaceQueue(_ prompts: [QueuedPrompt]) {
+        queue = prompts
+    }
+
+    /// Applies one stream event. Returns true when the copy is invalid and
+    /// must be refetched (`snapshot.invalidated`).
+    mutating func apply(_ event: ThreadEvent) -> Bool {
+        switch event {
+        case .item_started(let event):
+            guard advance(to: event.seq) else { return false }
+            upsert(event.item)
+        case .item_updated(let event):
+            guard advance(to: event.seq) else { return false }
+            upsert(event.item)
+        case .item_completed(let event):
+            guard advance(to: event.seq) else { return false }
+            upsert(event.item)
+        case .turn_started(let event):
+            guard advance(to: event.seq) else { return false }
+            upsert(event.turn)
+        case .turn_completed(let event):
+            guard advance(to: event.seq) else { return false }
+            upsert(event.turn)
+        case .text_delta(let event):
+            guard let index = items.firstIndex(where: { $0.id == event.itemId }) else { return false }
+            items[index].appendText(event.delta)
+        case .request_opened(let event):
+            requests.removeAll { $0.id == event.request.id }
+            requests.append(event.request)
+        case .request_closed(let event):
+            requests.removeAll { $0.id == event.requestId }
+        case .queue_updated(let event):
+            queue = event.prompts
+        case .snapshot_invalidated:
+            return true
+        }
+        return false
+    }
+
+    /// Moves the durable cursor forward; false when the change is already
+    /// reflected and the event must be dropped.
+    private mutating func advance(to eventSeq: Int) -> Bool {
+        if let seq, eventSeq <= seq { return false }
+        seq = eventSeq
+        return true
+    }
+
+    private mutating func upsert(_ item: ThreadItem) {
+        if let index = items.firstIndex(where: { $0.id == item.id }) {
+            items[index] = item
+            return
+        }
+        items.append(item)
+    }
+
+    private mutating func upsert(_ turn: ThreadTurn) {
+        if let index = turns.firstIndex(where: { $0.id == turn.id }) {
+            turns[index] = turn
+            return
+        }
+        turns.append(turn)
+    }
+}

--- a/macos/ATC/Features/Threads/Chat/ThreadChatModel.swift
+++ b/macos/ATC/Features/Threads/Chat/ThreadChatModel.swift
@@ -1,0 +1,288 @@
+// One thread's Chat state: the transcript copy (`ChatTranscript`) plus the
+// stream and requests that keep it current. Owned by the thread's
+// `ConnectionRuntime` for as long as any window shows the thread in Chat, so
+// two windows on one thread share one copy and one subscription.
+//
+// Load and resume, all driven by the stream so there is one path:
+// - The subscription starts at once. On every `.connected` the copy is
+//   loaded if this subscription asked for no `after` (nothing was replayed:
+//   the copy is empty, or a reconnect raced the first read) or is invalid,
+//   then the live-only state (requests, queue) is refetched — and refetched
+//   again on a delay while either read fails, because those events are
+//   never replayed.
+// - `after` is the highest seq applied, asked on every reconnect, so a lost
+//   connection replays exactly the gap; the copy is never refetched for a
+//   plain reconnect and the transcript stays on screen.
+// - `snapshot.invalidated` marks the copy invalid and refetches the newest
+//   page in place. Until a page lands — likewise while the copy was never
+//   loaded — durable events are not applied and the cursor does not move (a
+//   reconnect meanwhile is answered with the invalidation again, never a
+//   silent resume of a dead copy); the stream itself stays up — replay is
+//   only ever for a gap.
+// - Every read is serialized with event handling: the stream loop waits for
+//   an in-flight page or live-state read before applying anything, so a page
+//   can never land beneath a change this connection already applied and a
+//   request list can never resurrect a request the stream already closed.
+//   Reads happen at the server after any change already applied here, so
+//   `page.seq` is never behind the cursor.
+//
+// Mutations go straight to the server and never touch the copy: what the
+// user did comes back through the stream like anyone else's action. Their
+// failures throw to the caller (the view's shared action alert); only a
+// prompt refusal is kept here, because the composer shows it inline.
+
+import ATCAppServerAPI
+import ATCAppServerTransport
+import Foundation
+import Observation
+
+@Observable
+final class ThreadChatModel {
+    typealias StreamFactory =
+        (_ after: @escaping @Sendable () -> Int?) -> AsyncStream<ThreadEventStream.Event>
+
+    enum ConnectionPhase: Equatable {
+        case connecting
+        case live
+        case reconnecting
+    }
+
+    /// Delay before re-reading requests/queue after a failed read.
+    var liveStateRetryDelay: Duration = .seconds(2)
+
+    let threadID: String
+    private(set) var transcript = ChatTranscript()
+    private(set) var connection: ConnectionPhase = .connecting
+    /// The last newest-page read failed; the copy shown is empty (never
+    /// loaded) or invalid (a provider re-read replaced it) until it succeeds.
+    private(set) var loadError: String?
+    private(set) var isLoadingOlder = false
+    /// The last `promptThread` refusal, cleared by the next send.
+    private(set) var promptError: String?
+
+    private let client: any APIProtocol
+    private let makeStream: StreamFactory
+    private let cursor = SeqCursor()
+    private var streamTask: Task<Void, Never>?
+    private var pageLoad: Task<Void, Never>?
+    private var liveStateRefresh: Task<Void, Never>?
+    private var liveStateRetry: Task<Void, Never>?
+    /// A `snapshot.invalidated` has not yet been answered by a landed page.
+    private var needsResync = false
+
+    init(threadID: String, client: any APIProtocol, makeStream: @escaping StreamFactory) {
+        self.threadID = threadID
+        self.client = client
+        self.makeStream = makeStream
+    }
+
+    // MARK: - Lifecycle
+
+    func start() {
+        guard streamTask == nil else { return }
+        let stream = makeStream { [cursor] in cursor.ask() }
+        streamTask = Task { [weak self] in
+            for await event in stream {
+                guard let self, !Task.isCancelled else { return }
+                await self.handle(event)
+            }
+        }
+    }
+
+    func stop() {
+        for task in [streamTask, pageLoad, liveStateRefresh, liveStateRetry] {
+            task?.cancel()
+        }
+        streamTask = nil
+        pageLoad = nil
+        liveStateRefresh = nil
+        liveStateRetry = nil
+    }
+
+    private func handle(_ event: ThreadEventStream.Event) async {
+        // Never apply across an in-flight read (see header).
+        await pageLoad?.value
+        await liveStateRefresh?.value
+        switch event {
+        case .connected:
+            connection = .live
+            if cursor.lastAsked == nil || needsResync {
+                await loadNewest()
+            }
+            await refreshLiveState()
+        case .disconnected:
+            connection = .reconnecting
+        case .event(let event):
+            if needsResync || !transcript.isLoaded, event.seq != nil {
+                // The copy is dead or missing: a durable change is only
+                // ever picked up by the page, so retry the read instead of
+                // applying it.
+                await loadNewest()
+                return
+            }
+            if transcript.apply(event) {
+                needsResync = true
+                await loadNewest()
+            }
+            cursor.seq = transcript.seq
+        }
+    }
+
+    // MARK: - Reads
+
+    /// (Re)reads the newest page. Concurrent callers share one read; on
+    /// failure the previous copy (if any) stays and `loadError` is set.
+    func loadNewest() async {
+        if let pageLoad {
+            await pageLoad.value
+            return
+        }
+        let load = Task {
+            do {
+                let page = try await fetchTranscript(before: nil)
+                guard !Task.isCancelled else { return }
+                transcript.load(page)
+                cursor.seq = page.seq
+                needsResync = false
+                loadError = nil
+            } catch {
+                guard !Task.isCancelled else { return }
+                loadError = error.localizedDescription
+            }
+        }
+        pageLoad = load
+        await load.value
+        pageLoad = nil
+    }
+
+    /// The page before the oldest item on screen. A cursor from a replaced
+    /// copy reads as an empty page (or is discarded by the reducer when the
+    /// copy changed under it), which simply ends paging.
+    func loadOlder() async throws {
+        guard transcript.hasMore, !isLoadingOlder, let first = transcript.items.first else { return }
+        isLoadingOlder = true
+        defer { isLoadingOlder = false }
+        transcript.prependOlder(try await fetchTranscript(before: first.id))
+    }
+
+    /// Requests and the queue are live-only (never replayed): refetched on
+    /// every connect, and again after a delay while either read fails —
+    /// otherwise a pending approval could stay hidden for as long as the
+    /// stream stays healthy.
+    private func refreshLiveState() async {
+        if let liveStateRefresh {
+            await liveStateRefresh.value
+            return
+        }
+        liveStateRetry?.cancel()
+        liveStateRetry = nil
+        let refresh = Task {
+            async let requests = try? client.listThreadRequests(path: .init(threadId: threadID)).ok.body.json
+            async let queue = try? client.listThreadQueue(path: .init(threadId: threadID)).ok.body.json
+            let (readRequests, readQueue) = await (requests, queue)
+            guard !Task.isCancelled else { return }
+            if let readRequests { transcript.replaceRequests(readRequests) }
+            if let readQueue { transcript.replaceQueue(readQueue) }
+            guard readRequests == nil || readQueue == nil else { return }
+            liveStateRetry = Task { [weak self] in
+                try? await Task.sleep(for: self?.liveStateRetryDelay ?? .seconds(2))
+                guard !Task.isCancelled else { return }
+                await self?.refreshLiveState()
+            }
+        }
+        liveStateRefresh = refresh
+        await refresh.value
+        liveStateRefresh = nil
+    }
+
+    private func fetchTranscript(before: String?) async throws -> ThreadTranscriptPage {
+        switch try await client.getThreadTranscript(path: .init(threadId: threadID), query: .init(before: before)) {
+        case .ok(let ok): return try ok.body.json
+        case .notFound(let failure): throw ServerError(try failure.body.json)
+        case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
+        }
+    }
+
+    // MARK: - Actions
+
+    /// Prompts the thread. Returns false when the server refused (the error
+    /// is in `promptError`) so the composer keeps the text.
+    @discardableResult
+    func send(_ prompt: String) async -> Bool {
+        promptError = nil
+        do {
+            switch try await client.promptThread(path: .init(threadId: threadID), body: .json(.init(prompt: prompt))) {
+            case .ok: return true
+            case .notFound(let failure): throw ServerError(try failure.body.json)
+            case .conflict(let failure):
+                let payload = try failure.body.json
+                throw ServerError(anyOf: payload.value1, payload.value2)
+            case .serviceUnavailable(let failure): throw ServerError(try failure.body.json)
+            case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
+            }
+        } catch {
+            promptError = error.localizedDescription
+            return false
+        }
+    }
+
+    /// Interrupts the server-driven turn; a TUI-driven turn is a server
+    /// no-op, and queued prompts stay queued.
+    func interrupt() async throws {
+        switch try await client.interruptThread(path: .init(threadId: threadID)) {
+        case .noContent: break
+        case .notFound(let failure): throw ServerError(try failure.body.json)
+        case .serviceUnavailable(let failure): throw ServerError(try failure.body.json)
+        case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
+        }
+    }
+
+    func answer(requestID: String, _ answer: ThreadRequestAnswer) async throws {
+        switch try await client.answerThreadRequest(
+            path: .init(threadId: threadID, requestId: requestID), body: .json(answer))
+        {
+        case .noContent: break
+        case .badRequest(let failure): throw ServerError(try failure.body.json)
+        case .notFound(let failure):
+            let payload = try failure.body.json
+            throw ServerError(anyOf: payload.value1, payload.value2)
+        case .serviceUnavailable(let failure): throw ServerError(try failure.body.json)
+        case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
+        }
+    }
+
+    func withdraw(promptID: String) async throws {
+        switch try await client.deleteQueuedPrompt(path: .init(threadId: threadID, promptId: promptID)) {
+        case .noContent: break
+        case .notFound(let failure):
+            let payload = try failure.body.json
+            throw ServerError(anyOf: payload.value1, payload.value2)
+        case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
+        }
+    }
+}
+
+/// The resume cursor the stream reads on every (re)connect, and what it was
+/// last told — a subscription made with no `after` replays nothing, so its
+/// `.connected` must load the copy. Its own lock because the stream asks
+/// from off the main actor.
+private nonisolated final class SeqCursor: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Int?
+    private var asked: Int?
+
+    var seq: Int? {
+        get { lock.withLock { value } }
+        set { lock.withLock { value = newValue } }
+    }
+
+    /// The `after` handed to the subscription currently connecting.
+    var lastAsked: Int? { lock.withLock { asked } }
+
+    func ask() -> Int? {
+        lock.withLock {
+            asked = value
+            return value
+        }
+    }
+}

--- a/macos/ATC/Features/Threads/Chat/ThreadChatView.swift
+++ b/macos/ATC/Features/Threads/Chat/ThreadChatView.swift
@@ -1,0 +1,266 @@
+// The Chat mode of a thread: transcript above, pending requests, the prompt
+// queue, and the composer pinned below. The view holds the thread's Chat
+// model for exactly as long as it is on screen (`acquireChat` / `releaseChat`
+// on the Connection's runtime), so navigating away or flipping to TUI drops
+// the subscription while a second window on the same thread keeps it.
+//
+// The transcript follows the tail until the user scrolls up, and offers
+// "Load earlier" at the top while older pages exist. Connection loss shows a
+// floating "Reconnecting…" over a transcript that stays put — the stream
+// resumes from its seq, so nothing is refetched.
+
+import ATCAppServerAPI
+import SwiftUI
+
+struct ThreadChatView: View {
+    @Environment(AppModel.self) private var appModel
+    @Environment(WindowState.self) private var windowState
+    let ref: ThreadRef
+
+    /// The hold this view currently has on a Chat model. Rendering is gated
+    /// on it matching `ref`, and cleanup on its token, because holds overlap
+    /// during a switch (the replacement task starts before the cancelled one
+    /// unwinds) and `acquireChat` hands the same model to every holder.
+    @State private var acquisition: Acquisition?
+
+    var body: some View {
+        Group {
+            if let acquisition, acquisition.ref == ref, let thread = appModel.thread(for: ref) {
+                ChatPane(
+                    ref: ref, chat: acquisition.model, thread: thread, focusRequest: windowState.contentFocusRequest)
+            } else {
+                Color.clear
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(AppColors.canvas)
+        // Keyed on the runtime object too: a Connection rebuild (URL/token
+        // edit) replaces the runtime under the same ref, and the Chat must
+        // move to the new one.
+        .task(id: Hold(ref: ref, runtime: appModel.runtime(id: ref.connectionID).map(ObjectIdentifier.init))) {
+            guard let runtime = appModel.runtime(id: ref.connectionID) else { return }
+            let mine = Acquisition(ref: ref, model: runtime.acquireChat(threadID: ref.threadID))
+            acquisition = mine
+            defer {
+                runtime.releaseChat(threadID: ref.threadID)
+                if acquisition?.token == mine.token { acquisition = nil }
+            }
+            // The task's only job past this point is to be cancelled — when
+            // the view leaves the screen or moves to another thread — so the
+            // release above runs at exactly that moment.
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(3600))
+            }
+        }
+    }
+}
+
+/// What one Chat acquisition is bound to.
+private struct Hold: Equatable {
+    let ref: ThreadRef
+    let runtime: ObjectIdentifier?
+}
+
+private struct Acquisition {
+    let token = UUID()
+    let ref: ThreadRef
+    let model: ThreadChatModel
+}
+
+/// The Chat surface for one acquired model: transcript, requests, queue,
+/// composer. Actions run through the app's one mutation seam and report
+/// into the standard action alert.
+private struct ChatPane: View {
+    @Environment(AppModel.self) private var appModel
+    let ref: ThreadRef
+    let chat: ThreadChatModel
+    let thread: ATCThread
+    let focusRequest: UInt
+
+    @State private var draft = ""
+    @State private var isSending = false
+    @State private var isFollowingTail = true
+    @State private var actionError: String?
+
+    private var transcript: ChatTranscript { chat.transcript }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            transcriptList
+            bottomStack
+        }
+        .overlay(alignment: .top) { statusBanner }
+        .actionErrorAlert($actionError)
+    }
+
+    private func run(_ operation: @escaping () async throws -> Void) {
+        appModel.run(on: ref.connectionID, reporting: { actionError = $0 }, operation)
+    }
+
+    // MARK: - Transcript
+
+    private var transcriptList: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: Spacing.md) {
+                    if transcript.hasMore {
+                        HStack {
+                            Spacer()
+                            Button("Load earlier") { loadOlder(proxy) }
+                                .disabled(chat.isLoadingOlder)
+                            Spacer()
+                        }
+                    }
+                    if let error = chat.loadError {
+                        loadFailure(error)
+                    } else if !transcript.isLoaded {
+                        loadingIndicator
+                    } else if transcript.items.isEmpty, !isWorking {
+                        emptyState
+                    }
+                    ForEach(transcript.rows) { row in
+                        ChatRowView(row: row)
+                            .id(row.id)
+                    }
+                    if isWorking {
+                        HStack(spacing: Spacing.sm) {
+                            ProgressView().controlSize(.small)
+                            Text("Working…").foregroundStyle(.secondary)
+                        }
+                        .font(.callout)
+                    }
+                    Color.clear.frame(height: 1).id(tailAnchor)
+                }
+                .padding(.horizontal, Spacing.xxl)
+                .padding(.vertical, Spacing.lg)
+                .frame(maxWidth: 820)
+                .frame(maxWidth: .infinity)
+            }
+            // The toolbar floats over the content; keep the first row from
+            // starting under it.
+            .contentMargins(.top, Spacing.xxl, for: .scrollContent)
+            // The user scrolling away from the tail stops auto-follow;
+            // returning to it resumes.
+            .onScrollGeometryChange(for: Bool.self) { geometry in
+                geometry.contentOffset.y + geometry.containerSize.height
+                    >= geometry.contentSize.height - Spacing.xxl
+            } action: { _, atBottom in
+                isFollowingTail = atBottom
+            }
+            .onChange(of: transcript.items) { _, _ in
+                if isFollowingTail { proxy.scrollTo(tailAnchor, anchor: .bottom) }
+            }
+            .onChange(of: transcript.isLoaded) { _, _ in
+                proxy.scrollTo(tailAnchor, anchor: .bottom)
+            }
+        }
+    }
+
+    /// Older history goes in above; the row that was first stays where the
+    /// eye is instead of the tail-follow yanking the view back down.
+    private func loadOlder(_ proxy: ScrollViewProxy) {
+        guard let anchor = transcript.rows.first?.id else { return }
+        isFollowingTail = false
+        run {
+            try await chat.loadOlder()
+            proxy.scrollTo(anchor, anchor: .top)
+        }
+    }
+
+    private let tailAnchor = "tail"
+
+    /// The server drives a turn (Stop is offered), or the agent is busy under
+    /// a TUI (items land at idle — the server's re-read).
+    private var isWorking: Bool {
+        transcript.runningTurn != nil || thread.activityState == .working
+    }
+
+    private func loadFailure(_ error: String) -> some View {
+        HStack(spacing: Spacing.sm) {
+            Image(systemName: "exclamationmark.triangle").foregroundStyle(.orange)
+            Text(error).lineLimit(2)
+            Button("Retry") { Task { await chat.loadNewest() } }
+        }
+        .font(.callout)
+    }
+
+    private var loadingIndicator: some View {
+        HStack(spacing: Spacing.sm) {
+            ProgressView().controlSize(.small)
+            Text("Loading transcript…").foregroundStyle(.secondary)
+        }
+        .font(.callout)
+    }
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            Text(thread.displayName).font(.title3.weight(.semibold))
+            Text("Send a message to start the conversation.")
+                .foregroundStyle(.secondary)
+        }
+        .padding(.top, Spacing.xxl)
+    }
+
+    // MARK: - Bottom stack
+
+    private var bottomStack: some View {
+        VStack(spacing: Spacing.sm) {
+            ForEach(transcript.requests, id: \.id) { request in
+                ChatRequestCard(request: request) { answer in
+                    run { try await chat.answer(requestID: request.id, answer) }
+                }
+            }
+            if !transcript.queue.isEmpty {
+                ChatQueueStrip(prompts: transcript.queue) { prompt in
+                    run { try await chat.withdraw(promptID: prompt.id) }
+                }
+            }
+            ChatComposer(
+                text: $draft,
+                isSending: isSending,
+                showsStop: transcript.runningTurn != nil,
+                error: chat.promptError,
+                focusRequest: focusRequest,
+                send: send,
+                stop: { run { try await chat.interrupt() } }
+            )
+        }
+        .padding(.horizontal, Spacing.xxl)
+        .padding(.bottom, Spacing.lg)
+        .frame(maxWidth: 820)
+        .frame(maxWidth: .infinity)
+    }
+
+    private func send() {
+        let prompt = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty, !isSending else { return }
+        isSending = true
+        Task {
+            if await chat.send(prompt) {
+                draft = ""
+                isFollowingTail = true
+            }
+            isSending = false
+        }
+    }
+
+    // MARK: - Status
+
+    @ViewBuilder
+    private var statusBanner: some View {
+        switch chat.connection {
+        case .connecting:
+            FloatingBanner {
+                ProgressView().controlSize(.small)
+                Text("Connecting…")
+            }
+        case .reconnecting:
+            FloatingBanner {
+                ProgressView().controlSize(.small)
+                Text("Reconnecting…")
+            }
+        case .live:
+            EmptyView()
+        }
+    }
+}

--- a/macos/ATC/Features/Threads/ThreadContentView.swift
+++ b/macos/ATC/Features/Threads/ThreadContentView.swift
@@ -2,9 +2,13 @@
 // with nothing open, so live surfaces and their attach WebSockets survive
 // sidebar navigation; every other state draws over it.
 //
-// A thread whose TUI terminal has ended keeps its final frame: the relaunch
-// bar floats above the retained surface instead of replacing it, and
-// relaunching is just `openThread` again — the server's open is idempotent.
+// A thread shows in one of two modes (`AppModel.viewMode(for:)`): Chat draws
+// `ThreadChatView` over the pane with the thread's terminal hidden (a
+// retained surface survives the mode flip untouched); TUI shows the terminal
+// with the status/relaunch banners over it. A thread whose TUI terminal has
+// ended keeps its final frame: the relaunch bar floats above the retained
+// surface instead of replacing it, and relaunching is just `openThread`
+// again — the server's open is idempotent.
 
 import ATCAppServerAPI
 import ATCAppServerTransport
@@ -17,11 +21,20 @@ struct ThreadContentView: View {
     var body: some View {
         ZStack {
             TerminalPane(
-                visibleRef: windowState.visibleTerminal,
-                focusRequest: windowState.terminalFocusRequest
+                visibleRef: shownTerminal,
+                focusRequest: windowState.contentFocusRequest
             )
             cover
         }
+    }
+
+    /// The terminal the pane should actually show: none while the selected
+    /// thread is in Chat, even though its terminal stays retained.
+    private var shownTerminal: TerminalRef? {
+        if case .thread(let ref) = windowState.selectedContent, appModel.viewMode(for: ref) == .chat {
+            return nil
+        }
+        return windowState.visibleTerminal
     }
 
     @ViewBuilder
@@ -40,8 +53,12 @@ struct ThreadContentView: View {
     private func threadCover(_ ref: ThreadRef) -> some View {
         if appModel.thread(for: ref) == nil {
             unavailableCover
+        } else if appModel.viewMode(for: ref) == .chat {
+            // Identity per thread: the composer draft and scroll position
+            // belong to one thread, never carried to the next.
+            ThreadChatView(ref: ref).id(ref)
         } else if let message = windowState.threadOpenErrors[ref] {
-            banner {
+            FloatingBanner {
                 Image(systemName: "exclamationmark.triangle")
                     .foregroundStyle(.orange)
                 Text(message)
@@ -58,7 +75,7 @@ struct ThreadContentView: View {
                 TerminalStatusBanner(controller: controller)
             }
         } else if windowState.openingThreads.contains(ref) {
-            banner {
+            FloatingBanner {
                 ProgressView().controlSize(.small)
                 Text("Opening thread…")
             }
@@ -88,7 +105,7 @@ struct ThreadContentView: View {
     }
 
     private func relaunchBar(_ ref: ThreadRef) -> some View {
-        banner {
+        FloatingBanner {
             Image(systemName: "arrow.clockwise")
             Text("Terminal ended")
             Button("Relaunch") {
@@ -106,15 +123,6 @@ struct ThreadContentView: View {
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(AppColors.canvas)
-    }
-
-    private func banner(@ViewBuilder content: () -> some View) -> some View {
-        HStack(spacing: Spacing.sm, content: content)
-            .padding(.horizontal, Spacing.md)
-            .padding(.vertical, Spacing.sm)
-            .glassEffect()
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-            .padding(.top, Spacing.lg)
     }
 
     private func controller(for ref: ThreadRef) -> TerminalSessionController? {

--- a/macos/ATC/PreviewSupport/PreviewAppServerClient.swift
+++ b/macos/ATC/PreviewSupport/PreviewAppServerClient.swift
@@ -44,7 +44,8 @@ import OpenAPIRuntime
                     )
                 },
                 terminalRecoveryMonitor: .disabled(),
-                eventStreamFactory: { _, _ in AsyncStream { $0.yield(.connected) } }
+                eventStreamFactory: { _, _ in AsyncStream { $0.yield(.connected) } },
+                threadEventStreamFactory: { _, _, _, _ in AsyncStream { $0.yield(.connected) } }
             )
         }
     }

--- a/macos/ATC/RootView.swift
+++ b/macos/ATC/RootView.swift
@@ -45,6 +45,19 @@ struct RootView: View {
             ToolbarItem(placement: .status) {
                 exceptionalStatus
             }
+            // Chat | TUI for the displayed thread; the mode is app-wide per
+            // thread (AppModel), so two windows on one thread agree.
+            ToolbarItem(placement: .principal) {
+                if let ref = selectedThread {
+                    Picker("View", selection: viewModeBinding(ref)) {
+                        Text("Chat").tag(ThreadViewMode.chat)
+                        Text("TUI").tag(ThreadViewMode.tui)
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    .help("Show the thread as a native chat or its provider TUI")
+                }
+            }
             ToolbarItem(placement: .primaryAction) {
                 Toggle(isOn: $windowState.isInspectorPresented) {
                     Label("Inspector", systemImage: "sidebar.trailing")
@@ -62,7 +75,7 @@ struct RootView: View {
         .sheet(
             item: $windowState.newThreadContext,
             onDismiss: {
-                windowState.requestTerminalFocus()
+                windowState.requestContentFocus()
             }
         ) { context in
             NewThreadSheet(context: context)
@@ -70,7 +83,7 @@ struct RootView: View {
         .sheet(
             item: $windowState.newTerminalProject,
             onDismiss: {
-                windowState.requestTerminalFocus()
+                windowState.requestContentFocus()
             }
         ) { ref in
             NewTerminalSheet(projectRef: ref)
@@ -177,6 +190,13 @@ struct RootView: View {
 
     private var selectedThread: ThreadRef? {
         windowState.selectedThread
+    }
+
+    private func viewModeBinding(_ ref: ThreadRef) -> Binding<ThreadViewMode> {
+        Binding(
+            get: { appModel.viewMode(for: ref) },
+            set: { appModel.setViewMode($0, for: ref) }
+        )
     }
 
     private func projectName(for connectionID: UUID, projectID: String) -> String {

--- a/macos/ATC/Shared/FloatingBanner.swift
+++ b/macos/ATC/Shared/FloatingBanner.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+/// The content area's floating status pill: a glass capsule pinned to the
+/// top of whatever it overlays (terminal, chat). Every transient state
+/// banner — connecting, reconnecting, ended, open errors — is one of these,
+/// so they all sit in the same place with the same look.
+struct FloatingBanner<Content: View>: View {
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        HStack(spacing: Spacing.sm, content: content)
+            .padding(.horizontal, Spacing.md)
+            .padding(.vertical, Spacing.sm)
+            // Floating overlay on Liquid Glass, like the toolbar controls.
+            .glassEffect()
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .padding(.top, Spacing.lg)
+    }
+}

--- a/macos/ATC/Shared/ServerError.swift
+++ b/macos/ATC/Shared/ServerError.swift
@@ -39,6 +39,9 @@ extension Components.Schemas.ThreadArchivedJsonEncoding: ServerErrorPayload {}
 extension Components.Schemas.ThreadBusyJsonEncoding: ServerErrorPayload {}
 extension Components.Schemas.ProviderUnavailableJsonEncoding: ServerErrorPayload {}
 extension Components.Schemas.ProviderSessionConflictJsonEncoding: ServerErrorPayload {}
+extension Components.Schemas.RequestNotFoundJsonEncoding: ServerErrorPayload {}
+extension Components.Schemas.InvalidRequestAnswerJsonEncoding: ServerErrorPayload {}
+extension Components.Schemas.QueuedPromptNotFoundJsonEncoding: ServerErrorPayload {}
 
 extension ServerError {
     /// Wrap a single-schema failure payload.

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -94,10 +94,11 @@ final class WindowState {
         isCreateProjectPresented || newThreadContext != nil || newTerminalProject != nil
     }
 
-    /// Advances for every explicit request to type in the visible terminal.
-    /// Unlike selection, this also changes when the user re-selects the
-    /// same sidebar row.
-    private(set) var terminalFocusRequest: UInt = 0
+    /// Advances for every explicit request to type in the displayed content
+    /// — the visible terminal, or the Chat composer. Unlike selection, this
+    /// also changes when the user re-selects the same sidebar row. Only the
+    /// surface actually on screen answers it.
+    private(set) var contentFocusRequest: UInt = 0
 
     var selectedThread: ThreadRef? {
         guard case .thread(let ref) = selectedContent else { return nil }
@@ -136,34 +137,48 @@ final class WindowState {
     // MARK: - Navigation transitions
 
     /// The single thread-open transition used by every entry point: select
-    /// immediately (the content area shows the connecting state), then
-    /// idempotently open the TUI terminal and attach. Establishes the
-    /// thread's Project as the launch-local context.
+    /// immediately, establish the thread's Project as the launch-local
+    /// context, then — only in TUI mode — idempotently open the TUI terminal
+    /// and attach. Chat mode never opens or attaches a terminal; the Chat
+    /// view acquires the thread's transcript on display instead.
     func openThread(_ ref: ThreadRef, in appModel: AppModel, reveal: Bool = true) async {
         guard let thread = appModel.thread(for: ref) else { return }
         guard !thread.isArchived else { return }
 
+        appModel.noteThreadOpened()
         selectedContent = .thread(ref)
         if reveal { sidebarRevealToken += 1 }
         returnThread = ref
         activeProject = ProjectRef(connectionID: ref.connectionID, projectID: thread.projectId)
         threadOpenErrors[ref] = nil
-        requestTerminalFocus()
         // Opening is viewing (ATC-160). Guarded on the store's unread flag;
         // a finish the store hasn't refreshed into yet is caught by
         // reconciliation once it lands (markViewedIfDisplayed).
         if thread.unread { markViewed(ref, in: appModel) }
+        requestContentFocus()
 
+        guard appModel.viewMode(for: ref) == .tui else { return }
         guard !openingThreads.contains(ref) else { return }
         openingThreads.insert(ref)
         defer { openingThreads.remove(ref) }
         do {
             let terminalRef = try await appModel.openThread(ref, retentionContext: retentionContext)
             threadTerminals[ref] = terminalRef
-            requestTerminalFocus()
+            // The user may have flipped back to Chat while the open was in
+            // flight; the terminal stays retained (hidden), but Chat keeps
+            // the focus.
+            if appModel.viewMode(for: ref) == .tui { requestContentFocus() }
         } catch {
             threadOpenErrors[ref] = error.localizedDescription
         }
+    }
+
+    /// Flips the displayed thread between Chat and TUI. The mode is
+    /// app-wide (`AppModel.setViewMode`), which re-opens the thread in every
+    /// window showing it.
+    func toggleViewMode(in appModel: AppModel) {
+        guard let ref = selectedThread else { return }
+        appModel.setViewMode(appModel.viewMode(for: ref) == .chat ? .tui : .chat, for: ref)
     }
 
     /// Selects a standalone Terminal. Live terminals attach; an ended one
@@ -181,7 +196,7 @@ final class WindowState {
         } else {
             appModel.touchTerminal(ref)
         }
-        requestTerminalFocus()
+        requestContentFocus()
     }
 
     func showDashboard() {
@@ -189,11 +204,10 @@ final class WindowState {
         isInspectorPresented = false
     }
 
-    /// Reasserts terminal focus after transient UI (notably a creation
+    /// Reasserts content focus after transient UI (notably a creation
     /// sheet) has finished handing first-responder ownership back.
-    func requestTerminalFocus() {
-        guard visibleTerminal != nil else { return }
-        terminalFocusRequest &+= 1
+    func requestContentFocus() {
+        contentFocusRequest &+= 1
     }
 
     func toggleSidebar() {
@@ -348,12 +362,15 @@ final class WindowState {
 
     /// Keeps the displayed thread's terminal mapping and attach current:
     /// adopt the server's linked terminal when it differs (a relaunch made
-    /// a new one), and reattach a live terminal that lost its controller.
+    /// a new one), and — in TUI mode — reattach a live terminal that lost
+    /// its controller. Chat mode tracks the mapping but never attaches; the
+    /// switch to TUI opens (and attaches) on its own.
     private func reconcileThreadTerminal(_ ref: ThreadRef, thread: ATCThread, in appModel: AppModel) {
         if let linkedID = thread.linkedTerminalId {
             let linkedRef = TerminalRef(connectionID: ref.connectionID, terminalID: linkedID)
             threadTerminals[ref] = linkedRef
-            if let terminal = appModel.terminal(for: linkedRef), terminal.isLive,
+            if appModel.viewMode(for: ref) == .tui,
+                let terminal = appModel.terminal(for: linkedRef), terminal.isLive,
                 appModel.terminals[linkedRef] == nil
             {
                 appModel.attachIfNeeded(

--- a/macos/ATCTests/ChatTranscriptTests.swift
+++ b/macos/ATCTests/ChatTranscriptTests.swift
@@ -1,0 +1,179 @@
+import ATCAppServerAPI
+import Foundation
+import Testing
+
+@testable import ATC
+
+/// The Chat reducer: the contract's merge rules for items, turns, deltas,
+/// live state, and the seq cursor — pure, no server.
+@Suite("ChatTranscript")
+struct ChatTranscriptTests {
+    private func loaded() -> ChatTranscript {
+        var transcript = ChatTranscript()
+        transcript.load(
+            Fixtures.page(
+                items: [Fixtures.userMessage("u1"), Fixtures.assistantText("a1", text: "Hel")],
+                turns: [Fixtures.turn("turn1")],
+                seq: 10,
+                hasMore: true
+            ))
+        return transcript
+    }
+
+    @Test("load takes the page as-is: order, turns, seq, hasMore")
+    func load() {
+        let transcript = loaded()
+        #expect(transcript.isLoaded)
+        #expect(transcript.items.map(\.id) == ["u1", "a1"])
+        #expect(transcript.seq == 10)
+        #expect(transcript.hasMore)
+        #expect(transcript.runningTurn?.id == "turn1")
+    }
+
+    @Test("items upsert by id in place; unknown ids append; turns likewise")
+    func upsert() {
+        var transcript = loaded()
+        var needsReload = transcript.apply(
+            .item_updated(
+                .init(_type: .item_updated, seq: 11, item: Fixtures.assistantText("a1", text: "Hello", complete: true)))
+        )
+        #expect(!needsReload)
+        needsReload = transcript.apply(
+            .item_started(.init(_type: .item_started, seq: 12, item: Fixtures.command("c1"))))
+        #expect(!needsReload)
+        _ = transcript.apply(
+            .turn_completed(.init(_type: .turn_completed, seq: 13, turn: Fixtures.turn("turn1", status: .completed))))
+
+        #expect(transcript.items.map(\.id) == ["u1", "a1", "c1"])
+        guard case .assistantText(let text) = transcript.items[1] else {
+            Issue.record("expected assistant text")
+            return
+        }
+        #expect(text.text == "Hello")
+        #expect(text.complete)
+        #expect(transcript.seq == 13)
+        #expect(transcript.runningTurn == nil)
+        #expect(transcript.turn(id: "turn1")?.status == .completed)
+    }
+
+    @Test("a durable event at or below the cursor is already reflected and dropped")
+    func staleDurableEventsDropped() {
+        var transcript = loaded()
+        _ = transcript.apply(
+            .item_updated(.init(_type: .item_updated, seq: 10, item: Fixtures.assistantText("a1", text: "OLD"))))
+        _ = transcript.apply(
+            .item_updated(.init(_type: .item_updated, seq: 3, item: Fixtures.assistantText("a1", text: "OLDER"))))
+        guard case .assistantText(let text) = transcript.items[1] else {
+            Issue.record("expected assistant text")
+            return
+        }
+        #expect(text.text == "Hel")
+        #expect(transcript.seq == 10)
+    }
+
+    @Test("text.delta extends the named streaming item and nothing else")
+    func textDelta() {
+        var transcript = loaded()
+        _ = transcript.apply(.text_delta(.init(_type: .text_delta, itemId: "a1", delta: "lo")))
+        _ = transcript.apply(.text_delta(.init(_type: .text_delta, itemId: "ghost", delta: "!")))
+        _ = transcript.apply(.text_delta(.init(_type: .text_delta, itemId: "u1", delta: "!")))
+        // A delta replayed behind the page that completed its item is
+        // already in the text (deltas are never persisted; the completed
+        // item carries the whole text).
+        _ = transcript.apply(
+            .item_completed(
+                .init(
+                    _type: .item_completed, seq: 11, item: Fixtures.assistantText("a1", text: "Hello", complete: true)))
+        )
+        _ = transcript.apply(.text_delta(.init(_type: .text_delta, itemId: "a1", delta: "Hello")))
+        guard case .assistantText(let text) = transcript.items[1],
+            case .userMessage(let user) = transcript.items[0]
+        else {
+            Issue.record("expected the loaded items")
+            return
+        }
+        #expect(text.text == "Hello")
+        #expect(user.text == "hi")
+        #expect(transcript.items.count == 2)
+        #expect(transcript.seq == 11)
+    }
+
+    @Test("snapshot.invalidated asks for a reload and leaves the cursor where the copy is")
+    func snapshotInvalidated() {
+        var transcript = loaded()
+        let invalidated = transcript.apply(
+            .snapshot_invalidated(.init(_type: .snapshot_invalidated, seq: 14, snapshotVersion: 2)))
+        #expect(invalidated)
+        #expect(transcript.seq == 10)
+        #expect(transcript.snapshotVersion == 1)
+    }
+
+    @Test("an older page from another copy is discarded")
+    func olderPageFromOtherCopy() {
+        var transcript = loaded()
+        transcript.prependOlder(
+            Fixtures.page(items: [Fixtures.userMessage("u0")], seq: 10, snapshotVersion: 2, hasMore: false))
+        #expect(transcript.items.map(\.id) == ["u1", "a1"])
+        #expect(transcript.hasMore)
+    }
+
+    @Test("requests open and close by id; the queue is replaced wholesale")
+    func liveState() {
+        var transcript = loaded()
+        _ = transcript.apply(.request_opened(.init(_type: .request_opened, request: Fixtures.approval("r1"))))
+        _ = transcript.apply(.request_opened(.init(_type: .request_opened, request: Fixtures.approval("r2"))))
+        _ = transcript.apply(.request_opened(.init(_type: .request_opened, request: Fixtures.approval("r1"))))
+        #expect(transcript.requests.map(\.id) == ["r2", "r1"])
+        _ = transcript.apply(.request_closed(.init(_type: .request_closed, requestId: "r2")))
+        #expect(transcript.requests.map(\.id) == ["r1"])
+
+        _ = transcript.apply(
+            .queue_updated(.init(_type: .queue_updated, prompts: [Fixtures.queued("p1"), Fixtures.queued("p2")])))
+        _ = transcript.apply(.queue_updated(.init(_type: .queue_updated, prompts: [Fixtures.queued("p2")])))
+        #expect(transcript.queue.map(\.id) == ["p2"])
+    }
+
+    @Test("an older page prepends without duplicating and takes over hasMore")
+    func prependOlder() {
+        var transcript = loaded()
+        transcript.prependOlder(
+            Fixtures.page(
+                items: [
+                    Fixtures.userMessage("u-1", turn: "turn-1"), Fixtures.userMessage("u0", turn: "turn0"),
+                    Fixtures.userMessage("u1"),
+                ],
+                turns: [Fixtures.turn("turn-1", status: .completed), Fixtures.turn("turn0", status: .completed)],
+                seq: 10,
+                hasMore: false
+            ))
+        #expect(transcript.items.map(\.id) == ["u-1", "u0", "u1", "a1"])
+        #expect(transcript.turns.map(\.id) == ["turn-1", "turn0", "turn1"])
+        #expect(!transcript.hasMore)
+    }
+
+    @Test("rows nest children under their parent to any depth and mark abnormal turn ends after their last item")
+    func rows() {
+        var transcript = ChatTranscript()
+        transcript.load(
+            Fixtures.page(
+                items: [
+                    Fixtures.userMessage("u1", turn: "t1"),
+                    Fixtures.command("c1", turn: "t1"),
+                    Fixtures.command("c2", turn: "t1", parent: "c1"),
+                    Fixtures.command("c3", turn: "t1", parent: "c2"),
+                    Fixtures.command("orphan", turn: "t1", parent: "older-page"),
+                    Fixtures.userMessage("u2", turn: "t2"),
+                ],
+                turns: [Fixtures.turn("t1", status: .failed, error: "boom"), Fixtures.turn("t2")],
+                seq: 5
+            ))
+        let rows = transcript.rows
+        #expect(rows.map(\.id) == ["item:u1", "item:c1", "item:orphan", "turn:t1", "item:u2"])
+        guard case .item(let node) = rows[1] else {
+            Issue.record("expected the command row")
+            return
+        }
+        #expect(node.children.map(\.id) == ["c2"])
+        #expect(node.children.first?.children.map(\.id) == ["c3"])
+    }
+}

--- a/macos/ATCTests/CommandPaletteContentTests.swift
+++ b/macos/ATCTests/CommandPaletteContentTests.swift
@@ -26,6 +26,9 @@ struct CommandPaletteContentTests {
         await test.runtime.threads.loadArchivedIfNeeded()
 
         let state = WindowState()
+        // TUI mode: the palette's terminals test relies on the linked TUI
+        // terminal this open creates.
+        test.model.setViewMode(.tui, for: test.threadRef("thr1"))
         await state.openThread(test.threadRef("thr1"), in: test.model)
         let context = CommandContext(
             appModel: test.model,

--- a/macos/ATCTests/CommandRegistryTests.swift
+++ b/macos/ATCTests/CommandRegistryTests.swift
@@ -51,7 +51,7 @@ struct CommandRegistryTests {
             CommandID.allCases.map(\.rawValue) == [
                 "view.toggle-sidebar", "view.toggle-command-palette",
                 "view.search-threads", "view.search-terminals",
-                "view.show-dashboard", "thread.new", "terminal.new",
+                "view.show-dashboard", "thread.new", "thread.toggle-view-mode", "terminal.new",
                 "project.new", "data.refresh", "configuration.reload",
                 "configuration.reveal",
             ])
@@ -107,6 +107,22 @@ struct CommandRegistryTests {
         await state.openThread(test.threadRef("thr1"), in: test.model)
         #expect(state.activeProject != nil)
         #expect(CommandRegistry.descriptor(for: .newTerminal).availability(context).isAvailable)
+    }
+
+    @Test("Toggle Chat/TUI needs a displayed thread and flips its remembered mode")
+    func toggleThreadViewMode() async throws {
+        let (context, test) = try await connectedContext()
+        let ref = test.threadRef("thr1")
+        let descriptor = CommandRegistry.descriptor(for: .toggleThreadViewMode)
+        #expect(descriptor.availability(context).isAvailable)
+        #expect(test.model.viewMode(for: ref) == .chat)
+
+        CommandRegistry.execute(.toggleThreadViewMode, context: context)
+        #expect(test.model.viewMode(for: ref) == .tui)
+        await drainPendingTasks()
+
+        context.windowState.showDashboard()
+        #expect(!descriptor.availability(context).isAvailable)
     }
 
     @Test("the palette opener toggles and is unavailable while any sheet is up")

--- a/macos/ATCTests/KeymapResolutionTests.swift
+++ b/macos/ATCTests/KeymapResolutionTests.swift
@@ -44,8 +44,9 @@ struct KeymapResolutionTests {
         #expect(command(at: try stroke("cmd+shift+n"), in: keymap) == .newProject)
 
         let leader = try #require(prefix(at: try stroke("cmd+k"), in: keymap))
-        #expect(leader.count == 6)
+        #expect(leader.count == 7)
         #expect(command(in: leader[KeyStroke(key: "b", modifiers: [])]) == .toggleSidebar)
+        #expect(command(in: leader[KeyStroke(key: "c", modifiers: [])]) == .toggleThreadViewMode)
         #expect(command(in: leader[KeyStroke(key: "d", modifiers: [])]) == .showDashboard)
         #expect(command(in: leader[KeyStroke(key: "n", modifiers: [])]) == .newThread)
         #expect(command(in: leader[KeyStroke(key: "r", modifiers: [])]) == .refresh)

--- a/macos/ATCTests/ScriptableAppServerClient.swift
+++ b/macos/ATCTests/ScriptableAppServerClient.swift
@@ -35,6 +35,19 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
         /// While set, openThreadTerminal fails 503 with this payload — the
         /// install-or-configure message the unwrap seam must surface.
         var openThreadTerminalFailure: Components.Schemas.ProviderUnavailableJsonEncoding?
+        /// The Thread runtime (ATC-193) as seen by one client: a transcript
+        /// page per thread (an unseeded thread reads as empty), the pending
+        /// requests and queue, and what clients did about them.
+        var transcripts: [String: ThreadTranscriptPage] = [:]
+        var threadRequests: [String: [ThreadRequest]] = [:]
+        var threadQueues: [String: [QueuedPrompt]] = [:]
+        /// While set, promptThread fails 503 with this payload.
+        var promptThreadFailure: Components.Schemas.ProviderUnavailableJsonEncoding?
+        var transcriptReads: [(threadID: String, before: String?)] = []
+        var prompts: [(threadID: String, prompt: String)] = []
+        var answers: [(threadID: String, requestID: String, answer: ThreadRequestAnswer)] = []
+        var withdrawnPrompts: [(threadID: String, promptID: String)] = []
+        var interruptCount = 0
         var createdThreadRequests: [Components.Schemas.CreateThreadRequest] = []
         var createdTerminalRequests: [Components.Schemas.CreateTerminalRequest] = []
         var listProjectsCount = 0
@@ -148,6 +161,27 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
         set { lock.withLock { state.openThreadTerminalFailure = newValue } }
     }
 
+    /// Transcript page served for a thread id; unseeded threads read empty.
+    var transcripts: [String: ThreadTranscriptPage] {
+        get { lock.withLock { state.transcripts } }
+        set { lock.withLock { state.transcripts = newValue } }
+    }
+
+    var threadRequests: [String: [ThreadRequest]] {
+        get { lock.withLock { state.threadRequests } }
+        set { lock.withLock { state.threadRequests = newValue } }
+    }
+
+    var threadQueues: [String: [QueuedPrompt]] {
+        get { lock.withLock { state.threadQueues } }
+        set { lock.withLock { state.threadQueues = newValue } }
+    }
+
+    var promptThreadFailure: Components.Schemas.ProviderUnavailableJsonEncoding? {
+        get { lock.withLock { state.promptThreadFailure } }
+        set { lock.withLock { state.promptThreadFailure = newValue } }
+    }
+
     // MARK: - Captured requests and call counts
 
     var createdThreadRequests: [Components.Schemas.CreateThreadRequest] {
@@ -164,6 +198,13 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     var listAgentsCount: Int { lock.withLock { state.listAgentsCount } }
     var openThreadTerminalCount: Int { lock.withLock { state.openThreadTerminalCount } }
     var markThreadViewedCount: Int { lock.withLock { state.markThreadViewedCount } }
+    var transcriptReads: [(threadID: String, before: String?)] { lock.withLock { state.transcriptReads } }
+    var prompts: [(threadID: String, prompt: String)] { lock.withLock { state.prompts } }
+    var answers: [(threadID: String, requestID: String, answer: ThreadRequestAnswer)] {
+        lock.withLock { state.answers }
+    }
+    var withdrawnPrompts: [(threadID: String, promptID: String)] { lock.withLock { state.withdrawnPrompts } }
+    var interruptCount: Int { lock.withLock { state.interruptCount } }
 
     // MARK: - Projects
 
@@ -645,20 +686,53 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
         throw StubUnimplemented("subscribeEvents")
     }
 
-    // MARK: - Thread runtime (ATC-193): no macOS client yet (ATC-191)
+    // MARK: - Thread runtime (ATC-193)
 
+    /// Always admitted, always starting a turn at once (this stand-in never
+    /// models a busy thread — queue state is seeded directly).
     func promptThread(_ input: Operations.PromptThread.Input) async throws
         -> Operations.PromptThread.Output
     {
-        throw StubUnimplemented("promptThread")
+        guard case .json(let request) = input.body else { throw StubUnimplemented("promptThread") }
+        try await gate()
+        if let failure = promptThreadFailure {
+            return .serviceUnavailable(.init(body: .json(failure)))
+        }
+        let id = input.path.threadId
+        return mutate { model -> Operations.PromptThread.Output in
+            guard model.threads.contains(where: { $0.id == id }) else {
+                return .notFound(.init(body: .json(threadNotFound(id))))
+            }
+            model.prompts.append((id, request.prompt))
+            return .ok(.init(body: .json(.init(promptId: model.nextID("prm"), turnId: model.nextID("turn")))))
+        }
     }
 
+    /// Serves the seeded page for the thread; a `before` cursor reads as an
+    /// empty page (the contract's "cursor from a replaced copy" case) unless
+    /// the test seeded a page under `"<threadId>@before=<cursor>"`.
     func getThreadTranscript(_ input: Operations.GetThreadTranscript.Input) async throws
         -> Operations.GetThreadTranscript.Output
     {
-        throw StubUnimplemented("getThreadTranscript")
+        let id = input.path.threadId
+        let before = input.query.before
+        let page = mutate { model -> ThreadTranscriptPage? in
+            model.transcriptReads.append((id, before))
+            guard model.threads.contains(where: { $0.id == id }) else { return nil }
+            if let before {
+                return model.transcripts["\(id)@before=\(before)"]
+                    ?? ThreadTranscriptPage(items: [], turns: [], seq: 0, snapshotVersion: 0, hasMore: false)
+            }
+            return model.transcripts[id]
+                ?? ThreadTranscriptPage(items: [], turns: [], seq: 0, snapshotVersion: 0, hasMore: false)
+        }
+        try await gate()
+        guard let page else { return .notFound(.init(body: .json(threadNotFound(id)))) }
+        return .ok(.init(body: .json(page)))
     }
 
+    /// The app reaches the per-thread stream through `ThreadEventStream`,
+    /// never the contract client; `ScriptedThreadEventStream` is the seam.
     func subscribeThreadEvents(_ input: Operations.SubscribeThreadEvents.Input) async throws
         -> Operations.SubscribeThreadEvents.Output
     {
@@ -668,31 +742,92 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     func interruptThread(_ input: Operations.InterruptThread.Input) async throws
         -> Operations.InterruptThread.Output
     {
-        throw StubUnimplemented("interruptThread")
+        try await gate()
+        let id = input.path.threadId
+        return mutate { model -> Operations.InterruptThread.Output in
+            guard model.threads.contains(where: { $0.id == id }) else {
+                return .notFound(.init(body: .json(threadNotFound(id))))
+            }
+            model.interruptCount += 1
+            return .noContent(.init())
+        }
     }
 
     func listThreadRequests(_ input: Operations.ListThreadRequests.Input) async throws
         -> Operations.ListThreadRequests.Output
     {
-        throw StubUnimplemented("listThreadRequests")
+        let id = input.path.threadId
+        let requests = mutate { model -> [ThreadRequest]? in
+            model.threads.contains(where: { $0.id == id }) ? model.threadRequests[id] ?? [] : nil
+        }
+        try await gate()
+        guard let requests else { return .notFound(.init(body: .json(threadNotFound(id)))) }
+        return .ok(.init(body: .json(requests)))
     }
 
+    /// Records the answer and closes the request (a live server would also
+    /// emit `request.closed`; tests push that through the scripted stream).
     func answerThreadRequest(_ input: Operations.AnswerThreadRequest.Input) async throws
         -> Operations.AnswerThreadRequest.Output
     {
-        throw StubUnimplemented("answerThreadRequest")
+        guard case .json(let answer) = input.body else { throw StubUnimplemented("answerThreadRequest") }
+        try await gate()
+        let id = input.path.threadId
+        let requestID = input.path.requestId
+        return mutate { model -> Operations.AnswerThreadRequest.Output in
+            guard model.threads.contains(where: { $0.id == id }) else {
+                return .notFound(.init(body: .json(.init(value1: threadNotFound(id)))))
+            }
+            guard model.threadRequests[id, default: []].contains(where: { $0.id == requestID }) else {
+                return .notFound(
+                    .init(
+                        body: .json(
+                            .init(
+                                value2: .init(
+                                    _tag: .requestNotFound, threadId: id, requestId: requestID,
+                                    message: "No pending request \(requestID)")))))
+            }
+            model.answers.append((id, requestID, answer))
+            model.threadRequests[id]?.removeAll { $0.id == requestID }
+            return .noContent(.init())
+        }
     }
 
     func listThreadQueue(_ input: Operations.ListThreadQueue.Input) async throws
         -> Operations.ListThreadQueue.Output
     {
-        throw StubUnimplemented("listThreadQueue")
+        let id = input.path.threadId
+        let queue = mutate { model -> [QueuedPrompt]? in
+            model.threads.contains(where: { $0.id == id }) ? model.threadQueues[id] ?? [] : nil
+        }
+        try await gate()
+        guard let queue else { return .notFound(.init(body: .json(threadNotFound(id)))) }
+        return .ok(.init(body: .json(queue)))
     }
 
     func deleteQueuedPrompt(_ input: Operations.DeleteQueuedPrompt.Input) async throws
         -> Operations.DeleteQueuedPrompt.Output
     {
-        throw StubUnimplemented("deleteQueuedPrompt")
+        try await gate()
+        let id = input.path.threadId
+        let promptID = input.path.promptId
+        return mutate { model -> Operations.DeleteQueuedPrompt.Output in
+            guard model.threads.contains(where: { $0.id == id }) else {
+                return .notFound(.init(body: .json(.init(value1: threadNotFound(id)))))
+            }
+            guard model.threadQueues[id, default: []].contains(where: { $0.id == promptID }) else {
+                return .notFound(
+                    .init(
+                        body: .json(
+                            .init(
+                                value2: .init(
+                                    _tag: .queuedPromptNotFound, threadId: id, promptId: promptID,
+                                    message: "No queued prompt \(promptID)")))))
+            }
+            model.withdrawnPrompts.append((id, promptID))
+            model.threadQueues[id]?.removeAll { $0.id == promptID }
+            return .noContent(.init())
+        }
     }
 
     // MARK: - Private
@@ -823,6 +958,54 @@ enum Fixtures {
             updatedAt: createdAt,
             endedAt: status == .ended ? createdAt : nil
         )
+    }
+
+    // MARK: Thread runtime
+
+    static func userMessage(_ id: String, turn: String = "turn1", text: String = "hi", parent: String? = nil)
+        -> ThreadItem
+    {
+        .userMessage(.init(_type: .userMessage, id: id, turnId: turn, parentItemId: parent, text: text))
+    }
+
+    static func assistantText(
+        _ id: String, turn: String = "turn1", text: String = "", complete: Bool = false, parent: String? = nil
+    ) -> ThreadItem {
+        .assistantText(
+            .init(_type: .assistantText, id: id, turnId: turn, parentItemId: parent, text: text, complete: complete))
+    }
+
+    static func command(
+        _ id: String, turn: String = "turn1", title: String = "bun test", status: ToolStatus = .running,
+        parent: String? = nil, output: String? = nil, exitCode: Int? = nil
+    ) -> ThreadItem {
+        .command(
+            .init(
+                _type: .command, id: id, turnId: turn, parentItemId: parent, title: title, status: status,
+                command: title, output: output, exitCode: exitCode))
+    }
+
+    static func turn(_ id: String, status: Components.Schemas.ThreadTurnStatus = .running, error: String? = nil)
+        -> ThreadTurn
+    {
+        ThreadTurn(id: id, status: status, error: error)
+    }
+
+    static func page(
+        items: [ThreadItem], turns: [ThreadTurn] = [], seq: Int, snapshotVersion: Int = 1, hasMore: Bool = false
+    ) -> ThreadTranscriptPage {
+        ThreadTranscriptPage(items: items, turns: turns, seq: seq, snapshotVersion: snapshotVersion, hasMore: hasMore)
+    }
+
+    static func queued(_ id: String, prompt: String = "later") -> QueuedPrompt {
+        QueuedPrompt(id: id, prompt: prompt, queuedAt: epoch)
+    }
+
+    static func approval(_ id: String, turn: String = "turn1", title: String = "Run bun test?") -> ThreadRequest {
+        .approval(
+            .init(
+                kind: .approval, id: id, turnId: turn, openedAt: epoch, title: title,
+                subject: .command(.init(_type: .command, command: "bun test"))))
     }
 
     static func agent(_ id: AgentID, available: Bool = true) -> Agent {

--- a/macos/ATCTests/TestSupport.swift
+++ b/macos/ATCTests/TestSupport.swift
@@ -99,6 +99,58 @@ nonisolated final class ScriptedEventStream: @unchecked Sendable {
     }
 }
 
+// MARK: - Scripted thread event stream
+
+/// The per-thread SSE seam under test control: hand `factory` to a runtime
+/// through `threadEventStreamFactory`; every Chat model's subscription is
+/// recorded (thread id and its live `after` cursor) and driven from the
+/// test with `connect` / `send` / `disconnect`.
+nonisolated final class ScriptedThreadEventStream: @unchecked Sendable {
+    struct Subscription {
+        let threadID: String
+        /// The model's resume cursor, read live — what a reconnect would ask.
+        let after: @Sendable () -> Int?
+        let continuation: AsyncStream<ThreadEventStream.Event>.Continuation
+    }
+
+    private let lock = NSLock()
+    private var recorded: [Subscription] = []
+
+    var subscriptions: [Subscription] { lock.withLock { recorded } }
+
+    var factory: ConnectionRuntime.ThreadEventStreamFactory {
+        { [self] _, threadID, _, after in
+            let (stream, continuation) = AsyncStream.makeStream(of: ThreadEventStream.Event.self)
+            lock.withLock {
+                recorded.append(Subscription(threadID: threadID, after: after, continuation: continuation))
+            }
+            return stream
+        }
+    }
+
+    /// The most recent subscription for a thread (a model subscribes once
+    /// and resumes on the same stream).
+    private func subscription(_ threadID: String) -> Subscription? {
+        subscriptions.last { $0.threadID == threadID }
+    }
+
+    /// Connects as the live stream would: it asks the resume cursor first
+    /// (that is what a real (re)connect sends as `after`), then opens.
+    func connect(_ threadID: String) {
+        guard let subscription = subscription(threadID) else { return }
+        _ = subscription.after()
+        subscription.continuation.yield(.connected)
+    }
+
+    func send(_ threadID: String, _ event: ThreadEvent) {
+        subscription(threadID)?.continuation.yield(.event(event))
+    }
+
+    func disconnect(_ threadID: String) {
+        subscription(threadID)?.continuation.yield(.disconnected)
+    }
+}
+
 // MARK: - Attach harness
 
 /// Stands in for the attach WebSocket. Every connection attempt is recorded
@@ -209,6 +261,7 @@ struct TestModel {
 func makeModel(
     client: ScriptableAppServerClient = ScriptableAppServerClient(),
     events: ScriptedEventStream? = nil,
+    threadEvents: ScriptedThreadEventStream? = nil,
     attach: AttachHarness = AttachHarness(),
     attachmentBudget: Int = 12,
     threadNotifier: ThreadNotifier? = nil,
@@ -221,6 +274,7 @@ func makeModel(
         connections: store,
         client: client,
         events: events,
+        threadEvents: threadEvents,
         attach: attach,
         threadNotifier: threadNotifier,
         attachmentBudget: attachmentBudget
@@ -254,6 +308,7 @@ func makeEmptyAppModel(
         connections: makeConnectionsStore(),
         client: client,
         events: nil,
+        threadEvents: nil,
         attach: attach,
         threadNotifier: nil,
         attachmentBudget: 12
@@ -273,6 +328,7 @@ private func makeAppModel(
     connections: ConnectionsStore,
     client: ScriptableAppServerClient,
     events: ScriptedEventStream?,
+    threadEvents: ScriptedThreadEventStream?,
     attach: AttachHarness,
     threadNotifier: ThreadNotifier?,
     attachmentBudget: Int
@@ -291,6 +347,8 @@ private func makeAppModel(
         // An absent factory would leave the runtime on the live SSE stream,
         // pointing the suite at a real socket.
         eventStreamFactory: { _, _ in events?.stream ?? ScriptedEventStream.inert() },
+        // Same rule for the per-thread streams: never a live socket.
+        threadEventStreamFactory: threadEvents?.factory ?? { _, _, _, _ in AsyncStream { _ in } },
         threadNotifier: threadNotifier,
         attachmentBudget: attachmentBudget
     )

--- a/macos/ATCTests/ThreadChatModelTests.swift
+++ b/macos/ATCTests/ThreadChatModelTests.swift
@@ -1,0 +1,316 @@
+import ATCAppServerAPI
+import Foundation
+import Testing
+
+@testable import ATC
+
+/// The Chat model's I/O around the reducer: load-on-connect, the resume
+/// cursor, snapshot invalidation, live-state refetch, the runtime's
+/// acquire/release ownership, and the composer-facing actions.
+@MainActor
+@Suite("ThreadChatModel")
+struct ThreadChatModelTests {
+    private struct Harness {
+        let test: TestModel
+        let streams: ScriptedThreadEventStream
+        let chat: ThreadChatModel
+    }
+
+    private func acquired(
+        _ client: ScriptableAppServerClient = ScriptableAppServerClient(),
+        connect: Bool = true
+    ) async throws -> Harness {
+        Fixtures.seed(client)
+        client.transcripts["thr1"] = Fixtures.page(
+            items: [Fixtures.userMessage("u1"), Fixtures.assistantText("a1", text: "Hel")],
+            turns: [Fixtures.turn("turn1")],
+            seq: 10
+        )
+        client.threadRequests["thr1"] = [Fixtures.approval("r1")]
+        client.threadQueues["thr1"] = [Fixtures.queued("p1")]
+        let streams = ScriptedThreadEventStream()
+        let test = try await makeModel(client: client, threadEvents: streams)
+        let chat = test.runtime.acquireChat(threadID: "thr1")
+        if connect {
+            streams.connect("thr1")
+            await settle(until: { chat.transcript.isLoaded && !chat.transcript.requests.isEmpty })
+        }
+        return Harness(test: test, streams: streams, chat: chat)
+    }
+
+    @Test("connect loads the newest page, then the live-only state; the cursor is the page's seq")
+    func connectLoads() async throws {
+        let harness = try await acquired()
+        let chat = harness.chat
+
+        #expect(chat.connection == .live)
+        #expect(chat.transcript.items.map(\.id) == ["u1", "a1"])
+        #expect(chat.transcript.requests.map(\.id) == ["r1"])
+        #expect(chat.transcript.queue.map(\.id) == ["p1"])
+        #expect(harness.test.client.transcriptReads.map(\.before) == [nil])
+        let subscription = try #require(harness.streams.subscriptions.first)
+        #expect(subscription.threadID == "thr1")
+        #expect(subscription.after() == 10)
+    }
+
+    @Test("live events move the cursor; a reconnect refetches only requests and queue, never the transcript")
+    func reconnectResumes() async throws {
+        let harness = try await acquired()
+        let chat = harness.chat
+        let client = harness.test.client
+
+        harness.streams.send("thr1", .text_delta(.init(_type: .text_delta, itemId: "a1", delta: "lo")))
+        harness.streams.send(
+            "thr1",
+            .item_completed(
+                .init(
+                    _type: .item_completed, seq: 11, item: Fixtures.assistantText("a1", text: "Hello!", complete: true))
+            ))
+        await settle(until: { chat.transcript.seq == 11 })
+        #expect(harness.streams.subscriptions[0].after() == 11)
+
+        harness.streams.disconnect("thr1")
+        await settle(until: { chat.connection == .reconnecting })
+        // The transcript stays on screen through the outage.
+        #expect(chat.transcript.items.count == 2)
+
+        client.threadRequests["thr1"] = []
+        harness.streams.connect("thr1")
+        await settle(until: { chat.transcript.requests.isEmpty })
+        #expect(chat.connection == .live)
+        #expect(client.transcriptReads.count == 1)
+    }
+
+    @Test("snapshot.invalidated refetches the transcript in place and drops what the new page already holds")
+    func snapshotInvalidated() async throws {
+        let harness = try await acquired()
+        let chat = harness.chat
+        let client = harness.test.client
+
+        client.transcripts["thr1"] = Fixtures.page(
+            items: [Fixtures.userMessage("u1", text: "hi (re-read)")], turns: [], seq: 20, snapshotVersion: 2)
+        harness.streams.send(
+            "thr1", .snapshot_invalidated(.init(_type: .snapshot_invalidated, seq: 15, snapshotVersion: 2)))
+        await settle(until: { chat.transcript.seq == 20 })
+
+        #expect(client.transcriptReads.count == 2)
+        #expect(chat.transcript.items.count == 1)
+        // A change the re-read already contains is not applied twice.
+        harness.streams.send(
+            "thr1", .item_started(.init(_type: .item_started, seq: 18, item: Fixtures.command("stale"))))
+        harness.streams.send(
+            "thr1", .item_started(.init(_type: .item_started, seq: 21, item: Fixtures.command("fresh"))))
+        await settle(until: { chat.transcript.seq == 21 })
+        #expect(chat.transcript.items.map(\.id) == ["u1", "fresh"])
+        #expect(harness.streams.subscriptions[0].after() == 21)
+    }
+
+    @Test("a reconnect that raced the first read replays nothing, so its connect reloads the copy")
+    func liveOnlyResubscribeReloads() async throws {
+        let client = ScriptableAppServerClient()
+        let harness = try await acquired(client, connect: false)
+        let chat = harness.chat
+        client.delay = .milliseconds(50)
+        harness.streams.connect("thr1")
+        // The stream drops and comes back while the first read is in flight:
+        // that subscription asked for no `after`, so nothing between the read
+        // and the resubscribe would ever arrive — the copy must be reread.
+        harness.streams.disconnect("thr1")
+        harness.streams.connect("thr1")
+        await settle(until: { client.transcriptReads.count == 2 })
+        client.delay = nil
+        await settle(until: { chat.transcript.isLoaded && chat.connection == .live })
+        #expect(harness.streams.subscriptions[0].after() == 10)
+
+        // A reconnect that did ask with the cursor replays instead.
+        harness.streams.disconnect("thr1")
+        harness.streams.connect("thr1")
+        await settle(until: { chat.connection == .live })
+        await drainPendingTasks()
+        #expect(client.transcriptReads.count == 2)
+    }
+
+    @Test("a failed first load stays empty with an error, and the next connect retries it")
+    func failedLoadRetries() async throws {
+        let client = ScriptableAppServerClient()
+        let harness = try await acquired(client, connect: false)
+        let chat = harness.chat
+        client.shouldFail = true
+        harness.streams.connect("thr1")
+        await settle(until: { chat.loadError != nil })
+        #expect(!chat.transcript.isLoaded)
+        #expect(harness.streams.subscriptions[0].after() == nil)
+
+        client.shouldFail = false
+        harness.streams.disconnect("thr1")
+        harness.streams.connect("thr1")
+        await settle(until: { chat.transcript.isLoaded })
+        #expect(chat.loadError == nil)
+        #expect(chat.transcript.items.count == 2)
+    }
+
+    @Test("load earlier pages before the oldest item and prepends it")
+    func loadOlder() async throws {
+        let client = ScriptableAppServerClient()
+        Fixtures.seed(client)
+        client.transcripts["thr1"] = Fixtures.page(items: [Fixtures.userMessage("u5")], seq: 10, hasMore: true)
+        client.transcripts["thr1@before=u5"] = Fixtures.page(
+            items: [Fixtures.userMessage("u4")], seq: 10, hasMore: false)
+        let streams = ScriptedThreadEventStream()
+        let test = try await makeModel(client: client, threadEvents: streams)
+        let chat = test.runtime.acquireChat(threadID: "thr1")
+        streams.connect("thr1")
+        await settle(until: { chat.transcript.isLoaded })
+
+        try await chat.loadOlder()
+
+        #expect(chat.transcript.items.map(\.id) == ["u4", "u5"])
+        #expect(!chat.transcript.hasMore)
+        #expect(client.transcriptReads.map(\.before) == [nil, "u5"])
+    }
+
+    @Test("send goes to the server and reports refusal without touching the copy")
+    func send() async throws {
+        let harness = try await acquired()
+        let chat = harness.chat
+        let client = harness.test.client
+
+        #expect(await chat.send("do it"))
+        #expect(client.prompts.map(\.prompt) == ["do it"])
+        #expect(chat.promptError == nil)
+
+        client.promptThreadFailure = .init(
+            _tag: .providerUnavailable, agentId: "codex", reason: "not-installed", message: "Codex is not installed")
+        #expect(await chat.send("again") == false)
+        #expect(chat.promptError == "Codex is not installed")
+        #expect(chat.transcript.items.count == 2)
+    }
+
+    @Test("stop, answer, and withdraw reach the server as the contract's operations")
+    func actions() async throws {
+        let harness = try await acquired()
+        let chat = harness.chat
+        let client = harness.test.client
+
+        try await chat.interrupt()
+        try await chat.answer(requestID: "r1", .approval(.init(kind: .approval, decision: .acceptForSession)))
+        try await chat.withdraw(promptID: "p1")
+
+        #expect(client.interruptCount == 1)
+        #expect(client.answers.map(\.requestID) == ["r1"])
+        guard case .approval(let approval) = client.answers[0].answer else {
+            Issue.record("expected an approval answer")
+            return
+        }
+        #expect(approval.decision == .acceptForSession)
+        #expect(client.withdrawnPrompts.map(\.promptID) == ["p1"])
+        // The card closes only when the stream says so.
+        #expect(chat.transcript.requests.map(\.id) == ["r1"])
+        harness.streams.send("thr1", .request_closed(.init(_type: .request_closed, requestId: "r1")))
+        await settle(until: { chat.transcript.requests.isEmpty })
+
+        // A refused action throws the server's message.
+        await #expect(throws: ServerError.self) {
+            try await chat.withdraw(promptID: "gone")
+        }
+    }
+
+    @Test("a failed resync keeps the cursor and holds durable events until a page lands")
+    func failedResyncHoldsCursor() async throws {
+        let harness = try await acquired()
+        let chat = harness.chat
+        let client = harness.test.client
+
+        client.shouldFail = true
+        harness.streams.send(
+            "thr1", .snapshot_invalidated(.init(_type: .snapshot_invalidated, seq: 15, snapshotVersion: 2)))
+        await settle(until: { chat.loadError != nil })
+        // Neither the invalidation nor a later durable change moves the
+        // reconnect cursor: a reconnect must be told about the re-read again.
+        harness.streams.send("thr1", .item_started(.init(_type: .item_started, seq: 16, item: Fixtures.command("c16"))))
+        await drainPendingTasks()
+        #expect(harness.streams.subscriptions[0].after() == 10)
+        #expect(chat.transcript.items.map(\.id) == ["u1", "a1"])
+        #expect(client.transcriptReads.count == 3)
+
+        // The next durable event retries the read; once it lands the copy
+        // and cursor are the page's.
+        client.shouldFail = false
+        client.transcripts["thr1"] = Fixtures.page(items: [Fixtures.userMessage("u1")], seq: 20, snapshotVersion: 2)
+        harness.streams.send("thr1", .item_started(.init(_type: .item_started, seq: 17, item: Fixtures.command("c17"))))
+        await settle(until: { chat.transcript.seq == 20 })
+        #expect(chat.loadError == nil)
+        #expect(chat.transcript.items.map(\.id) == ["u1"])
+        #expect(harness.streams.subscriptions[0].after() == 20)
+    }
+
+    @Test("an older page from a replaced copy is discarded")
+    func olderPageFromReplacedCopyDiscarded() async throws {
+        let client = ScriptableAppServerClient()
+        Fixtures.seed(client)
+        client.transcripts["thr1"] = Fixtures.page(
+            items: [Fixtures.userMessage("u5")], seq: 10, snapshotVersion: 1, hasMore: true)
+        client.transcripts["thr1@before=u5"] = Fixtures.page(
+            items: [Fixtures.userMessage("u4")], seq: 10, snapshotVersion: 1, hasMore: false)
+        let streams = ScriptedThreadEventStream()
+        let test = try await makeModel(client: client, threadEvents: streams)
+        let chat = test.runtime.acquireChat(threadID: "thr1")
+        streams.connect("thr1")
+        await settle(until: { chat.transcript.isLoaded })
+
+        // The copy is replaced (snapshotVersion 2) before the older page,
+        // read from version 1, comes back.
+        client.transcripts["thr1"] = Fixtures.page(
+            items: [Fixtures.userMessage("u9")], seq: 30, snapshotVersion: 2, hasMore: true)
+        streams.send("thr1", .snapshot_invalidated(.init(_type: .snapshot_invalidated, seq: 25, snapshotVersion: 2)))
+        await settle(until: { chat.transcript.seq == 30 })
+        try await chat.loadOlder()
+
+        #expect(chat.transcript.items.map(\.id) == ["u9"])
+        #expect(chat.transcript.hasMore)
+    }
+
+    @Test("a failed live-state read is retried while the stream stays up")
+    func liveStateRetries() async throws {
+        let client = ScriptableAppServerClient()
+        let harness = try await acquired(client, connect: false)
+        let chat = harness.chat
+        chat.liveStateRetryDelay = .milliseconds(1)
+        client.threadRequests["thr1"] = []
+        harness.streams.connect("thr1")
+        await settle(until: { chat.transcript.isLoaded })
+        // Requests were read empty; the queue read is what a later retry
+        // will pick up. Make the next reads fail, then recover.
+        client.shouldFail = true
+        client.threadRequests["thr1"] = [Fixtures.approval("late")]
+        harness.streams.disconnect("thr1")
+        harness.streams.connect("thr1")
+        await settle(until: { chat.connection == .live })
+        await drainPendingTasks()
+        #expect(chat.transcript.requests.isEmpty)
+
+        client.shouldFail = false
+        await settle(until: { chat.transcript.requests.map(\.id) == ["late"] })
+    }
+
+    @Test("the runtime shares one model across holds and stops it on the last release")
+    func ownership() async throws {
+        let harness = try await acquired()
+        let runtime = harness.test.runtime
+
+        let again = runtime.acquireChat(threadID: "thr1")
+        #expect(again === harness.chat)
+        #expect(harness.streams.subscriptions.count == 1)
+
+        runtime.releaseChat(threadID: "thr1")
+        #expect(runtime.acquireChat(threadID: "thr1") === harness.chat)
+        runtime.releaseChat(threadID: "thr1")
+        runtime.releaseChat(threadID: "thr1")
+
+        // A fresh acquire is a fresh model with its own subscription.
+        let fresh = runtime.acquireChat(threadID: "thr1")
+        #expect(fresh !== harness.chat)
+        #expect(harness.streams.subscriptions.count == 2)
+        runtime.releaseChat(threadID: "thr1")
+    }
+}

--- a/macos/ATCTests/ThreadNotifierTests.swift
+++ b/macos/ATCTests/ThreadNotifierTests.swift
@@ -410,7 +410,7 @@ struct ThreadNotifierTests {
         // Parked: no window is registered yet.
         notifier.onOpenThread?(test.threadRef("thr3"))
 
-        _ = try await test.model.openThread(test.threadRef("thr1"))
+        await WindowState().openThread(test.threadRef("thr1"), in: test.model)
 
         // A window arriving later must not replay the superseded click.
         let window = WindowState()

--- a/macos/ATCTests/WindowStateTests.swift
+++ b/macos/ATCTests/WindowStateTests.swift
@@ -21,6 +21,13 @@ struct WindowStateTests {
         return test
     }
 
+    /// The terminal-first path: these suites predate Chat, so the thread
+    /// is put in TUI mode before opening.
+    private func openInTUI(_ ref: ThreadRef, state: WindowState, in test: TestModel) async {
+        test.model.setViewMode(.tui, for: ref)
+        await state.openThread(ref, in: test.model)
+    }
+
     // MARK: - Launch state
 
     @Test("a window opens on Dashboard with no project context and no filter")
@@ -36,13 +43,13 @@ struct WindowStateTests {
 
     // MARK: - Opening threads
 
-    @Test("openThread selects the thread, adopts its project, and records its terminal")
+    @Test("openThread in TUI selects the thread, adopts its project, and records its terminal")
     func openThreadSucceeds() async throws {
         let test = try await loadedModel()
         let state = WindowState()
         let ref = test.threadRef("thr1")
 
-        await state.openThread(ref, in: test.model)
+        await openInTUI(ref, state: state, in: test)
 
         #expect(state.selectedContent == .thread(ref))
         #expect(state.selectedThread == ref)
@@ -51,7 +58,7 @@ struct WindowStateTests {
         #expect(state.visibleTerminal == terminalRef)
         #expect(test.model.terminals[terminalRef] != nil)
         #expect(state.threadOpenErrors[ref] == nil)
-        #expect(state.terminalFocusRequest > 0)
+        #expect(state.contentFocusRequest > 0)
     }
 
     @Test("a failed open keeps the selection and records the error")
@@ -62,7 +69,7 @@ struct WindowStateTests {
         let ref = test.threadRef("thr1")
 
         client.shouldFail = true
-        await state.openThread(ref, in: test.model)
+        await openInTUI(ref, state: state, in: test)
 
         // The content area stays on the thread and explains itself; bouncing
         // back to Dashboard would lose the user's place on a transient error.
@@ -155,7 +162,7 @@ struct WindowStateTests {
         let test = try await loadedModel(client)
         let state = WindowState()
         let ref = test.threadRef("thr1")
-        await state.openThread(ref, in: test.model)
+        await openInTUI(ref, state: state, in: test)
 
         try await test.runtime.threads.archive(id: "thr1")
         state.reconcile(in: test.model)
@@ -217,7 +224,7 @@ struct WindowStateTests {
         let test = try await loadedModel()
         let state = WindowState()
         let ref = test.threadRef("thr1")
-        await state.openThread(ref, in: test.model)
+        await openInTUI(ref, state: state, in: test)
         state.threadFilter = .project(test.projectRef("prj"))
 
         test.model.removeConnection(id: test.connectionID)
@@ -246,7 +253,7 @@ struct WindowStateTests {
         let test = try await loadedModel(client)
         let state = WindowState()
         let ref = test.threadRef("thr1")
-        await state.openThread(ref, in: test.model)
+        await openInTUI(ref, state: state, in: test)
         let original = try #require(state.threadTerminals[ref])
 
         // A relaunch elsewhere replaced the thread's TUI terminal.
@@ -275,7 +282,7 @@ struct WindowStateTests {
         let test = try await loadedModel()
         let state = WindowState()
         let ref = test.threadRef("thr1")
-        await state.openThread(ref, in: test.model)
+        await openInTUI(ref, state: state, in: test)
         let terminalRef = try #require(state.threadTerminals[ref])
 
         // Eviction or Connection teardown released the controller while the
@@ -296,7 +303,7 @@ struct WindowStateTests {
         let test = try await loadedModel(client)
         let state = WindowState()
         let ref = test.threadRef("thr1")
-        await state.openThread(ref, in: test.model)
+        await openInTUI(ref, state: state, in: test)
         let terminalRef = try #require(state.threadTerminals[ref])
 
         // The thread lets go of its terminal but the terminal row stays
@@ -321,7 +328,7 @@ struct WindowStateTests {
         let test = try await loadedModel(client)
         let state = WindowState()
         let ref = test.threadRef("thr1")
-        await state.openThread(ref, in: test.model)
+        await openInTUI(ref, state: state, in: test)
         let terminalRef = try #require(state.threadTerminals[ref])
 
         client.terminals.removeAll { $0.id == terminalRef.terminalID }
@@ -442,17 +449,108 @@ struct WindowStateTests {
         #expect(state.columnVisibility == .all)
     }
 
-    @Test("terminal focus is only requested while a terminal is visible")
-    func focusRequestsRequireATerminal() async throws {
+    @Test("content focus advances on every request, including re-selecting the same row")
+    func focusRequestsAdvance() async throws {
         let test = try await loadedModel()
         let state = WindowState()
-        state.requestTerminalFocus()
-        #expect(state.terminalFocusRequest == 0)
-
         state.selectTerminal(test.terminalRef("trm_live"), in: test.model)
-        let after = state.terminalFocusRequest
-        #expect(after > 0)
-        state.requestTerminalFocus()
-        #expect(state.terminalFocusRequest == after + 1)
+        let first = state.contentFocusRequest
+        #expect(first > 0)
+        state.selectTerminal(test.terminalRef("trm_live"), in: test.model)
+        #expect(state.contentFocusRequest == first + 1)
+        state.requestContentFocus()
+        #expect(state.contentFocusRequest == first + 2)
+    }
+
+    // MARK: - Chat and TUI
+
+    @Test("Chat is the default: opening a thread selects it and never opens or attaches a terminal")
+    func chatIsDefault() async throws {
+        let test = try await loadedModel()
+        let state = WindowState()
+        let ref = test.threadRef("thr1")
+
+        await state.openThread(ref, in: test.model)
+
+        #expect(test.model.viewMode(for: ref) == .chat)
+        #expect(state.selectedContent == .thread(ref))
+        #expect(state.activeProject == test.projectRef("prj"))
+        #expect(state.threadTerminals[ref] == nil)
+        #expect(test.model.terminals.isEmpty)
+        #expect(test.client.openThreadTerminalCount == 0)
+        #expect(state.contentFocusRequest > 0)
+    }
+
+    @Test("switching the displayed thread to TUI opens its terminal; back to Chat leaves it retained")
+    func switchingModes() async throws {
+        let test = try await loadedModel()
+        let state = WindowState()
+        test.model.registerWindow(state)
+        let ref = test.threadRef("thr1")
+        await state.openThread(ref, in: test.model)
+
+        test.model.setViewMode(.tui, for: ref)
+        await settle(until: { state.threadTerminals[ref] != nil })
+        let terminalRef = try #require(state.threadTerminals[ref])
+        #expect(test.model.terminals[terminalRef] != nil)
+        #expect(test.client.openThreadTerminalCount == 1)
+
+        test.model.setViewMode(.chat, for: ref)
+        await drainPendingTasks()
+        // The surface survives the flip; only what the pane shows changes.
+        #expect(state.threadTerminals[ref] == terminalRef)
+        #expect(test.model.terminals[terminalRef] != nil)
+        #expect(test.client.openThreadTerminalCount == 1)
+
+        state.toggleViewMode(in: test.model)
+        #expect(test.model.viewMode(for: ref) == .tui)
+        await drainPendingTasks()
+    }
+
+    @Test("the mode is remembered per thread and shared by every window showing it")
+    func modeIsSharedAcrossWindows() async throws {
+        let test = try await loadedModel()
+        let first = WindowState()
+        let second = WindowState()
+        let elsewhere = WindowState()
+        for window in [first, second, elsewhere] { test.model.registerWindow(window) }
+        let ref = test.threadRef("thr1")
+        let other = test.threadRef("thr2")
+        await first.openThread(ref, in: test.model)
+        await second.openThread(ref, in: test.model)
+        await elsewhere.openThread(other, in: test.model)
+
+        first.toggleViewMode(in: test.model)
+        // Both windows on the thread open its terminal, without a second
+        // server open; the window on another thread is untouched.
+        await settle(until: { first.threadTerminals[ref] != nil && second.threadTerminals[ref] != nil })
+        #expect(test.model.viewMode(for: ref) == .tui)
+        #expect(test.model.viewMode(for: other) == .chat)
+        #expect(first.threadTerminals[ref] == second.threadTerminals[ref])
+        #expect(test.client.openThreadTerminalCount <= 2)
+        #expect(elsewhere.threadTerminals.isEmpty)
+    }
+
+    @Test("in Chat, reconciliation tracks the linked terminal but never attaches it")
+    func chatNeverAttachesOnReconcile() async throws {
+        let client = ScriptableAppServerClient()
+        let test = try await loadedModel(client)
+        let state = WindowState()
+        let ref = test.threadRef("thr1")
+        await state.openThread(ref, in: test.model)
+
+        // Another client (a TUI elsewhere) links a live terminal.
+        let linked = Fixtures.terminal(id: "trm_linked", threadId: "thr1")
+        client.terminals += [linked]
+        client.threads = client.threads.map { thread in
+            var thread = thread
+            if thread.id == "thr1" { thread.linkedTerminalId = "trm_linked" }
+            return thread
+        }
+        await test.runtime.refresh()
+        state.reconcile(in: test.model)
+
+        #expect(state.threadTerminals[ref] == test.terminalRef("trm_linked"))
+        #expect(test.model.terminals.isEmpty)
     }
 }

--- a/macos/CONTEXT.md
+++ b/macos/CONTEXT.md
@@ -23,10 +23,22 @@ _Avoid_: Local project, app project, Workspace
 **Thread**:
 A durable agent conversation (Codex or Claude Code) — the primary object users
 create and navigate. A Thread belongs to a Project, has an Agent and an
-immutable working directory, and is always reopenable: opening it launches or
-reuses its provider TUI in a linked Terminal. Threads have no Ended state; a
-Thread whose TUI terminal exited simply relaunches on open.
-_Avoid_: Session, conversation, chat
+immutable working directory, and is always reopenable in either of its two
+views, Chat or TUI. Threads have no Ended state; a Thread whose TUI terminal
+exited simply relaunches when opened in TUI.
+_Avoid_: Session, conversation
+
+**Chat**:
+One of the two views of a Thread, and the default: the Thread's transcript
+and a composer, driven natively through the App Server with no Terminal
+involved. Chat and TUI show the same conversation; which one a Thread is
+shown in is remembered for the app session and shared by every window.
+_Avoid_: Native mode, transcript view
+
+**TUI**:
+The other view of a Thread: its provider TUI running in the linked Terminal.
+Opening a Thread in TUI launches or reuses that Terminal.
+_Avoid_: Terminal mode, terminal view
 
 **Terminal**:
 A server-owned zmx-backed process. A Thread's TUI runs in a linked Terminal

--- a/macos/atc.xcodeproj/project.pbxproj
+++ b/macos/atc.xcodeproj/project.pbxproj
@@ -326,9 +326,6 @@
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				// CI seam: warnings-as-errors only when ATC_SWIFT_STRICT_WARNINGS=YES
-				// is passed on the xcodebuild command line (empty locally = off). Only
-				// this project's targets reference it, so package deps stay unaffected.
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = "$(ATC_SWIFT_STRICT_WARNINGS)";
 			};
 			name = Debug;
@@ -386,9 +383,6 @@
 				MTL_FAST_MATH = YES;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
-				// CI seam: warnings-as-errors only when ATC_SWIFT_STRICT_WARNINGS=YES
-				// is passed on the xcodebuild command line (empty locally = off). Only
-				// this project's targets reference it, so package deps stay unaffected.
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = "$(ATC_SWIFT_STRICT_WARNINGS)";
 			};
 			name = Release;


### PR DESCRIPTION
Part 2 of 2 for [ATC-191](https://linear.app/elevenideas/issue/ATC-191/native-thread-ui-macos-client-of-the-thread-runtime-api). Stacked on #210 (ATCKit `ThreadEventStream`). Server untouched.

## What

Threads have two views, **Chat** (default) and **TUI** (today's terminal), switched by a Chat | TUI segmented control in the toolbar and a *Toggle Chat/TUI* command (`leader>c`, palette, View menu). The mode is remembered per thread for the app session in `AppModel`, shared across windows; `AppModel.setViewMode` re-opens the thread in every window showing it.

- **`ChatTranscript`** — pure reducer over the contract's `ThreadEvent`s: items/turns upsert by id (order = transcript order, new ids append), `text.delta` extends the named item, requests open/close by id, the queue is replaced wholesale, and a durable event at or below the applied `seq` is dropped so a live event can never roll a row back past a transcript read.
- **`ThreadChatModel`** — the I/O around it, owned by `ConnectionRuntime` (`acquireChat`/`releaseChat`, held while any window shows the thread in Chat). One path for load and resume: the per-thread stream starts at once; on every `.connected` the newest page is read if it never was (or is invalid), then requests + queue are refetched (and retried on a delay while a read fails — they are never replayed); `after` is the highest seq applied, asked on every reconnect, so a lost connection replays only the gap and the transcript stays on screen; `snapshot.invalidated` marks the copy invalid and refetches the page in place — until a page lands, durable events are held and the cursor does not move, so a reconnect is told about the re-read again instead of silently resuming a dead copy. Every newest-page read is serialized with event handling so a page can never land beneath a change already applied; an older page from a replaced copy (`snapshotVersion`) is discarded. Send/stop/answer/withdraw go straight to the server (through `AppModel.run` + the standard action alert) and come back through the stream.
- **Views** under `Features/Threads/Chat/`: transcript (auto-follow until the user scrolls up, "Load earlier" while `hasMore`), rows for user/assistant text (inline markdown), collapsed Thinking, tool rows with disclosure (command output + exit code, per-file diffs, MCP/tool JSON), `parentItemId` nesting, compaction divider, failed/interrupted turn marker, "Working…" from a running turn or `activityState`; request cards (questions incl. multi-select/freeform/secret, approvals with Allow / Allow for Session / Deny / Deny & Stop); queued-prompt strip with ✕; composer (Return sends, Shift-Return newline, Stop while a turn runs, refusal shown inline keeping the text); "Connecting…/Reconnecting…" as a `FloatingBanner` (now shared with the terminal banners).
- **`WindowState.openThread`** selects/establishes context for both modes but only opens/attaches the terminal in TUI; `ThreadContentView` draws Chat over the always-mounted `TerminalPane` with the thread's terminal hidden, so a retained surface survives a mode flip. Reconciliation tracks the linked terminal in Chat but never attaches. Every open (Chat or TUI) still supersedes a parked notification click (`AppModel.noteThreadOpened`).
- Glossary: `macos/CONTEXT.md` gains Chat and TUI as the two views of a Thread.

## Tests

`ChatTranscriptTests` (reducer + rows), `ThreadChatModelTests` (load-on-connect, resume cursor, reconnect refetches only live state, snapshot invalidation, failed-load retry, paging, send refusal, actions, acquire/release ownership) on a `ScriptedThreadEventStream`; `ScriptableAppServerClient` now implements the runtime operations; `WindowStateTests` cover Chat default (no terminal opened/attached), mode switching, cross-window memory, and Chat reconciliation; command registry/keymap tests updated. Root `mise run check` green.

## Review

Two adversarial Codex (gpt-5.6-sol, high) passes — correctness and simplicity — were run and acted on: invalidation no longer advances the cursor and holds durable events until a page lands; newest-page reads are serialized with the stream; older pages are checked against `snapshotVersion`; live-state reads retry; nesting renders to any depth; a TUI open completing after a flip back to Chat no longer steals focus; "Load earlier" keeps the reader's place; actions use the app's one mutation seam and shared alert; one `contentFocusRequest` token replaces two; `ThreadItem` head fields read through one switch; a test-only runtime accessor was dropped. A further whole-stack review pass (Claude) added: deltas never extend a completed item (a replayed delta behind the page that completed it doubled text); a subscription that asked for no `after` always reloads on `.connected` (a reconnect racing the first read left a gap); a never-loaded copy holds durable events like an invalid one; live-state reads are serialized with the stream like page reads. CodeRabbit round 1 addressed inline.

## Not verified here

A live turn in the app UI: the machine's screen was locked for this session, so I could not drive the app visually. Everything else is covered by tests against the contract shapes; the SSE framing is the same one `/events` already uses in production.

https://claude.ai/code/session_01UUfpkWwiThwv7eGvAVTDun


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Chat view for threads with transcript history, streaming responses, markdown, reasoning, tool activity, queued prompts, and request handling.
  * Added Chat/TUI switching via toolbar picker or `leader>c`, with each thread’s mode remembered.
  * Added message composer with send, stop, multiline input, and error feedback.
  * Added expandable activity details, question-answering, approval controls, and queued-prompt withdrawal.
  * Added clearer connection, loading, retry, and status banners.
* **Bug Fixes**
  * Improved focus restoration and transcript recovery during reconnects.
* **Documentation**
  * Clarified Chat and TUI thread behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->