### PR TITLE
macOS Chat: Liquid Glass toolbar/composer edges, tail-follow, and live request cards

### DIFF
--- a/macos/ATC/Features/Dashboard/DashboardView.swift
+++ b/macos/ATC/Features/Dashboard/DashboardView.swift
@@ -26,6 +26,7 @@ struct DashboardView: View {
             .padding(Spacing.xxl)
             .frame(maxWidth: .infinity, alignment: .top)
         }
+        .scrollEdgeEffectUnderToolbar()
         .overlay {
             if appModel.hasStarted, appModel.runtimes.isEmpty {
                 noConnectionsState

--- a/macos/ATC/Features/Threads/Chat/ChatComposer.swift
+++ b/macos/ATC/Features/Threads/Chat/ChatComposer.swift
@@ -1,6 +1,6 @@
-// The prompt composer pinned under the transcript, shaped like the Codex
-// desktop composer: one rounded card, the text growing from a single line
-// to a few, and a round send button in the corner. Return sends,
+// The prompt composer floating over the transcript's tail, shaped like the
+// Codex desktop composer: one rounded Liquid Glass card, the text growing
+// from a single line to a few, and a round send button in the corner. Return sends,
 // Shift-Return inserts a newline. Send is never disabled while connected —
 // the server admits every prompt (idle starts a turn, busy queues it) — and
 // a refused prompt keeps its text with the server's message inline. Stop
@@ -59,8 +59,9 @@ struct ChatComposer: View {
                 }
             }
             .padding(Spacing.md)
-            .background(Surface.raised, in: RoundedRectangle(cornerRadius: Radius.card + Spacing.xs))
-            .overlay(RoundedRectangle(cornerRadius: Radius.card + Spacing.xs).strokeBorder(Surface.chipBorder))
+            // The composer floats over the transcript, so it is glass like
+            // the toolbar controls, not a card on the canvas.
+            .glassEffect(in: RoundedRectangle(cornerRadius: Radius.card + Spacing.xs))
         }
         .onAppear { isFocused = true }
         .onChange(of: focusRequest) { _, _ in isFocused = true }

--- a/macos/ATC/Features/Threads/Chat/ChatQueueStrip.swift
+++ b/macos/ATC/Features/Threads/Chat/ChatQueueStrip.swift
@@ -10,7 +10,7 @@ struct ChatQueueStrip: View {
     let withdraw: (QueuedPrompt) -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.xs) {
+        VStack(alignment: .leading, spacing: 0) {
             ForEach(prompts, id: \.id) { prompt in
                 HStack(spacing: Spacing.sm) {
                     Image(systemName: "clock")
@@ -30,9 +30,10 @@ struct ChatQueueStrip: View {
                 }
                 .font(.callout)
                 .padding(.horizontal, Spacing.md)
-                .padding(.vertical, Spacing.xs)
-                .background(Surface.raised, in: RoundedRectangle(cornerRadius: Radius.chip))
+                .padding(.vertical, Spacing.sm)
             }
         }
+        // One glass strip floating with the composer, not a chip per row.
+        .glassEffect(in: RoundedRectangle(cornerRadius: Radius.card + Spacing.xs))
     }
 }

--- a/macos/ATC/Features/Threads/Chat/ChatRequestCard.swift
+++ b/macos/ATC/Features/Threads/Chat/ChatRequestCard.swift
@@ -19,8 +19,8 @@ struct ChatRequestCard: View {
             }
         }
         .padding(Spacing.lg)
-        .background(Surface.card, in: RoundedRectangle(cornerRadius: Radius.card))
-        .overlay(RoundedRectangle(cornerRadius: Radius.card).strokeBorder(Surface.cardBorder))
+        // Floats over the transcript with the composer, so glass like it.
+        .glassEffect(in: RoundedRectangle(cornerRadius: Radius.card + Spacing.xs))
     }
 }
 

