### PR TITLE
macOS Chat: the composer draft survives switching views (ATC-208)

### DIFF
--- a/macos/ATC/AppModel.swift
+++ b/macos/ATC/AppModel.swift
@@ -62,6 +62,11 @@ final class AppModel {
     /// history.
     private(set) var threadViewModes: [ThreadRef: ThreadViewMode] = [:]
 
+    /// Unsent composer text per thread, for this app session only — app-level
+    /// like the view mode, so every window on one thread shares one draft and
+    /// switching views (TUI, another thread, Dashboard) never loses it.
+    private(set) var threadDrafts: [ThreadRef: String] = [:]
+
     /// Live terminal attaches by composite ref. Connections and surfaces
     /// stay alive here while the user switches around the sidebar, bounded
     /// by `attachmentBudget`.
@@ -256,6 +261,14 @@ final class AppModel {
 
     func viewMode(for ref: ThreadRef) -> ThreadViewMode {
         threadViewModes[ref] ?? .chat
+    }
+
+    func draft(for ref: ThreadRef) -> String {
+        threadDrafts[ref] ?? ""
+    }
+
+    func setDraft(_ text: String, for ref: ThreadRef) {
+        threadDrafts[ref] = text.isEmpty ? nil : text
     }
 
     /// Remembers the mode and re-opens the thread in every window showing

--- a/macos/ATC/Features/Threads/Chat/ThreadChatView.swift
+++ b/macos/ATC/Features/Threads/Chat/ThreadChatView.swift
@@ -5,6 +5,7 @@
 // model for exactly as long as it is on screen (`acquireChat` / `releaseChat`
 // on the Connection's runtime), so navigating away or flipping to TUI drops
 // the subscription while a second window on the same thread keeps it.
+// The composer draft lives on `AppModel`, so it survives leaving Chat.
 //
 // The transcript follows the tail until the user scrolls up, and offers
 // "Load earlier" at the top while older pages exist. Connection loss shows a
@@ -79,7 +80,6 @@ private struct ChatPane: View {
     let thread: ATCThread
     let focusRequest: UInt
 
-    @State private var draft = ""
     @State private var isSending = false
     @State private var isFollowingTail = true
     /// Bumped to jump to the tail and follow it again (a sent prompt).
@@ -87,6 +87,13 @@ private struct ChatPane: View {
     @State private var actionError: String?
 
     private var transcript: ChatTranscript { chat.transcript }
+
+    private var draftBinding: Binding<String> {
+        Binding(
+            get: { appModel.draft(for: ref) },
+            set: { appModel.setDraft($0, for: ref) }
+        )
+    }
 
     var body: some View {
         transcriptList
@@ -234,7 +241,7 @@ private struct ChatPane: View {
                     }
                 }
                 ChatComposer(
-                    text: $draft,
+                    text: draftBinding,
                     isSending: isSending,
                     showsStop: transcript.runningTurn != nil,
                     error: chat.promptError,
@@ -252,12 +259,16 @@ private struct ChatPane: View {
     }
 
     private func send() {
-        let prompt = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        let submitted = appModel.draft(for: ref)
+        let prompt = submitted.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !prompt.isEmpty, !isSending else { return }
         isSending = true
         Task {
             if await chat.send(prompt) {
-                draft = ""
+                // Clear only what was sent: the draft is shared, and text
+                // typed while the send was in flight (here or in another
+                // window on the thread) is never discarded.
+                if appModel.draft(for: ref) == submitted { appModel.setDraft("", for: ref) }
                 followRequest += 1
             }
             isSending = false

--- a/macos/ATC/Features/Threads/ThreadContentView.swift
+++ b/macos/ATC/Features/Threads/ThreadContentView.swift
@@ -56,8 +56,9 @@ struct ThreadContentView: View {
         if appModel.thread(for: ref) == nil {
             unavailableCover
         } else if appModel.viewMode(for: ref) == .chat {
-            // Identity per thread: the composer draft and scroll position
-            // belong to one thread, never carried to the next.
+            // Identity per thread: scroll position and the Chat hold belong
+            // to one thread, never carried to the next (the composer draft
+            // lives on AppModel and survives the switch).
             ThreadChatView(ref: ref).id(ref)
         } else if let message = windowState.threadOpenErrors[ref] {
             FloatingBanner {

--- a/macos/ATCTests/WindowStateTests.swift
+++ b/macos/ATCTests/WindowStateTests.swift
@@ -511,6 +511,22 @@ struct WindowStateTests {
         #expect(test.client.closeThreadTerminalCount == 1)
     }
 
+    @Test("composer drafts are per-thread and survive switching modes")
+    func composerDraftsSurviveSwitchingModes() async throws {
+        let test = try await loadedModel()
+        let ref = test.threadRef("thr1")
+        let other = test.threadRef("thr2")
+
+        test.model.setDraft("unfinished prompt", for: ref)
+        #expect(test.model.draft(for: ref) == "unfinished prompt")
+        #expect(test.model.draft(for: other) == "")
+        test.model.setViewMode(.tui, for: ref)
+        test.model.setViewMode(.chat, for: ref)
+        #expect(test.model.draft(for: ref) == "unfinished prompt")
+        test.model.setDraft("", for: ref)
+        #expect(test.model.threadDrafts[ref] == nil)
+    }
+
     @Test("a TUI open refused while the server drives a turn waits, then attaches the terminal it launches")
     func deferredTuiOpenAttachesOnArrival() async throws {
         let client = ScriptableAppServerClient()


### PR DESCRIPTION
Closes ATC-208 — https://linear.app/elevenideas/issue/ATC-208

## Problem
Typing a prompt in a thread's Chat composer and then switching to TUI, another thread, or the Dashboard lost the text: `ThreadContentView` only mounts `ThreadChatView(ref).id(ref)` while the thread is selected in Chat, so `ChatPane` and its `@State draft` were torn down with it.

## Change
- `AppModel.threadDrafts: [ThreadRef: String]` with `draft(for:)` / `setDraft(_:for:)` — session-only and app-level, the same idiom as `threadViewModes`, so every window on one thread shares one draft and no switch loses it. An empty draft removes the entry.
- `ChatPane` binds the composer straight to the app-level draft (no local `@State`), and clears it only after a successful send — a refused prompt keeps its text as before.
- Comment updates in `ThreadChatView` / `ThreadContentView`; one test in `WindowStateTests` covering per-thread isolation, clear-on-empty, and survival across a TUI↔Chat flip.

## Verified
`mise run swift:fmt:check`, `mise run swift:lint`, `ATC_STRICT_WARNINGS=1 mise run macos:test` (324 tests pass).

https://claude.ai/code/session_01Pfp8DXsfxYeSN1ncWyJa6y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Composer drafts are saved separately for each conversation.
  * Drafts persist when switching between Chat and TUI modes.
  * Empty drafts are automatically removed.

* **Bug Fixes**
  * Sending a message trims and clears the saved draft after successful delivery without overwriting edits made during sending.

* **Tests**
  * Added coverage for draft isolation, persistence, clearing, and mode switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->