### PR TITLE
Chat mode model settings: contract, migration, adapters, runtime (ATC-210)

### DIFF
--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -701,6 +701,16 @@
               }
             }
           },
+          "400": {
+            "description": "The settings patch does not fit the agent's model catalog: an unknown model, or a reasoning level the model does not support.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidThreadSettingsJsonEncoding"
+                }
+              }
+            }
+          },
           "404": {
             "description": "No thread exists with the given id.",
             "content": {
@@ -710,9 +720,19 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "The thread's agent provider cannot be used right now (not installed, not ready, or unreachable). Retryable once the cause is fixed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderUnavailableJsonEncoding"
+                }
+              }
+            }
           }
         },
-        "description": "Update a thread's display label (the only mutable field).",
+        "description": "Update a thread's display label and/or settings. A model or reasoning change is validated against the agent's model catalog (ProviderUnavailable when the catalog cannot be read); other fields never consult the provider.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1649,7 +1669,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A built-in agent provider: availability report, detected on demand and never persisted.",
+            "description": "A built-in agent provider: availability report, detected on demand and never persisted, plus `defaults` — what a new thread of this agent starts with: the settings of the last thread whose settings were changed (write-through), read-only here.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1670,6 +1690,57 @@
           }
         },
         "description": "Fetch one built-in agent by its registry slug."
+      }
+    },
+    "/api/v1/agents/{agentId}/models": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "listAgentModels",
+        "parameters": [
+          {
+            "name": "agentId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An agent's model catalog, in the provider's order.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentModelList"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No built-in agent exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentNotFoundJsonEncoding"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The thread's agent provider cannot be used right now (not installed, not ready, or unreachable). Retryable once the cause is fixed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderUnavailableJsonEncoding"
+                }
+              }
+            }
+          }
+        },
+        "description": "The agent's model catalog as its provider reports it, cached server-side for a short while."
       }
     },
     "/api/v1/events": {
@@ -2233,6 +2304,61 @@
         ],
         "description": "Built-in agent registry slug."
       },
+      "ReasoningLevel": {
+        "type": "string",
+        "enum": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max",
+          "ultra"
+        ],
+        "description": "Reasoning effort. Which levels a model accepts comes from the agent's model catalog (listAgentModels)."
+      },
+      "ThreadMode": {
+        "type": "string",
+        "enum": [
+          "chat",
+          "plan"
+        ],
+        "description": "`chat` works normally; `plan` explores and proposes without mutating the workspace."
+      },
+      "ThreadAccess": {
+        "type": "string",
+        "enum": [
+          "supervised",
+          "autoAcceptEdits",
+          "auto",
+          "fullAccess"
+        ],
+        "description": "The access ladder: `supervised` asks before every write and command; `autoAcceptEdits` auto-approves edits inside the workspace; `auto` works within the workspace without asking; `fullAccess` bypasses approvals and sandboxing entirely."
+      },
+      "ThreadSettings": {
+        "type": "object",
+        "properties": {
+          "model": {
+            "type": "string",
+            "description": "The provider's model id, as listed by listAgentModels (`value`)."
+          },
+          "reasoning": {
+            "$ref": "#/components/schemas/ReasoningLevel"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/ThreadMode"
+          },
+          "access": {
+            "$ref": "#/components/schemas/ThreadAccess"
+          }
+        },
+        "required": [
+          "model",
+          "mode",
+          "access"
+        ],
+        "additionalProperties": false,
+        "description": "Per-thread model, reasoning, mode, and access. What the thread's next turn runs with; a change made in the provider itself (its TUI, another client) is adopted here as soon as ATC hears of it. `reasoning` is absent for a model that does not support effort levels."
+      },
       "ThreadActivityState": {
         "type": "string",
         "enum": [
@@ -2264,6 +2390,9 @@
           "workingDirectory": {
             "type": "string",
             "description": "Canonical directory the thread's agent session works in (immutable)."
+          },
+          "settings": {
+            "$ref": "#/components/schemas/ThreadSettings"
           },
           "activityState": {
             "$ref": "#/components/schemas/ThreadActivityState"
@@ -2302,6 +2431,7 @@
           "projectId",
           "agentId",
           "workingDirectory",
+          "settings",
           "activityState",
           "unread",
           "createdAt",
@@ -2368,16 +2498,95 @@
         ],
         "additionalProperties": false
       },
+      "ThreadSettingsPatch": {
+        "type": "object",
+        "properties": {
+          "model": {
+            "type": "string",
+            "description": "New model id."
+          },
+          "reasoning": {
+            "$ref": "#/components/schemas/ReasoningLevel"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/ThreadMode"
+          },
+          "access": {
+            "$ref": "#/components/schemas/ThreadAccess"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Partial settings update; only the given fields change. `reasoning` must be a level the (new or current) model supports; omitted on a model change, the current level carries over when the new model supports it, else the new model's default applies."
+      },
       "UpdateThreadRequest": {
         "type": "object",
         "properties": {
           "name": {
             "type": "string",
             "description": "New display label."
+          },
+          "settings": {
+            "$ref": "#/components/schemas/ThreadSettingsPatch"
           }
         },
         "additionalProperties": false,
-        "description": "Partial update; only the display label is mutable."
+        "description": "Partial update of the display label and/or the settings. A settings change writes ATC state only: it takes effect at the thread's next turn (a turn in flight is never disturbed) and becomes the agent's defaults for new threads."
+      },
+      "InvalidThreadSettingsJsonEncoding": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": [
+              "InvalidThreadSettings"
+            ]
+          },
+          "threadId": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic derived from the structured fields."
+          }
+        },
+        "required": [
+          "_tag",
+          "threadId",
+          "reason",
+          "message"
+        ],
+        "additionalProperties": false
+      },
+      "ProviderUnavailableJsonEncoding": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": [
+              "ProviderUnavailable"
+            ]
+          },
+          "agentId": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic derived from the structured fields."
+          }
+        },
+        "required": [
+          "_tag",
+          "agentId",
+          "reason",
+          "message"
+        ],
+        "additionalProperties": false
       },
       "ThreadBusyJsonEncoding": {
         "type": "object",
@@ -2450,34 +2659,6 @@
         "required": [
           "_tag",
           "threadId",
-          "reason",
-          "message"
-        ],
-        "additionalProperties": false
-      },
-      "ProviderUnavailableJsonEncoding": {
-        "type": "object",
-        "properties": {
-          "_tag": {
-            "type": "string",
-            "enum": [
-              "ProviderUnavailable"
-            ]
-          },
-          "agentId": {
-            "type": "string"
-          },
-          "reason": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string",
-            "description": "Human-readable diagnostic derived from the structured fields."
-          }
-        },
-        "required": [
-          "_tag",
-          "agentId",
           "reason",
           "message"
         ],
@@ -3515,14 +3696,18 @@
           "detectedVersion": {
             "type": "string",
             "description": "Installed CLI version, when it could be determined."
+          },
+          "defaults": {
+            "$ref": "#/components/schemas/ThreadSettings"
           }
         },
         "required": [
           "id",
-          "available"
+          "available",
+          "defaults"
         ],
         "additionalProperties": false,
-        "description": "A built-in agent provider: availability report, detected on demand and never persisted."
+        "description": "A built-in agent provider: availability report, detected on demand and never persisted, plus `defaults` — what a new thread of this agent starts with: the settings of the last thread whose settings were changed (write-through), read-only here."
       },
       "AgentList": {
         "type": "array",
@@ -3554,6 +3739,52 @@
           "message"
         ],
         "additionalProperties": false