--- a/macos/ATC/Features/Threads/Chat/ThreadChatView.swift
+++ b/macos/ATC/Features/Threads/Chat/ThreadChatView.swift
@@ -1,5 +1,7 @@
-// The Chat mode of a thread: transcript above, pending requests, the prompt
-// queue, and the composer pinned below. The view holds the thread's Chat
+// The Chat mode of a thread: the transcript, with pending requests, the
+// prompt queue, and the composer floating over its tail as a Liquid Glass
+// bar — the transcript scrolls under the window toolbar above and that bar
+// below, fading into both. The view holds the thread's Chat
 // model for exactly as long as it is on screen (`acquireChat` / `releaseChat`
 // on the Connection's runtime), so navigating away or flipping to TUI drops
 // the subscription while a second window on the same thread keeps it.
@@ -85,12 +87,9 @@ private struct ChatPane: View {
     private var transcript: ChatTranscript { chat.transcript }
 
     var body: some View {
-        VStack(spacing: 0) {
-            transcriptList
-            bottomStack
-        }
-        .overlay(alignment: .top) { statusBanner }
-        .actionErrorAlert($actionError)
+        transcriptList
+            .overlay(alignment: .top) { statusBanner }
+            .actionErrorAlert($actionError)
     }
 
     private func run(_ operation: @escaping () async throws -> Void) {
@@ -136,14 +135,19 @@ private struct ChatPane: View {
                 .frame(maxWidth: 820)
                 .frame(maxWidth: .infinity)
             }
-            // The toolbar floats over the content; keep the first row from
-            // starting under it.
-            .contentMargins(.top, Spacing.xxl, for: .scrollContent)
+            // The transcript scrolls under the toolbar above and the
+            // composer bar below, fading into both with the system's soft
+            // edge effect.
+            .scrollEdgeEffectUnderToolbar()
+            .safeAreaBar(edge: .bottom) { bottomStack }
             // The user scrolling away from the tail stops auto-follow;
-            // returning to it resumes.
+            // returning to it resumes. The toolbar and the composer bar
+            // are content insets that the visible rect spans, so the tail
+            // is where the visible rect reaches the content's end plus the
+            // bottom inset.
             .onScrollGeometryChange(for: Bool.self) { geometry in
-                geometry.contentOffset.y + geometry.containerSize.height
-                    >= geometry.contentSize.height - Spacing.xxl
+                geometry.visibleRect.maxY
+                    >= geometry.contentSize.height + geometry.contentInsets.bottom - Spacing.xxl
             } action: { _, atBottom in
                 isFollowingTail = atBottom
             }
@@ -203,29 +207,35 @@ private struct ChatPane: View {
 
     // MARK: - Bottom stack
 
+    /// Everything floating over the transcript's tail is Liquid Glass, and
+    /// one container renders them together (separate glass views sample
+    /// each other where they overlap).
     private var bottomStack: some View {
-        VStack(spacing: Spacing.sm) {
-            ForEach(transcript.requests, id: \.id) { request in
-                ChatRequestCard(request: request) { answer in
-                    run { try await chat.answer(requestID: request.id, answer) }
+        GlassEffectContainer {
+            VStack(spacing: Spacing.sm) {
+                ForEach(transcript.requests, id: \.id) { request in
+                    ChatRequestCard(request: request) { answer in
+                        run { try await chat.answer(requestID: request.id, answer) }
+                    }
                 }
-            }
-            if !transcript.queue.isEmpty {
-                ChatQueueStrip(prompts: transcript.queue) { prompt in
-                    run { try await chat.withdraw(promptID: prompt.id) }
+                if !transcript.queue.isEmpty {
+                    ChatQueueStrip(prompts: transcript.queue) { prompt in
+                        run { try await chat.withdraw(promptID: prompt.id) }
+                    }
                 }
+                ChatComposer(
+                    text: $draft,
+                    isSending: isSending,
+                    showsStop: transcript.runningTurn != nil,
+                    error: chat.promptError,
+                    focusRequest: focusRequest,
+                    send: send,
+                    stop: { run { try await chat.interrupt() } }
+                )
             }
-            ChatComposer(
-                text: $draft,
-                isSending: isSending,
-                showsStop: transcript.runningTurn != nil,
-                error: chat.promptError,
-                focusRequest: focusRequest,
-                send: send,
-                stop: { run { try await chat.interrupt() } }
-            )
         }
         .padding(.horizontal, Spacing.xxl)
+        .padding(.top, Spacing.md)
         .padding(.bottom, Spacing.lg)
         .frame(maxWidth: 820)
         .frame(maxWidth: .infinity)

--- a/macos/ATC/Features/Threads/Chat/ThreadChatView.swift
+++ b/macos/ATC/Features/Threads/Chat/ThreadChatView.swift
@@ -150,7 +150,7 @@ private struct ChatPane: View {
             // gesture leaves follow mode: content growth moves the geometry
             // too, so it must never be what decides. Ending a gesture at the
             // tail resumes following.
-            .onScrollGeometryChange(for: TailLayout.self, of: TailLayout.init) { _, _ in
+            .onScrollGeometryChange(for: ChatTailLayout.self, of: ChatTailLayout.init) { _, _ in
                 if isFollowingTail { proxy.scrollTo(tailAnchor, anchor: .bottom) }
             }
             .onScrollPhaseChange { previous, phase, context in
@@ -182,17 +182,6 @@ private struct ChatPane: View {
     }
 
     private let tailAnchor = "tail"
-
-    /// The sizes whose change moves the tail: the content's and the
-    /// viewport's (a window resize re-pins too).
-    private struct TailLayout: Equatable {
-        let content: CGFloat
-        let container: CGFloat
-        init(_ geometry: ScrollGeometry) {
-            content = geometry.contentSize.height
-            container = geometry.containerSize.height
-        }
-    }
 
     /// The server drives a turn (Stop is offered), or the agent is busy under
     /// a TUI (items land at idle — the server's re-read).
@@ -293,6 +282,25 @@ private struct ChatPane: View {
         case .live:
             EmptyView()
         }
+    }
+}
+
+/// The sizes whose change moves the tail: the content's, the viewport's (a
+/// window resize re-pins too), and the bars' — the composer growing with a
+/// draft, a request card or the queue appearing — so a change to any of them
+/// re-pins while following. Insets are tracked in their own right rather than
+/// through the container they shrink.
+struct ChatTailLayout: Equatable {
+    let content: CGFloat
+    let container: CGFloat
+    let insetTop: CGFloat
+    let insetBottom: CGFloat
+
+    init(_ geometry: ScrollGeometry) {
+        content = geometry.contentSize.height
+        container = geometry.containerSize.height
+        insetTop = geometry.contentInsets.top
+        insetBottom = geometry.contentInsets.bottom
     }
 }
 

--- a/macos/ATC/Features/Threads/Chat/ThreadChatView.swift
+++ b/macos/ATC/Features/Threads/Chat/ThreadChatView.swift
@@ -82,6 +82,8 @@ private struct ChatPane: View {
     @State private var draft = ""
     @State private var isSending = false
     @State private var isFollowingTail = true
+    /// Bumped to jump to the tail and follow it again (a sent prompt).
+    @State private var followRequest = 0
     @State private var actionError: String?
 
     private var transcript: ChatTranscript { chat.transcript }
@@ -140,21 +142,29 @@ private struct ChatPane: View {
             // edge effect.
             .scrollEdgeEffectUnderToolbar()
             .safeAreaBar(edge: .bottom) { bottomStack }
-            // The user scrolling away from the tail stops auto-follow;
-            // returning to it resumes. The toolbar and the composer bar
-            // are content insets that the visible rect spans, so the tail
-            // is where the visible rect reaches the content's end plus the
-            // bottom inset.
-            .onScrollGeometryChange(for: Bool.self) { geometry in
-                geometry.visibleRect.maxY
-                    >= geometry.contentSize.height + geometry.contentInsets.bottom - Spacing.xxl
-            } action: { _, atBottom in
-                isFollowingTail = atBottom
-            }
-            .onChange(of: transcript.items) { _, _ in
+            // Tail-follow, T3Code style: while following, every content
+            // or viewport size change re-pins the tail above the composer
+            // (done from the geometry change, once layout has the new
+            // sizes — a scroll issued when the model changes lands short of
+            // rows that are not measured yet). Only the user's own scroll
+            // gesture leaves follow mode: content growth moves the geometry
+            // too, so it must never be what decides. Ending a gesture at the
+            // tail resumes following.
+            .onScrollGeometryChange(for: TailLayout.self, of: TailLayout.init) { _, _ in
                 if isFollowingTail { proxy.scrollTo(tailAnchor, anchor: .bottom) }
             }
-            .onChange(of: transcript.isLoaded) { _, _ in
+            .onScrollPhaseChange { previous, phase, context in
+                // A gesture leaves follow mode; a gesture ending at the tail
+                // resumes it. An idle that no gesture led to (the first
+                // callback, a programmatic scroll settling) decides nothing.
+                if phase.isGesture {
+                    isFollowingTail = false
+                } else if phase == .idle, previous.isGesture {
+                    isFollowingTail = context.geometry.isAtTail
+                }
+            }
+            .onChange(of: followRequest) { _, _ in
+                isFollowingTail = true
                 proxy.scrollTo(tailAnchor, anchor: .bottom)
             }
         }
@@ -172,6 +182,17 @@ private struct ChatPane: View {
     }
 
     private let tailAnchor = "tail"
+
+    /// The sizes whose change moves the tail: the content's and the
+    /// viewport's (a window resize re-pins too).
+    private struct TailLayout: Equatable {
+        let content: CGFloat
+        let container: CGFloat
+        init(_ geometry: ScrollGeometry) {
+            content = geometry.contentSize.height
+            container = geometry.containerSize.height
+        }
+    }
 
     /// The server drives a turn (Stop is offered), or the agent is busy under
     /// a TUI (items land at idle — the server's re-read).
@@ -248,7 +269,7 @@ private struct ChatPane: View {
         Task {
             if await chat.send(prompt) {
                 draft = ""
-                isFollowingTail = true
+                followRequest += 1
             }
             isSending = false
         }
@@ -272,5 +293,28 @@ private struct ChatPane: View {
         case .live:
             EmptyView()
         }
+    }
+}
+
+extension ScrollPhase {
+    /// The user is scrolling: their finger or wheel is driving it, or its
+    /// momentum still is.
+    var isGesture: Bool {
+        switch self {
+        case .tracking, .interacting, .decelerating: true
+        case .idle, .animating: false
+        @unknown default: false
+        }
+    }
+}
+
+extension ScrollGeometry {
+    /// The toolbar and the composer bar are content insets: the container is
+    /// the area between them, so the tail is in view when the container's
+    /// bottom edge — offset plus insets plus container — reaches the
+    /// content's end plus the bottom inset (with some slack).
+    var isAtTail: Bool {
+        let viewportBottom = contentOffset.y + contentInsets.top + containerSize.height + contentInsets.bottom
+        return viewportBottom >= contentSize.height + contentInsets.bottom - Spacing.xxl
     }
 }

--- a/macos/ATC/RootView.swift
+++ b/macos/ATC/RootView.swift
@@ -32,6 +32,9 @@ struct RootView: View {
         // constant color to rest on.
         .containerBackground(AppColors.canvas, for: .window)
         .toolbar(removing: .title)
+        // The toolbar floats over a seamless canvas (ATC-41): no bar behind
+        // it, just its glass controls. Scrolling content gets the system's
+        // soft edge effect under it through `scrollEdgeEffectUnderToolbar`.
         .toolbarBackgroundVisibility(.hidden, for: .windowToolbar)
         .toolbar {
             // Plain text, not a control: hide the glass capsule the toolbar

--- a/macos/ATC/Shared/ScrollEdgeEffects.swift
+++ b/macos/ATC/Shared/ScrollEdgeEffects.swift
@@ -1,0 +1,24 @@
+// The window toolbar floats over the canvas with its background hidden
+// (RootView, ATC-41). On macOS 26 that also drops the toolbar's own scroll
+// edge effect, so content would scroll under the toolbar controls unfaded.
+// SwiftUI does draw its soft edge effect — the system's progressive blur and
+// fade — under any `safeAreaBar` that holds Liquid Glass, and the effect
+// spans the whole top safe area, toolbar included. So a scroll view under the
+// toolbar gets a 1pt bar of identity glass: nothing to see, but the system
+// takes over the fade. (A clear color or empty view in the bar is not enough;
+// verified against the macOS 26.5 SDK.)
+
+import SwiftUI
+
+extension View {
+    /// Fades scrolling content under the floating window toolbar with the
+    /// system's soft scroll edge effect. Apply to the `ScrollView` itself.
+    func scrollEdgeEffectUnderToolbar() -> some View {
+        safeAreaBar(edge: .top) {
+            Color.clear
+                .frame(maxWidth: .infinity)
+                .frame(height: 1)
+                .glassEffect(.identity)
+        }
+    }
+}

--- a/macos/ATCTests/ChatTailFollowTests.swift
+++ b/macos/ATCTests/ChatTailFollowTests.swift
@@ -35,6 +35,22 @@ struct ChatTailFollowTests {
         #expect(!geometry(offsetY: -52).isAtTail)
     }
 
+    @Test("a bar growing under the tail is a layout change that re-pins")
+    func insetOnlyChangeIsALayoutChange() {
+        let before = ChatTailLayout(geometry(offsetY: 62))
+        // The composer grew by a line: only the bottom inset moved.
+        let after = ChatTailLayout(
+            ScrollGeometry(
+                contentOffset: CGPoint(x: 0, y: 62),
+                contentSize: CGSize(width: 1162, height: 859),
+                contentInsets: EdgeInsets(top: 52, leading: 0, bottom: 138, trailing: 0),
+                containerSize: CGSize(width: 1162, height: 728)
+            ))
+        #expect(before != after)
+        // Scrolling alone is not.
+        #expect(before == ChatTailLayout(geometry(offsetY: 0)))
+    }
+
     @Test("only the user's own scrolling counts as a gesture")
     func gesturePhases() {
         #expect(ScrollPhase.tracking.isGesture)

--- a/macos/ATCTests/ChatTailFollowTests.swift
+++ b/macos/ATCTests/ChatTailFollowTests.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+import Testing
+
+@testable import ATC
+
+/// The Chat transcript's tail rule: the toolbar and composer bar are content
+/// insets around the container, so "at the tail" means the container's bottom
+/// reaches the content's end plus the composer inset — with a little slack.
+@Suite("Chat tail follow")
+struct ChatTailFollowTests {
+    /// The geometry the app logged live at the tail after opening a thread:
+    /// a 52pt toolbar and 114pt composer bar around a 728pt container, over
+    /// 859pt of content — the offset is `-top` at rest at the top.
+    private func geometry(offsetY: CGFloat) -> ScrollGeometry {
+        ScrollGeometry(
+            contentOffset: CGPoint(x: 0, y: offsetY),
+            contentSize: CGSize(width: 1162, height: 859),
+            contentInsets: EdgeInsets(top: 52, leading: 0, bottom: 114, trailing: 0),
+            containerSize: CGSize(width: 1162, height: 728)
+        )
+    }
+
+    @Test("the tail is where the container's bottom reaches the content end plus the composer inset")
+    func tailDetection() {
+        // 62 is where `scrollTo(tail, anchor: .bottom)` landed live: the
+        // tail's 1pt and the 16pt bottom padding under the bar.
+        #expect(geometry(offsetY: 62).isAtTail)
+        // Fully scrolled: 62 + 17.
+        #expect(geometry(offsetY: 79).isAtTail)
+        // Within the slack.
+        #expect(geometry(offsetY: 79 - Spacing.xxl).isAtTail)
+        // Past the slack: the last rows are hidden under the composer.
+        #expect(!geometry(offsetY: 79 - Spacing.xxl - 1).isAtTail)
+        // At the top.
+        #expect(!geometry(offsetY: -52).isAtTail)
+    }
+
+    @Test("only the user's own scrolling counts as a gesture")
+    func gesturePhases() {
+        #expect(ScrollPhase.tracking.isGesture)
+        #expect(ScrollPhase.interacting.isGesture)
+        #expect(ScrollPhase.decelerating.isGesture)
+        #expect(!ScrollPhase.idle.isGesture)
+        #expect(!ScrollPhase.animating.isGesture)
+    }
+}

--- a/packages/ATCKit/Sources/ATCAppServerAPI/ATCAppServerAPI.swift
+++ b/packages/ATCKit/Sources/ATCAppServerAPI/ATCAppServerAPI.swift
@@ -32,6 +32,21 @@ public func makeClient(baseURL: URL, bearerToken: String?) -> Client {
     )
 }
 
+/// The decoder for App Server JSON that reaches a client outside the
+/// generated operations — the SSE frames of the event streams. It decodes
+/// `format: date-time` fields exactly as `makeClient` does; a bare
+/// `JSONDecoder()` rejects every payload carrying a timestamp (request and
+/// turn events), and a stream that drops what it cannot decode would lose
+/// them silently.
+public func makeJSONDecoder() -> JSONDecoder {
+    let decoder = JSONDecoder()
+    let transcoder = ATCDateTranscoder()
+    decoder.dateDecodingStrategy = .custom { decoder in
+        try transcoder.decode(try decoder.singleValueContainer().decode(String.self))
+    }
+    return decoder
+}
+
 /// Adds `Authorization: Bearer <token>` to every request. Loopback servers
 /// ignore it today; remote bearer-token access lands additively on this seam.
 public struct BearerAuthMiddleware: ClientMiddleware {

--- a/packages/ATCKit/Sources/ATCAppServerTransport/ResourceEventStream.swift
+++ b/packages/ATCKit/Sources/ATCAppServerTransport/ResourceEventStream.swift
@@ -57,7 +57,7 @@ public enum ResourceEventStream {
             case .disconnected:
                 return .disconnected
             case .data(let payload):
-                guard let change = try? JSONDecoder().decode(Change.self, from: Data(payload.utf8))
+                guard let change = try? makeJSONDecoder().decode(Change.self, from: Data(payload.utf8))
                 else { return nil }
                 return .change(change)
             }

--- a/packages/ATCKit/Sources/ATCAppServerTransport/ThreadEventStream.swift
+++ b/packages/ATCKit/Sources/ATCAppServerTransport/ThreadEventStream.swift
@@ -75,7 +75,7 @@ public enum ThreadEventStream {
                 return .disconnected
             case .data(let payload):
                 guard
-                    let event = try? JSONDecoder().decode(ThreadEvent.self, from: Data(payload.utf8))
+                    let event = try? makeJSONDecoder().decode(ThreadEvent.self, from: Data(payload.utf8))
                 else { return nil }
                 return .event(event)
             }

--- a/packages/ATCKit/Tests/ATCAppServerTransportTests/ThreadEventStreamTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerTransportTests/ThreadEventStreamTests.swift
@@ -14,6 +14,19 @@ private let textDelta = """
 private let snapshotInvalidated = """
     data: {"type":"snapshot.invalidated","seq":9,"snapshotVersion":2}\n\n
     """
+// Exactly what the server's contract encoder emits for the request events.
+private let questionOpened = """
+    data: {"type":"request.opened","request":{"kind":"question","id":"req1","turnId":"t1","itemId":"i1","openedAt":"2026-08-18T10:00:00.000Z","questions":[{"id":"q1","header":"Pick","question":"Which?","options":[{"label":"A","description":"a"}],"multiSelect":false,"freeform":true,"secret":false}]}}\n\n
+    """
+private let approvalOpened = """
+    data: {"type":"request.opened","request":{"kind":"approval","id":"req2","turnId":"t1","openedAt":"2026-08-18T10:00:00.000Z","title":"Run command?","reason":"because","subject":{"type":"command","command":"ls","cwd":"/tmp"}}}\n\n
+    """
+private let requestClosed = """
+    data: {"type":"request.closed","requestId":"req1"}\n\n
+    """
+private let turnStarted = """
+    data: {"type":"turn.started","seq":8,"turn":{"id":"turn1","status":"running","startedAt":"2026-08-18T10:00:00.000Z"}}\n\n
+    """
 
 /// A resume cursor the test moves as the consumer would.
 private final class Cursor: @unchecked Sendable {
@@ -65,6 +78,50 @@ struct ThreadEventStreamTests {
         #expect(invalidated.seq == 9)
         // No `after` → a live-only subscribe, no query at all.
         #expect(connector.urls == [eventsURL])
+    }
+
+    // Requests and turns carry `date-time` fields: they decode only through
+    // the App Server's date transcoder, and a stream drops what it cannot
+    // decode — so this is the test that keeps request cards appearing live.
+    @Test("events with timestamps decode: a question, an approval, a close, a turn")
+    func timestampedEventsDecode() async {
+        let connector = ScriptedConnector([
+            .stream(
+                [": connected\n\n", questionOpened, approvalOpened, requestClosed, turnStarted], thenHang: true)
+        ])
+        let stream = ThreadEventStream.stream(
+            url: eventsURL, after: { nil }, configuration: fastConfiguration(), connector: connector.connect()
+        )
+
+        let events = await collect(stream, count: 5)
+
+        guard events.count == 5 else {
+            Issue.record("expected 5 events, got \(events)")
+            return
+        }
+        guard case .event(.request_opened(let opened)) = events[1], case .question(let question) = opened.request
+        else {
+            Issue.record("expected a question request.opened, got \(events[1])")
+            return
+        }
+        #expect(question.id == "req1")
+        #expect(question.questions.first?.options.first?.label == "A")
+        guard case .event(.request_opened(let opened)) = events[2], case .approval(let approval) = opened.request
+        else {
+            Issue.record("expected an approval request.opened, got \(events[2])")
+            return
+        }
+        #expect(approval.title == "Run command?")
+        guard case .event(.request_closed(let closed)) = events[3] else {
+            Issue.record("expected request.closed, got \(events[3])")
+            return
+        }
+        #expect(closed.requestId == "req1")
+        guard case .event(.turn_started(let started)) = events[4] else {
+            Issue.record("expected turn.started, got \(events[4])")
+            return
+        }
+        #expect(started.turn.startedAt != nil)
     }
 
     @Test("every (re)connect asks the caller for its resume seq")

--- a/packages/ATCKit/Tests/ATCAppServerTransportTests/ThreadEventStreamTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerTransportTests/ThreadEventStreamTests.swift
@@ -27,6 +27,8 @@ private let requestClosed = """
 private let turnStarted = """
     data: {"type":"turn.started","seq":8,"turn":{"id":"turn1","status":"running","startedAt":"2026-08-18T10:00:00.000Z"}}\n\n
     """
+/// 2026-08-18T10:00:00.000Z, the timestamp in the payloads above.
+private let payloadDate = Date(timeIntervalSince1970: 1_787_047_200)
 
 /// A resume cursor the test moves as the consumer would.
 private final class Cursor: @unchecked Sendable {
@@ -105,6 +107,7 @@ struct ThreadEventStreamTests {
             return
         }
         #expect(question.id == "req1")
+        #expect(question.openedAt == payloadDate)
         #expect(question.questions.first?.options.first?.label == "A")
         guard case .event(.request_opened(let opened)) = events[2], case .approval(let approval) = opened.request
         else {
@@ -112,6 +115,7 @@ struct ThreadEventStreamTests {
             return
         }
         #expect(approval.title == "Run command?")
+        #expect(approval.openedAt == payloadDate)
         guard case .event(.request_closed(let closed)) = events[3] else {
             Issue.record("expected request.closed, got \(events[3])")
             return
@@ -121,7 +125,7 @@ struct ThreadEventStreamTests {
             Issue.record("expected turn.started, got \(events[4])")
             return
         }
-        #expect(started.turn.startedAt != nil)
+        #expect(started.turn.startedAt == payloadDate)
     }
 
     @Test("every (re)connect asks the caller for its resume seq")


### PR DESCRIPTION
## What

Three commits on the native Chat view, from a visual pass plus manual testing follow-ups:

1. **Transcript scrolls under the toolbar and a Liquid Glass composer bar** with the system's soft scroll edge effect.
   - The window toolbar keeps its hidden background (seamless canvas, ATC-41), which on macOS 26 also drops the toolbar's own edge effect — content scrolled under the Chat/TUI picker unfaded. `scrollEdgeEffectUnderToolbar()` (`Shared/ScrollEdgeEffects.swift`) adds a 1pt identity-glass top `safeAreaBar`, which makes SwiftUI draw its soft edge effect across the whole toolbar zone (verified in a scratch app: `Color.clear`/empty bars don't trigger it; `.automatic` toolbar background is a static opaque band, not a fade). Used by the transcript and the Dashboard.
   - The composer, queue strip and request cards become a bottom `safeAreaBar` of Liquid Glass in one `GlassEffectContainer`; the transcript scrolls under it and fades into it. The 32pt `contentMargins` hack is gone.
2. **ATCKit: decode SSE frames with the App Server date transcoder.** `ThreadEventStream`/`ResourceEventStream` used a bare `JSONDecoder()`, whose default date strategy rejects the server's ISO timestamps, so `request.opened` (`openedAt`) and `turn.started/completed` never decoded and were dropped silently — request cards only appeared after a TUI→Chat re-acquire read them over REST. `makeJSONDecoder()` next to `makeClient()` is now the one decoder for contract JSON outside the generated operations. The stream test covers timestamped events (it fails without the fix).
3. **Tail-follow that streaming cannot break, T3Code style.** Follow mode was decided by `onScrollGeometryChange` — which content growth moves too — and the pin ran on the model change before `LazyVStack` measured the new row, so a sent prompt landed under the composer. Now only a user scroll gesture (`onScrollPhaseChange`) leaves follow mode, a gesture ending at the tail resumes it, and while following every content/viewport size change re-pins the tail above the composer; a send jumps to the tail and follows. (`defaultScrollAnchor(.bottom)` was tried first: it anchors the initial load but does not track growth under a bottom bar.)

## Reviewer notes

- The 1pt identity-glass bar is the least-hacky public-API way I found to get the system fade under a hidden-background toolbar; the header comment in `ScrollEdgeEffects.swift` records what was tried.
- Not done (possible follow-up): T3Code additionally anchors the *sent prompt at the top* of the viewport with end-space; this PR pins the tail instead.
- Verified visually against a live server (dev build, read-only), and the follow behavior in a scratch app with streaming content (follows, no yank on scroll-up, resumes on scroll-back).

## Verification

`swift:lint`, `swift:fmt:check`, ATCKit tests (51), `macos:test` (322) — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a refined Liquid Glass appearance for chat composers, request cards, and queued prompts.
  * Added floating chat controls with improved transcript scrolling and automatic tail-following behavior.
  * Added seamless scroll-edge effects beneath window toolbars.
  * Improved handling of timestamped live events, including fractional-second timestamps.

* **Bug Fixes**
  * Chat event streams now reliably decode timestamp-bearing events while preserving invalid-payload handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->