### PR TITLE
Stabilize macOS release signing

### DIFF
--- a/scripts/ExportOptions.DeveloperID.plist
+++ b/scripts/ExportOptions.DeveloperID.plist
@@ -9,7 +9,9 @@
 	<key>method</key>
 	<string>developer-id</string>
 	<key>signingStyle</key>
-	<string>automatic</string>
+	<string>manual</string>
+	<key>signingCertificate</key>
+	<string>Developer ID Application</string>
 	<key>stripSwiftSymbols</key>
 	<true/>
 	<key>teamID</key>

--- a/scripts/release-macos.sh
+++ b/scripts/release-macos.sh
@@ -126,7 +126,6 @@ fi
 
 DEVELOPER_ID_IDENTITY=""
 NOTARY_ARGS=()
-XCODE_AUTH_ARGS=(-allowProvisioningUpdates)
 
 find_developer_id_identity() {
   local identities line
@@ -165,16 +164,6 @@ configure_notary_credentials() {
       --key-id "$ATC_APP_STORE_CONNECT_KEY_ID"
       --issuer "$ATC_APP_STORE_CONNECT_ISSUER_ID"
     )
-    # The ephemeral runner imports only the long-lived Developer ID identity.
-    # Automatic archive signing can use the same App Store Connect API key to
-    # obtain its short-lived development signing assets; export then selects
-    # the locally imported Developer ID certificate.
-    XCODE_AUTH_ARGS=(
-      -authenticationKeyPath "$ATC_APP_STORE_CONNECT_KEY_PATH"
-      -authenticationKeyID "$ATC_APP_STORE_CONNECT_KEY_ID"
-      -authenticationKeyIssuerID "$ATC_APP_STORE_CONNECT_ISSUER_ID"
-      -allowProvisioningUpdates
-    )
     return
   fi
   report_error "configure ATC_NOTARY_PROFILE or the three ATC_APP_STORE_CONNECT_KEY_* credentials"
@@ -209,6 +198,21 @@ validate_exported_app() {
   assert_plist_value ATCBuildVersion "$VERSION"
   assert_plist_value ATCBuildCommit "$COMMIT"
   assert_plist_value ATCBuildBuiltAt "$BUILT_AT"
+}
+
+verify_exported_app_signature() {
+  local details
+  codesign --verify --deep --strict --verbose=2 "$APP_PATH" || return
+  details="$(codesign --display --verbose=4 "$APP_PATH" 2>&1)" || {
+    printf '%s\n' "$details" >&2
+    return 1
+  }
+  if [[ "$details" != *"Authority=Developer ID Application:"*"($ATC_TEAM_ID)"* ||
+    "$details" != *"TeamIdentifier=$ATC_TEAM_ID"* ]]; then
+    printf '%s\n' "$details" >&2
+    report_error "exported app is not signed with Team $ATC_TEAM_ID's Developer ID identity"
+    return 1
+  fi
 }
 
 assert_plist_value() {
@@ -309,7 +313,10 @@ XCODE_OVERRIDES=(
   "PRODUCT_NAME=$APP_NAME"
   "PRODUCT_BUNDLE_IDENTIFIER=$BUNDLE_ID"
   "DEVELOPMENT_TEAM=$ATC_TEAM_ID"
-  "CODE_SIGN_STYLE=Automatic"
+  # Release CI imports this long-lived identity into an isolated keychain.
+  # Manual signing keeps Xcode from creating per-run development certificates.
+  "CODE_SIGN_STYLE=Manual"
+  "CODE_SIGN_IDENTITY=$DEVELOPER_ID_IDENTITY"
   "MARKETING_VERSION=$MARKETING_VERSION"
   "CURRENT_PROJECT_VERSION=$BUILD_NUMBER"
   "ATC_BUILD_VERSION=$VERSION"
@@ -327,18 +334,15 @@ run_step "Archive $APP_NAME.app" "02-archive" xcodebuild archive \
   -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_PATH" \
   -skipPackagePluginValidation \
   -skipMacroValidation \
-  "${XCODE_AUTH_ARGS[@]}" \
   "${XCODE_OVERRIDES[@]}"
 
 run_step "Export Developer ID app" "03-export" xcodebuild -exportArchive \
   -archivePath "$ARCHIVE_PATH" \
   -exportPath "$EXPORT_PATH" \
-  -exportOptionsPlist "$EXPORT_OPTIONS_PLIST" \
-  "${XCODE_AUTH_ARGS[@]}"
+  -exportOptionsPlist "$EXPORT_OPTIONS_PLIST"
 
 run_step "Validate exported app identity" "04-validate-app" validate_exported_app
-run_step "Verify exported app signature" "05-verify-app" \
-  codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+run_step "Verify exported app signature" "05-verify-app" verify_exported_app_signature
 run_step "Create DMG" "06-create-dmg" create_dmg
 run_step "Sign and verify DMG" "07-sign-dmg" sign_dmg
 run_step "Submit DMG for notarization" "08-notarize" \

--- a/scripts/release-test.sh
+++ b/scripts/release-test.sh
@@ -410,8 +410,64 @@ set -e
 [[ $verbose_status -eq 1 ]]
 [[ "$verbose_output" == *"Archive atc.app failed"* ]]
 grep -Fq -- \
-  "<-authenticationKeyPath> <$api_key_path> <-authenticationKeyID> <KEY123> <-authenticationKeyIssuerID> <ISSUER123>" \
+  "<CODE_SIGN_STYLE=Manual> <CODE_SIGN_IDENTITY=Developer ID Application: Test (337D6CNU4E)>" \
   "$tool_log"
+if grep -Eq -- '-allowProvisioningUpdates|-authenticationKey(Path|ID|IssuerID)' "$tool_log"; then
+  echo "release builds must not let Xcode create or update signing assets" >&2
+  exit 1
+fi
+grep -Fq '<key>signingStyle</key>' "$REPO_ROOT/scripts/ExportOptions.DeveloperID.plist"
+grep -Fq '<string>manual</string>' "$REPO_ROOT/scripts/ExportOptions.DeveloperID.plist"
+grep -Fq '<key>signingCertificate</key>' "$REPO_ROOT/scripts/ExportOptions.DeveloperID.plist"
+grep -Fq '<string>Developer ID Application</string>' "$REPO_ROOT/scripts/ExportOptions.DeveloperID.plist"
+
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  '{ printf '\''xcodebuild'\''; for arg in "$@"; do printf '\'' <%s>'\'' "$arg"; done; printf '\''\n'\''; } >> "$TOOL_LOG"' \
+  'if [[ "$1" == "-exportArchive" ]]; then' \
+  '  while [[ $# -gt 0 ]]; do' \
+  '    if [[ "$1" == "-exportPath" ]]; then mkdir -p "$2/atc.app/Contents"; exit; fi' \
+  '    shift' \
+  '  done' \
+  'fi' > "$fake_bin/xcodebuild"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'case "$2" in' \
+  '  *CFBundleIdentifier) printf '\''ElevenIdeas.atc.dev\n'\'' ;;' \
+  '  *CFBundleShortVersionString) printf '\''1.2.3\n'\'' ;;' \
+  '  *CFBundleVersion) printf '\''2\n'\'' ;;' \
+  '  *ATCBuildVersion) printf '\''1.2.3-dev.2\n'\'' ;;' \
+  '  *ATCBuildCommit) printf '\''%s\n'\'' "$EXPECTED_COMMIT" ;;' \
+  '  *ATCBuildBuiltAt) printf '\''2026-08-15T12:34:56Z\n'\'' ;;' \
+  '  *) exit 1 ;;' \
+  'esac' > "$fake_bin/PlistBuddy"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'if [[ "$1" == "--display" ]]; then' \
+  '  printf '\''Authority=Developer ID Application: Test (337D6CNU4E)\nTeamIdentifier=337D6CNU4E\n'\'' >&2' \
+  'fi' > "$fake_bin/codesign"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'for path in "$@"; do :; done' \
+  'touch "$path"' > "$fake_bin/hdiutil"
+chmod +x "$fake_bin/xcodebuild" "$fake_bin/PlistBuddy" "$fake_bin/codesign" "$fake_bin/hdiutil"
+
+: > "$tool_log"
+PATH="$fake_bin:$PATH" \
+  SECURITY_LOG="$security_log" \
+  TOOL_LOG="$tool_log" \
+  EXPECTED_COMMIT="$commit" \
+  ATC_APP_STORE_CONNECT_KEY_PATH="$api_key_path" \
+  ATC_APP_STORE_CONNECT_KEY_ID="KEY123" \
+  ATC_APP_STORE_CONNECT_ISSUER_ID="ISSUER123" \
+  run_macos_release_test "$TEST_ROOT/successful-release-artifacts" "$TEST_ROOT/successful-release-logs"
+[[ -f "$TEST_ROOT/atc.dmg" ]]
+grep -Fq '<-exportArchive>' "$tool_log"
+if grep -Eq -- '-allowProvisioningUpdates|-authenticationKey(Path|ID|IssuerID)' "$tool_log"; then
+  echo "successful release build mutated Xcode signing assets" >&2
+  exit 1
+fi
 
 missing_key_path="$TEST_ROOT/missing-key.p8"
 missing_key_log_dir="$TEST_ROOT/missing-key-logs"


### PR DESCRIPTION
## Summary

- sign macOS archives and exports manually with the imported Developer ID Application identity
- keep the App Store Connect key scoped to notarization and prevent Xcode from creating development certificates
- verify the exported app’s Developer ID authority and team before packaging
- cover the complete release path and automatic-provisioning invariant in the release tooling tests

## Testing

- `TMPDIR=/tmp mise run check`
- XcodeBuildMCP macOS Release build with signing disabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS releases now use explicit Developer ID signing.
  * Added validation to confirm the exported app has a valid signature and expected developer authority before packaging.

* **Bug Fixes**
  * Improved release reliability by removing unnecessary authentication and provisioning requirements.
  * Added automated checks to prevent incorrectly signed release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->