+      },
+      "AgentModel": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "The id to store in ThreadSettings.model."
+          },
+          "displayName": {
+            "type": "string",
+            "description": "The provider's own display name."
+          },
+          "description": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean",
+            "description": "The provider's default model (what a session gets when none is chosen)."
+          },
+          "supportedEffortLevels": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReasoningLevel"
+            },
+            "description": "The reasoning levels the model accepts; empty for a model with no effort support (its threads carry no reasoning)."
+          },
+          "defaultEffortLevel": {
+            "$ref": "#/components/schemas/ReasoningLevel"
+          }
+        },
+        "required": [
+          "value",
+          "displayName",
+          "description",
+          "isDefault",
+          "supportedEffortLevels"
+        ],
+        "additionalProperties": false,
+        "description": "One entry of an agent's model catalog, as the provider itself reports it. `defaultEffortLevel` is the level a thread gets on switching to this model when its current level is unsupported; absent for a model with no effort support."
+      },
+      "AgentModelList": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/AgentModel"
+        },
+        "description": "An agent's model catalog, in the provider's order."
       },
       "ResourceChangedEventJsonEncoding": {
         "type": "string",

--- a/app-server/src/agents/agentAdapter.ts
+++ b/app-server/src/agents/agentAdapter.ts
@@ -33,6 +33,18 @@ import { resolveExecutable } from "../platform/subprocess.ts"
 //     no auto-reject; the request dies with its turn (closed on
 //     turnCompleted) or its connection. Requests raised for a turn another
 //     writer started are never ours to answer.
+//   - Settings (ATC-205) cross the seam in the contract's ThreadSettings
+//     vocabulary. The caller's settings are what a turn RUNS with:
+//     `startTurn` (and `createSession`) take them, and the adapter pushes
+//     only what differs from the live session's own values — an unchanged
+//     turn costs no extra provider round-trip. The provider's word on its
+//     session settings — a change made in its TUI or another client, or what
+//     a fresh process actually applied — comes back as a `settings` event,
+//     partial (only what the provider reported), and the caller adopts it.
+//     The access ladder and the plan/chat mode are translated INSIDE the
+//     adapters (Claude permissionMode; Codex approvalPolicy + sandbox +
+//     collaborationMode); no rung name leaks below the seam and no provider
+//     knob leaks above it.
 //
 // The fake adapter for tests lives in test/agents/fakeAgentAdapter.ts; per-provider
 // service tags live with their adapters (codexAdapter.ts, claudeAdapter.ts).
@@ -116,6 +128,23 @@ export type ThreadRequestAnswer = typeof Contract.ThreadRequestAnswer.Type
 export type ApprovalSubject = typeof Contract.ApprovalSubject.Type
 export type FileChange = typeof Contract.FileChange.Type
 export type ToolStatus = typeof Contract.ToolStatus.Type
+export type ThreadSettings = typeof Contract.ThreadSettings.Type
+export type ReasoningLevel = typeof Contract.ReasoningLevel.Type
+export type ThreadAccess = typeof Contract.ThreadAccess.Type
+export type ThreadMode = typeof Contract.ThreadMode.Type
+export type AgentModel = typeof Contract.AgentModel.Type
+
+/**
+ * What a provider reported about its session's settings (ATC-205): only the
+ * fields it spoke about are present; `reasoning: null` is "the model runs
+ * with no effort level" (as opposed to "not reported").
+ */
+export interface ProviderSettings {
+  readonly model?: string
+  readonly reasoning?: ReasoningLevel | null
+  readonly mode?: ThreadMode
+  readonly access?: ThreadAccess
+}
 
 /** One turn of provider history, as `readHistory` returns it. */
 export interface HistoryTurn {
@@ -152,6 +181,7 @@ export type AgentItemEvent =
 export type AgentSessionEvent =
   | { readonly type: "activity"; readonly activity: AgentActivity }
   | { readonly type: "userPrompt"; readonly text: string }
+  | { readonly type: "settings"; readonly settings: ProviderSettings }
   | AgentItemEvent
 
 /**
@@ -179,6 +209,8 @@ export type AgentEvent =
   | { readonly type: "textDelta"; readonly itemId: string; readonly delta: string }
   | { readonly type: "requestOpened"; readonly request: ThreadRequest }
   | { readonly type: "requestClosed"; readonly requestId: string }
+  /** The provider's word on the session's settings (see the header). */
+  | { readonly type: "settings"; readonly settings: ProviderSettings }
 
 /** Correlation handle for exactly one turn — interrupt targets this turn. */
 export interface AgentTurn {
@@ -238,14 +270,18 @@ export interface AgentConnection {
    */
   readonly events: Stream.Stream<AgentEvent, AgentProtocolError>
   /**
-   * Start exactly one turn with user input. Fails with `AgentConflict`
-   * while another turn is active on this connection; completion arrives on
-   * the feed as `turnCompleted`. A provider whose resume verification is
-   * deferred (Claude) completes it here on the connection's first turn, so
-   * `AgentResumeFailed` / `AgentIdentityMismatch` can surface fail-closed.
+   * Start exactly one turn with user input, running with `settings`: the
+   * adapter pushes whatever differs from the live session's own values
+   * before the input goes out (nothing when nothing changed). Fails with
+   * `AgentConflict` while another turn is active on this connection;
+   * completion arrives on the feed as `turnCompleted`. A provider whose
+   * resume verification is deferred (Claude) completes it here on the
+   * connection's first turn, so `AgentResumeFailed` /
+   * `AgentIdentityMismatch` can surface fail-closed.
    */
   readonly startTurn: (
     input: string,
+    settings: ThreadSettings,
   ) => Effect.Effect<
     AgentTurn,
     | AgentConflict
@@ -340,6 +376,7 @@ export interface AgentAdapter {
   readonly createSession: (options: {
     readonly cwd: string
     readonly input: string
+    readonly settings: ThreadSettings
   }) => Effect.Effect<
     AgentSessionStart,
     AgentUnavailable | AgentConflict | AgentIdentityMismatch | AgentProtocolError,
@@ -352,11 +389,16 @@ export interface AgentAdapter {
    * evidence available: Codex verifies here (thread/resume echoes identity);
    * the Claude SDK emits no identity evidence until a turn starts (probed
    * 2026-08-03), so its verification completes — still fail-closed — at the
-   * connection's first `startTurn`.
+   * connection's first `startTurn`. `settings` are what the connection is
+   * opened with: a one-process provider (Claude) spawns its child with them
+   * so the first turn pushes nothing; a shared-server provider (Codex) reads
+   * its baseline from the resume reply instead and lets the first turn push
+   * the difference — the resume itself never reconfigures a session.
    */
   readonly resumeSession: (options: {
     readonly providerSessionId: string
     readonly cwd: string
+    readonly settings: ThreadSettings
   }) => Effect.Effect<
     AgentConnection,
     | AgentUnavailable
@@ -408,6 +450,17 @@ export interface AgentAdapter {
     readonly providerSessionId: string
     readonly providerMetadata: string | undefined
   }) => Effect.Effect<Stream.Stream<AgentSessionEvent>, AgentUnavailable, Scope.Scope>
+  /**
+   * The provider's model catalog (ATC-205), normalized: `value` is the id
+   * ThreadSettings.model stores and the adapter sends back to the provider;
+   * every entry names a real model (Claude's `default` meta-entry is folded
+   * into the alias it resolves to). Never a persisted session; the caller
+   * caches it.
+   */
+  readonly listModels: () => Effect.Effect<
+    ReadonlyArray<AgentModel>,
+    AgentUnavailable | AgentProtocolError
+  >
   /**
    * One bounded, session-less completion: a short display title for a
    * thread whose first user prompt is `prompt` (ATC-155). Runs as the
@@ -858,19 +911,37 @@ export const versionIsOlder = (installed: string, tested: string): boolean => {
 }
 
 /**
+ * Memoize one effect's success for `ttl`, safely under concurrency (the
+ * version gate and the model catalogs use it). NOT plain Effect.cached: the
+ * cache memoizes whatever exit its driving fiber produces, interruption and
+ * failure included, so a dropped request driving the first run would poison
+ * every later caller for the process, and a provider that was down once
+ * would stay "down" until the TTL. Instead the memo is invalidated when its
+ * driver fails or is interrupted, and the semaphore keeps callers out of the
+ * cache's waiter path (a waiter racing an invalidate would replay a cleared
+ * exit).
+ */
+export const memoizeSuccess = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+  ttl: Duration.Input,
+): Effect.Effect<Effect.Effect<A, E, R>> =>
+  Effect.gen(function* () {
+    const lock = yield* Semaphore.make(1)
+    const [cached, invalidate] = yield* Effect.cachedInvalidateWithTTL(effect, ttl)
+    return lock.withPermits(1)(
+      Effect.onInterrupt(cached, () => invalidate).pipe(Effect.tapError(() => invalidate)),
+    )
+  })
+
+/**
  * The shared version-drift rule (record + warn, never block), memoized to
- * one single-flight check per adapter: resolve the configured executable,
- * read the installed version via `--version`, and log one actionable
- * warning when it is below the floor the adapter was validated against.
- * Warn-only: a missing executable never fails the gate — every call site
- * resolves or spawns the executable itself and reports the actionable
- * diagnostic there — and a memoized failure would pin "unavailable" past a
- * mid-session install. NOT plain Effect.cached: the cache memoizes whatever
- * exit its driving fiber produces, interruption included, so a dropped
- * request driving the first check would poison every later caller for the
- * process. Instead the memo is invalidated when its driver is interrupted,
- * and the semaphore keeps callers out of the cache's waiter path (a waiter
- * racing an invalidate would replay a cleared exit).
+ * one single-flight check per adapter (`memoizeSuccess`): resolve the
+ * configured executable, read the installed version via `--version`, and log
+ * one actionable warning when it is below the floor the adapter was
+ * validated against. Warn-only: a missing executable never fails the gate —
+ * every call site resolves or spawns the executable itself and reports the
+ * actionable diagnostic there — and a memoized failure would pin
+ * "unavailable" past a mid-session install.
  */
 export const makeVersionGate = (
   subprocess: Subprocess["Service"],
@@ -879,7 +950,6 @@ export const makeVersionGate = (
   testedVersion: string,
 ): Effect.Effect<Effect.Effect<void>> =>
   Effect.gen(function* () {
-    const lock = yield* Semaphore.make(1)
     const check = Effect.gen(function* () {
       const executable = yield* resolveProviderExecutable(provider, configured)
       const installed = yield* readInstalledVersion(subprocess, executable)
@@ -894,6 +964,5 @@ export const makeVersionGate = (
         )
       }
     }).pipe(Effect.catchTag("AgentUnavailable", () => Effect.void))
-    const [cached, invalidate] = yield* Effect.cachedInvalidateWithTTL(check, Duration.infinity)
-    return lock.withPermits(1)(Effect.onInterrupt(cached, () => invalidate))
+    return yield* memoizeSuccess(check, Duration.infinity)
   })

--- a/app-server/src/agents/agentDefaultsRepository.ts
+++ b/app-server/src/agents/agentDefaultsRepository.ts
@@ -1,0 +1,71 @@
+import { Context, Effect, Layer, Option, Schema } from "effect"
+import { SqlClient, SqlSchema } from "effect/unstable/sql"
+import { rowHelpers } from "../platform/repositoryHelpers.ts"
+import { settingsFromColumns, settingsToColumns } from "../threads/threadSettings.ts"
+import type { ThreadSettings } from "../threads/threadSettings.ts"
+
+// The per-agent write-through defaults (ATC-205): the only module that
+// speaks SQL for `agent_defaults`. One row per agent id, holding the settings
+// the last changed thread of that agent ended up with — what a new thread
+// inherits. There is no editor and no write endpoint; the Threads domain
+// writes it whenever a thread's settings change, and reads it on create.
+// Rows are decoded permissively (settingsFromColumns), so a row a newer
+// build wrote never bricks reads.
+
+const DefaultsRow = Schema.Struct({
+  agent_id: Schema.String,
+  model: Schema.String,
+  reasoning: Schema.NullOr(Schema.String),
+  mode: Schema.String,
+  access: Schema.String,
+  updated_at: Schema.String,
+})
+
+export class AgentDefaultsRepository extends Context.Service<
+  AgentDefaultsRepository,
+  {
+    readonly get: (agentId: string) => Effect.Effect<Option.Option<ThreadSettings>>
+    /** Upsert the agent's row. */
+    readonly set: (agentId: string, settings: ThreadSettings) => Effect.Effect<void>
+  }
+>()("app-server/AgentDefaultsRepository") {}
+
+// Database failures are defects, not domain errors (see threadRepository.ts).
+export const layer = Layer.effect(AgentDefaultsRepository)(
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+
+    const getRows = SqlSchema.findAll({
+      Request: Schema.String,
+      Result: DefaultsRow,
+      execute: (agentId) => sql`SELECT * FROM agent_defaults WHERE agent_id = ${agentId}`,
+    })
+
+    const upsertRow = SqlSchema.void({
+      Request: DefaultsRow,
+      execute: (row) => sql`
+        INSERT INTO agent_defaults ${sql.insert(row)}
+        ON CONFLICT (agent_id) DO UPDATE SET
+          model = excluded.model,
+          reasoning = excluded.reasoning,
+          mode = excluded.mode,
+          access = excluded.access,
+          updated_at = excluded.updated_at
+      `,
+    })
+
+    const { firstRecord } = rowHelpers("agent defaults", settingsFromColumns)
+
+    return {
+      get: (agentId) => getRows(agentId).pipe(Effect.map(firstRecord), Effect.orDie),
+      set: (agentId, settings) =>
+        Effect.suspend(() =>
+          upsertRow({
+            agent_id: agentId,
+            ...settingsToColumns(settings),
+            updated_at: new Date().toISOString(),
+          }),
+        ).pipe(Effect.orDie),
+    }
+  }),
+)

--- a/app-server/src/agents/agentRegistry.ts
+++ b/app-server/src/agents/agentRegistry.ts
@@ -1,27 +1,41 @@
-import { Context, Effect, Layer } from "effect"
-import { AGENT_IDS, AgentNotFound, isAgentId } from "../api/contract.ts"
+import { Context, Duration, Effect, Layer, Option } from "effect"
+import { AGENT_IDS, AgentNotFound, isAgentId, ProviderUnavailable } from "../api/contract.ts"
 import type * as Contract from "../api/contract.ts"
 import type { AgentId } from "../api/contract.ts"
 import { AppConfig } from "../platform/config.ts"
 import * as Subprocess from "../platform/subprocess.ts"
-import type { AgentAdapter } from "./agentAdapter.ts"
+import type { AgentAdapter, AgentModel, ThreadSettings } from "./agentAdapter.ts"
 import {
+  memoizeSuccess,
   PROVIDER_FOR_AGENT,
   readInstalledVersion,
   resolveProviderExecutable,
 } from "./agentAdapter.ts"
+import { AgentDefaultsRepository } from "./agentDefaultsRepository.ts"
 import { ClaudeAdapter } from "./claudeAdapter.ts"
 import { CodexAdapter } from "./codexAdapter.ts"
 
 export type Agent = typeof Contract.Agent.Type
 
-// The read-only built-in agent registry (ATC-124): the one place the public
-// agent slugs meet the provider adapters. Availability and versions are
-// detected on demand — nothing persisted, no migration. Adding an agent is
-// one new adapter layer (wired in server.ts) plus registry entries: the
-// contract's AgentId literal, PROVIDER_FOR_AGENT in agentAdapter.ts, and
-// the table here — the Record types make a missed entry a compile error,
-// and threads/ never changes.
+// The built-in agent registry (ATC-124): the one place the public agent
+// slugs meet the provider adapters. Availability and versions are detected
+// on demand — nothing persisted. Adding an agent is one new adapter layer
+// (wired in server.ts) plus registry entries: the contract's AgentId
+// literal, PROVIDER_FOR_AGENT in agentAdapter.ts, and the table here — the
+// Record types make a missed entry a compile error, and threads/ never
+// changes.
+//
+// It also owns the two per-agent facts the Chat settings need (ATC-205):
+//   - the model catalog, read from the adapter and cached for a short while
+//     (Claude's read spawns a process; Codex's is a socket call) — a failed
+//     read is never cached, so a provider that comes up later is seen;
+//   - the write-through defaults a new thread inherits: the agent_defaults
+//     row when one exists, else the entry's seed here. The seed is a
+//     starting point only (the first change any thread makes replaces it);
+//     it moves with the adapters' tested versions, like their title models.
+
+/** How long one catalog read is served before the provider is asked again. */
+const MODEL_CATALOG_TTL: Duration.Input = "10 minutes"
 
 export class AgentRegistry extends Context.Service<
   AgentRegistry,
@@ -30,6 +44,14 @@ export class AgentRegistry extends Context.Service<
     readonly get: (id: string) => Effect.Effect<Agent, AgentNotFound>
     /** The adapter behind a public slug — the domain's only door to providers. */
     readonly adapterFor: (id: typeof AgentId.Type) => AgentAdapter
+    /** The agent's model catalog (cached; see the header). */
+    readonly models: (
+      id: string,
+    ) => Effect.Effect<ReadonlyArray<AgentModel>, AgentNotFound | ProviderUnavailable>
+    /** What a new thread of this agent starts with (see the header). */
+    readonly defaults: (id: typeof AgentId.Type) => Effect.Effect<ThreadSettings>
+    /** Write-through: the settings the last changed thread ended up with. */
+    readonly setDefaults: (id: typeof AgentId.Type, settings: ThreadSettings) => Effect.Effect<void>
   }
 >()("app-server/AgentRegistry") {}
 
@@ -37,40 +59,78 @@ export const layer = Layer.effect(AgentRegistry)(
   Effect.gen(function* () {
     const config = yield* AppConfig
     const subprocess = yield* Subprocess.Subprocess
+    const defaultsRepository = yield* AgentDefaultsRepository
     const codex = yield* CodexAdapter
     const claude = yield* ClaudeAdapter
 
     // The one registry table: adding an agent adds one entry here.
     const entries: Record<
       typeof AgentId.Type,
-      { readonly adapter: AgentAdapter; readonly executable: string }
+      {
+        readonly adapter: AgentAdapter
+        readonly executable: string
+        readonly seed: ThreadSettings
+      }
     > = {
-      codex: { adapter: codex, executable: config.codexExecutable },
-      "claude-code": { adapter: claude, executable: config.claudeExecutable },
+      codex: {
+        adapter: codex,
+        executable: config.codexExecutable,
+        seed: { model: "gpt-5.6-sol", reasoning: "high", mode: "chat", access: "auto" },
+      },
+      "claude-code": {
+        adapter: claude,
+        executable: config.claudeExecutable,
+        seed: { model: "opus[1m]", reasoning: "high", mode: "chat", access: "auto" },
+      },
     }
 
-    const describe = (id: typeof AgentId.Type): Effect.Effect<Agent> => {
-      const { executable } = entries[id]
-      return resolveProviderExecutable(PROVIDER_FOR_AGENT[id], executable).pipe(
-        Effect.flatMap((executable) =>
-          readInstalledVersion(subprocess, executable).pipe(
-            Effect.map((detected) => ({
-              id,
-              available: true,
-              ...(detected !== null ? { detectedVersion: detected } : {}),
-            })),
+    const defaults = (id: typeof AgentId.Type): Effect.Effect<ThreadSettings> =>
+      defaultsRepository.get(id).pipe(Effect.map(Option.getOrElse(() => entries[id].seed)))
+
+    // One memoized catalog read per agent (memoizeSuccess: a failed read
+    // is never served to later callers).
+    const catalogs = yield* Effect.forEach(AGENT_IDS, (id) =>
+      memoizeSuccess(
+        entries[id].adapter
+          .listModels()
+          .pipe(
+            Effect.mapError(
+              (error) => new ProviderUnavailable({ agentId: id, reason: error.message }),
+            ),
           ),
-        ),
-        Effect.catchTag("AgentUnavailable", (error) =>
-          Effect.succeed({ id, available: false, reason: error.reason }),
-        ),
-      )
-    }
+        MODEL_CATALOG_TTL,
+      ).pipe(Effect.map((models) => [id, models] as const)),
+    ).pipe(Effect.map((pairs) => new Map(pairs)))
+
+    const describe = (id: typeof AgentId.Type): Effect.Effect<Agent> =>
+      Effect.gen(function* () {
+        const availability: Omit<Agent, "id" | "defaults"> = yield* resolveProviderExecutable(
+          PROVIDER_FOR_AGENT[id],
+          entries[id].executable,
+        ).pipe(
+          Effect.flatMap((executable) =>
+            readInstalledVersion(subprocess, executable).pipe(
+              Effect.map((detected) => ({
+                available: true,
+                ...(detected !== null ? { detectedVersion: detected } : {}),
+              })),
+            ),
+          ),
+          Effect.catchTag("AgentUnavailable", (error) =>
+            Effect.succeed({ available: false, reason: error.reason }),
+          ),
+        )
+        return { id, ...availability, defaults: yield* defaults(id) }
+      })
 
     return {
       list: () => Effect.forEach(AGENT_IDS, describe),
       get: (id) => (isAgentId(id) ? describe(id) : Effect.fail(new AgentNotFound({ agentId: id }))),
       adapterFor: (id) => entries[id].adapter,
+      models: (id) =>
+        isAgentId(id) ? catalogs.get(id)! : Effect.fail(new AgentNotFound({ agentId: id })),
+      defaults,
+      setDefaults: (id, settings) => defaultsRepository.set(id, settings),
     }
   }),
 )

--- a/app-server/src/agents/claudeAdapter.ts
+++ b/app-server/src/agents/claudeAdapter.ts
@@ -1,8 +1,11 @@
 import type {
   CanUseTool,
+  EffortLevel,
   HookCallbackMatcher,
   HookEvent,
+  ModelInfo,
   Options,
+  PermissionMode,
   PermissionResult,
   PermissionUpdate,
   SDKMessage,
@@ -30,12 +33,16 @@ import type {
   AgentConnection,
   AgentEvent,
   AgentIdentityMismatch,
+  AgentModel,
   AgentProtocolError,
   AgentSessionEvent,
   AgentUnavailable,
   HistoryTurn,
+  ProviderSettings,
+  ThreadAccess,
   ThreadItem,
   ThreadRequest,
+  ThreadSettings,
 } from "./agentAdapter.ts"
 import {
   AgentResumeFailed,
@@ -51,6 +58,7 @@ import {
   withToolStatus,
 } from "./agentAdapter.ts"
 import * as path from "node:path"
+import { isReasoningLevel } from "../api/contract.ts"
 import * as ClaudeHooks from "./claudeHooks.ts"
 import * as ClaudeItems from "./claudeItems.ts"
 import { AppConfig } from "../platform/config.ts"
@@ -136,6 +144,28 @@ import * as Subprocess from "../platform/subprocess.ts"
 //     TUI's submitted prompt as an observed `userMessage` item (the seam's
 //     one hooks-carried item), so a Chat reader shows what the TUI is
 //     working on before the turn's re-read lands.
+//   - Settings (ATC-205): a fresh child is spawned with the caller's model,
+//     effort, and permission mode, so its first turn pushes nothing; later
+//     turns on the resident connection push only what changed, through the
+//     live control requests (`setModel`, `applyFlagSettings({effortLevel})`,
+//     `setPermissionMode`) before the input goes out. The ladder is ONE knob
+//     here — Supervised `default`, Auto-accept edits `acceptEdits`, Auto
+//     `auto` (the classifier mode: works within the workspace unasked and
+//     still routes borderline calls to canUseTool; `dontAsk` denies every
+//     unlisted tool outright, probed 2026-08-18), Full access
+//     `bypassPermissions` — and Plan mode is `permissionMode: "plan"`, which
+//     stands in for the access rung while planning. The child is always
+//     spawned with `allowDangerouslySkipPermissions` so Full access can be
+//     switched to mid-session; the mode itself is only ever what the caller
+//     asked for. Every `system/init` (one per turn) reports the model and
+//     permission mode the child actually applied — a model without auto
+//     support silently runs `default` — and `getSettings().applied.effort`
+//     the effort; both come back as the seam's `settings` event, the model
+//     mapped through the child's own catalog to the alias the catalog lists
+//     (init reports the wire id: `sonnet` → `claude-sonnet-5`). getSettings
+//     is undeclared on the SDK's Query type (0.3.235) but real: it is reached
+//     through a narrow local interface and schema-decoded; a decode failure
+//     keeps the caller's stored effort and warns once.
 
 /** The Claude Code version this adapter was validated against. */
 const CLAUDE_TESTED_VERSION = "2.1.235"
@@ -144,11 +174,128 @@ export class ClaudeAdapter extends Context.Service<ClaudeAdapter, AgentAdapter>(
   "app-server/ClaudeAdapter",
 ) {}
 
+/** The held query() handle: the message stream plus the control requests this adapter uses. */
+export interface ClaudeQueryHandle extends AsyncIterable<SDKMessage> {
+  readonly interrupt: () => Promise<unknown>
+  readonly setModel: (model?: string) => Promise<void>
+  readonly setPermissionMode: (mode: PermissionMode) => Promise<void>
+  readonly applyFlagSettings: (settings: { effortLevel?: EffortLevel | null }) => Promise<void>
+  readonly supportedModels: () => Promise<ReadonlyArray<ModelInfo>>
+}
+
 /** The query() seam, injectable so fixture tests can script SDK streams. */
 export type ClaudeQueryFn = (args: {
   readonly prompt: AsyncIterable<SDKUserMessage>
   readonly options: Options
-}) => AsyncIterable<SDKMessage> & { readonly interrupt: () => Promise<unknown> }
+}) => ClaudeQueryHandle
+
+// getSettings() exists at runtime but is absent from the declared Query
+// interface (see the header): reached through this narrow shape only.
+interface SettingsProbe {
+  readonly getSettings: () => Promise<unknown>
+}
+const settingsProbe = (handle: object): SettingsProbe | null =>
+  typeof (handle as Partial<SettingsProbe>).getSettings === "function"
+    ? (handle as SettingsProbe)
+    : null
+const AppliedSettings = Schema.Struct({
+  applied: Schema.Struct({ effort: Schema.optional(Schema.NullOr(Schema.String)) }),
+})
+const decodeAppliedSettings = Schema.decodeUnknownOption(AppliedSettings)
+
+// --- The access ladder, both directions (see the header) ---------------------
+
+const ACCESS_TO_PERMISSION_MODE: Record<ThreadAccess, PermissionMode> = {
+  supervised: "default",
+  autoAcceptEdits: "acceptEdits",
+  auto: "auto",
+  fullAccess: "bypassPermissions",
+}
+
+/** The permission mode a turn runs with: plan mode stands in for the rung. */
+const permissionModeFor = (settings: ThreadSettings): PermissionMode =>
+  settings.mode === "plan" ? "plan" : ACCESS_TO_PERMISSION_MODE[settings.access]
+
+/**
+ * The reverse read of a reported permission mode: `plan` is the mode (the
+ * rung is untouched); `dontAsk` — never asks — is nearest Auto; anything
+ * unrecognized reports nothing.
+ */
+const settingsFromPermissionMode = (mode: unknown): ProviderSettings => {
+  if (mode === "plan") return { mode: "plan" }
+  const access =
+    mode === "default"
+      ? "supervised"
+      : mode === "acceptEdits"
+        ? "autoAcceptEdits"
+        : mode === "auto" || mode === "dontAsk"
+          ? "auto"
+          : mode === "bypassPermissions"
+            ? "fullAccess"
+            : undefined
+  return access === undefined ? {} : { mode: "chat", access }
+}
+
+/** Claude's own effort vocabulary (no `ultra`); anything else is not pushed. */
+const CLAUDE_EFFORTS: ReadonlyArray<EffortLevel> = ["low", "medium", "high", "xhigh", "max"]
+const claudeEffort = (level: string | undefined): EffortLevel | undefined =>
+  CLAUDE_EFFORTS.find((candidate) => candidate === level)
+
+/**
+ * The CLI names models by family alone ("Opus (1M context)", "Fable"); the
+ * version lives in the wire id (`claude-opus-5[1m]`, `claude-haiku-4-5-20251001`).
+ * Fold it back in after the family word — "Opus 5 (1M context)", "Haiku
+ * 4.5" — and leave a name the id does not explain untouched.
+ */
+export const claudeDisplayName = (displayName: string, wireModel: string): string => {
+  const match = /^claude-([a-z]+)-(\d+)(?:-(\d+))?(?:-\d{8})?(?:\[1m\])?$/.exec(wireModel)
+  const family = match?.[1]
+  const major = match?.[2]
+  if (family === undefined || major === undefined) return displayName
+  const minor = match?.[3]
+  const version = minor === undefined ? major : `${major}.${minor}`
+  const prefix = new RegExp(`^${family}(?![a-z])`, "i")
+  if (!prefix.test(displayName) || displayName.includes(version)) return displayName
+  return displayName.replace(prefix, (word) => `${word} ${version}`)
+}
+
+/**
+ * The catalog as the seam lists it: the `default` meta-entry is folded into
+ * the alias it resolves to (that alias becomes the default), so every entry
+ * names a real model and the stored value round-trips.
+ */
+export const normalizeClaudeCatalog = (
+  models: ReadonlyArray<ModelInfo>,
+): ReadonlyArray<AgentModel> => {
+  const meta = models.find((model) => model.value === "default")
+  const defaultWire = meta?.resolvedModel ?? meta?.value
+  return models
+    .filter((model) => model.value !== "default")
+    .map((model) => {
+      const levels = (
+        model.supportsEffort === true ? (model.supportedEffortLevels ?? []) : []
+      ).filter(isReasoningLevel)
+      const entry: { -readonly [K in keyof AgentModel]: AgentModel[K] } = {
+        value: model.value,
+        displayName: claudeDisplayName(model.displayName, model.resolvedModel ?? model.value),
+        description: model.description,
+        isDefault:
+          defaultWire !== undefined && (model.resolvedModel ?? model.value) === defaultWire,
+        supportedEffortLevels: levels,
+      }
+      // The CLI applies `high` unless told otherwise (probed 2026-08-18),
+      // clamped to what this model lists.
+      const preferred = levels.includes("high") ? "high" : levels[0]
+      if (preferred !== undefined) entry.defaultEffortLevel = preferred
+      return entry
+    })
+}
+
+/** The catalog value for a wire model id init reported (else the id itself). */
+const catalogValueFor = (models: ReadonlyArray<ModelInfo>, wireModel: string): string =>
+  models.find(
+    (model) => model.value !== "default" && (model.resolvedModel ?? model.value) === wireModel,
+  )?.value ?? wireModel
 
 export interface ClaudeAdapterOptions {
   readonly queryFn?: ClaudeQueryFn
@@ -296,6 +443,12 @@ interface StreamingMessage {
   readonly blocks: Map<number, ThreadItem>
 }
 
+/** What one system/init said about the child's applied settings. */
+interface InitEvidence {
+  readonly model: string
+  readonly permissionMode: unknown
+}
+
 interface LiveSession {
   /** The id resume promised (null for create — any id is acceptable). */
   readonly expectedSessionId: string | null
@@ -307,7 +460,13 @@ interface LiveSession {
   readonly pushInput: (text: string) => void
   readonly closeInput: () => void
   readonly initGate: Deferred.Deferred<void, GateError>
-  interrupt: () => Promise<unknown>
+  /** The held query() handle, once opened (control requests, interrupt). */
+  handle: ClaudeQueryHandle | null
+  /** Each init's model/permission evidence, drained by the probe fiber. */
+  readonly probes: Queue.Queue<InitEvidence, Cause.Done>
+  /** The settings baseline: what the child runs with — spawned with, last
+   * pushed, or last reported by init. */
+  live: ProviderSettings
   sessionId: string | null
   activity: AgentActivity
   activeTurn: string | null
@@ -425,6 +584,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
           Queue.endUnsafe(session.queue)
         }
         session.closeInput()
+        Queue.endUnsafe(session.probes)
         session.abort.abort()
       }
 
@@ -608,6 +768,10 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
           session.sessionId = message.session_id
           if (!sessions.has(message.session_id)) sessions.set(message.session_id, session)
           Deferred.doneUnsafe(session.initGate, Effect.void)
+          Queue.offerUnsafe(session.probes, {
+            model: message.model,
+            permissionMode: message.permissionMode,
+          })
           return
         }
         if (message.type === "system" && message.subtype === "session_state_changed") {
@@ -866,7 +1030,11 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
           return { secret, settingsFile }
         })
 
-      const openSession = (options: { readonly cwd: string; readonly resume?: string }) =>
+      const openSession = (options: {
+        readonly cwd: string
+        readonly resume?: string
+        readonly settings: ThreadSettings
+      }) =>
         Effect.gen(function* () {
           const executable = yield* resolvedExecutable
           // The held query() drains this queue as its async input iterable;
@@ -882,6 +1050,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
             capacity: 256,
           })
           const initGate = yield* Deferred.make<void, GateError>()
+          const probes = yield* Queue.make<InitEvidence, Cause.Done>()
           const session: LiveSession = {
             expectedSessionId: options.resume ?? null,
             cwd: options.cwd,
@@ -895,7 +1064,14 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
               Queue.endUnsafe(inputQueue)
             },
             initGate,
-            interrupt: () => Promise.resolve(),
+            handle: null,
+            probes,
+            live: {
+              model: options.settings.model,
+              reasoning: options.settings.reasoning ?? null,
+              mode: options.settings.mode,
+              access: options.settings.access,
+            },
             sessionId: null,
             activity: "unknown",
             activeTurn: null,
@@ -929,6 +1105,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
           if (claim !== "claimed") {
             return yield* Effect.fail(writerConnected(claim.conflict))
           }
+          const effort = claudeEffort(options.settings.reasoning)
           const handle = queryFn({
             prompt: yield* Stream.toAsyncIterableEffect(Stream.fromQueue(inputQueue)),
             options: {
@@ -938,16 +1115,115 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
               pathToClaudeCodeExecutable: executable,
               ...(options.resume !== undefined ? { resume: options.resume } : {}),
               settingSources: [],
-              permissionMode: "default",
+              model: options.settings.model,
+              ...(effort !== undefined ? { effort } : {}),
+              permissionMode: permissionModeFor(options.settings),
+              allowDangerouslySkipPermissions: true,
               persistSession: true,
               includePartialMessages: true,
               canUseTool: makeCanUseTool(session),
               hooks: makeHooks(session),
             },
           })
-          session.interrupt = () => handle.interrupt()
+          session.handle = handle
           yield* consume(session, handle).pipe(Effect.forkScoped)
+          yield* Stream.fromQueue(probes).pipe(
+            Stream.runForEach((init) => reportApplied(session, init)),
+            Effect.forkScoped,
+          )
           return session
+        })
+
+      /**
+       * Push what differs between the caller's settings and the child's
+       * baseline (the header's settings bullet), each through its live
+       * control request; the baseline moves as each lands.
+       */
+      const pushSettings = (
+        session: LiveSession,
+        settings: ThreadSettings,
+      ): Effect.Effect<void, AgentProtocolError> =>
+        Effect.gen(function* () {
+          const handle = session.handle
+          if (handle === null) return
+          const control = (what: string, run: () => Promise<void>) =>
+            Effect.tryPromise({
+              try: run,
+              catch: (error) =>
+                protocolError(
+                  `${what} failed: ${error instanceof Error ? error.message : String(error)}`,
+                ),
+            })
+          if (session.live.model !== settings.model) {
+            yield* control("setModel", () => handle.setModel(settings.model))
+            session.live = { ...session.live, model: settings.model }
+          }
+          // A model with no effort support carries no reasoning: the flag
+          // layer is cleared rather than left holding the previous model's.
+          const effort = claudeEffort(settings.reasoning) ?? null
+          if (session.live.reasoning !== effort) {
+            yield* control("applyFlagSettings", () =>
+              handle.applyFlagSettings({ effortLevel: effort }),
+            )
+            session.live = { ...session.live, reasoning: effort }
+          }
+          const wanted = permissionModeFor(settings)
+          const current =
+            session.live.mode === "plan"
+              ? "plan"
+              : session.live.access === undefined
+                ? undefined
+                : ACCESS_TO_PERMISSION_MODE[session.live.access]
+          if (current !== wanted) {
+            yield* control("setPermissionMode", () => handle.setPermissionMode(wanted))
+            session.live = { ...session.live, mode: settings.mode, access: settings.access }
+          }
+        })
+
+      /**
+       * What the child actually applied, read at each init (the header's
+       * settings bullet): the catalog maps the wire model id back to the
+       * listed alias, and getSettings — reached through its narrow probe —
+       * says the effort. Runs on the session's probe fiber (openSession),
+       * never on the message loop; a session that closed meanwhile reports
+       * nothing.
+       */
+      let warnedSettingsProbe = false
+      const reportApplied = (session: LiveSession, init: InitEvidence): Effect.Effect<void> =>
+        Effect.gen(function* () {
+          const handle = session.handle
+          if (handle === null) return
+          const probe = settingsProbe(handle)
+          const models = yield* Effect.promise(() =>
+            handle.supportedModels().catch(() => [] as ReadonlyArray<ModelInfo>),
+          )
+          const applied =
+            probe === null
+              ? undefined
+              : yield* Effect.promise(() => probe.getSettings().catch(() => undefined))
+          if (session.closed) return
+          const effort = decodeAppliedSettings(applied).pipe(
+            Option.map((decoded) => decoded.applied.effort ?? null),
+            Option.getOrUndefined,
+          )
+          if (effort === undefined && !warnedSettingsProbe) {
+            warnedSettingsProbe = true
+            yield* Effect.logWarning(
+              "claude getSettings() gave no decodable effort; keeping the stored reasoning level (re-verify the SDK's undeclared getSettings after an upgrade)",
+            )
+          }
+          // Without the catalog the wire id cannot be mapped back to a
+          // listed value, and adopting it raw would replace the stored alias
+          // with an id nothing else recognizes — so the model goes unreported.
+          const reported: ProviderSettings = {
+            ...(models.length === 0 ? {} : { model: catalogValueFor(models, init.model) }),
+            ...settingsFromPermissionMode(init.permissionMode),
+            ...(effort === undefined
+              ? {}
+              : { reasoning: effort !== null && isReasoningLevel(effort) ? effort : null }),
+          }
+          session.live = { ...session.live, ...reported }
+          emit(session, { type: "settings", settings: reported })
         })
 
       const awaitVerified = (session: LiveSession) =>
@@ -1048,8 +1324,15 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
           cwd: session.cwd,
           activity: Effect.sync(() => session.activity),
           events: Stream.fromQueue(session.queue),
-          startTurn: (text) =>
+          startTurn: (text, settings) =>
             Effect.gen(function* () {
+              yield* requireOpen
+              if (session.activeTurn !== null) {
+                return yield* Effect.fail(turnStillActive(session.activeTurn))
+              }
+              yield* pushSettings(session, settings)
+              // The pushes suspended: the seam's one-turn rule is re-checked
+              // before the input goes out.
               yield* requireOpen
               if (session.activeTurn !== null) {
                 return yield* Effect.fail(turnStillActive(session.activeTurn))
@@ -1076,7 +1359,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
               }
               session.interruptRequested = true
               yield* Effect.tryPromise({
-                try: () => session.interrupt(),
+                try: () => session.handle?.interrupt() ?? Promise.resolve(),
                 catch: (error) => protocolError(`interrupt failed: ${error}`),
               }).pipe(
                 // A failed interrupt must not relabel the turn's real
@@ -1126,7 +1409,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
         sharedServer: false,
         createSession: (options) =>
           Effect.gen(function* () {
-            const session = yield* openSession({ cwd: options.cwd })
+            const session = yield* openSession({ cwd: options.cwd, settings: options.settings })
             const turnId = beginTurn(session, options.input)
             // A create has no expected id, so AgentResumeFailed cannot
             // happen here — same rule as the codex adapter.
@@ -1140,6 +1423,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
             const session = yield* openSession({
               cwd: options.cwd,
               resume: options.providerSessionId,
+              settings: options.settings,
             })
             return makeConnection(session)
           }),
@@ -1244,6 +1528,50 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
             })
             return Stream.fromQueue(queue)
           }),
