### PR TITLE
Claude history: read every branch of the session file; settle the idle re-read (ATC-191)

### DIFF
--- a/app-server/src/agents/claudeAdapter.ts
+++ b/app-server/src/agents/claudeAdapter.ts
@@ -33,6 +33,7 @@ import type {
   AgentProtocolError,
   AgentSessionEvent,
   AgentUnavailable,
+  HistoryTurn,
   ThreadItem,
   ThreadRequest,
 } from "./agentAdapter.ts"
@@ -49,6 +50,7 @@ import {
   withTitleTimeout,
   withToolStatus,
 } from "./agentAdapter.ts"
+import * as os from "node:os"
 import * as path from "node:path"
 import * as ClaudeHooks from "./claudeHooks.ts"
 import * as ClaudeItems from "./claudeItems.ts"
@@ -105,6 +107,20 @@ import * as Subprocess from "../platform/subprocess.ts"
 //     ThreadRequests until `respond` resolves them; a turn's end or the
 //     session's close resolves any survivor with a deny so the SDK child
 //     never waits on a request nothing will answer.
+//   - History (ATC-191): the session's own JSONL is read directly and every
+//     branch is kept, in file order. A session driven from two surfaces
+//     FORKS — a running TUI holds its conversation in memory, so its next
+//     prompt parents to its own last message, not to a turn ATC drove
+//     through the SDK, and vice versa — and the SDK's getSessionMessages
+//     returns only the branch of the last-written leaf, which would wipe the
+//     other surface's turns from ATC's copy on every re-read. The union is
+//     what actually happened in the session; whichever surface resumes next
+//     continues from the last-written leaf (Claude Code's rule), which is
+//     the provider's limitation, not ATC's. getSessionMessages remains the
+//     fallback when the file cannot be located. Claude also appends a turn's
+//     assistant line only after its Stop hook has run, so a read at the
+//     observed idle settles briefly while the newest turn is still output-
+//     less (readHistory).
 //   - One writer per session id, enforced here. Webhook hook activity is
 //     NOT bridged into these feeds: a TUI-driven session has no adapter
 //     connection by definition, and while ATC drives, the same vocabulary
