### PR TITLE
macOS Chat: the composer's settings controls (ATC-211)

### DIFF
--- a/macos/ATC/AppServer/ServerModels.swift
+++ b/macos/ATC/AppServer/ServerModels.swift
@@ -22,6 +22,12 @@ typealias QueuedPrompt = Components.Schemas.QueuedPrompt
 typealias ThreadEvent = Components.Schemas.ThreadEvent
 typealias ThreadTranscriptPage = Components.Schemas.ThreadTranscript
 typealias ToolStatus = Components.Schemas.ToolStatus
+typealias ThreadSettings = Components.Schemas.ThreadSettings
+typealias ThreadSettingsPatch = Components.Schemas.ThreadSettingsPatch
+typealias ReasoningLevel = Components.Schemas.ReasoningLevel
+typealias ThreadMode = Components.Schemas.ThreadMode
+typealias ThreadAccess = Components.Schemas.ThreadAccess
+typealias AgentModel = Components.Schemas.AgentModel
 
 extension AgentID {
     var displayName: String {
@@ -36,6 +42,39 @@ extension AgentID {
         switch self {
         case .codex: "hexagon"
         case .claudeCode: "asterisk"
+        }
+    }
+}
+
+extension ReasoningLevel {
+    var displayName: String {
+        switch self {
+        case .low: "Low"
+        case .medium: "Medium"
+        case .high: "High"
+        case .xhigh: "Extra high"
+        case .max: "Max"
+        case .ultra: "Ultra"
+        }
+    }
+}
+
+extension ThreadMode {
+    var displayName: String {
+        switch self {
+        case .chat: "Chat"
+        case .plan: "Plan"
+        }
+    }
+}
+
+extension ThreadAccess {
+    var displayName: String {
+        switch self {
+        case .supervised: "Supervised"
+        case .autoAcceptEdits: "Auto-accept edits"
+        case .auto: "Auto"
+        case .fullAccess: "Full access"
         }
     }
 }

--- a/macos/ATC/Features/Agents/AgentsStore.swift
+++ b/macos/ATC/Features/Agents/AgentsStore.swift
@@ -1,7 +1,10 @@
 // Shared domain state for one Connection's agent registry: live-detected
 // availability plus the actionable reason when a provider is missing. The
 // server never persists this — every refresh is a fresh detection — so the
-// store refreshes with the SSE-driven cycle like every other list.
+// store refreshes with the SSE-driven cycle like every other list. The
+// per-agent model catalogs (ATC-205) are read on demand — the first Chat of
+// an agent asks for its catalog — and kept for the store's life; the server
+// caches them too, so a re-read is cheap when a view wants one.
 
 import ATCAppServerAPI
 import Foundation
@@ -12,7 +15,12 @@ final class AgentsStore {
     let client: any APIProtocol
 
     private(set) var agents: [Agent] = []
+    /// Model catalogs by agent, once read (see the header).
+    private(set) var models: [AgentID: [AgentModel]] = [:]
+    /// The last failed catalog read per agent, until a read succeeds.
+    private(set) var modelErrors: [AgentID: String] = [:]
     private let refreshState = RefreshState(category: "agents")
+    private var modelReads: [AgentID: Task<Void, Never>] = [:]
 
     var hasLoadedOnce: Bool { refreshState.hasLoadedOnce }
     var lastError: String? { refreshState.lastError }
@@ -32,5 +40,27 @@ final class AgentsStore {
 
     func agent(id: AgentID) -> Agent? {
         agents.first { $0.id == id }
+    }
+
+    /// The agent's catalog, or nil until `loadModels` has read it.
+    func models(for id: AgentID) -> [AgentModel]? {
+        models[id]
+    }
+
+    /// Read the agent's catalog once (idempotent while a read is in flight
+    /// or already landed); a failed read records its error and is retried
+    /// on the next call.
+    func loadModels(for id: AgentID) {
+        guard models[id] == nil, modelReads[id] == nil else { return }
+        modelReads[id] = Task { [weak self] in
+            defer { self?.modelReads[id] = nil }
+            guard let self else { return }
+            do {
+                models[id] = try await client.listAgentModels(path: .init(agentId: id.rawValue)).ok.body.json
+                modelErrors[id] = nil
+            } catch {
+                modelErrors[id] = error.localizedDescription
+            }
+        }
     }
 }

--- a/macos/ATC/Features/Navigator/NavigatorSidebar.swift
+++ b/macos/ATC/Features/Navigator/NavigatorSidebar.swift
@@ -482,8 +482,8 @@ struct NavigatorSidebar: View {
         }
     }
 
-    private func filterEntries(_ model: ThreadListModel) -> [NavigatorDropdownEntry] {
-        var entries: [NavigatorDropdownEntry] = [
+    private func filterEntries(_ model: ThreadListModel) -> [PopupMenuEntry] {
+        var entries: [PopupMenuEntry] = [
             .item(
                 title: "All Projects",
                 isSelected: windowState.threadFilter == .all,

--- a/macos/ATC/Features/Threads/Chat/ChatComposer.swift
+++ b/macos/ATC/Features/Threads/Chat/ChatComposer.swift
@@ -1,15 +1,22 @@
 // The prompt composer floating over the transcript's tail, shaped like the
-// Codex desktop composer: one rounded Liquid Glass card, the text growing
-// from a single line to a few, and a round send button in the corner. Return sends,
-// Shift-Return inserts a newline. Send is never disabled while connected —
-// the server admits every prompt (idle starts a turn, busy queues it) — and
-// a refused prompt keeps its text with the server's message inline. Stop
-// shows only while the server is driving a turn.
+// Codex desktop composer: one rounded Liquid Glass card, the text starting
+// a few lines tall and growing to more, the thread's settings controls
+// leading the bottom row (ChatSettingsControls, taking every point the send
+// button leaves so they fold only when the row truly is too narrow), and a
+// round send button in the corner.
+// Return sends, Shift-Return inserts a newline. Send is never disabled while
+// connected — the server admits every prompt (idle starts a turn, busy
+// queues it) — and a refused prompt keeps its text with the server's message
+// inline. Stop shows only while the server is driving a turn.
 
 import SwiftUI
 
 struct ChatComposer: View {
     @Binding var text: String
+    let thread: ATCThread
+    /// The agent's model catalog, nil until read (the chip shows the raw id).
+    let models: [AgentModel]?
+    let modelsError: String?
     let isSending: Bool
     let showsStop: Bool
     let error: String?
@@ -17,6 +24,8 @@ struct ChatComposer: View {
     let focusRequest: UInt
     let send: () -> Void
     let stop: () -> Void
+    let updateSettings: (ThreadSettingsPatch) -> Void
+    let reloadModels: () -> Void
 
     @FocusState private var isFocused: Bool
     @State private var editorHeight: CGFloat = 24
@@ -32,7 +41,11 @@ struct ChatComposer: View {
             VStack(alignment: .leading, spacing: Spacing.sm) {
                 editor
                 HStack(spacing: Spacing.sm) {
-                    Spacer()
+                    ChatSettingsControls(
+                        thread: thread, models: models, modelsError: modelsError,
+                        update: updateSettings, reloadModels: reloadModels
+                    )
+                    .frame(maxWidth: .infinity, alignment: .leading)
                     if showsStop {
                         Button(action: stop) {
                             Label("Stop", systemImage: "stop.fill")
@@ -67,14 +80,15 @@ struct ChatComposer: View {
         .onChange(of: focusRequest) { _, _ in isFocused = true }
     }
 
-    /// A TextEditor sized by the text behind it: it grows with the message
-    /// from one line to a few, then scrolls. TextEditor claims every point
-    /// it is offered, so its height is pinned to the measured text.
+    /// A TextEditor sized by the text behind it: it starts three lines tall
+    /// (room to type before the controls row), grows with the message, then
+    /// scrolls. TextEditor claims every point it is offered, so its height
+    /// is pinned to the measured text.
     private var editor: some View {
         ZStack(alignment: .topLeading) {
             Text(text.isEmpty ? " " : text)
                 .font(.body)
-                .lineLimit(1...8)
+                .lineLimit(3...10)
                 .padding(.vertical, Spacing.xs)
                 .padding(.horizontal, Spacing.xs + 1)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/macos/ATC/Features/Threads/Chat/ChatSettingsControls.swift
+++ b/macos/ATC/Features/Threads/Chat/ChatSettingsControls.swift
@@ -1,0 +1,180 @@
+// The Chat composer's settings controls (ATC-205), shaped like the Codex
+// desktop composer's: quiet text controls on the composer's bottom row, no
+// bezel at rest, each popping a native menu. The model control — the
+// agent's mark, the provider's model name, and the reasoning level — pops
+// the catalog with the selected model's levels beneath it (a model without
+// effort support lists none); Mode and Access are their own controls, with
+// Full access in warning color and behind a confirmation, so it is never a
+// mis-click. When the row is too narrow for all three, Mode and Access fold
+// into one ⋯ menu.
+// The controls show what the server holds and send one patch per choice;
+// the server validates it, applies the per-model reasoning rule, and the
+// thread's refetch repaints — nothing is derived here beyond looking the
+// selected model up in the agent's catalog.
+
+import ATCAppServerAPI
+import SwiftUI
+
+struct ChatSettingsControls: View {
+    let thread: ATCThread
+    /// The agent's catalog, nil until the store has read it.
+    let models: [AgentModel]?
+    /// Why the catalog is missing, when a read failed (nil while loading).
+    let modelsError: String?
+    let update: (ThreadSettingsPatch) -> Void
+    /// Ask for the catalog again (a failed read).
+    let reloadModels: () -> Void
+
+    /// The Full access confirmation is up (the one Access choice that is
+    /// not applied straight from the menu).
+    @State private var confirmingFullAccess = false
+
+    private var settings: ThreadSettings { thread.settings }
+
+    private var selectedModel: AgentModel? {
+        models?.first { $0.value == settings.model }
+    }
+
+    private var modelName: String { selectedModel?.displayName ?? settings.model }
+
+    var body: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 0) {
+                modelControl
+                modeControl
+                accessControl
+            }
+            HStack(spacing: 0) {
+                modelControl
+                PopupMenuButton(entries: settingsEntries, appearance: .accessoryBar) {
+                    controlLabel { Image(systemName: "ellipsis") }
+                }
+                .help("Mode and access")
+                .accessibilityLabel("Chat settings")
+            }
+        }
+        .confirmationDialog("Turn on Full access?", isPresented: $confirmingFullAccess) {
+            Button("Turn On Full Access", role: .destructive) { update(.init(access: .fullAccess)) }
+        } message: {
+            Text(
+                """
+                From the next turn the agent runs commands and edits files without asking,                 and outside the sandbox. Every other level asks first or stays in the workspace.
+                """)
+        }
+    }
+
+    private var modelControl: some View {
+        PopupMenuButton(entries: modelEntries, appearance: .accessoryBar) {
+            controlLabel(chevron: true) {
+                Image(systemName: thread.agentId.systemImage)
+                Text(modelName).foregroundStyle(.primary)
+                if let reasoning = settings.reasoning {
+                    Text(reasoning.displayName)
+                }
+            }
+        }
+        .help("Model and reasoning")
+        .accessibilityLabel(
+            "Model: \(modelName)" + (settings.reasoning.map { ", reasoning \($0.displayName)" } ?? ""))
+    }
+
+    private var modeControl: some View {
+        PopupMenuButton(entries: modeEntries, appearance: .accessoryBar) {
+            controlLabel { Text(settings.mode.displayName) }
+        }
+        .help("Mode")
+        .accessibilityLabel("Mode: \(settings.mode.displayName)")
+    }
+
+    private var accessControl: some View {
+        PopupMenuButton(entries: accessEntries, appearance: .accessoryBar) {
+            controlLabel(tint: settings.access == .fullAccess ? .orange : nil) {
+                if settings.access == .fullAccess {
+                    Image(systemName: "exclamationmark.shield")
+                }
+                Text(settings.access.displayName)
+            }
+        }
+        .help("Access")
+        .accessibilityLabel("Access: \(settings.access.displayName)")
+    }
+
+    /// One control's face: quiet secondary text (or a warning tint), a
+    /// chevron only where the label reads as a value (the model).
+    private func controlLabel(
+        chevron: Bool = false, tint: Color? = nil, @ViewBuilder _ content: () -> some View
+    ) -> some View {
+        HStack(spacing: Spacing.xs) {
+            content()
+            if chevron {
+                Image(systemName: "chevron.down")
+                    .font(.caption2.weight(.semibold))
+            }
+        }
+        .font(.callout)
+        .foregroundStyle(tint.map(AnyShapeStyle.init) ?? AnyShapeStyle(.secondary))
+        .lineLimit(1)
+        .padding(.horizontal, Spacing.xs)
+        .padding(.vertical, 2)
+    }
+
+    // Re-picking the checked entry of any menu is a no-op (nothing to send).
+    var modelEntries: [PopupMenuEntry] {
+        guard let models else {
+            guard let modelsError else { return [.header("Loading models…")] }
+            return [
+                .header(modelsError),
+                .item(title: "Retry", isSelected: false) { reloadModels() },
+            ]
+        }
+        var entries: [PopupMenuEntry] = [.header("Model")]
+        for model in models {
+            entries.append(
+                .item(title: model.displayName, isSelected: model.value == settings.model) {
+                    if model.value != settings.model { update(.init(model: model.value)) }
+                })
+        }
+        if let selectedModel, !selectedModel.supportedEffortLevels.isEmpty {
+            entries.append(.separator)
+            entries.append(.header("Reasoning"))
+            for level in selectedModel.supportedEffortLevels {
+                entries.append(
+                    .item(title: level.displayName, isSelected: settings.reasoning == level) {
+                        if settings.reasoning != level { update(.init(reasoning: level)) }
+                    })
+            }
+        }
+        return entries
+    }
+
+    var modeEntries: [PopupMenuEntry] {
+        ThreadMode.allCases.map { mode in
+            .item(title: mode.displayName, isSelected: settings.mode == mode) {
+                if settings.mode != mode { update(.init(mode: mode)) }
+            }
+        }
+    }
+
+    /// Full access alone goes through the confirmation.
+    var accessEntries: [PopupMenuEntry] {
+        ThreadAccess.allCases.map { access in
+            .item(
+                title: access.displayName,
+                isSelected: settings.access == access,
+                isDestructive: access == .fullAccess
+            ) {
+                guard access != settings.access else { return }
+                if access == .fullAccess {
+                    confirmingFullAccess = true
+                } else {
+                    update(.init(access: access))
+                }
+            }
+        }
+    }
+
+    /// The ⋯ menu when the row is too narrow: Mode and Access as sections.
+    var settingsEntries: [PopupMenuEntry] {
+        [.header("Mode")] + modeEntries + [.separator, .header("Access")] + accessEntries
+    }
+}

--- a/macos/ATC/Features/Threads/Chat/ThreadChatView.swift
+++ b/macos/ATC/Features/Threads/Chat/ThreadChatView.swift
@@ -87,6 +87,7 @@ private struct ChatPane: View {
     @State private var actionError: String?
 
     private var transcript: ChatTranscript { chat.transcript }
+    private var agents: AgentsStore? { appModel.runtime(id: ref.connectionID)?.agents }
 
     private var draftBinding: Binding<String> {
         Binding(
@@ -99,6 +100,8 @@ private struct ChatPane: View {
         transcriptList
             .overlay(alignment: .top) { statusBanner }
             .actionErrorAlert($actionError)
+            // The composer's model chip and menu need the agent's catalog.
+            .task(id: thread.agentId) { agents?.loadModels(for: thread.agentId) }
     }
 
     private func run(_ operation: @escaping () async throws -> Void) {
@@ -242,12 +245,22 @@ private struct ChatPane: View {
                 }
                 ChatComposer(
                     text: draftBinding,
+                    thread: thread,
+                    models: agents?.models(for: thread.agentId),
+                    modelsError: agents?.modelErrors[thread.agentId],
                     isSending: isSending,
                     showsStop: transcript.runningTurn != nil,
                     error: chat.promptError,
                     focusRequest: focusRequest,
                     send: send,
-                    stop: { run { try await chat.interrupt() } }
+                    stop: { run { try await chat.interrupt() } },
+                    updateSettings: { patch in
+                        run {
+                            try await appModel.runtime(id: ref.connectionID)?.threads
+                                .updateSettings(id: ref.threadID, patch)
+                        }
+                    },
+                    reloadModels: { agents?.loadModels(for: thread.agentId) }
                 )
             }
         }

--- a/macos/ATC/Features/Threads/NewThreadSheet.swift
+++ b/macos/ATC/Features/Threads/NewThreadSheet.swift
@@ -370,8 +370,10 @@ struct NewThreadSheet: View {
     private var agents: [Agent] {
         let detected = selectedRuntime?.agents.agents ?? []
         guard detected.isEmpty else { return detected }
+        // Only id/available are read here; the placeholder settings never
+        // reach a thread (creation reads the server's defaults).
         return AgentID.allCases.map {
-            Agent(id: $0, available: true)
+            Agent(id: $0, available: true, defaults: .init(model: "", mode: .chat, access: .auto))
         }
     }
 

--- a/macos/ATC/Features/Threads/ThreadsStore.swift
+++ b/macos/ATC/Features/Threads/ThreadsStore.swift
@@ -84,10 +84,24 @@ final class ThreadsStore {
 
     @discardableResult
     func rename(id: String, name: String) async throws -> ATCThread {
+        try await update(id: id, .init(name: name))
+    }
+
+    /// Patch the thread's Chat settings (ATC-205): the server validates a
+    /// model or reasoning change against the agent's catalog and applies the
+    /// per-model reasoning rule; the change takes effect at the next turn.
+    @discardableResult
+    func updateSettings(id: String, _ patch: ThreadSettingsPatch) async throws -> ATCThread {
+        try await update(id: id, .init(settings: patch))
+    }
+
+    private func update(id: String, _ request: Components.Schemas.UpdateThreadRequest) async throws -> ATCThread {
         let thread: ATCThread
-        switch try await client.updateThread(path: .init(threadId: id), body: .json(.init(name: name))) {
+        switch try await client.updateThread(path: .init(threadId: id), body: .json(request)) {
         case .ok(let ok): thread = try ok.body.json
         case .notFound(let failure): throw ServerError(try failure.body.json)
+        case .badRequest(let failure): throw ServerError(try failure.body.json)
+        case .serviceUnavailable(let failure): throw ServerError(try failure.body.json)
         case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
         }
         merge(thread)
@@ -220,7 +234,14 @@ final class ThreadsStore {
 
     /// Places a server-returned thread into whichever list its archive state
     /// says it belongs to, preserving newest-first order by creation time.
+    /// Fold one server response into the lists. A response older than what
+    /// the store already holds (`updatedAt` — every server-side write stamps
+    /// it) is dropped: rapid settings changes overlap in flight and their
+    /// responses can land out of order, and a late one must never roll the
+    /// store back to a state a newer response or refresh has already moved
+    /// past.
     private func merge(_ thread: ATCThread) {
+        if let held = self.thread(id: thread.id), held.updatedAt > thread.updatedAt { return }
         refreshState.invalidateInFlight()
         threads.removeAll { $0.id == thread.id }
         archivedThreads.removeAll { $0.id == thread.id }

--- a/macos/ATC/PreviewSupport/PreviewAppServerClient.swift
+++ b/macos/ATC/PreviewSupport/PreviewAppServerClient.swift
@@ -14,6 +14,28 @@ import OpenAPIRuntime
 // Fixtures only: previews and tests. Never compiled into a Release build.
 #if DEBUG
 
+    extension ThreadSettings {
+        /// The server's settings rule, mirrored for the stand-ins (this
+        /// client and the tests' scriptable one) so what they echo is a
+        /// contract-valid `ThreadSettings`: on a model change, reasoning
+        /// carries over when the new model supports it, else the model's
+        /// default applies — none for a model without effort support.
+        /// Production never applies patches; the server does.
+        nonisolated func applying(_ patch: ThreadSettingsPatch, catalog: [AgentModel]) -> ThreadSettings {
+            var settings = self
+            if let model = patch.model { settings.model = model }
+            if let entry = catalog.first(where: { $0.value == settings.model }), patch.model != nil {
+                settings.reasoning =
+                    settings.reasoning.map { entry.supportedEffortLevels.contains($0) } == true
+                    ? settings.reasoning : entry.defaultEffortLevel
+            }
+            if let reasoning = patch.reasoning { settings.reasoning = reasoning }
+            if let mode = patch.mode { settings.mode = mode }
+            if let access = patch.access { settings.access = access }
+            return settings
+        }
+    }
+
     extension AppModel {
         /// Preview/test fixture: an ephemeral Connection store (unique
         /// UserDefaults suite, nothing persisted to `.standard`) holding one
@@ -79,6 +101,7 @@ import OpenAPIRuntime
                     agentId: .claudeCode,
                     name: "Parser rewrite",
                     workingDirectory: Self.atelier.defaultWorkingDirectory,
+                    settings: Self.claudeSettings,
                     activityState: .working,
                     unread: false,
                     linkedTerminalId: "0192f4c0-0000-7000-8000-000000000001",
@@ -92,6 +115,7 @@ import OpenAPIRuntime
                     agentId: .codex,
                     name: "Flaky test triage",
                     workingDirectory: Self.atelier.defaultWorkingDirectory,
+                    settings: Self.codexSettings,
                     activityState: .needsInput,
                     unread: false,
                     createdAt: Date(timeIntervalSinceNow: -7_200),
@@ -102,6 +126,7 @@ import OpenAPIRuntime
                     projectId: Self.atelier.id,
                     agentId: .codex,
                     workingDirectory: "/Users/dev/Projects/atelier/packages/core",
+                    settings: Self.codexSettings,
                     activityState: .idle,
                     // The Done card: finished while nobody was looking.
                     unread: true,
@@ -114,6 +139,7 @@ import OpenAPIRuntime
                     agentId: .claudeCode,
                     name: "Spike: streaming uploads",
                     workingDirectory: Self.blazerr.defaultWorkingDirectory,
+                    settings: Self.claudeSettings,
                     activityState: .idle,
                     unread: false,
                     createdAt: Date(timeIntervalSinceNow: -90_000),
@@ -125,6 +151,7 @@ import OpenAPIRuntime
                     agentId: .codex,
                     name: "Dependency bump",
                     workingDirectory: Self.blazerr.defaultWorkingDirectory,
+                    settings: Self.codexSettings,
                     activityState: .unknown,
                     unread: false,
                     createdAt: Date(timeIntervalSinceNow: -150_000),
@@ -141,6 +168,7 @@ import OpenAPIRuntime
                     agentId: .claudeCode,
                     name: "Abandoned migration",
                     workingDirectory: Self.atelier.defaultWorkingDirectory,
+                    settings: Self.claudeSettings,
                     activityState: .unknown,
                     unread: false,
                     archivedAt: Date(timeIntervalSinceNow: -40_000),
@@ -192,15 +220,46 @@ import OpenAPIRuntime
                 Agent(
                     id: .codex,
                     available: true,
-                    detectedVersion: "0.52.0"
+                    detectedVersion: "0.52.0",
+                    defaults: Self.codexSettings
                 ),
                 Agent(
                     id: .claudeCode,
                     available: false,
-                    reason: "Install the Claude Code CLI"
+                    reason: "Install the Claude Code CLI",
+                    defaults: Self.claudeSettings
                 ),
             ]
         }
+
+        static let codexSettings = ThreadSettings(
+            model: "gpt-5.6-sol", reasoning: .high, mode: .chat, access: .auto)
+        static let claudeSettings = ThreadSettings(
+            model: "opus[1m]", reasoning: .high, mode: .chat, access: .auto)
+
+        static let codexModels: [AgentModel] = [
+            AgentModel(
+                value: "gpt-5.6-sol", displayName: "GPT-5.6-Sol", description: "Latest frontier agentic coding model.",
+                isDefault: true,
+                supportedEffortLevels: [.low, .medium, .high, .xhigh, .max, .ultra], defaultEffortLevel: .low),
+            AgentModel(
+                value: "gpt-5.6-luna", displayName: "GPT-5.6-Luna", description: "Fast and affordable.",
+                isDefault: false,
+                supportedEffortLevels: [.low, .medium, .high, .xhigh, .max], defaultEffortLevel: .medium),
+        ]
+        static let claudeModels: [AgentModel] = [
+            AgentModel(
+                value: "opus[1m]", displayName: "Opus 5 (1M context)", description: "Opus 5 with 1M context",
+                isDefault: true,
+                supportedEffortLevels: [.low, .medium, .high, .xhigh, .max], defaultEffortLevel: .high),
+            AgentModel(
+                value: "claude-fable-5[1m]", displayName: "Fable 5", description: "Fable 5",
+                isDefault: false,
+                supportedEffortLevels: [.low, .medium, .high, .xhigh, .max], defaultEffortLevel: .high),
+            AgentModel(
+                value: "haiku", displayName: "Haiku 4.5", description: "Haiku 4.5",
+                isDefault: false, supportedEffortLevels: []),
+        ]
 
         init() {}
 
@@ -374,6 +433,7 @@ import OpenAPIRuntime
                             agentId: request.agentId,
                             name: request.name,
                             workingDirectory: request.workingDirectory ?? project.defaultWorkingDirectory,
+                            settings: request.agentId == .codex ? Self.codexSettings : Self.claudeSettings,
                             activityState: .unknown,
                             unread: false,
                             createdAt: Date(),
@@ -388,7 +448,11 @@ import OpenAPIRuntime
         func updateThread(_ input: Operations.UpdateThread.Input) async throws -> Operations.UpdateThread.Output {
             guard case .json(let request) = input.body else { throw PreviewUnavailable() }
             var thread = try thread(input.path.threadId)
-            thread.name = request.name
+            if let name = request.name { thread.name = name }
+            if let patch = request.settings {
+                let catalog = thread.agentId == .codex ? Self.codexModels : Self.claudeModels
+                thread.settings = thread.settings.applying(patch, catalog: catalog)
+            }
             thread.updatedAt = Date()
             return .ok(.init(body: .json(thread)))
         }
@@ -515,6 +579,12 @@ import OpenAPIRuntime
 
         func listAgents(_ input: Operations.ListAgents.Input) async throws -> Operations.ListAgents.Output {
             .ok(.init(body: .json(agents)))
+        }
+
+        func listAgentModels(
+            _ input: Operations.ListAgentModels.Input
+        ) async throws -> Operations.ListAgentModels.Output {
+            .ok(.init(body: .json(input.path.agentId == AgentID.codex.rawValue ? Self.codexModels : Self.claudeModels)))
         }
 
         func getAgent(_ input: Operations.GetAgent.Input) async throws -> Operations.GetAgent.Output {

--- a/macos/ATC/Shared/NavigatorComponents.swift
+++ b/macos/ATC/Shared/NavigatorComponents.swift
@@ -1,4 +1,3 @@
-import AppKit
 import SwiftUI
 
 /// Shared geometry for every Navigator. Sidebar-specific values live here so
@@ -131,94 +130,18 @@ struct NavigatorActionButton: View {
     }
 }
 
-/// One entry in a `NavigatorDropdown` menu.
-enum NavigatorDropdownEntry {
-    case item(title: String, isSelected: Bool, action: @MainActor () -> Void)
-    case separator
-}
-
-/// A full-width dropdown with a caller-drawn label that pops a native
-/// NSMenu. SwiftUI's borderless `Menu` sizes to its label's compressed
-/// ideal width — every frame-based expansion collapses back to a text
-/// pill — so the label is an ordinary Button (layout we fully control)
-/// and AppKit owns the popup.
+/// The sidebar's full-width dropdown: a `PopupMenuButton` on the chip
+/// surface, with a caller-drawn label.
 struct NavigatorDropdown<Label: View>: View {
-    let entries: [NavigatorDropdownEntry]
+    let entries: [PopupMenuEntry]
     @ViewBuilder let label: () -> Label
 
-    @State private var anchor = AnchorHolder()
-
     var body: some View {
-        Button {
-            popUp()
-        } label: {
+        PopupMenuButton(entries: entries) {
             label()
                 .contentShape(RoundedRectangle(cornerRadius: Radius.chip, style: .continuous))
         }
-        .buttonStyle(.plain)
         .navigatorChipSurface()
-        .background {
-            AnchorView(holder: anchor)
-        }
-    }
-
-    private func popUp() {
-        guard let view = anchor.view else { return }
-        let menu = NSMenu()
-        for entry in entries {
-            switch entry {
-            case .separator:
-                menu.addItem(.separator())
-            case .item(let title, let isSelected, let action):
-                let item = ClosureMenuItem(title: title, handler: action)
-                item.state = isSelected ? .on : .off
-                menu.addItem(item)
-            }
-        }
-        menu.popUp(positioning: nil, at: NSPoint(x: 0, y: view.bounds.maxY + 4), in: view)
-    }
-
-    /// Bridges the SwiftUI position to AppKit: the invisible background
-    /// view is the menu's positioning anchor.
-    private final class AnchorHolder {
-        weak var view: NSView?
-    }
-
-    private struct AnchorView: NSViewRepresentable {
-        let holder: AnchorHolder
-
-        func makeNSView(context: Context) -> NSView {
-            let view = NSView()
-            holder.view = view
-            return view
-        }
-
-        func updateNSView(_ nsView: NSView, context: Context) {
-            holder.view = nsView
-        }
-    }
-
-    /// NSMenuItem needs a target/selector pair; this carries the closure
-    /// and targets itself. Nonisolated to match NSMenuItem's initializers
-    /// (Swift 6 rejects isolation-narrowing overrides); the handler stays
-    /// main-actor because menu actions always fire there.
-    private nonisolated final class ClosureMenuItem: NSMenuItem {
-        private let handler: @MainActor () -> Void
-
-        init(title: String, handler: @escaping @MainActor () -> Void) {
-            self.handler = handler
-            super.init(title: title, action: #selector(invoke), keyEquivalent: "")
-            target = self
-        }
-
-        @available(*, unavailable)
-        required init(coder: NSCoder) {
-            fatalError("not used")
-        }
-
-        @objc @MainActor private func invoke() {
-            handler()
-        }
     }
 }
 

--- a/macos/ATC/Shared/PopupMenuButton.swift
+++ b/macos/ATC/Shared/PopupMenuButton.swift
@@ -1,0 +1,125 @@
+// A caller-drawn button that pops a native NSMenu. SwiftUI's borderless
+// `Menu` sizes to its label's compressed ideal width — every frame-based
+// expansion collapses back to a text pill — so the label is an ordinary
+// Button (layout the caller fully controls) and AppKit owns the popup:
+// radio-style checkmarks, section headers, separators, and a destructive
+// styling for entries that must never be a mis-click. `NavigatorDropdown`
+// (the sidebar chip) and the Chat composer's settings controls both wrap it.
+
+import AppKit
+import SwiftUI
+
+/// One entry in a `PopupMenuButton` menu.
+enum PopupMenuEntry {
+    case item(title: String, isSelected: Bool, isDestructive: Bool = false, action: @MainActor () -> Void)
+    case header(String)
+    case separator
+}
+
+/// How the label is drawn: `.plain` leaves it entirely to the caller (the
+/// sidebar chip draws its own surface); `.accessoryBar` is the system's
+/// quiet bar control — nothing at rest, a rollover highlight under the
+/// pointer — for controls that must stay out of the way (the composer's).
+enum PopupMenuAppearance {
+    case plain
+    case accessoryBar
+}
+
+struct PopupMenuButton<Label: View>: View {
+    let entries: [PopupMenuEntry]
+    var appearance: PopupMenuAppearance = .plain
+    @ViewBuilder let label: () -> Label
+
+    @State private var anchor = AnchorHolder()
+
+    var body: some View {
+        switch appearance {
+        case .plain: button.buttonStyle(.plain)
+        case .accessoryBar: button.buttonStyle(.accessoryBar)
+        }
+    }
+
+    private var button: some View {
+        Button {
+            popUp()
+        } label: {
+            label()
+        }
+        .background {
+            AnchorView(holder: anchor)
+        }
+    }
+
+    private func popUp() {
+        guard let view = anchor.view else { return }
+        let menu = NSMenu()
+        for entry in entries {
+            switch entry {
+            case .separator:
+                menu.addItem(.separator())
+            case .header(let title):
+                menu.addItem(.sectionHeader(title: title))
+            case .item(let title, let isSelected, let isDestructive, let action):
+                let item = ClosureMenuItem(title: title, handler: action)
+                item.state = isSelected ? .on : .off
+                if isDestructive {
+                    // attributedTitle replaces every attribute: keep the menu's
+                    // own font, only the color changes.
+                    item.attributedTitle = NSAttributedString(
+                        string: title,
+                        attributes: [
+                            .foregroundColor: NSColor.systemRed,
+                            .font: NSFont.menuFont(ofSize: 0),
+                        ])
+                    item.image = NSImage(
+                        systemSymbolName: "exclamationmark.triangle.fill", accessibilityDescription: nil)
+                }
+                menu.addItem(item)
+            }
+        }
+        menu.popUp(positioning: nil, at: NSPoint(x: 0, y: view.bounds.maxY + 4), in: view)
+    }
+
+    /// Bridges the SwiftUI position to AppKit: the invisible background
+    /// view is the menu's positioning anchor.
+    private final class AnchorHolder {
+        weak var view: NSView?
+    }
+
+    private struct AnchorView: NSViewRepresentable {
+        let holder: AnchorHolder
+
+        func makeNSView(context: Context) -> NSView {
+            let view = NSView()
+            holder.view = view
+            return view
+        }
+
+        func updateNSView(_ nsView: NSView, context: Context) {
+            holder.view = nsView
+        }
+    }
+
+    /// NSMenuItem needs a target/selector pair; this carries the closure
+    /// and targets itself. Nonisolated to match NSMenuItem's initializers
+    /// (Swift 6 rejects isolation-narrowing overrides); the handler stays
+    /// main-actor because menu actions always fire there.
+    private nonisolated final class ClosureMenuItem: NSMenuItem {
+        private let handler: @MainActor () -> Void
+
+        init(title: String, handler: @escaping @MainActor () -> Void) {
+            self.handler = handler
+            super.init(title: title, action: #selector(invoke), keyEquivalent: "")
+            target = self
+        }
+
+        @available(*, unavailable)
+        required init(coder: NSCoder) {
+            fatalError("not used")
+        }
+
+        @objc @MainActor private func invoke() {
+            handler()
+        }
+    }
+}

--- a/macos/ATC/Shared/ServerError.swift
+++ b/macos/ATC/Shared/ServerError.swift
@@ -42,6 +42,7 @@ extension Components.Schemas.ProviderSessionConflictJsonEncoding: ServerErrorPay
 extension Components.Schemas.RequestNotFoundJsonEncoding: ServerErrorPayload {}
 extension Components.Schemas.InvalidRequestAnswerJsonEncoding: ServerErrorPayload {}
 extension Components.Schemas.QueuedPromptNotFoundJsonEncoding: ServerErrorPayload {}
+extension Components.Schemas.InvalidThreadSettingsJsonEncoding: ServerErrorPayload {}
 
 extension ServerError {
     /// Wrap a single-schema failure payload.

--- a/macos/ATCTests/ChatSettingsControlsTests.swift
+++ b/macos/ATCTests/ChatSettingsControlsTests.swift
@@ -1,0 +1,64 @@
+import ATCAppServerAPI
+import Foundation
+import Testing
+
+@testable import ATC
+
+/// The composer's menu entries (ATC-205): the model menu carries the
+/// selected model's reasoning levels (none for a model without effort),
+/// radios reflect the thread's settings, a missing catalog degrades to
+/// loading / retry, and the narrow-row ⋯ menu holds Mode and Access.
+@MainActor
+@Suite("ChatSettingsControls")
+struct ChatSettingsControlsTests {
+    private let catalog = [
+        Fixtures.model("big", displayName: "Big", isDefault: true, effortLevels: [.low, .high]),
+        Fixtures.model("tiny", effortLevels: []),
+    ]
+
+    private func controls(model: String, models: [AgentModel]?, error: String? = nil) -> ChatSettingsControls {
+        ChatSettingsControls(
+            thread: Fixtures.thread(id: "t", settings: Fixtures.settings(model: model, reasoning: .high)),
+            models: models, modelsError: error, update: { _ in }, reloadModels: {})
+    }
+
+    private func titles(_ entries: [PopupMenuEntry]) -> [String] {
+        entries.map { entry in
+            switch entry {
+            case .header(let title): "#\(title)"
+            case .separator: "-"
+            case .item(let title, let isSelected, let isDestructive, _):
+                "\(title)\(isSelected ? "*" : "")\(isDestructive ? "!" : "")"
+            }
+        }
+    }
+
+    @Test("the model menu radios the stored model and lists its reasoning levels; no effort, no section")
+    func modelMenu() {
+        #expect(
+            titles(controls(model: "big", models: catalog).modelEntries) == [
+                "#Model", "Big*", "tiny", "-", "#Reasoning", "Low", "High*",
+            ])
+        #expect(titles(controls(model: "tiny", models: catalog).modelEntries) == ["#Model", "Big", "tiny*"])
+    }
+
+    @Test("no catalog is loading; a failed read offers retry")
+    func missingCatalog() {
+        #expect(titles(controls(model: "big", models: nil).modelEntries) == ["#Loading models…"])
+        #expect(
+            titles(controls(model: "big", models: nil, error: "Claude is not installed").modelEntries)
+                == ["#Claude is not installed", "Retry"])
+    }
+
+    @Test("mode and access radio the thread's settings; the ⋯ menu sections them; Full access is marked")
+    func modeAndAccess() {
+        let controls = controls(model: "big", models: catalog)
+        #expect(titles(controls.modeEntries) == ["Chat*", "Plan"])
+        #expect(titles(controls.accessEntries) == ["Supervised", "Auto-accept edits", "Auto*", "Full access!"])
+        #expect(
+            titles(controls.settingsEntries) == [
+                "#Mode", "Chat*", "Plan", "-",
+                "#Access", "Supervised", "Auto-accept edits", "Auto*", "Full access!",
+            ])
+    }
+}

--- a/macos/ATCTests/NewThreadLauncherModelTests.swift
+++ b/macos/ATCTests/NewThreadLauncherModelTests.swift
@@ -34,7 +34,8 @@ struct NewThreadLauncherModelTests {
         Agent(
             id: id,
             available: available,
-            reason: reason
+            reason: reason,
+            defaults: Fixtures.settings()
         )
     }
 

--- a/macos/ATCTests/ScriptableAppServerClient.swift
+++ b/macos/ATCTests/ScriptableAppServerClient.swift
@@ -27,6 +27,10 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
         var threads: [ATCThread] = []
         var terminals: [Terminal] = []
         var agents: [Agent] = []
+        /// Model catalogs served by listAgentModels, by agent.
+        var models: [AgentID: [AgentModel]] = [:]
+        /// updateThread settings patches received, in order.
+        var settingsPatches: [(id: String, patch: ThreadSettingsPatch)] = []
         var shouldFail = false
         var delay: Duration?
         var directoryCheck: Components.Schemas.FsCheckResponse?
@@ -123,6 +127,15 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     var agents: [Agent] {
         get { lock.withLock { state.agents } }
         set { lock.withLock { state.agents = newValue } }
+    }
+
+    var models: [AgentID: [AgentModel]] {
+        get { lock.withLock { state.models } }
+        set { lock.withLock { state.models = newValue } }
+    }
+
+    var settingsPatches: [(id: String, patch: ThreadSettingsPatch)] {
+        lock.withLock { state.settingsPatches }
     }
 
     // MARK: - Behavior knobs
@@ -424,6 +437,7 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
                 agentId: request.agentId,
                 name: request.name,
                 workingDirectory: request.workingDirectory ?? project.defaultWorkingDirectory,
+                settings: model.agents.first { $0.id == request.agentId }?.defaults ?? Fixtures.settings(),
                 activityState: .idle,
                 unread: false,
                 createdAt: now,
@@ -449,16 +463,32 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
         -> Operations.UpdateThread.Output
     {
         guard case .json(let request) = input.body else { throw StubUnimplemented("updateThread") }
-        try await gate()
         let id = input.path.threadId
-        return mutate { model -> Operations.UpdateThread.Output in
+        // Applied before the gate: a delayed response is one the server
+        // already committed, so two overlapping patches can complete out
+        // of order the way they do over a real connection.
+        let output = mutate { model -> Operations.UpdateThread.Output in
             guard let index = model.threads.firstIndex(where: { $0.id == id }) else {
                 return .notFound(.init(body: .json(threadNotFound(id))))
             }
-            model.threads[index].name = request.name
+            if let name = request.name { model.threads[index].name = name }
+            if let patch = request.settings {
+                // The server's per-model reasoning rule, as the preview
+                // client mirrors it (ThreadSettings.applying).
+                let catalog = model.models[model.threads[index].agentId] ?? []
+                let settings = model.threads[index].settings.applying(patch, catalog: catalog)
+                model.threads[index].settings = settings
+                model.settingsPatches.append((id, patch))
+                // Like the server: the change writes through to the agent's defaults.
+                if let agent = model.agents.firstIndex(where: { $0.id == model.threads[index].agentId }) {
+                    model.agents[agent].defaults = settings
+                }
+            }
             model.threads[index].updatedAt = model.tick()
             return .ok(.init(body: .json(model.threads[index])))
         }
+        try await gate()
+        return output
     }
 
     func deleteThread(_ input: Operations.DeleteThread.Input) async throws
@@ -654,6 +684,18 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
         }
         try await gate()
         return .ok(.init(body: .json(payload)))
+    }
+
+    func listAgentModels(_ input: Operations.ListAgentModels.Input) async throws
+        -> Operations.ListAgentModels.Output
+    {
+        try await gate()
+        let id = input.path.agentId
+        guard let agentId = AgentID(rawValue: id) else {
+            return .notFound(
+                .init(body: .json(.init(_tag: .agentNotFound, agentId: id, message: "No agent \(id)"))))
+        }
+        return .ok(.init(body: .json(mutate { model in model.models[agentId] ?? [] })))
     }
 
     func getAgent(_ input: Operations.GetAgent.Input) async throws
@@ -953,6 +995,7 @@ enum Fixtures {
         agentId: AgentID = .codex,
         name: String? = nil,
         workingDirectory: String = "/home/dev/app",
+        settings: ThreadSettings = Fixtures.settings(),
         activityState: ThreadActivityState = .idle,
         unread: Bool = false,
         linkedTerminalId: String? = nil,
@@ -966,6 +1009,7 @@ enum Fixtures {
             agentId: agentId,
             name: name,
             workingDirectory: workingDirectory,
+            settings: settings,
             activityState: activityState,
             unread: unread,
             linkedTerminalId: linkedTerminalId,
@@ -1055,7 +1099,33 @@ enum Fixtures {
             id: id,
             available: available,
             reason: available ? nil : "Not installed",
-            detectedVersion: available ? "1.0.0" : nil
+            detectedVersion: available ? "1.0.0" : nil,
+            defaults: settings()
+        )
+    }
+
+    nonisolated static func settings(
+        model: String = "test-model",
+        reasoning: ReasoningLevel? = .high,
+        mode: ThreadMode = .chat,
+        access: ThreadAccess = .auto
+    ) -> ThreadSettings {
+        ThreadSettings(model: model, reasoning: reasoning, mode: mode, access: access)
+    }
+
+    static func model(
+        _ value: String,
+        displayName: String? = nil,
+        isDefault: Bool = false,
+        effortLevels: [ReasoningLevel] = [.low, .medium, .high]
+    ) -> AgentModel {
+        AgentModel(
+            value: value,
+            displayName: displayName ?? value,
+            description: "",
+            isDefault: isDefault,
+            supportedEffortLevels: effortLevels,
+            defaultEffortLevel: effortLevels.contains(.medium) ? .medium : effortLevels.first
         )
     }
 

--- a/macos/ATCTests/ThreadsStoreTests.swift
+++ b/macos/ATCTests/ThreadsStoreTests.swift
@@ -165,6 +165,55 @@ struct ThreadsStoreTests {
         #expect(client.createdThreadRequests.map(\.agentId) == [.claudeCode])
     }
 
+    @Test("updateSettings sends one patch and merges the server's settings in place")
+    func updateSettingsMerges() async throws {
+        let (store, client) = await loadedStore()
+        let updated = try await store.updateSettings(id: "thr2", .init(access: .fullAccess))
+        #expect(updated.settings.access == .fullAccess)
+        #expect(store.thread(id: "thr2")?.settings.access == .fullAccess)
+        #expect(client.settingsPatches.map(\.id) == ["thr2"])
+        #expect(client.settingsPatches.first?.patch.access == .fullAccess)
+        #expect(client.settingsPatches.first?.patch.model == nil)
+        // Merge keeps the creation ordering — a settings change never reorders.
+        #expect(store.threads.map(\.id) == ["thr3", "thr2", "thr1"])
+    }
+
+    @Test("the stand-in applies the server's reasoning rule on a model change")
+    func standInReasoningRule() async throws {
+        let (store, client) = await loadedStore()
+        client.models[.codex] = [
+            Fixtures.model("big", effortLevels: [.low, .high]),
+            Fixtures.model("tiny", effortLevels: []),
+        ]
+        // thr2 starts at reasoning .high: kept by a model that supports it,
+        // dropped by one without effort support, back to the default after.
+        var thread = try await store.updateSettings(id: "thr2", .init(model: "big"))
+        #expect(thread.settings.reasoning == .high)
+        thread = try await store.updateSettings(id: "thr2", .init(model: "tiny"))
+        #expect(thread.settings.reasoning == nil)
+        thread = try await store.updateSettings(id: "thr2", .init(model: "big"))
+        #expect(thread.settings.reasoning == .low)
+    }
+
+    @Test("a settings response landing after a newer one never rolls the store back")
+    func staleSettingsResponseDoesNotClobber() async throws {
+        let (store, client) = await loadedStore()
+        client.delay = .milliseconds(200)
+        let slow = Task { try await store.updateSettings(id: "thr2", .init(access: .fullAccess)) }
+        // The scriptable server commits before it parks the response, so
+        // the second patch below is computed on top of the first.
+        await settle(until: { client.settingsPatches.count == 1 })
+        client.delay = nil
+        _ = try await store.updateSettings(id: "thr2", .init(mode: .plan))
+        #expect(store.thread(id: "thr2")?.settings.mode == .plan)
+        #expect(store.thread(id: "thr2")?.settings.access == .fullAccess)
+
+        // The older response (mode still Chat) arrives last and is dropped.
+        _ = try await slow.value
+        #expect(store.thread(id: "thr2")?.settings.mode == .plan)
+        #expect(store.thread(id: "thr2")?.settings.access == .fullAccess)
+    }
+
     @Test("a failed refresh keeps the last-loaded data and records the error")
     func failedRefreshPreservesData() async {
         let (store, client) = await loadedStore()


### PR DESCRIPTION
macOS half of ATC-205 (Chat mode model settings) — [ATC-211](https://linear.app/elevenideas/issue/ATC-211). **Stacked on #219 (ATC-210); merge that first**, then this — this PR is based on the #219 branch, so its diff and CI cover just the macOS half; GitHub retargets it to main when #219 merges.

## What
- `ChatSettingsControls` leads the composer's bottom row, shaped like the Codex desktop composer: quiet accessory-bar controls (nothing at rest, the system rollover highlight under the pointer), all inline while they fit —
  - the **model** control: the agent's mark, the provider's model name (`GPT-5.6-Sol`, `Fable 5`), the reasoning level, and a chevron; it pops the catalog with **Reasoning** (the selected model's levels) beneath it — no section for a model without effort support;
  - **Mode** (Chat / Plan) and **Access** (Supervised / Auto-accept edits / Auto / Full access) as their own controls; Full access is orange with a warning shield inline, red with a warning mark in the menu, and asks for confirmation before it is sent, so it is never a mis-click. Re-picking a menu's checked entry sends nothing.
  - When the row is too narrow for all three (`ViewThatFits`), Mode and Access fold into one `⋯` menu with both as radio sections. The controls take every point the send button leaves, so folding happens only when the row truly is too narrow.
- The editor starts three lines tall (room to type above the controls row) and grows to ten before scrolling. The tail-follow already tracks the composer bar's inset, so the taller composer keeps the transcript pinned the same way.
- Every choice sends one settings patch; the server validates it and applies the per-model reasoning rule; the thread's SSE refetch repaints. Nothing is added to the New Thread sheet — new threads inherit the agent's defaults server-side.
- `NavigatorDropdown`'s NSMenu popup moves into the shared `PopupMenuButton` (items, section headers, separators, destructive styling, and a `.plain` / `.accessoryBar` face); the sidebar chip wraps it as before.
- `AgentsStore` reads each agent's model catalog on demand (once per store); `ThreadsStore.updateSettings` is the mutation (400 `InvalidThreadSettings` / 503 `ProviderUnavailable` surface through the standard action alert). `ThreadsStore.merge` drops a response older (`updatedAt`) than what it holds, so overlapping patches whose responses land out of order never roll the store back.
- Fixtures, the scriptable client, and the preview client carry `settings`, `Agent.defaults`, and catalogs; the New Thread sheet's pre-detection placeholder rows carry placeholder defaults (only `id`/`available` are read there).

## Verified
- `mise run macos:test` (329 tests), `swift:lint`, `swift:fmt:check`; `ChatSettingsControlsTests` cover the model menu (with / without reasoning), the loading / retry states, Mode / Access, and the `⋯` fallback; `ThreadsStoreTests.updateSettingsMerges`.
- Screenshots of the dev build against the local server (Claude thread): the quiet row at rest, the accessory-bar rollover on the model control, and the model menu with the Reasoning section beneath the catalog. The narrow fold was not exercised on screen — the window would not shrink below the toolbar's width during the session — it is `ViewThatFits` over the same two rows.
- One observation while driving the dev build with synthetic events: a single crash during an inspector-divider drag, thrown from AppKit's constraint pass (`NSHostingView.minSize()` → `_postWindowNeedsUpdateConstraints` inside `NSSplitView mouseDown:`), no atc frames; it did not reproduce on a second run and nothing in this diff touches that path (the same tail-follow / editor-measure state changes predate it). Noting it rather than hiding it.

https://claude.ai/code/session_012Z59VLDXmduFvKXowv3uD1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added chat settings for model, reasoning level, mode, and access.
  * Added agent-specific model catalogs with loading and retry support.
  * Saved thread settings and applied agent defaults to new threads.
* **Bug Fixes**
  * Prevented stale updates from overwriting newer thread settings.
  * Improved handling of invalid or unavailable setting updates.
* **UI Improvements**
  * Added responsive, accessible settings controls to the chat composer.
  * Updated menus with native presentation and destructive styling for Full access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

