### PR TITLE
Claude threads: one live process per thread, native owns by default (ATC-203)

### DIFF
--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -1040,13 +1040,16 @@
             }
           },
           "409": {
-            "description": "The thread is archived; unarchive it first. | The thread's provider session cannot be driven as requested (resume failed, identity mismatch, or a concurrent writer). Fail-closed: no changed identity was adopted.",
+            "description": "The thread is archived; unarchive it first. | The thread's agent session is actively working; retry once the turn completes. | The thread's provider session cannot be driven as requested (resume failed, identity mismatch, or a concurrent writer). Fail-closed: no changed identity was adopted.",
             "content": {
               "application/json": {
                 "schema": {
                   "anyOf": [
                     {
                       "$ref": "#/components/schemas/ThreadArchivedJsonEncoding"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ThreadBusyJsonEncoding"
                     },
                     {
                       "$ref": "#/components/schemas/ProviderSessionConflictJsonEncoding"
@@ -1094,7 +1097,73 @@
             }
           }
         },
-        "description": "Open the thread's TUI terminal. Idempotent: a live linked terminal is returned as-is. Otherwise the provider TUI is launched in a new terminal — a confirmed session is relaunched against its exact persisted identity (ATC never adopts a different one), an unconfirmed one materializes a fresh provider session whose identity is established and persisted before this call returns. A provider that can be probed (Codex) fails fast when the persisted session no longer exists; one that cannot (Claude) launches blind — a successful open whose terminal dies within seconds is a state clients must expect and surface."
+        "description": "Open the thread's TUI terminal — the client is showing the TUI. Idempotent: a live linked terminal is returned as-is. Otherwise the provider TUI is launched in a new terminal — a confirmed session is relaunched against its exact persisted identity (ATC never adopts a different one), an unconfirmed one materializes a fresh provider session whose identity is established and persisted before this call returns. A provider that can be probed (Codex) fails fast when the persisted session no longer exists; one that cannot (Claude Code) launches blind — a successful open whose terminal dies within seconds is a state clients must expect and surface. One live process per thread (Claude Code): while the server is driving a turn the open fails ThreadBusy and the TUI launches by itself when that turn ends — watch the thread's `linkedTerminalId`; a prompt sent while the TUI is live takes the thread over (the TUI ends once idle, the turn runs, and the TUI relaunches when the queue drains). Codex, whose shared server lets both coexist, needs none of this."
+      },
+      "delete": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "closeThreadTerminal",
+        "parameters": [
+          {
+            "name": "threadId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A durable Thread: the primary unit of agent work. Its ATC identity is separate from provider identity, and it never requires a Terminal.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Thread"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No thread exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadNotFoundJsonEncoding"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The thread's provider session cannot be driven as requested (resume failed, identity mismatch, or a concurrent writer). Fail-closed: no changed identity was adopted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderSessionConflictJsonEncoding"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The thread's agent provider cannot be used right now (not installed, not ready, or unreachable). Retryable once the cause is fixed. | The zmx multiplexer cannot be consulted right now. Retryable; stored terminal state is untouched.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ProviderUnavailableJsonEncoding"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ZmxUnavailableJsonEncoding"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Close the thread's TUI — the client stopped showing it (switched to Chat). On a provider whose session lives in one process at a time (Claude Code) this hands the thread back to the App Server: an idle TUI ends now, a busy one when its turn completes — either way only once that turn is on disk (a history read that fails leaves the TUI running and fails the call retryably) — and the next prompt resumes the full conversation natively; opening the terminal again relaunches the TUI. On a shared-server provider (Codex) the TUI needs no hand-off and keeps running; the call changes nothing. Returns the thread."
       }
     },
     "/api/v1/threads/{threadId}/prompt": {
@@ -1162,7 +1231,7 @@
             }
           }
         },