+        // The catalog is the CLI's initialize response: one child, no
+        // prompt ever sent, aborted as soon as it has answered.
+        listModels: () =>
+          Effect.scoped(
+            Effect.gen(function* () {
+              const executable = yield* resolvedExecutable
+              const abort = new AbortController()
+              yield* Effect.addFinalizer(() => Effect.sync(() => abort.abort()))
+              const prompt = yield* Stream.toAsyncIterableEffect(Stream.never)
+              const handle = yield* Effect.try({
+                try: () =>
+                  queryFn({
+                    prompt,
+                    options: {
+                      abortController: abort,
+                      cwd: config.stateDir,
+                      env: claudeEnvironment(),
+                      pathToClaudeCodeExecutable: executable,
+                      settingSources: [],
+                      strictMcpConfig: true,
+                      tools: [],
+                      persistSession: false,
+                    },
+                  }),
+                catch: (error) =>
+                  protocolError(
+                    `the model catalog read failed to start: ${error instanceof Error ? error.message : String(error)}`,
+                  ),
+              })
+              const models = yield* Effect.tryPromise({
+                try: () => handle.supportedModels(),
+                catch: (error) =>
+                  protocolError(
+                    `the model catalog read failed: ${error instanceof Error ? error.message : String(error)}`,
+                  ),
+              }).pipe(
+                Effect.timeoutOrElse({
+                  duration: "30 seconds",
+                  orElse: () => Effect.fail(protocolError("the model catalog read timed out")),
+                }),
+              )
+              return normalizeClaudeCatalog(models)
+            }),
+          ),
         generateTitle: (options) =>
           Effect.scoped(
             Effect.gen(function* () {

--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -23,12 +23,16 @@ import type {
   AgentEvent,
   AgentIdentityMismatch,
   AgentItemEvent,
+  AgentModel,
   AgentProtocolError,
   AgentSessionEvent,
   AgentUnavailable,
   EstablishedIdentity,
+  ProviderSettings,
+  ThreadAccess,
   ThreadItem,
   ThreadRequest,
+  ThreadSettings,
 } from "./agentAdapter.ts"
 import {
   AgentResumeFailed,
@@ -46,6 +50,7 @@ import {
   withTitleTimeout,
   withToolStatus,
 } from "./agentAdapter.ts"
+import { isReasoningLevel } from "../api/contract.ts"
 import * as BuildInfo from "../platform/buildInfo.ts"
 import * as CodexItems from "./codexItems.ts"
 import * as CodexServer from "./codexServer.ts"
@@ -94,6 +99,21 @@ import * as UnixWebSocket from "../platform/unixWebSocket.ts"
 //     checkSession reconciles demand-driven via thread/loaded/list +
 //     per-id thread/read. Descendant bookkeeping is in-memory and pruned
 //     on teardown, root unobserve/unregister, and release.
+//   - Settings (ATC-205) ride `turn/start` as overrides, which the protocol
+//     keeps "for this turn and subsequent turns": model, effort,
+//     approvalPolicy, and sandboxPolicy go out only when they differ from
+//     what the session's `thread/start` / `thread/resume` reply echoed (the
+//     live baseline), so an unchanged turn carries none. Two things always
+//     ride: `approvalsReviewer: "user"` (omitting it keeps a previous
+//     reviewer sticky) and `collaborationMode` (the reply echoes no mode,
+//     so the caller's chat/plan is asserted every turn; the mode's
+//     model/effort mirror the turn's). The access ladder is two knobs here
+//     — Supervised is `untrusted` + `read-only` (workspace-write never asks
+//     before edits), Full access is `never` + `danger-full-access` — and
+//     the reverse read projects any (approvalPolicy, sandbox) pair onto the
+//     nearest rung. `thread/settings/updated` (a change made in the TUI or
+//     another client) reaches the thread's writer feed and its observers as
+//     the seam's `settings` event; the catalog is `model/list`.
 
 /** The codex-cli version this adapter was validated against (record + warn).
  * Gated twice: the CLI ATC resolves (TUI launches, title one-shots) and the
@@ -139,6 +159,11 @@ class RpcError extends Schema.TaggedErrorClass<RpcError>()("RpcError", {
   text: Schema.String,
 }) {}
 
+// The reply's top level echoes the session's model / effort / approval /
+// sandbox (probed live 2026-08-18) — the settings baseline (see the header).
+// Decoded loosely: an unrecognized policy shape is "not reported", never a
+// failed reply.
+const SandboxPolicy = Schema.Struct({ type: Schema.String })
 const ThreadReply = Schema.Struct({
   thread: Schema.Struct({
     id: Schema.String,
@@ -147,7 +172,143 @@ const ThreadReply = Schema.Struct({
     // Populated on thread/resume only (generated schema): the history read.
     turns: Schema.optional(Schema.Unknown),
   }),
+  model: Schema.optional(Schema.String),
+  reasoningEffort: Schema.optional(Schema.NullOr(Schema.String)),
+  approvalPolicy: Schema.optional(Schema.Unknown),
+  sandbox: Schema.optional(Schema.Unknown),
 })
+
+// model/list (verified without the experimentalApi capability, 2026-08-18).
+const ModelListReply = Schema.Struct({
+  data: Schema.Array(
+    Schema.Struct({
+      model: Schema.String,
+      displayName: Schema.String,
+      description: Schema.String,
+      hidden: Schema.Boolean,
+      isDefault: Schema.Boolean,
+      supportedReasoningEfforts: Schema.Array(Schema.Struct({ reasoningEffort: Schema.String })),
+      defaultReasoningEffort: Schema.String,
+    }),
+  ),
+  nextCursor: Schema.optional(Schema.NullOr(Schema.String)),
+})
+
+// thread/settings/updated: the thread's full settings after a change made
+// by any client. `collaborationMode.mode` is the only channel that reports
+// the plan/chat mode.
+const ThreadSettingsUpdatedNotification = Schema.Struct({
+  threadId: Schema.String,
+  threadSettings: Schema.Struct({
+    model: Schema.String,
+    effort: Schema.optional(Schema.NullOr(Schema.String)),
+    approvalPolicy: Schema.Unknown,
+    sandboxPolicy: Schema.Unknown,
+    collaborationMode: Schema.optional(Schema.Struct({ mode: Schema.String })),
+  }),
+})
+const decodeThreadSettingsUpdated = Schema.decodeUnknownOption(ThreadSettingsUpdatedNotification)
+const decodeSandboxPolicy = Schema.decodeUnknownOption(SandboxPolicy)
+
+// --- The access ladder, both directions (see the header) ---------------------
+
+/** ... and its `turn/start` knobs (sandboxPolicy as a typed object). */
+const SANDBOX_POLICY_TYPE = {
+  "read-only": "readOnly",
+  "workspace-write": "workspaceWrite",
+  "danger-full-access": "dangerFullAccess",
+} as const
+
+/** The rung's `thread/start` knobs (sandbox as a mode string) ... */
+const ACCESS_TO_THREAD_KNOBS: Record<
+  ThreadAccess,
+  { readonly approvalPolicy: string; readonly sandbox: keyof typeof SANDBOX_POLICY_TYPE }
+> = {
+  supervised: { approvalPolicy: "untrusted", sandbox: "read-only" },
+  autoAcceptEdits: { approvalPolicy: "on-request", sandbox: "workspace-write" },
+  auto: { approvalPolicy: "never", sandbox: "workspace-write" },
+  fullAccess: { approvalPolicy: "never", sandbox: "danger-full-access" },
+}
+
+const turnKnobs = (access: ThreadAccess) => {
+  const knobs = ACCESS_TO_THREAD_KNOBS[access]
+  return {
+    approvalPolicy: knobs.approvalPolicy,
+    sandboxPolicy: { type: SANDBOX_POLICY_TYPE[knobs.sandbox] },
+  }
+}
+
+/**
+ * Project a reported (approvalPolicy, sandbox type) pair onto the nearest
+ * rung: the sandbox decides the extremes (read-only is Supervised,
+ * danger-full-access is Full access, whatever the approval policy), and
+ * within workspace-write only `never` is Auto — every asking policy
+ * (on-request, untrusted, granular) is Auto-accept edits. Undefined when
+ * neither knob was reported.
+ */
+const accessFromKnobs = (
+  approvalPolicy: unknown,
+  sandboxType: string | undefined,
+): ThreadAccess | undefined => {
+  if (sandboxType === "readOnly") return "supervised"
+  if (sandboxType === "dangerFullAccess") return "fullAccess"
+  if (sandboxType === "workspaceWrite")
+    return approvalPolicy === "never" ? "auto" : "autoAcceptEdits"
+  return undefined
+}
+
+/** The baseline a thread/start or thread/resume reply establishes. */
+const echoedSettings = (reply: typeof ThreadReply.Type): ProviderSettings =>
+  reportedSettings({
+    model: reply.model,
+    effort: reply.reasoningEffort,
+    approvalPolicy: reply.approvalPolicy,
+    sandbox: reply.sandbox,
+  })
+
+/**
+ * The turn/start overrides for `settings` against the live baseline: only
+ * what differs, plus the two that always ride (see the header).
+ */
+const settingsOverrides = (live: ProviderSettings, settings: ThreadSettings) => ({
+  ...(live.model !== settings.model ? { model: settings.model } : {}),
+  ...(settings.reasoning !== undefined && live.reasoning !== settings.reasoning
+    ? { effort: settings.reasoning }
+    : {}),
+  ...(live.access !== settings.access ? turnKnobs(settings.access) : {}),
+  approvalsReviewer: "user",
+  collaborationMode: {
+    mode: settings.mode === "plan" ? "plan" : "default",
+    settings: { model: settings.model, reasoning_effort: settings.reasoning ?? null },
+  },
+})
+
+/** The seam's report from a reply or notification's echoed knobs. */
+const reportedSettings = (echo: {
+  readonly model?: string | undefined
+  readonly effort?: string | null | undefined
+  readonly approvalPolicy?: unknown
+  readonly sandbox?: unknown
+  readonly mode?: string | undefined
+}): ProviderSettings => {
+  const sandboxType = decodeSandboxPolicy(echo.sandbox).pipe(
+    Option.map((policy) => policy.type),
+    Option.getOrUndefined,
+  )
+  const access = accessFromKnobs(echo.approvalPolicy, sandboxType)
+  return {
+    ...(echo.model !== undefined ? { model: echo.model } : {}),
+    ...(echo.effort === undefined
+      ? {}
+      : { reasoning: isReasoningLevel(echo.effort) ? echo.effort : null }),
+    ...(access !== undefined ? { access } : {}),
+    ...(echo.mode === "plan"
+      ? { mode: "plan" as const }
+      : echo.mode === "default"
+        ? { mode: "chat" as const }
+        : {}),
+  }
+}
 
 const TurnReply = Schema.Struct({ turn: Schema.Struct({ id: Schema.String }) })
 
@@ -312,6 +473,9 @@ interface LiveSession {
   readonly pendingRequests: Map<string, PendingRequest>
   /** Set when the transport died underneath the session (vs. caller close). */
   failed: boolean
+  /** The settings baseline: what the session runs with, as last echoed
+   * (thread/start, thread/resume, thread/settings/updated) or pushed. */
+  live: ProviderSettings
 }
 
 /** Reserves the active-turn slot between the local check and the RPC reply. */
@@ -764,6 +928,25 @@ export const layer = Layer.effect(CodexAdapter)(
         observe(decoded.value.threadId, event)
         return
       }
+      if (message.method === "thread/settings/updated") {
+        const decoded = decodeThreadSettingsUpdated(params)
+        if (Option.isNone(decoded)) return
+        const { threadId, threadSettings } = decoded.value
+        const reported = reportedSettings({
+          model: threadSettings.model,
+          effort: threadSettings.effort,
+          approvalPolicy: threadSettings.approvalPolicy,
+          sandbox: threadSettings.sandboxPolicy,
+          mode: threadSettings.collaborationMode?.mode,
+        })
+        const session = sessions.get(threadId)
+        if (session !== undefined) {
+          session.live = { ...session.live, ...reported }
+          emit(session, { type: "settings", settings: reported })
+        }
+        observe(threadId, { type: "settings", settings: reported })
+        return
+      }
       if (message.method === "serverRequest/resolved") {
         // Resolved elsewhere (another client answered, or the turn's
         // cleanup cleared it): the parked request is gone, and a later
@@ -925,7 +1108,10 @@ export const layer = Layer.effect(CodexAdapter)(
       // eventual death, could not be told apart from the live one.
       const reply = yield* request(state, "initialize", {
         clientInfo: { name: "atc", title: "ATC App Server", version: build.version },
-        capabilities: null,
+        // turn/start's collaborationMode (the plan/chat mode) is gated behind
+        // the experimental capability (probed live 2026-08-18); T3Code opens
+        // the same way.
+        capabilities: { experimentalApi: true },
       }).pipe(
         Effect.mapError(rpcToProtocol),
         Effect.flatMap((reply) => decodeReply(InitializeReply, reply)),
@@ -996,6 +1182,7 @@ export const layer = Layer.effect(CodexAdapter)(
       threadId: string,
       cwd: string,
       initialStatus: unknown,
+      live: ProviderSettings,
     ) =>
       Effect.gen(function* () {
         // Bounded (overflow ends the stream — see emit); a session that
@@ -1012,6 +1199,7 @@ export const layer = Layer.effect(CodexAdapter)(
           toolItems: new Map(),
           pendingRequests: new Map(),
           failed: false,
+          live,
         }
         const unregister = (): void => {
           if (sessions.get(threadId) !== session) return
@@ -1072,7 +1260,7 @@ export const layer = Layer.effect(CodexAdapter)(
           cwd,
           activity: Effect.sync(() => session.activity),
           events: Stream.fromQueue(queue),
-          startTurn: (input) =>
+          startTurn: (input, settings) =>
             Effect.gen(function* () {
               yield* requireLive
               if (session.activeTurn !== null) {
@@ -1082,9 +1270,11 @@ export const layer = Layer.effect(CodexAdapter)(
               // concurrent startTurn calls would both pass the check.
               session.activeTurn = PENDING_TURN
               session.ownTurn = PENDING_TURN
+              const overrides = settingsOverrides(session.live, settings)
               const decoded = yield* request(state, "turn/start", {
                 threadId,
                 input: [{ type: "text", text: input }],
+                ...overrides,
               }).pipe(
                 Effect.mapError(rpcToProtocol),
                 Effect.flatMap((reply) => decodeReply(TurnReply, reply)),
@@ -1099,6 +1289,13 @@ export const layer = Layer.effect(CodexAdapter)(
               // turn/started may have landed first with the real id.
               if (session.activeTurn === PENDING_TURN) session.activeTurn = decoded.turn.id
               session.ownTurn = decoded.turn.id
+              // The overrides are sticky: the session now runs with them.
+              session.live = {
+                model: settings.model,
+                reasoning: settings.reasoning ?? null,
+                mode: settings.mode,
+                access: settings.access,
+              }
               return { turnId: decoded.turn.id }
             }),
           interrupt: (turn) =>
@@ -1223,8 +1420,9 @@ export const layer = Layer.effect(CodexAdapter)(
               const state = yield* getClient
               const reply = yield* request(state, "thread/start", {
                 cwd: options.cwd,
-                approvalPolicy: "never",
-                sandbox: "workspace-write",
+                model: options.settings.model,
+                ...ACCESS_TO_THREAD_KNOBS[options.settings.access],
+                approvalsReviewer: "user",
               }).pipe(Effect.mapError(rpcToProtocol))
               const decoded = yield* decodeReply(ThreadReply, reply)
               if (!samePath(decoded.thread.cwd, options.cwd)) {
@@ -1235,6 +1433,7 @@ export const layer = Layer.effect(CodexAdapter)(
                 decoded.thread.id,
                 options.cwd,
                 decoded.thread.status,
+                echoedSettings(decoded),
               )
             }),
           )
@@ -1242,7 +1441,7 @@ export const layer = Layer.effect(CodexAdapter)(
           // providers; codex verified above, so those tags are impossible.
           // A failed first turn releases the writer slot — the caller got
           // no connection handle, so nothing must stay claimed.
-          const turn = yield* connection.startTurn(options.input).pipe(
+          const turn = yield* connection.startTurn(options.input, options.settings).pipe(
             Effect.catchTag("AgentResumeFailed", (error) => Effect.die(error)),
             Effect.tapError(() => Effect.sync(unregister)),
           )
@@ -1275,6 +1474,7 @@ export const layer = Layer.effect(CodexAdapter)(
               decoded.thread.id,
               options.cwd,
               decoded.thread.status,
+              echoedSettings(decoded),
             )
             // A turn still running on the shared server (ours before a
             // restart, or a TUI's) is the interrupt target this connection
@@ -1471,6 +1671,51 @@ export const layer = Layer.effect(CodexAdapter)(
             ),
           )
           return Stream.merge(observedEvents, Stream.fromQueue(promptQueue))
+        }),
+      // model/list, every page (walkPaginated; a walk that cannot complete
+      // is a protocol error, never a partial catalog), hidden entries
+      // dropped; efforts outside the seam's ReasoningLevel vocabulary are
+      // dropped too (the model still lists).
+      listModels: () =>
+        Effect.gen(function* () {
+          const state = yield* getClient
+          const collected: Array<(typeof ModelListReply.Type.data)[number]> = []
+          const walked = yield* walkPaginated({
+            page: (cursor) =>
+              request(state, "model/list", cursor === undefined ? {} : { cursor }).pipe(
+                Effect.mapError(rpcToProtocol),
+                Effect.flatMap((reply) => decodeReply(ModelListReply, reply)),
+              ),
+            onPage: (page) => {
+              collected.push(...page.data)
+              return undefined
+            },
+            complete: () => "complete" as const,
+          })
+          if (walked !== "complete") {
+            return yield* Effect.fail(protocolError("model/list pagination did not complete"))
+          }
+          return collected
+            .filter((model) => !model.hidden)
+            .map((model) => {
+              const levels = model.supportedReasoningEfforts
+                .map((option) => option.reasoningEffort)
+                .filter(isReasoningLevel)
+              // Clamped to what the model lists: a default outside its own
+              // levels would be adopted on a model switch and then rejected.
+              const reported = model.defaultReasoningEffort
+              const defaultLevel =
+                isReasoningLevel(reported) && levels.includes(reported) ? reported : levels[0]
+              const entry: { -readonly [K in keyof AgentModel]: AgentModel[K] } = {
+                value: model.model,
+                displayName: model.displayName,
+                description: model.description,
+                isDefault: model.isDefault,
+                supportedEffortLevels: levels,
+              }
+              if (defaultLevel !== undefined) entry.defaultEffortLevel = defaultLevel
+              return entry
+            })
         }),
       generateTitle: (options) =>
         Effect.scoped(

--- a/app-server/src/api/contract.ts
+++ b/app-server/src/api/contract.ts
@@ -279,6 +279,96 @@ export const AgentId = Schema.Literals(AGENT_IDS).annotate({
 export const isAgentId = (id: string): id is typeof AgentId.Type =>
   (AGENT_IDS as ReadonlyArray<string>).includes(id)
 
+// --- Chat mode settings (ATC-205) -------------------------------------------
+//
+// One vocabulary for both providers; the adapters translate it (the access
+// ladder → Claude permissionMode / Codex approvalPolicy + sandbox, mode →
+// Claude `plan` / Codex collaborationMode). `reasoning` is per MODEL, not
+// per agent: it is absent for models with no effort support, and a model
+// change resets it to the new model's default.
+
+export const ReasoningLevel = Schema.Literals([
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+  "ultra",
+]).annotate({
+  identifier: "ReasoningLevel",
+  description:
+    "Reasoning effort. Which levels a model accepts comes from the agent's model catalog (listAgentModels).",
+})
+
+/** Whether `value` is a reasoning level this build knows (narrows like isAgentId). */
+export const isReasoningLevel = Schema.is(ReasoningLevel)
+
+export const ThreadMode = Schema.Literals(["chat", "plan"]).annotate({
+  identifier: "ThreadMode",
+  description:
+    "`chat` works normally; `plan` explores and proposes without mutating the workspace.",
+})
+
+export const ThreadAccess = Schema.Literals([
+  "supervised",
+  "autoAcceptEdits",
+  "auto",
+  "fullAccess",
+]).annotate({
+  identifier: "ThreadAccess",
+  description:
+    "The access ladder: `supervised` asks before every write and command; `autoAcceptEdits` auto-approves edits inside the workspace; `auto` works within the workspace without asking; `fullAccess` bypasses approvals and sandboxing entirely.",
+})
+
+export const ThreadSettings = Schema.Struct({
+  model: Schema.String.annotate({
+    description: "The provider's model id, as listed by listAgentModels (`value`).",
+  }),
+  // Absent keys (not null) for optional fields — see UpdateProjectRequest.
+  // Reasoning is absent for a model that does not support effort levels.
+  reasoning: Schema.optionalKey(ReasoningLevel),
+  mode: ThreadMode,
+  access: ThreadAccess,
+}).annotate({
+  identifier: "ThreadSettings",
+  description:
+    "Per-thread model, reasoning, mode, and access. What the thread's next turn runs with; a change made in the provider itself (its TUI, another client) is adopted here as soon as ATC hears of it. `reasoning` is absent for a model that does not support effort levels.",
+})
+
+export const ThreadSettingsPatch = Schema.Struct({
+  model: Schema.optionalKey(Schema.String.annotate({ description: "New model id." })),
+  reasoning: Schema.optionalKey(ReasoningLevel),
+  mode: Schema.optionalKey(ThreadMode),
+  access: Schema.optionalKey(ThreadAccess),
+}).annotate({
+  identifier: "ThreadSettingsPatch",
+  description:
+    "Partial settings update; only the given fields change. `reasoning` must be a level the (new or current) model supports; omitted on a model change, the current level carries over when the new model supports it, else the new model's default applies.",
+})
+
+export const AgentModel = Schema.Struct({
+  value: Schema.String.annotate({ description: "The id to store in ThreadSettings.model." }),
+  displayName: Schema.String.annotate({ description: "The provider's own display name." }),
+  description: Schema.String,
+  isDefault: Schema.Boolean.annotate({
+    description: "The provider's default model (what a session gets when none is chosen).",
+  }),
+  supportedEffortLevels: Schema.Array(ReasoningLevel).annotate({
+    description:
+      "The reasoning levels the model accepts; empty for a model with no effort support (its threads carry no reasoning).",
+  }),
+  defaultEffortLevel: Schema.optionalKey(ReasoningLevel),
+}).annotate({
+  identifier: "AgentModel",
+  description:
+    "One entry of an agent's model catalog, as the provider itself reports it. `defaultEffortLevel` is the level a thread gets on switching to this model when its current level is unsupported; absent for a model with no effort support.",
+})
+
+export const AgentModelList = Schema.Array(AgentModel).annotate({
+  identifier: "AgentModelList",
+  description: "An agent's model catalog, in the provider's order.",
+})
+
 export const Agent = Schema.Struct({
   id: AgentId,
   available: Schema.Boolean.annotate({
@@ -295,10 +385,11 @@ export const Agent = Schema.Struct({
       description: "Installed CLI version, when it could be determined.",
     }),
   ),
+  defaults: ThreadSettings,
 }).annotate({
   identifier: "Agent",
   description:
-    "A built-in agent provider: availability report, detected on demand and never persisted.",
+    "A built-in agent provider: availability report, detected on demand and never persisted, plus `defaults` — what a new thread of this agent starts with: the settings of the last thread whose settings were changed (write-through), read-only here.",
 })
 
 export const AgentList = Schema.Array(Agent).annotate({
@@ -326,6 +417,7 @@ export const Thread = Schema.Struct({
   workingDirectory: Schema.String.annotate({
     description: "Canonical directory the thread's agent session works in (immutable).",
   }),
+  settings: ThreadSettings,
   activityState: ThreadActivityState,
   unread: Schema.Boolean.annotate({
     description:
@@ -373,9 +465,11 @@ export const CreateThreadRequest = Schema.Struct({
 
 export const UpdateThreadRequest = Schema.Struct({
   name: Schema.optionalKey(Schema.String.annotate({ description: "New display label." })),
+  settings: Schema.optionalKey(ThreadSettingsPatch),
 }).annotate({
   identifier: "UpdateThreadRequest",
-  description: "Partial update; only the display label is mutable.",
+  description:
+    "Partial update of the display label and/or the settings. A settings change writes ATC state only: it takes effect at the thread's next turn (a turn in flight is never disturbed) and becomes the agent's defaults for new threads.",
 })
 
 export const ResourceChangedEvent = Schema.Struct({
@@ -1078,6 +1172,22 @@ export class InvalidRequestAnswer extends Schema.TaggedErrorClass<InvalidRequest
   }
 }
 
+/** A settings patch names a model the agent's catalog does not list, or a reasoning level the model does not support. */
+export class InvalidThreadSettings extends Schema.TaggedErrorClass<InvalidThreadSettings>()(
+  "InvalidThreadSettings",
+  { threadId: Schema.String, reason: Schema.String, message: errorMessage },
+  {
+    identifier: "InvalidThreadSettings",
+    description:
+      "The settings patch does not fit the agent's model catalog: an unknown model, or a reasoning level the model does not support.",
+    httpApiStatus: 400,
+  },
+) {
+  constructor(props: { readonly threadId: string; readonly reason: string }) {
+    super({ ...props, message: props.reason })
+  }
+}
+
 /** Unknown queued prompt id, or the prompt already started (it is a turn now). */
 export class QueuedPromptNotFound extends Schema.TaggedErrorClass<QueuedPromptNotFound>()(
   "QueuedPromptNotFound",
@@ -1280,10 +1390,13 @@ export class V1 extends HttpApiGroup.make("v1")
       params: threadIdParam,
       payload: UpdateThreadRequest,
       success: Thread,
-      error: ThreadNotFound,
+      error: [ThreadNotFound, InvalidThreadSettings, ProviderUnavailable],
     })
       .annotate(OpenApi.Identifier, "updateThread")
-      .annotate(OpenApi.Description, "Update a thread's display label (the only mutable field)."),
+      .annotate(
+        OpenApi.Description,
+        "Update a thread's display label and/or settings. A model or reasoning change is validated against the agent's model catalog (ProviderUnavailable when the catalog cannot be read); other fields never consult the provider.",
+      ),
     HttpApiEndpoint.post("archiveThread", "/threads/:threadId/archive", {
       params: threadIdParam,
       success: Thread,
@@ -1485,6 +1598,16 @@ export class V1 extends HttpApiGroup.make("v1")
     })
       .annotate(OpenApi.Identifier, "getAgent")
       .annotate(OpenApi.Description, "Fetch one built-in agent by its registry slug."),
+    HttpApiEndpoint.get("listAgentModels", "/agents/:agentId/models", {
+      params: { agentId: Schema.String },
+      success: AgentModelList,
+      error: [AgentNotFound, ProviderUnavailable],
+    })
+      .annotate(OpenApi.Identifier, "listAgentModels")
+      .annotate(
+        OpenApi.Description,
+        "The agent's model catalog as its provider reports it, cached server-side for a short while.",
+      ),
     HttpApiEndpoint.get("subscribeEvents", "/events", {
       success: HttpApiSchema.StreamSse({ data: ResourceChangedEvent }),
     })

--- a/app-server/src/api/handlers.ts
+++ b/app-server/src/api/handlers.ts
@@ -118,6 +118,7 @@ export const V1Handlers = HttpApiBuilder.group(
         )
         .handle("listAgents", () => agents.list())
         .handle("getAgent", ({ params }) => agents.get(params.agentId))
+        .handle("listAgentModels", ({ params }) => agents.models(params.agentId))
         // handleRaw instead of the typed handler for one reason: this stream
         // emits nothing until the first change, and Bun's fetch (every Bun
         // client, the contract TS client included) does not resolve a

--- a/app-server/src/platform/migrations.ts
+++ b/app-server/src/platform/migrations.ts
@@ -147,4 +147,33 @@ export const migrations: Record<string, Effect.Effect<void, unknown, SqlClient.S
     `
     yield* sql`CREATE INDEX thread_queue_thread_id ON thread_queue(thread_id)`
   }),
+  // Chat mode settings (ATC-205): the thread's model / reasoning / mode /
+  // access — what its next turn runs with — and the per-agent write-through
+  // defaults a new thread inherits. Rows that predate the columns are
+  // backfilled with the seed each agent's registry entry carried when this
+  // migration shipped (the registry table is the living seed for agents
+  // with no defaults row); their next turn runs with it until the user
+  // picks another. `reasoning` is NULL for models without effort support.
+  "0007_thread_settings": Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+    yield* sql`ALTER TABLE threads ADD COLUMN model TEXT NOT NULL DEFAULT ''`
+    yield* sql`ALTER TABLE threads ADD COLUMN reasoning TEXT`
+    yield* sql`ALTER TABLE threads ADD COLUMN mode TEXT NOT NULL DEFAULT 'chat'`
+    yield* sql`ALTER TABLE threads ADD COLUMN access TEXT NOT NULL DEFAULT 'auto'`
+    yield* sql`
+      UPDATE threads SET
+        model = CASE agent_id WHEN 'claude-code' THEN 'opus[1m]' ELSE 'gpt-5.6-sol' END,
+        reasoning = 'high'
+    `
+    yield* sql`
+      CREATE TABLE agent_defaults (
+        agent_id TEXT PRIMARY KEY,
+        model TEXT NOT NULL,
+        reasoning TEXT,
+        mode TEXT NOT NULL,
+        access TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      ) STRICT
+    `
+  }),
 }

--- a/app-server/src/platform/persistence.ts
+++ b/app-server/src/platform/persistence.ts
@@ -8,7 +8,9 @@ import { migrations } from "./migrations.ts"
 // directory, exposed as the `SqlClient` service with the checked-in migration
 // record already applied. `SqlClient` is the persistence boundary —
 // repositories consume it and own their row types; `sql.withTransaction` is
-// the transaction boundary. Nothing outside a repository speaks SQL.
+// the transaction boundary, and a domain module may hold the client for
+// that alone, to commit writes across repositories together (Threads'
+// settings write-through). Nothing outside a repository speaks SQL.
 //
 // Deliberate SQLite settings:
 //   journal_mode = WAL   concurrent readers during writes (driver default)

--- a/app-server/src/server.ts
+++ b/app-server/src/server.ts
@@ -4,6 +4,7 @@ import { HttpMiddleware, HttpRouter, HttpServer, HttpServerResponse } from "effe
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { Api } from "./api/contract.ts"
 import * as AdminUi from "./adminUi/adminUi.ts"
+import * as AgentDefaultsRepository from "./agents/agentDefaultsRepository.ts"
 import * as AgentRegistry from "./agents/agentRegistry.ts"
 import * as AuthToken from "./platform/authToken.ts"
 import * as ClaudeAdapter from "./agents/claudeAdapter.ts"
@@ -153,6 +154,7 @@ export const production = (options: { readonly port: number; readonly hostname?:
       TerminalRepository.layer,
       ThreadRepository.layer,
       TranscriptRepository.layer,
+      AgentDefaultsRepository.layer,
       Directories.layer,
       Zmx.layer,
       ClaudeHooks.layer,

--- a/app-server/src/threads/threadRepository.ts
+++ b/app-server/src/threads/threadRepository.ts
@@ -3,6 +3,8 @@ import { SqlClient, SqlSchema } from "effect/unstable/sql"
 import { requireFound, rowHelpers } from "../platform/repositoryHelpers.ts"
 import { ThreadNotFound } from "../api/contract.ts"
 import type { AgentId } from "../api/contract.ts"
+import { sameSettings, settingsFromColumns, settingsToColumns } from "./threadSettings.ts"
+import type { ThreadSettings } from "./threadSettings.ts"
 
 // The Threads repository (ATC-124): the only module that speaks SQL for
 // threads. Row types stay here — the service and handlers see camelCase
@@ -13,7 +15,8 @@ import type { AgentId } from "../api/contract.ts"
 // agent_id is validated at the write boundary (the contract's AgentId) but
 // decoded permissively as a plain string: a row holding a slug this build
 // does not know (written by a newer build) must never brick reads — above
-// all delete, the recovery path.
+// all delete, the recovery path. The settings columns (ATC-205) are read
+// the same way (threadSettings.ts settingsFromColumns).
 
 export interface ThreadRecord {
   readonly id: string
@@ -21,6 +24,8 @@ export interface ThreadRecord {
   readonly agentId: string
   readonly name?: string
   readonly workingDirectory: string
+  /** What the thread's next turn runs with (ATC-205). */
+  readonly settings: ThreadSettings
   readonly providerSessionId?: string
   /** Set when the session's first turn completed (the confirmed marker). */
   readonly confirmedAt?: string
@@ -43,6 +48,10 @@ const ThreadRow = Schema.Struct({
   agent_id: Schema.String,
   name: Schema.NullOr(Schema.String),
   working_directory: Schema.String,
+  model: Schema.String,
+  reasoning: Schema.NullOr(Schema.String),
+  mode: Schema.String,
+  access: Schema.String,
   provider_session_id: Schema.NullOr(Schema.String),
   confirmed_at: Schema.NullOr(Schema.String),
   provider_metadata: Schema.NullOr(Schema.String),
@@ -60,6 +69,7 @@ const toRecord = (row: typeof ThreadRow.Type): ThreadRecord => ({
   agentId: row.agent_id,
   ...(row.name !== null ? { name: row.name } : {}),
   workingDirectory: row.working_directory,
+  settings: settingsFromColumns(row),
   ...(row.provider_session_id !== null ? { providerSessionId: row.provider_session_id } : {}),
   ...(row.confirmed_at !== null ? { confirmedAt: row.confirmed_at } : {}),
   ...(row.provider_metadata !== null ? { providerMetadata: row.provider_metadata } : {}),
@@ -80,6 +90,7 @@ export class ThreadRepository extends Context.Service<
       readonly agentId: typeof AgentId.Type
       readonly name?: string | undefined
       readonly workingDirectory: string
+      readonly settings: ThreadSettings
     }) => Effect.Effect<ThreadRecord>
     /** All records (archived included), newest first; optionally one project's. */
     readonly list: (projectId?: string) => Effect.Effect<ReadonlyArray<ThreadRecord>>
@@ -87,6 +98,19 @@ export class ThreadRepository extends Context.Service<
     readonly require: (id: string) => Effect.Effect<ThreadRecord, ThreadNotFound>
     /** Update the display label; callers hold the record — a vanished row is a bug. */
     readonly rename: (id: string, name: string) => Effect.Effect<ThreadRecord>
+    /**
+     * Replace the settings (ATC-205) ONLY while they are still exactly
+     * `expected`: the guard is in the UPDATE itself, so two writers that
+     * read the same baseline — a client patch and a provider report, or
+     * two disjoint patches — cannot silently overwrite each other; the
+     * loser sees None, re-reads, and re-applies its own change on top.
+     * None also for a vanished row (a delete racing the write).
+     */
+    readonly setSettingsIfUnchanged: (
+      id: string,
+      expected: ThreadSettings,
+      settings: ThreadSettings,
+    ) => Effect.Effect<Option.Option<ThreadRecord>>
     /**
      * Adopt a generated name ONLY while the name is still exactly
      * `expected` (null = still unnamed): the null-safe guard is in the
@@ -177,6 +201,42 @@ export const layer = Layer.effect(ThreadRepository)(
       execute: (patch) => sql`
         UPDATE threads SET name = ${patch.name}, updated_at = ${patch.updated_at}
         WHERE id = ${patch.id}
+        RETURNING *
+      `,
+    })
+
+    // The compare-and-swap guard is null-safe on reasoning (`IS`), like
+    // renameIfUnchanged's on name. It names the literals AS STORED — read
+    // just before, and compared with the caller's expectation only after
+    // decoding — because settingsFromColumns coerces a literal this build
+    // does not know, and a guard on the coerced value could never match
+    // such a row (every write to it would spin and fail).
+    const setSettingsIfUnchangedRows = SqlSchema.findAll({
+      Request: Schema.Struct({
+        id: Schema.String,
+        model: Schema.String,
+        reasoning: Schema.NullOr(Schema.String),
+        mode: Schema.String,
+        access: Schema.String,
+        expected_model: Schema.String,
+        expected_reasoning: Schema.NullOr(Schema.String),
+        expected_mode: Schema.String,
+        expected_access: Schema.String,
+        updated_at: Schema.String,
+      }),
+      Result: ThreadRow,
+      execute: (patch) => sql`
+        UPDATE threads SET
+          model = ${patch.model},
+          reasoning = ${patch.reasoning},
+          mode = ${patch.mode},
+          access = ${patch.access},
+          updated_at = ${patch.updated_at}
+        WHERE id = ${patch.id}
+          AND model = ${patch.expected_model}
+          AND reasoning IS ${patch.expected_reasoning}
+          AND mode = ${patch.expected_mode}
+          AND access = ${patch.expected_access}
         RETURNING *
       `,
     })
@@ -337,6 +397,7 @@ export const layer = Layer.effect(ThreadRepository)(
             agent_id: input.agentId,
             name: input.name ?? null,
             working_directory: input.workingDirectory,
+            ...settingsToColumns(input.settings),
             provider_session_id: null,
             confirmed_at: null,
             provider_metadata: null,
@@ -361,6 +422,23 @@ export const layer = Layer.effect(ThreadRepository)(
           Effect.orDie,
           Effect.flatMap(requireFirst("rename")),
         ),
+      setSettingsIfUnchanged: (id, expected, settings) =>
+        Effect.gen(function* () {
+          const stored = (yield* getRows(id))[0]
+          if (stored === undefined || !sameSettings(settingsFromColumns(stored), expected)) {
+            return Option.none()
+          }
+          const rows = yield* setSettingsIfUnchangedRows({
+            id,
+            ...settingsToColumns(settings),
+            expected_model: stored.model,
+            expected_reasoning: stored.reasoning,
+            expected_mode: stored.mode,
+            expected_access: stored.access,
+            updated_at: new Date().toISOString(),
+          })
+          return firstRecord(rows)
+        }).pipe(Effect.orDie),
       renameIfUnchanged: (id, name, expected) =>
         Effect.suspend(() =>
           renameIfUnchangedRows({ id, name, expected, updated_at: new Date().toISOString() }),

--- a/app-server/src/threads/threadRuntime.ts
+++ b/app-server/src/threads/threadRuntime.ts
@@ -23,6 +23,7 @@ import type {
   AgentItemEvent,
   AgentSessionEvent,
   AgentTurn,
+  ProviderSettings,
   ThreadRequest,
   ThreadRequestAnswer,
   ThreadTurn,
@@ -45,6 +46,8 @@ import type { Terminal } from "../terminals/terminals.ts"
 import { ThreadNaming } from "./threadNaming.ts"
 import { ThreadRepository } from "./threadRepository.ts"
 import type { ThreadRecord } from "./threadRepository.ts"
+import { applyProviderSettings } from "./threadSettings.ts"
+import type { ThreadSettings } from "./threadSettings.ts"
 import { ThreadTui } from "./threadTui.ts"
 import { TranscriptRepository } from "./transcriptRepository.ts"
 import type { TranscriptChange, TurnSource } from "./transcriptRepository.ts"
@@ -130,6 +133,17 @@ export type QueuedPrompt = typeof Contract.QueuedPrompt.Type
 //     `answerRequest`; they die with their turn or the process (a re-run
 //     turn re-asks). Answers are validated against the request here, so
 //     adapters only ever see well-formed answers.
+//   - Settings (ATC-205): every turn starts with the thread's stored
+//     settings (re-read under the start lock, so a change made while a
+//     prompt waited is what the turn runs with); the adapter pushes only
+//     what differs from the live session. The provider's own word on its
+//     session settings — the seam's `settings` events, on the writer feed
+//     and the observation feed alike — is adopted into the row as it
+//     arrives (provider state wins), which is how a change made in a TUI or
+//     another provider client shows up here — except that a report merely
+//     confirming what the writer's last turn pushed is not news
+//     (applyProviderSettings): a confirmation that lands after the user
+//     changed a setting again must not roll that change back.
 //   - The activity ledger is the one place live activity lives (the
 //     observation drain and threads.ts's demand-driven re-derivation feed
 //     it too): a first busy confirms the thread, a busy→idle drop stamps
@@ -192,6 +206,9 @@ interface Writer {
   closing: Deferred.Deferred<void> | undefined
   /** The idle-close timer of a resident writer (see armIdleClose). */
   idleClose: Fiber.Fiber<void> | undefined
+  /** The settings the last turn on this connection was started with — what
+   * the provider's next report merely confirms (applyProviderSettings). */
+  pushed: ThreadSettings | undefined
 }
 
 export interface ThreadRuntimeOptions {
@@ -630,6 +647,41 @@ const make = (options: ThreadRuntimeOptions) =>
         )
       })
 
+    /**
+     * Provider state wins (the header's settings bullet): merge what the
+     * provider reported — minus what merely confirms the writer's own push
+     * — over the row as it stands NOW, never over the record the feed was
+     * opened with, which a client patch may have moved on from; publish
+     * only a real change. The write is the repository's compare-and-swap:
+     * a client patch landing between the read and the write makes it miss,
+     * and the report is re-merged on top of that patch rather than over
+     * it. A vanished row (a delete racing the feed) is a no-op.
+     */
+    const adoptSettings = (
+      record: ThreadRecord,
+      reported: ProviderSettings,
+      pushed: ThreadSettings | undefined,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        for (let attempt = 0; attempt < 8; attempt++) {
+          const current = yield* repository.get(record.id)
+          if (Option.isNone(current)) return
+          const adopted = applyProviderSettings(current.value.settings, reported, pushed)
+          if (adopted === undefined) return
+          const updated = yield* repository.setSettingsIfUnchanged(
+            record.id,
+            current.value.settings,
+            adopted,
+          )
+          if (Option.isSome(updated)) {
+            return yield* events.publish({ resource: "thread", id: record.id, change: "updated" })
+          }
+        }
+        yield* Effect.logWarning("a provider settings report never settled against the row").pipe(
+          Effect.annotateLogs({ threadId: record.id }),
+        )
+      })
+
     const handleEvent = (
       record: ThreadRecord,
       writer: Writer,
@@ -662,6 +714,8 @@ const make = (options: ThreadRuntimeOptions) =>
             if (run?.requests.delete(event.requestId) !== true) return
             publish(record.id, { type: "request.closed", requestId: event.requestId })
           })
+        case "settings":
+          return adoptSettings(record, event.settings, writer.pushed)
         case "turnStarted":
           // Another writer's turn on a connection we hold (a TUI mid-run on
           // a shared server): observed, not ours.
@@ -761,6 +815,7 @@ const make = (options: ThreadRuntimeOptions) =>
       run: undefined,
       closing: undefined,
       idleClose: undefined,
+      pushed: undefined,
     })
 
     /**
@@ -787,9 +842,14 @@ const make = (options: ThreadRuntimeOptions) =>
             const connection = yield* adapter.resumeSession({
               providerSessionId: record.providerSessionId,
               cwd,
+              settings: record.settings,
             })
-            const turn = yield* connection.startTurn(prompt)
-            return { writer: makeWriter(scope, connection), turn, record }
+            const turn = yield* connection.startTurn(prompt, record.settings)
+            return {
+              writer: { ...makeWriter(scope, connection), pushed: record.settings },
+              turn,
+              record,
+            }
           }
           // Unconfirmed (none, or zero completed turns): a fresh session,
           // as openTerminal's materialize does — there is no history to
@@ -800,7 +860,11 @@ const make = (options: ThreadRuntimeOptions) =>
               providerMetadata: record.providerMetadata,
             })
           }
-          const session = yield* adapter.createSession({ cwd, input: prompt })
+          const session = yield* adapter.createSession({
+            cwd,
+            input: prompt,
+            settings: record.settings,
+          })
           const still = yield* repository.get(record.id)
           if (Option.isNone(still)) {
             return yield* Effect.die(new Error(`thread ${record.id} vanished mid-prompt`))
@@ -813,7 +877,7 @@ const make = (options: ThreadRuntimeOptions) =>
           yield* repository.confirm(record.id)
           yield* events.publish({ resource: "thread", id: record.id, change: "updated" })
           return {
-            writer: makeWriter(scope, session.connection),
+            writer: { ...makeWriter(scope, session.connection), pushed: record.settings },
             turn: session.turn,
             record: adopted,
           }
@@ -913,7 +977,8 @@ const make = (options: ThreadRuntimeOptions) =>
       writer.lock.withPermit(
         Effect.uninterruptible(
           Effect.gen(function* () {
-            const turn = yield* writer.connection.startTurn(queued.prompt)
+            const turn = yield* writer.connection.startTurn(queued.prompt, record.settings)
+            writer.pushed = record.settings
             yield* registerRun(record, writer, queued, turn)
             return Option.some({ promptId: queued.id, turnId: turn.turnId })
           }).pipe(
@@ -1170,10 +1235,12 @@ const make = (options: ThreadRuntimeOptions) =>
       Effect.gen(function* () {
         if (event.type === "userPrompt") return yield* naming.notePrompt(record, event.text)
         // While the runtime holds a writer, its feed already carries every
-        // item and every activity edge; the observer copy of a shared
-        // server's fan-out would double the items, and a one-process
-        // provider's dead TUI can only report its own SessionEnd.
+        // item, every activity edge, and every settings report; the observer
+        // copy of a shared server's fan-out would double the items, and a
+        // one-process provider's dead TUI can only report its own SessionEnd.
         if (writers.has(record.id)) return
+        if (event.type === "settings")
+          return yield* adoptSettings(record, event.settings, undefined)
         if (event.type !== "activity") return yield* recordItem(record.id, event)
         const { previous } = yield* noteActivity(record, event.activity)
         // The busy→idle drop is the turn's end (forked: the drain must never
@@ -1265,7 +1332,11 @@ const make = (options: ThreadRuntimeOptions) =>
         if (providerSessionId === undefined) return yield* markInterrupted(record, turn)
         const scope = Scope.forkUnsafe(serviceScope)
         const connection = yield* adapter
-          .resumeSession({ providerSessionId, cwd: record.workingDirectory })
+          .resumeSession({
+            providerSessionId,
+            cwd: record.workingDirectory,
+            settings: record.settings,
+          })
           .pipe(Scope.provide(scope))
         if (!isBusy(yield* connection.activity)) {
           yield* Scope.close(scope, Exit.void)
@@ -1276,6 +1347,11 @@ const make = (options: ThreadRuntimeOptions) =>
           if (still !== undefined) yield* markInterrupted(record, still)
           return
         }
+        // The turn's own pushed baseline died with the old process, so the
+        // provider's first report after reattach is adopted as its word —
+        // right unless a setting changed mid-turn before the restart, when
+        // the row briefly follows the running turn again (accepted: the
+        // window is a server restart inside a running turn).
         const writer = makeWriter(scope, connection)
         writer.run = {
           turnId: turn.id,

--- a/app-server/src/threads/threadSettings.ts
+++ b/app-server/src/threads/threadSettings.ts
@@ -1,0 +1,129 @@
+import { Schema } from "effect"
+import { isReasoningLevel, ThreadAccess, ThreadMode } from "../api/contract.ts"
+import type * as Contract from "../api/contract.ts"
+import type { ProviderSettings } from "../agents/agentAdapter.ts"
+
+// The pure settings rules (ATC-205), shared by the repositories that store
+// settings, the Threads domain that patches them, and the runtime that
+// adopts the provider's reports. Nothing here touches a provider or the
+// database.
+
+export type ThreadSettings = typeof Contract.ThreadSettings.Type
+export type ThreadSettingsPatch = typeof Contract.ThreadSettingsPatch.Type
+export type AgentModel = typeof Contract.AgentModel.Type
+
+const isMode = Schema.is(ThreadMode)
+const isAccess = Schema.is(ThreadAccess)
+
+/**
+ * The permissive stored→settings read both repositories use: a literal
+ * this build does not know (written by a newer build) falls back to its
+ * seed value rather than failing the row, so rows stay readable and the
+ * provider's next report corrects them.
+ */
+export const settingsFromColumns = (row: {
+  readonly model: string
+  readonly reasoning: string | null
+  readonly mode: string
+  readonly access: string
+}): ThreadSettings => ({
+  model: row.model,
+  ...(isReasoningLevel(row.reasoning) ? { reasoning: row.reasoning } : {}),
+  mode: isMode(row.mode) ? row.mode : "chat",
+  access: isAccess(row.access) ? row.access : "auto",
+})
+
+/** The inverse: the settings as the four columns store them. */
+export const settingsToColumns = (settings: ThreadSettings) => ({
+  model: settings.model,
+  reasoning: settings.reasoning ?? null,
+  mode: settings.mode,
+  access: settings.access,
+})
+
+/** Field-wise equality (reasoning absent ≡ absent). */
+export const sameSettings = (a: ThreadSettings, b: ThreadSettings): boolean =>
+  a.model === b.model && a.reasoning === b.reasoning && a.mode === b.mode && a.access === b.access
+
+/**
+ * Adopt a provider's report over the settings a thread holds — provider
+ * state wins — EXCEPT for the fields that merely confirm what ATC itself
+ * pushed for the running turn (`pushed`): a delayed confirmation must never
+ * roll back a change the user made meanwhile (Claude's child reports its
+ * settings only once its ~seconds-long spawn has completed; Codex echoes
+ * every override). Undefined when nothing changes.
+ */
+export const applyProviderSettings = (
+  current: ThreadSettings,
+  reported: ProviderSettings,
+  pushed: ThreadSettings | undefined,
+): ThreadSettings | undefined => {
+  const pushedReasoning = pushed === undefined ? undefined : (pushed.reasoning ?? null)
+  const reasoning =
+    reported.reasoning === undefined || reported.reasoning === pushedReasoning
+      ? current.reasoning
+      : reported.reasoning === null
+        ? undefined
+        : reported.reasoning
+  const adopted: ThreadSettings = {
+    model:
+      reported.model === undefined || reported.model === pushed?.model
+        ? current.model
+        : reported.model,
+    ...(reasoning !== undefined ? { reasoning } : {}),
+    mode:
+      reported.mode === undefined || reported.mode === pushed?.mode ? current.mode : reported.mode,
+    access:
+      reported.access === undefined || reported.access === pushed?.access
+        ? current.access
+        : reported.access,
+  }
+  return sameSettings(adopted, current) ? undefined : adopted
+}
+
+/**
+ * Apply a settings patch against the agent's model catalog. Reasoning is
+ * per model: an explicit reasoning must be one the model supports, and on
+ * a model change without one the current level carries over when the new
+ * model supports it, else the new model's default applies (absent when the
+ * model has no effort support). `catalog` is null when the caller did not
+ * need it (a patch touching neither model nor reasoning); with a catalog,
+ * a change to an unknown model is a rejection.
+ */
+export const applySettingsPatch = (
+  current: ThreadSettings,
+  patch: ThreadSettingsPatch,
+  catalog: ReadonlyArray<AgentModel> | null,
+): { readonly settings: ThreadSettings } | { readonly rejected: string } => {
+  const model = patch.model ?? current.model
+  const entry = catalog?.find((candidate) => candidate.value === model)
+  // Only a model CHANGE is held to the catalog: a thread already on a model
+  // the catalog no longer lists (retired, or hidden by the provider) keeps
+  // taking mode/access/reasoning patches; its reasoning cannot be validated
+  // then and is accepted as given.
+  if (patch.model !== undefined && catalog !== null && entry === undefined) {
+    return { rejected: `unknown model "${model}"` }
+  }
+  if (
+    entry !== undefined &&
+    patch.reasoning !== undefined &&
+    !entry.supportedEffortLevels.includes(patch.reasoning)
+  ) {
+    return { rejected: `model "${model}" does not support reasoning "${patch.reasoning}"` }
+  }
+  const carried =
+    entry === undefined || model === current.model
+      ? current.reasoning
+      : current.reasoning !== undefined && entry.supportedEffortLevels.includes(current.reasoning)
+        ? current.reasoning
+        : entry.defaultEffortLevel
+  const reasoning = patch.reasoning ?? carried
+  return {
+    settings: {
+      model,
+      ...(reasoning !== undefined ? { reasoning } : {}),
+      mode: patch.mode ?? current.mode,
+      access: patch.access ?? current.access,
+    },
+  }
+}

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -11,6 +11,7 @@ import type {
 } from "../agents/agentAdapter.ts"
 import { isBusyActivity } from "../agents/agentAdapter.ts"
 import {
+  InvalidThreadSettings,
   isAgentId,
   ProviderSessionConflict,
   ProviderUnavailable,
@@ -25,8 +26,10 @@ import type {
   DirectoryUnavailable,
   ProjectNotFound,
   TerminalLaunchFailed,
+  ThreadSettingsPatch,
   ZmxUnavailable,
 } from "../api/contract.ts"
+import { SqlClient } from "effect/unstable/sql"
 import { Events } from "../events/events.ts"
 import { Directories } from "../platform/directories.ts"
 import { ProjectRepository } from "../projects/projectRepository.ts"
@@ -36,6 +39,8 @@ import { ThreadNaming } from "./threadNaming.ts"
 import { ThreadRepository } from "./threadRepository.ts"
 import type { ThreadRecord } from "./threadRepository.ts"
 import { ThreadRuntime } from "./threadRuntime.ts"
+import { applySettingsPatch, sameSettings } from "./threadSettings.ts"
+import type { ThreadSettings } from "./threadSettings.ts"
 import { ThreadTui } from "./threadTui.ts"
 
 export type Thread = typeof Contract.Thread.Type
@@ -85,6 +90,15 @@ export type Thread = typeof Contract.Thread.Type
 //     vocabulary is untouched; "Done" is client-side display translation.
 //   - Auto-naming lives in ThreadNaming (ATC-155/190/202), fed by the
 //     runtime's observation and turns.
+//   - Settings (ATC-205) are stored state the runtime hands to the adapter
+//     at every turn start; a change here never touches a provider — it
+//     takes effect at the next turn, and a turn in flight is never
+//     disturbed. Only a model or reasoning change consults the agent's
+//     model catalog (validation and the per-model reasoning rule,
+//     threadSettings.ts). Every change writes through to the agent's
+//     defaults, which `create` reads — a new thread starts as the last
+//     changed one ended. Provider-side changes are adopted by the runtime
+//     (its `settings` events), never here.
 //   - archived threads are never pinned: pin refuses archived records, and
 //     archive clears the pin in the same repository write so no client can
 //     observe or restore an archived pin.
@@ -132,8 +146,11 @@ export class Threads extends Context.Service<
     /** Patch mutable fields; an empty patch changes nothing, updatedAt included. */
     readonly update: (
       id: string,
-      patch: { readonly name?: string | undefined },
-    ) => Effect.Effect<Thread, ThreadNotFound>
+      patch: {
+        readonly name?: string | undefined
+        readonly settings?: typeof ThreadSettingsPatch.Type | undefined
+      },
+    ) => Effect.Effect<Thread, ThreadNotFound | InvalidThreadSettings | ProviderUnavailable>
     /** Kill the live linked terminal and release adapter runtime resources,
      * then set archivedAt (idempotent and convergent — see the header);
      * refused while the agent session is actively working. */
@@ -191,6 +208,10 @@ export const layerWith = (options: ThreadsOptions) =>
       const runtime = yield* ThreadRuntime
       const naming = yield* ThreadNaming
       const tui = yield* ThreadTui
+      // No SQL is written here: the client is held for `withTransaction`
+      // alone, so the settings write and its defaults write-through commit
+      // together (both repositories run on this one client).
+      const sql = yield* SqlClient.SqlClient
       // Forked work (a discovered finish's re-read) outlives its request;
       // it lives in the service's own scope.
       const serviceScope = yield* Effect.scope
@@ -304,6 +325,7 @@ export const layerWith = (options: ThreadsOptions) =>
         agentId: record.agentId as Thread["agentId"],
         ...(record.name !== undefined ? { name: record.name } : {}),
         workingDirectory: record.workingDirectory,
+        settings: record.settings,
         activityState,
         unread: isUnread(record),
         ...(linkedTerminalId !== undefined ? { linkedTerminalId } : {}),
@@ -617,6 +639,89 @@ export const layerWith = (options: ThreadsOptions) =>
           }),
         )
 
+      /**
+       * Resolve the settings half of an `update` (the header's settings
+       * bullet) BEFORE anything is written: the catalog is consulted only
+       * when the patch touches model or reasoning, so an access or mode
+       * change never waits on — or fails with — the provider, and a
+       * rejection leaves the row (name included) untouched.
+       */
+      const resolveSettings = (
+        record: ThreadRecord,
+        patch: typeof ThreadSettingsPatch.Type,
+      ): Effect.Effect<ThreadSettings, InvalidThreadSettings | ProviderUnavailable> =>
+        Effect.gen(function* () {
+          const needsCatalog = patch.model !== undefined || patch.reasoning !== undefined
+          const catalog = needsCatalog
+            ? yield* registry.models(record.agentId).pipe(
+                Effect.catchTag("AgentNotFound", () =>
+                  Effect.fail(
+                    new ProviderUnavailable({
+                      agentId: record.agentId,
+                      reason: `this build knows no agent "${record.agentId}"`,
+                    }),
+                  ),
+                ),
+              )
+            : null
+          const applied = applySettingsPatch(record.settings, patch, catalog)
+          if ("rejected" in applied) {
+            return yield* Effect.fail(
+              new InvalidThreadSettings({ threadId: record.id, reason: applied.rejected }),
+            )
+          }
+          return applied.settings
+        })
+
+      /**
+       * Apply and store a settings patch: resolve it against the row as it
+       * stands, write only while the row still stands there (the
+       * repository's compare-and-swap), and on losing that race — a
+       * provider report or another patch landed in between — re-read and
+       * re-apply the patch on top, so a partial patch never overwrites a
+       * change it did not make. A patch that resolves to what the row
+       * already holds is a no-op: no write, no defaults write-through, no
+       * event (a re-pick of the checked entry must never reset another
+       * thread's future defaults). The write-through to the agent's
+       * defaults carries the thread's whole settings, so a new thread
+       * starts exactly as this one now stands; it commits with the row.
+       */
+      const patchSettings = (
+        record: ThreadRecord,
+        patch: typeof ThreadSettingsPatch.Type,
+      ): Effect.Effect<
+        { readonly record: ThreadRecord; readonly changed: boolean },
+        ThreadNotFound | InvalidThreadSettings | ProviderUnavailable
+      > =>
+        Effect.gen(function* () {
+          let current = record
+          for (let attempt = 0; attempt < 8; attempt++) {
+            const settings = yield* resolveSettings(current, patch)
+            if (sameSettings(settings, current.settings)) return { record: current, changed: false }
+            const written = yield* sql
+              .withTransaction(
+                Effect.gen(function* () {
+                  const updated = yield* repository.setSettingsIfUnchanged(
+                    current.id,
+                    current.settings,
+                    settings,
+                  )
+                  if (Option.isSome(updated) && isAgentId(current.agentId)) {
+                    yield* registry.setDefaults(current.agentId, settings)
+                  }
+                  return updated
+                }),
+                // A transaction failure is a database failure: a defect, like
+                // the repositories' own.
+              )
+              .pipe(Effect.orDie)
+            if (Option.isSome(written)) return { record: written.value, changed: true }
+            // Lost the race (or the row vanished: require's typed 404).
+            current = yield* repository.require(record.id)
+          }
+          return yield* Effect.die(new Error(`thread ${record.id}: settings never settled`))
+        })
+
       return {
         list: (listOptions) =>
           Effect.gen(function* () {
@@ -663,20 +768,30 @@ export const layerWith = (options: ThreadsOptions) =>
               agentId: input.agentId,
               name: input.name,
               workingDirectory: canonical,
+              settings: yield* registry.defaults(input.agentId),
             })
             yield* events.publish({ resource: "thread", id: record.id, change: "created" })
             return toThread(record, undefined, "idle")
           }),
         update: (id, patch) =>
-          // An empty patch changes nothing — including updatedAt (the same
-          // rule the other repositories apply).
-          patch.name === undefined
-            ? repository.require(id).pipe(Effect.flatMap(assembleAlone))
-            : repository.require(id).pipe(
-                Effect.andThen(repository.rename(id, patch.name)),
-                Effect.tap(() => events.publish({ resource: "thread", id, change: "updated" })),
-                Effect.flatMap(assembleAlone),
-              ),
+          Effect.gen(function* () {
+            const record = yield* repository.require(id)
+            // Settings are validated BEFORE the rename lands (a rejection
+            // leaves the row untouched, name included); a patch that
+            // changes nothing changes nothing — updatedAt included, the
+            // rule the other repositories apply — and publishes nothing.
+            const settled =
+              patch.settings === undefined || Object.keys(patch.settings).length === 0
+                ? { record, changed: false }
+                : yield* patchSettings(record, patch.settings)
+            const renamed =
+              patch.name === undefined ? settled.record : yield* repository.rename(id, patch.name)
+            if (!settled.changed && patch.name === undefined) {
+              return yield* assembleAlone(record)
+            }
+            yield* events.publish({ resource: "thread", id, change: "updated" })
+            return yield* assembleAlone(renamed)
+          }),
         archive: (id) =>
           withLifecycleLock(id)(
             Effect.gen(function* () {

--- a/app-server/test/agents/agentAdapter.test.ts
+++ b/app-server/test/agents/agentAdapter.test.ts
@@ -1,10 +1,12 @@
 import { assert, describe, it } from "@effect/vitest"
+import { TEST_SETTINGS } from "./agentTestKit.ts"
 import { Deferred, Effect, Fiber, Stream } from "effect"
 import type { AgentEvent } from "../../src/agents/agentAdapter.ts"
 import {
   aggregateActivity,
   buildTitleContext,
   makeVersionGate,
+  memoizeSuccess,
   parseVersion,
   sanitizeTitle,
   titleInstruction,
@@ -161,6 +163,7 @@ describe("AgentAdapter seam semantics (fake adapter)", () => {
       const { connection, turn } = yield* fake.adapter.createSession({
         cwd: "/work",
         input: "do the thing",
+        settings: TEST_SETTINGS,
       })
       const sink = yield* collectEvents(connection.events)
       assert.strictEqual(yield* connection.activity, "working")
@@ -183,8 +186,12 @@ describe("AgentAdapter seam semantics (fake adapter)", () => {
   it.effect("a second turn while one is active is a conflict", () =>
     Effect.gen(function* () {
       const fake = makeFakeAgentAdapter()
-      const { connection } = yield* fake.adapter.createSession({ cwd: "/work", input: "one" })
-      const second = yield* Effect.flip(connection.startTurn("two"))
+      const { connection } = yield* fake.adapter.createSession({
+        cwd: "/work",
+        input: "one",
+        settings: TEST_SETTINGS,
+      })
+      const second = yield* Effect.flip(connection.startTurn("two", TEST_SETTINGS))
       assert.strictEqual(second._tag, "AgentConflict")
     }).pipe(Effect.scoped),
   )
@@ -193,7 +200,11 @@ describe("AgentAdapter seam semantics (fake adapter)", () => {
     Effect.gen(function* () {
       const fake = makeFakeAgentAdapter()
       const failure = yield* Effect.flip(
-        fake.adapter.resumeSession({ providerSessionId: "nope", cwd: "/work" }),
+        fake.adapter.resumeSession({
+          providerSessionId: "nope",
+          cwd: "/work",
+          settings: TEST_SETTINGS,
+        }),
       )
       assert.strictEqual(failure._tag, "AgentResumeFailed")
     }).pipe(Effect.scoped),
@@ -204,7 +215,11 @@ describe("AgentAdapter seam semantics (fake adapter)", () => {
       const fake = makeFakeAgentAdapter()
       fake.seed("session-1", "/original")
       const failure = yield* Effect.flip(
-        fake.adapter.resumeSession({ providerSessionId: "session-1", cwd: "/elsewhere" }),
+        fake.adapter.resumeSession({
+          providerSessionId: "session-1",
+          cwd: "/elsewhere",
+          settings: TEST_SETTINGS,
+        }),
       )
       assert.strictEqual(failure._tag, "AgentIdentityMismatch")
     }).pipe(Effect.scoped),
@@ -214,9 +229,17 @@ describe("AgentAdapter seam semantics (fake adapter)", () => {
     Effect.gen(function* () {
       const fake = makeFakeAgentAdapter()
       fake.seed("session-1", "/work")
-      yield* fake.adapter.resumeSession({ providerSessionId: "session-1", cwd: "/work" })
+      yield* fake.adapter.resumeSession({
+        providerSessionId: "session-1",
+        cwd: "/work",
+        settings: TEST_SETTINGS,
+      })
       const second = yield* Effect.flip(
-        fake.adapter.resumeSession({ providerSessionId: "session-1", cwd: "/work" }),
+        fake.adapter.resumeSession({
+          providerSessionId: "session-1",
+          cwd: "/work",
+          settings: TEST_SETTINGS,
+        }),
       )
       assert.strictEqual(second._tag, "AgentConflict")
     }).pipe(Effect.scoped),
@@ -227,12 +250,17 @@ describe("AgentAdapter seam semantics (fake adapter)", () => {
       const fake = makeFakeAgentAdapter()
       fake.seed("session-1", "/work")
       yield* Effect.scoped(
-        fake.adapter.resumeSession({ providerSessionId: "session-1", cwd: "/work" }),
+        fake.adapter.resumeSession({
+          providerSessionId: "session-1",
+          cwd: "/work",
+          settings: TEST_SETTINGS,
+        }),
       )
       // The first writer's scope closed, so a new writer may connect.
       const connection = yield* fake.adapter.resumeSession({
         providerSessionId: "session-1",
         cwd: "/work",
+        settings: TEST_SETTINGS,
       })
       assert.strictEqual(connection.providerSessionId, "session-1")
     }).pipe(Effect.scoped),
@@ -244,6 +272,7 @@ describe("AgentAdapter seam semantics (fake adapter)", () => {
       const { connection, turn } = yield* fake.adapter.createSession({
         cwd: "/work",
         input: "long task",
+        settings: TEST_SETTINGS,
       })
       const sink = yield* collectEvents(connection.events)
       yield* connection.interrupt(turn)
@@ -263,7 +292,11 @@ describe("AgentAdapter seam semantics (fake adapter)", () => {
   it.effect("a pending provider request wins: needs_input beats working", () =>
     Effect.gen(function* () {
       const fake = makeFakeAgentAdapter()
-      const { connection } = yield* fake.adapter.createSession({ cwd: "/work", input: "ask me" })
+      const { connection } = yield* fake.adapter.createSession({
+        cwd: "/work",
+        input: "ask me",
+        settings: TEST_SETTINGS,
+      })
       const sink = yield* collectEvents(connection.events)
       const requestId = fake.openRequest(connection.providerSessionId, "approval")
       yield* waitForEvent(
@@ -279,7 +312,11 @@ describe("AgentAdapter seam semantics (fake adapter)", () => {
   it.effect("respond answers a parked request; unknown or mismatched answers conflict", () =>
     Effect.gen(function* () {
       const fake = makeFakeAgentAdapter()
-      const { connection } = yield* fake.adapter.createSession({ cwd: "/work", input: "ask me" })
+      const { connection } = yield* fake.adapter.createSession({
+        cwd: "/work",
+        input: "ask me",
+        settings: TEST_SETTINGS,
+      })
       const sink = yield* collectEvents(connection.events)
       const requestId = fake.openRequest(connection.providerSessionId, "question")
       yield* waitForEvent(sink, (event) => event.type === "requestOpened")
@@ -326,7 +363,9 @@ describe("AgentAdapter seam semantics (fake adapter)", () => {
     Effect.gen(function* () {
       const fake = makeFakeAgentAdapter()
       fake.setUnavailable("fake outage")
-      const failure = yield* Effect.flip(fake.adapter.createSession({ cwd: "/work", input: "hi" }))
+      const failure = yield* Effect.flip(
+        fake.adapter.createSession({ cwd: "/work", input: "hi", settings: TEST_SETTINGS }),
+      )
       assert.strictEqual(failure._tag, "AgentUnavailable")
     }).pipe(Effect.scoped),
   )
@@ -426,6 +465,25 @@ describe("makeVersionGate", () => {
       fake.release()
       yield* gate
       assert.strictEqual(fake.spawns(), 2)
+    }),
+  )
+})
+
+describe("memoizeSuccess", () => {
+  it.effect("a failure is never served to later callers; the next success is memoized", () =>
+    Effect.gen(function* () {
+      let attempts = 0
+      const read = Effect.suspend(() => {
+        attempts++
+        return attempts === 1 ? Effect.fail("provider down") : Effect.succeed(attempts)
+      })
+      const memo = yield* memoizeSuccess(read, "1 hour")
+      assert.strictEqual(yield* Effect.flip(memo), "provider down")
+      // The failure was invalidated on the way out: this run re-reads.
+      assert.strictEqual(yield* memo, 2)
+      // The success is served from the memo.
+      assert.strictEqual(yield* memo, 2)
+      assert.strictEqual(attempts, 2)
     }),
   )
 })

--- a/app-server/test/agents/agentRegistry.test.ts
+++ b/app-server/test/agents/agentRegistry.test.ts
@@ -79,6 +79,7 @@ describe("/api/v1/agents", () => {
               claudeExecutable: "/definitely/not/claude",
             }),
             Subprocess.layer.pipe(Layer.provide(BunServices.layer)),
+            kit.services,
           ]),
         ),
       ),

--- a/app-server/test/agents/agentTestKit.ts
+++ b/app-server/test/agents/agentTestKit.ts
@@ -3,7 +3,7 @@ import { Duration, Effect, Layer, Stream } from "effect"
 import * as fs from "node:fs"
 import * as path from "node:path"
 import { fileURLToPath } from "node:url"
-import type { AgentEvent } from "../../src/agents/agentAdapter.ts"
+import type { AgentEvent, ThreadSettings } from "../../src/agents/agentAdapter.ts"
 import * as ClaudeAdapter from "../../src/agents/claudeAdapter.ts"
 import * as ClaudeHooks from "../../src/agents/claudeHooks.ts"
 import * as CodexAdapter from "../../src/agents/codexAdapter.ts"
@@ -18,6 +18,14 @@ import { TestBuildInfoLayer } from "../testBuildInfo.ts"
 // sandbox (wrapper-script seam, like makeFakeZmxSandbox), the layer stacks
 // under supervision/adapter tests, and the event-feed helpers every adapter
 // test asserts with.
+
+/** The settings every adapter test starts turns with unless it says otherwise. */
+export const TEST_SETTINGS: ThreadSettings = {
+  model: "test-model",
+  reasoning: "medium",
+  mode: "chat",
+  access: "auto",
+}
 
 const fakeCodexFixture = fileURLToPath(
   new URL("../fixtures/fake-codex-listener.ts", import.meta.url),

--- a/app-server/test/agents/claudeAdapter.smoke.test.ts
+++ b/app-server/test/agents/claudeAdapter.smoke.test.ts
@@ -13,6 +13,9 @@ import { trackTempDir } from "../blackbox.ts"
 // interrupted outcome. Needs an installed, authenticated Claude Code; runs
 // real (cheap) turns from a directory outside any repository.
 
+/** Cheap real-provider settings for the smoke turns (a real, small model). */
+const SMOKE_SETTINGS = { model: "haiku", mode: "chat", access: "supervised" } as const
+
 const enabled = process.env["ATC_SMOKE"] === "1"
 
 describe.skipIf(!enabled)("live claude adapter smoke (opt-in)", () => {
@@ -33,6 +36,7 @@ describe.skipIf(!enabled)("live claude adapter smoke (opt-in)", () => {
               const { connection, turn } = yield* adapter.createSession({
                 cwd,
                 input: "Reply with exactly: SMOKE-OK",
+                settings: SMOKE_SETTINGS,
               })
               const sink = yield* collectAgentEvents(connection.events)
               yield* waitForAgentEvent(
@@ -53,10 +57,12 @@ describe.skipIf(!enabled)("live claude adapter smoke (opt-in)", () => {
               const connection = yield* adapter.resumeSession({
                 providerSessionId: sessionId,
                 cwd,
+                settings: SMOKE_SETTINGS,
               })
               const sink = yield* collectAgentEvents(connection.events)
               const turn = yield* connection.startTurn(
                 "What exact text did I ask you to reply with earlier? Answer with just that text.",
+                SMOKE_SETTINGS,
               )
               assert.strictEqual(connection.providerSessionId, sessionId)
               yield* waitForAgentEvent(
@@ -76,10 +82,12 @@ describe.skipIf(!enabled)("live claude adapter smoke (opt-in)", () => {
               const connection = yield* adapter.resumeSession({
                 providerSessionId: sessionId,
                 cwd,
+                settings: SMOKE_SETTINGS,
               })
               const sink = yield* collectAgentEvents(connection.events)
               const turn = yield* connection.startTurn(
                 "Count from 1 to 500, one number per line. Do not stop early.",
+                SMOKE_SETTINGS,
               )
               yield* waitForAgentEvent(
                 sink,
@@ -104,8 +112,9 @@ describe.skipIf(!enabled)("live claude adapter smoke (opt-in)", () => {
               const connection = yield* adapter.resumeSession({
                 providerSessionId: "00000000-0000-4000-8000-000000000000",
                 cwd,
+                settings: SMOKE_SETTINGS,
               })
-              return yield* Effect.flip(connection.startTurn("hello?"))
+              return yield* Effect.flip(connection.startTurn("hello?", SMOKE_SETTINGS))
             }),
           )
           assert.strictEqual(failure._tag, "AgentResumeFailed")

--- a/app-server/test/agents/claudeAdapter.test.ts
+++ b/app-server/test/agents/claudeAdapter.test.ts
@@ -7,10 +7,15 @@ import * as path from "node:path"
 import type { AgentSessionEvent } from "../../src/agents/agentAdapter.ts"
 import * as ClaudeAdapter from "../../src/agents/claudeAdapter.ts"
 import * as ClaudeHooks from "../../src/agents/claudeHooks.ts"
-import { claudeAdapterLayer, collectAgentEvents, waitForAgentEvent } from "./agentTestKit.ts"
+import {
+  claudeAdapterLayer,
+  collectAgentEvents,
+  waitForAgentEvent,
+  TEST_SETTINGS,
+} from "./agentTestKit.ts"
 import { eventually } from "../testLayers.ts"
 import { trackTempDir } from "../blackbox.ts"
-import { makeFakeClaudeQuery } from "./fakeClaudeQuery.ts"
+import { FAKE_CLAUDE_MODELS, makeFakeClaudeQuery } from "./fakeClaudeQuery.ts"
 import type { FakeClaudeQueryOptions } from "./fakeClaudeQuery.ts"
 
 // Claude adapter tests over the scripted query() seam (fakeClaudeQuery.ts):
@@ -37,7 +42,11 @@ describe("ClaudeAdapter", () => {
         const adapter = yield* ClaudeAdapter.ClaudeAdapter
         yield* Effect.scoped(
           Effect.gen(function* () {
-            const { connection, turn } = yield* adapter.createSession({ cwd, input: "hello" })
+            const { connection, turn } = yield* adapter.createSession({
+              cwd,
+              input: "hello",
+              settings: TEST_SETTINGS,
+            })
             assert.strictEqual(connection.providerSessionId, "session-a")
             assert.strictEqual(connection.cwd, cwd)
             const sink = yield* collectAgentEvents(connection.events)
@@ -61,7 +70,9 @@ describe("ClaudeAdapter", () => {
       yield* Effect.gen(function* () {
         const adapter = yield* ClaudeAdapter.ClaudeAdapter
         const failure = yield* Effect.scoped(
-          Effect.flip(adapter.createSession({ cwd: workDir(), input: "hello" })),
+          Effect.flip(
+            adapter.createSession({ cwd: workDir(), input: "hello", settings: TEST_SETTINGS }),
+          ),
         )
         assert.strictEqual(failure._tag, "AgentIdentityMismatch")
         if (failure._tag === "AgentIdentityMismatch") assert.strictEqual(failure.field, "cwd")
@@ -80,11 +91,12 @@ describe("ClaudeAdapter", () => {
             const connection = yield* adapter.resumeSession({
               providerSessionId: "session-b",
               cwd,
+              settings: TEST_SETTINGS,
             })
             // No identity evidence yet — the SDK sends none until a turn.
             assert.strictEqual(yield* connection.activity, "unknown")
             const sink = yield* collectAgentEvents(connection.events)
-            const turn = yield* connection.startTurn("continue please")
+            const turn = yield* connection.startTurn("continue please", TEST_SETTINGS)
             assert.strictEqual(connection.providerSessionId, "session-b")
             yield* waitForAgentEvent(
               sink,
@@ -109,8 +121,9 @@ describe("ClaudeAdapter", () => {
             const connection = yield* adapter.resumeSession({
               providerSessionId: "missing-session",
               cwd: workDir(),
+              settings: TEST_SETTINGS,
             })
-            return yield* Effect.flip(connection.startTurn("hello?"))
+            return yield* Effect.flip(connection.startTurn("hello?", TEST_SETTINGS))
           }),
         )
         assert.strictEqual(failure._tag, "AgentResumeFailed")
@@ -131,8 +144,9 @@ describe("ClaudeAdapter", () => {
             const connection = yield* adapter.resumeSession({
               providerSessionId: "session-c",
               cwd: workDir(),
+              settings: TEST_SETTINGS,
             })
-            return yield* Effect.flip(connection.startTurn("hello?"))
+            return yield* Effect.flip(connection.startTurn("hello?", TEST_SETTINGS))
           }),
         )
         assert.strictEqual(failure._tag, "AgentIdentityMismatch")
@@ -151,15 +165,25 @@ describe("ClaudeAdapter", () => {
         const adapter = yield* ClaudeAdapter.ClaudeAdapter
         yield* Effect.scoped(
           Effect.gen(function* () {
-            yield* adapter.resumeSession({ providerSessionId: "session-d", cwd })
+            yield* adapter.resumeSession({
+              providerSessionId: "session-d",
+              cwd,
+              settings: TEST_SETTINGS,
+            })
             const failure = yield* Effect.flip(
-              adapter.resumeSession({ providerSessionId: "session-d", cwd }),
+              adapter.resumeSession({
+                providerSessionId: "session-d",
+                cwd,
+                settings: TEST_SETTINGS,
+              }),
             )
             assert.strictEqual(failure._tag, "AgentConflict")
           }),
         )
         // The writer role is released with the scope.
-        yield* Effect.scoped(adapter.resumeSession({ providerSessionId: "session-d", cwd }))
+        yield* Effect.scoped(
+          adapter.resumeSession({ providerSessionId: "session-d", cwd, settings: TEST_SETTINGS }),
+        )
       }).pipe(Effect.provide(layer))
     }),
   )
@@ -175,6 +199,7 @@ describe("ClaudeAdapter", () => {
             const { connection, turn } = yield* adapter.createSession({
               cwd,
               input: "HANG until told otherwise",
+              settings: TEST_SETTINGS,
             })
             const sink = yield* collectAgentEvents(connection.events)
             const stale = yield* Effect.flip(connection.interrupt({ turnId: "wrong-turn" }))
@@ -192,7 +217,7 @@ describe("ClaudeAdapter", () => {
             // An interrupted turn ends the held query; the session is over
             // (AgentUnavailable — the seam's "resume it" signal), not a
             // caller-side handle conflict.
-            const closed = yield* Effect.flip(connection.startTurn("another"))
+            const closed = yield* Effect.flip(connection.startTurn("another", TEST_SETTINGS))
             assert.strictEqual(closed._tag, "AgentUnavailable")
           }),
         )
@@ -211,6 +236,7 @@ describe("ClaudeAdapter", () => {
             const { connection, turn } = yield* adapter.createSession({
               cwd,
               input: "FAILTURN please",
+              settings: TEST_SETTINGS,
             })
             const sink = yield* collectAgentEvents(connection.events)
             yield* waitForAgentEvent(
@@ -240,6 +266,7 @@ describe("ClaudeAdapter", () => {
             const { connection, turn } = yield* adapter.createSession({
               cwd,
               input: "needs PERMISSION for a tool",
+              settings: TEST_SETTINGS,
             })
             const sink = yield* collectAgentEvents(connection.events)
             yield* waitForAgentEvent(sink, (event) => event.type === "requestOpened")
@@ -309,6 +336,7 @@ describe("ClaudeAdapter", () => {
             const { connection, turn } = yield* adapter.createSession({
               cwd,
               input: "needs PERMISSION for a tool",
+              settings: TEST_SETTINGS,
             })
             const sink = yield* collectAgentEvents(connection.events)
             yield* waitForAgentEvent(sink, (event) => event.type === "requestOpened")
@@ -344,6 +372,7 @@ describe("ClaudeAdapter", () => {
             const { connection, turn } = yield* adapter.createSession({
               cwd,
               input: "needs PERMISSION again",
+              settings: TEST_SETTINGS,
             })
             const sink = yield* collectAgentEvents(connection.events)
             yield* waitForAgentEvent(sink, (event) => event.type === "requestOpened")
@@ -374,6 +403,7 @@ describe("ClaudeAdapter", () => {
             const { connection, turn } = yield* adapter.createSession({
               cwd,
               input: "STREAM please",
+              settings: TEST_SETTINGS,
             })
             const sink = yield* collectAgentEvents(connection.events)
             yield* waitForAgentEvent(
@@ -439,6 +469,7 @@ describe("ClaudeAdapter", () => {
             const { connection, turn } = yield* adapter.createSession({
               cwd,
               input: "use a TOOL",
+              settings: TEST_SETTINGS,
             })
             const sink = yield* collectAgentEvents(connection.events)
             yield* waitForAgentEvent(
@@ -504,7 +535,11 @@ describe("ClaudeAdapter", () => {
         const adapter = yield* ClaudeAdapter.ClaudeAdapter
         yield* Effect.scoped(
           Effect.gen(function* () {
-            const { connection, turn } = yield* adapter.createSession({ cwd, input: "hello" })
+            const { connection, turn } = yield* adapter.createSession({
+              cwd,
+              input: "hello",
+              settings: TEST_SETTINGS,
+            })
             const sink = yield* collectAgentEvents(connection.events)
             yield* waitForAgentEvent(
               sink,
@@ -531,7 +566,11 @@ describe("ClaudeAdapter", () => {
         const adapter = yield* ClaudeAdapter.ClaudeAdapter
         yield* Effect.scoped(
           Effect.gen(function* () {
-            const { connection, turn } = yield* adapter.createSession({ cwd, input: "spawn" })
+            const { connection, turn } = yield* adapter.createSession({
+              cwd,
+              input: "spawn",
+              settings: TEST_SETTINGS,
+            })
             const sink = yield* collectAgentEvents(connection.events)
             yield* waitForAgentEvent(
               sink,
@@ -584,7 +623,11 @@ describe("ClaudeAdapter", () => {
         const adapter = yield* ClaudeAdapter.ClaudeAdapter
         yield* Effect.scoped(
           Effect.gen(function* () {
-            const { connection, turn } = yield* adapter.createSession({ cwd, input: "hello" })
+            const { connection, turn } = yield* adapter.createSession({
+              cwd,
+              input: "hello",
+              settings: TEST_SETTINGS,
+            })
             const sink = yield* collectAgentEvents(connection.events)
             yield* waitForAgentEvent(
               sink,
@@ -594,7 +637,7 @@ describe("ClaudeAdapter", () => {
             assert.strictEqual(yield* connection.activity, "working")
             // A whole further turn completes (Stop without a snapshot,
             // result success, state idle): the background evidence holds.
-            const second = yield* connection.startTurn("again")
+            const second = yield* connection.startTurn("again", TEST_SETTINGS)
             yield* waitForAgentEvent(
               sink,
               (event) => event.type === "turnCompleted" && event.turnId === second.turnId,
@@ -616,7 +659,11 @@ describe("ClaudeAdapter", () => {
         const adapter = yield* ClaudeAdapter.ClaudeAdapter
         yield* Effect.scoped(
           Effect.gen(function* () {
-            const { connection, turn } = yield* adapter.createSession({ cwd, input: "hello" })
+            const { connection, turn } = yield* adapter.createSession({
+              cwd,
+              input: "hello",
+              settings: TEST_SETTINGS,
+            })
             const sink = yield* collectAgentEvents(connection.events)
             yield* waitForAgentEvent(
               sink,
@@ -650,6 +697,7 @@ describe("ClaudeAdapter", () => {
             const { connection, turn } = yield* adapter.createSession({
               cwd,
               input: "ASK me something",
+              settings: TEST_SETTINGS,
             })
             const sink = yield* collectAgentEvents(connection.events)
             yield* waitForAgentEvent(
@@ -808,9 +856,11 @@ describe("ClaudeAdapter TUI session plumbing", () => {
                 ? event.activity
                 : event.type === "userPrompt"
                   ? `prompt:${event.text}`
-                  : event.item.type === "userMessage"
-                    ? `item:userMessage:${event.item.text}`
-                    : `item:${event.item.type}`,
+                  : event.type === "settings"
+                    ? "settings"
+                    : event.item.type === "userMessage"
+                      ? `item:userMessage:${event.item.text}`
+                      : `item:${event.item.type}`,
             ),
           ),
         ),
@@ -1319,4 +1369,193 @@ describe("ClaudeAdapter collectTitleContext", () => {
       }).pipe(Effect.provide(layer))
     }),
   )
+
+  // --- Chat mode settings (ATC-205) -------------------------------------------
+
+  it.live(
+    "settings: the child spawns with the caller's settings; init reports what it applied",
+    () =>
+      Effect.gen(function* () {
+        const cwd = workDir()
+        const { fake, layer } = adapterStack({ sessionId: "session-settings" })
+        yield* Effect.gen(function* () {
+          const adapter = yield* ClaudeAdapter.ClaudeAdapter
+          yield* Effect.scoped(
+            Effect.gen(function* () {
+              const { connection, turn } = yield* adapter.createSession({
+                cwd,
+                input: "hello",
+                settings: {
+                  model: "sonnet",
+                  reasoning: "low",
+                  mode: "chat",
+                  access: "autoAcceptEdits",
+                },
+              })
+              const sink = yield* collectAgentEvents(connection.events)
+              yield* waitForAgentEvent(
+                sink,
+                (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
+              )
+              // Spawn options: the ladder as one knob, effort, the alias model,
+              // and the standing allowance that lets Full access be chosen later.
+              const spawn = fake.spawns[0]!
+              assert.strictEqual(spawn["model"], "sonnet")
+              assert.strictEqual(spawn["effort"], "low")
+              assert.strictEqual(spawn["permissionMode"], "acceptEdits")
+              assert.strictEqual(spawn["allowDangerouslySkipPermissions"], true)
+              // Nothing to push on the first turn.
+              assert.deepStrictEqual(fake.controls, [])
+              // init reported the wire id and the mode; the report maps the id
+              // back to the catalog alias and reads the effort via getSettings.
+              yield* waitForAgentEvent(sink, (event) => event.type === "settings")
+              assert.deepStrictEqual(
+                sink.find((event) => event.type === "settings"),
+                {
+                  type: "settings",
+                  settings: {
+                    model: "sonnet",
+                    mode: "chat",
+                    access: "autoAcceptEdits",
+                    reasoning: "low",
+                  },
+                },
+              )
+
+              // A later turn on the resident connection pushes only what
+              // changed, and plan mode stands in for the rung.
+              const second = yield* connection.startTurn("again", {
+                model: "opus[1m]",
+                reasoning: "xhigh",
+                mode: "plan",
+                access: "autoAcceptEdits",
+              })
+              yield* waitForAgentEvent(
+                sink,
+                (event) => event.type === "turnCompleted" && event.turnId === second.turnId,
+              )
+              assert.deepStrictEqual(fake.controls, [
+                "setModel:opus[1m]",
+                "applyFlagSettings:xhigh",
+                "setPermissionMode:plan",
+              ])
+              // Unchanged settings push nothing; leaving plan restores the rung.
+              const third = yield* connection.startTurn("once more", {
+                model: "opus[1m]",
+                reasoning: "xhigh",
+                mode: "chat",
+                access: "fullAccess",
+              })
+              yield* waitForAgentEvent(
+                sink,
+                (event) => event.type === "turnCompleted" && event.turnId === third.turnId,
+              )
+              assert.deepStrictEqual(fake.controls.slice(3), [
+                "setPermissionMode:bypassPermissions",
+              ])
+              const fourth = yield* connection.startTurn("and again", {
+                model: "opus[1m]",
+                reasoning: "xhigh",
+                mode: "chat",
+                access: "fullAccess",
+              })
+              yield* waitForAgentEvent(
+                sink,
+                (event) => event.type === "turnCompleted" && event.turnId === fourth.turnId,
+              )
+              assert.strictEqual(fake.controls.length, 4)
+              // A model with no effort support clears the flag layer's effort.
+              const fifth = yield* connection.startTurn("haiku now", {
+                model: "haiku",
+                mode: "chat",
+                access: "fullAccess",
+              })
+              yield* waitForAgentEvent(
+                sink,
+                (event) => event.type === "turnCompleted" && event.turnId === fifth.turnId,
+              )
+              assert.deepStrictEqual(fake.controls.slice(4), [
+                "setModel:haiku",
+                "applyFlagSettings:null",
+              ])
+            }),
+          )
+        }).pipe(Effect.provide(layer))
+      }),
+  )
+
+  it.live(
+    "settings: a silently downgraded permission mode and a missing getSettings are reported truthfully",
+    () =>
+      Effect.gen(function* () {
+        const cwd = workDir()
+        // The CLI runs `default` when the model has no auto support; the SDK
+        // in this test also lacks getSettings, so the effort stays unreported.
+        const { layer } = adapterStack({
+          sessionId: "session-downgrade",
+          reportPermissionMode: "default",
+          withoutGetSettings: true,
+        })
+        yield* Effect.gen(function* () {
+          const adapter = yield* ClaudeAdapter.ClaudeAdapter
+          yield* Effect.scoped(
+            Effect.gen(function* () {
+              const { connection } = yield* adapter.createSession({
+                cwd,
+                input: "hello",
+                settings: { model: "haiku", mode: "chat", access: "auto" },
+              })
+              const sink = yield* collectAgentEvents(connection.events)
+              yield* waitForAgentEvent(sink, (event) => event.type === "settings")
+              assert.deepStrictEqual(
+                sink.find((event) => event.type === "settings"),
+                {
+                  type: "settings",
+                  settings: { model: "haiku", mode: "chat", access: "supervised" },
+                },
+              )
+            }),
+          )
+        }).pipe(Effect.provide(layer))
+      }),
+  )
+
+  it("listModels: the default meta-entry folds into its alias; effort support per model", () => {
+    assert.deepStrictEqual(ClaudeAdapter.normalizeClaudeCatalog(FAKE_CLAUDE_MODELS), [
+      {
+        value: "opus[1m]",
+        displayName: "Opus 5 (1M context)",
+        description: "Opus 5 with 1M context",
+        isDefault: true,
+        supportedEffortLevels: ["low", "medium", "high", "xhigh", "max"],
+        defaultEffortLevel: "high",
+      },
+      {
+        value: "sonnet",
+        displayName: "Sonnet 5",
+        description: "Sonnet 5",
+        isDefault: false,
+        supportedEffortLevels: ["low", "medium", "high", "xhigh", "max"],
+        defaultEffortLevel: "high",
+      },
+      {
+        value: "haiku",
+        displayName: "Haiku 4.5",
+        description: "Haiku 4.5",
+        isDefault: false,
+        supportedEffortLevels: [],
+      },
+    ])
+  })
+
+  it("listModels: the version comes from the wire id, after the family word", () => {
+    const name = ClaudeAdapter.claudeDisplayName
+    assert.strictEqual(name("Fable", "claude-fable-5[1m]"), "Fable 5")
+    assert.strictEqual(name("Opus (1M context)", "claude-opus-5[1m]"), "Opus 5 (1M context)")
+    assert.strictEqual(name("Haiku", "claude-haiku-4-5-20251001"), "Haiku 4.5")
+    // Already versioned, or a name the id does not explain: unchanged.
+    assert.strictEqual(name("Sonnet 5", "claude-sonnet-5"), "Sonnet 5")
+    assert.strictEqual(name("Legacy", "claude-sonnet-5"), "Legacy")
+    assert.strictEqual(name("Sonnet", "some-custom-model"), "Sonnet")
+  })
 })

--- a/app-server/test/agents/claudeTui.smoke.test.ts
+++ b/app-server/test/agents/claudeTui.smoke.test.ts
@@ -28,6 +28,9 @@ import { claudeAdapterLayer, collectAgentEvents, waitForAgentEvent } from "./age
 //     again that must answer with the context of BOTH earlier turns. One
 //     conversation, one leaf; getSessionMessages agrees.
 
+/** Cheap real-provider settings for the smoke turns (a real, small model). */
+const SMOKE_SETTINGS = { model: "haiku", mode: "chat", access: "supervised" } as const
+
 const enabled = process.env["ATC_SMOKE"] === "1"
 
 interface HookDelivery {
@@ -161,6 +164,7 @@ describe.skipIf(!enabled)("live claude TUI smoke (opt-in)", () => {
             const { connection, turn } = yield* adapter.createSession({
               cwd,
               input: "The first code word is ALPHA. Reply with exactly: OK",
+              settings: SMOKE_SETTINGS,
             })
             const sink = yield* collectAgentEvents(connection.events)
             yield* completedTurn(sink, turn.turnId)
@@ -215,10 +219,15 @@ describe.skipIf(!enabled)("live claude TUI smoke (opt-in)", () => {
         // 3. Native again: the model must know both code words.
         yield* Effect.scoped(
           Effect.gen(function* () {
-            const connection = yield* adapter.resumeSession({ providerSessionId: sessionId, cwd })
+            const connection = yield* adapter.resumeSession({
+              providerSessionId: sessionId,
+              cwd,
+              settings: SMOKE_SETTINGS,
+            })
             const sink = yield* collectAgentEvents(connection.events)
             const turn = yield* connection.startTurn(
               "Reply with the two code words I gave you, in order, separated by a space, and nothing else.",
+              SMOKE_SETTINGS,
             )
             yield* completedTurn(sink, turn.turnId)
             const text = sink

--- a/app-server/test/agents/codexAdapter.smoke.test.ts
+++ b/app-server/test/agents/codexAdapter.smoke.test.ts
@@ -19,6 +19,14 @@ import { TestBuildInfoLayer } from "../testBuildInfo.ts"
 // and orphans the detached server, the next run adopts and stops it
 // (adopt-or-replace is the cleanup story, not temp-dir tracking).
 
+/** Cheap real-provider settings for the smoke turns (a real, small model). */
+const SMOKE_SETTINGS = {
+  model: "gpt-5.6-luna",
+  reasoning: "low",
+  mode: "chat",
+  access: "auto",
+} as const
+
 const enabled = process.env["ATC_SMOKE"] === "1"
 
 const stateDir = path.join(os.tmpdir(), "atc-codex-smoke-state")
@@ -54,6 +62,7 @@ describe.skipIf(!enabled)("live codex adapter smoke (opt-in)", () => {
                 const { connection, turn } = yield* adapter.createSession({
                   cwd,
                   input: "Reply with exactly: SMOKE-OK",
+                  settings: SMOKE_SETTINGS,
                 })
                 const sink = yield* collectAgentEvents(connection.events)
                 yield* waitForAgentEvent(
@@ -74,11 +83,13 @@ describe.skipIf(!enabled)("live codex adapter smoke (opt-in)", () => {
                 const connection = yield* adapter.resumeSession({
                   providerSessionId: threadId,
                   cwd,
+                  settings: SMOKE_SETTINGS,
                 })
                 assert.strictEqual(connection.providerSessionId, threadId)
                 const sink = yield* collectAgentEvents(connection.events)
                 const turn = yield* connection.startTurn(
                   "Count from 1 to 200, one number per line. Do not stop early.",
+                  SMOKE_SETTINGS,
                 )
                 yield* waitForAgentEvent(
                   sink,
@@ -103,6 +114,7 @@ describe.skipIf(!enabled)("live codex adapter smoke (opt-in)", () => {
                 const connection = yield* adapter.resumeSession({
                   providerSessionId: threadId,
                   cwd,
+                  settings: SMOKE_SETTINGS,
                 })
                 assert.strictEqual(connection.providerSessionId, threadId)
               }),

--- a/app-server/test/agents/codexAdapter.test.ts
+++ b/app-server/test/agents/codexAdapter.test.ts
@@ -13,6 +13,7 @@ import {
   makeCodexSandbox,
   openExternal,
   waitForAgentEvent,
+  TEST_SETTINGS,
 } from "./agentTestKit.ts"
 
 // Codex adapter tests against the fake app-server fixture, through the real
@@ -44,6 +45,7 @@ describe("CodexAdapter", () => {
               const { connection, turn } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
                 input: "hello",
+                settings: TEST_SETTINGS,
               })
               assert.isString(connection.providerSessionId)
               assert.strictEqual(connection.cwd, sandbox.cwd)
@@ -79,6 +81,7 @@ describe("CodexAdapter", () => {
                 const { connection, turn } = yield* adapter.createSession({
                   cwd: sandbox.cwd,
                   input: "seed",
+                  settings: TEST_SETTINGS,
                 })
                 const sink = yield* collectAgentEvents(connection.events)
                 yield* waitForAgentEvent(
@@ -94,6 +97,7 @@ describe("CodexAdapter", () => {
                 const resumed = yield* adapter.resumeSession({
                   providerSessionId: threadId,
                   cwd: sandbox.cwd,
+                  settings: TEST_SETTINGS,
                 })
                 assert.strictEqual(resumed.providerSessionId, threadId)
               }),
@@ -104,6 +108,7 @@ describe("CodexAdapter", () => {
                 adapter.resumeSession({
                   providerSessionId: "00000000-0000-7000-8000-000000000000",
                   cwd: sandbox.cwd,
+                  settings: TEST_SETTINGS,
                 }),
               ),
             )
@@ -122,7 +127,13 @@ describe("CodexAdapter", () => {
         yield* withAdapter(sandbox, (adapter) =>
           Effect.gen(function* () {
             const failure = yield* Effect.scoped(
-              Effect.flip(adapter.createSession({ cwd: sandbox.cwd, input: "hello" })),
+              Effect.flip(
+                adapter.createSession({
+                  cwd: sandbox.cwd,
+                  input: "hello",
+                  settings: TEST_SETTINGS,
+                }),
+              ),
             )
             assert.strictEqual(failure._tag, "AgentIdentityMismatch")
             if (failure._tag === "AgentIdentityMismatch") {
@@ -146,6 +157,7 @@ describe("CodexAdapter", () => {
                 const { connection, turn } = yield* adapter.createSession({
                   cwd: sandbox.cwd,
                   input: "seed",
+                  settings: TEST_SETTINGS,
                 })
                 const sink = yield* collectAgentEvents(connection.events)
                 yield* waitForAgentEvent(
@@ -156,7 +168,13 @@ describe("CodexAdapter", () => {
               }),
             )
             const failure = yield* Effect.scoped(
-              Effect.flip(adapter.resumeSession({ providerSessionId: threadId, cwd: sandbox.cwd })),
+              Effect.flip(
+                adapter.resumeSession({
+                  providerSessionId: threadId,
+                  cwd: sandbox.cwd,
+                  settings: TEST_SETTINGS,
+                }),
+              ),
             )
             assert.strictEqual(failure._tag, "AgentIdentityMismatch")
             if (failure._tag === "AgentIdentityMismatch") {
@@ -179,11 +197,13 @@ describe("CodexAdapter", () => {
               const { connection } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
                 input: "HANG on",
+                settings: TEST_SETTINGS,
               })
               const failure = yield* Effect.flip(
                 adapter.resumeSession({
                   providerSessionId: connection.providerSessionId,
                   cwd: sandbox.cwd,
+                  settings: TEST_SETTINGS,
                 }),
               )
               assert.strictEqual(failure._tag, "AgentConflict")
@@ -205,6 +225,7 @@ describe("CodexAdapter", () => {
               const { connection, turn } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
                 input: "HANG until interrupted",
+                settings: TEST_SETTINGS,
               })
               const sink = yield* collectAgentEvents(connection.events)
               yield* waitForAgentEvent(
@@ -242,6 +263,7 @@ describe("CodexAdapter", () => {
               const { connection, turn } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
                 input: "needs APPROVAL for this",
+                settings: TEST_SETTINGS,
               })
               const sink = yield* collectAgentEvents(connection.events)
               yield* waitForAgentEvent(sink, (event) => event.type === "requestOpened")
@@ -311,6 +333,7 @@ describe("CodexAdapter", () => {
               const { connection, turn } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
                 input: "needs APPROVAL for this",
+                settings: TEST_SETTINGS,
               })
               const sink = yield* collectAgentEvents(connection.events)
               yield* waitForAgentEvent(sink, (event) => event.type === "requestOpened")
@@ -336,7 +359,7 @@ describe("CodexAdapter", () => {
 
               // A question round trip: answers keyed by the question id reach
               // the provider (the fixture echoes them back as its reply).
-              const asked = yield* connection.startTurn("QUESTION time")
+              const asked = yield* connection.startTurn("QUESTION time", TEST_SETTINGS)
               yield* waitForAgentEvent(
                 sink,
                 (event) => event.type === "requestOpened" && event.request.kind === "question",
@@ -386,6 +409,7 @@ describe("CodexAdapter", () => {
               const { connection, turn } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
                 input: "seed",
+                settings: TEST_SETTINGS,
               })
               const sink = yield* collectAgentEvents(connection.events)
               yield* waitForAgentEvent(
@@ -428,7 +452,7 @@ describe("CodexAdapter", () => {
             // A session the provider actually has: the probe passes.
             const sessionId = yield* Effect.scoped(
               Effect.map(
-                adapter.createSession({ cwd: sandbox.cwd, input: "seed" }),
+                adapter.createSession({ cwd: sandbox.cwd, input: "seed", settings: TEST_SETTINGS }),
                 ({ connection }) => connection.providerSessionId,
               ),
             )
@@ -473,6 +497,7 @@ describe("CodexAdapter", () => {
               const { connection, turn } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
                 input: "STREAM me",
+                settings: TEST_SETTINGS,
               })
               const sink = yield* collectAgentEvents(connection.events)
               yield* waitForAgentEvent(
@@ -532,6 +557,7 @@ describe("CodexAdapter", () => {
                 const { connection, turn } = yield* adapter.createSession({
                   cwd: sandbox.cwd,
                   input: "run a COMMAND",
+                  settings: TEST_SETTINGS,
                 })
                 const sink = yield* collectAgentEvents(connection.events)
                 yield* waitForAgentEvent(
@@ -588,6 +614,7 @@ describe("CodexAdapter", () => {
               const { connection, turn } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
                 input: "hello",
+                settings: TEST_SETTINGS,
               })
               const sink = yield* collectAgentEvents(connection.events)
               yield* waitForAgentEvent(
@@ -750,7 +777,9 @@ describe("CodexAdapter TUI session plumbing", () => {
                         ? event.activity
                         : event.type === "userPrompt"
                           ? `prompt:${event.text}`
-                          : `item:${event.item.type}`,
+                          : event.type === "settings"
+                            ? "settings"
+                            : `item:${event.item.type}`,
                     ),
                   ),
                 ),
@@ -801,7 +830,9 @@ describe("CodexAdapter TUI session plumbing", () => {
                         ? event.activity
                         : event.type === "userPrompt"
                           ? `prompt:${event.text}`
-                          : `item:${event.item.type}`,
+                          : event.type === "settings"
+                            ? "settings"
+                            : `item:${event.item.type}`,
                     ),
                   ),
                 ),
@@ -902,7 +933,9 @@ describe("CodexAdapter TUI session plumbing", () => {
                         ? event.activity
                         : event.type === "userPrompt"
                           ? `prompt:${event.text}`
-                          : `item:${event.item.type}`,
+                          : event.type === "settings"
+                            ? "settings"
+                            : `item:${event.item.type}`,
                     ),
                   ),
                 ),
@@ -962,7 +995,9 @@ describe("CodexAdapter TUI session plumbing", () => {
                         ? event.activity
                         : event.type === "userPrompt"
                           ? `prompt:${event.text}`
-                          : `item:${event.item.type}`,
+                          : event.type === "settings"
+                            ? "settings"
+                            : `item:${event.item.type}`,
                     ),
                   ),
                 ),
@@ -1085,6 +1120,7 @@ describe("CodexAdapter descendant aggregation", () => {
               const { connection, turn } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
                 input: "SPAWN one worker",
+                settings: TEST_SETTINGS,
               })
               const sink = yield* collectAgentEvents(connection.events)
               yield* waitForAgentEvent(
@@ -1123,6 +1159,7 @@ describe("CodexAdapter descendant aggregation", () => {
               const { connection, turn } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
                 input: "SPAWN NEEDSINPUT worker",
+                settings: TEST_SETTINGS,
               })
               const sink = yield* collectAgentEvents(connection.events)
               yield* waitForAgentEvent(
@@ -1175,7 +1212,9 @@ describe("CodexAdapter descendant aggregation", () => {
                         ? event.activity
                         : event.type === "userPrompt"
                           ? `prompt:${event.text}`
-                          : `item:${event.item.type}`,
+                          : event.type === "settings"
+                            ? "settings"
+                            : `item:${event.item.type}`,
                     ),
                   ),
                 ),
@@ -1267,6 +1306,7 @@ describe("CodexAdapter descendant aggregation", () => {
               const { connection, turn } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
                 input: "SPAWN worker",
+                settings: TEST_SETTINGS,
               })
               const sink = yield* collectAgentEvents(connection.events)
               yield* waitForAgentEvent(
@@ -1333,7 +1373,9 @@ describe("CodexAdapter descendant aggregation", () => {
                           ? event.activity
                           : event.type === "userPrompt"
                             ? `prompt:${event.text}`
-                            : `item:${event.item.type}`,
+                            : event.type === "settings"
+                              ? "settings"
+                              : `item:${event.item.type}`,
                       ),
                     ),
                   ),
@@ -1409,6 +1451,7 @@ describe("CodexAdapter collectTitleContext", () => {
                 const { connection, turn } = yield* adapter.createSession({
                   cwd: sandbox.cwd,
                   input: "seed turn",
+                  settings: TEST_SETTINGS,
                 })
                 const id = connection.providerSessionId
                 const sink = yield* collectAgentEvents(connection.events)
@@ -1427,7 +1470,7 @@ describe("CodexAdapter collectTitleContext", () => {
                   providerSessionId: id,
                   providerMetadata: undefined,
                 })
-                const second = yield* connection.startTurn("hello context")
+                const second = yield* connection.startTurn("hello context", TEST_SETTINGS)
                 yield* waitForAgentEvent(
                   sink,
                   (event) => event.type === "turnCompleted" && event.turnId === second.turnId,
@@ -1448,6 +1491,203 @@ describe("CodexAdapter collectTitleContext", () => {
                 cwd: sandbox.cwd,
               }),
             )
+          }),
+        )
+      }),
+    30_000,
+  )
+
+  // --- Chat mode settings (ATC-205) -------------------------------------------
+
+  it.live(
+    "settings: thread/start carries the ladder, turn/start pushes only the difference plus the two constants",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.scoped(
+            Effect.gen(function* () {
+              const settings = {
+                model: "fake-sol",
+                reasoning: "high",
+                mode: "chat",
+                access: "supervised",
+              } as const
+              const { connection, turn } = yield* adapter.createSession({
+                cwd: sandbox.cwd,
+                input: "hello",
+                settings,
+              })
+              const sink = yield* collectAgentEvents(connection.events)
+              yield* waitForAgentEvent(
+                sink,
+                (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
+              )
+              // The second turn changes access and reasoning: exactly those
+              // ride as overrides; model is unchanged and stays home.
+              const second = yield* connection.startTurn("again", {
+                ...settings,
+                reasoning: "low",
+                access: "fullAccess",
+                mode: "plan",
+              })
+              yield* waitForAgentEvent(
+                sink,
+                (event) => event.type === "turnCompleted" && event.turnId === second.turnId,
+              )
+              const external = yield* openExternal(sandbox.socketPath)
+              const resumed = yield* external.request(1, "thread/resume", {
+                threadId: connection.providerSessionId,
+              })
+              // thread/start received the Supervised knobs; the last turn's
+              // overrides moved the thread to Full access.
+              assert.strictEqual(resumed["model"], "fake-sol")
+              assert.strictEqual(resumed["reasoningEffort"], "low")
+              assert.strictEqual(resumed["approvalPolicy"], "never")
+              assert.deepStrictEqual(resumed["sandbox"], { type: "dangerFullAccess" })
+              const turns = (resumed["thread"] as { turns: Array<{ overrides: unknown }> }).turns
+              assert.deepStrictEqual(turns[0]!.overrides, {
+                // thread/start carried model + Supervised; the reply echoed the
+                // model's default effort (medium), so only effort differed.
+                effort: "high",
+                approvalsReviewer: "user",
+                collaborationMode: {
+                  mode: "default",
+                  settings: { model: "fake-sol", reasoning_effort: "high" },
+                },
+              })
+              assert.deepStrictEqual(turns[1]!.overrides, {
+                effort: "low",
+                approvalPolicy: "never",
+                sandboxPolicy: { type: "dangerFullAccess" },
+                approvalsReviewer: "user",
+                collaborationMode: {
+                  mode: "plan",
+                  settings: { model: "fake-sol", reasoning_effort: "low" },
+                },
+              })
+            }),
+          ),
+        )
+      }),
+    30_000,
+  )
+
+  it.live(
+    "settings: a change made by another client reaches the writer feed and observers as the seam's report",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.scoped(
+            Effect.gen(function* () {
+              const { connection, turn } = yield* adapter.createSession({
+                cwd: sandbox.cwd,
+                input: "hello",
+                settings: TEST_SETTINGS,
+              })
+              const sink = yield* collectAgentEvents(connection.events)
+              yield* waitForAgentEvent(
+                sink,
+                (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
+              )
+              const observed: Array<AgentSessionEvent> = []
+              const stream = yield* adapter.observeSession({
+                providerSessionId: connection.providerSessionId,
+                providerMetadata: undefined,
+              })
+              yield* stream.pipe(
+                Stream.runForEach((event) => Effect.sync(() => observed.push(event))),
+                Effect.forkScoped,
+              )
+              // The "TUI" switches model, effort, sandbox, and mode.
+              const external = yield* openExternal(sandbox.socketPath)
+              yield* external.request(1, "thread/settings/update", {
+                threadId: connection.providerSessionId,
+                model: "fake-luna",
+                effort: "low",
+                approvalPolicy: "on-request",
+                sandboxType: "readOnly",
+                mode: "plan",
+              })
+              yield* waitForAgentEvent(sink, (event) => event.type === "settings")
+              assert.deepStrictEqual(
+                sink.find((event) => event.type === "settings"),
+                {
+                  type: "settings",
+                  settings: {
+                    model: "fake-luna",
+                    reasoning: "low",
+                    access: "supervised",
+                    mode: "plan",
+                  },
+                },
+              )
+              yield* eventually(
+                Effect.sync(() => observed),
+                (entries) => entries.some((event) => event.type === "settings"),
+              )
+              // Codex reports the ladder as two knobs; the reverse read projects
+              // read-only onto Supervised whatever the approval policy says,
+              // and an unknown effort onto "no level".
+              yield* external.request(2, "thread/settings/update", {
+                threadId: connection.providerSessionId,
+                effort: "galactic",
+                approvalPolicy: "never",
+                sandboxType: "workspaceWrite",
+                mode: "default",
+              })
+              yield* waitForAgentEvent(
+                sink,
+                (event) => event.type === "settings" && event.settings.access === "auto",
+              )
+              assert.deepStrictEqual(
+                sink.findLast((event) => event.type === "settings"),
+                {
+                  type: "settings",
+                  settings: { model: "fake-luna", reasoning: null, access: "auto", mode: "chat" },
+                },
+              )
+            }),
+          ),
+        )
+      }),
+    30_000,
+  )
+
+  it.live(
+    "listModels: every page of the catalog, hidden entries dropped, efforts and defaults decoded",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox({ FAKE_CODEX_MODEL_PAGED: "1" })
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.gen(function* () {
+            assert.deepStrictEqual(yield* adapter.listModels(), [
+              {
+                value: "fake-sol",
+                displayName: "Fake Sol",
+                description: "the default",
+                isDefault: true,
+                supportedEffortLevels: ["low", "medium", "high", "xhigh"],
+                defaultEffortLevel: "medium",
+              },
+              {
+                value: "fake-luna",
+                displayName: "Fake Luna",
+                description: "smaller",
+                isDefault: false,
+                supportedEffortLevels: ["low", "medium"],
+                defaultEffortLevel: "low",
+              },
+              {
+                value: "fake-terra",
+                displayName: "Fake Terra",
+                description: "misreports its default",
+                isDefault: false,
+                supportedEffortLevels: ["low", "medium"],
+                defaultEffortLevel: "low",
+              },
+            ])
           }),
         )
       }),

--- a/app-server/test/agents/fakeAgentAdapter.ts
+++ b/app-server/test/agents/fakeAgentAdapter.ts
@@ -4,13 +4,16 @@ import type {
   AgentAdapter,
   AgentConnection,
   AgentEvent,
+  AgentModel,
   AgentSessionEvent,
   AgentTurn,
   AgentTurnOutcome,
   HistoryTurn,
+  ProviderSettings,
   ThreadItem,
   ThreadRequest,
   ThreadRequestAnswer,
+  ThreadSettings,
 } from "../../src/agents/agentAdapter.ts"
 import {
   AgentConflict,
@@ -41,6 +44,8 @@ export interface FakeAgentSession {
   readonly cwd: string
   /** Inputs received via createSession/startTurn, for assertions. */
   readonly inputs: Array<string>
+  /** Settings each turn was started with (createSession/startTurn), in order. */
+  readonly turnSettings: Array<ThreadSettings>
 }
 
 export interface FakeAgentAdapter {
@@ -133,6 +138,17 @@ export interface FakeAgentAdapter {
   readonly prepared: Array<{ providerSessionId: string; cwd: string }>
   /** releaseSession calls, in order. */
   readonly released: Array<{ providerSessionId: string; providerMetadata: string | undefined }>
+  /** Push one provider settings report onto the live connection's feed and
+   * to every observer of `providerSessionId` (a change made in the TUI). */
+  readonly emitSettings: (providerSessionId: string, settings: ProviderSettings) => void
+  /** Script what listModels returns (default: a two-model catalog). */
+  readonly setModels: (models: ReadonlyArray<AgentModel>) => void
+  /** listModels calls so far. */
+  readonly modelReads: () => number
+  /** Park every listModels (after it is counted) on `gate` — a slow
+   * catalog read, so a caller can be caught between reading a row and
+   * writing it. `Effect.void` restores the instant answer. */
+  readonly gateModels: (gate: Effect.Effect<void>) => void
 }
 
 export interface FakeAgentAdapterOptions {
@@ -175,6 +191,25 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
   let inFlightChecks = 0
   let maxInFlightChecks = 0
   let unavailableReason: string | null = null
+  let models: ReadonlyArray<AgentModel> = [
+    {
+      value: "fake-large",
+      displayName: "Fake Large",
+      description: "The default fake model",
+      isDefault: true,
+      supportedEffortLevels: ["low", "medium", "high"],
+      defaultEffortLevel: "medium",
+    },
+    {
+      value: "fake-small",
+      displayName: "Fake Small",
+      description: "No effort support",
+      isDefault: false,
+      supportedEffortLevels: [],
+    },
+  ]
+  let modelReads = 0
+  let modelsGate: Effect.Effect<void> = Effect.void
   let nextSessionId = 1
   let nextTurnId = 1
   const instance = crypto.randomUUID().slice(0, 8)
@@ -245,7 +280,7 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
           : Effect.void,
       )
 
-      const startTurn = (input: string) =>
+      const startTurn = (input: string, settings: ThreadSettings) =>
         Effect.gen(function* () {
           yield* requireAvailable
           yield* requireOpen
@@ -258,6 +293,7 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
             )
           }
           session.inputs.push(input)
+          session.turnSettings.push(settings)
           // Unique across fake instances: turn ids are persisted, and a
           // "restarted" fake must not collide with the previous one's turns.
           const turnId = `fake-turn-${nextTurnId++}-${instance}`
@@ -352,13 +388,14 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
           providerSessionId: `fake-session-${nextSessionId++}`,
           cwd: options.cwd,
           inputs: [],
+          turnSettings: [],
         }
         sessions.set(session.providerSessionId, session)
         const connection = yield* openConnection(session)
         // The fake verifies eagerly, so deferred-verification tags cannot
         // occur on its first turn.
         const turn = yield* connection
-          .startTurn(options.input)
+          .startTurn(options.input, options.settings)
           .pipe(Effect.catchTag("AgentResumeFailed", (error) => Effect.die(error)))
         return { connection, turn }
       }),
@@ -414,7 +451,12 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
         // The prepared session becomes resumable once identity resolves —
         // mirroring "a completed first interaction materializes it".
         const resolve = Effect.sync(() => {
-          sessions.set(providerSessionId, { providerSessionId, cwd: options.cwd, inputs: [] })
+          sessions.set(providerSessionId, {
+            providerSessionId,
+            cwd: options.cwd,
+            inputs: [],
+            turnSettings: [],
+          })
           return {
             providerSessionId,
             cwd: options.cwd,
@@ -448,6 +490,13 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
           }),
         )
         return Stream.fromQueue(queue)
+      }),
+    listModels: () =>
+      Effect.gen(function* () {
+        yield* requireAvailable
+        modelReads++
+        yield* modelsGate
+        return models
       }),
     generateTitle: (options) =>
       Effect.gen(function* () {
@@ -510,7 +559,7 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
       unavailableReason = reason
     },
     seed: (providerSessionId, cwd) => {
-      const session: FakeAgentSession = { providerSessionId, cwd, inputs: [] }
+      const session: FakeAgentSession = { providerSessionId, cwd, inputs: [], turnSettings: [] }
       sessions.set(providerSessionId, session)
       return session
     },
@@ -594,6 +643,20 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
       for (const queue of observers.get(providerSessionId) ?? []) {
         Queue.offerUnsafe(queue, { type: "userPrompt", text })
       }
+    },
+    emitSettings: (providerSessionId, settings) => {
+      const live = connections.get(providerSessionId)
+      if (live !== undefined) emit(live, { type: "settings", settings })
+      for (const queue of observers.get(providerSessionId) ?? []) {
+        Queue.offerUnsafe(queue, { type: "settings", settings })
+      }
+    },
+    setModels: (next) => {
+      models = next
+    },
+    modelReads: () => modelReads,
+    gateModels: (gate) => {
+      modelsGate = gate
     },
     titleRequests,
     titleOutcomes,

--- a/app-server/test/agents/fakeClaudeQuery.ts
+++ b/app-server/test/agents/fakeClaudeQuery.ts
@@ -1,5 +1,5 @@
-import type { SDKMessage, SDKUserMessage } from "@anthropic-ai/claude-agent-sdk"
-import type { ClaudeQueryFn } from "../../src/agents/claudeAdapter.ts"
+import type { ModelInfo, SDKMessage, SDKUserMessage } from "@anthropic-ai/claude-agent-sdk"
+import type { ClaudeQueryFn, ClaudeQueryHandle } from "../../src/agents/claudeAdapter.ts"
 
 // A scripted stand-in for the Agent SDK's query() (the ClaudeQueryFn seam):
 // consumes the streaming prompt like the real SDK, emits the message shapes
@@ -34,7 +34,54 @@ export interface FakeClaudeQueryOptions {
    * tests can prove activity flows from the in-process hook callbacks too.
    */
   readonly stateEvents?: boolean
+  /** The catalog supportedModels() answers with (default: the recorded shape). */
+  readonly models?: ReadonlyArray<ModelInfo>
+  /** Report this permission mode in init instead of the spawned one (the
+   * CLI's silent `auto` → `default` downgrade on a model without auto support). */
+  readonly reportPermissionMode?: string
+  /** Leave getSettings() undeclared on the handle (an SDK that dropped it). */
+  readonly withoutGetSettings?: boolean
 }
+
+/** The catalog shape recorded from the CLI (2026-08-18), trimmed. */
+export const FAKE_CLAUDE_MODELS: ReadonlyArray<ModelInfo> = [
+  {
+    value: "default",
+    resolvedModel: "claude-opus-5[1m]",
+    displayName: "Default (recommended)",
+    description: "Opus 5 with 1M context",
+    supportsEffort: true,
+    supportedEffortLevels: ["low", "medium", "high", "xhigh", "max"],
+  },
+  {
+    value: "opus[1m]",
+    resolvedModel: "claude-opus-5[1m]",
+    displayName: "Opus (1M context)",
+    description: "Opus 5 with 1M context",
+    supportsEffort: true,
+    supportedEffortLevels: ["low", "medium", "high", "xhigh", "max"],
+  },
+  {
+    value: "sonnet",
+    resolvedModel: "claude-sonnet-5",
+    displayName: "Sonnet",
+    description: "Sonnet 5",
+    supportsEffort: true,
+    supportedEffortLevels: ["low", "medium", "high", "xhigh", "max"],
+  },
+  {
+    value: "haiku",
+    resolvedModel: "claude-haiku-4-5-20251001",
+    displayName: "Haiku",
+    description: "Haiku 4.5",
+  },
+]
+
+/** The wire id the CLI reports for a catalog value (init's `model`). */
+const wireModel = (value: string | undefined): string =>
+  FAKE_CLAUDE_MODELS.find((model) => model.value === value)?.resolvedModel ??
+  value ??
+  "claude-opus-5[1m]"
 
 export interface FakeClaudeQuery {
   readonly queryFn: ClaudeQueryFn
@@ -42,6 +89,11 @@ export interface FakeClaudeQuery {
   readonly decisions: Array<{ toolName: string; result: unknown }>
   /** Interrupt calls observed. */
   readonly interrupts: Array<string>
+  /** Live control requests observed (setModel / applyFlagSettings /
+   * setPermissionMode), in order, with their argument. */
+  readonly controls: Array<string>
+  /** The query() options each spawn received, in order. */
+  readonly spawns: Array<Record<string, unknown>>
   /**
    * Fire one hook event into the most recent query's registered callbacks
    * with a scripted payload (session_id filled in) — how tests replay
@@ -54,6 +106,8 @@ export const makeFakeClaudeQuery = (options: FakeClaudeQueryOptions = {}): FakeC
   const decisions: FakeClaudeQuery["decisions"] = []
   let nextMessage = 1
   const interrupts: Array<string> = []
+  const controls: Array<string> = []
+  const spawns: Array<Record<string, unknown>> = []
   let lastFire: ((eventName: string, payload?: Record<string, unknown>) => Promise<void>) | null =
     null
 
@@ -67,6 +121,13 @@ export const makeFakeClaudeQuery = (options: FakeClaudeQueryOptions = {}): FakeC
     const sessionId =
       options.reportSessionId ?? resumeId ?? options.sessionId ?? "fake-claude-session"
     const cwd = (options.wrongCwd ? "/somewhere/else" : args.options.cwd) ?? "/"
+    spawns.push({ ...args.options } as unknown as Record<string, unknown>)
+    // The applied settings, as the CLI would hold them: spawned, then moved
+    // by the control requests.
+    let model = wireModel(args.options.model)
+    let permissionMode: string =
+      options.reportPermissionMode ?? args.options.permissionMode ?? "default"
+    let effort: string | null = args.options.effort ?? "high"
 
     const push = (message: Record<string, unknown>): void => {
       output.push(message as unknown as SDKMessage)
@@ -126,7 +187,7 @@ export const makeFakeClaudeQuery = (options: FakeClaudeQueryOptions = {}): FakeC
       return () => {
         if (sent) return
         sent = true
-        push({ type: "system", subtype: "init", session_id: sessionId, cwd })
+        push({ type: "system", subtype: "init", session_id: sessionId, cwd, model, permissionMode })
       }
     })()
 
@@ -290,7 +351,25 @@ export const makeFakeClaudeQuery = (options: FakeClaudeQueryOptions = {}): FakeC
 
     args.options.abortController?.signal.addEventListener("abort", () => finish())
 
-    const iterator: AsyncIterable<SDKMessage> & { interrupt: () => Promise<unknown> } = {
+    const getSettings = () => Promise.resolve({ applied: { model, effort } })
+    const iterator: ClaudeQueryHandle & { getSettings?: () => Promise<unknown> } = {
+      setModel: (next) => {
+        controls.push(`setModel:${next ?? ""}`)
+        model = wireModel(next)
+        return Promise.resolve()
+      },
+      setPermissionMode: (next) => {
+        controls.push(`setPermissionMode:${next}`)
+        permissionMode = next
+        return Promise.resolve()
+      },
+      applyFlagSettings: (settings) => {
+        controls.push(`applyFlagSettings:${settings.effortLevel ?? "null"}`)
+        effort = settings.effortLevel ?? null
+        return Promise.resolve()
+      },
+      supportedModels: () => Promise.resolve(options.models ?? FAKE_CLAUDE_MODELS),
+      ...(options.withoutGetSettings === true ? {} : { getSettings }),
       interrupt: () => {
         interrupts.push(hanging ?? "(no hanging turn)")
         if (hanging !== null) {
@@ -336,6 +415,8 @@ export const makeFakeClaudeQuery = (options: FakeClaudeQueryOptions = {}): FakeC
     queryFn,
     decisions,
     interrupts,
+    controls,
+    spawns,
     fireHook: (eventName, payload) => {
       if (lastFire === null) throw new Error("no query started yet")
       return lastFire(eventName, payload)

--- a/app-server/test/api/openapi.test.ts
+++ b/app-server/test/api/openapi.test.ts
@@ -191,6 +191,7 @@ describe("openapi document vs runtime", () => {
       "/api/v1/threads/{threadId}/queue/{promptId}",
       "/api/v1/agents",
       "/api/v1/agents/{agentId}",
+      "/api/v1/agents/{agentId}/models",
       "/api/v1/events",
       "/api/v1/fs/check",
       "/api/v1/fs/list",
@@ -552,6 +553,25 @@ describe("openapi document vs runtime", () => {
         agentId: "nope",
         message: "no agent with id nope",
       })
+
+      // The model catalog (ATC-205), over the fake adapter's stock catalog.
+      const models = yield* client.get("http://127.0.0.1/api/v1/agents/codex/models")
+      assert.strictEqual(models.status, 200)
+      const catalog = (yield* models.json) as Array<Record<string, unknown>>
+      assert.isAtLeast(catalog.length, 1, "the fake catalog lists at least one model")
+      const modelSchema = componentSchema("AgentModel")
+      for (const model of catalog) {
+        assert.includeMembers(Object.keys(modelSchema.properties), Object.keys(model))
+        assert.sameMembers(
+          [...modelSchema.required].filter((key) => !(key in model)),
+          [],
+        )
+      }
+      assert.deepStrictEqual(
+        operation("/api/v1/agents/{agentId}/models").responses["200"]!.content["application/json"]!
+          .schema,
+        { $ref: "#/components/schemas/AgentModelList" },
+      )
     }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
   )
 

--- a/app-server/test/fixtures/fake-codex-listener.ts
+++ b/app-server/test/fixtures/fake-codex-listener.ts
@@ -27,6 +27,16 @@
 // "NEEDSINPUT" makes the child wait on approval. The test-only
 // "test/child/finish" request completes a child.
 //
+// Settings (ATC-205): each thread holds model / effort / approvalPolicy /
+// sandbox / mode as the real server does. thread/start takes model,
+// approvalPolicy and sandbox; thread/start and thread/resume echo them at the
+// reply's top level; turn/start applies its overrides (model, effort,
+// approvalPolicy, sandboxPolicy, collaborationMode) and records the params
+// it received on the turn (`overrides`, visible via thread/resume for
+// assertions); thread/settings/update changes settings and broadcasts
+// thread/settings/updated like a TUI change would; model/list serves a
+// small catalog.
+//
 // Env switches (baked into the wrapper script by tests):
 //   FAKE_CODEX_MODE       "ok" (default) | "never-ready" (alive, never binds)
 //   FAKE_CODEX_WRONG_CWD  "start" | "resume" — lie about cwd in that reply
@@ -40,6 +50,7 @@
 //   FAKE_CODEX_READ_DELAY_MS  delay root thread/read replies, so tests can
 //                         prove activity never waits on the ATC-155
 //                         prompt (preview) read
+//   FAKE_CODEX_MODEL_PAGED  "1" — serve model/list one model per page
 //   FAKE_CODEX_PREVIEW_DELAY_MS  make preview readable only this long
 //                         after the first turn starts (the real rollout
 //                         flush lag), so tests can prove the ATC-155
@@ -156,12 +167,23 @@ interface Turn {
   readonly startedAt: number
   completedAt: number | null
   error: { message: string } | null
+  /** Fixture-only: the turn/start params beyond input/threadId. */
+  readonly overrides?: Record<string, unknown>
+}
+
+interface ThreadSettings {
+  model: string
+  effort: string | null
+  approvalPolicy: unknown
+  sandboxType: string
+  mode: string
 }
 
 interface Thread {
   readonly id: string
   readonly cwd: string
   readonly turns: Array<Turn>
+  readonly settings: ThreadSettings
   // "Usually the first user message in the thread, if available" — set at
   // the first turn/start, like the real rollout history (ATC-155).
   preview: string
@@ -194,6 +216,85 @@ const threadShape = (thread: Thread, cwd: string) => ({
   status: { type: "idle" },
   turns: thread.turns,
 })
+
+const SANDBOX_TYPES: Record<string, string> = {
+  "read-only": "readOnly",
+  "workspace-write": "workspaceWrite",
+  "danger-full-access": "dangerFullAccess",
+}
+
+/** The reply's top-level settings echo, as the real thread/start and thread/resume carry it. */
+const settingsEcho = (thread: Thread) => ({
+  model: thread.settings.model,
+  reasoningEffort: thread.settings.effort,
+  approvalPolicy: thread.settings.approvalPolicy,
+  sandbox: { type: thread.settings.sandboxType },
+})
+
+const settingsUpdatedParams = (thread: Thread) => ({
+  threadId: thread.id,
+  threadSettings: {
+    model: thread.settings.model,
+    effort: thread.settings.effort,
+    approvalPolicy: thread.settings.approvalPolicy,
+    sandboxPolicy: { type: thread.settings.sandboxType },
+    collaborationMode: { mode: thread.settings.mode },
+  },
+})
+
+const FAKE_MODELS = [
+  {
+    id: "fake-sol",
+    model: "fake-sol",
+    displayName: "Fake Sol",
+    description: "the default",
+    hidden: false,
+    isDefault: true,
+    supportedReasoningEfforts: ["low", "medium", "high", "xhigh"].map((level) => ({
+      reasoningEffort: level,
+      description: level,
+    })),
+    defaultReasoningEffort: "medium",
+  },
+  {
+    id: "fake-luna",
+    model: "fake-luna",
+    displayName: "Fake Luna",
+    description: "smaller",
+    hidden: false,
+    isDefault: false,
+    supportedReasoningEfforts: ["low", "medium"].map((level) => ({
+      reasoningEffort: level,
+      description: level,
+    })),
+    defaultReasoningEffort: "low",
+  },
+  {
+    // A default the model does not itself list (seen on real catalogs):
+    // the seam clamps it to the first listed level.
+    id: "fake-terra",
+    model: "fake-terra",
+    displayName: "Fake Terra",
+    description: "misreports its default",
+    hidden: false,
+    isDefault: false,
+    supportedReasoningEfforts: ["low", "medium"].map((level) => ({
+      reasoningEffort: level,
+      description: level,
+    })),
+    defaultReasoningEffort: "high",
+  },
+  {
+    id: "fake-hidden",
+    model: "fake-hidden",
+    displayName: "Hidden",
+    description: "not listed",
+    hidden: true,
+    isDefault: false,
+    supportedReasoningEfforts: [],
+    defaultReasoningEffort: "low",
+  },
+]
 
 const childStatus = (child: Child) =>
   child.status === "idle"
@@ -277,13 +378,24 @@ const handle = (
         id: crypto.randomUUID(),
         cwd,
         turns: [],
+        settings: {
+          model: String(params["model"] ?? "fake-sol"),
+          // Like the real reply: a fresh thread echoes its model's default effort.
+          effort:
+            FAKE_MODELS.find((model) => model.model === String(params["model"] ?? "fake-sol"))
+              ?.defaultReasoningEffort ?? null,
+          approvalPolicy: params["approvalPolicy"] ?? "on-request",
+          sandboxType:
+            SANDBOX_TYPES[String(params["sandbox"] ?? "workspace-write")] ?? "workspaceWrite",
+          mode: "default",
+        },
         preview: "",
         previewReadableAt: 0,
         archived: false,
       }
       threads.set(thread.id, thread)
       const reported = wrongCwd === "start" ? `${cwd}-wrong` : cwd
-      respond({ thread: threadShape(thread, reported) })
+      respond({ thread: threadShape(thread, reported), ...settingsEcho(thread) })
       return broadcast("thread/started", { thread: { id: thread.id, cwd: reported } })
     }
     case "thread/resume": {
@@ -304,8 +416,36 @@ const handle = (
             error: turn.error,
             startedAt: turn.startedAt,
             completedAt: turn.completedAt,
+            // Fixture-only: what turn/start received (settings assertions).
+            overrides: turn.overrides,
           })),
         },
+        ...settingsEcho(thread),
+      })
+    }
+    case "thread/settings/update": {
+      const thread = threads.get(String(params["threadId"] ?? ""))
+      if (thread === undefined) return respondError(-32600, "unknown thread")
+      if (typeof params["model"] === "string") thread.settings.model = params["model"]
+      if ("effort" in params) thread.settings.effort = (params["effort"] as string | null) ?? null
+      if ("approvalPolicy" in params) thread.settings.approvalPolicy = params["approvalPolicy"]
+      if (typeof params["sandboxType"] === "string")
+        thread.settings.sandboxType = params["sandboxType"]
+      if (typeof params["mode"] === "string") thread.settings.mode = params["mode"]
+      respond({})
+      return broadcast("thread/settings/updated", settingsUpdatedParams(thread))
+    }
+    case "model/list": {
+      // Paginated like the real reply: one model per page under
+      // FAKE_CODEX_MODEL_PAGED, else everything at once.
+      if (process.env["FAKE_CODEX_MODEL_PAGED"] !== "1") {
+        return respond({ data: FAKE_MODELS, nextCursor: null })
+      }
+      const start = Number.parseInt(String(params["cursor"] ?? "0"), 10)
+      const next = start + 1
+      return respond({
+        data: FAKE_MODELS.slice(start, next),
+        nextCursor: next < FAKE_MODELS.length ? String(next) : null,
       })
     }
     case "thread/unsubscribe":
@@ -400,6 +540,15 @@ const handle = (
       const input = params["input"] as Array<{ text?: string }> | undefined
       const text = input?.[0]?.text ?? ""
       const turnId = crypto.randomUUID()
+      // Overrides are sticky for this and subsequent turns, like the real server.
+      if (typeof params["model"] === "string") thread.settings.model = params["model"]
+      if (typeof params["effort"] === "string") thread.settings.effort = params["effort"]
+      if ("approvalPolicy" in params) thread.settings.approvalPolicy = params["approvalPolicy"]
+      const sandboxPolicy = params["sandboxPolicy"] as { type?: string } | undefined
+      if (typeof sandboxPolicy?.type === "string") thread.settings.sandboxType = sandboxPolicy.type
+      const collaboration = params["collaborationMode"] as { mode?: string } | undefined
+      if (typeof collaboration?.mode === "string") thread.settings.mode = collaboration.mode
+      const { input: _input, threadId: _threadId, ...overrides } = params
       thread.turns.push({
         id: turnId,
         status: "inProgress",
@@ -407,6 +556,7 @@ const handle = (
         startedAt: Math.floor(Date.now() / 1000),
         completedAt: null,
         error: null,
+        overrides,
       })
       if (thread.preview === "") {
         thread.preview = text

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -1,12 +1,14 @@
 import { assert } from "@effect/vitest"
 import { BunHttpServer, BunServices } from "@effect/platform-bun"
 import { Context, Effect, Exit, Layer, Scope, Stream } from "effect"
+import { SqlClient } from "effect/unstable/sql"
 import type { Duration } from "effect"
 import { HttpServer } from "effect/unstable/http"
 import * as fs from "node:fs"
 import * as os from "node:os"
 import * as path from "node:path"
 import { fileURLToPath } from "node:url"
+import * as AgentDefaultsRepository from "../src/agents/agentDefaultsRepository.ts"
 import * as AgentRegistry from "../src/agents/agentRegistry.ts"
 import * as AuthToken from "../src/platform/authToken.ts"
 import * as ClaudeAdapter from "../src/agents/claudeAdapter.ts"
@@ -48,9 +50,11 @@ type ServiceLayer = Layer.Layer<
   | ProjectRepository.ProjectRepository
   | TerminalRepository.TerminalRepository
   | ThreadRepository.ThreadRepository
+  | AgentDefaultsRepository.AgentDefaultsRepository
   | Directories.Directories
   | TerminalAdapter
-  | ClaudeHooks.ClaudeHooks,
+  | ClaudeHooks.ClaudeHooks
+  | SqlClient.SqlClient,
   unknown
 >
 
@@ -142,7 +146,10 @@ export const makeTestServiceLayers = (
     TerminalRepository.layer,
     ThreadRepository.layer,
     TranscriptRepository.layer,
-  ).pipe(Layer.provide(Persistence.layerFile(dbFile)))
+    AgentDefaultsRepository.layer,
+    // Merged, not just provided: Threads holds the SqlClient for its
+    // settings write-through transaction.
+  ).pipe(Layer.provideMerge(Persistence.layerFile(dbFile)))
   const services = Layer.mergeAll(
     base,
     Directories.layer.pipe(Layer.provide(testAppConfig(configOverrides))),
@@ -153,6 +160,7 @@ export const makeTestServiceLayers = (
   const terminals = Terminals.layer.pipe(Layer.provide([services, eventsLayer]))
   const registry = AgentRegistry.layer.pipe(
     Layer.provide([
+      services,
       Layer.succeed(CodexAdapter.CodexAdapter)(fakeAgents.codex.adapter),
       Layer.succeed(ClaudeAdapter.ClaudeAdapter)(fakeAgents.claude.adapter),
       testAppConfig({ codexExecutable: "/bin/echo", claudeExecutable: "/bin/echo" }),

--- a/app-server/test/threads/threadRuntime.test.ts
+++ b/app-server/test/threads/threadRuntime.test.ts
@@ -568,7 +568,11 @@ describe("ThreadRuntime", () => {
       assert.isFalse(yield* runtime.hasWriter(thread.id))
       // The fake connection was closed with the run: no writer remains.
       const resumed = yield* Effect.scoped(
-        fake.adapter.resumeSession({ providerSessionId, cwd: thread.workingDirectory }),
+        fake.adapter.resumeSession({
+          providerSessionId,
+          cwd: thread.workingDirectory,
+          settings: thread.settings,
+        }),
       )
       assert.strictEqual(resumed.providerSessionId, providerSessionId)
     }).pipe(Effect.scoped, Effect.provide(kit.layer)),

--- a/app-server/test/threads/threadSettings.test.ts
+++ b/app-server/test/threads/threadSettings.test.ts
@@ -1,0 +1,343 @@
+import { assert, describe, it } from "@effect/vitest"
+import { BunHttpServer } from "@effect/platform-bun"
+import { Deferred, Effect, Fiber, Layer } from "effect"
+import { HttpApiTest } from "effect/unstable/httpapi"
+import { SqlClient } from "effect/unstable/sql"
+import { mkdtempSync, realpathSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll } from "vitest"
+import { Api } from "../../src/api/contract.ts"
+import { V1Handlers } from "../../src/api/handlers.ts"
+import { ThreadRuntime } from "../../src/threads/threadRuntime.ts"
+import { applySettingsPatch } from "../../src/threads/threadSettings.ts"
+import { TestBuildInfoLayer } from "../testBuildInfo.ts"
+import { eventually, makeTestServiceLayers } from "../testLayers.ts"
+
+// Chat mode settings (ATC-205) through the public contract and the runtime,
+// over the fake adapters: the settings patch and its per-model reasoning
+// rule, the write-through agent defaults a new thread inherits, the settings
+// a turn starts with, and provider-side changes adopted from the feed.
+
+const kit = makeTestServiceLayers()
+const TestLayer = Layer.mergeAll(
+  V1Handlers.pipe(Layer.provide([TestBuildInfoLayer, kit.layer])),
+  kit.layer,
+  BunHttpServer.layerHttpServices,
+)
+
+const scratch = mkdtempSync(join(tmpdir(), "atc-thread-settings-test-"))
+afterAll(() => rmSync(scratch, { recursive: true, force: true }))
+const realDir = realpathSync(scratch)
+
+const testClient = Effect.gen(function* () {
+  const client = yield* HttpApiTest.groups(Api, ["v1"])
+  const project = yield* client.v1.createProject({
+    payload: { name: "Settings", defaultWorkingDirectory: realDir },
+  })
+  return { client, project }
+})
+
+describe("applySettingsPatch", () => {
+  const catalog = [
+    {
+      value: "big",
+      displayName: "Big",
+      description: "",
+      isDefault: true,
+      supportedEffortLevels: ["low", "medium", "high", "xhigh"] as const,
+      defaultEffortLevel: "medium" as const,
+    },
+    {
+      value: "mid",
+      displayName: "Mid",
+      description: "",
+      isDefault: false,
+      supportedEffortLevels: ["low", "medium"] as const,
+      defaultEffortLevel: "low" as const,
+    },
+    {
+      value: "tiny",
+      displayName: "Tiny",
+      description: "",
+      isDefault: false,
+      supportedEffortLevels: [] as const,
+    },
+  ]
+  const current = { model: "big", reasoning: "xhigh", mode: "chat", access: "auto" } as const
+
+  it("a model change keeps a supported level, else resets to the new model's default", () => {
+    assert.deepStrictEqual(applySettingsPatch(current, { model: "mid" }, catalog), {
+      settings: { model: "mid", reasoning: "low", mode: "chat", access: "auto" },
+    })
+    assert.deepStrictEqual(
+      applySettingsPatch({ ...current, reasoning: "low" }, { model: "mid" }, catalog),
+      { settings: { model: "mid", reasoning: "low", mode: "chat", access: "auto" } },
+    )
+    // No effort support: reasoning disappears.
+    assert.deepStrictEqual(applySettingsPatch(current, { model: "tiny" }, catalog), {
+      settings: { model: "tiny", mode: "chat", access: "auto" },
+    })
+  })
+
+  it("rejects an unknown model and an unsupported level; mode/access need no catalog", () => {
+    assert.deepStrictEqual(applySettingsPatch(current, { model: "nope" }, catalog), {
+      rejected: 'unknown model "nope"',
+    })
+    assert.deepStrictEqual(applySettingsPatch(current, { reasoning: "ultra" }, catalog), {
+      rejected: 'model "big" does not support reasoning "ultra"',
+    })
+    assert.deepStrictEqual(
+      applySettingsPatch(current, { mode: "plan", access: "supervised" }, null),
+      { settings: { model: "big", reasoning: "xhigh", mode: "plan", access: "supervised" } },
+    )
+    // A thread already on an unlisted model keeps taking patches; only a
+    // CHANGE to an unknown model is held to the catalog.
+    assert.deepStrictEqual(
+      applySettingsPatch({ ...current, model: "retired" }, { reasoning: "low" }, catalog),
+      { settings: { model: "retired", reasoning: "low", mode: "chat", access: "auto" } },
+    )
+  })
+})
+
+describe("thread settings", () => {
+  it.effect("patches settings per thread; a model change is validated against the catalog", () =>
+    Effect.gen(function* () {
+      const { client, project } = yield* testClient
+      const thread = yield* client.v1.createThread({
+        payload: { projectId: project.id, agentId: "codex" },
+      })
+      // A fresh install: the registry seed, until a thread changes something.
+      assert.deepStrictEqual(thread.settings, {
+        model: "gpt-5.6-sol",
+        reasoning: "high",
+        mode: "chat",
+        access: "auto",
+      })
+
+      // An empty settings object is an empty patch: nothing changes,
+      // updatedAt included.
+      const empty = yield* client.v1.updateThread({
+        params: { threadId: thread.id },
+        payload: { settings: {} },
+      })
+      assert.strictEqual(empty.updatedAt, thread.updatedAt)
+
+      // Access and mode never touch the catalog.
+      const reads = kit.fakeAgents.codex.modelReads()
+      const patched = yield* client.v1.updateThread({
+        params: { threadId: thread.id },
+        payload: { settings: { access: "supervised", mode: "plan" } },
+      })
+      assert.deepStrictEqual(patched.settings, {
+        model: "gpt-5.6-sol",
+        reasoning: "high",
+        mode: "plan",
+        access: "supervised",
+      })
+      assert.strictEqual(kit.fakeAgents.codex.modelReads(), reads)
+
+      // A model change consults the catalog (once — cached after) and is
+      // validated BEFORE anything is written: the rename in the same patch
+      // never lands when the settings are rejected.
+      const rejected = yield* Effect.flip(
+        client.v1.updateThread({
+          params: { threadId: thread.id },
+          payload: { name: "Renamed", settings: { model: "nope" } },
+        }),
+      )
+      assert.strictEqual(rejected._tag, "InvalidThreadSettings")
+      const untouched = yield* client.v1.getThread({ params: { threadId: thread.id } })
+      assert.isUndefined(untouched.name)
+      const switched = yield* client.v1.updateThread({
+        params: { threadId: thread.id },
+        payload: { name: "Renamed", settings: { model: "fake-large" } },
+      })
+      assert.strictEqual(switched.name, "Renamed")
+      assert.strictEqual(switched.settings.model, "fake-large")
+      assert.strictEqual(kit.fakeAgents.codex.modelReads(), reads + 1)
+
+      // Persisted: a fresh read agrees.
+      const fetched = yield* client.v1.getThread({ params: { threadId: thread.id } })
+      assert.deepStrictEqual(fetched.settings, switched.settings)
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("the last changed thread's settings become the agent's defaults", () =>
+    Effect.gen(function* () {
+      const { client, project } = yield* testClient
+      const first = yield* client.v1.createThread({
+        payload: { projectId: project.id, agentId: "claude-code" },
+      })
+      yield* client.v1.updateThread({
+        params: { threadId: first.id },
+        payload: { settings: { model: "fake-large", reasoning: "low", access: "fullAccess" } },
+      })
+      const agent = yield* client.v1.getAgent({ params: { agentId: "claude-code" } })
+      assert.deepStrictEqual(agent.defaults, {
+        model: "fake-large",
+        reasoning: "low",
+        mode: "chat",
+        access: "fullAccess",
+      })
+      const second = yield* client.v1.createThread({
+        payload: { projectId: project.id, agentId: "claude-code" },
+      })
+      assert.deepStrictEqual(second.settings, agent.defaults)
+      // Per agent: codex is untouched by a claude change.
+      const codex = yield* client.v1.getAgent({ params: { agentId: "codex" } })
+      assert.notStrictEqual(codex.defaults.access, "fullAccess")
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  // it.live: the test polls (`eventually`) on the real clock.
+  it.live("concurrent patches merge rather than overwrite; a no-op patch writes nothing", () =>
+    Effect.gen(function* () {
+      const { client, project } = yield* testClient
+      const fake = kit.fakeAgents.claude
+      const thread = yield* client.v1.createThread({
+        payload: { projectId: project.id, agentId: "claude-code" },
+      })
+      // Park the catalog read the model patch needs, so a mode patch lands
+      // between that patch's read of the row and its write.
+      const gate = yield* Deferred.make<void>()
+      fake.gateModels(Deferred.await(gate))
+      const modelPatch = yield* Effect.forkChild(
+        client.v1.updateThread({
+          params: { threadId: thread.id },
+          payload: { settings: { model: "fake-large" } },
+        }),
+      )
+      yield* eventually(
+        Effect.sync(() => fake.modelReads()),
+        (reads) => reads >= 1,
+      )
+      const modePatch = yield* client.v1.updateThread({
+        params: { threadId: thread.id },
+        payload: { settings: { mode: "plan" } },
+      })
+      assert.strictEqual(modePatch.settings.mode, "plan")
+      yield* Deferred.succeed(gate, undefined)
+      fake.gateModels(Effect.void)
+      // The model patch lost the write race and re-applied itself on top:
+      // both changes stand.
+      const merged = yield* Fiber.join(modelPatch)
+      assert.strictEqual(merged.settings.model, "fake-large")
+      assert.strictEqual(merged.settings.mode, "plan")
+
+      // Another thread of the agent takes the defaults on; re-picking what
+      // the first already holds must not write it back (updatedAt) nor
+      // reset the defaults to it.
+      const other = yield* client.v1.createThread({
+        payload: { projectId: project.id, agentId: "claude-code" },
+      })
+      yield* client.v1.updateThread({
+        params: { threadId: other.id },
+        payload: { settings: { access: "supervised" } },
+      })
+      const repicked = yield* client.v1.updateThread({
+        params: { threadId: thread.id },
+        payload: { settings: { mode: "plan", model: "fake-large" } },
+      })
+      assert.strictEqual(repicked.updatedAt, merged.updatedAt)
+      const agent = yield* client.v1.getAgent({ params: { agentId: "claude-code" } })
+      assert.strictEqual(agent.defaults.access, "supervised")
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("a row holding a literal this build does not know still takes patches", () =>
+    Effect.gen(function* () {
+      const { client, project } = yield* testClient
+      const sql = yield* SqlClient.SqlClient
+      const thread = yield* client.v1.createThread({
+        payload: { projectId: project.id, agentId: "codex" },
+      })
+      // A newer build wrote a mode this one cannot decode: the read coerces
+      // it (settingsFromColumns), and the compare-and-swap must still match
+      // the row — the guard names the literal as stored, not as read.
+      yield* sql`UPDATE threads SET mode = 'from-the-future' WHERE id = ${thread.id}`
+      const coerced = yield* client.v1.getThread({ params: { threadId: thread.id } })
+      assert.strictEqual(coerced.settings.mode, "chat")
+      const patched = yield* client.v1.updateThread({
+        params: { threadId: thread.id },
+        payload: { settings: { access: "supervised" } },
+      })
+      assert.strictEqual(patched.settings.access, "supervised")
+      // The write normalized the row: the unknown literal is gone.
+      const rows = yield* sql<{ mode: string }>`SELECT mode FROM threads WHERE id = ${thread.id}`
+      assert.deepStrictEqual(rows, [{ mode: "chat" }])
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.live("a turn starts with the thread's stored settings, and provider reports are adopted", () =>
+    Effect.gen(function* () {
+      const { client, project } = yield* testClient
+      const runtime = yield* ThreadRuntime
+      const fake = kit.fakeAgents.codex
+      const thread = yield* client.v1.createThread({
+        payload: { projectId: project.id, agentId: "codex" },
+      })
+      yield* client.v1.updateThread({
+        params: { threadId: thread.id },
+        payload: { settings: { access: "autoAcceptEdits" } },
+      })
+      const started = yield* runtime.prompt(thread.id, "hello")
+      assert.isString(started.turnId)
+      const session = [...fake.sessions.values()].find((entry) => entry.inputs.includes("hello"))
+      assert.isDefined(session)
+      assert.deepStrictEqual(session!.turnSettings, [
+        { model: "gpt-5.6-sol", reasoning: "high", mode: "chat", access: "autoAcceptEdits" },
+      ])
+
+      // A change made while the turn runs is stored, not pushed: the turn
+      // in flight is untouched, and the next turn carries it.
+      yield* client.v1.updateThread({
+        params: { threadId: thread.id },
+        payload: { settings: { mode: "plan" } },
+      })
+      assert.strictEqual(session!.turnSettings.length, 1)
+      fake.completeTurn(session!.providerSessionId, "completed")
+      yield* eventually(
+        client.v1.getThread({ params: { threadId: thread.id } }),
+        (current) => current.activityState === "idle",
+      )
+      yield* runtime.prompt(thread.id, "again")
+      yield* eventually(
+        Effect.sync(() => session!.turnSettings.length),
+        (count) => count === 2,
+      )
+      assert.deepStrictEqual(session!.turnSettings[1], {
+        model: "gpt-5.6-sol",
+        reasoning: "high",
+        mode: "plan",
+        access: "autoAcceptEdits",
+      })
+
+      // A change made while this turn runs is stored; the provider's late
+      // confirmation of what the turn was started with must not roll it
+      // back — but a genuine provider-side change (a TUI switching the
+      // model) still wins as it arrives.
+      yield* client.v1.updateThread({
+        params: { threadId: thread.id },
+        payload: { settings: { access: "supervised" } },
+      })
+      fake.emitSettings(session!.providerSessionId, {
+        model: "gpt-5.6-sol",
+        reasoning: "high",
+        mode: "plan",
+        access: "autoAcceptEdits",
+      })
+      fake.emitSettings(session!.providerSessionId, { model: "fake-large", reasoning: null })
+      const adopted = yield* eventually(
+        client.v1.getThread({ params: { threadId: thread.id } }),
+        (current) => current.settings.model === "fake-large",
+      )
+      assert.deepStrictEqual(adopted.settings, {
+        model: "fake-large",
+        mode: "plan",
+        access: "supervised",
+      })
+      fake.completeTurn(session!.providerSessionId, "completed")
+    }).pipe(Effect.provide(TestLayer)),
+  )
+})

--- a/packages/ATCKit/Tests/ATCAppServerAPITests/ClientTests.swift
+++ b/packages/ATCKit/Tests/ATCAppServerAPITests/ClientTests.swift
@@ -166,7 +166,7 @@ struct ClientTests {
     func pinThread() async throws {
         let (client, recorder) = try client(
             returning:
-                #"{"id":"t1","projectId":"p1","agentId":"codex","workingDirectory":"/code/atc","activityState":"idle","unread":false,"pinnedAt":"2026-08-06T12:34:56.789Z","createdAt":"2026-08-06T12:00:00.000Z","updatedAt":"2026-08-06T12:34:56.789Z"}"#
+                #"{"id":"t1","projectId":"p1","agentId":"codex","workingDirectory":"/code/atc","settings":{"model":"gpt-5.6-sol","reasoning":"high","mode":"chat","access":"auto"},"activityState":"idle","unread":false,"pinnedAt":"2026-08-06T12:34:56.789Z","createdAt":"2026-08-06T12:00:00.000Z","updatedAt":"2026-08-06T12:34:56.789Z"}"#
         )
         let thread = try await client.pinThread(path: .init(threadId: "t1")).ok.body.json
         #expect(thread.pinnedAt == Date(timeIntervalSince1970: 1_786_019_696.789))


### PR DESCRIPTION
Server half of ATC-205 (Chat mode model settings) — [ATC-210](https://linear.app/elevenideas/issue/ATC-210). The macOS half (#220, ATC-211) is stacked on this branch; **merge this first, then that** — a wire-contract change turns macOS CI red on a server-only PR (`Thread.settings` is required), which is expected here.

## What
- **Contract**: `Thread.settings { model, reasoning?, mode, access }`, `UpdateThreadRequest.settings` patch, `Agent.defaults` (write-through per-agent defaults a new thread inherits), `GET /agents/:agentId/models` (server-cached catalog), `InvalidThreadSettings` (400). `openapi.json` regenerated.
- **Migration** `0007_thread_settings`: four columns on `threads` (legacy rows backfilled), `agent_defaults` table.
- **Seam** (`agentAdapter.ts`): `startTurn(input, settings)` / `createSession` / `resumeSession` carry settings; adapters push only what differs from the live session; `settings` events (partial provider reports) on writer + observation feeds; `listModels`.
- **Codex**: `thread/start` carries model + ladder; `turn/start` pushes the diff vs the reply echo plus `approvalsReviewer: "user"` and `collaborationMode` (probed live: it requires `initialize` with `experimentalApi: true` — T3Code opens the same way — and Codex answers every override with `thread/settings/updated`, which becomes the settings event); paginated `model/list`.
- **Claude**: the child spawns with model / effort / permission mode (+ `allowDangerouslySkipPermissions` so Full access can be switched to mid-session); resident turns push via `setModel` / `applyFlagSettings` / `setPermissionMode`; each `system/init` reports the applied model (mapped back through the child's catalog) and permission mode, effort via the undeclared `getSettings()` behind a narrow interface (warns once on decode failure); catalog via a prompt-less query.
- **Runtime**: every turn starts with the stored settings (re-read under the start lock); provider reports are adopted (provider state wins) except fields that merely confirm the writer's own push — a delayed confirmation (Claude's spawn takes seconds) must not roll back a change made meanwhile.
- **Claude catalog names carry the version**: the CLI names models by family alone (`Fable`, `Opus (1M context)`); the version is folded in from the wire id (`claude-fable-5[1m]` → `Fable 5`, `Opus 5 (1M context)`, `Haiku 4.5`) so the composer's model control says which generation. A name the id does not explain is left as is.
- **Threads.update**: validates a model/reasoning change against the catalog before writing anything (only those fields consult the provider); every settings change writes through to the agent's defaults, in one transaction with the row. Settings writes are a compare-and-swap (`setSettingsIfUnchanged`): a client patch and a provider report — or two disjoint patches — that read the same baseline re-apply themselves on top instead of overwriting each other; a patch that resolves to what the row already holds is a no-op (no write, no write-through, no event).

## Deviations from the issue text (deliberate)
- **Claude Auto = `permissionMode: "auto"`**, not `dontAsk`. Probed live: `dontAsk` denies Write and Bash outright with no rules configured (worse than Supervised); `auto` (the classifier mode, T3Code's choice too) works within the workspace unasked and routes borderline calls to `canUseTool`. A model without auto support (Haiku) silently runs `default`; the init report adopts that as Supervised.
- `AgentModel` has no `supportsEffort` — `supportedEffortLevels` being empty says the same thing.
- On a model change the current reasoning level carries over when the new model supports it, else the model's default applies (the acceptance criterion; the "always reset" wording would drop a user's xhigh going Fable → Sonnet).
- Legacy rows are backfilled by the migration (seed model per agent + `high`); provider state corrects a stale model on the next attach.

## Verified
- `mise run -C app-server check`, `mise run contract:check` (ATCKit fixture updated here — the one shared-contract test).
- Live: `ATC_SMOKE=1` Claude adapter + thread runtime smoke pass with the new spawn options; Codex `turn/start` overrides / `collaborationMode` / `thread/settings/updated` / `model/list` probed against the live shared server (scratch thread, archived + deleted after).

https://claude.ai/code/session_012Z59VLDXmduFvKXowv3uD1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added thread settings for model, reasoning level, mode, and access.
  * Settings can be updated per thread and saved as defaults for new threads.
  * Added agent model catalogs with supported models and reasoning levels.
  * Settings apply when starting, resuming, and continuing conversations, including live updates.
* **Bug Fixes**
  * Added validation for unsupported models and reasoning levels.
  * Added clear errors for invalid settings and unavailable providers.
* **Documentation**
  * Updated the API contract for thread settings, model catalogs, and related responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
