### PR TITLE
Attachments: image uploads on threads, server and macOS (ATC-221)

### DIFF
--- a/app-server/README.md
+++ b/app-server/README.md
@@ -35,11 +35,11 @@ naming the offending source — never a partial boot.
 Paths follow one XDG rule on every platform (macOS included), honoring `XDG_*`
 overrides:
 
-| Location    | Default                     | Holds                                            |
-| ----------- | --------------------------- | ------------------------------------------------ |
-| Config file | `~/.config/atc/config.toml` | Settings (TOML, camelCase)                       |
-| Data dir    | `~/.local/share/atc/`       | SQLite database (`atc.db`)                       |
-| State dir   | `~/.local/state/atc/`       | JSON log (`atc.log`), zmx sockets (`terminals/`) |
+| Location    | Default                     | Holds                                                                 |
+| ----------- | --------------------------- | --------------------------------------------------------------------- |
+| Config file | `~/.config/atc/config.toml` | Settings (TOML, camelCase)                                            |
+| Data dir    | `~/.local/share/atc/`       | SQLite database (`atc.db`), prompt images (`attachments/<threadId>/`) |
+| State dir   | `~/.local/state/atc/`       | JSON log (`atc.log`), zmx sockets (`terminals/`)                      |
 
 Environment variables are flat `ATC_<KEY>`: `ATC_PORT`, `ATC_BIND`,
 `ATC_TAILSCALE`, `ATC_LOG_LEVEL`, `ATC_DATA_DIR`, `ATC_ZMX_EXECUTABLE`,

--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -1214,11 +1214,18 @@
             }
           },
           "404": {
-            "description": "No thread exists with the given id.",
+            "description": "No thread exists with the given id. | No attachment with the given id on this thread.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ThreadNotFoundJsonEncoding"
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ThreadNotFoundJsonEncoding"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AttachmentNotFoundJsonEncoding"
+                    }
+                  ]
                 }
               }
             }
@@ -1627,6 +1634,175 @@
           }
         },
         "description": "Withdraw a waiting prompt. A prompt that already started is a turn now (404); interrupt the thread instead."
+      }
+    },
+    "/api/v1/threads/{threadId}/attachments": {
+      "post": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "createThreadAttachment",
+        "parameters": [
+          {
+            "name": "threadId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "description": "Display filename; omitted derives one from the type (\"image.png\")."
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An image a client uploaded to a thread for a prompt. Attachments live with their thread and die with it; the bytes come back from getThreadAttachment.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadAttachment"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No thread exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadNotFoundJsonEncoding"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The thread is archived; unarchive it first.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadArchivedJsonEncoding"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "The upload exceeds the per-attachment cap (8388608 bytes); downscale the image and retry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttachmentTooLargeJsonEncoding"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The body is not a usable image of the declared Content-Type: empty, or its bytes do not carry that format's signature.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttachmentInvalidJsonEncoding"
+                }
+              }
+            }
+          }
+        },
+        "description": "Upload one image for a later prompt on this thread: the raw bytes as the body, the image type as Content-Type (PNG, JPEG, GIF, or WebP — anything else is 415), at most 8388608 bytes (413 beyond). The bytes are held under the server's data directory for the thread's life and deleted with it; the returned path is stable and readable by any process on the server host. Reference the id in promptThread's attachments (up to 10 per prompt). Nothing is garbage-collected before the thread goes: upload at send time, not ahead of it.",
+        "requestBody": {
+          "content": {
+            "image/png": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "image/jpeg": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "image/gif": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "image/webp": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/api/v1/threads/{threadId}/attachments/{attachmentId}": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "getThreadAttachment",
+        "parameters": [
+          {
+            "name": "threadId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "attachmentId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                },
+                "x-effect-stream": {
+                  "encoding": "uint8array"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No thread exists with the given id. | No attachment with the given id on this thread.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ThreadNotFoundJsonEncoding"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AttachmentNotFoundJsonEncoding"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "The attachment's bytes, as uploaded (served as application/octet-stream; the image type is in the attachment's metadata on the item or queue entry that carries it)."
       }
     },
     "/api/v1/agents": {
@@ -2669,15 +2845,21 @@
         "properties": {
           "prompt": {
             "type": "string",
-            "minLength": 1,
-            "description": "The user's message."
+            "description": "The user's message; may be empty only when attachments are present."
+          },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 10,
+            "description": "Ids of attachments previously uploaded to THIS thread (createThreadAttachment), in display order. An id the thread does not own is a 404."
           }
         },
         "required": [
           "prompt"
         ],
-        "additionalProperties": false,
-        "description": "Payload for prompting a thread: text only (attachments are additive later)."
+        "additionalProperties": false
       },
       "PromptThreadResponse": {
         "type": "object",
@@ -2696,6 +2878,83 @@
         ],
         "additionalProperties": false,
         "description": "A prompt was admitted: it started a turn now, or waits in the queue."
+      },
+      "AttachmentNotFoundJsonEncoding": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": [
+              "AttachmentNotFound"
+            ]
+          },
+          "threadId": {
+            "type": "string"
+          },
+          "attachmentId": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic derived from the structured fields."
+          }
+        },
+        "required": [
+          "_tag",
+          "threadId",
+          "attachmentId",
+          "message"
+        ],
+        "additionalProperties": false
+      },
+      "AttachmentMediaType": {
+        "type": "string",
+        "enum": [
+          "image/png",
+          "image/jpeg",
+          "image/gif",
+          "image/webp"
+        ],
+        "description": "The image type of an attachment; the accepted set of the upload endpoint."
+      },
+      "ThreadAttachment": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "UUIDv7 attachment id, unique within the thread."
+          },
+          "name": {
+            "type": "string",
+            "description": "Display filename (the uploader's, sanitized)."
+          },
+          "mediaType": {
+            "$ref": "#/components/schemas/AttachmentMediaType"
+          },
+          "byteSize": {
+            "type": "integer",
+            "description": "Size of the stored bytes."
+          },
+          "path": {
+            "type": "string",
+            "description": "Server-host absolute path of the stored bytes — stable for the attachment's life, so an agent on that machine (a TUI, a script) can be pointed at it."
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Upload time.",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "mediaType",
+          "byteSize",
+          "path",
+          "createdAt"
+        ],
+        "additionalProperties": false,
+        "description": "An image a client uploaded to a thread for a prompt. Attachments live with their thread and die with it; the bytes come back from getThreadAttachment."
       },
       "ThreadItemUserMessage": {
         "type": "object",
@@ -2726,6 +2985,13 @@
           },
           "text": {
             "type": "string"
+          },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ThreadAttachment"
+            },
+            "description": "Images sent with the prompt; absent when none. Present for prompts ATC sent natively; a provider re-read keeps them where the provider's turn ids are stable (Codex), and loses them where they are not (Claude) — the bytes stay fetchable by id either way."
           }
         },
         "required": [
@@ -2735,7 +3001,7 @@
           "text"
         ],
         "additionalProperties": false,
-        "description": "A user prompt (text only)."
+        "description": "A user prompt: text plus any image attachments."
       },
       "ThreadItemAssistantText": {
         "type": "object",
@@ -3690,6 +3956,13 @@
           "prompt": {
             "type": "string"
           },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ThreadAttachment"
+            },
+            "description": "Images waiting with the prompt."
+          },
           "queuedAt": {
             "type": "string",
             "description": "When the prompt was admitted.",
@@ -3735,6 +4008,66 @@
           "_tag",
           "threadId",
           "promptId",
+          "message"
+        ],
+        "additionalProperties": false
+      },
+      "AttachmentTooLargeJsonEncoding": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": [
+              "AttachmentTooLarge"
+            ]
+          },
+          "threadId": {
+            "type": "string"
+          },
+          "byteSize": {
+            "type": "integer"
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic derived from the structured fields."
+          }
+        },
+        "required": [
+          "_tag",
+          "threadId",
+          "byteSize",
+          "limit",
+          "message"
+        ],
+        "additionalProperties": false
+      },
+      "AttachmentInvalidJsonEncoding": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": [
+              "AttachmentInvalid"
+            ]
+          },
+          "threadId": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable diagnostic derived from the structured fields."
+          }
+        },
+        "required": [
+          "_tag",
+          "threadId",
+          "reason",
           "message"
         ],
         "additionalProperties": false

--- a/app-server/src/agents/agentAdapter.ts
+++ b/app-server/src/agents/agentAdapter.ts
@@ -133,6 +133,20 @@ export type ReasoningLevel = typeof Contract.ReasoningLevel.Type
 export type ThreadAccess = typeof Contract.ThreadAccess.Type
 export type ThreadMode = typeof Contract.ThreadMode.Type
 export type AgentModel = typeof Contract.AgentModel.Type
+export type ThreadAttachment = typeof Contract.ThreadAttachment.Type
+
+/**
+ * What a turn is started with (ATC-216): the user's text and the images it
+ * carries, each stored at `path` on this host (attachments.ts). Adapters
+ * hand the images to the provider in its own shape — bytes read here and
+ * inlined (Claude), or the path for the provider to read (Codex) — and put
+ * them on the prompt's `userMessage` item, so the transcript shows what the
+ * provider saw.
+ */
+export interface TurnInput {
+  readonly text: string
+  readonly attachments: ReadonlyArray<ThreadAttachment>
+}
 
 /**
  * What a provider reported about its session's settings (ATC-205): only the
@@ -280,7 +294,7 @@ export interface AgentConnection {
    * `AgentIdentityMismatch` can surface fail-closed.
    */
   readonly startTurn: (
-    input: string,
+    input: TurnInput,
     settings: ThreadSettings,
   ) => Effect.Effect<
     AgentTurn,