-        "description": "Prompt the thread. Always admitted: an idle thread starts a turn at once (`turnId` present) and a busy one queues the prompt to run at the next idle (`turnId` absent) — there is no busy error and no lock between surfaces. The turn is server-owned: the client's connection never matters to it. When the prompt would start now and the provider refuses, it is un-admitted (the error means not accepted; nothing stays queued); a prompt queued behind others is admitted regardless. Follow the turn on the per-thread event stream.",
+        "description": "Prompt the thread. Always admitted: an idle thread starts a turn at once (`turnId` present) and a busy one queues the prompt to run at the next idle (`turnId` absent) — there is no busy error and no lock between surfaces. On a one-process provider (Claude Code) a prompt while the TUI is live takes the thread over: the TUI ends once idle, the turn runs natively, and the TUI relaunches when the queue drains (see openThreadTerminal). The turn is server-owned: the client's connection never matters to it. When the prompt would start now and the provider refuses, it is un-admitted (the error means not accepted; nothing stays queued); a prompt queued behind others is admitted regardless. Follow the turn on the per-thread event stream.",
         "requestBody": {
           "content": {
             "application/json": {

--- a/app-server/src/agents/agentAdapter.ts
+++ b/app-server/src/agents/agentAdapter.ts
@@ -142,9 +142,12 @@ export type AgentItemEvent =
  * evidence source carries it (Claude: the UserPromptSubmit webhook; Codex:
  * a demand-driven thread/read of the session's preview), and consumers
  * must tolerate duplicates, later prompts, and absence. Item events arrive
- * only from a provider whose shared server fans conversation items out to
- * passive observers (Codex); a hooks-fed observation (Claude) is
- * activity-only and its turns reach ATC through `readHistory`.
+ * from a provider whose shared server fans conversation items out to
+ * passive observers (Codex), and — the one item a hooks-fed observation
+ * (Claude) can carry — the submitted prompt itself, as a completed
+ * `userMessage` under an observed turn id, so a Chat reader shows what the
+ * TUI is working on; the turn's remaining items reach ATC through
+ * `readHistory` at its end.
  */
 export type AgentSessionEvent =
   | { readonly type: "activity"; readonly activity: AgentActivity }
@@ -317,13 +320,17 @@ export interface PreparedTuiSession {
 export interface AgentAdapter {
   readonly provider: AgentProvider
   /**
-   * Whether observeSession's feed stays authoritative once no TUI drives
-   * the session: a shared provider server (Codex) keeps streaming evidence
-   * after the TUI dies, so a busy state under a live observation is
-   * current; a hooks feed (Claude) dies silently with the TUI, so a busy
-   * state must re-derive through checkSession instead.
+   * Whether the provider runs one shared server that every process — the
+   * TUI, ATC's own connection — attaches to (Codex): observeSession's feed
+   * stays authoritative once no TUI drives the session, a turn ATC started
+   * survives ATC's restart, and a TUI and a native connection coexist on
+   * one session. Without it (Claude) each process holds the session in
+   * memory: the hooks feed dies silently with the TUI (a busy state must
+   * re-derive through checkSession), and two live processes FORK the
+   * session — so the Thread runtime keeps one live process per thread
+   * (its surface-ownership rules, threadRuntime.ts).
    */
-  readonly observationOutlivesTui: boolean
+  readonly sharedServer: boolean
   /**
    * Create a new provider session in `cwd` and start its first turn. The
    * provider's echoed working directory is verified like resume's — a

--- a/app-server/src/agents/claudeAdapter.ts
+++ b/app-server/src/agents/claudeAdapter.ts
@@ -50,7 +50,6 @@ import {
   withTitleTimeout,
   withToolStatus,
 } from "./agentAdapter.ts"
-import * as os from "node:os"
 import * as path from "node:path"
 import * as ClaudeHooks from "./claudeHooks.ts"
 import * as ClaudeItems from "./claudeItems.ts"
@@ -107,30 +106,39 @@ import * as Subprocess from "../platform/subprocess.ts"
 //     ThreadRequests until `respond` resolves them; a turn's end or the
 //     session's close resolves any survivor with a deny so the SDK child
 //     never waits on a request nothing will answer.
-//   - History (ATC-191): the session's own JSONL is read directly and every
-//     branch is kept, in file order. A session driven from two surfaces
-//     FORKS — a running TUI holds its conversation in memory, so its next
-//     prompt parents to its own last message, not to a turn ATC drove
-//     through the SDK, and vice versa — and the SDK's getSessionMessages
-//     returns only the branch of the last-written leaf, which would wipe the
-//     other surface's turns from ATC's copy on every re-read. The union is
-//     what actually happened in the session; whichever surface resumes next
-//     continues from the last-written leaf (Claude Code's rule), which is
-//     the provider's limitation, not ATC's. getSessionMessages remains the
-//     fallback when the file cannot be located. Claude also appends a turn's
-//     assistant line only after its Stop hook has run, so a read at the
-//     observed idle settles briefly while the newest turn is still output-
-//     less (readHistory).
+//   - One live `claude` process per thread (ATC-203). Claude Code has no
+//     shared brain: two live processes on one session id FORK it — each
+//     holds its conversation in memory and appends with its own leaf, and
+//     neither sees the other's turns. So a session is driven by exactly one
+//     process at a time, owned by the active surface — the SDK child this
+//     adapter opens with `query()`, or the TUI launched from the launch spec
+//     below (`sharedServer: false` tells the Thread runtime to hand off
+//     between them: it ends one before starting the other, and it never
+//     ends a process it did not start). History is therefore read through
+//     the SDK's `getSessionMessages` (the official surface — no direct
+//     JSONL reads); with a single writer there is one leaf, so it is
+//     truthful. Threads that forked under the old adapter resume from
+//     their last-written leaf; the orphaned branch is history the model
+//     will not see (one-time, no compatibility path).
+//   - End a TUI only after its last turn is on disk: Claude appends a
+//     turn's assistant line AFTER its Stop hook has run, so a read at the
+//     observed idle settles briefly while the newest turn is still
+//     output-less (readHistory) — that bounded settle is the gate the
+//     runtime runs before ending a TUI, and the only wait this adapter
+//     keeps.
 //   - One writer per session id, enforced here. Webhook hook activity is
 //     NOT bridged into these feeds: a TUI-driven session has no adapter
 //     connection by definition, and while ATC drives, the same vocabulary
 //     already arrives as in-process SDK callbacks — a webhook delivery for
 //     a live connection could only be stale or spoofed. TUI-driven activity
 //     flows through observeSession below, which is the claudeHooks
-//     subscriber; consumers stay above the seam.
+//     subscriber; consumers stay above the seam. That feed also carries the
+//     TUI's submitted prompt as an observed `userMessage` item (the seam's
+//     one hooks-carried item), so a Chat reader shows what the TUI is
+//     working on before the turn's re-read lands.
 
 /** The Claude Code version this adapter was validated against. */
-const CLAUDE_TESTED_VERSION = "2.1.221"
+const CLAUDE_TESTED_VERSION = "2.1.234"
 
 export class ClaudeAdapter extends Context.Service<ClaudeAdapter, AgentAdapter>()(
   "app-server/ClaudeAdapter",
@@ -144,13 +152,8 @@ export type ClaudeQueryFn = (args: {
 
 export interface ClaudeAdapterOptions {
   readonly queryFn?: ClaudeQueryFn
-  /** The getSessionMessages seam (fallback reader), injectable so tests can script transcripts. */
+  /** The getSessionMessages seam, injectable so tests can script transcripts. */
   readonly sessionMessagesFn?: typeof getSessionMessages
-  /**
-   * The session-file seam: the raw JSONL of `<config>/projects/<cwd key>/<id>.jsonl`,
-   * null when it cannot be located. Injectable so tests script transcripts.
-   */
-  readonly sessionFileFn?: (sessionId: string, cwd: string) => Promise<string | null>
   /** How long create/first-turn waits for the SDK's identity evidence. */
   readonly initTimeout?: Duration.Input
   /** Pause between readHistory's settle re-reads (see the header). */
@@ -159,67 +162,6 @@ export interface ClaudeAdapterOptions {
 
 /** How many settle re-reads readHistory allows before taking the transcript as it is. */
 const HISTORY_SETTLE_ATTEMPTS = 8
-
-/** A Claude session id as it appears on disk: one path segment, never a traversal. */
-const SessionFileId = Schema.String.check(
-  Schema.isPattern(/^[A-Za-z0-9_-]+$/, { description: "a Claude session id" }),
-)
-const decodeSessionFileId = Schema.decodeUnknownOption(SessionFileId)
-
-/**
- * Where Claude Code keeps a session's JSONL: the config dir's `projects/`,
- * one directory per cwd with every non-alphanumeric character replaced by
- * `-` (Claude's own rule; a very long cwd is hashed instead, and reads as
- * "not located" here — the SDK fallback covers it). The config dir is read
- * from the same environment the SDK child gets, because that is what
- * decides where Claude writes; an ATC setting could only disagree with it.
- */
-const claudeSessionFile = (env: Record<string, string>, sessionId: string, cwd: string): string => {
-  const configDir = env["CLAUDE_CONFIG_DIR"] || path.join(env["HOME"] || os.homedir(), ".claude")
-  return path.join(configDir, "projects", cwd.replace(/[^a-zA-Z0-9]/g, "-"), `${sessionId}.jsonl`)
-}
-
-const readClaudeSessionFile = async (sessionId: string, cwd: string): Promise<string | null> => {
-  if (Option.isNone(decodeSessionFileId(sessionId))) return null
-  const file = Bun.file(claudeSessionFile(claudeEnvironment(), sessionId, cwd))
-  return (await file.exists()) ? file.text() : null
-}
-
-/** One conversation line of a session file — anything else is skipped. */
-const SessionFileLine = Schema.Struct({
-  type: Schema.Literals(["user", "assistant"]),
-  uuid: Schema.String,
-  sessionId: Schema.optional(Schema.String),
-  message: Schema.Unknown,
-  timestamp: Schema.optional(Schema.String),
-  isSidechain: Schema.optional(Schema.Boolean),
-  isMeta: Schema.optional(Schema.Boolean),
-})
-const decodeSessionFileLine = Schema.decodeUnknownOption(SessionFileLine)
-
-/**
- * The session file's top-level user/assistant lines as SessionMessages, in
- * file order — every branch. Sidechain (subagent) and meta lines are not
- * conversation; unparseable lines (a write in progress) are skipped.
- */
-const sessionMessagesFromFile = (text: string, sessionId: string): ReadonlyArray<SessionMessage> =>
-  text.split("\n").flatMap((line) => {
-    const parsed = Option.liftThrowable(() => JSON.parse(line) as unknown)()
-    const entry = Option.flatMap(parsed, decodeSessionFileLine)
-    if (Option.isNone(entry)) return []
-    if (entry.value.isSidechain === true || entry.value.isMeta === true) return []
-    return [
-      {
-        type: entry.value.type,
-        uuid: entry.value.uuid,
-        session_id: entry.value.sessionId ?? sessionId,
-        message: entry.value.message,
-        parent_tool_use_id: null,
-        parent_agent_id: null,
-        ...(entry.value.timestamp !== undefined ? { timestamp: entry.value.timestamp } : {}),
-      } as SessionMessage,
-    ]
-  })
 
 // The thread's opaque providerMetadata, as this adapter mints it. Decoded
 // tolerantly: unknown or malformed metadata is "no secret", never an error.
@@ -396,7 +338,6 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
       const hooks = yield* ClaudeHooks.ClaudeHooks
       const queryFn: ClaudeQueryFn = adapterOptions.queryFn ?? (query as unknown as ClaudeQueryFn)
       const sessionMessagesFn = adapterOptions.sessionMessagesFn ?? getSessionMessages
-      const sessionFileFn = adapterOptions.sessionFileFn ?? readClaudeSessionFile
       const initTimeout = adapterOptions.initTimeout ?? "60 seconds"
       const historySettleDelay = adapterOptions.historySettleDelay ?? "250 millis"
 
@@ -1049,21 +990,13 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
         return turnId
       }
 
-      /**
-       * The bounded transcript read behind both readers: the session file
-       * (every branch, see the header), else getSessionMessages.
-       */
+      /** The bounded transcript read behind both readers (getSessionMessages). */
       const readTranscript = (
         providerSessionId: string,
         cwd: string,
       ): Effect.Effect<ReadonlyArray<SessionMessage>, string> =>
         Effect.tryPromise({
-          try: async () => {
-            const text = await sessionFileFn(providerSessionId, cwd)
-            return text === null
-              ? sessionMessagesFn(providerSessionId, { dir: cwd })
-              : sessionMessagesFromFile(text, providerSessionId)
-          },
+          try: () => sessionMessagesFn(providerSessionId, { dir: cwd }),
           catch: (error) => (error instanceof Error ? error.message : String(error)),
         }).pipe(
           Effect.timeoutOrElse({
@@ -1190,7 +1123,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
 
       const adapter: AgentAdapter = {
         provider: "claude",
-        observationOutlivesTui: false,
+        sharedServer: false,
         createSession: (options) =>
           Effect.gen(function* () {
             const session = yield* openSession({ cwd: options.cwd })
@@ -1292,9 +1225,22 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
             // Registered before the subscription so it runs after it on
             // scope close: unsubscribe first, then end the queue.
             yield* Effect.addFinalizer(() => Effect.sync(() => Queue.endUnsafe(queue)))
+            const offer = (event: AgentSessionEvent): void => {
+              if (!Queue.offerUnsafe(queue, event)) Queue.endUnsafe(queue)
+            }
             yield* hooks.subscribe((sessionId, event) => {
               if (sessionId !== options.providerSessionId) return
-              if (!Queue.offerUnsafe(queue, event)) Queue.endUnsafe(queue)
+              offer(event)
+              // The TUI's prompt as an observed item (see the header): its
+              // own turn id, replaced wholesale by the re-read at the
+              // turn's end.
+              if (event.type === "userPrompt") {
+                const turnId = `claude-observed-${crypto.randomUUID()}`
+                offer({
+                  type: "itemCompleted",
+                  item: { type: "userMessage", id: `${turnId}:prompt`, turnId, text: event.text },
+                })
+              }
             })
             return Stream.fromQueue(queue)
           }),
@@ -1358,9 +1304,9 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
               }).pipe(withTitleTimeout(protocolError))
             }),
           ),
-        // On-demand transcript read via the SDK (ATC-190) — the session
-        // JSONL under the project directory is the conversation the primary
-        // agent already produced; nothing is retained here. Best-effort by
+        // On-demand transcript read via the SDK (ATC-190) — the conversation
+        // the primary agent already produced; nothing is retained here.
+        // Best-effort by
         // contract: any read failure — a hung read included, hence the
         // bound — is debug-logged and reads as "nothing usable".
         collectTitleContext: (options) =>

--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -1211,7 +1211,7 @@ export const layer = Layer.effect(CodexAdapter)(
 
     const adapter: AgentAdapter = {
       provider: "codex",
-      observationOutlivesTui: true,
+      sharedServer: true,
       createSession: (options) =>
         Effect.gen(function* () {
           // thread/start broadcasts thread/started to every socket — ours

--- a/app-server/src/api/contract.ts
+++ b/app-server/src/api/contract.ts
@@ -1344,6 +1344,7 @@ export class V1 extends HttpApiGroup.make("v1")
       error: [
         ThreadNotFound,
         ThreadArchived,
+        ThreadBusy,
         ProviderUnavailable,
         ProviderSessionConflict,
         DirectoryUnavailable,
@@ -1355,8 +1356,19 @@ export class V1 extends HttpApiGroup.make("v1")
       .annotate(OpenApi.Identifier, "openThreadTerminal")
       .annotate(
         OpenApi.Description,
-        "Open the thread's TUI terminal. Idempotent: a live linked terminal is returned as-is. Otherwise the provider TUI is launched in a new terminal — a confirmed session is relaunched against its exact persisted identity (ATC never adopts a different one), an unconfirmed one materializes a fresh provider session whose identity is established and persisted before this call returns. " +
-          "A provider that can be probed (Codex) fails fast when the persisted session no longer exists; one that cannot (Claude) launches blind — a successful open whose terminal dies within seconds is a state clients must expect and surface.",
+        "Open the thread's TUI terminal — the client is showing the TUI. Idempotent: a live linked terminal is returned as-is. Otherwise the provider TUI is launched in a new terminal — a confirmed session is relaunched against its exact persisted identity (ATC never adopts a different one), an unconfirmed one materializes a fresh provider session whose identity is established and persisted before this call returns. " +
+          "A provider that can be probed (Codex) fails fast when the persisted session no longer exists; one that cannot (Claude Code) launches blind — a successful open whose terminal dies within seconds is a state clients must expect and surface. " +
+          "One live process per thread (Claude Code): while the server is driving a turn the open fails ThreadBusy and the TUI launches by itself when that turn ends — watch the thread's `linkedTerminalId`; a prompt sent while the TUI is live takes the thread over (the TUI ends once idle, the turn runs, and the TUI relaunches when the queue drains). Codex, whose shared server lets both coexist, needs none of this.",
+      ),
+    HttpApiEndpoint.delete("closeThreadTerminal", "/threads/:threadId/terminal", {
+      params: threadIdParam,
+      success: Thread,
+      error: [ThreadNotFound, ProviderUnavailable, ProviderSessionConflict, ZmxUnavailable],
+    })
+      .annotate(OpenApi.Identifier, "closeThreadTerminal")
+      .annotate(
+        OpenApi.Description,
+        "Close the thread's TUI — the client stopped showing it (switched to Chat). On a provider whose session lives in one process at a time (Claude Code) this hands the thread back to the App Server: an idle TUI ends now, a busy one when its turn completes — either way only once that turn is on disk (a history read that fails leaves the TUI running and fails the call retryably) — and the next prompt resumes the full conversation natively; opening the terminal again relaunches the TUI. On a shared-server provider (Codex) the TUI needs no hand-off and keeps running; the call changes nothing. Returns the thread.",
       ),
     // --- The Thread runtime (ATC-193): drive a thread with no Terminal ---
     HttpApiEndpoint.post("promptThread", "/threads/:threadId/prompt", {
@@ -1368,7 +1380,7 @@ export class V1 extends HttpApiGroup.make("v1")
       .annotate(OpenApi.Identifier, "promptThread")
       .annotate(
         OpenApi.Description,
-        "Prompt the thread. Always admitted: an idle thread starts a turn at once (`turnId` present) and a busy one queues the prompt to run at the next idle (`turnId` absent) — there is no busy error and no lock between surfaces. " +
+        "Prompt the thread. Always admitted: an idle thread starts a turn at once (`turnId` present) and a busy one queues the prompt to run at the next idle (`turnId` absent) — there is no busy error and no lock between surfaces. On a one-process provider (Claude Code) a prompt while the TUI is live takes the thread over: the TUI ends once idle, the turn runs natively, and the TUI relaunches when the queue drains (see openThreadTerminal). " +
           "The turn is server-owned: the client's connection never matters to it. When the prompt would start now and the provider refuses, it is un-admitted (the error means not accepted; nothing stays queued); a prompt queued behind others is admitted regardless. Follow the turn on the per-thread event stream.",
       ),
     HttpApiEndpoint.get("getThreadTranscript", "/threads/:threadId/transcript", {

--- a/app-server/src/api/handlers.ts
+++ b/app-server/src/api/handlers.ts
@@ -100,6 +100,7 @@ export const V1Handlers = HttpApiBuilder.group(
         .handle("markThreadViewed", ({ params }) => threads.markViewed(params.threadId))
         .handle("deleteThread", ({ params }) => threads.delete(params.threadId))
         .handle("openThreadTerminal", ({ params }) => threads.openTerminal(params.threadId))
+        .handle("closeThreadTerminal", ({ params }) => threads.closeTerminal(params.threadId))
         .handle("promptThread", ({ params, payload }) =>
           runtime.prompt(params.threadId, payload.prompt),
         )

--- a/app-server/src/cli/threads.ts
+++ b/app-server/src/cli/threads.ts
@@ -114,6 +114,13 @@ const threadOpen = Command.make("open", { threadId: threadIdArgument }, ({ threa
   ),
 )
 
+const threadClose = Cli.clientCommand(
+  "thread close",
+  "Close the thread's TUI: hand the thread back to Chat/API prompts (a Claude TUI ends once its turn is on disk; a Codex TUI keeps running)",
+  { threadId: threadIdArgument },
+  (client, { threadId }) => client.v1.closeThreadTerminal({ params: { threadId } }),
+)
+
 const threadDelete = Cli.clientCommand(
   "thread delete",
   "Delete a thread: kill its live linked terminal, remove the record (provider history is untouched)",
@@ -289,6 +296,7 @@ export const thread = Command.make("thread").pipe(
     threadCreate,
     threadUpdate,
     threadOpen,
+    threadClose,
     threadPrompt,
     threadFollow,
     threadInterrupt,

--- a/app-server/src/server.ts
+++ b/app-server/src/server.ts
@@ -26,6 +26,7 @@ import * as ThreadRepository from "./threads/threadRepository.ts"
 import * as ThreadNaming from "./threads/threadNaming.ts"
 import * as ThreadRuntime from "./threads/threadRuntime.ts"
 import * as Threads from "./threads/threads.ts"
+import * as ThreadTui from "./threads/threadTui.ts"
 import * as TranscriptRepository from "./threads/transcriptRepository.ts"
 import * as Zmx from "./terminals/zmxAdapter.ts"
 
@@ -131,12 +132,15 @@ export const production = (options: { readonly port: number; readonly hostname?:
     // server-info handler and the optional trust allowlist read one instance.
     Layer.provideMerge(Tailscale.layer),
     // Projects sits above Threads (its delete cascades through them), which
-    // sits above the ThreadRuntime (activity ledger, transcript, turns) and
-    // Terminals; ThreadNaming serves both Threads and the runtime — each
-    // provide feeds everything composed so far.
+    // sits above the ThreadRuntime (activity ledger, transcript, turns,
+    // observation, TUI ownership); ThreadTui and Terminals serve both, and
+    // ThreadNaming serves Threads and the runtime — each provide feeds
+    // everything composed so far.
     Layer.provide(Projects.layer),
     Layer.provide(Threads.layer),
-    Layer.provide([Terminals.layer, ThreadRuntime.layer]),
+    Layer.provide(ThreadRuntime.layer),
+    Layer.provide(ThreadTui.layer),
+    Layer.provide(Terminals.layer),
     Layer.provide(ThreadNaming.layer),
     Layer.provide(AgentRegistry.layer),
     // Below Terminals (the deepest publisher) so one memoized Events instance

--- a/app-server/src/threads/threadRuntime.ts
+++ b/app-server/src/threads/threadRuntime.ts
@@ -75,8 +75,9 @@ export type QueuedPrompt = typeof Contract.QueuedPrompt.Type
 //     live processes fork the session). The native side owns the thread by
 //     default; the TUI owns it only while clients want it: `tuiWanted` is a
 //     per-thread, last-writer-wins mark — openTui sets it, closeTui clears
-//     it, and a TUI found live when observation begins is wanted until a
-//     client says otherwise. It is deliberately not per-client presence
+//     it, and a TUI found live at a thread's first observation (no client
+//     has spoken for it yet — after a restart) is wanted until a client
+//     says otherwise. It is deliberately not per-client presence
 //     (single user; a client that quits without closing leaves the TUI in
 //     charge until the next close, nothing worse). A native turn against a
 //     live TUI queues while the TUI is busy (the ledger), then ENDS the TUI
@@ -286,6 +287,11 @@ export const layer = Layer.effect(ThreadRuntime)(
     const observed = new Map<string, Observation>()
     /** Threads whose clients want the TUI (the header's ownership rule). */
     const tuiWanted = new Set<string>()
+    /** Threads whose TUI want is settled — a client said open or close, or
+     * a live TUI was adopted at first observation. Only an unsettled
+     * thread's observation may mark the TUI wanted: a feed that ends and is
+     * re-observed must not undo an explicit close. */
+    const tuiSettled = new Set<string>()
     /** Threads with a TUI launch in flight: no native turn starts meanwhile. */
     const tuiOpening = new Set<string>()
     // Threads the startup pass has not settled yet: their prompts wait.
@@ -813,6 +819,7 @@ export const layer = Layer.effect(ThreadRuntime)(
     const openTui: ThreadRuntime["Service"]["openTui"] = (record, launch) =>
       Effect.gen(function* () {
         tuiWanted.add(record.id)
+        tuiSettled.add(record.id)
         // The refusal, the linked re-check, and the launch claim are one
         // step under the start lock: a prompt cannot start a run between
         // them, and a relaunch (which holds the lock while it launches) is
@@ -847,6 +854,7 @@ export const layer = Layer.effect(ThreadRuntime)(
       withStartLock(record.id)(
         Effect.gen(function* () {
           tuiWanted.delete(record.id)
+          tuiSettled.add(record.id)
           if (!oneProcess(record)) return
           // Busy: the observed idle ends it (observedIdle below).
           if (isBusy(liveActivity.get(record.id) ?? "unknown")) return
@@ -883,6 +891,9 @@ export const layer = Layer.effect(ThreadRuntime)(
             ),
           )
           if (!settled || !oneProcess(record) || tuiWanted.has(record.id)) return
+          // A prompt typed into the TUI while the read was in flight keeps
+          // the thread (the rule endTui applies); its own idle ends it.
+          if (isBusy(liveActivity.get(record.id) ?? "unknown")) return
           const linked = yield* tui.linked(record)
           if (linked === undefined) return
           yield* tui
@@ -903,6 +914,7 @@ export const layer = Layer.effect(ThreadRuntime)(
         // driving the thread, whose own evidence stays authoritative.
         if (!runs.has(id)) liveActivity.delete(id)
         tuiWanted.delete(id)
+        tuiSettled.delete(id)
         const observation = observed.get(id)
         if (observation === undefined) return
         observed.delete(id)
@@ -928,9 +940,9 @@ export const layer = Layer.effect(ThreadRuntime)(
 
     /**
      * Start (once) the thread's normalized session subscription. A TUI is
-     * live or launching whenever this is called, so a NEW observation marks
-     * the TUI wanted (a live TUI found after a restart stays in charge until
-     * a client says otherwise).
+     * live or launching whenever this is called, so the FIRST observation
+     * of a thread no client has spoken for marks the TUI wanted (a live TUI
+     * found after a restart stays in charge until a client says otherwise).
      */
     const observe = (record: ThreadRecord): Effect.Effect<void> =>
       Effect.gen(function* () {
@@ -952,7 +964,10 @@ export const layer = Layer.effect(ThreadRuntime)(
         const child = Scope.forkUnsafe(serviceScope)
         const observation: Observation = { providerSessionId, scope: child }
         observed.set(record.id, observation)
-        tuiWanted.add(record.id)
+        if (!tuiSettled.has(record.id)) {
+          tuiWanted.add(record.id)
+          tuiSettled.add(record.id)
+        }
         const releaseClaim = Effect.gen(function* () {
           if (observed.get(record.id) !== observation) return
           observed.delete(record.id)
@@ -1262,7 +1277,6 @@ export const layer = Layer.effect(ThreadRuntime)(
           Effect.gen(function* () {
             const run = runs.get(id)
             liveActivity.delete(id)
-            tuiWanted.delete(id)
             yield* unobserve(id)
             if (run !== undefined) {
               run.finished = true

--- a/app-server/src/threads/threadRuntime.ts
+++ b/app-server/src/threads/threadRuntime.ts
@@ -18,6 +18,7 @@ import type {
   AgentConnection,
   AgentEvent,
   AgentItemEvent,
+  AgentSessionEvent,
   AgentTurn,
   ThreadRequest,
   ThreadRequestAnswer,
@@ -32,12 +33,16 @@ import {
   QueuedPromptNotFound,
   RequestNotFound,
   ThreadArchived,
+  ThreadBusy,
   ThreadNotFound,
 } from "../api/contract.ts"
+import type { ZmxUnavailable } from "../api/contract.ts"
 import { Events } from "../events/events.ts"
+import type { Terminal } from "../terminals/terminals.ts"
 import { ThreadNaming } from "./threadNaming.ts"
 import { ThreadRepository } from "./threadRepository.ts"
 import type { ThreadRecord } from "./threadRepository.ts"
+import { ThreadTui } from "./threadTui.ts"
 import { TranscriptRepository } from "./transcriptRepository.ts"
 import type { TranscriptChange, TurnSource } from "./transcriptRepository.ts"
 
@@ -45,13 +50,15 @@ export type ThreadEvent = typeof Contract.ThreadEvent.Type
 export type ThreadTranscript = typeof Contract.ThreadTranscript.Type
 export type QueuedPrompt = typeof Contract.QueuedPrompt.Type
 
-// The Thread runtime (ATC-193): the server-owned run. It drives a thread's
-// conversation through the AgentAdapter seam with no Terminal involved —
-// prompts, the durable prompt queue, the turn loop, parked provider
-// requests, the transcript projection with its per-thread event stream, and
-// the live activity ledger every surface reads. Every surface (macOS, CLI,
-// Linear) is a client of this one service; nothing here is provider-
-// specific. Invariants:
+// The Thread runtime (ATC-193): the server-owned run, and everything live
+// about a thread's provider session. It drives a thread's conversation
+// through the AgentAdapter seam with no Terminal involved — prompts, the
+// durable prompt queue, the turn loop, parked provider requests, the
+// transcript projection with its per-thread event stream, the observation
+// of TUI-driven sessions, and the live activity ledger every surface reads.
+// Every surface (macOS, CLI, Linear) is a client of this one service;
+// nothing here is provider-specific beyond the seam's `sharedServer`
+// capability. Invariants:
 //
 //   - A prompt is admitted, always: it lands in the queue (durable), and if
 //     the thread is idle it starts a turn at once — the one exception being
@@ -63,26 +70,63 @@ export type QueuedPrompt = typeof Contract.QueuedPrompt.Type
 //     between turns a thread holds nothing, and client connections never
 //     matter to a run's lifetime. A run stays registered until its
 //     connection has closed, so the next prompt never races the writer.
+//   - One live process per thread (ATC-203), on a provider whose sessions
+//     live in one process at a time (`sharedServer: false` — Claude; two
+//     live processes fork the session). The native side owns the thread by
+//     default; the TUI owns it only while clients want it: `tuiWanted` is a
+//     per-thread, last-writer-wins mark — openTui sets it, closeTui clears
+//     it, and a TUI found live when observation begins is wanted until a
+//     client says otherwise. It is deliberately not per-client presence
+//     (single user; a client that quits without closing leaves the TUI in
+//     charge until the next close, nothing worse). A native turn against a
+//     live TUI queues while the TUI is busy (the ledger), then ENDS the TUI
+//     and resumes the session itself; when the run ends with the queue
+//     drained and the TUI still wanted, the TUI is relaunched. The ledger
+//     is the only liveness evidence Claude offers (checkSession is
+//     `unknown`), so `unknown` — a TUI observed since a restart that has
+//     not spoken yet — is taken as idle: the settle gate below is the
+//     remaining guard, and a queue that could otherwise never drain is the
+//     worse failure. A TUI open
+//     during a native run is refused (ThreadBusy) and happens at the run's
+//     end instead, and no native turn starts while a TUI launch is in
+//     flight. Closing the TUI ends it at once when idle, at its next
+//     observed idle when busy. A TUI ends only after its last turn is on
+//     disk — `endTui`: the settled re-read (the adapter's readHistory)
+//     first, then the kill; a read that fails leaves the TUI alive (the
+//     prompt stays queued / the close fails retryably) rather than guess.
+//     While a run is active, observed activity is ignored: the ended TUI's
+//     own SessionEnd must not read as the native turn's end. A
+//     shared-server provider (Codex) needs none of this — its TUI and
+//     native connection coexist — and its observation keeps writing the
+//     ledger between runs as before.
+//   - Observation is per thread and demand-driven: `observe` starts (once
+//     per provider session) the adapter's normalized subscription for a
+//     TUI-driven session and drains it into the ledger, the transcript copy
+//     (observed items), and ThreadNaming; `unobserve` ends it. A superseded
+//     session's subscription must never keep driving the thread, and a
+//     feed that ends on its own releases its claim so the next read
+//     re-subscribes instead of trusting a dead stream.
 //   - The transcript copy is a projection of provider history, never the
 //     authority: `seq` (allocated by the repository) orders durable changes
 //     and replays them (subscribe after=seq); a re-read (`readHistory`)
 //     replaces the copy wholesale and bumps snapshotVersion — triggered at
-//     startup for threads mid-work and when a TUI-driven thread goes idle,
-//     never for a turn ATC drove itself. An empty history never replaces
-//     the copy (a swept Claude transcript keeps ATC's copy readable).
+//     startup for threads mid-work, when a TUI-driven thread goes idle, and
+//     before a TUI is ended (its last turn), never for a turn ATC drove
+//     itself. An empty history never replaces the copy (a swept Claude
+//     transcript keeps ATC's copy readable).
 //   - Provider requests park in memory until answered through
 //     `answerRequest`; they die with their turn or the process (a re-run
 //     turn re-asks). Answers are validated against the request here, so
 //     adapters only ever see well-formed answers.
 //   - The activity ledger is the one place live activity lives (the
-//     terminal-observation drain in threads.ts feeds it too): a first busy
-//     confirms the thread, a busy→idle drop stamps last_finished_at
-//     (unread, ATC-160), and every transition publishes the thread as
-//     updated. Turn end forces idle — the connection is released, so no
-//     later evidence can arrive on it. While the runtime drives a thread,
-//     its ledger entry is authoritative and never re-derived. The ledger
-//     also feeds ThreadNaming every busy/idle edge, whichever surface
-//     produced it (ATC-202).
+//     observation drain and threads.ts's demand-driven re-derivation feed
+//     it too): a first busy confirms the thread, a busy→idle drop stamps
+//     last_finished_at (unread, ATC-160), and every transition publishes
+//     the thread as updated. Turn end forces idle — the connection is
+//     released, so no later evidence can arrive on it. While the runtime
+//     drives a thread, its ledger entry is authoritative: never re-derived,
+//     and observed activity is ignored. The ledger also feeds ThreadNaming
+//     every busy/idle edge, whichever surface produced it (ATC-202).
 //   - Startup: threads with a running turn re-read history (their status
 //     is whatever the provider says); a turn still running on a shared
 //     provider server (Codex) is reattached and followed to its end, any
@@ -178,16 +222,42 @@ export class ThreadRuntime extends Context.Service<
       record: ThreadRecord,
       activity: AgentActivity,
     ) => Effect.Effect<{ readonly previous: AgentActivity | undefined }>
-    /** Drop the ledger entry (an observation ended) — unless the runtime is
-     * driving the thread, whose own evidence stays authoritative. */
-    readonly clearActivity: (id: string) => Effect.Effect<void>
-    /** Record an item observed on a TUI-driven session (the shared-server fan-out). */
-    readonly recordObserved: (record: ThreadRecord, event: AgentItemEvent) => Effect.Effect<void>
-    /** The thread went idle under observation: re-read unless the busy was ours. */
+    /** The thread went idle under observation: re-read unless the busy was
+     * ours, end a TUI no client shows, drain the queue. */
     readonly observedIdle: (record: ThreadRecord) => Effect.Effect<void>
-    /** Release the run and end the thread's event streams (archive/delete):
-     * the connection closes, its turn is recorded interrupted, and the
-     * provider keeps its own state. */
+    /** Start (once) the thread's session observation — call it whenever a
+     * TUI is live or being launched on the record's session. */
+    readonly observe: (record: ThreadRecord) => Effect.Effect<void>
+    /** End the thread's observation (a superseded session, a put-away). */
+    readonly unobserve: (id: string) => Effect.Effect<void>
+    /** Whether the record's current session is under observation. */
+    readonly observing: (record: ThreadRecord) => Effect.Effect<boolean>
+    /**
+     * A client shows the TUI (openThreadTerminal): mark it wanted, then
+     * launch under the ownership rules — the live linked terminal is
+     * returned as-is (checked again once the launch claim is held, so an
+     * automatic relaunch and an explicit open can never both launch); on a
+     * one-process provider a native run in progress refuses (ThreadBusy;
+     * the run's end launches the TUI itself), and no native turn starts
+     * while the launch is in flight.
+     */
+    readonly openTui: <E, R>(
+      record: ThreadRecord,
+      launch: Effect.Effect<Terminal, E, R>,
+    ) => Effect.Effect<Terminal, E | ThreadBusy, R>
+    /**
+     * A client stopped showing the TUI (closeThreadTerminal): the native
+     * side takes the thread back on a one-process provider — an idle TUI
+     * ends now (its last turn on disk first — a failed read fails the close
+     * retryably and leaves the TUI running), a busy one at its observed
+     * idle. A shared-server provider's TUI keeps running.
+     */
+    readonly closeTui: (
+      record: ThreadRecord,
+    ) => Effect.Effect<void, ProviderUnavailable | ProviderSessionConflict | ZmxUnavailable>
+    /** Release the run, the observation, the surface marks, and the thread's
+     * event streams (archive/delete): the connection closes, its turn is
+     * recorded interrupted, and the provider keeps its own state. */
     readonly release: (id: string) => Effect.Effect<void>
   }
 >()("app-server/ThreadRuntime") {}
@@ -199,18 +269,27 @@ export const layer = Layer.effect(ThreadRuntime)(
     const registry = yield* AgentRegistry
     const events = yield* Events
     const naming = yield* ThreadNaming
-    // Runs and their drain fibers outlive their originating requests; they
-    // live in the service scope so shutdown releases every connection.
+    const tui = yield* ThreadTui
+    // Runs, observations, and their drain fibers outlive their originating
+    // requests; they live in the service scope so shutdown releases every
+    // connection and subscription.
     const serviceScope = yield* Effect.scope
 
     const runs = new Map<string, Run>()
     const hubs = new Map<string, Set<Queue.Queue<ThreadEvent, Cause.Done>>>()
     const liveActivity = new Map<string, AgentActivity>()
+    /** The observed session per thread; the child scope closes it. */
+    interface Observation {
+      readonly providerSessionId: string
+      readonly scope: Scope.Closeable
+    }
+    const observed = new Map<string, Observation>()
+    /** Threads whose clients want the TUI (the header's ownership rule). */
+    const tuiWanted = new Set<string>()
+    /** Threads with a TUI launch in flight: no native turn starts meanwhile. */
+    const tuiOpening = new Set<string>()
     // Threads the startup pass has not settled yet: their prompts wait.
     const recovering = new Set(yield* transcripts.threadsNeedingAttention())
-    /** Threads whose latest busy spell was a native turn: the observed idle
-     * that ends it is not a TUI turn's end (observedIdle consumes the mark). */
-    const nativeBusy = new Set<string>()
     /** Per-thread serialization of "is a run active → start the next prompt". */
     const startLocks = new Map<string, Semaphore.Semaphore>()
     const withStartLock =
@@ -239,6 +318,10 @@ export const layer = Layer.effect(ThreadRuntime)(
       })
 
     const isBusy = isBusyActivity
+
+    /** The thread's provider keeps a session in one process at a time (the
+     * header's ownership rule applies); an unknown agent needs no hand-off. */
+    const oneProcess = (record: ThreadRecord): boolean => adapterFor(record)?.sharedServer === false
 
     // --- Per-thread event hub -------------------------------------------------
 
@@ -326,12 +409,10 @@ export const layer = Layer.effect(ThreadRuntime)(
       Effect.gen(function* () {
         const previous = liveActivity.get(record.id)
         liveActivity.set(record.id, activity)
-        if (isBusy(activity)) {
-          if (runs.has(record.id)) nativeBusy.add(record.id)
-          else nativeBusy.delete(record.id)
-          // The first busy confirms (idempotent in the repository): a
-          // submitted prompt is durable provider history worth protecting.
-          if (previous === undefined || !isBusy(previous)) yield* repository.confirm(record.id)
+        // The first busy confirms (idempotent in the repository): a
+        // submitted prompt is durable provider history worth protecting.
+        if (isBusy(activity) && (previous === undefined || !isBusy(previous))) {
+          yield* repository.confirm(record.id)
         }
         // The busy→idle drop IS the turn-finished signal (ATC-160): stamp
         // before publishing so the refetch already sees the thread unread.
@@ -363,8 +444,9 @@ export const layer = Layer.effect(ThreadRuntime)(
     /**
      * The run's last act: close the connection, deregister only once it is
      * closed (a prompt arriving meanwhile queues rather than racing the
-     * writer), then start the next queued prompt. Runs in the service scope
-     * — the callers sit on the run's own drain fiber, which the scope close
+     * writer), then start the next queued prompt — and with nothing left to
+     * start, hand a wanted TUI back (relaunch). Runs in the service scope —
+     * the callers sit on the run's own drain fiber, which the scope close
      * interrupts.
      */
     const closeRun = (
@@ -380,6 +462,7 @@ export const layer = Layer.effect(ThreadRuntime)(
         ),
         Effect.andThen(then),
         Effect.andThen(startNextLogged(record.id)),
+        Effect.andThen(relaunchTui(record.id)),
         Effect.forkIn(serviceScope),
       )
 
@@ -547,9 +630,17 @@ export const layer = Layer.effect(ThreadRuntime)(
           if (Option.isNone(found) || found.value.archivedAt !== undefined) return Option.none()
           const record = found.value
           if (isBusy(liveActivity.get(id) ?? "unknown")) return Option.none()
+          if (tuiOpening.has(id)) return Option.none()
           const next = yield* transcripts.peek(id)
           if (Option.isNone(next)) return Option.none()
           const adapter = yield* requireAdapter(record)
+          // Native wins (the header's ownership rule): a live TUI on a
+          // one-process provider ends before this turn resumes the session
+          // — unless it turns out busy, in which case the observed idle
+          // drains this prompt.
+          if (!adapter.sharedServer && (yield* takeOverTui(record)) === "busy") {
+            return Option.none()
+          }
           const scope = Scope.forkUnsafe(serviceScope)
           const started = yield* Effect.gen(function* () {
             const cwd = record.workingDirectory
@@ -640,6 +731,264 @@ export const layer = Layer.effect(ThreadRuntime)(
         ),
       )
 
+    // --- Surface ownership (the header's one-process rule) ---------------------------
+
+    /**
+     * End the thread's TUI terminal, its last turn on disk first: the
+     * settled re-read is the gate (Claude appends the assistant line after
+     * the Stop hook that reported idle) — and it lands the turn in the copy
+     * — then the kill. A read that fails leaves the TUI alive: unverified
+     * is not "on disk". So does a TUI that went busy during the read (a
+     * prompt typed into it meanwhile): "busy", and it keeps the thread
+     * until its idle.
+     */
+    const endTui = (
+      record: ThreadRecord,
+      terminalId: string,
+    ): Effect.Effect<
+      "ended" | "busy",
+      ProviderUnavailable | ProviderSessionConflict | ZmxUnavailable
+    > =>
+      Effect.gen(function* () {
+        yield* rereadRecord(record)
+        if (isBusy(liveActivity.get(record.id) ?? "unknown")) return "busy"
+        yield* tui.end(terminalId)
+        return "ended"
+      })
+
+    /** A native turn is about to start on a one-process provider: a live
+     * TUI (idle — the caller checked the ledger) ends first. "busy" when
+     * it is not idle after all: the turn waits for the observed idle. */
+    const takeOverTui = (
+      record: ThreadRecord,
+    ): Effect.Effect<"taken" | "busy", ProviderUnavailable | ProviderSessionConflict> =>
+      Effect.gen(function* () {
+        const linked = yield* tui.linked(record)
+        if (linked === undefined) return "taken"
+        const outcome = yield* endTui(record, linked.id).pipe(
+          Effect.catchTag("ZmxUnavailable", (error) =>
+            Effect.fail(
+              new ProviderUnavailable({
+                agentId: record.agentId,
+                reason: `the thread's TUI could not be ended: ${error.message}`,
+              }),
+            ),
+          ),
+        )
+        return outcome === "ended" ? "taken" : "busy"
+      })
+
+    /**
+     * The native side is done (no run, nothing queued): a TUI clients still
+     * want comes back on the thread's confirmed session. Best-effort — a
+     * failed relaunch is logged, and the next open launches it. Under the
+     * start lock so it cannot interleave with a prompt starting.
+     */
+    const relaunchTui = (id: string): Effect.Effect<void> =>
+      withStartLock(id)(
+        Effect.gen(function* () {
+          if (!tuiWanted.has(id) || runs.has(id) || tuiOpening.has(id)) return
+          const found = yield* repository.get(id)
+          if (Option.isNone(found) || found.value.archivedAt !== undefined) return
+          const record = found.value
+          const adapter = adapterFor(record)
+          if (adapter === undefined || adapter.sharedServer) return
+          if (record.providerSessionId === undefined || record.confirmedAt === undefined) return
+          // A waiting prompt drains first (or stays queued on a provider
+          // failure); the TUI comes back only once the queue is empty.
+          if (Option.isSome(yield* transcripts.peek(id))) return
+          if ((yield* tui.linked(record)) !== undefined) return
+          const { record: current } = yield* tui.reopen(record, adapter)
+          yield* observe(current)
+          yield* events.publish({ resource: "thread", id, change: "updated" })
+        }).pipe(
+          Effect.catch((error) =>
+            Effect.logWarning("the TUI could not be relaunched; the next open launches it").pipe(
+              Effect.annotateLogs({ threadId: id, reason: error.message }),
+            ),
+          ),
+        ),
+      )
+
+    const openTui: ThreadRuntime["Service"]["openTui"] = (record, launch) =>
+      Effect.gen(function* () {
+        tuiWanted.add(record.id)
+        // The refusal, the linked re-check, and the launch claim are one
+        // step under the start lock: a prompt cannot start a run between
+        // them, and a relaunch (which holds the lock while it launches) is
+        // seen as the live terminal it produced.
+        const claimed = yield* withStartLock(record.id)(
+          Effect.gen(function* () {
+            if (oneProcess(record) && runs.has(record.id)) {
+              return yield* Effect.fail(new ThreadBusy({ threadId: record.id }))
+            }
+            const linked = yield* tui.linked(record)
+            if (linked !== undefined) return linked
+            if (oneProcess(record)) tuiOpening.add(record.id)
+            return undefined
+          }),
+        )
+        if (claimed !== undefined) return claimed
+        if (!oneProcess(record)) return yield* launch
+        return yield* launch.pipe(
+          Effect.ensuring(
+            Effect.sync(() => tuiOpening.delete(record.id)).pipe(
+              // Prompts that queued behind the launch drain now (native
+              // wins: they take the fresh TUI over).
+              Effect.andThen(startNextLogged(record.id)),
+            ),
+          ),
+        )
+      })
+
+    // Under the start lock: a relaunch in flight finishes first (and is
+    // then ended here), and none starts once the mark is gone.
+    const closeTui: ThreadRuntime["Service"]["closeTui"] = (record) =>
+      withStartLock(record.id)(
+        Effect.gen(function* () {
+          tuiWanted.delete(record.id)
+          if (!oneProcess(record)) return
+          // Busy: the observed idle ends it (observedIdle below).
+          if (isBusy(liveActivity.get(record.id) ?? "unknown")) return
+          const linked = yield* tui.linked(record)
+          if (linked === undefined) return
+          yield* endTui(record, linked.id)
+        }),
+      )
+
+    // --- Observation of TUI-driven sessions ---------------------------------------
+
+    /**
+     * The thread went idle under observation — a TUI turn's end (a native
+     * turn's own idle never comes this way: observed activity is ignored
+     * while the runtime drives): re-read the provider's history before the
+     * queue drains, so the next turn's live items survive it; then end a
+     * TUI no client wants any more (a Chat switch while it was busy) — the
+     * settled read that just landed is its on-disk gate, so a failed read
+     * leaves it running; then drain. The read and the end hold the start
+     * lock: a prompt admitted meanwhile starts after them, so the replaced
+     * copy can never wipe a native turn's fresh rows.
+     */
+    const observedIdle = (record: ThreadRecord): Effect.Effect<void> =>
+      withStartLock(record.id)(
+        Effect.gen(function* () {
+          if (runs.has(record.id)) return
+          const settled = yield* rereadRecord(record).pipe(
+            Effect.as(true),
+            Effect.catch((error) =>
+              Effect.logDebug("re-read after observed idle failed").pipe(
+                Effect.annotateLogs({ threadId: record.id, reason: error.message }),
+                Effect.as(false),
+              ),
+            ),
+          )
+          if (!settled || !oneProcess(record) || tuiWanted.has(record.id)) return
+          const linked = yield* tui.linked(record)
+          if (linked === undefined) return
+          yield* tui
+            .end(linked.id)
+            .pipe(
+              Effect.catch((error) =>
+                Effect.logWarning("the closed TUI could not be ended at its idle").pipe(
+                  Effect.annotateLogs({ threadId: record.id, reason: error.message }),
+                ),
+              ),
+            )
+        }),
+      ).pipe(Effect.andThen(startNextLogged(record.id)))
+
+    const unobserve = (id: string): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        // The ledger entry goes with the observation — unless the runtime is
+        // driving the thread, whose own evidence stays authoritative.
+        if (!runs.has(id)) liveActivity.delete(id)
+        tuiWanted.delete(id)
+        const observation = observed.get(id)
+        if (observation === undefined) return
+        observed.delete(id)
+        yield* Scope.close(observation.scope, Exit.void)
+      })
+
+    const drainObserved = (record: ThreadRecord, event: AgentSessionEvent): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        if (event.type === "userPrompt") return yield* naming.notePrompt(record, event.text)
+        // While the runtime drives, its writer feed already carries every
+        // item and every activity edge; the observer copy of a shared
+        // server's fan-out would double the items, and a one-process
+        // provider's dead TUI can only report its own SessionEnd.
+        if (runs.has(record.id)) return
+        if (event.type !== "activity") return yield* recordItem(record.id, event)
+        const { previous } = yield* noteActivity(record, event.activity)
+        // The busy→idle drop is the turn's end (forked: the drain must never
+        // wait on the provider).
+        if (previous !== undefined && isBusy(previous) && event.activity === "idle") {
+          yield* observedIdle(record).pipe(Effect.forkIn(serviceScope))
+        }
+      })
+
+    /**
+     * Start (once) the thread's normalized session subscription. A TUI is
+     * live or launching whenever this is called, so a NEW observation marks
+     * the TUI wanted (a live TUI found after a restart stays in charge until
+     * a client says otherwise).
+     */
+    const observe = (record: ThreadRecord): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        const adapter = adapterFor(record)
+        const providerSessionId = record.providerSessionId
+        if (adapter === undefined || providerSessionId === undefined) return
+        const existing = observed.get(record.id)
+        if (existing?.providerSessionId === providerSessionId) return
+        // A superseded session's subscription must never keep driving the
+        // thread (its feed would confirm a session it never saw).
+        if (existing !== undefined) yield* unobserve(record.id)
+        // The re-check, unsafe fork, and claim are ONE synchronous step:
+        // concurrent first reads of the same live thread (sidebar list +
+        // detail get at relaunch) race exactly here, and a loser that
+        // proceeded would leak its adapter subscription until shutdown.
+        // Whoever claimed during the unobserve above wins, whatever
+        // session it observes — the next read re-checks and heals.
+        if (observed.get(record.id) !== undefined) return
+        const child = Scope.forkUnsafe(serviceScope)
+        const observation: Observation = { providerSessionId, scope: child }
+        observed.set(record.id, observation)
+        tuiWanted.add(record.id)
+        const releaseClaim = Effect.gen(function* () {
+          if (observed.get(record.id) !== observation) return
+          observed.delete(record.id)
+          yield* Scope.close(child, Exit.void)
+        })
+        yield* Effect.gen(function* () {
+          // The subscription is established HERE, before the caller
+          // proceeds — only the drain loop is forked. An unavailable
+          // evidence source yields an empty feed: `unknown` on reads,
+          // never a guess or a crash.
+          const stream = yield* adapter
+            .observeSession({ providerSessionId, providerMetadata: record.providerMetadata })
+            .pipe(
+              Effect.catchTag("AgentUnavailable", () =>
+                Effect.succeed(Stream.empty as Stream.Stream<AgentSessionEvent>),
+              ),
+              Scope.provide(child),
+            )
+          yield* stream.pipe(
+            Stream.runForEach((event) => drainObserved(record, event)),
+            // A feed that ends on its own must not pin the entry (the next
+            // read re-subscribes instead of trusting a dead stream) nor
+            // leak its child scope into the service scope. An ended
+            // observation also ends the refinement's wait — its turn-end
+            // evidence is gone, so the catch-up must not park forever.
+            Effect.ensuring(naming.noteFeedEnded(record).pipe(Effect.andThen(releaseClaim))),
+            Effect.forkIn(child),
+          )
+        }).pipe(
+          // A caller interrupted (a dropped read) or failing before the
+          // drain fiber arms must not leave a claim with no consumer — that
+          // would freeze the thread's activity until shutdown.
+          Effect.onExit((exit) => (exit._tag === "Failure" ? releaseClaim : Effect.void)),
+        )
+      })
+
     // --- Startup ---------------------------------------------------------------------
 
     /**
@@ -712,7 +1061,7 @@ export const layer = Layer.effect(ThreadRuntime)(
             // A shared provider server (the observation-outlives-TUI shape)
             // keeps running our turn across ATC's restart; anything else
             // died with the process.
-            yield* adapter?.observationOutlivesTui === true
+            yield* adapter?.sharedServer === true
               ? reattach(record, turn)
               : markInterrupted(record, turn)
           }
@@ -901,39 +1250,20 @@ export const layer = Layer.effect(ThreadRuntime)(
       activity: (id) => Effect.sync(() => liveActivity.get(id)),
       isDriving: (id) => Effect.sync(() => runs.has(id)),
       noteActivity,
-      clearActivity: (id) =>
-        Effect.sync(() => {
-          if (runs.has(id)) return
-          liveActivity.delete(id)
-          nativeBusy.delete(id)
-        }),
-      // While the runtime drives, the writer feed already carries every
-      // item; the observer copy of the same fan-out would double it.
-      recordObserved: (record, event) =>
-        runs.has(record.id) ? Effect.void : recordItem(record.id, event),
-      observedIdle: (record) =>
-        Effect.gen(function* () {
-          if (runs.has(record.id)) return
-          // Our own turn's idle is not a TUI turn ending: the copy is live.
-          // A TUI turn's end is what the re-read is for — before the queue
-          // drains, so the new turn's live items survive it.
-          if (!nativeBusy.delete(record.id)) {
-            yield* rereadRecord(record).pipe(
-              Effect.catch((error) =>
-                Effect.logDebug("re-read after observed idle failed").pipe(
-                  Effect.annotateLogs({ threadId: record.id, reason: error.message }),
-                ),
-              ),
-            )
-          }
-          yield* startNextLogged(record.id)
-        }),
+      observedIdle,
+      observe,
+      unobserve,
+      observing: (record) =>
+        Effect.sync(() => observed.get(record.id)?.providerSessionId === record.providerSessionId),
+      openTui,
+      closeTui,
       release: (id) =>
         withStartLock(id)(
           Effect.gen(function* () {
             const run = runs.get(id)
             liveActivity.delete(id)
-            nativeBusy.delete(id)
+            tuiWanted.delete(id)
+            yield* unobserve(id)
             if (run !== undefined) {
               run.finished = true
               closeRequests(id, run)

--- a/app-server/src/threads/threadTui.ts
+++ b/app-server/src/threads/threadTui.ts
@@ -1,0 +1,133 @@
+import { Context, Effect, Layer, Option } from "effect"
+import type { AgentAdapter, TuiLaunchSpec } from "../agents/agentAdapter.ts"
+import { NESTED_SESSION_ENV_VARIABLES } from "../agents/agentAdapter.ts"
+import { ProviderSessionConflict, ProviderUnavailable, ThreadNotFound } from "../api/contract.ts"
+import type {
+  DirectoryCheckTimedOut,
+  DirectoryUnavailable,
+  TerminalLaunchFailed,
+  ZmxUnavailable,
+} from "../api/contract.ts"
+import { Terminals } from "../terminals/terminals.ts"
+import type { Terminal } from "../terminals/terminals.ts"
+import { ThreadRepository } from "./threadRepository.ts"
+import type { ThreadRecord } from "./threadRepository.ts"
+
+// A thread's TUI terminal (ATC-124 / ATC-203): the one place a Terminal is
+// found, launched, or ended on a thread's behalf, shared by the Threads
+// domain (open, archive, delete) and the ThreadRuntime (the one-process
+// hand-off between a TUI and a native turn) so both launch and end a TUI
+// the same way. Invariants:
+//
+//   - Every launch scrubs the nested-session markers uniformly
+//     (agentAdapter.ts NESTED_SESSION_ENV_VARIABLES): inherited from a
+//     dev-mode ATC running inside an agent session, they silently change
+//     provider behavior.
+//   - `reopen` is the confirmed-session relaunch: the adapter's launch spec
+//     against the thread's exact persisted identity, and any metadata the
+//     launch minted or rotated persisted BEFORE the terminal exists — a
+//     TUI must never run on state that dies with the process. A thread
+//     deleted mid-launch adopts nothing (ThreadNotFound).
+//   - `end` follows the terminals confirmed-kill rules: a terminal that
+//     vanished since the lookup is already the goal state, and a kill the
+//     multiplexer cannot verify fails ZmxUnavailable — the caller decides
+//     whether that blocks it.
+
+export class ThreadTui extends Context.Service<
+  ThreadTui,
+  {
+    /** The thread's live linked TUI terminal, from the reconciled inventory
+     * — a terminal that just died stops being linked the moment the
+     * inventory says so. */
+    readonly linked: (record: ThreadRecord) => Effect.Effect<Terminal | undefined>
+    /** Launch a TUI terminal from an adapter launch spec. */
+    readonly create: (
+      record: ThreadRecord,
+      spec: TuiLaunchSpec,
+    ) => Effect.Effect<
+      Terminal,
+      DirectoryUnavailable | DirectoryCheckTimedOut | ZmxUnavailable | TerminalLaunchFailed
+    >
+    /** Relaunch the TUI on the thread's confirmed session; returns the
+     * terminal and the record as persisted (metadata may have rotated). */
+    readonly reopen: (
+      record: ThreadRecord,
+      adapter: AgentAdapter,
+    ) => Effect.Effect<
+      { readonly terminal: Terminal; readonly record: ThreadRecord },
+      | ThreadNotFound
+      | ProviderUnavailable
+      | ProviderSessionConflict
+      | DirectoryUnavailable
+      | DirectoryCheckTimedOut
+      | ZmxUnavailable
+      | TerminalLaunchFailed
+    >
+    /** Kill the terminal (its zmx session, hence the TUI process) and
+     * remove its record; already gone is success. */
+    readonly end: (terminalId: string) => Effect.Effect<void, ZmxUnavailable>
+  }
+>()("app-server/ThreadTui") {}
+
+export const layer = Layer.effect(ThreadTui)(
+  Effect.gen(function* () {
+    const terminals = yield* Terminals
+    const repository = yield* ThreadRepository
+
+    const create: ThreadTui["Service"]["create"] = (record, spec) =>
+      terminals
+        .create({
+          projectId: record.projectId,
+          threadId: record.id,
+          ...(record.name !== undefined ? { name: record.name } : {}),
+          command: spec.command,
+          workingDirectory: record.workingDirectory,
+          env: {
+            ...spec.env,
+            ...Object.fromEntries(NESTED_SESSION_ENV_VARIABLES.map((name) => [name, undefined])),
+          },
+        })
+        // The owning project cannot vanish under a live thread (FK).
+        .pipe(Effect.catchTag("ProjectNotFound", (error) => Effect.die(error)))
+
+    return {
+      linked: (record) =>
+        terminals
+          .list({ threadId: record.id })
+          .pipe(Effect.map((list) => list.find((terminal) => terminal.status === "live"))),
+      create,
+      reopen: (record, adapter) =>
+        Effect.gen(function* () {
+          const providerSessionId = record.providerSessionId ?? ""
+          const launch = yield* adapter
+            .tuiLaunch({
+              providerSessionId,
+              cwd: record.workingDirectory,
+              providerMetadata: record.providerMetadata,
+            })
+            .pipe(
+              Effect.mapError((error) =>
+                error._tag === "AgentUnavailable"
+                  ? new ProviderUnavailable({ agentId: record.agentId, reason: error.message })
+                  : new ProviderSessionConflict({ threadId: record.id, reason: error.message }),
+              ),
+            )
+          // Deleted mid-open: adopt nothing (the metadata write would die
+          // on the vanished row, the terminal would violate the FK).
+          const still = yield* repository.get(record.id)
+          if (Option.isNone(still)) {
+            return yield* Effect.fail(new ThreadNotFound({ threadId: record.id }))
+          }
+          const current =
+            launch.providerMetadata !== undefined &&
+            launch.providerMetadata !== record.providerMetadata
+              ? yield* repository.setProviderMetadata(record.id, launch.providerMetadata)
+              : record
+          const terminal = yield* create(current, launch.launchSpec)
+          return { terminal, record: current }
+        }),
+      end: (terminalId) =>
+        terminals.delete(terminalId).pipe(Effect.catchTag("TerminalNotFound", () => Effect.void)),
+    }
+  }),
+)

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -1,15 +1,4 @@
-import {
-  Context,
-  Duration,
-  Effect,
-  Exit,
-  Layer,
-  Option,
-  Schedule,
-  Scope,
-  Semaphore,
-  Stream,
-} from "effect"
+import { Context, Duration, Effect, Layer, Option, Schedule, Semaphore } from "effect"
 import { AgentRegistry } from "../agents/agentRegistry.ts"
 import type {
   AgentActivity,
@@ -18,11 +7,9 @@ import type {
   AgentIdentityMismatch,
   AgentProtocolError,
   AgentResumeFailed,
-  AgentSessionEvent,
   AgentUnavailable,
-  TuiLaunchSpec,
 } from "../agents/agentAdapter.ts"
-import { isBusyActivity, NESTED_SESSION_ENV_VARIABLES } from "../agents/agentAdapter.ts"
+import { isBusyActivity } from "../agents/agentAdapter.ts"
 import {
   isAgentId,
   ProviderSessionConflict,
@@ -49,6 +36,7 @@ import { ThreadNaming } from "./threadNaming.ts"
 import { ThreadRepository } from "./threadRepository.ts"
 import type { ThreadRecord } from "./threadRepository.ts"
 import { ThreadRuntime } from "./threadRuntime.ts"
+import { ThreadTui } from "./threadTui.ts"
 
 export type Thread = typeof Contract.Thread.Type
 
@@ -70,34 +58,33 @@ export type Thread = typeof Contract.Thread.Type
 //     id; unconfirmed ones re-materialize with fresh identity — there is
 //     no history to protect yet.
 //   - No lock between surfaces (ATC-193): a TUI may open while the runtime
-//     drives a turn and a prompt may arrive while a TUI is live — the
-//     provider taking one turn at a time is its own affair, and the only
-//     guard is the in-progress state plus the queue. Nothing binds a Thread
-//     to one surface.
+//     drives a turn and a prompt may arrive while a TUI is live — the only
+//     guard is the in-progress state plus the queue, and nothing binds a
+//     Thread to one surface. Which PROCESS runs the session is the
+//     runtime's affair (ATC-203): openTerminal and closeTerminal only tell
+//     it what clients show (`openTui` / `closeTui`), and it hands a
+//     one-process provider's session between the TUI and its own turns.
 //   - workingDirectory is validated, canonicalized, and immutable.
 //   - activityState is in-memory evidence, never persisted, and lives in
-//     the ThreadRuntime's activity ledger — fed by the terminal-observation
-//     drain here and by native turns there, one set of rules (first busy
-//     confirms, busy→idle stamps the finish, every transition publishes).
-//     `unknown` when there is no evidence; a busy state whose driver is
-//     gone re-derives demand-driven from the adapter's reconciliation
-//     check on read, unless the runtime is driving the thread (its
-//     evidence is authoritative) or a shared-server observation still
-//     covers it. The confirmed marker is persisted at the FIRST busy signal
-//     — a submitted prompt is already durable provider history worth
-//     protecting — the same signal for every provider.
+//     the ThreadRuntime's activity ledger — fed by its observation of a
+//     TUI-driven session (started here on demand: `runtime.observe`
+//     whenever a read finds a live linked TUI, or an open launches one) and
+//     by its native turns, one set of rules (first busy confirms, busy→idle
+//     stamps the finish, every transition publishes). `unknown` when there
+//     is no evidence; a busy state whose driver is gone re-derives
+//     demand-driven from the adapter's reconciliation check on read, unless
+//     the runtime is driving the thread (its evidence is authoritative) or a
+//     shared-server observation still covers it. The confirmed marker is
+//     persisted at the FIRST busy signal — a submitted prompt is already
+//     durable provider history worth protecting — the same signal for every
+//     provider.
 //   - The unread overlay (ATC-160) is derived, never stored as a flag:
 //     last_finished_at is stamped at the observed busy→idle drop — the
 //     ledger and the driver-gone re-derivation alike — last_viewed_at by
 //     markViewed, and archived rows are never unread. The activity
 //     vocabulary is untouched; "Done" is client-side display translation.
-//   - Observed conversation items (the shared-server fan-out on a
-//     TUI-driven Codex thread) feed the runtime's transcript copy, and an
-//     observed busy→idle asks the runtime to re-read the provider's
-//     history — the copy for turns ATC did not drive.
-//   - Auto-naming lives in ThreadNaming (ATC-155/190/202); the drain feeds
-//     it observed user prompts and its feed's end, judged on the record at
-//     subscription start.
+//   - Auto-naming lives in ThreadNaming (ATC-155/190/202), fed by the
+//     runtime's observation and turns.
 //   - archived threads are never pinned: pin refuses archived records, and
 //     archive clears the pin in the same repository write so no client can
 //     observe or restore an archived pin.
@@ -164,19 +151,30 @@ export class Threads extends Context.Service<
     /** Kill the live linked terminal and release adapter resources, then
      * remove the record. */
     readonly delete: (id: string) => Effect.Effect<void, ThreadNotFound | ZmxUnavailable>
-    /** Open (or return) the thread's TUI terminal — the header's workflow. */
+    /** Open (or return) the thread's TUI terminal — the header's workflow.
+     * ThreadBusy: a one-process provider's native turn is running; the
+     * runtime launches the TUI when it ends. */
     readonly openTerminal: (
       id: string,
     ) => Effect.Effect<
       Terminal,
       | ThreadNotFound
       | ThreadArchived
+      | ThreadBusy
       | ProviderUnavailable
       | ProviderSessionConflict
       | DirectoryUnavailable
       | DirectoryCheckTimedOut
       | ZmxUnavailable
       | TerminalLaunchFailed
+    >
+    /** The client stopped showing the TUI: hand the thread back to the
+     * native side (`runtime.closeTui` — the runtime's ownership rules). */
+    readonly closeTerminal: (
+      id: string,
+    ) => Effect.Effect<
+      Thread,
+      ThreadNotFound | ProviderUnavailable | ProviderSessionConflict | ZmxUnavailable
     >
   }
 >()("app-server/Threads") {}
@@ -192,18 +190,13 @@ export const layerWith = (options: ThreadsOptions) =>
       const events = yield* Events
       const runtime = yield* ThreadRuntime
       const naming = yield* ThreadNaming
-      // Observation fibers outlive their originating requests; they live in
-      // the service's own scope so shutdown reaps every subscription.
+      const tui = yield* ThreadTui
+      // Forked work (a discovered finish's re-read) outlives its request;
+      // it lives in the service's own scope.
       const serviceScope = yield* Effect.scope
       const identityTimeout = options.identityTimeout ?? "30 seconds"
       const launchWatchInterval = options.launchWatchInterval ?? "500 millis"
 
-      /** The observed session per thread; the child scope closes it. */
-      interface Observation {
-        readonly providerSessionId: string
-        readonly scope: Scope.Closeable
-      }
-      const observed = new Map<string, Observation>()
       /** Threads with an openTerminal in flight — the one-open guard. */
       const opening = new Set<string>()
       /**
@@ -242,103 +235,6 @@ export const layerWith = (options: ThreadsOptions) =>
         (record.lastViewedAt === undefined || record.lastViewedAt < record.lastFinishedAt)
 
       /**
-       * Start (once) the thread's normalized activity subscription. The
-       * consumer keeps the in-memory snapshot current and persists the
-       * confirmed marker at the first busy evidence it sees (the header's
-       * confirmation invariant).
-       */
-      const ensureObserved = (record: ThreadRecord): Effect.Effect<void> =>
-        Effect.gen(function* () {
-          const adapter = adapterFor(record)
-          const providerSessionId = record.providerSessionId
-          if (adapter === undefined || providerSessionId === undefined) return
-          const existing = observed.get(record.id)
-          if (existing?.providerSessionId === providerSessionId) return
-          // A superseded session's subscription must never keep driving
-          // the thread (its feed would confirm a session it never saw).
-          if (existing !== undefined) yield* unobserve(record.id)
-          // The re-check, unsafe fork, and claim are ONE synchronous step:
-          // concurrent first reads of the same live thread (sidebar list +
-          // detail get at relaunch) race exactly here, and a loser that
-          // proceeded would leak its adapter subscription until shutdown.
-          // Whoever claimed during the unobserve above wins, whatever
-          // session it observes — the next read re-checks and heals.
-          if (observed.get(record.id) !== undefined) return
-          const child = Scope.forkUnsafe(serviceScope)
-          const observation: Observation = { providerSessionId, scope: child }
-          observed.set(record.id, observation)
-          const releaseClaim = Effect.gen(function* () {
-            if (observed.get(record.id) !== observation) return
-            observed.delete(record.id)
-            yield* Scope.close(child, Exit.void)
-          })
-          yield* Effect.gen(function* () {
-            // The subscription is established HERE, before the caller
-            // proceeds — only the drain loop is forked. An unavailable
-            // evidence source yields an empty feed: `unknown` on reads,
-            // never a guess or a crash.
-            const stream = yield* adapter
-              .observeSession({
-                providerSessionId,
-                providerMetadata: record.providerMetadata,
-              })
-              .pipe(
-                Effect.catchTag("AgentUnavailable", () =>
-                  Effect.succeed(Stream.empty as Stream.Stream<AgentSessionEvent>),
-                ),
-                Scope.provide(child),
-              )
-            yield* stream.pipe(
-              Stream.runForEach((event) =>
-                Effect.gen(function* () {
-                  if (event.type === "userPrompt") {
-                    yield* naming.notePrompt(record, event.text)
-                    return
-                  }
-                  // Conversation items observed on the shared server feed
-                  // the runtime's transcript copy (ATC-193).
-                  if (event.type !== "activity") {
-                    yield* runtime.recordObserved(record, event)
-                    return
-                  }
-                  const activity = event.activity
-                  // The ledger applies the confirm / finish / publish rules.
-                  const { previous } = yield* runtime.noteActivity(record, activity)
-                  // The busy→idle drop is the turn's end — for a turn ATC
-                  // did not drive, the moment to re-read the provider's
-                  // history (forked: the drain must never wait on the
-                  // provider).
-                  if (previous !== undefined && isBusy(previous) && activity === "idle") {
-                    yield* runtime.observedIdle(record).pipe(Effect.forkIn(serviceScope))
-                  }
-                }),
-              ),
-              // A feed that ends on its own must not pin the entry (the
-              // next read re-subscribes instead of trusting a dead stream)
-              // nor leak its child scope into the service scope. An ended
-              // observation also ends the refinement's wait — its turn-end
-              // evidence is gone, so the catch-up must not park forever.
-              Effect.ensuring(naming.noteFeedEnded(record).pipe(Effect.andThen(releaseClaim))),
-              Effect.forkIn(child),
-            )
-          }).pipe(
-            // A caller interrupted (a dropped read) or failing before the
-            // drain fiber arms must not leave a claim with no consumer —
-            // that would freeze the thread's activity until shutdown.
-            Effect.onExit((exit) => (exit._tag === "Failure" ? releaseClaim : Effect.void)),
-          )
-        })
-
-      const unobserve = (threadId: string): Effect.Effect<void> =>
-        Effect.gen(function* () {
-          yield* runtime.clearActivity(threadId)
-          const observation = observed.get(threadId)
-          if (observation === undefined) return
-          observed.delete(threadId)
-          yield* Scope.close(observation.scope, Exit.void)
-        })
-
-      /**
        * The activity snapshot for one read. A busy state whose driver (the
        * live linked terminal) is gone is presumed stale and re-derived
        * from the adapter's reconciliation check — unless a live observation
@@ -366,10 +262,7 @@ export const layerWith = (options: ThreadsOptions) =>
           // so their busy states must still re-derive below (for Codex the
           // re-derivation costs paginated provider walks; skipping it here
           // is what keeps the listing hot path off the provider).
-          if (
-            adapter?.observationOutlivesTui === true &&
-            observed.get(record.id)?.providerSessionId === record.providerSessionId
-          ) {
+          if (adapter?.sharedServer === true && (yield* runtime.observing(record))) {
             return { activity: live, record }
           }
           const providerSessionId = record.providerSessionId
@@ -421,18 +314,6 @@ export const layerWith = (options: ThreadsOptions) =>
       })
 
       /**
-       * The thread's live linked terminal, if any, from the reconciled
-       * terminals listing — a terminal that just died stops being "linked"
-       * the moment the inventory says so, not at its next explicit read.
-       */
-      const linkedFor = (record: ThreadRecord): Effect.Effect<Terminal | undefined> =>
-        terminals
-          .list({ projectId: record.projectId })
-          .pipe(
-            Effect.map((list) => list.find((t) => t.threadId === record.id && t.status === "live")),
-          )
-
-      /**
        * Assemble one Thread from an already-looked-up linked terminal —
        * listing callers batch one reconciled inventory pass for the whole
        * page instead of one per record.
@@ -447,15 +328,15 @@ export const layerWith = (options: ThreadsOptions) =>
           // while an open is in flight: a mid-materialize row still names
           // the superseded session, and a read subscribing to it could
           // confirm a session the thread no longer references — the open's
-          // own ensureObserved covers the fresh identity.
-          if (linked !== undefined && !opening.has(record.id)) yield* ensureObserved(record)
+          // own observe covers the fresh identity.
+          if (linked !== undefined && !opening.has(record.id)) yield* runtime.observe(record)
           const resolved = yield* resolveActivity(record, linked?.id)
           return toThread(resolved.record, linked?.id, resolved.activity)
         })
 
       /** `assemble` for single-record callers (one listing pass of its own). */
       const assembleAlone = (record: ThreadRecord): Effect.Effect<Thread> =>
-        linkedFor(record).pipe(Effect.flatMap((linked) => assemble(record, linked)))
+        tui.linked(record).pipe(Effect.flatMap((linked) => assemble(record, linked)))
 
       const mapAgentError =
         (record: ThreadRecord) =>
@@ -520,24 +401,6 @@ export const layerWith = (options: ThreadsOptions) =>
         )
       }
 
-      /** Launch a TUI terminal for the thread from an adapter launch spec,
-       * with the nested-session markers scrubbed uniformly. */
-      const createTuiTerminal = (record: ThreadRecord, spec: TuiLaunchSpec) =>
-        terminals
-          .create({
-            projectId: record.projectId,
-            threadId: record.id,
-            ...(record.name !== undefined ? { name: record.name } : {}),
-            command: spec.command,
-            workingDirectory: record.workingDirectory,
-            env: {
-              ...spec.env,
-              ...Object.fromEntries(NESTED_SESSION_ENV_VARIABLES.map((name) => [name, undefined])),
-            },
-          })
-          // The owning project cannot vanish under a live thread (FK).
-          .pipe(Effect.catchTag("ProjectNotFound", (error) => Effect.die(error)))
-
       /**
        * The single identity-establishment transition: launch fresh via the
        * uniform prepareTuiSession contract, await verified identity
@@ -551,7 +414,7 @@ export const layerWith = (options: ThreadsOptions) =>
             // feed (it must never confirm the successor) and release its
             // adapter resources before minting the replacement.
             if (record.providerSessionId !== undefined) {
-              yield* unobserve(record.id)
+              yield* runtime.unobserve(record.id)
               yield* adapter.releaseSession({
                 providerSessionId: record.providerSessionId,
                 providerMetadata: record.providerMetadata,
@@ -560,10 +423,8 @@ export const layerWith = (options: ThreadsOptions) =>
             const prepared = yield* adapter
               .prepareTuiSession({ cwd: record.workingDirectory })
               .pipe(Effect.mapError(mapAgentError(record)))
-            const terminal = yield* createTuiTerminal(record, prepared.launchSpec)
-            const cleanupTerminal = terminals
-              .delete(terminal.id)
-              .pipe(Effect.catch(() => Effect.void))
+            const terminal = yield* tui.create(record, prepared.launchSpec)
+            const cleanupTerminal = tui.end(terminal.id).pipe(Effect.catch(() => Effect.void))
             yield* Effect.uninterruptibleMask((restore) =>
               Effect.gen(function* () {
                 // The identity await stays interruptible (openTerminal's
@@ -594,7 +455,7 @@ export const layerWith = (options: ThreadsOptions) =>
                       identity.providerMetadata ?? null,
                     )
                     adopted = true
-                    yield* ensureObserved(updated)
+                    yield* runtime.observe(updated)
                   }),
                 ).pipe(
                   Effect.onExit((exit) =>
@@ -621,28 +482,9 @@ export const layerWith = (options: ThreadsOptions) =>
       /** Reopen a confirmed session: exact identity, mismatches fail closed. */
       const reopen = (record: ThreadRecord, adapter: AgentAdapter) =>
         Effect.gen(function* () {
-          const providerSessionId = record.providerSessionId ?? ""
-          const launch = yield* adapter
-            .tuiLaunch({
-              providerSessionId,
-              cwd: record.workingDirectory,
-              providerMetadata: record.providerMetadata,
-            })
-            .pipe(Effect.mapError(mapAgentError(record)))
-          // Deleted mid-open: adopt nothing (the metadata write would die
-          // on the vanished row, the terminal would violate the FK).
-          const still = yield* repository.get(record.id)
-          if (Option.isNone(still)) {
-            return yield* Effect.fail(new ThreadNotFound({ threadId: record.id }))
-          }
-          const current =
-            launch.providerMetadata !== undefined &&
-            launch.providerMetadata !== record.providerMetadata
-              ? yield* repository.setProviderMetadata(record.id, launch.providerMetadata)
-              : record
-          const terminal = yield* createTuiTerminal(current, launch.launchSpec)
-          yield* ensureObserved(current)
-          return terminal
+          const launched = yield* tui.reopen(record, adapter)
+          yield* runtime.observe(launched.record)
+          return launched.terminal
         })
 
       /**
@@ -666,12 +508,7 @@ export const layerWith = (options: ThreadsOptions) =>
               }),
             )
           }
-          // Defense in depth: nothing else can have linked a live terminal
-          // while this caller held the claim, but returning one beats
-          // double-launching if that ever changes.
-          const linked = yield* linkedFor(record)
-          if (linked !== undefined) return linked
-          return yield* (
+          const launch =
             record.providerSessionId !== undefined && record.confirmedAt !== undefined
               ? reopen(record, adapter)
               : // Unconfirmed (none, or zero completed turns): re-materialize
@@ -691,7 +528,11 @@ export const layerWith = (options: ThreadsOptions) =>
                       ),
                   }),
                 )
-          ).pipe(
+          // The runtime's ownership rules wrap the launch (the header) —
+          // including the last "already live" check, so a relaunch the
+          // runtime made while this caller waited is returned, never
+          // doubled.
+          return yield* runtime.openTui(record, launch).pipe(
             // The open changed the thread (linked terminal, and possibly
             // provider identity); the idempotent return above changed nothing.
             Effect.tap(() => events.publish({ resource: "thread", id, change: "updated" })),
@@ -708,10 +549,12 @@ export const layerWith = (options: ThreadsOptions) =>
           if (record.archivedAt !== undefined) {
             return yield* Effect.fail(new ThreadArchived({ threadId: id }))
           }
-          const linked = yield* linkedFor(record)
+          const linked = yield* tui.linked(record)
           if (linked !== undefined) {
-            if (!opening.has(id)) yield* ensureObserved(record)
-            return linked
+            if (!opening.has(id)) yield* runtime.observe(record)
+            // Already live — still an open: the TUI is wanted again (a
+            // pending Chat hand-off is called off).
+            return yield* runtime.openTui(record, Effect.succeed(linked))
           }
           if (opening.has(id)) {
             return yield* Effect.fail(
@@ -731,19 +574,26 @@ export const layerWith = (options: ThreadsOptions) =>
           )
         })
 
+      const closeTerminal: Threads["Service"]["closeTerminal"] = (id) =>
+        withLifecycleLock(id)(
+          Effect.gen(function* () {
+            const record = yield* repository.require(id)
+            yield* runtime.closeTui(record)
+            return yield* assembleAlone(record)
+          }),
+        )
+
       const del: Threads["Service"]["delete"] = (id) =>
         withLifecycleLock(id)(
           Effect.gen(function* () {
             const record = yield* repository.require(id)
-            const linked = yield* linkedFor(record)
-            if (linked !== undefined) {
-              // Confirmed-kill rules live in Terminals.delete; a terminal
-              // that vanished since the lookup is already the goal state.
-              yield* terminals
-                .delete(linked.id)
-                .pipe(Effect.catchTag("TerminalNotFound", () => Effect.void))
-            }
+            // The runtime first: it waits out a TUI relaunch in flight and
+            // forbids another, so the kill below sees every terminal.
+            // Confirmed-kill rules live in Terminals.delete; a terminal that
+            // vanished since the lookup is already the goal state.
             yield* runtime.release(id)
+            const linked = yield* tui.linked(record)
+            if (linked !== undefined) yield* tui.end(linked.id)
             yield* naming.release(id)
             const adapter = adapterFor(record)
             if (adapter !== undefined && record.providerSessionId !== undefined) {
@@ -752,7 +602,6 @@ export const layerWith = (options: ThreadsOptions) =>
                 providerMetadata: record.providerMetadata,
               })
             }
-            yield* unobserve(id)
             // Ended linked terminals survive as unlinked tombstones (FK SET
             // NULL) — their client-visible threadId changes with the delete,
             // so each publishes alongside the thread's own event.
@@ -832,7 +681,7 @@ export const layerWith = (options: ThreadsOptions) =>
           withLifecycleLock(id)(
             Effect.gen(function* () {
               const record = yield* repository.require(id)
-              const linked = yield* linkedFor(record)
+              const linked = yield* tui.linked(record)
               // Repeat archive with nothing live left is a pure no-op; with
               // a lingering live terminal (a legacy row) it falls through to
               // the kill below and converges.
@@ -844,21 +693,21 @@ export const layerWith = (options: ThreadsOptions) =>
               if (isBusy((yield* resolveActivity(record, linked?.id)).activity)) {
                 return yield* Effect.fail(new ThreadBusy({ threadId: id }))
               }
-              if (linked !== undefined) {
-                // Confirmed-kill rules live in Terminals.delete: a kill that
-                // cannot verify death fails ZmxUnavailable and the thread
-                // stays active; a terminal that vanished since the lookup is
-                // already the goal state.
-                yield* terminals
-                  .delete(linked.id)
-                  .pipe(Effect.catchTag("TerminalNotFound", () => Effect.void))
-              }
-              // Suspend the runtime only after terminal death is confirmed:
-              // release adapter-owned session resources (Claude revokes its
-              // hook plumbing; the next tuiLaunch recreates it) and stop
-              // observation. The provider conversation itself is untouched,
-              // so unarchive + open resumes it exactly.
+              // Suspend the runtime first: it waits out a TUI relaunch in
+              // flight and forbids another, so the kill sees every terminal
+              // (its run and observation are gone either way — the busy
+              // check above already found nothing running). Then the
+              // confirmed-kill rules of Terminals.delete: a kill that cannot
+              // verify death fails ZmxUnavailable and the thread stays
+              // active (a re-archive converges); a terminal that vanished
+              // since the lookup is already the goal state. Then release
+              // adapter-owned session resources (Claude revokes its hook
+              // plumbing; the next tuiLaunch recreates it). The provider
+              // conversation itself is untouched, so unarchive + open
+              // resumes it exactly.
               yield* runtime.release(id)
+              const live = yield* tui.linked(record)
+              if (live !== undefined) yield* tui.end(live.id)
               yield* naming.release(id)
               const adapter = adapterFor(record)
               if (adapter !== undefined && record.providerSessionId !== undefined) {
@@ -867,7 +716,6 @@ export const layerWith = (options: ThreadsOptions) =>
                   providerMetadata: record.providerMetadata,
                 })
               }
-              yield* unobserve(id)
               if (record.archivedAt !== undefined) return yield* assemble(record, undefined)
               const updated = yield* repository.setArchived(id, true)
               yield* events.publish({ resource: "thread", id, change: "updated" })
@@ -919,6 +767,7 @@ export const layerWith = (options: ThreadsOptions) =>
           }),
         delete: del,
         openTerminal,
+        closeTerminal,
       }
     }),
   )

--- a/app-server/test/agents/agentTestKit.ts
+++ b/app-server/test/agents/agentTestKit.ts
@@ -114,9 +114,9 @@ export const claudeAdapterLayer = (
   configOverrides: Partial<Parameters<typeof testAppConfig>[0]> = {},
   hooksLayer: Layer.Layer<ClaudeHooks.ClaudeHooks> = ClaudeHooks.layer,
 ): Layer.Layer<ClaudeAdapter.ClaudeAdapter | ClaudeHooks.ClaudeHooks, unknown> =>
-  // No session file unless a test scripts one: history reads must never
+  // No transcript unless a test scripts one: history reads must never
   // reach the developer's real ~/.claude.
-  ClaudeAdapter.layerWith({ sessionFileFn: () => Promise.resolve(null), ...options }).pipe(
+  ClaudeAdapter.layerWith({ sessionMessagesFn: () => Promise.resolve([]), ...options }).pipe(
     Layer.provideMerge(hooksLayer),
     Layer.provide(testAppConfig({ claudeExecutable: executable, ...configOverrides })),
     Layer.provide(Subprocess.layer),

--- a/app-server/test/agents/claudeAdapter.test.ts
+++ b/app-server/test/agents/claudeAdapter.test.ts
@@ -808,7 +808,9 @@ describe("ClaudeAdapter TUI session plumbing", () => {
                 ? event.activity
                 : event.type === "userPrompt"
                   ? `prompt:${event.text}`
-                  : `item:${event.item.type}`,
+                  : event.item.type === "userMessage"
+                    ? `item:userMessage:${event.item.text}`
+                    : `item:${event.item.type}`,
             ),
           ),
         ),
@@ -1044,7 +1046,7 @@ describe("ClaudeAdapter TUI session plumbing", () => {
     }),
   )
 
-  it.live("observeSession streams root user prompts and ignores subagent ones", () =>
+  it.live("observeSession streams root user prompts (and them as observed items) only", () =>
     Effect.gen(function* () {
       const dir = stateDir()
       yield* Effect.gen(function* () {
@@ -1082,9 +1084,11 @@ describe("ClaudeAdapter TUI session plumbing", () => {
               hook_event_name: "Stop",
             })
             yield* waitForActivity(sink, "idle")
+            // The prompt, then the same prompt as the TUI turn's one
+            // observed item (a Chat reader shows it while the TUI works).
             assert.deepStrictEqual(
-              sink.filter((entry) => entry.startsWith("prompt:")),
-              ["prompt:add a login page"],
+              sink.filter((entry) => entry.startsWith("prompt:") || entry.startsWith("item:")),
+              ["prompt:add a login page", "item:userMessage:add a login page"],
             )
           }),
         )
@@ -1254,129 +1258,19 @@ describe("ClaudeAdapter collectTitleContext", () => {
       }),
   )
 
-  it.live(
-    "readHistory reads the session file with every branch in file order; the SDK is the fallback",
-    () =>
-      Effect.gen(function* () {
-        // A session driven from two surfaces: the TUI's second prompt forks
-        // from before the native turn (its in-memory conversation never saw
-        // it), so the last-written leaf's branch (what getSessionMessages
-        // returns) would drop the native turn entirely.
-        const line = (entry: Record<string, unknown>) => JSON.stringify(entry)
-        const file = [
-          line({
-            type: "user",
-            uuid: "u1",
-            parentUuid: null,
-            sessionId: "s",
-            message: { role: "user", content: "hi" },
-          }),
-          line({
-            type: "assistant",
-            uuid: "a1",
-            parentUuid: "u1",
-            sessionId: "s",
-            message: { role: "assistant", content: [{ type: "text", text: "hello" }] },
-          }),
-          line({
-            type: "user",
-            uuid: "n1",
-            parentUuid: "a1",
-            sessionId: "s",
-            origin: "sdk",
-            message: { role: "user", content: "native" },
-          }),
-          line({
-            type: "assistant",
-            uuid: "na1",
-            parentUuid: "n1",
-            sessionId: "s",
-            message: { role: "assistant", content: [{ type: "text", text: "native reply" }] },
-          }),
-          line({
-            type: "user",
-            uuid: "u2",
-            parentUuid: "a1",
-            sessionId: "s",
-            message: { role: "user", content: "tui again" },
-          }),
-          line({ type: "attachment", uuid: "att", parentUuid: "u2", sessionId: "s" }),
-          line({
-            type: "user",
-            uuid: "meta",
-            parentUuid: "u2",
-            sessionId: "s",
-            isMeta: true,
-            message: { role: "user", content: "reminder" },
-          }),
-          line({
-            type: "assistant",
-            uuid: "a2",
-            parentUuid: "u2",
-            sessionId: "s",
-            message: { role: "assistant", content: [{ type: "text", text: "tui reply" }] },
-          }),
-          "{not json",
-        ].join("\n")
-        const sdkCalls: Array<string> = []
-        const layer = claudeAdapterLayer({
-          sessionFileFn: (sessionId) => Promise.resolve(sessionId === "s" ? file : null),
-          sessionMessagesFn: (sessionId) => {
-            sdkCalls.push(sessionId)
-            return Promise.resolve([
-              transcriptMessage("user", "from the sdk"),
-              transcriptMessage("assistant", "reply"),
-            ])
-          },
-        })
-        yield* Effect.gen(function* () {
-          const adapter = yield* ClaudeAdapter.ClaudeAdapter
-          const history = yield* adapter.readHistory({ providerSessionId: "s", cwd: "/work" })
-          assert.deepStrictEqual(
-            history.map((turn) =>
-              turn.items.map((item) => ("text" in item ? item.text : item.type)),
-            ),
-            [
-              ["hi", "hello"],
-              ["native", "native reply"],
-              ["tui again", "tui reply"],
-            ],
-          )
-          assert.deepStrictEqual(sdkCalls, [])
-          const fallback = yield* adapter.readHistory({
-            providerSessionId: "elsewhere",
-            cwd: "/work",
-          })
-          assert.deepStrictEqual(sdkCalls, ["elsewhere"])
-          assert.strictEqual(fallback.length, 1)
-        }).pipe(Effect.provide(layer))
-      }),
-  )
-
   it.live("readHistory settles while the newest turn is still output-less", () =>
     Effect.gen(function* () {
       // Claude appends the assistant line after the Stop hook that triggers
-      // the observed-idle read: the first read sees the prompt alone.
-      const prompt = JSON.stringify({
-        type: "user",
-        uuid: "u1",
-        parentUuid: null,
-        sessionId: "s",
-        message: { role: "user", content: "hi" },
-      })
-      const reply = JSON.stringify({
-        type: "assistant",
-        uuid: "a1",
-        parentUuid: "u1",
-        sessionId: "s",
-        message: { role: "assistant", content: [{ type: "text", text: "hello" }] },
-      })
+      // the observed-idle read: the first read sees the prompt alone. This
+      // settle is also the gate the runtime runs before ending a TUI.
+      const prompt = transcriptMessage("user", "hi")
+      const reply = transcriptMessage("assistant", "hello")
       let reads = 0
       const layer = claudeAdapterLayer({
         historySettleDelay: "1 millis",
-        sessionFileFn: () => {
+        sessionMessagesFn: () => {
           reads += 1
-          return Promise.resolve(reads < 3 ? prompt : `${prompt}\n${reply}`)
+          return Promise.resolve(reads < 3 ? [prompt] : [prompt, reply])
         },
       })
       yield* Effect.gen(function* () {
@@ -1391,9 +1285,9 @@ describe("ClaudeAdapter collectTitleContext", () => {
         reads = 0
         const quiet = claudeAdapterLayer({
           historySettleDelay: "1 millis",
-          sessionFileFn: () => {
+          sessionMessagesFn: () => {
             reads += 1
-            return Promise.resolve(prompt)
+            return Promise.resolve([prompt])
           },
         })
         yield* Effect.gen(function* () {

--- a/app-server/test/agents/claudeTui.smoke.test.ts
+++ b/app-server/test/agents/claudeTui.smoke.test.ts
@@ -4,21 +4,108 @@ import { Effect, Layer } from "effect"
 import * as fs from "node:fs"
 import * as os from "node:os"
 import * as path from "node:path"
+import { getSessionMessages } from "@anthropic-ai/claude-agent-sdk"
 import { NESTED_SESSION_ENV_VARIABLES } from "../../src/agents/agentAdapter.ts"
+import * as ClaudeAdapter from "../../src/agents/claudeAdapter.ts"
 import * as Subprocess from "../../src/platform/subprocess.ts"
+import type { PtyChild } from "../../src/platform/subprocess.ts"
 import { trackTempDir } from "../blackbox.ts"
+import { eventually } from "../testLayers.ts"
+import { claudeAdapterLayer, collectAgentEvents, waitForAgentEvent } from "./agentTestKit.ts"
 
-// Live interactive-TUI smoke (opt-in: mise run test:smoke): the one
-// implementation-time check the ATC-124 decision record left open —
-// `--session-id` pre-assignment on an INTERACTIVE Claude launch (the -p
-// engine-shared evidence was probed; this proves the TUI path). A real
-// `claude --session-id <minted> --settings <hooks>` is spawned in a PTY and
-// must report the exact minted id through its own hook delivery, before any
-// prompt is typed. A possible first-run trust dialog is answered with Enter.
+// Live interactive-TUI smoke (opt-in: mise run test:smoke). Two checks:
+//
+//   - `--session-id` pre-assignment on an INTERACTIVE Claude launch (the
+//     ATC-124 decision record's one open item; the -p engine-shared
+//     evidence was probed, this proves the TUI path): a real
+//     `claude --session-id <minted> --settings <hooks>` is spawned in a PTY
+//     and must report the exact minted id through its own hook delivery,
+//     before any prompt is typed. A possible first-run trust dialog is
+//     answered with Enter.
+//   - The one-process hand-off (ATC-203): a native SDK turn, then a TUI
+//     turn on the same session (`--resume`) once the SDK process is gone,
+//     then — the TUI ended after its last turn is on disk — a native turn
+//     again that must answer with the context of BOTH earlier turns. One
+//     conversation, one leaf; getSessionMessages agrees.
 
 const enabled = process.env["ATC_SMOKE"] === "1"
 
-describe.skipIf(!enabled)("live claude TUI pre-assignment smoke (opt-in)", () => {
+interface HookDelivery {
+  readonly session_id?: string
+  readonly hook_event_name?: string
+}
+
+/** The hook capture server, a settings file wiring the TUI's hooks to it,
+ * and the user's environment minus the nested-session markers this test
+ * process may itself carry. */
+const tuiHarness = (base: string) =>
+  Effect.gen(function* () {
+    const captured: Array<HookDelivery> = []
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: async (request) => {
+        captured.push((await request.json()) as HookDelivery)
+        return new Response(null, { status: 204 })
+      },
+    })
+    yield* Effect.addFinalizer(() => Effect.promise(() => server.stop(true)))
+    const command = `curl -fsS -m 5 -X POST -H 'Content-Type: application/json' --data-binary @- 'http://127.0.0.1:${server.port}/hook'`
+    const settingsFile = path.join(base, "settings.json")
+    fs.writeFileSync(
+      settingsFile,
+      JSON.stringify({
+        hooks: Object.fromEntries(
+          ["SessionStart", "UserPromptSubmit", "Stop"].map((event) => [
+            event,
+            [{ hooks: [{ type: "command", command }] }],
+          ]),
+        ),
+      }),
+    )
+    const env: Record<string, string> = {}
+    for (const [key, value] of Object.entries(process.env)) {
+      if (value !== undefined) env[key] = value
+    }
+    for (const name of NESTED_SESSION_ENV_VARIABLES) delete env[name]
+    return { captured, settingsFile, env }
+  })
+
+/** Spawn the real Claude TUI in a PTY (scoped: the scope's close ends it). */
+const spawnTui = (cwd: string, args: ReadonlyArray<string>, env: Record<string, string>) =>
+  Effect.gen(function* () {
+    const subprocess = yield* Subprocess.Subprocess
+    const child = yield* subprocess.spawnPty({
+      executable: Subprocess.resolveExecutable("claude") ?? "claude",
+      args,
+      cwd,
+      env,
+      captureOutputTail: true,
+    })
+    yield* child.resize({ cols: 120, rows: 40 })
+    return child
+  })
+
+/** Wait for a hook delivery matching `predicate`, nudging Enter through
+ * occasionally in case the TUI is sitting on a first-run trust dialog. */
+const awaitHook = (
+  child: PtyChild,
+  captured: ReadonlyArray<HookDelivery>,
+  predicate: (delivery: HookDelivery) => boolean,
+  attempts: number,
+) =>
+  Effect.gen(function* () {
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      if (captured.some(predicate)) return true
+      if (attempt > 0 && attempt % 20 === 0) yield* child.write("\r")
+      yield* Effect.sleep("250 millis")
+    }
+    return false
+  })
+
+const slow = { attempts: 900, interval: "200 millis" } as const
+
+describe.skipIf(!enabled)("live claude TUI smoke (opt-in)", () => {
   it.live(
     "an interactive launch adopts the minted --session-id and confirms via hooks",
     () =>
@@ -26,59 +113,14 @@ describe.skipIf(!enabled)("live claude TUI pre-assignment smoke (opt-in)", () =>
         const base = trackTempDir(fs.mkdtempSync(path.join(os.tmpdir(), "atc-claude-tui-")))
         const cwd = path.join(base, "work")
         fs.mkdirSync(cwd)
-
-        // Capture server: every hook delivery lands here as JSON.
-        const captured: Array<{ session_id?: string; hook_event_name?: string }> = []
-        const server = Bun.serve({
-          hostname: "127.0.0.1",
-          port: 0,
-          fetch: async (request) => {
-            captured.push((await request.json()) as (typeof captured)[number])
-            return new Response(null, { status: 204 })
-          },
-        })
-        yield* Effect.addFinalizer(() => Effect.promise(() => server.stop(true)))
-
-        const command = `curl -fsS -m 5 -X POST -H 'Content-Type: application/json' --data-binary @- 'http://127.0.0.1:${server.port}/hook'`
-        const hookConfig = Object.fromEntries(
-          ["SessionStart", "UserPromptSubmit", "Stop"].map((event) => [
-            event,
-            [{ hooks: [{ type: "command", command }] }],
-          ]),
-        )
-        const settingsFile = path.join(base, "settings.json")
-        fs.writeFileSync(settingsFile, JSON.stringify({ hooks: hookConfig }))
-
+        const { captured, settingsFile, env } = yield* tuiHarness(base)
         const sessionId = crypto.randomUUID()
-        // The user's env (credentials) minus the nested-session markers this
-        // test process may itself carry.
-        const env: Record<string, string> = {}
-        for (const [key, value] of Object.entries(process.env)) {
-          if (value !== undefined) env[key] = value
-        }
-        for (const name of NESTED_SESSION_ENV_VARIABLES) delete env[name]
-
-        const subprocess = yield* Subprocess.Subprocess
-        const child = yield* subprocess.spawnPty({
-          executable: Subprocess.resolveExecutable("claude") ?? "claude",
-          args: ["--session-id", sessionId, "--settings", settingsFile],
+        const child = yield* spawnTui(
           cwd,
+          ["--session-id", sessionId, "--settings", settingsFile],
           env,
-          captureOutputTail: true,
-        })
-        yield* child.resize({ cols: 120, rows: 40 })
-
-        // Wait for the hook confirmation; nudge Enter through occasionally
-        // in case the TUI is sitting on a first-run trust dialog.
-        const confirmed = yield* Effect.gen(function* () {
-          for (let attempt = 0; attempt < 240; attempt++) {
-            const hit = captured.find((payload) => payload.session_id === sessionId)
-            if (hit !== undefined) return true
-            if (attempt > 0 && attempt % 20 === 0) yield* child.write("\r")
-            yield* Effect.sleep("250 millis")
-          }
-          return false
-        })
+        )
+        const confirmed = yield* awaitHook(child, captured, (p) => p.session_id === sessionId, 240)
         const tail = yield* child.outputTail
         assert.isTrue(
           confirmed,
@@ -90,5 +132,114 @@ describe.skipIf(!enabled)("live claude TUI pre-assignment smoke (opt-in)", () =>
         Effect.provide(Subprocess.layer.pipe(Layer.provideMerge(BunServices.layer))),
       ),
     120_000,
+  )
+
+  it.live(
+    "native → TUI → native on one session keeps one conversation with full context",
+    () =>
+      Effect.gen(function* () {
+        const base = trackTempDir(fs.mkdtempSync(path.join(os.tmpdir(), "atc-claude-handoff-")))
+        const cwd = path.join(base, "work")
+        fs.mkdirSync(cwd)
+        const { captured, settingsFile, env } = yield* tuiHarness(base)
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+
+        const completedTurn = (sink: Parameters<typeof waitForAgentEvent>[0], turnId: string) =>
+          waitForAgentEvent(
+            sink,
+            (event) =>
+              event.type === "turnCompleted" &&
+              event.turnId === turnId &&
+              event.outcome === "completed",
+            slow,
+          )
+
+        // 1. Native turn; the connection scope closes, so the SDK process
+        //    is gone before the TUI starts (one live process per thread).
+        const sessionId = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const { connection, turn } = yield* adapter.createSession({
+              cwd,
+              input: "The first code word is ALPHA. Reply with exactly: OK",
+            })
+            const sink = yield* collectAgentEvents(connection.events)
+            yield* completedTurn(sink, turn.turnId)
+            return connection.providerSessionId
+          }),
+        )
+
+        // 2. TUI turn on the same session; ended only after its last turn is
+        //    on disk (the adapter's readHistory settle), as the runtime does.
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const child = yield* spawnTui(
+              cwd,
+              ["--resume", sessionId, "--settings", settingsFile],
+              env,
+            )
+            const started = yield* awaitHook(
+              child,
+              captured,
+              (p) => p.session_id === sessionId,
+              240,
+            )
+            assert.isTrue(
+              started,
+              `the TUI never started: ${(yield* child.outputTail).slice(-500)}`,
+            )
+            // Type the prompt once the TUI echoes it (its input is live),
+            // then submit.
+            const prompt = "The second code word is BRAVO. Reply with exactly: OK"
+            yield* eventually(
+              child.write(prompt).pipe(Effect.andThen(child.outputTail)),
+              (tail) => tail.includes(prompt),
+              { attempts: 20, interval: "500 millis" },
+            )
+            yield* child.write("\r")
+            const stopped = yield* awaitHook(
+              child,
+              captured,
+              (p) => p.session_id === sessionId && p.hook_event_name === "Stop",
+              600,
+            )
+            assert.isTrue(
+              stopped,
+              `the TUI turn never stopped: ${(yield* child.outputTail).slice(-800)}`,
+            )
+            const history = yield* adapter.readHistory({ providerSessionId: sessionId, cwd })
+            assert.strictEqual(history.length, 2)
+            assert.isAtLeast(history[1]?.items.length ?? 0, 2)
+          }),
+        )
+
+        // 3. Native again: the model must know both code words.
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const connection = yield* adapter.resumeSession({ providerSessionId: sessionId, cwd })
+            const sink = yield* collectAgentEvents(connection.events)
+            const turn = yield* connection.startTurn(
+              "Reply with the two code words I gave you, in order, separated by a space, and nothing else.",
+            )
+            yield* completedTurn(sink, turn.turnId)
+            const text = sink
+              .flatMap((event) =>
+                event.type === "itemCompleted" && event.item.type === "assistantText"
+                  ? [event.item.text]
+                  : [],
+              )
+              .join(" ")
+            assert.include(text, "ALPHA")
+            assert.include(text, "BRAVO")
+          }),
+        )
+        const messages = yield* Effect.promise(() => getSessionMessages(sessionId, { dir: cwd }))
+        const prompts = messages.filter((m) => m.type === "user" && m.parent_tool_use_id === null)
+        assert.strictEqual(prompts.length, 3)
+      }).pipe(
+        Effect.scoped,
+        Effect.provide(claudeAdapterLayer({ sessionMessagesFn: getSessionMessages }, "claude")),
+        Effect.provide(Subprocess.layer.pipe(Layer.provideMerge(BunServices.layer))),
+      ),
+    300_000,
   )
 })

--- a/app-server/test/agents/fakeAgentAdapter.ts
+++ b/app-server/test/agents/fakeAgentAdapter.ts
@@ -123,7 +123,7 @@ export interface FakeAgentAdapter {
 
 export interface FakeAgentAdapterOptions {
   /** Adapter's observation-authority shape (default true — codex-like). */
-  readonly observationOutlivesTui?: boolean
+  readonly sharedServer?: boolean
 }
 
 interface LiveConnection {
@@ -324,7 +324,7 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
 
   const adapter: AgentAdapter = {
     provider: "codex",
-    observationOutlivesTui: options.observationOutlivesTui ?? true,
+    sharedServer: options.sharedServer ?? true,
     createSession: (options) =>
       Effect.gen(function* () {
         yield* requireAvailable

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -26,6 +26,7 @@ import * as Terminals from "../src/terminals/terminals.ts"
 import * as ThreadRepository from "../src/threads/threadRepository.ts"
 import * as ThreadNaming from "../src/threads/threadNaming.ts"
 import * as ThreadRuntime from "../src/threads/threadRuntime.ts"
+import * as ThreadTui from "../src/threads/threadTui.ts"
 import * as TranscriptRepository from "../src/threads/transcriptRepository.ts"
 import * as Threads from "../src/threads/threads.ts"
 import * as Zmx from "../src/terminals/zmxAdapter.ts"
@@ -131,7 +132,7 @@ export const makeTestServiceLayers = (
     claude: makeFakeAgentAdapter({
       // Hooks-shaped: its observation feed dies silently with the TUI, so
       // stale-busy re-derivation stays reachable through this fake.
-      observationOutlivesTui: false,
+      sharedServer: false,
     }),
   }
   const base = Layer.mergeAll(
@@ -159,9 +160,12 @@ export const makeTestServiceLayers = (
   const naming = ThreadNaming.layerWith(threadOptions).pipe(
     Layer.provide([services, registry, eventsLayer]),
   )
-  const runtime = ThreadRuntime.layer.pipe(Layer.provide([services, registry, eventsLayer, naming]))
+  const threadTui = ThreadTui.layer.pipe(Layer.provide([services, terminals]))
+  const runtime = ThreadRuntime.layer.pipe(
+    Layer.provide([services, registry, eventsLayer, naming, threadTui]),
+  )
   const threads = Threads.layerWith(threadOptions).pipe(
-    Layer.provide([services, terminals, registry, eventsLayer, runtime, naming]),
+    Layer.provide([services, terminals, registry, eventsLayer, runtime, naming, threadTui]),
   )
   return {
     fake,

--- a/app-server/test/threads/threadTuiOwnership.test.ts
+++ b/app-server/test/threads/threadTuiOwnership.test.ts
@@ -1,0 +1,215 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import { mkdtempSync, realpathSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll } from "vitest"
+import { sessionNameForTerminalId } from "../../src/terminals/terminalAdapter.ts"
+import { ThreadRepository } from "../../src/threads/threadRepository.ts"
+import { ThreadRuntime } from "../../src/threads/threadRuntime.ts"
+import { Threads } from "../../src/threads/threads.ts"
+import { Projects } from "../../src/projects/projects.ts"
+import { eventually, makeTestServiceLayers } from "../testLayers.ts"
+
+// One live process per thread (ATC-203), through the fake adapters and the
+// uniform seam only: the runtime hands a one-process provider's session
+// between the TUI (a fake terminal) and its own turns — native wins, the
+// TUI ends after its last turn is on disk and comes back when the queue
+// drains, closing hands back, and a shared-server provider is untouched.
+
+const scratch = mkdtempSync(join(tmpdir(), "atc-tui-ownership-"))
+afterAll(() => rmSync(scratch, { recursive: true, force: true }))
+const realDir = realpathSync(scratch)
+
+const kit = makeTestServiceLayers()
+const claude = kit.fakeAgents.claude
+const codex = kit.fakeAgents.codex
+
+let sessionCounter = 0
+
+/** A confirmed thread on `agentId` whose provider session the fake knows,
+ * with its TUI open: the state every hand-off starts from. */
+const openedThread = (agentId: "claude-code" | "codex") =>
+  Effect.gen(function* () {
+    const projects = yield* Projects
+    const threads = yield* Threads
+    const repository = yield* ThreadRepository
+    const project = yield* projects.create({ name: "Ownership", defaultWorkingDirectory: realDir })
+    const thread = yield* threads.create({ projectId: project.id, agentId })
+    const sessionId = `${agentId}-session-${++sessionCounter}`
+    const fake = agentId === "claude-code" ? claude : codex
+    fake.seed(sessionId, realDir)
+    yield* repository.setProviderSession(thread.id, sessionId, null)
+    yield* repository.confirm(thread.id)
+    const terminal = yield* threads.openTerminal(thread.id)
+    return { threadId: thread.id, sessionId, terminal, fake }
+  })
+
+const terminalAlive = (terminalId: string): boolean =>
+  kit.fake.sessions.has(sessionNameForTerminalId(terminalId))
+
+const waitFor = <A>(read: Effect.Effect<A>, predicate: (value: A) => boolean) =>
+  eventually(read, predicate, { attempts: 400, interval: "10 millis" })
+
+describe("Thread TUI ownership", () => {
+  it.live("a native prompt takes an idle one-process TUI over, then relaunches it", () =>
+    Effect.gen(function* () {
+      const runtime = yield* ThreadRuntime
+      const threads = yield* Threads
+      const { threadId, sessionId, terminal, fake } = yield* openedThread("claude-code")
+      assert.isTrue(terminalAlive(terminal.id))
+      const readsBefore = fake.historyReads.length
+
+      const started = yield* runtime.prompt(threadId, "native wins")
+      // The turn started at once: the TUI ended first — after a settled
+      // history read (its last turn on disk) — and the session resumed
+      // natively with the prompt.
+      assert.isString(started.turnId)
+      assert.isFalse(terminalAlive(terminal.id))
+      assert.strictEqual(fake.historyReads.slice(readsBefore)[0], sessionId)
+      assert.deepStrictEqual(fake.sessions.get(sessionId)?.inputs, ["native wins"])
+      const mid = yield* threads.get(threadId).pipe(Effect.orDie)
+      assert.isUndefined(mid.linkedTerminalId)
+
+      // The run ends with nothing queued: the TUI (still shown) comes back
+      // in a fresh terminal on the same session.
+      fake.completeTurn(sessionId, "completed")
+      const after = yield* waitFor(
+        threads.get(threadId).pipe(Effect.orDie),
+        (current) => current.linkedTerminalId !== undefined,
+      )
+      assert.notStrictEqual(after.linkedTerminalId, terminal.id)
+      assert.isTrue(terminalAlive(after.linkedTerminalId ?? ""))
+    }).pipe(Effect.provide(kit.layer)),
+  )
+
+  it.live("a TUI whose last turn cannot be read stays alive: the take-over fails closed", () =>
+    Effect.gen(function* () {
+      const runtime = yield* ThreadRuntime
+      const { threadId, sessionId, terminal, fake } = yield* openedThread("claude-code")
+      fake.setUnavailable("transcript reads are down")
+      const refused = yield* runtime.prompt(threadId, "not yet").pipe(Effect.flip)
+      assert.strictEqual(refused._tag, "ProviderUnavailable")
+      assert.isTrue(terminalAlive(terminal.id))
+      // Un-admitted, not queued: the caller's error means "not accepted".
+      assert.deepStrictEqual(yield* runtime.listQueue(threadId), [])
+      fake.setUnavailable(null)
+      const started = yield* runtime.prompt(threadId, "now")
+      assert.isString(started.turnId)
+      assert.isFalse(terminalAlive(terminal.id))
+      fake.completeTurn(sessionId, "completed")
+    }).pipe(Effect.provide(kit.layer)),
+  )
+
+  it.live("a prompt while the TUI is busy queues, and drains at its idle by taking over", () =>
+    Effect.gen(function* () {
+      const runtime = yield* ThreadRuntime
+      const threads = yield* Threads
+      const { threadId, sessionId, terminal, fake } = yield* openedThread("claude-code")
+
+      fake.emitActivity(sessionId, "working")
+      yield* waitFor(
+        threads.get(threadId).pipe(Effect.orDie),
+        (current) => current.activityState === "working",
+      )
+      const queued = yield* runtime.prompt(threadId, "after the tui")
+      assert.isUndefined(queued.turnId)
+      assert.isTrue(terminalAlive(terminal.id))
+      assert.deepStrictEqual(fake.sessions.get(sessionId)?.inputs, [])
+
+      // The TUI's turn ends: re-read, then the queued prompt takes over.
+      fake.emitActivity(sessionId, "idle")
+      yield* waitFor(
+        Effect.sync(() => fake.sessions.get(sessionId)?.inputs ?? []),
+        (inputs) => inputs.includes("after the tui"),
+      )
+      assert.isFalse(terminalAlive(terminal.id))
+      fake.completeTurn(sessionId, "completed")
+      yield* waitFor(
+        threads.get(threadId).pipe(Effect.orDie),
+        (current) => current.linkedTerminalId !== undefined,
+      )
+    }).pipe(Effect.provide(kit.layer)),
+  )
+
+  it.live("closing the TUI hands back at once when idle, at its idle when busy", () =>
+    Effect.gen(function* () {
+      const runtime = yield* ThreadRuntime
+      const threads = yield* Threads
+      const { threadId, sessionId, terminal, fake } = yield* openedThread("claude-code")
+
+      const closed = yield* threads.closeTerminal(threadId)
+      assert.isUndefined(closed.linkedTerminalId)
+      assert.isFalse(terminalAlive(terminal.id))
+
+      // Reopen, then close while busy: the TUI stays until its idle.
+      const reopened = yield* threads.openTerminal(threadId)
+      fake.emitActivity(sessionId, "working")
+      yield* waitFor(
+        threads.get(threadId).pipe(Effect.orDie),
+        (current) => current.activityState === "working",
+      )
+      const stillOpen = yield* threads.closeTerminal(threadId)
+      assert.strictEqual(stillOpen.linkedTerminalId, reopened.id)
+      // Showing the TUI again before the idle calls the hand-off off: the
+      // idle passes and the TUI stays.
+      const shownAgain = yield* threads.openTerminal(threadId)
+      assert.strictEqual(shownAgain.id, reopened.id)
+      fake.emitActivity(sessionId, "idle")
+      yield* waitFor(
+        threads.get(threadId).pipe(Effect.orDie),
+        (current) => current.activityState === "idle",
+      )
+      assert.isTrue(terminalAlive(reopened.id))
+      // Closed again while idle: gone now.
+      yield* threads.closeTerminal(threadId)
+      assert.isFalse(terminalAlive(reopened.id))
+
+      // Closed means not shown: a native turn ends with no relaunch.
+      const started = yield* runtime.prompt(threadId, "chat only")
+      assert.isString(started.turnId)
+      fake.completeTurn(sessionId, "completed")
+      yield* waitFor(runtime.isDriving(threadId), (driving) => !driving)
+      const after = yield* threads.get(threadId).pipe(Effect.orDie)
+      assert.isUndefined(after.linkedTerminalId)
+    }).pipe(Effect.provide(kit.layer)),
+  )
+
+  it.live("a TUI open during a native turn is refused and happens at the run's end", () =>
+    Effect.gen(function* () {
+      const runtime = yield* ThreadRuntime
+      const threads = yield* Threads
+      const { threadId, sessionId, fake } = yield* openedThread("claude-code")
+      yield* threads.closeTerminal(threadId)
+
+      const started = yield* runtime.prompt(threadId, "busy natively")
+      assert.isString(started.turnId)
+      const refused = yield* threads.openTerminal(threadId).pipe(Effect.flip)
+      assert.strictEqual(refused._tag, "ThreadBusy")
+
+      fake.completeTurn(sessionId, "completed")
+      const after = yield* waitFor(
+        threads.get(threadId).pipe(Effect.orDie),
+        (current) => current.linkedTerminalId !== undefined,
+      )
+      assert.isTrue(terminalAlive(after.linkedTerminalId ?? ""))
+    }).pipe(Effect.provide(kit.layer)),
+  )
+
+  it.live("a shared-server provider's TUI and native turns coexist untouched", () =>
+    Effect.gen(function* () {
+      const runtime = yield* ThreadRuntime
+      const threads = yield* Threads
+      const { threadId, sessionId, terminal, fake } = yield* openedThread("codex")
+
+      const started = yield* runtime.prompt(threadId, "alongside the tui")
+      assert.isString(started.turnId)
+      assert.isTrue(terminalAlive(terminal.id))
+      fake.completeTurn(sessionId, "completed")
+      yield* waitFor(runtime.isDriving(threadId), (driving) => !driving)
+      assert.isTrue(terminalAlive(terminal.id))
+      const closed = yield* threads.closeTerminal(threadId)
+      assert.strictEqual(closed.linkedTerminalId, terminal.id)
+    }).pipe(Effect.provide(kit.layer)),
+  )
+})

--- a/macos/ATC/AppModel.swift
+++ b/macos/ATC/AppModel.swift
@@ -280,7 +280,12 @@ final class AppModel {
     /// failed close leaves the TUI in charge until the next prompt or close.
     func closeTerminalIfChat(_ ref: ThreadRef) {
         guard viewMode(for: ref) == .chat, let runtime = runtime(id: ref.connectionID) else { return }
-        Task { _ = try? await runtime.threads.closeTerminal(threadID: ref.threadID) }
+        Task { [weak self] in
+            // A flip back to TUI before this Task ran makes the close stale:
+            // it must not end the terminal that open just made.
+            guard self?.viewMode(for: ref) == .chat else { return }
+            _ = try? await runtime.threads.closeTerminal(threadID: ref.threadID)
+        }
     }
 
     func terminal(for ref: TerminalRef) -> Terminal? {

--- a/macos/ATC/AppModel.swift
+++ b/macos/ATC/AppModel.swift
@@ -260,12 +260,27 @@ final class AppModel {
 
     /// Remembers the mode and re-opens the thread in every window showing
     /// it: TUI runs the idempotent terminal open, Chat needs nothing opened
-    /// (each window's `openThread` decides).
+    /// (each window's `openThread` decides) but tells the server the TUI is
+    /// no longer shown (`closeTerminalIfChat`).
     func setViewMode(_ mode: ThreadViewMode, for ref: ThreadRef) {
+        let previous = viewMode(for: ref)
         threadViewModes[ref] = mode
+        if previous == .tui { closeTerminalIfChat(ref) }
         for window in windowReconcilers.compactMap(\.value) where window.selectedThread == ref {
             Task { await window.openThread(ref, in: self, reveal: false) }
         }
+    }
+
+    /// Tells the server the TUI is no longer shown when the thread's mode
+    /// is Chat: the server hands a one-process (Claude) thread back to Chat,
+    /// ending its TUI once the current turn is on disk; a Codex TUI keeps
+    /// running. Called on the switch to Chat and after any TUI open that
+    /// completes once the mode has flipped back (the open and the close are
+    /// independent requests, so the later one must win). Best-effort: a
+    /// failed close leaves the TUI in charge until the next prompt or close.
+    func closeTerminalIfChat(_ ref: ThreadRef) {
+        guard viewMode(for: ref) == .chat, let runtime = runtime(id: ref.connectionID) else { return }
+        Task { _ = try? await runtime.threads.closeTerminal(threadID: ref.threadID) }
     }
 
     func terminal(for ref: TerminalRef) -> Terminal? {

--- a/macos/ATC/Features/Threads/ThreadContentView.swift
+++ b/macos/ATC/Features/Threads/ThreadContentView.swift
@@ -4,11 +4,13 @@
 //
 // A thread shows in one of two modes (`AppModel.viewMode(for:)`): Chat draws
 // `ThreadChatView` over the pane with the thread's terminal hidden (a
-// retained surface survives the mode flip untouched); TUI shows the terminal
-// with the status/relaunch banners over it. A thread whose TUI terminal has
+// retained surface survives the mode flip untouched — though the server may
+// end a Claude TUI once Chat is shown, ATC-203); TUI shows the terminal with
+// the status/relaunch banners over it. A thread whose TUI terminal has
 // ended keeps its final frame: the relaunch bar floats above the retained
 // surface instead of replacing it, and relaunching is just `openThread`
-// again — the server's open is idempotent.
+// again — the server's open is idempotent. A TUI open the server defers
+// (it is driving a turn) shows a waiting banner until the terminal appears.
 
 import ATCAppServerAPI
 import ATCAppServerTransport
@@ -67,6 +69,17 @@ struct ThreadContentView: View {
                     Task { await windowState.openThread(ref, in: appModel) }
                 }
                 .keyboardShortcut(.defaultAction)
+            }
+        } else if windowState.threadsAwaitingTui.contains(ref) {
+            // The server is driving a turn on this thread and launches the
+            // TUI itself when it ends; the linked terminal then attaches
+            // through reconciliation. Retry re-asks (still busy, or launched).
+            FloatingBanner {
+                ProgressView().controlSize(.small)
+                Text("Waiting for the current turn to finish…")
+                Button("Retry") {
+                    Task { await windowState.openThread(ref, in: appModel) }
+                }
             }
         } else if let controller = controller(for: ref) {
             if case .ended(.terminalEnded) = controller.phase {

--- a/macos/ATC/Features/Threads/ThreadsStore.swift
+++ b/macos/ATC/Features/Threads/ThreadsStore.swift
@@ -185,7 +185,9 @@ final class ThreadsStore {
         case .notFound(let failure): throw ServerError(try failure.body.json)
         case .conflict(let failure):
             let payload = try failure.body.json
-            if payload.value2 != nil { throw ThreadTerminalBusy() }
+            // By tag, so a reordered anyOf fails to compile here rather
+            // than misclassify.
+            if payload.value2?._tag == .threadBusy { throw ThreadTerminalBusy() }
             throw ServerError(anyOf: payload.value1, payload.value2, payload.value3)
         case .unprocessableContent(let failure):
             let payload = try failure.body.json

--- a/macos/ATC/Features/Threads/ThreadsStore.swift
+++ b/macos/ATC/Features/Threads/ThreadsStore.swift
@@ -176,13 +176,17 @@ final class ThreadsStore {
     /// is returned as-is, otherwise the provider TUI is (re)launched. The
     /// failure messages here are the install-or-configure guidance the
     /// server exists to provide — never collapse them into a status dump.
+    /// `ThreadTerminalBusy` is the one refusal that is not an error to show:
+    /// the server is driving a turn and launches the TUI itself when it
+    /// ends (the thread's `linkedTerminalId` appears).
     func openTerminal(threadID: String) async throws -> Terminal {
         switch try await client.openThreadTerminal(path: .init(threadId: threadID)) {
         case .ok(let ok): return try ok.body.json
         case .notFound(let failure): throw ServerError(try failure.body.json)
         case .conflict(let failure):
             let payload = try failure.body.json
-            throw ServerError(anyOf: payload.value1, payload.value2)
+            if payload.value2 != nil { throw ThreadTerminalBusy() }
+            throw ServerError(anyOf: payload.value1, payload.value2, payload.value3)
         case .unprocessableContent(let failure):
             let payload = try failure.body.json
             throw ServerError(anyOf: payload.value1, payload.value2, payload.value3)
@@ -191,6 +195,25 @@ final class ThreadsStore {
             throw ServerError(anyOf: payload.value1, payload.value2)
         case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
         }
+    }
+
+    /// The window stopped showing the TUI (switched to Chat): the server
+    /// hands a Claude thread back to Chat once its turn is on disk (the
+    /// terminal ends); a Codex TUI keeps running. Merges the returned thread.
+    @discardableResult
+    func closeTerminal(threadID: String) async throws -> ATCThread {
+        let thread: ATCThread
+        switch try await client.closeThreadTerminal(path: .init(threadId: threadID)) {
+        case .ok(let ok): thread = try ok.body.json
+        case .notFound(let failure): throw ServerError(try failure.body.json)
+        case .conflict(let failure): throw ServerError(try failure.body.json)
+        case .serviceUnavailable(let failure):
+            let payload = try failure.body.json
+            throw ServerError(anyOf: payload.value1, payload.value2)
+        case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
+        }
+        merge(thread)
+        return thread
     }
 
     /// Places a server-returned thread into whichever list its archive state

--- a/macos/ATC/PreviewSupport/PreviewAppServerClient.swift
+++ b/macos/ATC/PreviewSupport/PreviewAppServerClient.swift
@@ -457,6 +457,12 @@ import OpenAPIRuntime
                         ))))
         }
 
+        func closeThreadTerminal(
+            _ input: Operations.CloseThreadTerminal.Input
+        ) async throws -> Operations.CloseThreadTerminal.Output {
+            .ok(.init(body: .json(try thread(input.path.threadId))))
+        }
+
         // MARK: - Agents
 
         // MARK: - Thread runtime (ATC-193) — previews show an idle, empty runtime.

--- a/macos/ATC/Shared/ServerError.swift
+++ b/macos/ATC/Shared/ServerError.swift
@@ -57,3 +57,8 @@ extension ServerError {
         self.init(message: branches.compactMap { $0?.message }.first ?? "Unknown server error.")
     }
 }
+
+/// openThreadTerminal's ThreadBusy refusal (ATC-203): the server is driving
+/// a turn on a one-process provider and launches the TUI itself when the
+/// turn ends — a wait, not a failure to alert on.
+struct ThreadTerminalBusy: Error {}

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -183,7 +183,14 @@ final class WindowState {
         } catch is ThreadTerminalBusy {
             // The server is driving a turn: it launches the TUI when the
             // turn ends, and reconciliation attaches it (the linked
-            // terminal appears on the thread). Not an error to show.
+            // terminal appears on the thread). Not an error to show — unless
+            // the user flipped back to Chat meanwhile: then the request is
+            // retracted (a close after the open, so the later one wins).
+            guard appModel.viewMode(for: ref) == .tui else {
+                threadsAwaitingTui.remove(ref)
+                appModel.closeTerminalIfChat(ref)
+                return
+            }
             threadsAwaitingTui.insert(ref)
         } catch {
             threadOpenErrors[ref] = error.localizedDescription

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -82,6 +82,12 @@ final class WindowState {
     /// Most recent failed open per thread, cleared on the next attempt.
     private(set) var threadOpenErrors: [ThreadRef: String] = [:]
 
+    /// Threads whose TUI open was refused because the server is driving a
+    /// turn (ATC-203): the server launches the TUI when the turn ends and
+    /// reconciliation attaches it. Cleared when the linked terminal appears
+    /// or an open succeeds.
+    private(set) var threadsAwaitingTui: Set<ThreadRef> = []
+
     /// Whether the app is frontmost — the seam tests override; production
     /// asks AppKit. Viewing only counts when the user can actually see it.
     @ObservationIgnored var isAppActive: () -> Bool = { AppActivity.isActive() }
@@ -164,10 +170,21 @@ final class WindowState {
         do {
             let terminalRef = try await appModel.openThread(ref, retentionContext: retentionContext)
             threadTerminals[ref] = terminalRef
+            threadsAwaitingTui.remove(ref)
             // The user may have flipped back to Chat while the open was in
-            // flight; the terminal stays retained (hidden), but Chat keeps
-            // the focus.
-            if appModel.viewMode(for: ref) == .tui { requestContentFocus() }
+            // flight; the terminal stays retained (hidden), Chat keeps the
+            // focus, and the server hears that Chat is what is shown (the
+            // open must not be the last word).
+            if appModel.viewMode(for: ref) == .tui {
+                requestContentFocus()
+            } else {
+                appModel.closeTerminalIfChat(ref)
+            }
+        } catch is ThreadTerminalBusy {
+            // The server is driving a turn: it launches the TUI when the
+            // turn ends, and reconciliation attaches it (the linked
+            // terminal appears on the thread). Not an error to show.
+            threadsAwaitingTui.insert(ref)
         } catch {
             threadOpenErrors[ref] = error.localizedDescription
         }
@@ -369,6 +386,7 @@ final class WindowState {
         if let linkedID = thread.linkedTerminalId {
             let linkedRef = TerminalRef(connectionID: ref.connectionID, terminalID: linkedID)
             threadTerminals[ref] = linkedRef
+            threadsAwaitingTui.remove(ref)
             if appModel.viewMode(for: ref) == .tui,
                 let terminal = appModel.terminal(for: linkedRef), terminal.isLive,
                 appModel.terminals[linkedRef] == nil

--- a/macos/ATCTests/ScriptableAppServerClient.swift
+++ b/macos/ATCTests/ScriptableAppServerClient.swift
@@ -35,6 +35,10 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
         /// While set, openThreadTerminal fails 503 with this payload — the
         /// install-or-configure message the unwrap seam must surface.
         var openThreadTerminalFailure: Components.Schemas.ProviderUnavailableJsonEncoding?
+        /// While set, openThreadTerminal is refused 409 ThreadBusy (the
+        /// server is driving a turn and launches the TUI itself later).
+        var openThreadTerminalBusy = false
+        var closeThreadTerminalCount = 0
         /// The Thread runtime (ATC-193) as seen by one client: a transcript
         /// page per thread (an unseeded thread reads as empty), the pending
         /// requests and queue, and what clients did about them.
@@ -160,6 +164,13 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
         get { lock.withLock { state.openThreadTerminalFailure } }
         set { lock.withLock { state.openThreadTerminalFailure = newValue } }
     }
+
+    var openThreadTerminalBusy: Bool {
+        get { lock.withLock { state.openThreadTerminalBusy } }
+        set { lock.withLock { state.openThreadTerminalBusy = newValue } }
+    }
+
+    var closeThreadTerminalCount: Int { lock.withLock { state.closeThreadTerminalCount } }
 
     /// Transcript page served for a thread id; unseeded threads read empty.
     var transcripts: [String: ThreadTranscriptPage] {
@@ -579,6 +590,15 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
             guard let index = model.threads.firstIndex(where: { $0.id == id }) else {
                 return .notFound(.init(body: .json(threadNotFound(id))))
             }
+            if model.openThreadTerminalBusy {
+                return .conflict(
+                    .init(
+                        body: .json(
+                            .init(
+                                value2: .init(
+                                    _tag: .threadBusy, threadId: id,
+                                    message: "thread \(id) is working; retry once the turn completes")))))
+            }
             let thread = model.threads[index]
             if let linkedID = thread.linkedTerminalId,
                 let existing = model.terminals.first(where: {
@@ -598,6 +618,28 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
             model.threads[index].linkedTerminalId = terminal.id
             model.threads[index].updatedAt = terminal.createdAt
             return .ok(.init(body: .json(terminal)))
+        }
+    }
+
+    /// The Claude hand-off as one client sees it: the linked terminal ends
+    /// (its record removed, the thread unlinked). A Codex TUI would keep
+    /// running; this double models the one-process provider.
+    func closeThreadTerminal(_ input: Operations.CloseThreadTerminal.Input) async throws
+        -> Operations.CloseThreadTerminal.Output
+    {
+        try await gate()
+        let id = input.path.threadId
+        return mutate { model -> Operations.CloseThreadTerminal.Output in
+            model.closeThreadTerminalCount += 1
+            guard let index = model.threads.firstIndex(where: { $0.id == id }) else {
+                return .notFound(.init(body: .json(threadNotFound(id))))
+            }
+            if let linkedID = model.threads[index].linkedTerminalId {
+                model.terminals.removeAll { $0.id == linkedID }
+                model.threads[index].linkedTerminalId = nil
+                model.threads[index].updatedAt = model.tick()
+            }
+            return .ok(.init(body: .json(model.threads[index])))
         }
     }
 

--- a/macos/ATCTests/WindowStateTests.swift
+++ b/macos/ATCTests/WindowStateTests.swift
@@ -497,14 +497,52 @@ struct WindowStateTests {
 
         test.model.setViewMode(.chat, for: ref)
         await drainPendingTasks()
-        // The surface survives the flip; only what the pane shows changes.
+        // The surface survives the flip; only what the pane shows changes —
+        // and the server is told the TUI is no longer shown (ATC-203), so
+        // it can hand a one-process thread back to Chat.
         #expect(state.threadTerminals[ref] == terminalRef)
         #expect(test.model.terminals[terminalRef] != nil)
         #expect(test.client.openThreadTerminalCount == 1)
+        await settle(until: { test.client.closeThreadTerminalCount == 1 })
 
         state.toggleViewMode(in: test.model)
         #expect(test.model.viewMode(for: ref) == .tui)
         await drainPendingTasks()
+        #expect(test.client.closeThreadTerminalCount == 1)
+    }
+
+    @Test("a TUI open refused while the server drives a turn waits, then attaches the terminal it launches")
+    func deferredTuiOpenAttachesOnArrival() async throws {
+        let client = ScriptableAppServerClient()
+        let test = try await loadedModel(client)
+        let state = WindowState()
+        test.model.registerWindow(state)
+        let ref = test.threadRef("thr1")
+        client.openThreadTerminalBusy = true
+
+        test.model.setViewMode(.tui, for: ref)
+        await state.openThread(ref, in: test.model)
+        await settle(until: { state.threadsAwaitingTui.contains(ref) })
+        // A wait, not an error: no banner message, nothing attached.
+        #expect(state.threadOpenErrors[ref] == nil)
+        #expect(state.threadTerminals[ref] == nil)
+
+        // The server's turn ends and it launches the TUI itself: the linked
+        // terminal appears on the thread and reconciliation attaches it.
+        client.openThreadTerminalBusy = false
+        let linked = Fixtures.terminal(id: "trm_deferred", threadId: "thr1")
+        client.terminals += [linked]
+        client.threads = client.threads.map { thread in
+            var thread = thread
+            if thread.id == "thr1" { thread.linkedTerminalId = "trm_deferred" }
+            return thread
+        }
+        await test.runtime.refresh()
+        state.reconcile(in: test.model)
+
+        #expect(state.threadTerminals[ref] == test.terminalRef("trm_deferred"))
+        #expect(!state.threadsAwaitingTui.contains(ref))
+        #expect(test.model.terminals[test.terminalRef("trm_deferred")] != nil)
     }
 
     @Test("the mode is remembered per thread and shared by every window showing it")

--- a/macos/CONTEXT.md
+++ b/macos/CONTEXT.md
@@ -32,12 +32,18 @@ _Avoid_: Session, conversation
 One of the two views of a Thread, and the default: the Thread's transcript
 and a composer, driven natively through the App Server with no Terminal
 involved. Chat and TUI show the same conversation; which one a Thread is
-shown in is remembered for the app session and shared by every window.
+shown in is remembered for the app session and shared by every window. The
+App Server owns a Thread by default: switching a Claude Code Thread to Chat
+hands it back (its TUI ends once the current turn is on disk), and a Chat
+prompt sent while its TUI is live takes over the same way — the TUI comes
+back when the prompt is done. Codex Threads need no hand-off.
 _Avoid_: Native mode, transcript view
 
 **TUI**:
 The other view of a Thread: its provider TUI running in the linked Terminal.
-Opening a Thread in TUI launches or reuses that Terminal.
+Opening a Thread in TUI launches or reuses that Terminal; while the App
+Server is driving a turn on a Claude Code Thread, the TUI opens once that
+turn ends.
 _Avoid_: Terminal mode, terminal view
 
 **Terminal**:


### PR DESCRIPTION
Closes ATC-203.

## Why

Claude Code has no shared brain: two live `claude` processes on one session id fork it — each holds its conversation in memory and appends with its own leaf. The adapter kept an SDK `query()` open **and** launched a long-lived `claude --resume` for TUI mode, so the fork was structural; #212's JSONL reader only papered over the reader side.

## The rule

The native side (App Server) owns a Claude thread by default. The TUI owns it only while a client wants it (`openThreadTerminal` marks that, `closeThreadTerminal` clears it; last writer wins across clients). Handing off in either direction restarts whichever process takes over, from the full history on disk. Never more than one live `claude` process per thread. Codex — whose shared app-server lets both coexist — is unchanged.

## What changed

**Server**
- `claudeAdapter.ts`: the JSONL reader is gone; `getSessionMessages` is the read again and its bounded settle doubles as the "last turn is on disk" gate. The observed (hooks) feed now carries the TUI's submitted prompt as an observed `userMessage` item so Chat shows *prompt + Working…* during a TUI turn. Tested version bumped to 2.1.234.
- Seam: `observationOutlivesTui` → `sharedServer` — one capability: a shared provider server (Codex) vs one process per session (Claude).
- New `threads/threadTui.ts` (`ThreadTui`): the one place a thread's TUI terminal is found / launched (confirmed-session reopen, metadata persisted first) / ended — shared by Threads and the runtime.
- `threadRuntime.ts` now owns observation (moved from `threads.ts`) and the hand-off:
  - native prompt vs live TUI: queue while busy (ledger); otherwise settled re-read → end TUI → resume; when the run ends with the queue drained and the TUI still wanted, relaunch it (under the start lock, so it can never double with an explicit open);
  - `openTui` (open during a native run → `ThreadBusy`, launched at run end; live-terminal recheck under the launch claim; no native turn starts while a launch is in flight);
  - `closeTui` (idle → end now, busy → end at its observed idle);
  - the settle read is fail-closed: a failed read leaves the TUI alive (the prompt is un-admitted / stays queued, the close fails retryably); a TUI that goes busy during the read keeps the thread;
  - observed activity is ignored while a run is active (the ended TUI's SessionEnd must not read as the native turn's end); observed-idle re-read runs under the start lock so it cannot wipe a fresh native turn's rows.
- Contract: `closeThreadTerminal` (`DELETE /threads/:threadId/terminal`, returns the Thread), `ThreadBusy` added to `openThreadTerminal`; descriptions state the rule. CLI: `atc thread close`.

**macOS**
- Switching TUI → Chat calls `closeThreadTerminal` (also after a TUI open that completes once the mode flipped back, so the later signal wins).
- A TUI open refused `ThreadBusy` shows *Waiting for the current turn to finish…* (not an error) and reconciliation attaches the terminal the server launches at the run's end. `CONTEXT.md` states the hand-off in the Chat/TUI vocabulary.

## Tests

- `test/threads/threadTuiOwnership.test.ts` (fake adapters + fake terminals): take-over + relaunch, queue-while-busy + drain, close idle/busy + reopen calling a pending close off, open-during-run refused then auto-launched, fail-closed settle read, Codex untouched.
- `claudeAdapter.test.ts`: file-based history tests replaced by the SDK-read settle test; observed prompt item.
- Live smoke (`claudeTui.smoke.test.ts`, opt-in): native → TUI → native on one session, the third turn answers with both code words; `getSessionMessages` shows 3 prompts on one leaf. Both Claude smokes green locally on 2.1.234 / SDK 0.3.220.
- macOS: mode switch closes; deferred open waits and attaches.
- `mise run check` green.

## Known trade-offs (recorded in the runtime header)

- "Wanted" is a per-thread last-writer-wins mark, not per-client presence: a client that quits without switching to Chat leaves the TUI in charge until the next close — nothing worse.
- Claude offers no liveness probe, so `unknown` (a TUI observed since a restart that has not spoken yet) is taken as idle for a take-over; the settle gate is the remaining guard, and a queue that could never drain would be the worse failure.

https://claude.ai/code/session_01Pfp8DXsfxYeSN1ncWyJa6y


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added controls to close a thread’s terminal through the API, CLI, and macOS app.
  * Added smoother Chat and TUI handoff, including automatic relaunching and prompt queuing.
  * Preserved conversation history when switching between native runs and TUI sessions.

* **Bug Fixes**
  * Threads now show when TUI launch is delayed, with progress and Retry options.
  * Improved handling of busy, unavailable, archived, and missing terminal states.
  * Returning from TUI to Chat now closes the server-side terminal reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->