@@ -128,11 +144,82 @@ export type ClaudeQueryFn = (args: {
 
 export interface ClaudeAdapterOptions {
   readonly queryFn?: ClaudeQueryFn
-  /** The getSessionMessages seam, injectable so tests can script transcripts. */
+  /** The getSessionMessages seam (fallback reader), injectable so tests can script transcripts. */
   readonly sessionMessagesFn?: typeof getSessionMessages
+  /**
+   * The session-file seam: the raw JSONL of `<config>/projects/<cwd key>/<id>.jsonl`,
+   * null when it cannot be located. Injectable so tests script transcripts.
+   */
+  readonly sessionFileFn?: (sessionId: string, cwd: string) => Promise<string | null>
   /** How long create/first-turn waits for the SDK's identity evidence. */
   readonly initTimeout?: Duration.Input
+  /** Pause between readHistory's settle re-reads (see the header). */
+  readonly historySettleDelay?: Duration.Input
 }
+
+/** How many settle re-reads readHistory allows before taking the transcript as it is. */
+const HISTORY_SETTLE_ATTEMPTS = 8
+
+/** A Claude session id as it appears on disk: one path segment, never a traversal. */
+const SessionFileId = Schema.String.check(
+  Schema.isPattern(/^[A-Za-z0-9_-]+$/, { description: "a Claude session id" }),
+)
+const decodeSessionFileId = Schema.decodeUnknownOption(SessionFileId)
+
+/**
+ * Where Claude Code keeps a session's JSONL: the config dir's `projects/`,
+ * one directory per cwd with every non-alphanumeric character replaced by
+ * `-` (Claude's own rule; a very long cwd is hashed instead, and reads as
+ * "not located" here — the SDK fallback covers it). The config dir is read
+ * from the same environment the SDK child gets, because that is what
+ * decides where Claude writes; an ATC setting could only disagree with it.
+ */
+const claudeSessionFile = (env: Record<string, string>, sessionId: string, cwd: string): string => {
+  const configDir = env["CLAUDE_CONFIG_DIR"] || path.join(env["HOME"] || os.homedir(), ".claude")
+  return path.join(configDir, "projects", cwd.replace(/[^a-zA-Z0-9]/g, "-"), `${sessionId}.jsonl`)
+}
+
+const readClaudeSessionFile = async (sessionId: string, cwd: string): Promise<string | null> => {
+  if (Option.isNone(decodeSessionFileId(sessionId))) return null
+  const file = Bun.file(claudeSessionFile(claudeEnvironment(), sessionId, cwd))
+  return (await file.exists()) ? file.text() : null
+}
+
+/** One conversation line of a session file — anything else is skipped. */
+const SessionFileLine = Schema.Struct({
+  type: Schema.Literals(["user", "assistant"]),
+  uuid: Schema.String,
+  sessionId: Schema.optional(Schema.String),
+  message: Schema.Unknown,
+  timestamp: Schema.optional(Schema.String),
+  isSidechain: Schema.optional(Schema.Boolean),
+  isMeta: Schema.optional(Schema.Boolean),
+})
+const decodeSessionFileLine = Schema.decodeUnknownOption(SessionFileLine)
+
+/**
+ * The session file's top-level user/assistant lines as SessionMessages, in
+ * file order — every branch. Sidechain (subagent) and meta lines are not
+ * conversation; unparseable lines (a write in progress) are skipped.
+ */
+const sessionMessagesFromFile = (text: string, sessionId: string): ReadonlyArray<SessionMessage> =>
+  text.split("\n").flatMap((line) => {
+    const parsed = Option.liftThrowable(() => JSON.parse(line) as unknown)()
+    const entry = Option.flatMap(parsed, decodeSessionFileLine)
+    if (Option.isNone(entry)) return []
+    if (entry.value.isSidechain === true || entry.value.isMeta === true) return []
+    return [
+      {
+        type: entry.value.type,
+        uuid: entry.value.uuid,
+        session_id: entry.value.sessionId ?? sessionId,
+        message: entry.value.message,
+        parent_tool_use_id: null,
+        parent_agent_id: null,
+        ...(entry.value.timestamp !== undefined ? { timestamp: entry.value.timestamp } : {}),
+      } as SessionMessage,
+    ]
+  })
 
 // The thread's opaque providerMetadata, as this adapter mints it. Decoded
 // tolerantly: unknown or malformed metadata is "no secret", never an error.
@@ -309,7 +396,9 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
       const hooks = yield* ClaudeHooks.ClaudeHooks
       const queryFn: ClaudeQueryFn = adapterOptions.queryFn ?? (query as unknown as ClaudeQueryFn)
       const sessionMessagesFn = adapterOptions.sessionMessagesFn ?? getSessionMessages
+      const sessionFileFn = adapterOptions.sessionFileFn ?? readClaudeSessionFile
       const initTimeout = adapterOptions.initTimeout ?? "60 seconds"
+      const historySettleDelay = adapterOptions.historySettleDelay ?? "250 millis"
 
       /** Live sessions by verified (and, for resumes, expected) session id. */
       const sessions = new Map<string, LiveSession>()
@@ -960,18 +1049,50 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
         return turnId
       }
 
-      /** The bounded getSessionMessages read behind both transcript readers. */
+      /**
+       * The bounded transcript read behind both readers: the session file
+       * (every branch, see the header), else getSessionMessages.
+       */
       const readTranscript = (
         providerSessionId: string,
         cwd: string,
       ): Effect.Effect<ReadonlyArray<SessionMessage>, string> =>
         Effect.tryPromise({
-          try: () => sessionMessagesFn(providerSessionId, { dir: cwd }),
+          try: async () => {
+            const text = await sessionFileFn(providerSessionId, cwd)
+            return text === null
+              ? sessionMessagesFn(providerSessionId, { dir: cwd })
+              : sessionMessagesFromFile(text, providerSessionId)
+          },
           catch: (error) => (error instanceof Error ? error.message : String(error)),
         }).pipe(
           Effect.timeoutOrElse({
             duration: "10 seconds",
             orElse: () => Effect.fail("the transcript read timed out"),
+          }),
+        )
+
+      /**
+       * readHistory's read: re-read while the newest turn holds nothing but
+       * its prompt, because Claude appends the assistant line after the Stop
+       * hook that triggers the observed-idle read (bounded — a turn that
+       * really produced nothing simply reads as such after the last try).
+       */
+      const readSettledHistory = (
+        providerSessionId: string,
+        cwd: string,
+        attempt = 0,
+      ): Effect.Effect<ReadonlyArray<HistoryTurn>, string> =>
+        readTranscript(providerSessionId, cwd).pipe(
+          Effect.map(ClaudeItems.mapHistory),
+          Effect.flatMap((history) => {
+            const newest = history.at(-1)
+            const settled = newest === undefined || newest.items.length > 1
+            return settled || attempt >= HISTORY_SETTLE_ATTEMPTS
+              ? Effect.succeed(history)
+              : Effect.sleep(historySettleDelay).pipe(
+                  Effect.andThen(readSettledHistory(providerSessionId, cwd, attempt + 1)),
+                )
           }),
         )
 
@@ -1260,8 +1381,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
         // reads as empty — the SDK cannot tell "no such session" from "no
         // messages yet"; only a failing read is an error.
         readHistory: (options) =>
-          readTranscript(options.providerSessionId, options.cwd).pipe(
-            Effect.map(ClaudeItems.mapHistory),
+          readSettledHistory(options.providerSessionId, options.cwd).pipe(
             Effect.mapError((reason) => protocolError(`the transcript read failed: ${reason}`)),
           ),
         // Claude offers no cheap truthful liveness query for a session it

--- a/app-server/test/agents/agentTestKit.ts
+++ b/app-server/test/agents/agentTestKit.ts
@@ -114,7 +114,9 @@ export const claudeAdapterLayer = (
   configOverrides: Partial<Parameters<typeof testAppConfig>[0]> = {},
   hooksLayer: Layer.Layer<ClaudeHooks.ClaudeHooks> = ClaudeHooks.layer,
 ): Layer.Layer<ClaudeAdapter.ClaudeAdapter | ClaudeHooks.ClaudeHooks, unknown> =>
-  ClaudeAdapter.layerWith(options).pipe(
+  // No session file unless a test scripts one: history reads must never
+  // reach the developer's real ~/.claude.
+  ClaudeAdapter.layerWith({ sessionFileFn: () => Promise.resolve(null), ...options }).pipe(
     Layer.provideMerge(hooksLayer),
     Layer.provide(testAppConfig({ claudeExecutable: executable, ...configOverrides })),
     Layer.provide(Subprocess.layer),

--- a/app-server/test/agents/claudeAdapter.test.ts
+++ b/app-server/test/agents/claudeAdapter.test.ts
@@ -1254,6 +1254,158 @@ describe("ClaudeAdapter collectTitleContext", () => {
       }),
   )
 
+  it.live(
+    "readHistory reads the session file with every branch in file order; the SDK is the fallback",
+    () =>
+      Effect.gen(function* () {
+        // A session driven from two surfaces: the TUI's second prompt forks
+        // from before the native turn (its in-memory conversation never saw
+        // it), so the last-written leaf's branch (what getSessionMessages
+        // returns) would drop the native turn entirely.
+        const line = (entry: Record<string, unknown>) => JSON.stringify(entry)
+        const file = [
+          line({
+            type: "user",
+            uuid: "u1",
+            parentUuid: null,
+            sessionId: "s",
+            message: { role: "user", content: "hi" },
+          }),
+          line({
+            type: "assistant",
+            uuid: "a1",
+            parentUuid: "u1",
+            sessionId: "s",
+            message: { role: "assistant", content: [{ type: "text", text: "hello" }] },
+          }),
+          line({
+            type: "user",
+            uuid: "n1",
+            parentUuid: "a1",
+            sessionId: "s",
+            origin: "sdk",
+            message: { role: "user", content: "native" },
+          }),
+          line({
+            type: "assistant",
+            uuid: "na1",
+            parentUuid: "n1",
+            sessionId: "s",
+            message: { role: "assistant", content: [{ type: "text", text: "native reply" }] },
+          }),
+          line({
+            type: "user",
+            uuid: "u2",
+            parentUuid: "a1",
+            sessionId: "s",
+            message: { role: "user", content: "tui again" },
+          }),
+          line({ type: "attachment", uuid: "att", parentUuid: "u2", sessionId: "s" }),
+          line({
+            type: "user",
+            uuid: "meta",
+            parentUuid: "u2",
+            sessionId: "s",
+            isMeta: true,
+            message: { role: "user", content: "reminder" },
+          }),
+          line({
+            type: "assistant",
+            uuid: "a2",
+            parentUuid: "u2",
+            sessionId: "s",
+            message: { role: "assistant", content: [{ type: "text", text: "tui reply" }] },
+          }),
+          "{not json",
+        ].join("\n")
+        const sdkCalls: Array<string> = []
+        const layer = claudeAdapterLayer({
+          sessionFileFn: (sessionId) => Promise.resolve(sessionId === "s" ? file : null),
+          sessionMessagesFn: (sessionId) => {
+            sdkCalls.push(sessionId)
+            return Promise.resolve([
+              transcriptMessage("user", "from the sdk"),
+              transcriptMessage("assistant", "reply"),
+            ])
+          },
+        })
+        yield* Effect.gen(function* () {
+          const adapter = yield* ClaudeAdapter.ClaudeAdapter
+          const history = yield* adapter.readHistory({ providerSessionId: "s", cwd: "/work" })
+          assert.deepStrictEqual(
+            history.map((turn) =>
+              turn.items.map((item) => ("text" in item ? item.text : item.type)),
+            ),
+            [
+              ["hi", "hello"],
+              ["native", "native reply"],
+              ["tui again", "tui reply"],
+            ],
+          )
+          assert.deepStrictEqual(sdkCalls, [])
+          const fallback = yield* adapter.readHistory({
+            providerSessionId: "elsewhere",
+            cwd: "/work",
+          })
+          assert.deepStrictEqual(sdkCalls, ["elsewhere"])
+          assert.strictEqual(fallback.length, 1)
+        }).pipe(Effect.provide(layer))
+      }),
+  )
+
+  it.live("readHistory settles while the newest turn is still output-less", () =>
+    Effect.gen(function* () {
+      // Claude appends the assistant line after the Stop hook that triggers
+      // the observed-idle read: the first read sees the prompt alone.
+      const prompt = JSON.stringify({
+        type: "user",
+        uuid: "u1",
+        parentUuid: null,
+        sessionId: "s",
+        message: { role: "user", content: "hi" },
+      })
+      const reply = JSON.stringify({
+        type: "assistant",
+        uuid: "a1",
+        parentUuid: "u1",
+        sessionId: "s",
+        message: { role: "assistant", content: [{ type: "text", text: "hello" }] },
+      })
+      let reads = 0
+      const layer = claudeAdapterLayer({
+        historySettleDelay: "1 millis",
+        sessionFileFn: () => {
+          reads += 1
+          return Promise.resolve(reads < 3 ? prompt : `${prompt}\n${reply}`)
+        },
+      })
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        const history = yield* adapter.readHistory({ providerSessionId: "s", cwd: "/work" })
+        assert.strictEqual(reads, 3)
+        assert.deepStrictEqual(
+          history[0]?.items.map((item) => item.type),
+          ["userMessage", "assistantText"],
+        )
+        // A turn that truly produced nothing settles out after the bound.
+        reads = 0
+        const quiet = claudeAdapterLayer({
+          historySettleDelay: "1 millis",
+          sessionFileFn: () => {
+            reads += 1
+            return Promise.resolve(prompt)
+          },
+        })
+        yield* Effect.gen(function* () {
+          const bounded = yield* ClaudeAdapter.ClaudeAdapter
+          const history = yield* bounded.readHistory({ providerSessionId: "s", cwd: "/work" })
+          assert.strictEqual(history[0]?.items.length, 1)
+          assert.strictEqual(reads, 9)
+        }).pipe(Effect.provide(quiet))
+      }).pipe(Effect.provide(layer))
+    }),
+  )
+
   it.live("a failed or empty transcript read is silently no context", () =>
     Effect.gen(function* () {
       const layer = claudeAdapterLayer({

--- a/app-server/test/threads/threadTitle.test.ts
+++ b/app-server/test/threads/threadTitle.test.ts
@@ -139,16 +139,22 @@ describe("thread auto-naming", () => {
       })
 
       // A later native prompt on the (now confirmed) thread never re-titles.
+      // Idle lands before the run's connection is released, so the prompt
+      // may start at once or queue and start moments later — either way
+      // it runs, and it must not name again.
       fake.completeTurn(yield* readSessionId, "completed")
       yield* eventually(
         client.v1.getThread({ params: { threadId } }),
         (read) => read.activityState === "idle",
       )
-      const second = yield* client.v1.promptThread({
+      yield* client.v1.promptThread({
         params: { threadId },
         payload: { prompt: "now remove it again" },
       })
-      assert.isString(second.turnId)
+      yield* eventually(
+        client.v1.getThread({ params: { threadId } }),
+        (read) => read.activityState === "working",
+      )
       assert.strictEqual(fake.titleRequests.length, requestsBefore + 1)
 
       fake.completeTurn(yield* readSessionId, "completed")


### PR DESCRIPTION
Server follow-up found while verifying [ATC-191](https://linear.app/elevenideas/issue/ATC-191/native-thread-ui-macos-client-of-the-thread-runtime-api) Chat mode against a live Claude thread. Independent of #210/#211 (base `main`).

## What was wrong

Chat and TUI did not stay in sync for Claude: turns vanished from Chat, and a TUI turn's response was missing until the next re-read. Diagnosed against the real session file (`~/.claude/projects/…/c5cc6737….jsonl`) vs ATC's copy:

1. **The session forks across surfaces.** A running Claude TUI keeps its conversation in memory, so its next prompt parents (`parentUuid`) to *its* last message — not to the turn ATC drove through the SDK — and the SDK-resumed turn likewise continued its own leaf. The SDK's `getSessionMessages` (what `readHistory` used) returns only the branch of the **last-written leaf** (it picks the max-file-index leaf and walks parents), so every observed-idle re-read replaced ATC's copy with one branch and wiped the other surface's turns. That session had 8 turns in the file; the SDK returned 5.
2. **The idle re-read races the write.** Claude appends a turn's assistant line only *after* its Stop hook has run — the hook that triggers ATC's observed-idle re-read — so the just-finished response was consistently absent from the copy.

## Fix

- `claudeAdapter.readTranscript` reads the session JSONL directly (`<CLAUDE_CONFIG_DIR|~/.claude>/projects/<cwd with non-alphanumerics → '-'>/<id>.jsonl`, Claude's own layout) and keeps **every** top-level `user`/`assistant` line in file order — the union of branches, which is what actually happened in the session. Sidechain/meta lines and half-written lines are skipped. `getSessionMessages` stays the fallback when the file cannot be located (e.g. Claude's hashed long-path dirs). Both readers (history and title context) go through it.
- `readHistory` **settles**: while the newest turn holds nothing but its prompt it re-reads after 250 ms, up to 8 times, then takes the transcript as it is (a turn that truly produced nothing costs ≤2 s once).
- Verified the union reader against that real session file: all 8 turns, chronological.

## What this does not fix (provider limitation — flagged on the issue)

The *model context* still forks: a live Claude TUI won't see native turns until it is relaunched, and whichever surface resumes next continues from the last-written leaf. ATC's copy is now a truthful record of everything said on either surface; making the surfaces share one context would need routing native prompts into a live TUI (a design change, not part of ATC-191).

## Tests

`claudeAdapter.test.ts`: forked-file fixture → all turns in file order, SDK fallback when the file is absent; settle loop (re-reads until the reply lands; bounded). Test layer scripts `sessionFileFn` to null by default so history reads never touch the developer's real `~/.claude`. `mise run -C app-server check` green.

https://claude.ai/code/session_01UUfpkWwiThwv7eGvAVTDun

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation history loading across branched sessions while preserving the correct message order.
  * Excluded invalid, sidechain, attachment, and metadata entries from displayed history.
  * Added fallback handling when session history files are unavailable.
  * Improved reliability when assistant responses are saved shortly after the user prompt.
  * Added bounded retries to capture responses that finish loading shortly after the initial history read.
  * Improved handling of incomplete or malformed history data without disrupting the conversation view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->