@@ -375,7 +389,7 @@ export interface AgentAdapter {
    */
   readonly createSession: (options: {
     readonly cwd: string
-    readonly input: string
+    readonly input: TurnInput
     readonly settings: ThreadSettings
   }) => Effect.Effect<
     AgentSessionStart,

--- a/app-server/src/agents/claudeAdapter.ts
+++ b/app-server/src/agents/claudeAdapter.ts
@@ -43,6 +43,7 @@ import type {
   ThreadItem,
   ThreadRequest,
   ThreadSettings,
+  TurnInput,
 } from "./agentAdapter.ts"
 import {
   AgentResumeFailed,
@@ -385,11 +386,46 @@ const HOOK_EVENTS: ReadonlyArray<HookEvent> = [
   "PermissionDenied",
 ]
 
-const userMessage = (text: string): SDKUserMessage => ({
+type UserContent = SDKUserMessage["message"]["content"]
+
+const userMessage = (content: UserContent): SDKUserMessage => ({
   type: "user",
-  message: { role: "user", content: text },
+  message: { role: "user", content },
   parent_tool_use_id: null,
 })
+
+/**
+ * The turn input as SDK content (ATC-216): plain text, or the text followed
+ * by each image inlined as a base64 block — the Anthropic API's image shape,
+ * read from the attachment's stored bytes here (the SDK child sees no
+ * paths). An unreadable attachment fails the turn before it starts.
+ */
+const readUserContent = (input: TurnInput): Effect.Effect<UserContent, AgentProtocolError> =>
+  input.attachments.length === 0
+    ? Effect.succeed(input.text)
+    : Effect.forEach(input.attachments, (attachment) =>
+        Effect.tryPromise({
+          try: () => Bun.file(attachment.path).arrayBuffer(),
+          catch: (error) =>
+            protocolError(
+              `attachment ${attachment.name} could not be read: ${error instanceof Error ? error.message : String(error)}`,
+            ),
+        }).pipe(
+          Effect.map((buffer) => ({
+            type: "image" as const,
+            source: {
+              type: "base64" as const,
+              media_type: attachment.mediaType,
+              data: Buffer.from(buffer).toString("base64"),
+            },
+          })),
+        ),
+      ).pipe(
+        Effect.map((images) => [
+          ...(input.text === "" ? [] : [{ type: "text" as const, text: input.text }]),
+          ...images,
+        ]),
+      )
 
 /**
  * Labeled plain-text lines from a transcript read (ATC-190): root user and
@@ -457,7 +493,7 @@ interface LiveSession {
   readonly abort: AbortController
   /** Aggregate session-tree activity state (ATC-158). */
   readonly tracker: ClaudeHooks.ActivityTracker
-  readonly pushInput: (text: string) => void
+  readonly pushInput: (message: SDKUserMessage) => void
   readonly closeInput: () => void
   readonly initGate: Deferred.Deferred<void, GateError>
   /** The held query() handle, once opened (control requests, interrupt). */
@@ -698,7 +734,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
             )
             return
           }
-          if (streamed || block.type === "tool_result") return
+          if (streamed || block.type === "tool_result" || block.type === "image") return
           // Already complete: one event, like a history item.
           emitItem(
             session,
@@ -1057,8 +1093,8 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
             queue,
             abort: new AbortController(),
             tracker: ClaudeHooks.makeActivityTracker(),
-            pushInput: (text) => {
-              Queue.offerUnsafe(inputQueue, userMessage(text))
+            pushInput: (message) => {
+              Queue.offerUnsafe(inputQueue, message)
             },
             closeInput: () => {
               Queue.endUnsafe(inputQueue)
@@ -1249,7 +1285,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
        * Turn ids are uuids — the Thread runtime persists them, so a process-local
        * counter would collide with an earlier process's turns.
        */
-      const beginTurn = (session: LiveSession, text: string): string => {
+      const beginTurn = (session: LiveSession, input: TurnInput, content: UserContent): string => {
         const turnId = `claude-turn-${crypto.randomUUID()}`
         session.activeTurn = turnId
         // Emitted before anything can await: the consume fiber may deliver
@@ -1260,9 +1296,10 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
           type: "userMessage",
           id: `${turnId}:prompt`,
           turnId,
-          text,
+          text: input.text,
+          ...(input.attachments.length > 0 ? { attachments: input.attachments } : {}),
         })
-        session.pushInput(text)
+        session.pushInput(userMessage(content))
         return turnId
       }
 
@@ -1324,12 +1361,13 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
           cwd: session.cwd,
           activity: Effect.sync(() => session.activity),
           events: Stream.fromQueue(session.queue),
-          startTurn: (text, settings) =>
+          startTurn: (input, settings) =>
             Effect.gen(function* () {
               yield* requireOpen
               if (session.activeTurn !== null) {
                 return yield* Effect.fail(turnStillActive(session.activeTurn))
               }
+              const content = yield* readUserContent(input)
               yield* pushSettings(session, settings)
               // The pushes suspended: the seam's one-turn rule is re-checked
               // before the input goes out.
@@ -1337,7 +1375,7 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
               if (session.activeTurn !== null) {
                 return yield* Effect.fail(turnStillActive(session.activeTurn))
               }
-              const turnId = beginTurn(session, text)
+              const turnId = beginTurn(session, input, content)
               if (session.sessionId === null) {
                 // First turn after a resume: this is where the deferred
                 // identity verification lands (see the module header).
@@ -1409,8 +1447,9 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
         sharedServer: false,
         createSession: (options) =>
           Effect.gen(function* () {
+            const content = yield* readUserContent(options.input)
             const session = yield* openSession({ cwd: options.cwd, settings: options.settings })
-            const turnId = beginTurn(session, options.input)
+            const turnId = beginTurn(session, options.input, content)
             // A create has no expected id, so AgentResumeFailed cannot
             // happen here — same rule as the codex adapter.
             yield* awaitVerified(session).pipe(

--- a/app-server/src/agents/claudeItems.ts
+++ b/app-server/src/agents/claudeItems.ts
@@ -31,8 +31,8 @@ import { fileChangeTitle, toolOutcome } from "./agentAdapter.ts"
 //     `tool_use_result` (live only — history drops it) supplies the Write
 //     create-vs-update kind and the structured patch rendered as a diff.
 //   - History is grouped into turns at each top-level user message that
-//     carries text (tool_result-only and synthetic messages never open a
-//     turn); the turn id is that message's uuid. A turn whose tool_use never
+//     carries text or an image (tool_result-only and synthetic messages
+//     never open a turn); the turn id is that message's uuid. A turn whose tool_use never
 //     got a result reads as interrupted. getSessionMessages exposes system
 //     entries without their subtype (probed 2026-08-17, still true at SDK
 //     0.3.235), so compaction markers come only from the live
@@ -46,6 +46,9 @@ const FILE_TOOLS = new Set(["Edit", "Write", "MultiEdit", "NotebookEdit"])
 const MCP_PREFIX = /^mcp__([^_]+(?:_[^_]+)*)__(.+)$/
 
 const TextBlock = Schema.Struct({ type: Schema.Literal("text"), text: Schema.String })
+// An inlined prompt image (ATC-216): history carries no ATC attachment id,
+// so the block only marks a user message as a prompt.
+const ImageBlock = Schema.Struct({ type: Schema.Literal("image") })
 const ThinkingBlock = Schema.Struct({ type: Schema.Literal("thinking"), thinking: Schema.String })
 const ToolUseBlock = Schema.Struct({
   type: Schema.Literal("tool_use"),
@@ -59,7 +62,13 @@ const ToolResultBlock = Schema.Struct({
   content: Schema.optional(Schema.Unknown),
   is_error: Schema.optional(Schema.Boolean),
 })
-const ContentBlock = Schema.Union([TextBlock, ThinkingBlock, ToolUseBlock, ToolResultBlock])
+const ContentBlock = Schema.Union([
+  TextBlock,
+  ImageBlock,
+  ThinkingBlock,
+  ToolUseBlock,
+  ToolResultBlock,
+])
 type ContentBlock = typeof ContentBlock.Type
 const decodeBlock = Schema.decodeUnknownOption(ContentBlock)
 
@@ -380,10 +389,13 @@ export const permissionResult = (
 // --- History ----------------------------------------------------------------
 
 /** The user-text test that opens a turn: string content, or a text block. */
+/** The prompt of a top-level user message: its text, "" for an image-only
+ * prompt, null when it is no prompt at all (tool results, synthetic). */
 const userText = (content: unknown): string | null => {
   const blocks = contentBlocks(content)
   const texts = blocks.flatMap((block) => (block.type === "text" ? [block.text] : []))
-  return texts.length === 0 ? null : texts.join("\n")
+  if (texts.length > 0) return texts.join("\n")
+  return blocks.some((block) => block.type === "image") ? "" : null
 }
 
 const messageTimestamp = (message: SessionMessage): string | undefined => {

--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -30,9 +30,11 @@ import type {
   EstablishedIdentity,
   ProviderSettings,
   ThreadAccess,
+  ThreadAttachment,
   ThreadItem,
   ThreadRequest,
   ThreadSettings,
+  TurnInput,
 } from "./agentAdapter.ts"
 import {
   AgentResumeFailed,
@@ -471,6 +473,9 @@ interface LiveSession {
   readonly toolItems: Map<string, ThreadItem>
   /** Parked requests by request id, closed with their turn. */
   readonly pendingRequests: Map<string, PendingRequest>
+  /** The attachments this client sent, by the localImage path it named, so
+   * the provider's echo of the prompt maps back to them (ATC-216). */
+  readonly attachmentsByPath: Map<string, ThreadAttachment>
   /** Set when the transport died underneath the session (vs. caller close). */
   failed: boolean
   /** The settings baseline: what the session runs with, as last echoed
@@ -480,6 +485,16 @@ interface LiveSession {
 
 /** Reserves the active-turn slot between the local check and the RPC reply. */
 const PENDING_TURN = "(pending)"
+
+/** The turn input in the protocol's shape: the text, then each image as a
+ * `localImage` the app-server reads from the shared host (ATC-216). */
+const turnInputBlocks = (input: TurnInput) => [
+  ...(input.text === "" ? [] : [{ type: "text" as const, text: input.text }]),
+  ...input.attachments.map((attachment) => ({
+    type: "localImage" as const,
+    path: attachment.path,
+  })),
+]
 
 interface PendingReply {
   readonly succeed: (result: unknown) => void
@@ -916,11 +931,13 @@ export const layer = Layer.effect(CodexAdapter)(
         const decoded = decodeItemNotification(params)
         if (Option.isNone(decoded)) return
         const phase = message.method === "item/started" ? "started" : "completed"
-        const item = CodexItems.mapItem(decoded.value.item, decoded.value.turnId, phase)
+        const session = sessions.get(decoded.value.threadId)
+        const item = CodexItems.mapItem(decoded.value.item, decoded.value.turnId, phase, (path) =>
+          session?.attachmentsByPath.get(path),
+        )
         if (item === null) return
         const event: AgentItemEvent =
           phase === "started" ? { type: "itemStarted", item } : { type: "itemCompleted", item }
-        const session = sessions.get(decoded.value.threadId)
         if (session !== undefined) {
           if ("status" in item) session.toolItems.set(item.id, item)
           emit(session, event)
@@ -1198,6 +1215,7 @@ export const layer = Layer.effect(CodexAdapter)(
           ownTurn: null,
           toolItems: new Map(),
           pendingRequests: new Map(),
+          attachmentsByPath: new Map(),
           failed: false,
           live,
         }
@@ -1271,9 +1289,12 @@ export const layer = Layer.effect(CodexAdapter)(
               session.activeTurn = PENDING_TURN
               session.ownTurn = PENDING_TURN
               const overrides = settingsOverrides(session.live, settings)
+              for (const attachment of input.attachments) {
+                session.attachmentsByPath.set(attachment.path, attachment)
+              }
               const decoded = yield* request(state, "turn/start", {
                 threadId,
-                input: [{ type: "text", text: input }],
+                input: turnInputBlocks(input),
                 ...overrides,
               }).pipe(
                 Effect.mapError(rpcToProtocol),

--- a/app-server/src/agents/codexItems.ts
+++ b/app-server/src/agents/codexItems.ts
@@ -2,6 +2,7 @@ import { Option, Schema } from "effect"
 import * as path from "node:path"
 import type {
   HistoryTurn,
+  ThreadAttachment,
   ThreadItem,
   ThreadRequest,
   ThreadRequestAnswer,
@@ -46,9 +47,15 @@ const codexToolStatus = (
 const ItemBase = Schema.Struct({ type: Schema.String, id: Schema.String })
 const decodeItemBase = Schema.decodeUnknownOption(ItemBase)
 
+// Text blocks carry `text`; localImage blocks (ATC-216) carry the `path`
+// the turn input named.
 const UserMessage = Schema.Struct({
   content: Schema.Array(
-    Schema.Struct({ type: Schema.String, text: Schema.optional(Schema.String) }),
+    Schema.Struct({
+      type: Schema.String,
+      text: Schema.optional(Schema.String),
+      path: Schema.optional(Schema.String),
+    }),
   ),
 })
 const AgentMessage = Schema.Struct({ text: Schema.String, phase: nullable(Schema.String) })
@@ -126,9 +133,17 @@ const genericTitle = (type: string, input: Record<string, unknown>): string => {
 /**
  * Normalize one Codex item. `phase` decides the lifecycle of items that
  * carry no status of their own (text completes with the notification;
- * status-less tools run until completed).
+ * status-less tools run until completed). `attachmentAt` names the ATC
+ * attachment behind a localImage path the adapter itself sent (ATC-216);
+ * a path it does not know — another client's image — is simply not an
+ * attachment of ours.
  */
-export const mapItem = (raw: unknown, turnId: string, phase: Phase): ThreadItem | null => {
+export const mapItem = (
+  raw: unknown,
+  turnId: string,
+  phase: Phase,
+  attachmentAt: (path: string) => ThreadAttachment | undefined = () => undefined,
+): ThreadItem | null => {
   const base = decodeItemBase(raw)
   if (Option.isNone(base) || NOT_EMITTED.has(base.value.type)) return null
   const { id, type } = base.value
@@ -140,7 +155,19 @@ export const mapItem = (raw: unknown, turnId: string, phase: Phase): ThreadItem 
       const text = decoded.value.content
         .flatMap((block) => (block.type === "text" && block.text !== undefined ? [block.text] : []))
         .join("\n")
-      return { type: "userMessage", ...common, text }
+      const attachments = decoded.value.content.flatMap((block) => {
+        const attachment =
+          block.type === "localImage" && block.path !== undefined
+            ? attachmentAt(block.path)
+            : undefined
+        return attachment === undefined ? [] : [attachment]
+      })
+      return {
+        type: "userMessage",
+        ...common,
+        text,
+        ...(attachments.length > 0 ? { attachments } : {}),
+      }
     }
     case "agentMessage": {
       const decoded = decoders.agentMessage(raw)

--- a/app-server/src/api/contract.ts
+++ b/app-server/src/api/contract.ts
@@ -556,11 +556,53 @@ const toolFields = {
   ),
 }
 
+/** The image types an attachment may be (ATC-216); anything else is refused at upload. */
+export const ATTACHMENT_MEDIA_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+] as const
+
+export const AttachmentMediaType = Schema.Literals(ATTACHMENT_MEDIA_TYPES).annotate({
+  identifier: "AttachmentMediaType",
+  description: "The image type of an attachment; the accepted set of the upload endpoint.",
+})
+
+/** Per-attachment byte cap and per-prompt count cap, enforced server-side. */
+export const ATTACHMENT_MAX_BYTES = 8 * 1024 * 1024
+export const ATTACHMENTS_PER_PROMPT = 10
+
+export const ThreadAttachment = Schema.Struct({
+  id: Schema.String.annotate({ description: "UUIDv7 attachment id, unique within the thread." }),
+  name: Schema.String.annotate({ description: "Display filename (the uploader's, sanitized)." }),
+  mediaType: AttachmentMediaType,
+  byteSize: Schema.Int.annotate({ description: "Size of the stored bytes." }),
+  path: Schema.String.annotate({
+    description:
+      "Server-host absolute path of the stored bytes — stable for the attachment's life, so an agent on that machine (a TUI, a script) can be pointed at it.",
+  }),
+  createdAt: timestamp("Upload time."),
+}).annotate({
+  identifier: "ThreadAttachment",
+  description:
+    "An image a client uploaded to a thread for a prompt. Attachments live with their thread and die with it; the bytes come back from getThreadAttachment.",
+})
+
 export const ThreadItemUserMessage = Schema.Struct({
   type: Schema.Literal("userMessage"),
   ...threadItemBase,
   text: Schema.String,
-}).annotate({ identifier: "ThreadItemUserMessage", description: "A user prompt (text only)." })
+  attachments: Schema.optionalKey(
+    Schema.Array(ThreadAttachment).annotate({
+      description:
+        "Images sent with the prompt; absent when none. Present for prompts ATC sent natively; a provider re-read keeps them where the provider's turn ids are stable (Codex), and loses them where they are not (Claude) — the bytes stay fetchable by id either way.",
+    }),
+  ),
+}).annotate({
+  identifier: "ThreadItemUserMessage",
+  description: "A user prompt: text plus any image attachments.",
+})
 
 export const ThreadItemAssistantText = Schema.Struct({
   type: Schema.Literal("assistantText"),
@@ -779,11 +821,35 @@ export const ThreadRequestAnswer = Schema.Union(
 })
 
 export const PromptThreadRequest = Schema.Struct({
-  prompt: Schema.NonEmptyString.annotate({ description: "The user's message." }),
-}).annotate({
-  identifier: "PromptThreadRequest",
-  description: "Payload for prompting a thread: text only (attachments are additive later).",
+  prompt: Schema.String.annotate({
+    description: "The user's message; may be empty only when attachments are present.",
+  }),
+  attachments: Schema.optionalKey(
+    Schema.Array(Schema.String)
+      .check(
+        Schema.isMaxLength(ATTACHMENTS_PER_PROMPT, {
+          description: `at most ${ATTACHMENTS_PER_PROMPT} attachments per prompt`,
+        }),
+      )
+      .annotate({
+        description:
+          "Ids of attachments previously uploaded to THIS thread (createThreadAttachment), in display order. An id the thread does not own is a 404.",
+      }),
+  ),
 })
+  .check(
+    Schema.makeFilter(
+      (request) =>
+        request.prompt.trim() !== "" || (request.attachments?.length ?? 0) > 0
+          ? undefined
+          : "a prompt needs text or at least one attachment",
+      { description: "text or at least one attachment" },
+    ),
+  )
+  .annotate({
+    identifier: "PromptThreadRequest",
+    description: "Payload for prompting a thread: text, and optionally uploaded image attachments.",
+  })
 
 export const PromptThreadResponse = Schema.Struct({
   promptId: Schema.String.annotate({ description: "The admitted prompt's id." }),
@@ -800,6 +866,9 @@ export const PromptThreadResponse = Schema.Struct({
 export const QueuedPrompt = Schema.Struct({
   id: Schema.String,
   prompt: Schema.String,
+  attachments: Schema.optionalKey(
+    Schema.Array(ThreadAttachment).annotate({ description: "Images waiting with the prompt." }),
+  ),
   queuedAt: timestamp("When the prompt was admitted."),
 }).annotate({
   identifier: "QueuedPrompt",
@@ -1217,9 +1286,75 @@ export class QueuedPromptNotFound extends Schema.TaggedErrorClass<QueuedPromptNo
   }
 }
 
+/** Unknown attachment id on this thread (attachments never cross threads). */
+export class AttachmentNotFound extends Schema.TaggedErrorClass<AttachmentNotFound>()(
+  "AttachmentNotFound",
+  { threadId: Schema.String, attachmentId: Schema.String, message: errorMessage },
+  {
+    identifier: "AttachmentNotFound",
+    description: "No attachment with the given id on this thread.",
+    httpApiStatus: 404,
+  },
+) {
+  constructor(props: { readonly threadId: string; readonly attachmentId: string }) {
+    super({
+      ...props,
+      message: `thread ${props.threadId} has no attachment ${props.attachmentId}`,
+    })
+  }
+}
+
+/** The upload exceeds the per-attachment byte cap. */
+export class AttachmentTooLarge extends Schema.TaggedErrorClass<AttachmentTooLarge>()(
+  "AttachmentTooLarge",
+  { threadId: Schema.String, byteSize: Schema.Int, limit: Schema.Int, message: errorMessage },
+  {
+    identifier: "AttachmentTooLarge",
+    description: `The upload exceeds the per-attachment cap (${ATTACHMENT_MAX_BYTES} bytes); downscale the image and retry.`,
+    httpApiStatus: 413,
+  },
+) {
+  constructor(props: {
+    readonly threadId: string
+    readonly byteSize: number
+    readonly limit: number
+  }) {
+    super({
+      ...props,
+      message: `attachment of ${props.byteSize} bytes exceeds the ${props.limit}-byte limit`,
+    })
+  }
+}
+
+/** The uploaded bytes are not the image the request declared (or are empty). */
+export class AttachmentInvalid extends Schema.TaggedErrorClass<AttachmentInvalid>()(
+  "AttachmentInvalid",
+  { threadId: Schema.String, reason: Schema.String, message: errorMessage },
+  {
+    identifier: "AttachmentInvalid",
+    description:
+      "The body is not a usable image of the declared Content-Type: empty, or its bytes do not carry that format's signature.",
+    httpApiStatus: 422,
+  },
+) {
+  constructor(props: { readonly threadId: string; readonly reason: string }) {
+    super({ ...props, message: props.reason })
+  }
+}
+
 const projectIdParam = { projectId: Schema.String }
 const terminalIdParam = { terminalId: Schema.String }
 const threadIdParam = { threadId: Schema.String }
+const attachmentIdParam = { threadId: Schema.String, attachmentId: Schema.String }
+
+/**
+ * One raw-bytes payload per accepted image type: the router dispatches on the
+ * request's Content-Type, so an unsupported type is a 415 before any byte is
+ * read, and the document lists exactly what the endpoint takes.
+ */
+const attachmentPayloads = ATTACHMENT_MEDIA_TYPES.map((contentType) =>
+  Schema.Uint8Array.pipe(HttpApiSchema.asUint8Array({ contentType })),
+)
 
 export class V1 extends HttpApiGroup.make("v1")
   .add(
@@ -1498,7 +1633,13 @@ export class V1 extends HttpApiGroup.make("v1")
       params: threadIdParam,
       payload: PromptThreadRequest,
       success: PromptThreadResponse,
-      error: [ThreadNotFound, ThreadArchived, ProviderUnavailable, ProviderSessionConflict],
+      error: [
+        ThreadNotFound,
+        ThreadArchived,
+        AttachmentNotFound,
+        ProviderUnavailable,
+        ProviderSessionConflict,
+      ],
     })
       .annotate(OpenApi.Identifier, "promptThread")
       .annotate(
@@ -1594,6 +1735,35 @@ export class V1 extends HttpApiGroup.make("v1")
       .annotate(
         OpenApi.Description,
         "Withdraw a waiting prompt. A prompt that already started is a turn now (404); interrupt the thread instead.",
+      ),
+    // --- Attachments (ATC-216): images a prompt carries ---
+    HttpApiEndpoint.post("createThreadAttachment", "/threads/:threadId/attachments", {
+      params: threadIdParam,
+      query: {
+        name: Schema.optionalKey(
+          Schema.String.annotate({
+            description: 'Display filename; omitted derives one from the type ("image.png").',
+          }),
+        ),
+      },
+      payload: attachmentPayloads,
+      success: ThreadAttachment,
+      error: [ThreadNotFound, ThreadArchived, AttachmentTooLarge, AttachmentInvalid],
+    })
+      .annotate(OpenApi.Identifier, "createThreadAttachment")
+      .annotate(
+        OpenApi.Description,
+        `Upload one image for a later prompt on this thread: the raw bytes as the body, the image type as Content-Type (PNG, JPEG, GIF, or WebP — anything else is 415), at most ${ATTACHMENT_MAX_BYTES} bytes (413 beyond). The bytes are held under the server's data directory for the thread's life and deleted with it; the returned path is stable and readable by any process on the server host. Reference the id in promptThread's attachments (up to ${ATTACHMENTS_PER_PROMPT} per prompt). Nothing is garbage-collected before the thread goes: upload at send time, not ahead of it.`,
+      ),
+    HttpApiEndpoint.get("getThreadAttachment", "/threads/:threadId/attachments/:attachmentId", {
+      params: attachmentIdParam,
+      success: HttpApiSchema.StreamUint8Array(),
+      error: [ThreadNotFound, AttachmentNotFound],
+    })
+      .annotate(OpenApi.Identifier, "getThreadAttachment")
+      .annotate(
+        OpenApi.Description,
+        "The attachment's bytes, as uploaded (served as application/octet-stream; the image type is in the attachment's metadata on the item or queue entry that carries it).",
       ),
     HttpApiEndpoint.get("listAgents", "/agents", { success: AgentList })
       .annotate(OpenApi.Identifier, "listAgents")

--- a/app-server/src/api/handlers.ts
+++ b/app-server/src/api/handlers.ts
@@ -10,6 +10,7 @@ import * as Tailscale from "../platform/tailscale.ts"
 import { Projects } from "../projects/projects.ts"
 import { attachTerminal } from "../terminals/terminalAttach.ts"
 import { Terminals } from "../terminals/terminals.ts"
+import { Attachments } from "../threads/attachments.ts"
 import { ThreadRuntime } from "../threads/threadRuntime.ts"
 import { Threads } from "../threads/threads.ts"
 
@@ -44,6 +45,7 @@ export const V1Handlers = HttpApiBuilder.group(
     const terminals = yield* Terminals
     const threads = yield* Threads
     const runtime = yield* ThreadRuntime
+    const attachments = yield* Attachments
     const agents = yield* AgentRegistry
     const events = yield* Events
     // Attach bridges outlive their originating requests (Bun aborts the
@@ -101,9 +103,7 @@ export const V1Handlers = HttpApiBuilder.group(
         .handle("deleteThread", ({ params }) => threads.delete(params.threadId))
         .handle("openThreadTerminal", ({ params }) => threads.openTerminal(params.threadId))
         .handle("closeThreadTerminal", ({ params }) => threads.closeTerminal(params.threadId))
-        .handle("promptThread", ({ params, payload }) =>
-          runtime.prompt(params.threadId, payload.prompt),
-        )
+        .handle("promptThread", ({ params, payload }) => runtime.prompt(params.threadId, payload))
         .handle("getThreadTranscript", ({ params, query }) =>
           runtime.transcript(params.threadId, { before: query.before, limit: query.limit }),
         )
@@ -115,6 +115,19 @@ export const V1Handlers = HttpApiBuilder.group(
         .handle("listThreadQueue", ({ params }) => runtime.listQueue(params.threadId))
         .handle("deleteQueuedPrompt", ({ params }) =>
           runtime.deleteQueued(params.threadId, params.promptId),
+        )
+        // The router already matched the Content-Type to one of the accepted
+        // image types (anything else was a 415); the service re-reads it for
+        // the stored media type.
+        .handle("createThreadAttachment", ({ params, query, payload, request }) =>
+          attachments.create(params.threadId, {
+            bytes: payload,
+            mediaType: request.headers["content-type"] ?? "",
+            name: query.name,
+          }),
+        )
+        .handle("getThreadAttachment", ({ params }) =>
+          attachments.stream(params.threadId, params.attachmentId),
         )
         .handle("listAgents", () => agents.list())
         .handle("getAgent", ({ params }) => agents.get(params.agentId))

--- a/app-server/src/cli/gateway.ts
+++ b/app-server/src/cli/gateway.ts
@@ -57,16 +57,22 @@ const requestUrl = (baseUrl: URL, requestPath: string): Effect.Effect<URL, Error
   )
 }
 
-/** Request body source: a file path, or "-" for stdin. */
+/** Whether a response body is text to print as lines (JSON, problem
+ * details, plain text); anything else is raw bytes. */
+const isTextual = (contentType: string | undefined): boolean =>
+  contentType === undefined || /json|text\/|xml/i.test(contentType)
+
+/** Request body source: a file path, or "-" for stdin. Bytes, not text —
+ * an image upload (createThreadAttachment) rides the same flag. */
 const readRequestBody = (source: string) =>
   source === "-"
     ? Effect.tryPromise({
-        try: () => Bun.stdin.text(),
+        try: () => Bun.stdin.bytes(),
         catch: () => new Error("cannot read the request body from stdin"),
       })
     : Effect.gen(function* () {
         const fileSystem = yield* FileSystem.FileSystem
-        return yield* fileSystem.readFileString(source)
+        return yield* fileSystem.readFile(source)
       })
 
 export const api = Command.make(
@@ -78,10 +84,16 @@ export const api = Command.make(
     ),
     input: Flag.string("input").pipe(
       Flag.optional,
-      Flag.withDescription("JSON request body: a file path, or - to read stdin"),
+      Flag.withDescription("Request body: a file path, or - to read stdin"),
+    ),
+    contentType: Flag.string("content-type").pipe(
+      Flag.withDefault("application/json"),
+      Flag.withDescription(
+        "Content-Type of the request body (default application/json; e.g. image/png for an attachment upload)",
+      ),
     ),
   },
-  ({ method, path: requestPath, input }) =>
+  ({ method, path: requestPath, input, contentType }) =>
     Cli.withCliContext(
       "api",
       Effect.gen(function* () {
@@ -92,16 +104,23 @@ export const api = Command.make(
         const request = HttpClientRequest.make(method)(url, {
           acceptJson: true,
         }).pipe((base) =>
-          body === undefined ? base : HttpClientRequest.bodyText(base, body, "application/json"),
+          body === undefined ? base : HttpClientRequest.bodyUint8Array(base, body, contentType),
         )
         const response = yield* client.execute(request)
-        const text = yield* response.text
         if (response.status >= 200 && response.status < 300) {
-          // Success bodies pass through unchanged (plus the trailing
-          // newline); an empty response prints nothing.
+          // Success bodies pass through unchanged: text (JSON) plus the
+          // trailing newline — an empty response prints nothing — and a
+          // binary body (an attachment download) byte for byte.
+          if (!isTextual(response.headers["content-type"])) {
+            const bytes = yield* response.arrayBuffer
+            yield* Effect.promise(() => Bun.write(Bun.stdout, new Uint8Array(bytes)))
+            return
+          }
+          const text = yield* response.text
           if (text !== "") yield* Console.log(text)
           return
         }
+        const text = yield* response.text
         // API failures: the machine-readable error body, then the one-line
         // diagnostic — both on stderr, exit 1 like every other failure.
         if (text !== "") yield* Console.error(text)
@@ -148,9 +167,9 @@ export const context = Command.make("context", { json: jsonFlag }, ({ json }) =>
 const CAPABILITIES = {
   capabilitiesVersion: 1,
   api: {
-    command: "atc api <method> <path> [--input <file|->]",
+    command: "atc api <method> <path> [--input <file|->] [--content-type <type>]",
     description:
-      "Complete access to the canonical App Server HTTP API: every operation via GET, POST, PUT, PATCH, or DELETE, JSON body from a file or stdin, the raw JSON response on stdout.",
+      "Complete access to the canonical App Server HTTP API: every operation via GET, POST, PUT, PATCH, or DELETE, a body from a file or stdin (JSON by default, any Content-Type via --content-type), the response on stdout (JSON as text, anything else byte for byte).",
     example: "atc api GET /api/v1/projects",
   },
   openapi: {

--- a/app-server/src/platform/migrations.ts
+++ b/app-server/src/platform/migrations.ts
@@ -186,4 +186,24 @@ export const migrations: Record<string, Effect.Effect<void, unknown, SqlClient.S
     yield* sql`ALTER TABLE thread_items ADD COLUMN created_at TEXT`
     yield* sql`ALTER TABLE thread_items ADD COLUMN completed_at TEXT`
   }),
+  // Attachments (ATC-216): the metadata of images uploaded to a thread
+  // (the bytes live under the data directory, keyed by thread and
+  // attachment id — attachments.ts), and the attachment ids a queued prompt
+  // carries (a JSON array of ids, '[]' for none). Both cascade with the
+  // thread row; the blob directory is removed by Threads.delete.
+  "0009_thread_attachments": Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+    yield* sql`
+      CREATE TABLE thread_attachments (
+        id TEXT PRIMARY KEY,
+        thread_id TEXT NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
+        name TEXT NOT NULL,
+        media_type TEXT NOT NULL,
+        byte_size INTEGER NOT NULL,
+        created_at TEXT NOT NULL
+      ) STRICT
+    `
+    yield* sql`CREATE INDEX thread_attachments_thread_id ON thread_attachments(thread_id)`
+    yield* sql`ALTER TABLE thread_queue ADD COLUMN attachments TEXT NOT NULL DEFAULT '[]'`
+  }),
 }

--- a/app-server/src/server.ts
+++ b/app-server/src/server.ts
@@ -2,7 +2,7 @@ import { BunHttpServer } from "@effect/platform-bun"
 import { Effect, Layer } from "effect"
 import { HttpMiddleware, HttpRouter, HttpServer, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
-import { Api } from "./api/contract.ts"
+import { Api, ATTACHMENT_MAX_BYTES } from "./api/contract.ts"
 import * as AdminUi from "./adminUi/adminUi.ts"
 import * as AgentDefaultsRepository from "./agents/agentDefaultsRepository.ts"
 import * as AgentRegistry from "./agents/agentRegistry.ts"
@@ -23,6 +23,8 @@ import * as ProjectRepository from "./projects/projectRepository.ts"
 import * as Projects from "./projects/projects.ts"
 import * as TerminalRepository from "./terminals/terminalRepository.ts"
 import * as Terminals from "./terminals/terminals.ts"
+import * as AttachmentRepository from "./threads/attachmentRepository.ts"
+import * as Attachments from "./threads/attachments.ts"
 import * as ThreadRepository from "./threads/threadRepository.ts"
 import * as ThreadNaming from "./threads/threadNaming.ts"
 import * as ThreadRuntime from "./threads/threadRuntime.ts"
@@ -111,6 +113,10 @@ export const layer = (options: { readonly port: number; readonly hostname?: stri
         // long grace period turns every shutdown after a terminal attach
         // into a hang. Requests are local and short; two seconds is plenty.
         gracefulShutdownTimeout: "2 seconds",
+        // The largest body the API takes is one attachment (ATC-216); Bun
+        // refuses anything far beyond it before a byte is buffered, while
+        // the typed 413 still answers uploads just over the cap.
+        maxRequestBodySize: 2 * ATTACHMENT_MAX_BYTES,
         // Bun's default idleTimeout (10 s) counts a request that has not yet
         // written response bytes as idle, which severs openThreadTerminal
         // mid-materialization — a cold provider launch legitimately runs up
@@ -143,6 +149,9 @@ export const production = (options: { readonly port: number; readonly hostname?:
     Layer.provide(ThreadTui.layer),
     Layer.provide(Terminals.layer),
     Layer.provide(ThreadNaming.layer),
+    // Attachments serve the handlers, Threads (delete purges blobs), and the
+    // runtime (a prompt's images), so it sits below all three.
+    Layer.provide(Attachments.layer),
     Layer.provide(AgentRegistry.layer),
     // Below Terminals (the deepest publisher) so one memoized Events instance
     // serves every domain service, the handlers, and the shutdown drain.
@@ -154,6 +163,7 @@ export const production = (options: { readonly port: number; readonly hostname?:
       TerminalRepository.layer,
       ThreadRepository.layer,
       TranscriptRepository.layer,
+      AttachmentRepository.layer,
       AgentDefaultsRepository.layer,
       Directories.layer,
       Zmx.layer,

--- a/app-server/src/threads/attachmentRepository.ts
+++ b/app-server/src/threads/attachmentRepository.ts
@@ -1,0 +1,104 @@
+import { Context, Effect, Layer, Schema } from "effect"
+import { SqlClient, SqlSchema } from "effect/unstable/sql"
+
+// The attachments repository (ATC-216): the only module that speaks SQL for
+// thread_attachments. Rows are metadata only — the bytes live on disk under
+// the attachments service's directory layout, and the row's id is what names
+// them there. Database failures are defects, not domain errors.
+
+export interface AttachmentRecord {
+  readonly id: string
+  readonly threadId: string
+  readonly name: string
+  readonly mediaType: string
+  readonly byteSize: number
+  readonly createdAt: string
+}
+
+const AttachmentRow = Schema.Struct({
+  id: Schema.String,
+  thread_id: Schema.String,
+  name: Schema.String,
+  media_type: Schema.String,
+  byte_size: Schema.Number,
+  created_at: Schema.String,
+})
+
+const toRecord = (row: typeof AttachmentRow.Type): AttachmentRecord => ({
+  id: row.id,
+  threadId: row.thread_id,
+  name: row.name,
+  mediaType: row.media_type,
+  byteSize: row.byte_size,
+  createdAt: row.created_at,
+})
+
+export class AttachmentRepository extends Context.Service<
+  AttachmentRepository,
+  {
+    /** Insert one record with a generated id and return it. */
+    readonly create: (input: {
+      readonly threadId: string
+      readonly name: string
+      readonly mediaType: string
+      readonly byteSize: number
+    }) => Effect.Effect<AttachmentRecord>
+    /**
+     * The thread's records among `ids`, in the order of `ids`; an id the
+     * thread does not own is simply absent (the caller decides what that
+     * means). Attachments never cross threads.
+     */
+    readonly findMany: (
+      threadId: string,
+      ids: ReadonlyArray<string>,
+    ) => Effect.Effect<ReadonlyArray<AttachmentRecord>>
+  }
+>()("app-server/AttachmentRepository") {}
+
+export const layer = Layer.effect(AttachmentRepository)(
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+
+    const insertRow = SqlSchema.void({
+      Request: AttachmentRow,
+      execute: (row) => sql`INSERT INTO thread_attachments ${sql.insert(row)}`,
+    })
+
+    const rowsByIds = SqlSchema.findAll({
+      Request: Schema.Struct({ thread_id: Schema.String, ids: Schema.Array(Schema.String) }),
+      Result: AttachmentRow,
+      execute: (request) => sql`
+        SELECT * FROM thread_attachments
+        WHERE thread_id = ${request.thread_id} AND id IN ${sql.in(request.ids)}
+      `,
+    })
+
+    return {
+      create: (input) =>
+        Effect.suspend(() => {
+          const row: typeof AttachmentRow.Type = {
+            id: Bun.randomUUIDv7(),
+            thread_id: input.threadId,
+            name: input.name,
+            media_type: input.mediaType,
+            byte_size: input.byteSize,
+            created_at: new Date().toISOString(),
+          }
+          return insertRow(row).pipe(Effect.as(toRecord(row)))
+        }).pipe(Effect.orDie),
+      findMany: (threadId, ids) =>
+        ids.length === 0
+          ? Effect.succeed([])
+          : rowsByIds({ thread_id: threadId, ids: [...new Set(ids)] }).pipe(
+              Effect.map((rows) => {
+                const byId = new Map(rows.map((row) => [row.id, toRecord(row)]))
+                return ids.flatMap((id) => {
+                  const found = byId.get(id)
+                  return found === undefined ? [] : [found]
+                })
+              }),
+              Effect.orDie,
+            ),
+    } satisfies AttachmentRepository["Service"]
+  }),
+)

--- a/app-server/src/threads/attachments.ts
+++ b/app-server/src/threads/attachments.ts
@@ -1,0 +1,242 @@
+import { Context, Effect, FileSystem, Layer, Stream } from "effect"
+import { join } from "node:path"
+import {
+  ATTACHMENT_MAX_BYTES,
+  ATTACHMENT_MEDIA_TYPES,
+  AttachmentInvalid,
+  AttachmentNotFound,
+  AttachmentTooLarge,
+  ThreadArchived,
+  ThreadNotFound,
+} from "../api/contract.ts"
+import type * as Contract from "../api/contract.ts"
+import { AppConfig } from "../platform/config.ts"
+import { AttachmentRepository } from "./attachmentRepository.ts"
+import type { AttachmentRecord } from "./attachmentRepository.ts"
+import { ThreadRepository } from "./threadRepository.ts"
+
+// Thread attachments (ATC-216): the images a prompt carries. The first
+// per-thread state on disk — bytes live at
+// `<dataDir>/attachments/<threadId>/<attachmentId>.<ext>`, metadata in
+// thread_attachments (attachmentRepository.ts). Invariants:
+//
+//   - An attachment belongs to exactly one thread and is reachable only
+//     through it: `resolve` never finds another thread's id, and the blob
+//     directory is keyed by thread so `purge` (Threads.delete) removes every
+//     byte the thread ever held. Nothing else deletes blobs — there is no
+//     orphan collection, by design: clients upload at send time.
+//   - The stored media type is the truth of the bytes, not of the header:
+//     an upload whose bytes lack the declared format's signature is refused
+//     (AttachmentInvalid), so `path` can be handed to any consumer as the
+//     image it claims to be.
+//   - `path` is stable for the attachment's life and is what the adapters
+//     hand a provider that reads local files (Codex localImage); the Claude
+//     adapter reads the bytes itself.
+
+type MediaType = (typeof ATTACHMENT_MEDIA_TYPES)[number]
+type ThreadAttachment = typeof Contract.ThreadAttachment.Type
+
+const EXTENSION: Record<MediaType, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+}
+
+const isMediaType = (value: string): value is MediaType =>
+  (ATTACHMENT_MEDIA_TYPES as ReadonlyArray<string>).includes(value)
+
+/** Whether `bytes` opens with `mediaType`'s file signature. */
+const carriesSignature = (bytes: Uint8Array, mediaType: MediaType): boolean => {
+  const startsWith = (offset: number, expected: ReadonlyArray<number>): boolean =>
+    expected.every((byte, index) => bytes[offset + index] === byte)
+  switch (mediaType) {
+    case "image/png":
+      return startsWith(0, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+    case "image/jpeg":
+      return startsWith(0, [0xff, 0xd8, 0xff])
+    case "image/gif":
+      // "GIF8"
+      return startsWith(0, [0x47, 0x49, 0x46, 0x38])
+    case "image/webp":
+      // "RIFF" <size> "WEBP"
+      return startsWith(0, [0x52, 0x49, 0x46, 0x46]) && startsWith(8, [0x57, 0x45, 0x42, 0x50])
+  }
+}
+
+const isControlCharacter = (character: string): boolean => {
+  const code = character.codePointAt(0) ?? 0
+  return code < 0x20 || code === 0x7f
+}
+
+/** A display name safe to store and show: one path component, no control
+ * characters, bounded; the type's default when nothing usable remains. */
+const sanitizeName = (name: string | undefined, mediaType: MediaType): string => {
+  const cleaned = [...(name ?? "").split(/[\\/]/).at(-1)!]
+    .filter((character) => !isControlCharacter(character))
+    .join("")
+    .trim()
+    .slice(0, 120)
+  return cleaned === "" || cleaned === "." || cleaned === ".."
+    ? `image.${EXTENSION[mediaType]}`
+    : cleaned
+}
+
+export class Attachments extends Context.Service<
+  Attachments,
+  {
+    /**
+     * Store one uploaded image for the thread. `mediaType` is the request's
+     * Content-Type (parameters allowed, stripped here); the bytes must carry
+     * that format's signature and fit the cap.
+     */
+    readonly create: (
+      threadId: string,
+      input: {
+        readonly bytes: Uint8Array
+        readonly mediaType: string
+        readonly name?: string | undefined
+      },
+    ) => Effect.Effect<
+      ThreadAttachment,
+      ThreadNotFound | ThreadArchived | AttachmentTooLarge | AttachmentInvalid
+    >
+    /** The stored bytes of one of the thread's attachments. */
+    readonly stream: (
+      threadId: string,
+      attachmentId: string,
+    ) => Effect.Effect<Stream.Stream<Uint8Array>, ThreadNotFound | AttachmentNotFound>
+    /**
+     * The thread's attachments for `ids`, in that order. Every id must be
+     * one of the thread's own — the first that is not fails the call.
+     */
+    readonly resolve: (
+      threadId: string,
+      ids: ReadonlyArray<string>,
+    ) => Effect.Effect<ReadonlyArray<ThreadAttachment>, AttachmentNotFound>
+    /** Remove the thread's blob directory (its rows cascade with the thread).
+     * Best-effort: a failure is logged, never surfaced. */
+    readonly purge: (threadId: string) => Effect.Effect<void>
+  }
+>()("app-server/Attachments") {}
+
+export const layer = Layer.effect(Attachments)(
+  Effect.gen(function* () {
+    const config = yield* AppConfig
+    const fs = yield* FileSystem.FileSystem
+    const repository = yield* AttachmentRepository
+    const threads = yield* ThreadRepository
+
+    const root = join(config.dataDir, "attachments")
+    const directory = (threadId: string) => join(root, threadId)
+
+    // A stored media type is always one of ours (the write boundary
+    // validates); anything else is corruption, and a defect.
+    const asMediaType = (stored: string): MediaType => {
+      if (isMediaType(stored)) return stored
+      throw new Error(`attachment row carries unknown media type ${stored}`)
+    }
+
+    const pathOf = (record: AttachmentRecord) =>
+      join(directory(record.threadId), `${record.id}.${EXTENSION[asMediaType(record.mediaType)]}`)
+
+    const toAttachment = (record: AttachmentRecord): ThreadAttachment => ({
+      id: record.id,
+      name: record.name,
+      mediaType: asMediaType(record.mediaType),
+      byteSize: record.byteSize,
+      path: pathOf(record),
+      createdAt: record.createdAt,
+    })
+
+    const resolve: Attachments["Service"]["resolve"] = (threadId, ids) =>
+      repository.findMany(threadId, ids).pipe(
+        Effect.flatMap((records) => {
+          const found = new Set(records.map((record) => record.id))
+          const missing = ids.find((id) => !found.has(id))
+          return missing === undefined
+            ? Effect.succeed(records.map(toAttachment))
+            : Effect.fail(new AttachmentNotFound({ threadId, attachmentId: missing }))
+        }),
+      )
+
+    return {
+      create: (threadId, input) =>
+        Effect.gen(function* () {
+          const thread = yield* threads.require(threadId)
+          if (thread.archivedAt !== undefined) {
+            return yield* Effect.fail(new ThreadArchived({ threadId }))
+          }
+          const mediaType = input.mediaType.split(";")[0]!.trim().toLowerCase()
+          if (!isMediaType(mediaType)) {
+            return yield* Effect.fail(
+              new AttachmentInvalid({ threadId, reason: `unsupported image type ${mediaType}` }),
+            )
+          }
+          if (input.bytes.byteLength === 0) {
+            return yield* Effect.fail(
+              new AttachmentInvalid({ threadId, reason: "the body is empty" }),
+            )
+          }
+          if (input.bytes.byteLength > ATTACHMENT_MAX_BYTES) {
+            return yield* Effect.fail(
+              new AttachmentTooLarge({
+                threadId,
+                byteSize: input.bytes.byteLength,
+                limit: ATTACHMENT_MAX_BYTES,
+              }),
+            )
+          }
+          if (!carriesSignature(input.bytes, mediaType)) {
+            return yield* Effect.fail(
+              new AttachmentInvalid({
+                threadId,
+                reason: `the bytes are not ${mediaType} (no ${EXTENSION[mediaType]} signature)`,
+              }),
+            )
+          }
+          const record = yield* repository.create({
+            threadId,
+            name: sanitizeName(input.name, mediaType),
+            mediaType,
+            byteSize: input.bytes.byteLength,
+          })
+          // The row first (its foreign key proves the thread exists) so the
+          // path is known; a write that fails is a platform defect (disk
+          // full, permissions). A delete that cascaded the row while the
+          // bytes were landing already purged the directory, so the write
+          // is undone here rather than left as an orphan.
+          yield* fs
+            .makeDirectory(directory(threadId), { recursive: true })
+            .pipe(Effect.andThen(fs.writeFile(pathOf(record), input.bytes)), Effect.orDie)
+          const still = yield* repository.findMany(threadId, [record.id])
+          if (still.length === 0) {
+            yield* fs
+              .remove(directory(threadId), { recursive: true, force: true })
+              .pipe(Effect.orDie)
+            return yield* Effect.fail(new ThreadNotFound({ threadId }))
+          }
+          return toAttachment(record)
+        }),
+      stream: (threadId, attachmentId) =>
+        Effect.gen(function* () {
+          yield* threads.require(threadId)
+          const [attachment] = yield* resolve(threadId, [attachmentId])
+          // The row exists, so the file does too (create wrote it; only
+          // purge removes it, with the rows): a read failure is a defect.
+          return fs.stream(attachment!.path).pipe(Stream.orDie)
+        }),
+      resolve,
+      purge: (threadId) =>
+        fs
+          .remove(directory(threadId), { recursive: true, force: true })
+          .pipe(
+            Effect.catch((error) =>
+              Effect.logWarning("the thread's attachment directory could not be removed").pipe(
+                Effect.annotateLogs({ threadId, reason: error.message }),
+              ),
+            ),
+          ),
+    } satisfies Attachments["Service"]
+  }),
+)

--- a/app-server/src/threads/threadRuntime.ts
+++ b/app-server/src/threads/threadRuntime.ts
@@ -24,12 +24,15 @@ import type {
   AgentSessionEvent,
   AgentTurn,
   ProviderSettings,
+  ThreadAttachment,
   ThreadRequest,
   ThreadRequestAnswer,
   ThreadTurn,
+  TurnInput,
 } from "../agents/agentAdapter.ts"
 import type * as Contract from "../api/contract.ts"
 import {
+  AttachmentNotFound,
   InvalidRequestAnswer,
   isAgentId,
   ProviderSessionConflict,
@@ -43,6 +46,7 @@ import {
 import type { ZmxUnavailable } from "../api/contract.ts"
 import { Events } from "../events/events.ts"
 import type { Terminal } from "../terminals/terminals.ts"
+import { Attachments } from "./attachments.ts"
 import { ThreadNaming } from "./threadNaming.ts"
 import { ThreadRepository } from "./threadRepository.ts"
 import type { ThreadRecord } from "./threadRepository.ts"
@@ -50,7 +54,7 @@ import { applyProviderSettings } from "./threadSettings.ts"
 import type { ThreadSettings } from "./threadSettings.ts"
 import { ThreadTui } from "./threadTui.ts"
 import { TranscriptRepository } from "./transcriptRepository.ts"
-import type { TranscriptChange, TurnSource } from "./transcriptRepository.ts"
+import type { QueuedPromptRecord, TranscriptChange, TurnSource } from "./transcriptRepository.ts"
 
 export type ThreadEvent = typeof Contract.ThreadEvent.Type
 export type ThreadTranscript = typeof Contract.ThreadTranscript.Type
@@ -255,13 +259,22 @@ export interface ThreadRuntimeOptions {
 export class ThreadRuntime extends Context.Service<
   ThreadRuntime,
   {
-    /** Admit a prompt; `turnId` present ⇒ it started at once, else queued. */
+    /** Admit a prompt; `turnId` present ⇒ it started at once, else queued.
+     * `attachments` are ids of the thread's own uploads (ATC-216); a foreign
+     * or unknown id refuses the prompt before it is admitted. */
     readonly prompt: (
       id: string,
-      prompt: string,
+      input: {
+        readonly prompt: string
+        readonly attachments?: ReadonlyArray<string> | undefined
+      },
     ) => Effect.Effect<
       { readonly promptId: string; readonly turnId?: string },
-      ThreadNotFound | ThreadArchived | ProviderUnavailable | ProviderSessionConflict
+      | ThreadNotFound
+      | ThreadArchived
+      | AttachmentNotFound
+      | ProviderUnavailable
+      | ProviderSessionConflict
     >
     /** Interrupt the running turn; an idle thread is a no-op. Queued prompts stay. */
     readonly interrupt: (id: string) => Effect.Effect<void, ThreadNotFound | ProviderUnavailable>
@@ -361,6 +374,7 @@ const make = (options: ThreadRuntimeOptions) =>
   Effect.gen(function* () {
     const repository = yield* ThreadRepository
     const transcripts = yield* TranscriptRepository
+    const attachments = yield* Attachments
     const registry = yield* AgentRegistry
     const events = yield* Events
     const naming = yield* ThreadNaming
@@ -473,10 +487,41 @@ const make = (options: ThreadRuntimeOptions) =>
         })
       })
 
+    /** A waiting prompt's attachments (ATC-216). The ids are the thread's
+     * own and cascade with it, so a miss here is a defect, not a 404. */
+    const attachmentsOf = (
+      threadId: string,
+      queued: QueuedPromptRecord,
+    ): Effect.Effect<ReadonlyArray<ThreadAttachment>> =>
+      attachments.resolve(threadId, queued.attachmentIds).pipe(Effect.orDie)
+
+    /** What the turn starts with: the prompt and its resolved images. */
+    const turnInputOf = (threadId: string, queued: QueuedPromptRecord): Effect.Effect<TurnInput> =>
+      attachmentsOf(threadId, queued).pipe(
+        Effect.map((resolved) => ({ text: queued.prompt, attachments: resolved })),
+      )
+
+    /** The waiting prompts in the contract's shape, oldest first. */
+    const queuedPrompts = (threadId: string): Effect.Effect<ReadonlyArray<QueuedPrompt>> =>
+      transcripts.listWaiting(threadId).pipe(
+        Effect.flatMap(
+          Effect.forEach((queued) =>
+            attachmentsOf(threadId, queued).pipe(
+              Effect.map((resolved): QueuedPrompt => ({
+                id: queued.id,
+                prompt: queued.prompt,
+                queuedAt: queued.queuedAt,
+                ...(resolved.length > 0 ? { attachments: resolved } : {}),
+              })),
+            ),
+          ),
+        ),
+      )
+
     const publishQueue = (threadId: string): Effect.Effect<void> =>
-      transcripts
-        .listWaiting(threadId)
-        .pipe(Effect.map((prompts) => publish(threadId, { type: "queue.updated", prompts })))
+      queuedPrompts(threadId).pipe(
+        Effect.map((prompts) => publish(threadId, { type: "queue.updated", prompts })),
+      )
 
     const replayEvent = (change: TranscriptChange): ThreadEvent =>
       change.change.kind === "item"
@@ -940,7 +985,7 @@ const make = (options: ThreadRuntimeOptions) =>
     const openWriter = (
       record: ThreadRecord,
       adapter: AgentAdapter,
-      prompt: string,
+      input: TurnInput,
     ): Effect.Effect<
       { readonly writer: Writer; readonly turn: AgentTurn; readonly record: ThreadRecord },
       ProviderUnavailable | ProviderSessionConflict
@@ -955,7 +1000,7 @@ const make = (options: ThreadRuntimeOptions) =>
               cwd,
               settings: record.settings,
             })
-            const turn = yield* connection.startTurn(prompt, record.settings)
+            const turn = yield* connection.startTurn(input, record.settings)
             return {
               writer: { ...makeWriter(scope, connection), pushed: record.settings },
               turn,
@@ -973,7 +1018,7 @@ const make = (options: ThreadRuntimeOptions) =>
           }
           const session = yield* adapter.createSession({
             cwd,
-            input: prompt,
+            input,
             settings: record.settings,
           })
           const still = yield* repository.get(record.id)
@@ -1034,8 +1079,9 @@ const make = (options: ThreadRuntimeOptions) =>
           if (Option.isNone(next)) return Option.none()
           const adapter = yield* requireAdapter(record)
           const prompt = next.value.prompt
+          const input = yield* turnInputOf(record.id, next.value)
           if (held !== undefined) {
-            const reused = yield* startOnWriter(record, held, next.value)
+            const reused = yield* startOnWriter(record, held, next.value, input)
             if (Option.isSome(reused)) {
               yield* naming.notePrompt(record, prompt)
               return reused
@@ -1049,7 +1095,7 @@ const make = (options: ThreadRuntimeOptions) =>
           if (!adapter.sharedServer && (yield* takeOverTui(record)) === "busy") {
             return Option.none()
           }
-          const opened = yield* openWriter(record, adapter, prompt)
+          const opened = yield* openWriter(record, adapter, input)
           // The adopted record predates this turn's confirm (a fresh
           // session is unconfirmed by construction), which is what makes a
           // native first prompt eligible for naming (ATC-202).
@@ -1083,12 +1129,13 @@ const make = (options: ThreadRuntimeOptions) =>
     const startOnWriter = (
       record: ThreadRecord,
       writer: Writer,
-      queued: QueuedPrompt,
+      queued: QueuedPromptRecord,
+      input: TurnInput,
     ): Effect.Effect<Option.Option<{ readonly promptId: string; readonly turnId: string }>> =>
       writer.lock.withPermit(
         Effect.uninterruptible(
           Effect.gen(function* () {
-            const turn = yield* writer.connection.startTurn(queued.prompt, record.settings)
+            const turn = yield* writer.connection.startTurn(input, record.settings)
             writer.pushed = record.settings
             yield* registerRun(record, writer, queued, turn)
             return Option.some({ promptId: queued.id, turnId: turn.turnId })
@@ -1110,7 +1157,7 @@ const make = (options: ThreadRuntimeOptions) =>
     const registerRun = (
       record: ThreadRecord,
       writer: Writer,
-      queued: QueuedPrompt,
+      queued: QueuedPromptRecord,
       turn: AgentTurn,
     ): Effect.Effect<void> =>
       Effect.gen(function* () {
@@ -1552,16 +1599,21 @@ const make = (options: ThreadRuntimeOptions) =>
     }
 
     const service: ThreadRuntime["Service"] = {
-      prompt: (id, prompt) =>
+      prompt: (id, input) =>
         Effect.gen(function* () {
           const record = yield* repository.require(id)
           if (record.archivedAt !== undefined) {
             return yield* Effect.fail(new ThreadArchived({ threadId: id }))
           }
           yield* requireAdapter(record)
+          // The attachments must be this thread's own before the prompt is
+          // admitted — an unknown id is the caller's error, not a queued
+          // prompt that can never start.
+          const attachmentIds = input.attachments ?? []
+          yield* attachments.resolve(id, attachmentIds)
           // Whether THIS prompt is the one an immediate start would run.
           const first = runOf(id) === undefined && Option.isNone(yield* transcripts.peek(id))
-          const queued = yield* transcripts.enqueue(id, prompt)
+          const queued = yield* transcripts.enqueue(id, input.prompt, attachmentIds)
           // The drain runs the OLDEST waiting prompt. When that is ours, a
           // provider that refuses un-admits it (the caller's error means
           // "not accepted"); an older prompt's failure just leaves ours
@@ -1640,7 +1692,7 @@ const make = (options: ThreadRuntimeOptions) =>
             }),
           )
         }),
-      listQueue: (id) => repository.require(id).pipe(Effect.andThen(transcripts.listWaiting(id))),
+      listQueue: (id) => repository.require(id).pipe(Effect.andThen(queuedPrompts(id))),
       deleteQueued: (id, promptId) =>
         withStartLock(id)(
           Effect.gen(function* () {

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -36,6 +36,7 @@ import { ProjectRepository } from "../projects/projectRepository.ts"
 import { Terminals } from "../terminals/terminals.ts"
 import type { Terminal } from "../terminals/terminals.ts"
 import { ThreadNaming } from "./threadNaming.ts"
+import { Attachments } from "./attachments.ts"
 import { ThreadRepository } from "./threadRepository.ts"
 import type { ThreadRecord } from "./threadRepository.ts"
 import { ThreadRuntime } from "./threadRuntime.ts"
@@ -200,6 +201,7 @@ export const layerWith = (options: ThreadsOptions) =>
   Layer.effect(Threads)(
     Effect.gen(function* () {
       const repository = yield* ThreadRepository
+      const attachments = yield* Attachments
       const projects = yield* ProjectRepository
       const directories = yield* Directories
       const terminals = yield* Terminals
@@ -631,6 +633,9 @@ export const layerWith = (options: ThreadsOptions) =>
               (terminal) => terminal.threadId === id,
             )
             yield* repository.delete(id)
+            // The rows cascaded with the thread; the bytes on disk are ours
+            // to remove (ATC-216).
+            yield* attachments.purge(id)
             lifecycleLocks.delete(id)
             yield* events.publish({ resource: "thread", id, change: "deleted" })
             yield* Effect.forEach(orphaned, (terminal) =>

--- a/app-server/src/threads/transcriptRepository.ts
+++ b/app-server/src/threads/transcriptRepository.ts
@@ -1,6 +1,5 @@
 import { Context, Effect, Layer, Option, Schema } from "effect"
 import { SqlClient, SqlSchema } from "effect/unstable/sql"
-import type * as Contract from "../api/contract.ts"
 import { ThreadItem, ThreadTurn } from "../api/contract.ts"
 import type { HistoryTurn } from "../agents/agentAdapter.ts"
 
@@ -36,11 +35,23 @@ import type { HistoryTurn } from "../agents/agentAdapter.ts"
 //     way, and `replace` carries both forward by item id — a re-read must
 //     not re-date what ATC already dated. The stamped values live in the
 //     item JSON (and mirrored in columns for the carry-forward lookup), so
-//     every read serves them.
+//     every read serves them. A prompt's attachments (ATC-216) carry
+//     forward too, keyed by TURN id and the prompt's ordinal within the
+//     turn: providers re-number items on a history read (Codex
+//     positionally, Claude per message) and none echoes ATC's attachment
+//     ids, but Codex turn ids are stable — Claude's are not, so its re-read
+//     loses them (documented on the contract).
 
 export type ThreadTurnRecord = typeof ThreadTurn.Type
 export type ThreadItemRecord = typeof ThreadItem.Type
-export type QueuedPromptRecord = typeof Contract.QueuedPrompt.Type
+/** A waiting prompt as stored: the attachment ids, not the attachments —
+ * the runtime resolves them (attachments.ts) when it lists or starts one. */
+export interface QueuedPromptRecord {
+  readonly id: string
+  readonly prompt: string
+  readonly attachmentIds: ReadonlyArray<string>
+  readonly queuedAt: string
+}
 export type TurnSource = "native" | "observed" | "history"
 
 /** One replayable change: the row's current state at the seq that last touched it. */
@@ -87,9 +98,14 @@ const QueueRow = Schema.Struct({
   id: Schema.String,
   thread_id: Schema.String,
   prompt: Schema.String,
+  /** JSON array of attachment ids ('[]' for none). */
+  attachments: Schema.String,
   queued_at: Schema.String,
   started_turn_id: Schema.NullOr(Schema.String),
 })
+const AttachmentIds = Schema.fromJsonString(Schema.Array(Schema.String))
+const decodeAttachmentIds = Schema.decodeSync(AttachmentIds)
+const encodeAttachmentIds = Schema.encodeSync(AttachmentIds)
 
 const CountersRow = Schema.Struct({
   transcript_seq: Schema.Number,
@@ -109,8 +125,25 @@ const toTurn = (row: typeof TurnRow.Type): ThreadTurnRecord => ({
 const toQueued = (row: typeof QueueRow.Type): QueuedPromptRecord => ({
   id: row.id,
   prompt: row.prompt,
+  attachmentIds: decodeAttachmentIds(row.attachments),
   queuedAt: row.queued_at,
 })
+
+type UserMessageRecord = Extract<ThreadItemRecord, { type: "userMessage" }>
+type AttachmentList = NonNullable<UserMessageRecord["attachments"]>
+
+/** The images ATC attached, per turn in prompt order, as the stored copy
+ * holds them — what a re-read must not lose (ATC-216, the header). */
+const attachmentsByTurn = (
+  items: ReadonlyArray<ThreadItemRecord>,
+): Map<string, Array<AttachmentList>> => {
+  const byTurn = new Map<string, Array<AttachmentList>>()
+  for (const item of items) {
+    if (item.type !== "userMessage" || item.attachments === undefined) continue
+    byTurn.set(item.turnId, [...(byTurn.get(item.turnId) ?? []), item.attachments])
+  }
+  return byTurn
+}
 
 /** The stamped finish of a tool item; undefined for non-tool items. */
 const itemCompletedAt = (item: ThreadItemRecord): string | undefined => {
@@ -226,8 +259,12 @@ export class TranscriptRepository extends Context.Service<
       threadId: string,
       history: ReadonlyArray<HistoryTurn>,
     ) => Effect.Effect<TranscriptCounters>
-    /** Admit a prompt to the queue. */
-    readonly enqueue: (threadId: string, prompt: string) => Effect.Effect<QueuedPromptRecord>
+    /** Admit a prompt to the queue, with the ids of the attachments it carries. */
+    readonly enqueue: (
+      threadId: string,
+      prompt: string,
+      attachmentIds: ReadonlyArray<string>,
+    ) => Effect.Effect<QueuedPromptRecord>
     /** Prompts still waiting, oldest first. */
     readonly listWaiting: (threadId: string) => Effect.Effect<ReadonlyArray<QueuedPromptRecord>>
     /** The oldest waiting prompt (None when nothing waits). */
@@ -293,6 +330,18 @@ export const layer = Layer.effect(TranscriptRepository)(
       }),
       execute: (threadId) => sql`
         SELECT item_id, created_at, completed_at FROM thread_items WHERE thread_id = ${threadId}
+      `,
+    })
+
+    // The userMessage items carrying attachments, in transcript order, for
+    // replace's carry-forward.
+    const attachedItemRows = SqlSchema.findAll({
+      Request: Schema.String,
+      Result: Schema.Struct({ item: Schema.String }),
+      execute: (threadId) => sql`
+        SELECT item FROM thread_items
+        WHERE thread_id = ${threadId} AND json_extract(item, '$.attachments') IS NOT NULL
+        ORDER BY ord ASC
       `,
     })
 
@@ -623,15 +672,30 @@ export const layer = Layer.effect(TranscriptRepository)(
                   { created_at: row.created_at, completed_at: row.completed_at },
                 ]),
               )
+              const attached = attachmentsByTurn(
+                (yield* attachedItemRows(threadId)).map((row) => decodeItem(row.item)),
+              )
               const now = new Date().toISOString()
               yield* clearItems(threadId)
               yield* clearTurns(threadId)
               for (const entry of history) {
                 const turnSeq = yield* nextSeq(threadId)
                 yield* upsertTurnRows(turnRow(threadId, entry.turn, turnSeq, "history"))
+                // The turn's prompts, oldest first, take back the stored
+                // images in the same order (history names no ATC ids).
+                const turnAttachments = attached.get(entry.turn.id) ?? []
+                let promptIndex = 0
                 for (const item of entry.items) {
                   const itemSeq = yield* nextSeq(threadId)
-                  const stamped = stampItem(item, carried.get(item.id), now)
+                  const restore =
+                    item.type === "userMessage" && item.attachments === undefined
+                      ? turnAttachments[promptIndex++]
+                      : undefined
+                  const restored: ThreadItemRecord =
+                    item.type === "userMessage" && restore !== undefined
+                      ? { ...item, attachments: restore }
+                      : item
+                  const stamped = stampItem(restored, carried.get(item.id), now)
                   yield* upsertItemRow(itemRow(threadId, stamped, itemSeq))
                 }
               }
@@ -643,12 +707,13 @@ export const layer = Layer.effect(TranscriptRepository)(
             }),
           )
           .pipe(Effect.orDie),
-      enqueue: (threadId, prompt) =>
+      enqueue: (threadId, prompt, attachmentIds) =>
         Effect.suspend(() => {
           const row: typeof QueueRow.Type = {
             id: Bun.randomUUIDv7(),
             thread_id: threadId,
             prompt,
+            attachments: encodeAttachmentIds(attachmentIds),
             queued_at: new Date().toISOString(),
             started_turn_id: null,
           }

--- a/app-server/test/agents/agentAdapter.test.ts
+++ b/app-server/test/agents/agentAdapter.test.ts
@@ -162,7 +162,7 @@ describe("AgentAdapter seam semantics (fake adapter)", () => {
       const fake = makeFakeAgentAdapter()
       const { connection, turn } = yield* fake.adapter.createSession({
         cwd: "/work",
-        input: "do the thing",
+        input: { text: "do the thing", attachments: [] },
         settings: TEST_SETTINGS,
       })
       const sink = yield* collectEvents(connection.events)
@@ -188,10 +188,12 @@ describe("AgentAdapter seam semantics (fake adapter)", () => {
       const fake = makeFakeAgentAdapter()
       const { connection } = yield* fake.adapter.createSession({
         cwd: "/work",
-        input: "one",
+        input: { text: "one", attachments: [] },
         settings: TEST_SETTINGS,
       })
-      const second = yield* Effect.flip(connection.startTurn("two", TEST_SETTINGS))
+      const second = yield* Effect.flip(
+        connection.startTurn({ text: "two", attachments: [] }, TEST_SETTINGS),
+      )
       assert.strictEqual(second._tag, "AgentConflict")
     }).pipe(Effect.scoped),
   )
@@ -271,7 +273,7 @@ describe("AgentAdapter seam semantics (fake adapter)", () => {
       const fake = makeFakeAgentAdapter()
       const { connection, turn } = yield* fake.adapter.createSession({
         cwd: "/work",
-        input: "long task",
+        input: { text: "long task", attachments: [] },
         settings: TEST_SETTINGS,
       })
       const sink = yield* collectEvents(connection.events)
@@ -294,7 +296,7 @@ describe("AgentAdapter seam semantics (fake adapter)", () => {
       const fake = makeFakeAgentAdapter()
       const { connection } = yield* fake.adapter.createSession({
         cwd: "/work",
-        input: "ask me",
+        input: { text: "ask me", attachments: [] },
         settings: TEST_SETTINGS,
       })
       const sink = yield* collectEvents(connection.events)
@@ -314,7 +316,7 @@ describe("AgentAdapter seam semantics (fake adapter)", () => {
       const fake = makeFakeAgentAdapter()
       const { connection } = yield* fake.adapter.createSession({
         cwd: "/work",
-        input: "ask me",
+        input: { text: "ask me", attachments: [] },
         settings: TEST_SETTINGS,
       })
       const sink = yield* collectEvents(connection.events)
@@ -364,7 +366,11 @@ describe("AgentAdapter seam semantics (fake adapter)", () => {
       const fake = makeFakeAgentAdapter()
       fake.setUnavailable("fake outage")
       const failure = yield* Effect.flip(
-        fake.adapter.createSession({ cwd: "/work", input: "hi", settings: TEST_SETTINGS }),
+        fake.adapter.createSession({
+          cwd: "/work",
+          input: { text: "hi", attachments: [] },
+          settings: TEST_SETTINGS,
+        }),
       )
       assert.strictEqual(failure._tag, "AgentUnavailable")
     }).pipe(Effect.scoped),

--- a/app-server/test/agents/claudeAdapter.smoke.test.ts
+++ b/app-server/test/agents/claudeAdapter.smoke.test.ts
@@ -35,7 +35,7 @@ describe.skipIf(!enabled)("live claude adapter smoke (opt-in)", () => {
             Effect.gen(function* () {
               const { connection, turn } = yield* adapter.createSession({
                 cwd,
-                input: "Reply with exactly: SMOKE-OK",
+                input: { text: "Reply with exactly: SMOKE-OK", attachments: [] },
                 settings: SMOKE_SETTINGS,
               })
               const sink = yield* collectAgentEvents(connection.events)
@@ -61,7 +61,10 @@ describe.skipIf(!enabled)("live claude adapter smoke (opt-in)", () => {
               })
               const sink = yield* collectAgentEvents(connection.events)
               const turn = yield* connection.startTurn(
-                "What exact text did I ask you to reply with earlier? Answer with just that text.",
+                {
+                  text: "What exact text did I ask you to reply with earlier? Answer with just that text.",
+                  attachments: [],
+                },
                 SMOKE_SETTINGS,
               )
               assert.strictEqual(connection.providerSessionId, sessionId)
@@ -86,7 +89,10 @@ describe.skipIf(!enabled)("live claude adapter smoke (opt-in)", () => {
               })
               const sink = yield* collectAgentEvents(connection.events)
               const turn = yield* connection.startTurn(
-                "Count from 1 to 500, one number per line. Do not stop early.",
+                {
+                  text: "Count from 1 to 500, one number per line. Do not stop early.",
+                  attachments: [],
+                },
                 SMOKE_SETTINGS,
               )
               yield* waitForAgentEvent(
@@ -114,7 +120,9 @@ describe.skipIf(!enabled)("live claude adapter smoke (opt-in)", () => {
                 cwd,
                 settings: SMOKE_SETTINGS,
               })
-              return yield* Effect.flip(connection.startTurn("hello?", SMOKE_SETTINGS))
+              return yield* Effect.flip(
+                connection.startTurn({ text: "hello?", attachments: [] }, SMOKE_SETTINGS),
+              )
             }),
           )
           assert.strictEqual(failure._tag, "AgentResumeFailed")

--- a/app-server/test/agents/claudeAdapter.test.ts
+++ b/app-server/test/agents/claudeAdapter.test.ts
@@ -44,7 +44,7 @@ describe("ClaudeAdapter", () => {
           Effect.gen(function* () {
             const { connection, turn } = yield* adapter.createSession({
               cwd,
-              input: "hello",
+              input: { text: "hello", attachments: [] },
               settings: TEST_SETTINGS,
             })
             assert.strictEqual(connection.providerSessionId, "session-a")
@@ -64,6 +64,73 @@ describe("ClaudeAdapter", () => {
     }),
   )
 
+  it.live("a turn's images go out as base64 blocks and ride the prompt's item", () =>
+    Effect.gen(function* () {
+      const cwd = workDir()
+      const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3])
+      const shotPath = path.join(cwd, "shot.png")
+      fs.writeFileSync(shotPath, png)
+      const shot = {
+        id: "att-1",
+        name: "shot.png",
+        mediaType: "image/png" as const,
+        byteSize: png.byteLength,
+        path: shotPath,
+        createdAt: "2026-08-20T00:00:00.000Z",
+      }
+      const { fake, layer } = adapterStack({ sessionId: "session-img" })
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const { connection, turn } = yield* adapter.createSession({
+              cwd,
+              input: { text: "what is this", attachments: [shot] },
+              settings: TEST_SETTINGS,
+            })
+            const sink = yield* collectAgentEvents(connection.events)
+            yield* waitForAgentEvent(
+              sink,
+              (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
+            )
+            // The SDK child saw the text and the image inline, never a path.
+            assert.deepStrictEqual(fake.prompts[0], [
+              { type: "text", text: "what is this" },
+              {
+                type: "image",
+                source: {
+                  type: "base64",
+                  media_type: "image/png",
+                  data: Buffer.from(png).toString("base64"),
+                },
+              },
+            ])
+            const message = sink.find(
+              (event) => event.type === "itemCompleted" && event.item.type === "userMessage",
+            )
+            assert.deepStrictEqual(
+              message?.type === "itemCompleted" && message.item.type === "userMessage"
+                ? message.item.attachments
+                : undefined,
+              [shot],
+            )
+            // An unreadable image fails the turn before anything goes out.
+            const missing = yield* Effect.flip(
+              connection.startTurn(
+                { text: "again", attachments: [{ ...shot, path: path.join(cwd, "gone.png") }] },
+                TEST_SETTINGS,
+              ),
+            )
+            assert.strictEqual(missing._tag, "AgentProtocolError")
+            // Nothing reached the SDK: the failed turn pushed no message.
+            assert.lengthOf(fake.prompts, 1)
+            assert.strictEqual(yield* connection.activity, "idle")
+          }),
+        )
+      }).pipe(Effect.provide(layer))
+    }),
+  )
+
   it.live("create with a lying cwd fails closed", () =>
     Effect.gen(function* () {
       const { layer } = adapterStack({ wrongCwd: true })
@@ -71,7 +138,11 @@ describe("ClaudeAdapter", () => {
         const adapter = yield* ClaudeAdapter.ClaudeAdapter
         const failure = yield* Effect.scoped(
           Effect.flip(
-            adapter.createSession({ cwd: workDir(), input: "hello", settings: TEST_SETTINGS }),
+            adapter.createSession({
+              cwd: workDir(),
+              input: { text: "hello", attachments: [] },
+              settings: TEST_SETTINGS,
+            }),
           ),
         )
         assert.strictEqual(failure._tag, "AgentIdentityMismatch")
@@ -96,7 +167,10 @@ describe("ClaudeAdapter", () => {
             // No identity evidence yet — the SDK sends none until a turn.
             assert.strictEqual(yield* connection.activity, "unknown")
             const sink = yield* collectAgentEvents(connection.events)
-            const turn = yield* connection.startTurn("continue please", TEST_SETTINGS)
+            const turn = yield* connection.startTurn(
+              { text: "continue please", attachments: [] },
+              TEST_SETTINGS,
+            )
             assert.strictEqual(connection.providerSessionId, "session-b")
             yield* waitForAgentEvent(
               sink,
@@ -123,7 +197,9 @@ describe("ClaudeAdapter", () => {
               cwd: workDir(),
               settings: TEST_SETTINGS,
             })
-            return yield* Effect.flip(connection.startTurn("hello?", TEST_SETTINGS))
+            return yield* Effect.flip(
+              connection.startTurn({ text: "hello?", attachments: [] }, TEST_SETTINGS),
+            )
           }),
         )
         assert.strictEqual(failure._tag, "AgentResumeFailed")
@@ -146,7 +222,9 @@ describe("ClaudeAdapter", () => {
               cwd: workDir(),
               settings: TEST_SETTINGS,
             })
-            return yield* Effect.flip(connection.startTurn("hello?", TEST_SETTINGS))
+            return yield* Effect.flip(
+              connection.startTurn({ text: "hello?", attachments: [] }, TEST_SETTINGS),
+            )
           }),
         )
         assert.strictEqual(failure._tag, "AgentIdentityMismatch")
@@ -198,7 +276,7 @@ describe("ClaudeAdapter", () => {
           Effect.gen(function* () {
             const { connection, turn } = yield* adapter.createSession({
               cwd,
-              input: "HANG until told otherwise",
+              input: { text: "HANG until told otherwise", attachments: [] },
               settings: TEST_SETTINGS,
             })
             const sink = yield* collectAgentEvents(connection.events)
@@ -217,7 +295,9 @@ describe("ClaudeAdapter", () => {
             // An interrupted turn ends the held query; the session is over
             // (AgentUnavailable — the seam's "resume it" signal), not a
             // caller-side handle conflict.
-            const closed = yield* Effect.flip(connection.startTurn("another", TEST_SETTINGS))
+            const closed = yield* Effect.flip(
+              connection.startTurn({ text: "another", attachments: [] }, TEST_SETTINGS),
+            )
             assert.strictEqual(closed._tag, "AgentUnavailable")
           }),
         )
@@ -235,7 +315,7 @@ describe("ClaudeAdapter", () => {
           Effect.gen(function* () {
             const { connection, turn } = yield* adapter.createSession({
               cwd,
-              input: "FAILTURN please",
+              input: { text: "FAILTURN please", attachments: [] },
               settings: TEST_SETTINGS,
             })
             const sink = yield* collectAgentEvents(connection.events)
@@ -265,7 +345,7 @@ describe("ClaudeAdapter", () => {
           Effect.gen(function* () {
             const { connection, turn } = yield* adapter.createSession({
               cwd,
-              input: "needs PERMISSION for a tool",
+              input: { text: "needs PERMISSION for a tool", attachments: [] },
               settings: TEST_SETTINGS,
             })
             const sink = yield* collectAgentEvents(connection.events)
@@ -335,7 +415,7 @@ describe("ClaudeAdapter", () => {
           Effect.gen(function* () {
             const { connection, turn } = yield* adapter.createSession({
               cwd,
-              input: "needs PERMISSION for a tool",
+              input: { text: "needs PERMISSION for a tool", attachments: [] },
               settings: TEST_SETTINGS,
             })
             const sink = yield* collectAgentEvents(connection.events)
@@ -371,7 +451,7 @@ describe("ClaudeAdapter", () => {
           Effect.gen(function* () {
             const { connection, turn } = yield* adapter.createSession({
               cwd,
-              input: "needs PERMISSION again",
+              input: { text: "needs PERMISSION again", attachments: [] },
               settings: TEST_SETTINGS,
             })
             const sink = yield* collectAgentEvents(connection.events)
@@ -402,7 +482,7 @@ describe("ClaudeAdapter", () => {
           Effect.gen(function* () {
             const { connection, turn } = yield* adapter.createSession({
               cwd,
-              input: "STREAM please",
+              input: { text: "STREAM please", attachments: [] },
               settings: TEST_SETTINGS,
             })
             const sink = yield* collectAgentEvents(connection.events)
@@ -468,7 +548,7 @@ describe("ClaudeAdapter", () => {
           Effect.gen(function* () {
             const { connection, turn } = yield* adapter.createSession({
               cwd,
-              input: "use a TOOL",
+              input: { text: "use a TOOL", attachments: [] },
               settings: TEST_SETTINGS,
             })
             const sink = yield* collectAgentEvents(connection.events)
@@ -537,7 +617,7 @@ describe("ClaudeAdapter", () => {
           Effect.gen(function* () {
             const { connection, turn } = yield* adapter.createSession({
               cwd,
-              input: "hello",
+              input: { text: "hello", attachments: [] },
               settings: TEST_SETTINGS,
             })
             const sink = yield* collectAgentEvents(connection.events)
@@ -568,7 +648,7 @@ describe("ClaudeAdapter", () => {
           Effect.gen(function* () {
             const { connection, turn } = yield* adapter.createSession({
               cwd,
-              input: "spawn",
+              input: { text: "spawn", attachments: [] },
               settings: TEST_SETTINGS,
             })
             const sink = yield* collectAgentEvents(connection.events)
@@ -625,7 +705,7 @@ describe("ClaudeAdapter", () => {
           Effect.gen(function* () {
             const { connection, turn } = yield* adapter.createSession({
               cwd,
-              input: "hello",
+              input: { text: "hello", attachments: [] },
               settings: TEST_SETTINGS,
             })
             const sink = yield* collectAgentEvents(connection.events)
@@ -637,7 +717,10 @@ describe("ClaudeAdapter", () => {
             assert.strictEqual(yield* connection.activity, "working")
             // A whole further turn completes (Stop without a snapshot,
             // result success, state idle): the background evidence holds.
-            const second = yield* connection.startTurn("again", TEST_SETTINGS)
+            const second = yield* connection.startTurn(
+              { text: "again", attachments: [] },
+              TEST_SETTINGS,
+            )
             yield* waitForAgentEvent(
               sink,
               (event) => event.type === "turnCompleted" && event.turnId === second.turnId,
@@ -661,7 +744,7 @@ describe("ClaudeAdapter", () => {
           Effect.gen(function* () {
             const { connection, turn } = yield* adapter.createSession({
               cwd,
-              input: "hello",
+              input: { text: "hello", attachments: [] },
               settings: TEST_SETTINGS,
             })
             const sink = yield* collectAgentEvents(connection.events)
@@ -696,7 +779,7 @@ describe("ClaudeAdapter", () => {
           Effect.gen(function* () {
             const { connection, turn } = yield* adapter.createSession({
               cwd,
-              input: "ASK me something",
+              input: { text: "ASK me something", attachments: [] },
               settings: TEST_SETTINGS,
             })
             const sink = yield* collectAgentEvents(connection.events)
@@ -1384,7 +1467,7 @@ describe("ClaudeAdapter collectTitleContext", () => {
             Effect.gen(function* () {
               const { connection, turn } = yield* adapter.createSession({
                 cwd,
-                input: "hello",
+                input: { text: "hello", attachments: [] },
                 settings: {
                   model: "sonnet",
                   reasoning: "low",
@@ -1424,12 +1507,15 @@ describe("ClaudeAdapter collectTitleContext", () => {
 
               // A later turn on the resident connection pushes only what
               // changed, and plan mode stands in for the rung.
-              const second = yield* connection.startTurn("again", {
-                model: "opus[1m]",
-                reasoning: "xhigh",
-                mode: "plan",
-                access: "autoAcceptEdits",
-              })
+              const second = yield* connection.startTurn(
+                { text: "again", attachments: [] },
+                {
+                  model: "opus[1m]",
+                  reasoning: "xhigh",
+                  mode: "plan",
+                  access: "autoAcceptEdits",
+                },
+              )
               yield* waitForAgentEvent(
                 sink,
                 (event) => event.type === "turnCompleted" && event.turnId === second.turnId,
@@ -1440,12 +1526,15 @@ describe("ClaudeAdapter collectTitleContext", () => {
                 "setPermissionMode:plan",
               ])
               // Unchanged settings push nothing; leaving plan restores the rung.
-              const third = yield* connection.startTurn("once more", {
-                model: "opus[1m]",
-                reasoning: "xhigh",
-                mode: "chat",
-                access: "fullAccess",
-              })
+              const third = yield* connection.startTurn(
+                { text: "once more", attachments: [] },
+                {
+                  model: "opus[1m]",
+                  reasoning: "xhigh",
+                  mode: "chat",
+                  access: "fullAccess",
+                },
+              )
               yield* waitForAgentEvent(
                 sink,
                 (event) => event.type === "turnCompleted" && event.turnId === third.turnId,
@@ -1453,23 +1542,29 @@ describe("ClaudeAdapter collectTitleContext", () => {
               assert.deepStrictEqual(fake.controls.slice(3), [
                 "setPermissionMode:bypassPermissions",
               ])
-              const fourth = yield* connection.startTurn("and again", {
-                model: "opus[1m]",
-                reasoning: "xhigh",
-                mode: "chat",
-                access: "fullAccess",
-              })
+              const fourth = yield* connection.startTurn(
+                { text: "and again", attachments: [] },
+                {
+                  model: "opus[1m]",
+                  reasoning: "xhigh",
+                  mode: "chat",
+                  access: "fullAccess",
+                },
+              )
               yield* waitForAgentEvent(
                 sink,
                 (event) => event.type === "turnCompleted" && event.turnId === fourth.turnId,
               )
               assert.strictEqual(fake.controls.length, 4)
               // A model with no effort support clears the flag layer's effort.
-              const fifth = yield* connection.startTurn("haiku now", {
-                model: "haiku",
-                mode: "chat",
-                access: "fullAccess",
-              })
+              const fifth = yield* connection.startTurn(
+                { text: "haiku now", attachments: [] },
+                {
+                  model: "haiku",
+                  mode: "chat",
+                  access: "fullAccess",
+                },
+              )
               yield* waitForAgentEvent(
                 sink,
                 (event) => event.type === "turnCompleted" && event.turnId === fifth.turnId,
@@ -1502,7 +1597,7 @@ describe("ClaudeAdapter collectTitleContext", () => {
             Effect.gen(function* () {
               const { connection } = yield* adapter.createSession({
                 cwd,
-                input: "hello",
+                input: { text: "hello", attachments: [] },
                 settings: { model: "haiku", mode: "chat", access: "auto" },
               })
               const sink = yield* collectAgentEvents(connection.events)

--- a/app-server/test/agents/claudeItems.test.ts
+++ b/app-server/test/agents/claudeItems.test.ts
@@ -279,6 +279,32 @@ describe("ClaudeItems.mapHistory", () => {
       ...extra,
     }) as SessionMessage
 
+  it("an image-only prompt opens a turn with empty text (ATC-216)", () => {
+    const history = ClaudeItems.mapHistory([
+      message("user", "look", "u1"),
+      message("assistant", [{ type: "text", text: "ok" }], "a1"),
+      message(
+        "user",
+        [{ type: "image", source: { type: "base64", media_type: "image/png", data: "AAAA" } }],
+        "u2",
+      ),
+      message("assistant", [{ type: "text", text: "a picture" }], "a2"),
+    ])
+    assert.deepStrictEqual(
+      history.map((turn) => ({ id: turn.turn.id, items: turn.items.map((item) => item.id) })),
+      [
+        { id: "u1", items: ["u1:0", "a1:0"] },
+        { id: "u2", items: ["u2:0", "a2:0"] },
+      ],
+    )
+    assert.deepStrictEqual(history[1]?.items[0], {
+      type: "userMessage",
+      id: "u2:0",
+      turnId: "u2",
+      text: "",
+    })
+  })
+
   it("groups at each user text message, links tool results, and reads incomplete turns as interrupted", () => {
     const history = ClaudeItems.mapHistory([
       message("user", "first prompt", "u1", { timestamp: "2026-08-17T10:00:00.000Z" }),

--- a/app-server/test/agents/claudeTui.smoke.test.ts
+++ b/app-server/test/agents/claudeTui.smoke.test.ts
@@ -163,7 +163,10 @@ describe.skipIf(!enabled)("live claude TUI smoke (opt-in)", () => {
           Effect.gen(function* () {
             const { connection, turn } = yield* adapter.createSession({
               cwd,
-              input: "The first code word is ALPHA. Reply with exactly: OK",
+              input: {
+                text: "The first code word is ALPHA. Reply with exactly: OK",
+                attachments: [],
+              },
               settings: SMOKE_SETTINGS,
             })
             const sink = yield* collectAgentEvents(connection.events)
@@ -226,7 +229,10 @@ describe.skipIf(!enabled)("live claude TUI smoke (opt-in)", () => {
             })
             const sink = yield* collectAgentEvents(connection.events)
             const turn = yield* connection.startTurn(
-              "Reply with the two code words I gave you, in order, separated by a space, and nothing else.",
+              {
+                text: "Reply with the two code words I gave you, in order, separated by a space, and nothing else.",
+                attachments: [],
+              },
               SMOKE_SETTINGS,
             )
             yield* completedTurn(sink, turn.turnId)

--- a/app-server/test/agents/codexAdapter.smoke.test.ts
+++ b/app-server/test/agents/codexAdapter.smoke.test.ts
@@ -61,7 +61,7 @@ describe.skipIf(!enabled)("live codex adapter smoke (opt-in)", () => {
               Effect.gen(function* () {
                 const { connection, turn } = yield* adapter.createSession({
                   cwd,
-                  input: "Reply with exactly: SMOKE-OK",
+                  input: { text: "Reply with exactly: SMOKE-OK", attachments: [] },
                   settings: SMOKE_SETTINGS,
                 })
                 const sink = yield* collectAgentEvents(connection.events)
@@ -88,7 +88,10 @@ describe.skipIf(!enabled)("live codex adapter smoke (opt-in)", () => {
                 assert.strictEqual(connection.providerSessionId, threadId)
                 const sink = yield* collectAgentEvents(connection.events)
                 const turn = yield* connection.startTurn(
-                  "Count from 1 to 200, one number per line. Do not stop early.",
+                  {
+                    text: "Count from 1 to 200, one number per line. Do not stop early.",
+                    attachments: [],
+                  },
                   SMOKE_SETTINGS,
                 )
                 yield* waitForAgentEvent(

--- a/app-server/test/agents/codexAdapter.test.ts
+++ b/app-server/test/agents/codexAdapter.test.ts
@@ -44,7 +44,7 @@ describe("CodexAdapter", () => {
             Effect.gen(function* () {
               const { connection, turn } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
-                input: "hello",
+                input: { text: "hello", attachments: [] },
                 settings: TEST_SETTINGS,
               })
               assert.isString(connection.providerSessionId)
@@ -70,6 +70,51 @@ describe("CodexAdapter", () => {
   )
 
   it.live(
+    "a turn's images go out as localImage paths and map back onto the prompt's item",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        const shot = {
+          id: "att-1",
+          name: "shot.png",
+          mediaType: "image/png" as const,
+          byteSize: 11,
+          path: path.join(sandbox.cwd, "shot.png"),
+          createdAt: "2026-08-20T00:00:00.000Z",
+        }
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.scoped(
+            Effect.gen(function* () {
+              const { connection, turn } = yield* adapter.createSession({
+                cwd: sandbox.cwd,
+                input: { text: "", attachments: [shot] },
+                settings: TEST_SETTINGS,
+              })
+              const sink = yield* collectAgentEvents(connection.events)
+              yield* waitForAgentEvent(
+                sink,
+                (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
+              )
+              // The fixture echoes the input back as the real server does —
+              // a localImage block — and the adapter names our attachment.
+              const message = sink.find(
+                (event) => event.type === "itemCompleted" && event.item.type === "userMessage",
+              )
+              assert.isTrue(
+                message?.type === "itemCompleted" && message.item.type === "userMessage",
+              )
+              if (message?.type === "itemCompleted" && message.item.type === "userMessage") {
+                assert.strictEqual(message.item.text, "")
+                assert.deepStrictEqual(message.item.attachments, [shot])
+              }
+            }),
+          ),
+        )
+      }),
+    30_000,
+  )
+
+  it.live(
     "resume: exact identity round trip; unknown id fails closed",
     () =>
       Effect.gen(function* () {
@@ -80,7 +125,7 @@ describe("CodexAdapter", () => {
               Effect.gen(function* () {
                 const { connection, turn } = yield* adapter.createSession({
                   cwd: sandbox.cwd,
-                  input: "seed",
+                  input: { text: "seed", attachments: [] },
                   settings: TEST_SETTINGS,
                 })
                 const sink = yield* collectAgentEvents(connection.events)
@@ -130,7 +175,7 @@ describe("CodexAdapter", () => {
               Effect.flip(
                 adapter.createSession({
                   cwd: sandbox.cwd,
-                  input: "hello",
+                  input: { text: "hello", attachments: [] },
                   settings: TEST_SETTINGS,
                 }),
               ),
@@ -156,7 +201,7 @@ describe("CodexAdapter", () => {
               Effect.gen(function* () {
                 const { connection, turn } = yield* adapter.createSession({
                   cwd: sandbox.cwd,
-                  input: "seed",
+                  input: { text: "seed", attachments: [] },
                   settings: TEST_SETTINGS,
                 })
                 const sink = yield* collectAgentEvents(connection.events)
@@ -196,7 +241,7 @@ describe("CodexAdapter", () => {
             Effect.gen(function* () {
               const { connection } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
-                input: "HANG on",
+                input: { text: "HANG on", attachments: [] },
                 settings: TEST_SETTINGS,
               })
               const failure = yield* Effect.flip(
@@ -224,7 +269,7 @@ describe("CodexAdapter", () => {
             Effect.gen(function* () {
               const { connection, turn } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
-                input: "HANG until interrupted",
+                input: { text: "HANG until interrupted", attachments: [] },
                 settings: TEST_SETTINGS,
               })
               const sink = yield* collectAgentEvents(connection.events)
@@ -262,7 +307,7 @@ describe("CodexAdapter", () => {
             Effect.gen(function* () {
               const { connection, turn } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
-                input: "needs APPROVAL for this",
+                input: { text: "needs APPROVAL for this", attachments: [] },
                 settings: TEST_SETTINGS,
               })
               const sink = yield* collectAgentEvents(connection.events)
@@ -332,7 +377,7 @@ describe("CodexAdapter", () => {
             Effect.gen(function* () {
               const { connection, turn } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
-                input: "needs APPROVAL for this",
+                input: { text: "needs APPROVAL for this", attachments: [] },
                 settings: TEST_SETTINGS,
               })
               const sink = yield* collectAgentEvents(connection.events)
@@ -359,7 +404,10 @@ describe("CodexAdapter", () => {
 
               // A question round trip: answers keyed by the question id reach
               // the provider (the fixture echoes them back as its reply).
-              const asked = yield* connection.startTurn("QUESTION time", TEST_SETTINGS)
+              const asked = yield* connection.startTurn(
+                { text: "QUESTION time", attachments: [] },
+                TEST_SETTINGS,
+              )
               yield* waitForAgentEvent(
                 sink,
                 (event) => event.type === "requestOpened" && event.request.kind === "question",
@@ -408,7 +456,7 @@ describe("CodexAdapter", () => {
             Effect.gen(function* () {
               const { connection, turn } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
-                input: "seed",
+                input: { text: "seed", attachments: [] },
                 settings: TEST_SETTINGS,
               })
               const sink = yield* collectAgentEvents(connection.events)
@@ -452,7 +500,11 @@ describe("CodexAdapter", () => {
             // A session the provider actually has: the probe passes.
             const sessionId = yield* Effect.scoped(
               Effect.map(
-                adapter.createSession({ cwd: sandbox.cwd, input: "seed", settings: TEST_SETTINGS }),
+                adapter.createSession({
+                  cwd: sandbox.cwd,
+                  input: { text: "seed", attachments: [] },
+                  settings: TEST_SETTINGS,
+                }),
                 ({ connection }) => connection.providerSessionId,
               ),
             )
@@ -496,7 +548,7 @@ describe("CodexAdapter", () => {
             Effect.gen(function* () {
               const { connection, turn } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
-                input: "STREAM me",
+                input: { text: "STREAM me", attachments: [] },
                 settings: TEST_SETTINGS,
               })
               const sink = yield* collectAgentEvents(connection.events)
@@ -556,7 +608,7 @@ describe("CodexAdapter", () => {
               Effect.gen(function* () {
                 const { connection, turn } = yield* adapter.createSession({
                   cwd: sandbox.cwd,
-                  input: "run a COMMAND",
+                  input: { text: "run a COMMAND", attachments: [] },
                   settings: TEST_SETTINGS,
                 })
                 const sink = yield* collectAgentEvents(connection.events)
@@ -613,7 +665,7 @@ describe("CodexAdapter", () => {
             Effect.gen(function* () {
               const { connection, turn } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
-                input: "hello",
+                input: { text: "hello", attachments: [] },
                 settings: TEST_SETTINGS,
               })
               const sink = yield* collectAgentEvents(connection.events)
@@ -1119,7 +1171,7 @@ describe("CodexAdapter descendant aggregation", () => {
             Effect.gen(function* () {
               const { connection, turn } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
-                input: "SPAWN one worker",
+                input: { text: "SPAWN one worker", attachments: [] },
                 settings: TEST_SETTINGS,
               })
               const sink = yield* collectAgentEvents(connection.events)
@@ -1158,7 +1210,7 @@ describe("CodexAdapter descendant aggregation", () => {
             Effect.gen(function* () {
               const { connection, turn } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
-                input: "SPAWN NEEDSINPUT worker",
+                input: { text: "SPAWN NEEDSINPUT worker", attachments: [] },
                 settings: TEST_SETTINGS,
               })
               const sink = yield* collectAgentEvents(connection.events)
@@ -1305,7 +1357,7 @@ describe("CodexAdapter descendant aggregation", () => {
               // Live broadcasts teach the adapter about the child...
               const { connection, turn } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
-                input: "SPAWN worker",
+                input: { text: "SPAWN worker", attachments: [] },
                 settings: TEST_SETTINGS,
               })
               const sink = yield* collectAgentEvents(connection.events)
@@ -1450,7 +1502,7 @@ describe("CodexAdapter collectTitleContext", () => {
               Effect.gen(function* () {
                 const { connection, turn } = yield* adapter.createSession({
                   cwd: sandbox.cwd,
-                  input: "seed turn",
+                  input: { text: "seed turn", attachments: [] },
                   settings: TEST_SETTINGS,
                 })
                 const id = connection.providerSessionId
@@ -1470,7 +1522,10 @@ describe("CodexAdapter collectTitleContext", () => {
                   providerSessionId: id,
                   providerMetadata: undefined,
                 })
-                const second = yield* connection.startTurn("hello context", TEST_SETTINGS)
+                const second = yield* connection.startTurn(
+                  { text: "hello context", attachments: [] },
+                  TEST_SETTINGS,
+                )
                 yield* waitForAgentEvent(
                   sink,
                   (event) => event.type === "turnCompleted" && event.turnId === second.turnId,
@@ -1515,7 +1570,7 @@ describe("CodexAdapter collectTitleContext", () => {
               } as const
               const { connection, turn } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
-                input: "hello",
+                input: { text: "hello", attachments: [] },
                 settings,
               })
               const sink = yield* collectAgentEvents(connection.events)
@@ -1525,12 +1580,15 @@ describe("CodexAdapter collectTitleContext", () => {
               )
               // The second turn changes access and reasoning: exactly those
               // ride as overrides; model is unchanged and stays home.
-              const second = yield* connection.startTurn("again", {
-                ...settings,
-                reasoning: "low",
-                access: "fullAccess",
-                mode: "plan",
-              })
+              const second = yield* connection.startTurn(
+                { text: "again", attachments: [] },
+                {
+                  ...settings,
+                  reasoning: "low",
+                  access: "fullAccess",
+                  mode: "plan",
+                },
+              )
               yield* waitForAgentEvent(
                 sink,
                 (event) => event.type === "turnCompleted" && event.turnId === second.turnId,
@@ -1583,7 +1641,7 @@ describe("CodexAdapter collectTitleContext", () => {
             Effect.gen(function* () {
               const { connection, turn } = yield* adapter.createSession({
                 cwd: sandbox.cwd,
-                input: "hello",
+                input: { text: "hello", attachments: [] },
                 settings: TEST_SETTINGS,
               })
               const sink = yield* collectAgentEvents(connection.events)

--- a/app-server/test/agents/fakeAgentAdapter.ts
+++ b/app-server/test/agents/fakeAgentAdapter.ts
@@ -10,10 +10,12 @@ import type {
   AgentTurnOutcome,
   HistoryTurn,
   ProviderSettings,
+  ThreadAttachment,
   ThreadItem,
   ThreadRequest,
   ThreadRequestAnswer,
   ThreadSettings,
+  TurnInput,
 } from "../../src/agents/agentAdapter.ts"
 import {
   AgentConflict,
@@ -42,8 +44,10 @@ import {
 export interface FakeAgentSession {
   readonly providerSessionId: string
   readonly cwd: string
-  /** Inputs received via createSession/startTurn, for assertions. */
+  /** Input texts received via createSession/startTurn, for assertions. */
   readonly inputs: Array<string>
+  /** The attachments each input carried, aligned with `inputs`. */
+  readonly attachments: Array<ReadonlyArray<ThreadAttachment>>
   /** Settings each turn was started with (createSession/startTurn), in order. */
   readonly turnSettings: Array<ThreadSettings>
 }
@@ -280,7 +284,7 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
           : Effect.void,
       )
 
-      const startTurn = (input: string, settings: ThreadSettings) =>
+      const startTurn = (input: TurnInput, settings: ThreadSettings) =>
         Effect.gen(function* () {
           yield* requireAvailable
           yield* requireOpen
@@ -292,7 +296,8 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
               }),
             )
           }
-          session.inputs.push(input)
+          session.inputs.push(input.text)
+          session.attachments.push(input.attachments)
           session.turnSettings.push(settings)
           // Unique across fake instances: turn ids are persisted, and a
           // "restarted" fake must not collide with the previous one's turns.
@@ -303,7 +308,13 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
           // first item (Codex via the fan-out, Claude explicitly).
           emit(live, {
             type: "itemCompleted",
-            item: { type: "userMessage", id: `${turnId}:prompt`, turnId, text: input },
+            item: {
+              type: "userMessage",
+              id: `${turnId}:prompt`,
+              turnId,
+              text: input.text,
+              ...(input.attachments.length > 0 ? { attachments: input.attachments } : {}),
+            },
           })
           setActivity(live, "working")
           return { turnId }
@@ -388,6 +399,7 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
           providerSessionId: `fake-session-${nextSessionId++}`,
           cwd: options.cwd,
           inputs: [],
+          attachments: [],
           turnSettings: [],
         }
         sessions.set(session.providerSessionId, session)
@@ -455,6 +467,7 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
             providerSessionId,
             cwd: options.cwd,
             inputs: [],
+            attachments: [],
             turnSettings: [],
           })
           return {
@@ -559,7 +572,13 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
       unavailableReason = reason
     },
     seed: (providerSessionId, cwd) => {
-      const session: FakeAgentSession = { providerSessionId, cwd, inputs: [], turnSettings: [] }
+      const session: FakeAgentSession = {
+        providerSessionId,
+        cwd,
+        inputs: [],
+        attachments: [],
+        turnSettings: [],
+      }
       sessions.set(providerSessionId, session)
       return session
     },

--- a/app-server/test/agents/fakeClaudeQuery.ts
+++ b/app-server/test/agents/fakeClaudeQuery.ts
@@ -94,6 +94,8 @@ export interface FakeClaudeQuery {
   readonly controls: Array<string>
   /** The query() options each spawn received, in order. */
   readonly spawns: Array<Record<string, unknown>>
+  /** The user message content each prompt pushed (string, or content blocks). */
+  readonly prompts: Array<unknown>
   /**
    * Fire one hook event into the most recent query's registered callbacks
    * with a scripted payload (session_id filled in) — how tests replay
@@ -108,6 +110,7 @@ export const makeFakeClaudeQuery = (options: FakeClaudeQueryOptions = {}): FakeC
   const interrupts: Array<string> = []
   const controls: Array<string> = []
   const spawns: Array<Record<string, unknown>> = []
+  const prompts: Array<unknown> = []
   let lastFire: ((eventName: string, payload?: Record<string, unknown>) => Promise<void>) | null =
     null
 
@@ -344,7 +347,13 @@ export const makeFakeClaudeQuery = (options: FakeClaudeQueryOptions = {}): FakeC
     void (async () => {
       for await (const message of args.prompt) {
         const content = (message as SDKUserMessage).message.content
-        await runTurn(typeof content === "string" ? content : JSON.stringify(content))
+        prompts.push(content)
+        // Keyword behavior keys off the text blocks; image blocks ride along.
+        const text =
+          typeof content === "string"
+            ? content
+            : content.flatMap((block) => (block.type === "text" ? [block.text] : [])).join("\n")
+        await runTurn(text)
         if (done) return
       }
     })()
@@ -416,6 +425,7 @@ export const makeFakeClaudeQuery = (options: FakeClaudeQueryOptions = {}): FakeC
     decisions,
     interrupts,
     controls,
+    prompts,
     spawns,
     fireHook: (eventName, payload) => {
       if (lastFire === null) throw new Error("no query started yet")

--- a/app-server/test/api/openapi.test.ts
+++ b/app-server/test/api/openapi.test.ts
@@ -1,12 +1,13 @@
 import { assert, describe, it } from "@effect/vitest"
 import { BunHttpServer } from "@effect/platform-bun"
-import { Context, Effect, Layer, Option } from "effect"
+import { Cause, Context, Effect, Layer, Option } from "effect"
 import {
   HttpBody,
   HttpClient,
   HttpClientRequest,
   HttpRouter,
   HttpServerRequest,
+  HttpServerRespondable,
   HttpServerResponse,
 } from "effect/unstable/http"
 import { HttpApi, OpenApi } from "effect/unstable/httpapi"
@@ -16,7 +17,7 @@ import { openApiDocument, openApiJson } from "../../src/api/openapi.ts"
 import * as Server from "../../src/server.ts"
 import { appServerRoot } from "../blackbox.ts"
 import { TestBuildInfoLayer, testBuildInfo } from "../testBuildInfo.ts"
-import { startServer, TestAuthTokenLayer, TestRepositoryLayers } from "../testLayers.ts"
+import { eventually, startServer, TestAuthTokenLayer, TestRepositoryLayers } from "../testLayers.ts"
 
 // Contract-generation tests: the document must be deterministic, match the
 // checked-in artifact, cover every contract operation, and agree with what
@@ -28,6 +29,7 @@ const operation = (path: string, method = "get") =>
   ((openApiDocument.paths[path] as Record<string, unknown>)?.[method] ??
     assert.fail(`no ${method.toUpperCase()} operation documented for ${path}`)) as {
     readonly operationId: string
+    readonly requestBody?: { content: Record<string, unknown> }
     readonly responses: Record<string, { content: Record<string, { schema: { $ref?: string } }> }>
   }
 
@@ -152,7 +154,13 @@ const rawClient = Effect.gen(function* () {
         // The internal Claude hook route resolves its service per request;
         // the trust middleware resolves AuthToken the same way.
         Effect.provide([ClaudeHooks.layer, TestAuthTokenLayer]),
-        Effect.orDie,
+        // A request-decoding failure becomes the 400 the real listener sends.
+        Effect.catchCause((cause) =>
+          HttpServerRespondable.toResponseOrElse(
+            Cause.squash(cause),
+            HttpServerResponse.empty({ status: 500 }),
+          ),
+        ),
       )
       return HttpServerResponse.toClientResponse(response)
     }, Effect.scoped),
@@ -189,6 +197,8 @@ describe("openapi document vs runtime", () => {
       "/api/v1/threads/{threadId}/requests/{requestId}/answer",
       "/api/v1/threads/{threadId}/queue",
       "/api/v1/threads/{threadId}/queue/{promptId}",
+      "/api/v1/threads/{threadId}/attachments",
+      "/api/v1/threads/{threadId}/attachments/{attachmentId}",
       "/api/v1/agents",
       "/api/v1/agents/{agentId}",
       "/api/v1/agents/{agentId}/models",
@@ -887,6 +897,147 @@ describe("openapi document vs runtime", () => {
       assert.sameMembers(Object.keys(event), ["resource", "id", "change"])
       assert.deepStrictEqual(event, { resource: "project", id: created.id, change: "created" })
     }),
+  )
+
+  // Live: the transcript poll sleeps between reads (the TestClock would park it).
+  it.live(
+    "thread attachments: upload, fetch, reference from a prompt, and the documented refusals",
+    () =>
+      Effect.gen(function* () {
+        const client = yield* rawClient
+        const project = yield* client.post("http://127.0.0.1/api/v1/projects", {
+          body: HttpBody.jsonUnsafe({ name: "Attachment Docs", defaultWorkingDirectory: "/tmp" }),
+        })
+        const projectBody = (yield* project.json) as { id: string }
+        const created = yield* client.post("http://127.0.0.1/api/v1/threads", {
+          body: HttpBody.jsonUnsafe({ projectId: projectBody.id, agentId: "codex" }),
+        })
+        const thread = (yield* created.json) as { id: string }
+        const base = `http://127.0.0.1/api/v1/threads/${thread.id}`
+
+        // A PNG by signature; the server validates nothing past the header.
+        const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3])
+        const uploaded = yield* client.post(`${base}/attachments?name=shot.png`, {
+          body: HttpBody.uint8Array(png, "image/png"),
+        })
+        assert.strictEqual(uploaded.status, 200)
+        const attachment = (yield* uploaded.json) as Record<string, unknown>
+        assert.sameMembers(Object.keys(attachment), [
+          "id",
+          "name",
+          "mediaType",
+          "byteSize",
+          "path",
+          "createdAt",
+        ])
+        assert.strictEqual(attachment["name"], "shot.png")
+        assert.strictEqual(attachment["mediaType"], "image/png")
+        assert.strictEqual(attachment["byteSize"], png.byteLength)
+        assert.isTrue(
+          String(attachment["path"]).endsWith(`/attachments/${thread.id}/${attachment["id"]}.png`),
+          `path keyed by thread and id: ${attachment["path"]}`,
+        )
+        const post = operation("/api/v1/threads/{threadId}/attachments", "post")
+        // One raw-bytes body per accepted image type — the document IS the
+        // allowlist, and the Swift generator gets one typed case each.
+        assert.sameMembers(Object.keys(post.requestBody?.content ?? {}), [
+          "image/png",
+          "image/jpeg",
+          "image/gif",
+          "image/webp",
+        ])
+        assert.deepStrictEqual(post.responses["200"]!.content["application/json"]!.schema, {
+          $ref: "#/components/schemas/ThreadAttachment",
+        })
+        const schema = componentSchema("ThreadAttachment")
+        assert.sameMembers(
+          [...schema.required],
+          ["id", "name", "mediaType", "byteSize", "path", "createdAt"],
+        )
+
+        // The bytes come back whole, as the documented octet stream.
+        const fetched = yield* client.get(`${base}/attachments/${attachment["id"]}`)
+        assert.strictEqual(fetched.status, 200)
+        assert.strictEqual(fetched.headers["content-type"], "application/octet-stream")
+        assert.deepStrictEqual(new Uint8Array(yield* fetched.arrayBuffer), png)
+        const get = operation("/api/v1/threads/{threadId}/attachments/{attachmentId}")
+        assert.deepStrictEqual(Object.keys(get.responses["200"]!.content), [
+          "application/octet-stream",
+        ])
+
+        // The refusals, each as documented.
+        const unsupported = yield* client.post(`${base}/attachments`, {
+          body: HttpBody.text("not an image", "text/plain"),
+        })
+        assert.strictEqual(unsupported.status, 415)
+        const mislabeled = yield* client.post(`${base}/attachments`, {
+          body: HttpBody.uint8Array(png, "image/jpeg"),
+        })
+        assert.strictEqual(mislabeled.status, 422)
+        assert.strictEqual(
+          ((yield* mislabeled.json) as Record<string, unknown>)["_tag"],
+          "AttachmentInvalid",
+        )
+        const empty = yield* client.post(`${base}/attachments`, {
+          body: HttpBody.uint8Array(new Uint8Array(0), "image/png"),
+        })
+        assert.strictEqual(empty.status, 422)
+        const huge = new Uint8Array(8 * 1024 * 1024 + 1)
+        huge.set(png)
+        const tooLarge = yield* client.post(`${base}/attachments`, {
+          body: HttpBody.uint8Array(huge, "image/png"),
+        })
+        assert.strictEqual(tooLarge.status, 413)
+        assert.strictEqual(
+          ((yield* tooLarge.json) as Record<string, unknown>)["_tag"],
+          "AttachmentTooLarge",
+        )
+        const missing = yield* client.get(`${base}/attachments/nope`)
+        assert.strictEqual(missing.status, 404)
+        assert.strictEqual(
+          ((yield* missing.json) as Record<string, unknown>)["_tag"],
+          "AttachmentNotFound",
+        )
+
+        // A prompt may be the image alone; its item carries the attachment.
+        const prompted = yield* client.post(`${base}/prompt`, {
+          body: HttpBody.jsonUnsafe({ prompt: "", attachments: [attachment["id"]] }),
+        })
+        assert.strictEqual(prompted.status, 200)
+        const items = yield* eventually(
+          client.get(`${base}/transcript`).pipe(
+            Effect.flatMap((response) => response.json),
+            Effect.map((body) => (body as { items: Array<Record<string, unknown>> }).items),
+          ),
+          (list) => list.some((item) => item["type"] === "userMessage"),
+        )
+        const message = items.find((item) => item["type"] === "userMessage")
+        assert.deepStrictEqual(message?.["attachments"], [attachment])
+        // Another thread's attachment — a real one — refuses the prompt
+        // (attachments never cross threads); no text and no attachments is
+        // a malformed request.
+        const otherThread = yield* client.post("http://127.0.0.1/api/v1/threads", {
+          body: HttpBody.jsonUnsafe({ projectId: projectBody.id, agentId: "codex" }),
+        })
+        const other = (yield* otherThread.json) as { id: string }
+        const elsewhere = yield* client.post(
+          `http://127.0.0.1/api/v1/threads/${other.id}/attachments`,
+          { body: HttpBody.uint8Array(png, "image/png") },
+        )
+        const elsewhereId = ((yield* elsewhere.json) as { id: string }).id
+        const foreign = yield* client.post(`${base}/prompt`, {
+          body: HttpBody.jsonUnsafe({ prompt: "look", attachments: [elsewhereId] }),
+        })
+        assert.strictEqual(foreign.status, 404)
+        assert.strictEqual(
+          ((yield* foreign.json) as Record<string, unknown>)["_tag"],
+          "AttachmentNotFound",
+        )
+        const blank = yield* client.post(`${base}/prompt`, {
+          body: HttpBody.jsonUnsafe({ prompt: "   " }),
+        })
+        assert.strictEqual(blank.status, 400)
+      }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
   )
 
   it.effect("GET /api/v1/fs/check returns the documented payload", () =>

--- a/app-server/test/cli/cli.blackbox.test.ts
+++ b/app-server/test/cli/cli.blackbox.test.ts
@@ -607,9 +607,9 @@ describe("atc api / context / capabilities (black box)", () => {
     expect(JSON.parse(result.stdout)).toEqual({
       capabilitiesVersion: 1,
       api: {
-        command: "atc api <method> <path> [--input <file|->]",
+        command: "atc api <method> <path> [--input <file|->] [--content-type <type>]",
         description:
-          "Complete access to the canonical App Server HTTP API: every operation via GET, POST, PUT, PATCH, or DELETE, JSON body from a file or stdin, the raw JSON response on stdout.",
+          "Complete access to the canonical App Server HTTP API: every operation via GET, POST, PUT, PATCH, or DELETE, a body from a file or stdin (JSON by default, any Content-Type via --content-type), the response on stdout (JSON as text, anything else byte for byte).",
         example: "atc api GET /api/v1/projects",
       },
       openapi: {

--- a/app-server/test/fixtures/fake-codex-listener.ts
+++ b/app-server/test/fixtures/fake-codex-listener.ts
@@ -537,8 +537,14 @@ const handle = (
       const threadId = String(params["threadId"] ?? "")
       const thread = threads.get(threadId)
       if (thread === undefined) return respondError(-32600, `unknown thread ${threadId}`)
-      const input = params["input"] as Array<{ text?: string }> | undefined
-      const text = input?.[0]?.text ?? ""
+      const input = (params["input"] ?? []) as Array<{
+        type: string
+        text?: string
+        path?: string
+      }>
+      const text = input
+        .flatMap((block) => (block.type === "text" && block.text !== undefined ? [block.text] : []))
+        .join("\n")
       const turnId = crypto.randomUUID()
       // Overrides are sticky for this and subsequent turns, like the real server.
       if (typeof params["model"] === "string") thread.settings.model = params["model"]
@@ -572,10 +578,15 @@ const handle = (
       // The real server broadcasts the turn's input back as a completed
       // userMessage item — content text blocks, unlike agentMessage's
       // top-level text — the retention evidence for title refinement.
+      // Image inputs come back as localImage blocks, like the real server.
       emitItem(thread, turnId, "completed", {
         id: crypto.randomUUID(),
         type: "userMessage",
-        content: [{ type: "text", text, text_elements: [] }],
+        content: input.map((block) =>
+          block.type === "localImage"
+            ? { type: "localImage", path: block.path }
+            : { type: "text", text: block.text ?? "", text_elements: [] },
+        ),
       })
       if (text.includes("HANG")) {
         hangingTurns.add(threadId)

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -25,6 +25,8 @@ import * as Tailscale from "../src/platform/tailscale.ts"
 import type { TerminalAdapter } from "../src/terminals/terminalAdapter.ts"
 import * as TerminalRepository from "../src/terminals/terminalRepository.ts"
 import * as Terminals from "../src/terminals/terminals.ts"
+import * as AttachmentRepository from "../src/threads/attachmentRepository.ts"
+import * as Attachments from "../src/threads/attachments.ts"
 import * as ThreadRepository from "../src/threads/threadRepository.ts"
 import * as ThreadNaming from "../src/threads/threadNaming.ts"
 import * as ThreadRuntime from "../src/threads/threadRuntime.ts"
@@ -72,6 +74,9 @@ export const TestTailscaleLayer = Layer.succeed(Tailscale.Tailscale)({
 })
 
 /** A settled AppConfig for tests that only need a few fields overridden. */
+/** One scratch data directory per test process: attachments write under it. */
+const testDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "atc-test-data-"))
+
 export const testAppConfig = (overrides: Partial<AppConfig["Service"]>): Layer.Layer<AppConfig> =>
   Layer.succeed(AppConfig)({
     port: 0,
@@ -82,7 +87,7 @@ export const testAppConfig = (overrides: Partial<AppConfig["Service"]>): Layer.L
     logLevel: "Info",
     configFile: "/dev/null",
     home: os.homedir(),
-    dataDir: "/tmp",
+    dataDir: testDataDir,
     stateDir: "/tmp",
     dbFile: "/tmp/atc.db",
     tokenFile: "/tmp/atc-auth-token",
@@ -123,6 +128,7 @@ export const makeTestServiceLayers = (
     | Terminals.Terminals
     | Threads.Threads
     | ThreadRuntime.ThreadRuntime
+    | Attachments.Attachments
     | TranscriptRepository.TranscriptRepository
     | Projects.Projects
     | AgentRegistry.AgentRegistry
@@ -146,6 +152,7 @@ export const makeTestServiceLayers = (
     TerminalRepository.layer,
     ThreadRepository.layer,
     TranscriptRepository.layer,
+    AttachmentRepository.layer,
     AgentDefaultsRepository.layer,
     // Merged, not just provided: Threads holds the SqlClient for its
     // settings write-through transaction.
@@ -153,6 +160,9 @@ export const makeTestServiceLayers = (
   const services = Layer.mergeAll(
     base,
     Directories.layer.pipe(Layer.provide(testAppConfig(configOverrides))),
+    Attachments.layer.pipe(
+      Layer.provide([base, testAppConfig(configOverrides), BunServices.layer]),
+    ),
     fake.layer,
     ClaudeHooks.layer,
   )

--- a/app-server/test/threads/threadResidency.test.ts
+++ b/app-server/test/threads/threadResidency.test.ts
@@ -48,7 +48,7 @@ const settledThread = (layerKit: typeof kit, agentId: "claude-code" | "codex", p
     const fake = agentId === "claude-code" ? layerKit.fakeAgents.claude : layerKit.fakeAgents.codex
     const project = yield* projects.create({ name: "Residency", defaultWorkingDirectory: realDir })
     const thread = yield* threads.create({ projectId: project.id, agentId })
-    const started = yield* runtime.prompt(thread.id, prompt)
+    const started = yield* runtime.prompt(thread.id, { prompt: prompt })
     assert.isString(started.turnId)
     const record = yield* repository.require(thread.id)
     const sessionId = record.providerSessionId ?? ""
@@ -71,7 +71,7 @@ describe("Resident writer connections", () => {
       assert.isTrue(yield* runtime.hasWriter(threadId))
       assert.strictEqual(opened(claude, sessionId), 1)
 
-      const second = yield* runtime.prompt(threadId, "second")
+      const second = yield* runtime.prompt(threadId, { prompt: "second" })
       assert.isString(second.turnId)
       // startTurn twice on the same connection: no resume, no new process.
       assert.deepStrictEqual(claude.sessions.get(sessionId)?.inputs, ["first", "second"])
@@ -92,9 +92,9 @@ describe("Resident writer connections", () => {
     Effect.gen(function* () {
       const runtime = yield* ThreadRuntime
       const { threadId, sessionId } = yield* settledThread(kit, "claude-code")
-      const running = yield* runtime.prompt(threadId, "running")
+      const running = yield* runtime.prompt(threadId, { prompt: "running" })
       assert.isString(running.turnId)
-      const queued = yield* runtime.prompt(threadId, "queued")
+      const queued = yield* runtime.prompt(threadId, { prompt: "queued" })
       assert.isUndefined(queued.turnId)
       claude.completeTurn(sessionId, "completed")
       yield* waitFor(
@@ -124,7 +124,7 @@ describe("Resident writer connections", () => {
         )
         // Our own connection's busy is not "another surface": a prompt
         // starts on it at once rather than queueing behind it.
-        const started = yield* runtime.prompt(threadId, "while background runs")
+        const started = yield* runtime.prompt(threadId, { prompt: "while background runs" })
         assert.isString(started.turnId)
         claude.completeTurn(sessionId, "completed")
         yield* waitFor(
@@ -163,7 +163,7 @@ describe("Resident writer connections", () => {
         // same session — the writer count on that session was 1 until now.
         yield* threads.closeTerminal(threadId)
         assert.isFalse(terminalAlive(terminal.id))
-        const started = yield* runtime.prompt(threadId, "back to chat")
+        const started = yield* runtime.prompt(threadId, { prompt: "back to chat" })
         assert.isString(started.turnId)
         assert.strictEqual(opened(claude, sessionId), 2)
         assert.deepStrictEqual(claude.sessions.get(sessionId)?.inputs, ["first", "back to chat"])
@@ -187,7 +187,7 @@ describe("Resident writer connections", () => {
       // Native wins: the prompt ends the TUI and resumes; the TUI comes back
       // at the run's end because it is still wanted, so the resident
       // connection does not survive this turn.
-      const started = yield* runtime.prompt(threadId, "native again")
+      const started = yield* runtime.prompt(threadId, { prompt: "native again" })
       assert.isString(started.turnId)
       assert.isFalse(terminalAlive(terminal.id))
       claude.completeTurn(sessionId, "completed")
@@ -209,9 +209,9 @@ describe("Resident writer connections", () => {
       // the connection closes and the feed ends — synchronously, before
       // the runtime has seen either — with a prompt already queued behind
       // the turn.
-      const started = yield* runtime.prompt(threadId, "stop me")
+      const started = yield* runtime.prompt(threadId, { prompt: "stop me" })
       assert.isString(started.turnId)
-      const queued = yield* runtime.prompt(threadId, "and again")
+      const queued = yield* runtime.prompt(threadId, { prompt: "and again" })
       assert.isUndefined(queued.turnId)
       claude.completeTurn(sessionId, "interrupted")
       claude.endConnection(sessionId)
@@ -244,7 +244,7 @@ describe("Resident writer connections", () => {
       claude.endConnection(sessionId)
       yield* waitFor(runtime.hasWriter(threadId), (held) => !held)
       assert.strictEqual((yield* threads.get(threadId)).activityState, "idle")
-      const again = yield* runtime.prompt(threadId, "once more")
+      const again = yield* runtime.prompt(threadId, { prompt: "once more" })
       assert.isString(again.turnId)
       assert.strictEqual(opened(claude, sessionId), 3)
       claude.completeTurn(sessionId, "completed")
@@ -269,7 +269,7 @@ describe("Resident writer connections", () => {
       const { threadId, sessionId } = yield* settledThread(kit, "codex")
       yield* waitFor(runtime.hasWriter(threadId), (driving) => !driving)
       assert.isFalse(codex.isConnected(sessionId))
-      const second = yield* runtime.prompt(threadId, "second")
+      const second = yield* runtime.prompt(threadId, { prompt: "second" })
       assert.isString(second.turnId)
       assert.strictEqual(opened(codex, sessionId), 2)
       codex.completeTurn(sessionId, "completed")
@@ -289,7 +289,7 @@ describe("Resident writer connections", () => {
             (connected) => !connected,
           )
           assert.isFalse(yield* runtime.hasWriter(threadId))
-          const started = yield* runtime.prompt(threadId, "after the timeout")
+          const started = yield* runtime.prompt(threadId, { prompt: "after the timeout" })
           assert.isString(started.turnId)
           assert.strictEqual(opened(fake, sessionId), 2)
           assert.deepStrictEqual(fake.sessions.get(sessionId)?.inputs, [

--- a/app-server/test/threads/threadRuntime.test.ts
+++ b/app-server/test/threads/threadRuntime.test.ts
@@ -1,10 +1,11 @@
 import { assert, describe, it } from "@effect/vitest"
 import { Effect, Stream } from "effect"
-import { mkdtempSync, rmSync } from "node:fs"
+import { existsSync, mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { dirname, join } from "node:path"
 import { afterAll } from "vitest"
 import type { ThreadEvent } from "../../src/threads/threadRuntime.ts"
+import { Attachments } from "../../src/threads/attachments.ts"
 import { ThreadRuntime } from "../../src/threads/threadRuntime.ts"
 import { ThreadRepository } from "../../src/threads/threadRepository.ts"
 import { TranscriptRepository } from "../../src/threads/transcriptRepository.ts"
@@ -56,7 +57,7 @@ describe("ThreadRuntime", () => {
       const thread = yield* newThread
       const events = yield* collectEvents(runtime, thread.id)
 
-      const started = yield* runtime.prompt(thread.id, "hello")
+      const started = yield* runtime.prompt(thread.id, { prompt: "hello" })
       assert.isString(started.turnId)
       const turnId = started.turnId ?? ""
       // A fresh session was created with the prompt, and identity persisted
@@ -141,12 +142,120 @@ describe("ThreadRuntime", () => {
     }).pipe(Effect.scoped, Effect.provide(kit.layer)),
   )
 
+  it.live("a prompt's images reach the adapter, its item, and the queue; delete purges them", () =>
+    Effect.gen(function* () {
+      const runtime = yield* ThreadRuntime
+      const attachments = yield* Attachments
+      const threads = yield* Threads
+      const thread = yield* newThread
+      const events = yield* collectEvents(runtime, thread.id)
+      const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3])
+      const shot = yield* attachments.create(thread.id, {
+        bytes: png,
+        mediaType: "image/png",
+        name: "shot.png",
+      })
+      assert.isTrue(existsSync(shot.path))
+
+      // The turn starts with the image resolved; the fake, like both real
+      // adapters, puts it on the prompt's item.
+      const started = yield* runtime.prompt(thread.id, { prompt: "look", attachments: [shot.id] })
+      assert.isString(started.turnId)
+      const session = [...fake.sessions.values()].find((entry) => entry.inputs.includes("look"))
+      assert.deepStrictEqual(session?.attachments, [[shot]])
+      const page = yield* waitFor(runtime.transcript(thread.id).pipe(Effect.orDie), (current) =>
+        current.items.some((item) => item.type === "userMessage"),
+      )
+      const message = page.items.find((item) => item.type === "userMessage")
+      assert.deepStrictEqual(message?.type === "userMessage" ? message.attachments : undefined, [
+        shot,
+      ])
+
+      // A prompt queued behind the running turn lists its images, on the
+      // queue and on its event; a foreign id is refused before admission.
+      const second = yield* attachments.create(thread.id, { bytes: png, mediaType: "image/png" })
+      assert.strictEqual(second.name, "image.png")
+      const queued = yield* runtime.prompt(thread.id, {
+        prompt: "and this",
+        attachments: [second.id],
+      })
+      assert.isUndefined(queued.turnId)
+      assert.deepStrictEqual(
+        (yield* runtime.listQueue(thread.id)).map((entry) => entry.attachments),
+        [[second]],
+      )
+      const published = yield* waitFor(
+        Effect.sync(() => events.findLast((event) => event.type === "queue.updated")),
+        (event) => event?.type === "queue.updated" && event.prompts.length === 1,
+      )
+      assert.deepStrictEqual(
+        published?.type === "queue.updated" ? published.prompts[0]?.attachments : undefined,
+        [second],
+      )
+      const other = yield* newThread
+      const elsewhere = yield* attachments.create(other.id, { bytes: png, mediaType: "image/png" })
+      const refused = yield* Effect.flip(
+        runtime.prompt(thread.id, { prompt: "x", attachments: [elsewhere.id] }),
+      )
+      assert.strictEqual(refused._tag, "AttachmentNotFound")
+      assert.lengthOf(yield* runtime.listQueue(thread.id), 1)
+
+      // The queued prompt drains at the turn's end with its image resolved.
+      fake.completeTurn(session?.providerSessionId ?? "", "completed")
+      yield* waitFor(
+        Effect.sync(() => session?.inputs ?? []),
+        (inputs) => inputs.includes("and this"),
+      )
+      assert.deepStrictEqual(session?.attachments.at(-1), [second])
+
+      // The thread's bytes go with the thread.
+      yield* threads.delete(thread.id)
+      assert.isFalse(existsSync(dirname(shot.path)))
+    }).pipe(Effect.scoped, Effect.provide(kit.layer)),
+  )
+
+  it.live("a provider re-read keeps a prompt's images where its turn id is stable", () =>
+    Effect.gen(function* () {
+      const runtime = yield* ThreadRuntime
+      const attachments = yield* Attachments
+      const thread = yield* newThread
+      const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3])
+      const shot = yield* attachments.create(thread.id, { bytes: png, mediaType: "image/png" })
+      const started = yield* runtime.prompt(thread.id, { prompt: "keep", attachments: [shot.id] })
+      const turnId = started.turnId ?? ""
+      const session = [...fake.sessions.values()].find((entry) => entry.inputs.includes("keep"))
+      const providerSessionId = session?.providerSessionId ?? ""
+      yield* waitFor(runtime.transcript(thread.id).pipe(Effect.orDie), (current) =>
+        current.items.some((item) => item.type === "userMessage"),
+      )
+      fake.completeTurn(providerSessionId, "completed")
+      yield* waitFor(runtime.transcript(thread.id).pipe(Effect.orDie), (current) =>
+        current.turns.every((turn) => turn.status === "completed"),
+      )
+      // The provider's history keeps the turn id but re-numbers items and
+      // knows nothing of ATC's attachments (Codex echoes localImage paths).
+      fake.setHistory(providerSessionId, [
+        {
+          turn: { id: turnId, status: "completed" },
+          items: [{ type: "userMessage", id: "item-1", turnId, text: "keep" }],
+        },
+      ])
+      yield* runtime.reread(thread.id)
+      const page = yield* runtime.transcript(thread.id)
+      assert.strictEqual(page.snapshotVersion, 1)
+      const message = page.items.find((item) => item.type === "userMessage")
+      assert.deepStrictEqual(message?.type === "userMessage" ? message.attachments : undefined, [
+        shot,
+      ])
+    }).pipe(Effect.scoped, Effect.provide(kit.layer)),
+  )
+
   it.live("streamed text persists as durable partials while the answer streams", () =>
     Effect.gen(function* () {
       const runtime = yield* ThreadRuntime
       const thread = yield* newThread
       const events = yield* collectEvents(runtime, thread.id)
-      const started = yield* runtime.prompt(thread.id, "stream")
+      const started = yield* runtime.prompt(thread.id, { prompt: "stream" })
       const turnId = started.turnId ?? ""
       const providerSessionId =
         [...fake.sessions.values()].find((entry) => entry.inputs.includes("stream"))
@@ -215,7 +324,7 @@ describe("ThreadRuntime", () => {
     Effect.gen(function* () {
       const runtime = yield* ThreadRuntime
       const thread = yield* newThread
-      const started = yield* runtime.prompt(thread.id, "work")
+      const started = yield* runtime.prompt(thread.id, { prompt: "work" })
       const turnId = started.turnId ?? ""
       const providerSessionId =
         [...fake.sessions.values()].find((entry) => entry.inputs.includes("work"))
@@ -268,12 +377,12 @@ describe("ThreadRuntime", () => {
         const runtime = yield* ThreadRuntime
         const thread = yield* newThread
         const events = yield* collectEvents(runtime, thread.id)
-        const first = yield* runtime.prompt(thread.id, "one")
+        const first = yield* runtime.prompt(thread.id, { prompt: "one" })
         const providerSessionId =
           [...fake.sessions.values()].find((entry) => entry.inputs.includes("one"))
             ?.providerSessionId ?? ""
 
-        const second = yield* runtime.prompt(thread.id, "two")
+        const second = yield* runtime.prompt(thread.id, { prompt: "two" })
         assert.isUndefined(second.turnId)
         const queued = yield* runtime.listQueue(thread.id)
         assert.deepStrictEqual(
@@ -323,9 +432,9 @@ describe("ThreadRuntime", () => {
         )
         yield* runtime.interrupt(thread.id)
         // A waiting prompt can be withdrawn.
-        const third = yield* runtime.prompt(thread.id, "three")
+        const third = yield* runtime.prompt(thread.id, { prompt: "three" })
         assert.isString(third.turnId)
-        const fourth = yield* runtime.prompt(thread.id, "four")
+        const fourth = yield* runtime.prompt(thread.id, { prompt: "four" })
         yield* runtime.deleteQueued(thread.id, fourth.promptId)
         assert.deepStrictEqual(yield* runtime.listQueue(thread.id), [])
         fake.completeTurn(providerSessionId, "completed")
@@ -338,7 +447,7 @@ describe("ThreadRuntime", () => {
       const threads = yield* Threads
       const thread = yield* newThread
       const events = yield* collectEvents(runtime, thread.id)
-      yield* runtime.prompt(thread.id, "ask")
+      yield* runtime.prompt(thread.id, { prompt: "ask" })
       const providerSessionId =
         [...fake.sessions.values()].find((entry) => entry.inputs.includes("ask"))
           ?.providerSessionId ?? ""
@@ -415,7 +524,7 @@ describe("ThreadRuntime", () => {
       const runtime = yield* ThreadRuntime
       const thread = yield* newThread
       const live = yield* collectEvents(runtime, thread.id)
-      const started = yield* runtime.prompt(thread.id, "replay me")
+      const started = yield* runtime.prompt(thread.id, { prompt: "replay me" })
       const turnId = started.turnId ?? ""
       const providerSessionId =
         [...fake.sessions.values()].find((entry) => entry.inputs.includes("replay me"))
@@ -483,7 +592,7 @@ describe("ThreadRuntime", () => {
         const runtime = yield* ThreadRuntime
         const transcripts = yield* TranscriptRepository
         const thread = yield* newThread
-        const started = yield* runtime.prompt(thread.id, "order")
+        const started = yield* runtime.prompt(thread.id, { prompt: "order" })
         const turnId = started.turnId ?? ""
         const providerSessionId =
           [...fake.sessions.values()].find((entry) => entry.inputs.includes("order"))
@@ -569,7 +678,7 @@ describe("ThreadRuntime", () => {
       const confirmed = yield* repo.require(record.id)
       // The TUI is mid-turn: the observation drain reports busy.
       yield* runtime.noteActivity(confirmed, "working")
-      const queued = yield* runtime.prompt(thread.id, "after the tui")
+      const queued = yield* runtime.prompt(thread.id, { prompt: "after the tui" })
       assert.isUndefined(queued.turnId)
       assert.deepStrictEqual(seeded.inputs, [])
       assert.deepStrictEqual(
@@ -609,7 +718,7 @@ describe("ThreadRuntime", () => {
       const runtime = yield* ThreadRuntime
       const thread = yield* newThread
       const events = yield* collectEvents(runtime, thread.id)
-      const started = yield* runtime.prompt(thread.id, "history")
+      const started = yield* runtime.prompt(thread.id, { prompt: "history" })
       const providerSessionId =
         [...fake.sessions.values()].find((entry) => entry.inputs.includes("history"))
           ?.providerSessionId ?? ""
@@ -667,7 +776,7 @@ describe("ThreadRuntime", () => {
       const runtime = yield* ThreadRuntime
       const thread = yield* newThread
       fake.setUnavailable("provider down")
-      const failure = yield* Effect.flip(runtime.prompt(thread.id, "nothing")).pipe(
+      const failure = yield* Effect.flip(runtime.prompt(thread.id, { prompt: "nothing" })).pipe(
         Effect.ensuring(Effect.sync(() => fake.setUnavailable(null))),
       )
       assert.strictEqual(failure._tag, "ProviderUnavailable")
@@ -681,7 +790,7 @@ describe("ThreadRuntime", () => {
       const runtime = yield* ThreadRuntime
       const threads = yield* Threads
       const thread = yield* newThread
-      yield* runtime.prompt(thread.id, "busy")
+      yield* runtime.prompt(thread.id, { prompt: "busy" })
       const providerSessionId =
         [...fake.sessions.values()].find((entry) => entry.inputs.includes("busy"))
           ?.providerSessionId ?? ""
@@ -717,8 +826,8 @@ describe("ThreadRuntime restart", () => {
             defaultWorkingDirectory: scratch,
           })
           const thread = yield* threads.create({ projectId: project.id, agentId: "codex" })
-          const started = yield* runtime.prompt(thread.id, "long running")
-          yield* runtime.prompt(thread.id, "afterwards")
+          const started = yield* runtime.prompt(thread.id, { prompt: "long running" })
+          yield* runtime.prompt(thread.id, { prompt: "afterwards" })
           yield* waitFor(
             runtime.transcript(thread.id).pipe(Effect.orDie),
             (transcript) => transcript.items.length === 1,
@@ -788,8 +897,8 @@ describe("ThreadRuntime restart", () => {
           defaultWorkingDirectory: scratch,
         })
         const thread = yield* threads.create({ projectId: project.id, agentId: "codex" })
-        yield* runtime.prompt(thread.id, "before restart")
-        yield* runtime.prompt(thread.id, "after restart")
+        yield* runtime.prompt(thread.id, { prompt: "before restart" })
+        yield* runtime.prompt(thread.id, { prompt: "after restart" })
         // The prompt item has landed before the "crash".
         yield* waitFor(
           runtime.transcript(thread.id).pipe(Effect.orDie),

--- a/app-server/test/threads/threadSettings.test.ts
+++ b/app-server/test/threads/threadSettings.test.ts
@@ -281,7 +281,7 @@ describe("thread settings", () => {
         params: { threadId: thread.id },
         payload: { settings: { access: "autoAcceptEdits" } },
       })
-      const started = yield* runtime.prompt(thread.id, "hello")
+      const started = yield* runtime.prompt(thread.id, { prompt: "hello" })
       assert.isString(started.turnId)
       const session = [...fake.sessions.values()].find((entry) => entry.inputs.includes("hello"))
       assert.isDefined(session)
@@ -301,7 +301,7 @@ describe("thread settings", () => {
         client.v1.getThread({ params: { threadId: thread.id } }),
         (current) => current.activityState === "idle",
       )
-      yield* runtime.prompt(thread.id, "again")
+      yield* runtime.prompt(thread.id, { prompt: "again" })
       yield* eventually(
         Effect.sync(() => session!.turnSettings.length),
         (count) => count === 2,

--- a/app-server/test/threads/threadTuiOwnership.test.ts
+++ b/app-server/test/threads/threadTuiOwnership.test.ts
@@ -60,7 +60,7 @@ describe("Thread TUI ownership", () => {
       assert.isTrue(terminalAlive(terminal.id))
       const readsBefore = fake.historyReads.length
 
-      const started = yield* runtime.prompt(threadId, "native wins")
+      const started = yield* runtime.prompt(threadId, { prompt: "native wins" })
       // The turn started at once: the TUI ended first — after a settled
       // history read (its last turn on disk) — and the session resumed
       // natively with the prompt.
@@ -88,13 +88,13 @@ describe("Thread TUI ownership", () => {
       const runtime = yield* ThreadRuntime
       const { threadId, sessionId, terminal, fake } = yield* openedThread("claude-code")
       fake.setUnavailable("transcript reads are down")
-      const refused = yield* runtime.prompt(threadId, "not yet").pipe(Effect.flip)
+      const refused = yield* runtime.prompt(threadId, { prompt: "not yet" }).pipe(Effect.flip)
       assert.strictEqual(refused._tag, "ProviderUnavailable")
       assert.isTrue(terminalAlive(terminal.id))
       // Un-admitted, not queued: the caller's error means "not accepted".
       assert.deepStrictEqual(yield* runtime.listQueue(threadId), [])
       fake.setUnavailable(null)
-      const started = yield* runtime.prompt(threadId, "now")
+      const started = yield* runtime.prompt(threadId, { prompt: "now" })
       assert.isString(started.turnId)
       assert.isFalse(terminalAlive(terminal.id))
       fake.completeTurn(sessionId, "completed")
@@ -112,7 +112,7 @@ describe("Thread TUI ownership", () => {
         threads.get(threadId).pipe(Effect.orDie),
         (current) => current.activityState === "working",
       )
-      const queued = yield* runtime.prompt(threadId, "after the tui")
+      const queued = yield* runtime.prompt(threadId, { prompt: "after the tui" })
       assert.isUndefined(queued.turnId)
       assert.isTrue(terminalAlive(terminal.id))
       assert.deepStrictEqual(fake.sessions.get(sessionId)?.inputs, [])
@@ -166,7 +166,7 @@ describe("Thread TUI ownership", () => {
       assert.isFalse(terminalAlive(reopened.id))
 
       // Closed means not shown: a native turn ends with no relaunch.
-      const started = yield* runtime.prompt(threadId, "chat only")
+      const started = yield* runtime.prompt(threadId, { prompt: "chat only" })
       assert.isString(started.turnId)
       fake.completeTurn(sessionId, "completed")
       yield* waitFor(
@@ -188,7 +188,7 @@ describe("Thread TUI ownership", () => {
       const { threadId, sessionId, fake } = yield* openedThread("claude-code")
       yield* threads.closeTerminal(threadId)
 
-      const started = yield* runtime.prompt(threadId, "busy natively")
+      const started = yield* runtime.prompt(threadId, { prompt: "busy natively" })
       assert.isString(started.turnId)
       const refused = yield* threads.openTerminal(threadId).pipe(Effect.flip)
       assert.strictEqual(refused._tag, "ThreadBusy")
@@ -208,7 +208,7 @@ describe("Thread TUI ownership", () => {
       const threads = yield* Threads
       const { threadId, sessionId, terminal, fake } = yield* openedThread("codex")
 
-      const started = yield* runtime.prompt(threadId, "alongside the tui")
+      const started = yield* runtime.prompt(threadId, { prompt: "alongside the tui" })
       assert.isString(started.turnId)
       assert.isTrue(terminalAlive(terminal.id))
       fake.completeTurn(sessionId, "completed")

--- a/macos/ATC/AppModel.swift
+++ b/macos/ATC/AppModel.swift
@@ -1,5 +1,6 @@
 import ATCAppServerAPI
 import ATCAppServerTransport
+import ATCChat
 import Foundation
 import OSLog
 import Observation
@@ -62,10 +63,11 @@ final class AppModel {
     /// history.
     private(set) var threadViewModes: [ThreadRef: ThreadViewMode] = [:]
 
-    /// Unsent composer text per thread, for this app session only — app-level
-    /// like the view mode, so every window on one thread shares one draft and
-    /// switching views (TUI, another thread, Dashboard) never loses it.
-    private(set) var threadDrafts: [ThreadRef: String] = [:]
+    /// Unsent composer drafts (text and images) per thread, for this app
+    /// session only — app-level like the view mode, so every window on one
+    /// thread shares one draft and switching views (TUI, another thread,
+    /// Dashboard) never loses it.
+    private(set) var threadDrafts: [ThreadRef: ComposerDraft] = [:]
 
     /// Live terminal attaches by composite ref. Connections and surfaces
     /// stay alive here while the user switches around the sidebar, bounded
@@ -263,12 +265,12 @@ final class AppModel {
         threadViewModes[ref] ?? .chat
     }
 
-    func draft(for ref: ThreadRef) -> String {
-        threadDrafts[ref] ?? ""
+    func draft(for ref: ThreadRef) -> ComposerDraft {
+        threadDrafts[ref] ?? ComposerDraft()
     }
 
-    func setDraft(_ text: String, for ref: ThreadRef) {
-        threadDrafts[ref] = text.isEmpty ? nil : text
+    func setDraft(_ draft: ComposerDraft, for ref: ThreadRef) {
+        threadDrafts[ref] = draft.isEmpty ? nil : draft
     }
 
     /// Remembers the mode and re-opens the thread in every window showing
@@ -615,4 +617,13 @@ final class AppModel {
 /// Connection that no longer exists locally.
 struct AppServerUnavailable: LocalizedError {
     var errorDescription: String? { "This connection no longer exists." }
+}
+
+/// What the composer holds for one thread before a send: the text and the
+/// images attached to it, cleared and restored together.
+struct ComposerDraft: Equatable {
+    var text = ""
+    var attachments: [PendingAttachment] = []
+
+    var isEmpty: Bool { text.isEmpty && attachments.isEmpty }
 }

--- a/macos/ATC/Features/Threads/Chat/ChatComposer.swift
+++ b/macos/ATC/Features/Threads/Chat/ChatComposer.swift
@@ -13,14 +13,23 @@
 // turn. The composer autofocuses on appear unless a request is pending (a
 // bar card or an inline row) — answering the agent owns the keyboard until
 // it is done.
+//
+// Images (ATC-216) arrive by paste (the text view declines an image-only
+// pasteboard, so the paste command reaches us), drop, or the Attach button
+// (⌘⇧A); each is fitted to the server's caps at once
+// (`ImageAttachmentEncoder`) and held as bytes until send. A prompt may be
+// images alone.
 
 import ATCAppServerAPI
+import ATCChat
 import ATCDesign
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct ChatComposer: View {
     @Binding var text: String
+    @Binding var attachments: [PendingAttachment]
     let thread: ATCThread
     /// The agent's model catalog, nil until read (the chip shows the raw id).
     let models: [AgentModel]?
@@ -40,18 +49,41 @@ struct ChatComposer: View {
 
     @FocusState private var isFocused: Bool
     @State private var editorHeight: CGFloat = 24
+    /// The last image that could not be attached (unreadable, too many).
+    @State private var attachmentError: String?
+    @State private var isPicking = false
+    @State private var isDropTargeted = false
+
+    private static let imageTypes: [UTType] = [.image, .fileURL]
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
-            if let error {
+            if let error = error ?? attachmentError {
                 Label(error, systemImage: "exclamationmark.triangle")
                     .font(.callout)
                     .foregroundStyle(.orange)
                     .textSelection(.enabled)
             }
             VStack(alignment: .leading, spacing: Spacing.sm) {
+                if !attachments.isEmpty {
+                    AttachmentStrip(images: attachments.map { .local($0) }) { image in
+                        attachments.removeAll { $0.id.uuidString == image.id }
+                    }
+                }
                 editor
                 HStack(spacing: Spacing.sm) {
+                    Button {
+                        isPicking = true
+                    } label: {
+                        Image(systemName: "paperclip")
+                            .font(.body.weight(.medium))
+                            .frame(width: 24, height: 24)
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    .keyboardShortcut("a", modifiers: [.command, .shift])
+                    .help("Attach image… (⌘⇧A)")
+                    .accessibilityLabel("Attach image")
                     ChatSettingsControls(
                         thread: thread, models: models, modelsError: modelsError,
                         update: updateSettings, reloadModels: reloadModels
@@ -87,11 +119,55 @@ struct ChatComposer: View {
             // The composer floats over the transcript, so it is glass like
             // the toolbar controls, not a card on the canvas.
             .glassEffect(in: RoundedRectangle(cornerRadius: Radius.card + Spacing.xs))
+            .overlay {
+                if isDropTargeted {
+                    RoundedRectangle(cornerRadius: Radius.card + Spacing.xs)
+                        .strokeBorder(Color.accentColor, lineWidth: 2)
+                }
+            }
         }
+        .onDrop(of: Self.imageTypes, isTargeted: $isDropTargeted) { providers in
+            Task { attach(await ImagePasteboard.images(from: providers)) }
+            return true
+        }
+        .fileImporter(
+            isPresented: $isPicking, allowedContentTypes: [.image], allowsMultipleSelection: true,
+            onCompletion: attachPicked
+        )
         .onAppear {
             if !yieldsFocus { isFocused = true }
         }
         .onChange(of: focusRequest) { _, _ in isFocused = true }
+    }
+
+    private func attachPicked(_ result: Result<[URL], any Error>) {
+        guard case .success(let urls) = result else { return }
+        Task { attach(await Task.detached { urls.compactMap(ImagePasteboard.image(at:)) }.value) }
+    }
+
+    /// Fits each image to the caps — off the main actor, since a large
+    /// image decodes and re-encodes for a while — and appends it, up to the
+    /// per-prompt limit; the first failure is reported inline and the rest
+    /// still land.
+    private func attach(_ images: [ImagePasteboard.Image]) {
+        guard !images.isEmpty else { return }
+        attachmentError = nil
+        Task {
+            for image in images {
+                guard attachments.count < ImageAttachmentEncoder.maxPerPrompt else {
+                    attachmentError = "At most \(ImageAttachmentEncoder.maxPerPrompt) images per message."
+                    return
+                }
+                do {
+                    let prepared = try await Task.detached {
+                        try ImageAttachmentEncoder.prepare(image.data, name: image.name)
+                    }.value
+                    attachments.append(prepared)
+                } catch {
+                    attachmentError = "\(image.name ?? "Image"): \(error.localizedDescription)"
+                }
+            }
+        }
     }
 
     /// A TextEditor sized by the text behind it: it starts three lines tall
@@ -118,6 +194,11 @@ struct ChatComposer: View {
                 .scrollIndicators(.never)
                 .focused($isFocused)
                 .frame(height: editorHeight)
+                // The text view handles any paste it can read (text); an
+                // image-only pasteboard falls through to this.
+                .onPasteCommand(of: Self.imageTypes) { _ in
+                    attach(ImagePasteboard.images(from: .general))
+                }
                 .onKeyPress(.return, phases: .down) { press in
                     guard !press.modifiers.contains(.shift) else { return .ignored }
                     // Mid-IME composition, Return commits the marked text.
@@ -144,7 +225,7 @@ struct ChatComposer: View {
                     return .handled
                 }
             if text.isEmpty {
-                Text("Message the agent…")
+                Text(attachments.isEmpty ? "Message the agent…" : "Add a message, or send the images…")
                     .foregroundStyle(.tertiary)
                     .padding(.vertical, Spacing.xs)
                     .padding(.horizontal, Spacing.xs + 1)
@@ -154,7 +235,7 @@ struct ChatComposer: View {
     }
 
     private var canSend: Bool {
-        !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !attachments.isEmpty
     }
 
     /// The focused editor holds uncommitted IME marked text.

--- a/macos/ATC/Features/Threads/Chat/ChatQueueStrip.swift
+++ b/macos/ATC/Features/Threads/Chat/ChatQueueStrip.swift
@@ -16,9 +16,16 @@ struct ChatQueueStrip: View {
                 HStack(spacing: Spacing.sm) {
                     Image(systemName: "clock")
                         .foregroundStyle(.secondary)
-                    Text(prompt.prompt)
+                    if let attachments = prompt.attachments, !attachments.isEmpty {
+                        Label("\(attachments.count)", systemImage: "paperclip")
+                            .labelStyle(.titleAndIcon)
+                            .foregroundStyle(.secondary)
+                            .help("\(attachments.count) image\(attachments.count == 1 ? "" : "s") attached")
+                    }
+                    Text(prompt.prompt.isEmpty ? "Images only" : prompt.prompt)
                         .lineLimit(1)
                         .truncationMode(.tail)
+                        .foregroundStyle(prompt.prompt.isEmpty ? .secondary : .primary)
                     Spacer(minLength: 0)
                     Button {
                         withdraw(prompt)

--- a/macos/ATC/Features/Threads/Chat/ImagePasteboard.swift
+++ b/macos/ATC/Features/Threads/Chat/ImagePasteboard.swift
@@ -1,0 +1,74 @@
+// Reading images off the pasteboard and out of drops for the composer: file
+// URLs that point at images (Finder, the desktop) read as their file bytes
+// with the filename; anything else that is image data (a screenshot, a copy
+// from a browser) reads as PNG when the source offers it, else TIFF — the
+// encoder converts what the server does not accept.
+
+import AppKit
+import Foundation
+import UniformTypeIdentifiers
+
+nonisolated enum ImagePasteboard {
+    struct Image: Sendable {
+        let data: Data
+        let name: String?
+    }
+
+    /// Every image on `pasteboard`, file URLs first.
+    static func images(from pasteboard: NSPasteboard) -> [Image] {
+        let urls =
+            (pasteboard.readObjects(forClasses: [NSURL.self], options: [.urlReadingFileURLsOnly: true])
+                as? [URL]) ?? []
+        let files = urls.compactMap(image(at:))
+        if !files.isEmpty { return files }
+        for type in [NSPasteboard.PasteboardType.png, .tiff] {
+            if let data = pasteboard.data(forType: type) { return [Image(data: data, name: nil)] }
+        }
+        return []
+    }
+
+    /// Every image among dropped item providers (file URLs or image data).
+    static func images(from providers: [NSItemProvider]) async -> [Image] {
+        var images: [Image] = []
+        for provider in providers {
+            if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier),
+                let url = await loadURL(provider)
+            {
+                if let image = image(at: url) { images.append(image) }
+                continue
+            }
+            guard let type = provider.registeredContentTypes.first(where: { $0.conforms(to: .image) }),
+                let data = await loadData(provider, type: type)
+            else { continue }
+            images.append(Image(data: data, name: provider.suggestedName))
+        }
+        return images
+    }
+
+    /// The file's bytes when it is an image file the user can read.
+    static func image(at url: URL) -> Image? {
+        guard let type = UTType(filenameExtension: url.pathExtension), type.conforms(to: .image) else {
+            return nil
+        }
+        let scoped = url.startAccessingSecurityScopedResource()
+        defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return Image(data: data, name: url.lastPathComponent)
+    }
+
+    private static func loadURL(_ provider: NSItemProvider) async -> URL? {
+        await withCheckedContinuation { continuation in
+            _ = provider.loadObject(ofClass: URL.self) { url, _ in
+                continuation.resume(returning: url)
+            }
+        }
+    }
+
+    private static func loadData(_ provider: NSItemProvider, type: UTType) async -> Data? {
+        await withCheckedContinuation { continuation in
+            _ = provider.loadDataRepresentation(for: type) { data, _ in
+                continuation.resume(returning: data)
+            }
+        }
+    }
+}

--- a/macos/ATC/Features/Threads/Chat/ThreadChatView.swift
+++ b/macos/ATC/Features/Threads/Chat/ThreadChatView.swift
@@ -100,7 +100,7 @@ private struct ChatPane: View {
 
     private var agents: AgentsStore? { appModel.runtime(id: ref.connectionID)?.agents }
 
-    private var draftBinding: Binding<String> {
+    private var draftBinding: Binding<ComposerDraft> {
         Binding(
             get: { appModel.draft(for: ref) },
             set: { appModel.setDraft($0, for: ref) }
@@ -143,7 +143,8 @@ private struct ChatPane: View {
                     cards
                 }
                 ChatComposer(
-                    text: draftBinding,
+                    text: draftBinding.text,
+                    attachments: draftBinding.attachments,
                     thread: thread,
                     models: agents?.models(for: thread.agentId),
                     modelsError: agents?.modelErrors[thread.agentId],
@@ -265,19 +266,23 @@ private struct ChatPane: View {
         .transition(.opacity)
     }
 
-    /// The draft clears the moment the prompt leaves (the echo row carries
-    /// it); a refusal restores it in front of whatever was typed since, so
-    /// no text is ever lost.
+    /// The draft (text and images) clears the moment the prompt leaves (the
+    /// echo row carries it); a refusal restores it in front of whatever was
+    /// typed or attached since, so nothing is ever lost.
     private func send() {
-        let prompt = appModel.draft(for: ref).trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !prompt.isEmpty else { return }
-        appModel.setDraft("", for: ref)
+        let draft = appModel.draft(for: ref)
+        let prompt = draft.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty || !draft.attachments.isEmpty else { return }
+        appModel.setDraft(ComposerDraft(), for: ref)
         followRequest += 1
         Task {
-            guard await !chat.send(prompt) else { return }
-            let typedSince = appModel.draft(for: ref)
+            guard await !chat.send(prompt, attachments: draft.attachments) else { return }
+            let since = appModel.draft(for: ref)
             appModel.setDraft(
-                typedSince.isEmpty ? prompt : prompt + "\n" + typedSince, for: ref)
+                ComposerDraft(
+                    text: since.text.isEmpty ? prompt : prompt + "\n" + since.text,
+                    attachments: draft.attachments + since.attachments),
+                for: ref)
         }
     }
 

--- a/macos/ATC/PreviewSupport/PreviewAppServerClient.swift
+++ b/macos/ATC/PreviewSupport/PreviewAppServerClient.swift
@@ -541,6 +541,25 @@ import OpenAPIRuntime
             .ok(.init(body: .json(.init(items: [], turns: [], seq: 0, snapshotVersion: 0, hasMore: false))))
         }
 
+        func createThreadAttachment(
+            _ input: Operations.CreateThreadAttachment.Input
+        ) async throws -> Operations.CreateThreadAttachment.Output {
+            .ok(
+                .init(
+                    body: .json(
+                        .init(
+                            id: "0192f4c0-0000-7000-8000-00000000a001", name: input.query.name ?? "image.png",
+                            mediaType: .imagePng, byteSize: 0,
+                            path: "/Users/dev/.local/share/atc/attachments/\(input.path.threadId)/a001.png",
+                            createdAt: Date()))))
+        }
+
+        func getThreadAttachment(
+            _ input: Operations.GetThreadAttachment.Input
+        ) async throws -> Operations.GetThreadAttachment.Output {
+            throw PreviewUnavailable()
+        }
+
         func subscribeThreadEvents(
             _ input: Operations.SubscribeThreadEvents.Input
         ) async throws -> Operations.SubscribeThreadEvents.Output {

--- a/macos/ATCTests/ChatTranscriptTests.swift
+++ b/macos/ATCTests/ChatTranscriptTests.swift
@@ -228,6 +228,19 @@ struct ChatTranscriptTests {
         #expect(transcript.pendingPrompts.isEmpty)
     }
 
+    @Test("two image-only echoes are never told apart by their empty text")
+    func imageOnlyEchoesWaitForIds() {
+        var transcript = loaded()
+        let image = PendingAttachment(data: Data([1, 2, 3]), mediaType: .imagePng, name: "a.png")
+        _ = transcript.addPending("", attachments: [image])
+        _ = transcript.addPending("", attachments: [image])
+        let mutation = transcript.apply(
+            .item_completed(
+                .init(_type: .item_completed, seq: 11, item: Fixtures.userMessage("m1", turn: "t1", text: ""))))
+        #expect(mutation == .structure)
+        #expect(transcript.pendingPrompts.count == 2)
+    }
+
     @Test("a userMessage that outruns the send response settles the echo by text, as a handoff")
     func pendingSettlesByTextBeforeResponse() {
         var transcript = loaded()

--- a/macos/ATCTests/ScriptableAppServerClient.swift
+++ b/macos/ATCTests/ScriptableAppServerClient.swift
@@ -1,5 +1,7 @@
 import ATCAppServerAPI
+import ATCChat
 import Foundation
+import OpenAPIRuntime
 
 @testable import ATC
 
@@ -52,7 +54,9 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
         /// While set, promptThread fails 503 with this payload.
         var promptThreadFailure: Components.Schemas.ProviderUnavailableJsonEncoding?
         var transcriptReads: [(threadID: String, before: String?)] = []
-        var prompts: [(threadID: String, prompt: String)] = []
+        var prompts: [(threadID: String, prompt: String, attachments: [String]?)] = []
+        /// Uploads received, in order, with the bytes as sent.
+        var uploads: [(threadID: String, attachment: Components.Schemas.ThreadAttachment, bytes: Data)] = []
         var answers: [(threadID: String, requestID: String, answer: ThreadRequestAnswer)] = []
         var withdrawnPrompts: [(threadID: String, promptID: String)] = []
         var interruptCount = 0
@@ -223,7 +227,10 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     var openThreadTerminalCount: Int { lock.withLock { state.openThreadTerminalCount } }
     var markThreadViewedCount: Int { lock.withLock { state.markThreadViewedCount } }
     var transcriptReads: [(threadID: String, before: String?)] { lock.withLock { state.transcriptReads } }
-    var prompts: [(threadID: String, prompt: String)] { lock.withLock { state.prompts } }
+    var prompts: [(threadID: String, prompt: String, attachments: [String]?)] { lock.withLock { state.prompts } }
+    var uploads: [(threadID: String, attachment: Components.Schemas.ThreadAttachment, bytes: Data)] {
+        lock.withLock { state.uploads }
+    }
     var answers: [(threadID: String, requestID: String, answer: ThreadRequestAnswer)] {
         lock.withLock { state.answers }
     }
@@ -785,11 +792,69 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
         let id = input.path.threadId
         return mutate { model -> Operations.PromptThread.Output in
             guard model.threads.contains(where: { $0.id == id }) else {
-                return .notFound(.init(body: .json(threadNotFound(id))))
+                return .notFound(.init(body: .json(.init(value1: threadNotFound(id)))))
             }
-            model.prompts.append((id, request.prompt))
+            model.prompts.append((id, request.prompt, request.attachments))
             return .ok(.init(body: .json(.init(promptId: model.nextID("prm"), turnId: model.nextID("turn")))))
         }
+    }
+
+    func createThreadAttachment(_ input: Operations.CreateThreadAttachment.Input) async throws
+        -> Operations.CreateThreadAttachment.Output
+    {
+        let (mediaType, body): (Components.Schemas.AttachmentMediaType, HTTPBody) =
+            switch input.body {
+            case .png(let body): (.imagePng, body)
+            case .jpeg(let body): (.imageJpeg, body)
+            case .imageGif(let body): (.imageGif, body)
+            case .imageWebp(let body): (.imageWebp, body)
+            }
+        // Collect just past the server's cap so an oversized body is the
+        // documented 413, never a stored upload.
+        let cap = ImageAttachmentEncoder.maxBytes
+        let bytes = try await Data(collecting: body, upTo: cap + 1)
+        try await gate()
+        let id = input.path.threadId
+        return mutate { model -> Operations.CreateThreadAttachment.Output in
+            guard model.threads.contains(where: { $0.id == id }) else {
+                return .notFound(.init(body: .json(threadNotFound(id))))
+            }
+            guard bytes.count <= cap else {
+                return .contentTooLarge(
+                    .init(
+                        body: .json(
+                            .init(
+                                _tag: .attachmentTooLarge, threadId: id, byteSize: bytes.count, limit: cap,
+                                message: "attachment of \(bytes.count) bytes exceeds the \(cap)-byte limit"))))
+            }
+            let attachmentID = model.nextID("att")
+            let attachment = Components.Schemas.ThreadAttachment(
+                id: attachmentID, name: input.query.name ?? "image", mediaType: mediaType,
+                byteSize: bytes.count, path: "/data/attachments/\(id)/\(attachmentID)", createdAt: model.tick())
+            model.uploads.append((id, attachment, bytes))
+            return .ok(.init(body: .json(attachment)))
+        }
+    }
+
+    func getThreadAttachment(_ input: Operations.GetThreadAttachment.Input) async throws
+        -> Operations.GetThreadAttachment.Output
+    {
+        try await gate()
+        let upload = mutate { model in
+            model.uploads.first {
+                $0.threadID == input.path.threadId && $0.attachment.id == input.path.attachmentId
+            }
+        }
+        guard let upload else {
+            return .notFound(
+                .init(
+                    body: .json(
+                        .init(
+                            value2: .init(
+                                _tag: .attachmentNotFound, threadId: input.path.threadId,
+                                attachmentId: input.path.attachmentId, message: "No attachment")))))
+        }
+        return .ok(.init(body: .binary(HTTPBody(upload.bytes))))
     }
 
     /// Serves the seeded page for the thread; a `before` cursor reads as an

--- a/macos/ATCTests/ThreadChatModelTests.swift
+++ b/macos/ATCTests/ThreadChatModelTests.swift
@@ -202,6 +202,33 @@ struct ThreadChatModelTests {
         #expect(chat.transcript.items.count == 3)
     }
 
+    @Test("send uploads each image first, then prompts with their ids; the echo carries the images")
+    func sendWithAttachments() async throws {
+        let harness = try await acquired()
+        let chat = harness.chat
+        let client = harness.test.client
+        let images = [
+            PendingAttachment(data: Data([1, 2, 3]), mediaType: .imagePng, name: "one.png"),
+            PendingAttachment(data: Data([4, 5]), mediaType: .imageJpeg, name: "two.jpeg"),
+        ]
+
+        #expect(await chat.send("look", attachments: images))
+        #expect(client.uploads.map(\.attachment.name) == ["one.png", "two.jpeg"])
+        #expect(client.uploads.map(\.bytes) == [Data([1, 2, 3]), Data([4, 5])])
+        #expect(client.uploads.map(\.attachment.mediaType) == [.imagePng, .imageJpeg])
+        #expect(client.prompts.last?.attachments == client.uploads.map(\.attachment.id))
+        #expect(chat.transcript.pendingPrompts.first?.attachments == images)
+
+        // An image-only prompt is allowed; a refused upload restores nothing
+        // server-side and reports inline.
+        #expect(await chat.send("", attachments: [images[0]]))
+        #expect(client.prompts.last?.prompt == "")
+        client.shouldFail = true
+        #expect(await chat.send("again", attachments: [images[0]]) == false)
+        #expect(chat.promptError != nil)
+        #expect(chat.transcript.pendingPrompts.count == 2)
+    }
+
     @Test("perform refuses off-live inline and routes failures into actionError, never a throw")
     func performGatesAndReportsInline() async throws {
         let harness = try await acquired()

--- a/macos/ATCTests/WindowStateTests.swift
+++ b/macos/ATCTests/WindowStateTests.swift
@@ -517,13 +517,13 @@ struct WindowStateTests {
         let ref = test.threadRef("thr1")
         let other = test.threadRef("thr2")
 
-        test.model.setDraft("unfinished prompt", for: ref)
-        #expect(test.model.draft(for: ref) == "unfinished prompt")
-        #expect(test.model.draft(for: other) == "")
+        test.model.setDraft(ComposerDraft(text: "unfinished prompt"), for: ref)
+        #expect(test.model.draft(for: ref).text == "unfinished prompt")
+        #expect(test.model.draft(for: other).isEmpty)
         test.model.setViewMode(.tui, for: ref)
         test.model.setViewMode(.chat, for: ref)
-        #expect(test.model.draft(for: ref) == "unfinished prompt")
-        test.model.setDraft("", for: ref)
+        #expect(test.model.draft(for: ref).text == "unfinished prompt")
+        test.model.setDraft(ComposerDraft(), for: ref)
         #expect(test.model.threadDrafts[ref] == nil)
     }
 

--- a/packages/ATCKit/Sources/ATCAppServerAPI/ServerError.swift
+++ b/packages/ATCKit/Sources/ATCAppServerAPI/ServerError.swift
@@ -46,6 +46,9 @@ extension Components.Schemas.RequestNotFoundJsonEncoding: ServerErrorPayload {}
 extension Components.Schemas.InvalidRequestAnswerJsonEncoding: ServerErrorPayload {}
 extension Components.Schemas.QueuedPromptNotFoundJsonEncoding: ServerErrorPayload {}
 extension Components.Schemas.InvalidThreadSettingsJsonEncoding: ServerErrorPayload {}
+extension Components.Schemas.AttachmentNotFoundJsonEncoding: ServerErrorPayload {}
+extension Components.Schemas.AttachmentTooLargeJsonEncoding: ServerErrorPayload {}
+extension Components.Schemas.AttachmentInvalidJsonEncoding: ServerErrorPayload {}
 
 extension ServerError {
     /// Wrap a single-schema failure payload.

--- a/packages/ATCKit/Sources/ATCChat/ChatAttachmentViews.swift
+++ b/packages/ATCKit/Sources/ATCChat/ChatAttachmentViews.swift
@@ -1,0 +1,155 @@
+// Attachment thumbnails on user rows and in the composer (ATC-216), and the
+// full-size viewer a thumbnail opens. A thumbnail shows either local bytes
+// (a pending echo, the composer) or a server attachment read through the
+// row actions' loader; the viewer adds the filename and "Copy path" — the
+// stable server path any agent on that machine can be pointed at.
+
+import ATCAppServerAPI
+import ATCDesign
+import CoreGraphics
+import SwiftUI
+
+/// What a thumbnail renders: bytes already here, or an attachment to read.
+public enum AttachmentImage: Identifiable {
+    case local(PendingAttachment)
+    case remote(Components.Schemas.ThreadAttachment)
+
+    public var id: String {
+        switch self {
+        case .local(let pending): pending.id.uuidString
+        case .remote(let attachment): attachment.id
+        }
+    }
+
+    var name: String {
+        switch self {
+        case .local(let pending): pending.name
+        case .remote(let attachment): attachment.name
+        }
+    }
+
+    /// The server path, once the attachment has one.
+    var path: String? {
+        if case .remote(let attachment) = self { return attachment.path }
+        return nil
+    }
+
+    /// The decoded image: local bytes decode here, a server attachment goes
+    /// through `remote` (the row actions' loader).
+    func load(remote: (Components.Schemas.ThreadAttachment) async -> CGImage?) async -> CGImage? {
+        switch self {
+        case .local(let pending): ImageAttachmentEncoder.decode(pending.data)
+        case .remote(let attachment): await remote(attachment)
+        }
+    }
+}
+
+/// A row of thumbnails, each opening the viewer. `remove` adds an ✕ badge
+/// (the composer); rows pass nil.
+public struct AttachmentStrip: View {
+    let images: [AttachmentImage]
+    var remove: ((AttachmentImage) -> Void)?
+
+    @State private var viewing: AttachmentImage?
+
+    public init(images: [AttachmentImage], remove: ((AttachmentImage) -> Void)? = nil) {
+        self.images = images
+        self.remove = remove
+    }
+
+    public var body: some View {
+        HStack(spacing: Spacing.sm) {
+            ForEach(images) { image in
+                Button {
+                    viewing = image
+                } label: {
+                    AttachmentThumbnail(image: image)
+                }
+                .buttonStyle(.plain)
+                .help(image.name)
+                .accessibilityLabel("Image \(image.name)")
+                .overlay(alignment: .topTrailing) {
+                    if let remove {
+                        Button {
+                            remove(image)
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .symbolRenderingMode(.palette)
+                                .foregroundStyle(.white, .black.opacity(0.6))
+                        }
+                        .buttonStyle(.plain)
+                        .offset(x: 4, y: -4)
+                        .help("Remove \(image.name)")
+                        .accessibilityLabel("Remove \(image.name)")
+                    }
+                }
+            }
+        }
+        .sheet(item: $viewing) { image in
+            AttachmentViewer(image: image)
+        }
+    }
+}
+
+/// One thumbnail: a fixed square that shows the image once decoded.
+struct AttachmentThumbnail: View {
+    let image: AttachmentImage
+    var side: CGFloat = 72
+
+    @Environment(\.chatRowActions) private var actions
+    @State private var decoded: CGImage?
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: Radius.chip).fill(Surface.raised)
+            if let decoded {
+                Image(decorative: decoded, scale: 1)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                Image(systemName: "photo")
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .frame(width: side, height: side)
+        .clipShape(RoundedRectangle(cornerRadius: Radius.chip))
+        .task(id: image.id) { decoded = await image.load(remote: actions.loadAttachment) }
+    }
+}
+
+/// The full-size view of one attachment.
+private struct AttachmentViewer: View {
+    let image: AttachmentImage
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.chatRowActions) private var actions
+    @State private var decoded: CGImage?
+
+    var body: some View {
+        VStack(spacing: Spacing.md) {
+            HStack {
+                Text(image.name).font(.headline).lineLimit(1)
+                Spacer()
+                if let path = image.path {
+                    Button("Copy path") { Clipboard.copy(path) }
+                        .help(path)
+                }
+                Button("Done") { dismiss() }
+                    .keyboardShortcut(.defaultAction)
+            }
+            Group {
+                if let decoded {
+                    Image(decorative: decoded, scale: 1)
+                        .resizable()
+                        .scaledToFit()
+                } else {
+                    ProgressView()
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .padding(Spacing.lg)
+        .frame(minWidth: 480, minHeight: 360)
+        .task { decoded = await image.load(remote: actions.loadAttachment) }
+    }
+}

--- a/packages/ATCKit/Sources/ATCChat/ChatItemRows.swift
+++ b/packages/ATCKit/Sources/ATCChat/ChatItemRows.swift
@@ -22,6 +22,8 @@ import SwiftUI
 struct ChatRowActions {
     var retry: (String) -> Void = { _ in }
     var answer: (String, ThreadRequestAnswer) -> Void = { _, _ in }
+    /// The bytes of an attachment on a user row, decoded (nil = unreadable).
+    var loadAttachment: (Components.Schemas.ThreadAttachment) async -> CGImage? = { _ in nil }
 }
 
 extension EnvironmentValues {
@@ -76,10 +78,15 @@ struct ChatNodeView: View {
         switch node.box.item {
         case .userMessage(let message):
             VStack(alignment: .trailing, spacing: Spacing.xs) {
-                MarkdownText(text: message.text)
-                    .padding(Spacing.md)
-                    .background(Surface.raised, in: RoundedRectangle(cornerRadius: Radius.chip))
-                    .copyable(message.text)
+                if let attachments = message.attachments, !attachments.isEmpty {
+                    AttachmentStrip(images: attachments.map { .remote($0) })
+                }
+                if !message.text.isEmpty {
+                    MarkdownText(text: message.text)
+                        .padding(Spacing.md)
+                        .background(Surface.raised, in: RoundedRectangle(cornerRadius: Radius.chip))
+                        .copyable(message.text)
+                }
                 if node.turnIsSettled, let createdAt = message.createdAt {
                     TimestampCaption(date: createdAt)
                 }
@@ -178,9 +185,16 @@ private struct ChatPendingPromptRow: View {
     let prompt: PendingPrompt
 
     var body: some View {
-        MarkdownText(text: prompt.text)
-            .padding(Spacing.md)
-            .background(Surface.raised, in: RoundedRectangle(cornerRadius: Radius.chip))
+        VStack(alignment: .trailing, spacing: Spacing.xs) {
+            if !prompt.attachments.isEmpty {
+                AttachmentStrip(images: prompt.attachments.map { .local($0) })
+            }
+            if !prompt.text.isEmpty {
+                MarkdownText(text: prompt.text)
+                    .padding(Spacing.md)
+                    .background(Surface.raised, in: RoundedRectangle(cornerRadius: Radius.chip))
+            }
+        }
     }
 }
 

--- a/packages/ATCKit/Sources/ATCChat/ChatPreviews.swift
+++ b/packages/ATCKit/Sources/ATCChat/ChatPreviews.swift
@@ -69,7 +69,12 @@ import SwiftUI
                     .userMessage(
                         .init(
                             _type: .userMessage, id: "u1", turnId: "t1",
-                            createdAt: date(0), text: "Render **markdown** properly, please.")),
+                            createdAt: date(0), text: "Render **markdown** properly, please.",
+                            attachments: [
+                                .init(
+                                    id: "a1", name: "comp.png", mediaType: .imagePng, byteSize: 2048,
+                                    path: "/Users/dev/.local/share/atc/attachments/t/a1.png", createdAt: date(0))
+                            ])),
                     .reasoning(
                         .init(
                             _type: .reasoning, id: "r1", turnId: "t1",

--- a/packages/ATCKit/Sources/ATCChat/ChatTranscript.swift
+++ b/packages/ATCKit/Sources/ATCChat/ChatTranscript.swift
@@ -66,6 +66,8 @@ enum ChatMutation: Equatable {
 struct PendingPrompt: Identifiable, Equatable {
     let id: String
     let text: String
+    /// The images sent with it, shown from local bytes until the real item lands.
+    let attachments: [PendingAttachment]
     /// The admitted prompt's id, once the send response arrived.
     var promptId: String?
     /// The turn the prompt started, once known (response or turn event).
@@ -133,8 +135,8 @@ struct ChatTranscript: Equatable {
     // MARK: - Pending prompts
 
     /// A send left for the server: echo it at the tail immediately.
-    mutating func addPending(_ text: String) -> String {
-        let pending = PendingPrompt(id: UUID().uuidString, text: text)
+    mutating func addPending(_ text: String, attachments: [PendingAttachment] = []) -> String {
+        let pending = PendingPrompt(id: UUID().uuidString, text: text, attachments: attachments)
         pendingPrompts.append(pending)
         return pending.id
     }
@@ -185,11 +187,13 @@ struct ChatTranscript: Equatable {
     private mutating func settle(byAppended item: ThreadItem) -> Bool {
         guard case .userMessage(let message) = item, !pendingPrompts.isEmpty else { return false }
         matchPendingTurns()
-        let index = pendingPrompts.firstIndex { pending in
-            if let turnId = pending.turnId { return turnId == message.turnId }
-            return pending.promptId == nil && pending.text == message.text
+        let byTurn = pendingPrompts.firstIndex { $0.turnId != nil && $0.turnId == message.turnId }
+        // Text identifies an echo only when it is unambiguous: two image-only
+        // prompts in flight both read "", and the wrong one must not settle.
+        let byText = pendingPrompts.indices.filter {
+            pendingPrompts[$0].promptId == nil && pendingPrompts[$0].text == message.text
         }
-        guard let index else { return false }
+        guard let index = byTurn ?? (byText.count == 1 ? byText[0] : nil) else { return false }
         pendingPrompts.remove(at: index)
         return true
     }

--- a/packages/ATCKit/Sources/ATCChat/ChatTranscriptView.swift
+++ b/packages/ATCKit/Sources/ATCChat/ChatTranscriptView.swift
@@ -141,7 +141,8 @@ public struct ChatTranscriptView: View {
                     },
                     answer: { [chat] requestID, answer in
                         chat.perform { try await chat.answer(requestID: requestID, answer) }
-                    }
+                    },
+                    loadAttachment: { [chat] attachment in await chat.image(for: attachment) }
                 )
             )
             .onScrollGeometryChange(for: ChatFollowSignal.self, of: ChatFollowSignal.init) { old, new in

--- a/packages/ATCKit/Sources/ATCChat/ImageAttachmentEncoder.swift
+++ b/packages/ATCKit/Sources/ATCChat/ImageAttachmentEncoder.swift
@@ -1,0 +1,151 @@
+// Images the composer holds before a send (ATC-216): the bytes stay on the
+// client until the prompt goes, and every image is made to fit the server's
+// caps first — the accepted formats (PNG, JPEG, GIF, WebP) and the 8 MB
+// per-image limit. ImageIO only, so iOS shares the code; nothing here talks
+// to the server.
+//
+// Fitting rules: a supported format under the cap passes through byte for
+// byte (no recompression of what the user pasted). Anything else — an
+// unsupported format (TIFF from the pasteboard, HEIC from Photos) or an
+// oversized image — is decoded and re-encoded as PNG when it has alpha,
+// JPEG otherwise, at progressively smaller scales until it fits. A GIF that
+// needs re-encoding loses its animation (it becomes a PNG of the first
+// frame) — the cap wins. The filename keeps the user's stem and takes the
+// extension of the format actually sent.
+
+import ATCAppServerAPI
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+public typealias AttachmentMediaType = Components.Schemas.AttachmentMediaType
+
+/// An image ready to upload with the next prompt.
+public nonisolated struct PendingAttachment: Identifiable, Equatable, Sendable {
+    public let id: UUID
+    public let data: Data
+    public let mediaType: AttachmentMediaType
+    public let name: String
+
+    public init(id: UUID = UUID(), data: Data, mediaType: AttachmentMediaType, name: String) {
+        self.id = id
+        self.data = data
+        self.mediaType = mediaType
+        self.name = name
+    }
+}
+
+public nonisolated enum ImageAttachmentError: LocalizedError, Equatable {
+    case notAnImage
+    case cannotFit
+
+    public var errorDescription: String? {
+        switch self {
+        case .notAnImage: "That is not an image."
+        case .cannotFit: "The image cannot be made small enough to send."
+        }
+    }
+}
+
+// Nonisolated so the composer can run `prepare` off the main actor: a large
+// image decodes and re-encodes for long enough to freeze typing otherwise.
+public nonisolated enum ImageAttachmentEncoder {
+    /// The server's per-image cap.
+    public static let maxBytes = 8 * 1024 * 1024
+    /// The server's per-prompt cap.
+    public static let maxPerPrompt = 10
+
+    /// Scales tried when an image must shrink, largest first.
+    private static let scales: [CGFloat] = [1, 0.75, 0.5, 0.35, 0.25, 0.15, 0.1]
+
+    /// Makes `data` an attachment the server accepts (see the header).
+    /// `maxBytes` is the server's cap; tests lower it.
+    public static func prepare(_ data: Data, name: String? = nil, maxBytes: Int = maxBytes) throws
+        -> PendingAttachment
+    {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+            CGImageSourceGetCount(source) > 0
+        else { throw ImageAttachmentError.notAnImage }
+        let sourceType = (CGImageSourceGetType(source) as String?).flatMap(UTType.init)
+        if let mediaType = sourceType.flatMap(AttachmentMediaType.init(type:)), data.count <= maxBytes {
+            return PendingAttachment(data: data, mediaType: mediaType, name: fileName(name, for: mediaType))
+        }
+        guard let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            throw ImageAttachmentError.notAnImage
+        }
+        let mediaType: AttachmentMediaType = hasAlpha(image) ? .imagePng : .imageJpeg
+        for scale in scales {
+            guard let scaled = scale == 1 ? image : resized(image, scale: scale),
+                let encoded = encode(scaled, as: mediaType)
+            else { continue }
+            if encoded.count <= maxBytes {
+                return PendingAttachment(data: encoded, mediaType: mediaType, name: fileName(name, for: mediaType))
+            }
+        }
+        throw ImageAttachmentError.cannotFit
+    }
+
+    /// Decodes an image for display (thumbnails, the viewer).
+    public static func decode(_ data: Data) -> CGImage? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        return CGImageSourceCreateImageAtIndex(source, 0, nil)
+    }
+
+    private static func hasAlpha(_ image: CGImage) -> Bool {
+        switch image.alphaInfo {
+        case .none, .noneSkipFirst, .noneSkipLast: false
+        default: true
+        }
+    }
+
+    private static func resized(_ image: CGImage, scale: CGFloat) -> CGImage? {
+        let width = max(1, Int(CGFloat(image.width) * scale))
+        let height = max(1, Int(CGFloat(image.height) * scale))
+        guard
+            let context = CGContext(
+                data: nil, width: width, height: height, bitsPerComponent: 8, bytesPerRow: 0,
+                space: CGColorSpace(name: CGColorSpace.sRGB)!,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+        else { return nil }
+        context.interpolationQuality = .high
+        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+        return context.makeImage()
+    }
+
+    private static func encode(_ image: CGImage, as mediaType: AttachmentMediaType) -> Data? {
+        let data = NSMutableData()
+        guard
+            let destination = CGImageDestinationCreateWithData(
+                data, mediaType.utType.identifier as CFString, 1, nil)
+        else { return nil }
+        let options: [CFString: Any] =
+            mediaType == .imageJpeg ? [kCGImageDestinationLossyCompressionQuality: 0.85] : [:]
+        CGImageDestinationAddImage(destination, image, options as CFDictionary)
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return data as Data
+    }
+
+    /// The user's stem (or "image") with the sent format's extension.
+    private static func fileName(_ name: String?, for mediaType: AttachmentMediaType) -> String {
+        let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let stem = trimmed.isEmpty ? "image" : (trimmed as NSString).deletingPathExtension
+        return "\(stem.isEmpty ? "image" : stem).\(mediaType.utType.preferredFilenameExtension ?? "img")"
+    }
+}
+
+nonisolated extension AttachmentMediaType {
+    public var utType: UTType {
+        switch self {
+        case .imagePng: .png
+        case .imageJpeg: .jpeg
+        case .imageGif: .gif
+        case .imageWebp: .webP
+        }
+    }
+
+    init?(type: UTType) {
+        guard let match = Self.allCases.first(where: { type.conforms(to: $0.utType) }) else { return nil }
+        self = match
+    }
+}

--- a/packages/ATCKit/Sources/ATCChat/ThreadChatModel.swift
+++ b/packages/ATCKit/Sources/ATCChat/ThreadChatModel.swift
@@ -40,11 +40,19 @@
 // and resolves when the server shows it somewhere real. `perform` is the
 // action seam: gated on this stream being live (not the app-wide connection
 // dot) and reporting failures inline (`actionError`), never as a modal.
+//
+// Attachments (ATC-216) ride the send: each image uploads first, then the
+// prompt names their ids — an upload failure is a refusal like any other (the
+// composer keeps text and images). Attachment bytes for user rows are read
+// back lazily and cached here per id for the model's life; a pending echo
+// shows its local bytes and never fetches.
 
 import ATCAppServerAPI
 import ATCAppServerTransport
+import CoreGraphics
 import Foundation
 import Observation
+import OpenAPIRuntime
 import SwiftUI
 
 @Observable
@@ -91,6 +99,8 @@ public final class ThreadChatModel {
 
     private let client: any APIProtocol
     private let makeStream: StreamFactory
+    /// Decoded attachment images by id, shared by every row showing them.
+    @ObservationIgnored private var attachmentImages: [String: Task<CGImage?, Never>] = [:]
     private let cursor = SeqCursor()
     @ObservationIgnored private var boxes: [String: ChatItemModel] = [:]
     @ObservationIgnored private var folds: [String: ChatWorkModel] = [:]
@@ -311,24 +321,33 @@ public final class ThreadChatModel {
         actionError = nil
     }
 
-    /// Prompts the thread, echoing the prompt as a pending row at once.
+    /// Prompts the thread, echoing the prompt (and its images) as a pending
+    /// row at once. Images upload first; the prompt carries their ids.
     /// Returns false when the server refused (the error is in `promptError`)
-    /// so the composer restores the text.
+    /// so the composer restores text and images.
     @discardableResult
-    public func send(_ prompt: String) async -> Bool {
+    public func send(_ prompt: String, attachments: [PendingAttachment] = []) async -> Bool {
         promptError = nil
-        lastSentPrompt = prompt
-        let pendingID = transcript.addPending(prompt)
+        if !prompt.isEmpty { lastSentPrompt = prompt }
+        let pendingID = transcript.addPending(prompt, attachments: attachments)
         project(.structure)
         do {
-            switch try await client.promptThread(path: .init(threadId: threadID), body: .json(.init(prompt: prompt))) {
+            var ids: [String] = []
+            for attachment in attachments {
+                ids.append(try await upload(attachment).id)
+            }
+            let request = Components.Schemas.PromptThreadRequest(
+                prompt: prompt, attachments: ids.isEmpty ? nil : ids)
+            switch try await client.promptThread(path: .init(threadId: threadID), body: .json(request)) {
             case .ok(let ok):
                 let response = try ok.body.json
                 transcript.resolvePending(
                     id: pendingID, promptId: response.promptId, turnId: response.turnId)
                 project(.structure)
                 return true
-            case .notFound(let failure): throw ServerError(try failure.body.json)
+            case .notFound(let failure):
+                let payload = try failure.body.json
+                throw ServerError(anyOf: payload.value1, payload.value2)
             case .conflict(let failure):
                 let payload = try failure.body.json
                 throw ServerError(anyOf: payload.value1, payload.value2)
@@ -341,6 +360,47 @@ public final class ThreadChatModel {
             promptError = error.localizedDescription
             return false
         }
+    }
+
+    private func upload(_ attachment: PendingAttachment) async throws -> Components.Schemas.ThreadAttachment {
+        let body = HTTPBody(attachment.data)
+        let payload: Operations.CreateThreadAttachment.Input.Body =
+            switch attachment.mediaType {
+            case .imagePng: .png(body)
+            case .imageJpeg: .jpeg(body)
+            case .imageGif: .imageGif(body)
+            case .imageWebp: .imageWebp(body)
+            }
+        switch try await client.createThreadAttachment(
+            path: .init(threadId: threadID), query: .init(name: attachment.name), body: payload)
+        {
+        case .ok(let ok): return try ok.body.json
+        case .notFound(let failure): throw ServerError(try failure.body.json)
+        case .conflict(let failure): throw ServerError(try failure.body.json)
+        case .contentTooLarge(let failure): throw ServerError(try failure.body.json)
+        case .unprocessableContent(let failure): throw ServerError(try failure.body.json)
+        case .undocumented(statusCode: let status, _): throw ServerError.undocumented(status: status)
+        }
+    }
+
+    /// The decoded image of an attachment on a user row, fetched once per
+    /// model and shared. Nil when the read fails (the row shows a placeholder).
+    public func image(for attachment: Components.Schemas.ThreadAttachment) async -> CGImage? {
+        if let inFlight = attachmentImages[attachment.id] { return await inFlight.value }
+        let load = Task { [client, threadID] () -> CGImage? in
+            guard
+                case .ok(let ok) = try? await client.getThreadAttachment(
+                    path: .init(threadId: threadID, attachmentId: attachment.id)),
+                let body = try? ok.body.binary,
+                let data = try? await Data(collecting: body, upTo: ImageAttachmentEncoder.maxBytes)
+            else { return nil }
+            return ImageAttachmentEncoder.decode(data)
+        }
+        attachmentImages[attachment.id] = load
+        let image = await load.value
+        // A failed read is not cached: the next appearance retries.
+        if image == nil { attachmentImages[attachment.id] = nil }
+        return image
     }
 
     /// Interrupts the server-driven turn; a TUI-driven turn is a server

--- a/packages/ATCKit/Tests/ATCChatTests/ImageAttachmentEncoderTests.swift
+++ b/packages/ATCKit/Tests/ATCChatTests/ImageAttachmentEncoderTests.swift
@@ -1,0 +1,98 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import Testing
+import UniformTypeIdentifiers
+
+@testable import ATCChat
+
+/// The encoder's fitting rules: supported formats under the cap pass
+/// through untouched, unsupported formats convert (alpha → PNG, opaque →
+/// JPEG), oversized images shrink until they fit, and non-images are refused.
+@Suite("ImageAttachmentEncoder")
+struct ImageAttachmentEncoderTests {
+    /// A solid (or translucent) image of the given size, encoded as `type`.
+    private func image(width: Int, height: Int, alpha: Bool, as type: UTType) throws -> Data {
+        let space = try #require(CGColorSpace(name: CGColorSpace.sRGB))
+        // Deterministic per-pixel noise (a linear congruential sequence)
+        // defeats every encoder's compression, so a large image really is
+        // large at full size — the same bytes every run.
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        var seed: UInt32 = 7
+        for index in stride(from: 0, to: pixels.count, by: 4) {
+            seed = seed &* 1_664_525 &+ 1_013_904_223
+            // Premultiplied: color never exceeds the alpha byte.
+            let mask: UInt32 = alpha ? 0x7f : 0xff
+            pixels[index] = UInt8(truncatingIfNeeded: (seed >> 24) & mask)
+            pixels[index + 1] = UInt8(truncatingIfNeeded: (seed >> 16) & mask)
+            pixels[index + 2] = UInt8(truncatingIfNeeded: (seed >> 8) & mask)
+            pixels[index + 3] = alpha ? 0x80 : 0xff
+        }
+        let cgImage = try #require(
+            pixels.withUnsafeMutableBytes { buffer in
+                CGContext(
+                    data: buffer.baseAddress, width: width, height: height, bitsPerComponent: 8,
+                    bytesPerRow: width * 4, space: space,
+                    bitmapInfo: (alpha ? CGImageAlphaInfo.premultipliedLast : .noneSkipLast).rawValue
+                )?.makeImage()
+            })
+        let data = NSMutableData()
+        let destination = try #require(
+            CGImageDestinationCreateWithData(data, type.identifier as CFString, 1, nil))
+        CGImageDestinationAddImage(destination, cgImage, nil)
+        #expect(CGImageDestinationFinalize(destination))
+        return data as Data
+    }
+
+    @Test("a small PNG passes through byte for byte, keeping the user's stem")
+    func passThrough() throws {
+        let png = try image(width: 8, height: 8, alpha: true, as: .png)
+        let prepared = try ImageAttachmentEncoder.prepare(png, name: "Screenshot 1.png")
+        #expect(prepared.data == png)
+        #expect(prepared.mediaType == .imagePng)
+        #expect(prepared.name == "Screenshot 1.png")
+    }
+
+    @Test("TIFF converts: alpha becomes PNG, opaque becomes JPEG, and the extension follows")
+    func convertsUnsupported() throws {
+        let translucent = try image(width: 8, height: 8, alpha: true, as: .tiff)
+        let png = try ImageAttachmentEncoder.prepare(translucent, name: "shot.tiff")
+        #expect(png.mediaType == .imagePng)
+        #expect(png.name == "shot.png")
+        #expect(ImageAttachmentEncoder.decode(png.data) != nil)
+
+        let opaque = try image(width: 8, height: 8, alpha: false, as: .tiff)
+        let jpeg = try ImageAttachmentEncoder.prepare(opaque, name: nil)
+        #expect(jpeg.mediaType == .imageJpeg)
+        #expect(jpeg.name == "image.jpeg")
+    }
+
+    @Test("an oversized image shrinks until it fits the cap")
+    func shrinksToFit() throws {
+        // A lowered cap keeps the fixture small; the rule is the same.
+        let cap = 64 * 1024
+        let big = try image(width: 480, height: 480, alpha: false, as: .png)
+        try #require(big.count > cap)
+        let prepared = try ImageAttachmentEncoder.prepare(big, name: "big.png", maxBytes: cap)
+        #expect(prepared.data.count <= cap)
+        #expect(prepared.mediaType == .imageJpeg)
+        #expect(prepared.name == "big.jpeg")
+        let decoded = try #require(ImageAttachmentEncoder.decode(prepared.data))
+        #expect(decoded.width < 480)
+    }
+
+    @Test("an image that cannot fit the cap is refused")
+    func refusesUnfittable() throws {
+        let png = try image(width: 64, height: 64, alpha: true, as: .png)
+        #expect(throws: ImageAttachmentError.cannotFit) {
+            try ImageAttachmentEncoder.prepare(png, name: "tiny.png", maxBytes: 16)
+        }
+    }
+
+    @Test("non-image bytes are refused")
+    func refusesNonImages() {
+        #expect(throws: ImageAttachmentError.notAnImage) {
+            try ImageAttachmentEncoder.prepare(Data("hello".utf8), name: "notes.txt")
+        }
+    }
+}


### PR DESCRIPTION
PR A of ATC-216 (Composer as the front door), tracked as ATC-221. Image attachments for thread prompts, end to end: server capability first (so the CLI, iOS and integrations get it), macOS composer second.

## Server

- **Contract**: `ThreadAttachment { id, name, mediaType, byteSize, path, createdAt }`; `POST /threads/:id/attachments` takes the raw bytes with the image type as `Content-Type` — one `Uint8Array` payload per accepted type (PNG, JPEG, GIF, WebP), so anything else is a 415 before a byte is read and the OpenAPI document *is* the allowlist; `GET /threads/:id/attachments/:attachmentId` streams the bytes back (`application/octet-stream`). `PromptThreadRequest.attachments: [id]` (≤ 10; the prompt text may be empty when images are present), `userMessage.attachments`, `QueuedPrompt.attachments`. New tagged errors: `AttachmentNotFound` 404, `AttachmentTooLarge` 413, `AttachmentInvalid` 422.
- **Storage**: `thread_attachments` table + `thread_queue.attachments` (ids) in migration 0009; bytes at `<dataDir>/attachments/<threadId>/<id>.<ext>` — the first per-thread on-disk state, removed by `Threads.delete`. The stored media type is the truth of the bytes: an upload whose bytes lack the declared format's signature is refused, so `path` can be handed to any agent as the image it claims to be. No orphan GC by design (clients upload at send).
- **Seam**: `startTurn`/`createSession` take a `TurnInput { text, attachments }`. Claude inlines each image as a base64 block (the SDK child never sees a path); Codex sends `localImage { path }` and maps the provider's echoed item back to our attachments by path. Both put the attachments on the prompt's `userMessage` item. The transcript repository carries attachments forward across a provider re-read by item id (like timestamps) — which holds for Codex and is a documented no-op for Claude, whose history ids are minted per read.
- **CLI**: `atc api` grows `--content-type`, and `--input` is bytes, so `atc api POST /api/v1/threads/<id>/attachments --input shot.png --content-type image/png` works.

## macOS / ATCKit

- Composer: paste, drop, pick (⌘⇧A), thumbnails with remove, up to 10; bytes held locally until send; a prompt may be images alone. Draft attachments live with the text draft on `AppModel`.
- `ImageAttachmentEncoder` (ATCChat, ImageIO only so iOS shares it): supported formats under 8 MB pass through byte-for-byte; anything else (TIFF/HEIC, oversized) re-encodes as PNG (alpha) or JPEG at decreasing scales until it fits.
- Send = upload each image, then `promptThread` with the ids; an upload failure is a refusal that restores text and images. The pending echo shows local thumbnails; user rows load thumbnails through the API (cached per id on the chat model); a thumbnail opens a viewer with **Copy path**.
- Test doubles (`ScriptableAppServerClient`, `PreviewAppServerClient`) implement the two operations.

## Verification

`mise run -C app-server check` (497 tests), `mise run kit:test` (66), `mise run macos:test` (342), `swift:lint` / `swift:fmt:check` clean. New coverage: raw upload/download/refusals and prompt-with-attachments against the documented OpenAPI shapes; runtime (adapter input, item, queue event, delete purge, re-read carry-forward); Claude (base64 block, unreadable file fails the turn) and Codex (localImage round trip) adapters; encoder unit tests; `ThreadChatModel` send with attachments.

https://claude.ai/code/session_01Rk3dUZMQeQAJBmoeCxrHUp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image attachments to thread prompts.
  * Upload images by paste, drag-and-drop, or file selection.
  * View attachment thumbnails and full-size images in conversations.
  * Support image-only prompts and queued prompts with attachments.
  * Added attachment upload and download API support.
* **Bug Fixes**
  * Added validation and clear errors for unsupported, oversized, empty, or missing images.
  * Preserved attachments across queued prompts, history, and provider responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->