### PR TITLE
Composer intelligence: file search, commands, nudge a running turn (ATC-222)

### DIFF
--- a/app-server/bun.lock
+++ b/app-server/bun.lock
@@ -9,6 +9,7 @@
         "@effect/platform-bun": "4.0.0-beta.102",
         "@effect/sql-sqlite-bun": "4.0.0-beta.102",
         "effect": "4.0.0-beta.102",
+        "ignore": "7.0.5",
       },
       "devDependencies": {
         "@effect/vitest": "4.0.0-beta.102",
@@ -360,6 +361,8 @@
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
+
+    "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 

--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -1258,7 +1258,7 @@
             }
           }
         },
-        "description": "Prompt the thread. Always admitted: an idle thread starts a turn at once (`turnId` present) and a busy one queues the prompt to run at the next idle (`turnId` absent) — there is no busy error and no lock between surfaces. On a one-process provider (Claude Code) a prompt while the TUI is live takes the thread over: the TUI ends once idle, the turn runs natively, and the TUI relaunches when the queue drains (see openThreadTerminal). The turn is server-owned: the client's connection never matters to it. When the prompt would start now and the provider refuses, it is un-admitted (the error means not accepted; nothing stays queued); a prompt queued behind others is admitted regardless. Follow the turn on the per-thread event stream.",
+        "description": "Prompt the thread. Always admitted: an idle thread starts a turn at once and a busy one queues the prompt for the next idle — or hands it to the running turn with `when: \"now\"` (see PromptThreadRequest); `turnId` tells which. There is no busy error and no lock between surfaces. On a one-process provider (Claude Code) a prompt while the TUI is live takes the thread over: the TUI ends once idle, the turn runs natively, and the TUI relaunches when the queue drains (see openThreadTerminal). The turn is server-owned: the client's connection never matters to it. When the prompt would start now and the provider refuses, it is un-admitted (the error means not accepted; nothing stays queued); a prompt queued behind others is admitted regardless. Follow the turn on the per-thread event stream.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1919,6 +1919,84 @@
         "description": "The agent's model catalog as its provider reports it, cached server-side for a short while."
       }
     },
+    "/api/v1/agents/{agentId}/commands": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "listAgentCommands",
+        "parameters": [
+          {
+            "name": "agentId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "dir",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\/",
+              "description": "Directory the commands are resolved in (project and user scopes)."
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The agent's commands for a directory, as its provider lists them.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentCommandList"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No built-in agent exists with the given id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentNotFoundJsonEncoding"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The directory does not exist, is not a directory, or cannot be read/traversed. | The directory check did not complete within its bounded timeout. Retryable — a timeout is not proof the path is missing.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/DirectoryUnavailableJsonEncoding"
+                    },
+                    {
+                      "$ref": "#/components/schemas/DirectoryCheckTimedOutJsonEncoding"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The thread's agent provider cannot be used right now (not installed, not ready, or unreachable). Retryable once the cause is fixed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderUnavailableJsonEncoding"
+                }
+              }
+            }
+          }
+        },
+        "description": "The slash commands and skills the agent offers in `dir` — answerable with no thread and no live session, so a cold thread and a thread not yet created complete alike. Cached server-side per agent and directory for a short while; an empty list is a real answer. Commands are inserted into a prompt as plain text."
+      }
+    },
     "/api/v1/events": {
       "get": {
         "tags": [
@@ -2022,6 +2100,75 @@
           }
         },
         "description": "List a directory's subdirectories for the server-backed folder browser: non-recursive, dotfolders excluded, symlinks included when they resolve to directories, sorted case-insensitively. Omitting `path` lists the server's home directory. Same bounded timeout and tagged errors as the health check; nothing is persisted."
+      }
+    },
+    "/api/v1/fs/files": {
+      "get": {
+        "tags": [
+          "v1"
+        ],
+        "operationId": "searchFiles",
+        "parameters": [
+          {
+            "name": "dir",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\/",
+              "description": "Directory tree to search."
+            },
+            "required": true
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "description": "Filename query (case-insensitive); omitted or empty lists files in path order."
+            },
+            "required": false
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "pattern": "^\\d+$",
+              "description": "Entries to return (default 25, at most 200)."
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A ranked filename search over one directory tree (`@` mentions). Never persisted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FsFilesResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The directory does not exist, is not a directory, or cannot be read/traversed. | The directory check did not complete within its bounded timeout. Retryable — a timeout is not proof the path is missing.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/DirectoryUnavailableJsonEncoding"
+                    },
+                    {
+                      "$ref": "#/components/schemas/DirectoryCheckTimedOutJsonEncoding"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "description": "Search the files under `dir` by name (`@` mentions): best matches first, with `.git` and every `.gitignore`'s exclusions skipped and the tree capped (see `truncated`). Directory-driven, not project-scoped: pass a thread's working directory, a worktree, or the directory a new thread will use. Same validation and tagged errors as /fs/list; nothing is persisted."
       }
     }
   },
@@ -2854,6 +3001,14 @@
             },
             "maxItems": 10,
             "description": "Ids of attachments previously uploaded to THIS thread (createThreadAttachment), in display order. An id the thread does not own is a 404."
+          },
+          "when": {
+            "type": "string",
+            "enum": [
+              "queue",
+              "now"
+            ],
+            "description": "\"queue\" (the default) runs the prompt at the next idle. \"now\" hands it to the turn ATC is running as a mid-turn message — the provider folds it into the work in progress and it lands in the transcript as that turn's next user message — and queues only when no turn of ATC's is running (a TUI-driven turn included) or the turn ended first. The response says which: `turnId` present is the turn it joined or started."
           }
         },
         "required": [
@@ -2870,7 +3025,7 @@
           },
           "turnId": {
             "type": "string",
-            "description": "Present when the prompt started a turn at once; absent when it queued."
+            "description": "Present when the prompt started a turn at once or joined the running one (`when: \"now\"`); absent when it queued."
           }
         },
         "required": [
@@ -4179,6 +4334,35 @@
         },
         "description": "An agent's model catalog, in the provider's order."
       },
+      "AgentCommand": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Command name, without the leading slash."
+          },
+          "description": {
+            "type": "string"
+          },
+          "argumentHint": {
+            "type": "string",
+            "description": "Placeholder for the arguments the command takes."
+          }
+        },
+        "required": [
+          "name",
+          "description"
+        ],
+        "additionalProperties": false,
+        "description": "A slash command or skill the agent offers in a directory (`/` completions)."
+      },
+      "AgentCommandList": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/AgentCommand"
+        },
+        "description": "The agent's commands for a directory, as its provider lists them."
+      },
       "ResourceChangedEventJsonEncoding": {
         "type": "string",
         "contentMediaType": "application/json"
@@ -4266,6 +4450,52 @@
         ],
         "additionalProperties": false,
         "description": "A directory listing for the server-backed folder browser. Never persisted."
+      },
+      "FsFileEntry": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Path relative to `dir`, `/`-separated."
+          },
+          "name": {
+            "type": "string",
+            "description": "The file's basename."
+          }
+        },
+        "required": [
+          "path",
+          "name"
+        ],
+        "additionalProperties": false,
+        "description": "One file under a searched directory."
+      },
+      "FsFilesResponse": {
+        "type": "object",
+        "properties": {
+          "dir": {
+            "type": "string",
+            "description": "Canonical (symlink-resolved) absolute path of the searched directory."
+          },
+          "entries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FsFileEntry"
+            },
+            "description": "Best matches first; an empty query lists files in path order."
+          },
+          "truncated": {
+            "type": "boolean",
+            "description": "True when the tree holds more files than the index walks, so a file may be missing from every query of this directory."
+          }
+        },
+        "required": [
+          "dir",
+          "entries",
+          "truncated"
+        ],
+        "additionalProperties": false,
+        "description": "A ranked filename search over one directory tree (`@` mentions). Never persisted."
       },
       "ResourceChangedEvent": {
         "type": "object",

--- a/app-server/openapi.json
+++ b/app-server/openapi.json
@@ -1916,7 +1916,7 @@
             }
           }
         },
-        "description": "The agent's model catalog as its provider reports it, cached server-side for a short while."
+        "description": "The agent's model catalog as its provider reports it. Cached server-side for a short while; expiry is lazy — no periodic task, the provider is asked again only on the next request after it — so a client that wants a fresh catalog asks again."
       }
     },
     "/api/v1/agents/{agentId}/commands": {
@@ -1994,7 +1994,7 @@
             }
           }
         },
-        "description": "The slash commands and skills the agent offers in `dir` — answerable with no thread and no live session, so a cold thread and a thread not yet created complete alike. Cached server-side per agent and directory for a short while; an empty list is a real answer. Commands are inserted into a prompt as plain text."
+        "description": "The slash commands and skills the agent offers in `dir` — answerable with no thread and no live session, so a cold thread and a thread not yet created complete alike. Cached server-side per agent and directory for a short while; expiry is lazy — no periodic task, the provider is asked again only on the next request after it — so a client that wants to see a newly added or removed skill asks again. An empty list is a real answer. Commands are inserted into a prompt as plain text."
       }
     },
     "/api/v1/events": {

--- a/app-server/package.json
+++ b/app-server/package.json
@@ -15,7 +15,8 @@
     "@anthropic-ai/claude-agent-sdk": "0.3.235",
     "@effect/platform-bun": "4.0.0-beta.102",
     "@effect/sql-sqlite-bun": "4.0.0-beta.102",
-    "effect": "4.0.0-beta.102"
+    "effect": "4.0.0-beta.102",
+    "ignore": "7.0.5"
   },
   "devDependencies": {
     "@effect/vitest": "4.0.0-beta.102",

--- a/app-server/src/agents/agentAdapter.ts
+++ b/app-server/src/agents/agentAdapter.ts
@@ -133,6 +133,7 @@ export type ReasoningLevel = typeof Contract.ReasoningLevel.Type
 export type ThreadAccess = typeof Contract.ThreadAccess.Type
 export type ThreadMode = typeof Contract.ThreadMode.Type
 export type AgentModel = typeof Contract.AgentModel.Type
+export type AgentCommand = typeof Contract.AgentCommand.Type
 export type ThreadAttachment = typeof Contract.ThreadAttachment.Type
 
 /**
@@ -305,6 +306,18 @@ export interface AgentConnection {
     | AgentProtocolError
   >
   /**
+   * Hand `input` to exactly `turn` while it runs (ATC-216 "now"): the
+   * provider folds it into the work in progress and the feed carries it as
+   * the turn's next `userMessage` item (minted here for Claude, echoed by
+   * the shared server for Codex). A target that is not the active turn —
+   * it ended, or another is running — is `AgentConflict`, never a silent
+   * queue or a new turn: the caller decides what to do with the prompt.
+   */
+  readonly steer: (
+    input: TurnInput,
+    turn: AgentTurn,
+  ) => Effect.Effect<void, AgentConflict | AgentUnavailable | AgentProtocolError>
+  /**
    * Interrupt exactly `turn`. A stale or unknown target fails with
    * `AgentConflict` — never "interrupt whatever is active". Success means
    * the provider accepted the interrupt; the truthful outcome is the feed's
@@ -475,6 +488,14 @@ export interface AgentAdapter {
     ReadonlyArray<AgentModel>,
     AgentUnavailable | AgentProtocolError
   >
+  /**
+   * The slash commands and skills the provider offers in `cwd` (ATC-216),
+   * resolved with no session of ours involved. Never persisted; callers
+   * cache it.
+   */
+  readonly listCommands: (options: {
+    readonly cwd: string
+  }) => Effect.Effect<ReadonlyArray<AgentCommand>, AgentUnavailable | AgentProtocolError>
   /**
    * One bounded, session-less completion: a short display title for a
    * thread whose first user prompt is `prompt` (ATC-155). Runs as the

--- a/app-server/src/agents/agentRegistry.ts
+++ b/app-server/src/agents/agentRegistry.ts
@@ -32,7 +32,12 @@ export type Agent = typeof Contract.Agent.Type
 //     — a failed read is never cached, so a provider that comes up later is
 //     seen;
 //   - the command list per directory (ATC-216), read the same way and cached
-//     per agent and canonical directory — the probe is the freshness model;
+//     per agent and canonical directory.
+//   Both TTLs are demand-driven: nothing runs at expiry, the provider is
+//   asked again on the next request after it, and concurrent asks coalesce
+//   into one read. The TTL bounds how often a provider is probed, not how
+//   fresh a client sees — a client sees a change on its next ask after
+//   expiry, so clients re-ask on demand rather than holding one read.
 //   - the write-through defaults a new thread inherits: the agent_defaults
 //     row when one exists, else the entry's seed here. The seed is a
 //     starting point only (the first change any thread makes replaces it);

--- a/app-server/src/agents/agentRegistry.ts
+++ b/app-server/src/agents/agentRegistry.ts
@@ -1,10 +1,11 @@
-import { Context, Duration, Effect, Layer, Option } from "effect"
+import { Cache, Context, Duration, Effect, Exit, Layer, Option } from "effect"
 import { AGENT_IDS, AgentNotFound, isAgentId, ProviderUnavailable } from "../api/contract.ts"
 import type * as Contract from "../api/contract.ts"
-import type { AgentId } from "../api/contract.ts"
+import type { AgentId, DirectoryCheckTimedOut, DirectoryUnavailable } from "../api/contract.ts"
 import { AppConfig } from "../platform/config.ts"
+import { Directories } from "../platform/directories.ts"
 import * as Subprocess from "../platform/subprocess.ts"
-import type { AgentAdapter, AgentModel, ThreadSettings } from "./agentAdapter.ts"
+import type { AgentAdapter, AgentCommand, AgentModel, ThreadSettings } from "./agentAdapter.ts"
 import {
   memoizeSuccess,
   PROVIDER_FOR_AGENT,
@@ -25,10 +26,13 @@ export type Agent = typeof Contract.Agent.Type
 // Record types make a missed entry a compile error, and threads/ never
 // changes.
 //
-// It also owns the two per-agent facts the Chat settings need (ATC-205):
-//   - the model catalog, read from the adapter and cached for a short while
-//     (Claude's read spawns a process; Codex's is a socket call) — a failed
-//     read is never cached, so a provider that comes up later is seen;
+// It also owns the per-agent facts the Chat settings and composer need:
+//   - the model catalog (ATC-205), read from the adapter and cached for a
+//     short while (Claude's read spawns a process; Codex's is a socket call)
+//     — a failed read is never cached, so a provider that comes up later is
+//     seen;
+//   - the command list per directory (ATC-216), read the same way and cached
+//     per agent and canonical directory — the probe is the freshness model;
 //   - the write-through defaults a new thread inherits: the agent_defaults
 //     row when one exists, else the entry's seed here. The seed is a
 //     starting point only (the first change any thread makes replaces it);
@@ -36,6 +40,9 @@ export type Agent = typeof Contract.Agent.Type
 
 /** How long one catalog read is served before the provider is asked again. */
 const MODEL_CATALOG_TTL: Duration.Input = "10 minutes"
+
+/** How long one command listing (per agent and directory) is served. */
+const COMMANDS_TTL: Duration.Input = "1 minute"
 
 export class AgentRegistry extends Context.Service<
   AgentRegistry,
@@ -48,6 +55,14 @@ export class AgentRegistry extends Context.Service<
     readonly models: (
       id: string,
     ) => Effect.Effect<ReadonlyArray<AgentModel>, AgentNotFound | ProviderUnavailable>
+    /** The agent's commands in `dir` (validated and canonicalized here; see the header). */
+    readonly commands: (
+      id: string,
+      dir: string,
+    ) => Effect.Effect<
+      ReadonlyArray<AgentCommand>,
+      AgentNotFound | ProviderUnavailable | DirectoryUnavailable | DirectoryCheckTimedOut
+    >
     /** What a new thread of this agent starts with (see the header). */
     readonly defaults: (id: typeof AgentId.Type) => Effect.Effect<ThreadSettings>
     /** Write-through: the settings the last changed thread ended up with. */
@@ -58,6 +73,7 @@ export class AgentRegistry extends Context.Service<
 export const layer = Layer.effect(AgentRegistry)(
   Effect.gen(function* () {
     const config = yield* AppConfig
+    const directories = yield* Directories
     const subprocess = yield* Subprocess.Subprocess
     const defaultsRepository = yield* AgentDefaultsRepository
     const codex = yield* CodexAdapter
@@ -102,6 +118,25 @@ export const layer = Layer.effect(AgentRegistry)(
       ).pipe(Effect.map((models) => [id, models] as const)),
     ).pipe(Effect.map((pairs) => new Map(pairs)))
 
+    // One command cache per agent, keyed by canonical directory; a failed
+    // probe has zero time to live, so the next ask retries.
+    const commandLists = yield* Effect.forEach(AGENT_IDS, (id) =>
+      Cache.makeWith(
+        (dir: string) =>
+          entries[id].adapter
+            .listCommands({ cwd: dir })
+            .pipe(
+              Effect.mapError(
+                (error) => new ProviderUnavailable({ agentId: id, reason: error.message }),
+              ),
+            ),
+        {
+          capacity: 32,
+          timeToLive: (exit) => (Exit.isSuccess(exit) ? COMMANDS_TTL : Duration.zero),
+        },
+      ).pipe(Effect.map((cache) => [id, cache] as const)),
+    ).pipe(Effect.map((pairs) => new Map(pairs)))
+
     const describe = (id: typeof AgentId.Type): Effect.Effect<Agent> =>
       Effect.gen(function* () {
         const availability: Omit<Agent, "id" | "defaults"> = yield* resolveProviderExecutable(
@@ -129,6 +164,12 @@ export const layer = Layer.effect(AgentRegistry)(
       adapterFor: (id) => entries[id].adapter,
       models: (id) =>
         isAgentId(id) ? catalogs.get(id)! : Effect.fail(new AgentNotFound({ agentId: id })),
+      commands: (id, dir) =>
+        isAgentId(id)
+          ? directories
+              .canonicalize(dir)
+              .pipe(Effect.flatMap((canonical) => Cache.get(commandLists.get(id)!, canonical)))
+          : Effect.fail(new AgentNotFound({ agentId: id })),
       defaults,
       setDefaults: (id, settings) => defaultsRepository.set(id, settings),
     }

--- a/app-server/src/agents/claudeAdapter.ts
+++ b/app-server/src/agents/claudeAdapter.ts
@@ -8,6 +8,7 @@ import type {
   PermissionMode,
   PermissionResult,
   PermissionUpdate,
+  SDKControlInitializeResponse,
   SDKMessage,
   SDKUserMessage,
   SessionMessage,
@@ -182,6 +183,7 @@ export interface ClaudeQueryHandle extends AsyncIterable<SDKMessage> {
   readonly setPermissionMode: (mode: PermissionMode) => Promise<void>
   readonly applyFlagSettings: (settings: { effortLevel?: EffortLevel | null }) => Promise<void>
   readonly supportedModels: () => Promise<ReadonlyArray<ModelInfo>>
+  readonly initializationResult: () => Promise<Pick<SDKControlInitializeResponse, "commands">>
 }
 
 /** The query() seam, injectable so fixture tests can script SDK streams. */
@@ -1389,6 +1391,30 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
               }
               return { turnId }
             }),
+          steer: (input, turn) =>
+            Effect.gen(function* () {
+              yield* requireOpen
+              if (session.activeTurn !== turn.turnId) {
+                return yield* Effect.fail(staleTurn(turn.turnId))
+              }
+              const content = yield* readUserContent(input)
+              // The read suspended: the turn may have ended meanwhile.
+              yield* requireOpen
+              if (session.activeTurn !== turn.turnId) {
+                return yield* Effect.fail(staleTurn(turn.turnId))
+              }
+              // The held query() takes the message mid-turn (the CLI folds
+              // it into the next model call); the SDK never echoes it, so it
+              // is minted here like the turn's first prompt.
+              emitItem(session, "itemCompleted", {
+                type: "userMessage",
+                id: `${turn.turnId}:steer:${crypto.randomUUID()}`,
+                turnId: turn.turnId,
+                text: input.text,
+                ...(input.attachments.length > 0 ? { attachments: input.attachments } : {}),
+              })
+              session.pushInput(userMessage(content))
+            }),
           interrupt: (turn) =>
             Effect.gen(function* () {
               yield* requireOpen
@@ -1609,6 +1635,60 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
                 }),
               )
               return normalizeClaudeCatalog(models)
+            }),
+          ),
+        // T3Code's probe: a child in `cwd` with a prompt that never yields,
+        // read for its initialization (the command and skill list the CLI
+        // resolved from the user and project scopes), then aborted — no API
+        // request is ever made.
+        listCommands: (options) =>
+          Effect.scoped(
+            Effect.gen(function* () {
+              const executable = yield* resolvedExecutable
+              const abort = new AbortController()
+              yield* Effect.addFinalizer(() => Effect.sync(() => abort.abort()))
+              const prompt = yield* Stream.toAsyncIterableEffect(Stream.never)
+              const handle = yield* Effect.try({
+                try: () =>
+                  queryFn({
+                    prompt,
+                    options: {
+                      abortController: abort,
+                      cwd: options.cwd,
+                      env: claudeEnvironment(),
+                      pathToClaudeCodeExecutable: executable,
+                      settingSources: ["user", "project", "local"],
+                      strictMcpConfig: true,
+                      tools: [],
+                      persistSession: false,
+                    },
+                  }),
+                catch: (error) =>
+                  protocolError(
+                    `the command list read failed to start: ${error instanceof Error ? error.message : String(error)}`,
+                  ),
+              })
+              const initialized = yield* Effect.tryPromise({
+                try: () => handle.initializationResult(),
+                catch: (error) =>
+                  protocolError(
+                    `the command list read failed: ${error instanceof Error ? error.message : String(error)}`,
+                  ),
+              }).pipe(
+                Effect.timeoutOrElse({
+                  duration: "30 seconds",
+                  orElse: () => Effect.fail(protocolError("the command list read timed out")),
+                }),
+              )
+              return initialized.commands.map((command) =>
+                command.argumentHint === ""
+                  ? { name: command.name, description: command.description }
+                  : {
+                      name: command.name,
+                      description: command.description,
+                      argumentHint: command.argumentHint,
+                    },
+              )
             }),
           ),
         generateTitle: (options) =>

--- a/app-server/src/agents/codexAdapter.ts
+++ b/app-server/src/agents/codexAdapter.ts
@@ -483,6 +483,22 @@ interface LiveSession {
   live: ProviderSettings
 }
 
+/** skills/list, decoded to what a command listing needs. */
+const SkillsListReply = Schema.Struct({
+  data: Schema.Array(
+    Schema.Struct({
+      skills: Schema.Array(
+        Schema.Struct({
+          name: Schema.String,
+          description: Schema.String,
+          enabled: Schema.Boolean,
+          shortDescription: Schema.optional(Schema.NullOr(Schema.String)),
+        }),
+      ),
+    }),
+  ),
+})
+
 /** Reserves the active-turn slot between the local check and the RPC reply. */
 const PENDING_TURN = "(pending)"
 
@@ -1319,6 +1335,29 @@ export const layer = Layer.effect(CodexAdapter)(
               }
               return { turnId: decoded.turn.id }
             }),
+          steer: (input, turn) =>
+            Effect.gen(function* () {
+              yield* requireLive
+              if (session.activeTurn !== turn.turnId) {
+                return yield* Effect.fail(staleTurn(turn.turnId))
+              }
+              for (const attachment of input.attachments) {
+                session.attachmentsByPath.set(attachment.path, attachment)
+              }
+              // expectedTurnId is the server's own precondition; its
+              // rejection means the turn ended in flight — a conflict, as
+              // for interrupt. The server echoes the message as the turn's
+              // next userMessage item on the fan-out.
+              yield* request(state, "turn/steer", {
+                threadId,
+                expectedTurnId: turn.turnId,
+                input: turnInputBlocks(input),
+              }).pipe(
+                Effect.mapError((error) =>
+                  error._tag === "RpcError" ? conflict(error.text) : error,
+                ),
+              )
+            }),
           interrupt: (turn) =>
             Effect.gen(function* () {
               yield* requireLive
@@ -1692,6 +1731,24 @@ export const layer = Layer.effect(CodexAdapter)(
             ),
           )
           return Stream.merge(observedEvents, Stream.fromQueue(promptQueue))
+        }),
+      // The shared server's skill index for the directory (the protocol
+      // lists skills only — custom prompts have no listing); disabled
+      // skills are not offered.
+      listCommands: (options) =>
+        Effect.gen(function* () {
+          const state = yield* getClient
+          const reply = yield* request(state, "skills/list", { cwds: [options.cwd] }).pipe(
+            Effect.mapError(rpcToProtocol),
+            Effect.flatMap((raw) => decodeReply(SkillsListReply, raw)),
+          )
+          return reply.data
+            .flatMap((entry) => entry.skills)
+            .filter((skill) => skill.enabled)
+            .map((skill) => ({
+              name: skill.name,
+              description: skill.shortDescription ?? skill.description,
+            }))
         }),
       // model/list, every page (walkPaginated; a walk that cannot complete
       // is a protocol error, never a partial catalog), hidden entries

--- a/app-server/src/api/contract.ts
+++ b/app-server/src/api/contract.ts
@@ -1830,7 +1830,7 @@ export class V1 extends HttpApiGroup.make("v1")
       .annotate(OpenApi.Identifier, "listAgentModels")
       .annotate(
         OpenApi.Description,
-        "The agent's model catalog as its provider reports it, cached server-side for a short while.",
+        "The agent's model catalog as its provider reports it. Cached server-side for a short while; expiry is lazy — no periodic task, the provider is asked again only on the next request after it — so a client that wants a fresh catalog asks again.",
       ),
     HttpApiEndpoint.get("listAgentCommands", "/agents/:agentId/commands", {
       params: { agentId: Schema.String },
@@ -1845,7 +1845,7 @@ export class V1 extends HttpApiGroup.make("v1")
       .annotate(OpenApi.Identifier, "listAgentCommands")
       .annotate(
         OpenApi.Description,
-        "The slash commands and skills the agent offers in `dir` — answerable with no thread and no live session, so a cold thread and a thread not yet created complete alike. Cached server-side per agent and directory for a short while; an empty list is a real answer. Commands are inserted into a prompt as plain text.",
+        "The slash commands and skills the agent offers in `dir` — answerable with no thread and no live session, so a cold thread and a thread not yet created complete alike. Cached server-side per agent and directory for a short while; expiry is lazy — no periodic task, the provider is asked again only on the next request after it — so a client that wants to see a newly added or removed skill asks again. An empty list is a real answer. Commands are inserted into a prompt as plain text.",
       ),
     HttpApiEndpoint.get("subscribeEvents", "/events", {
       success: HttpApiSchema.StreamSse({ data: ResourceChangedEvent }),

--- a/app-server/src/api/contract.ts
+++ b/app-server/src/api/contract.ts
@@ -191,6 +191,27 @@ export const FsListResponse = Schema.Struct({
   description: "A directory listing for the server-backed folder browser. Never persisted.",
 })
 
+export const FsFileEntry = Schema.Struct({
+  path: Schema.String.annotate({ description: "Path relative to `dir`, `/`-separated." }),
+  name: Schema.String.annotate({ description: "The file's basename." }),
+}).annotate({ identifier: "FsFileEntry", description: "One file under a searched directory." })
+
+export const FsFilesResponse = Schema.Struct({
+  dir: Schema.String.annotate({
+    description: "Canonical (symlink-resolved) absolute path of the searched directory.",
+  }),
+  entries: Schema.Array(FsFileEntry).annotate({
+    description: "Best matches first; an empty query lists files in path order.",
+  }),
+  truncated: Schema.Boolean.annotate({
+    description:
+      "True when the tree holds more files than the index walks, so a file may be missing from every query of this directory.",
+  }),
+}).annotate({
+  identifier: "FsFilesResponse",
+  description: "A ranked filename search over one directory tree (`@` mentions). Never persisted.",
+})
+
 export const TerminalStatus = Schema.Literals(["live", "ended"]).annotate({
   identifier: "TerminalStatus",
   description:
@@ -362,6 +383,22 @@ export const AgentModel = Schema.Struct({
   identifier: "AgentModel",
   description:
     "One entry of an agent's model catalog, as the provider itself reports it. `defaultEffortLevel` is the level a thread gets on switching to this model when its current level is unsupported; absent for a model with no effort support.",
+})
+
+export const AgentCommand = Schema.Struct({
+  name: Schema.String.annotate({ description: "Command name, without the leading slash." }),
+  description: Schema.String,
+  argumentHint: Schema.optionalKey(
+    Schema.String.annotate({ description: "Placeholder for the arguments the command takes." }),
+  ),
+}).annotate({
+  identifier: "AgentCommand",
+  description: "A slash command or skill the agent offers in a directory (`/` completions).",
+})
+
+export const AgentCommandList = Schema.Array(AgentCommand).annotate({
+  identifier: "AgentCommandList",
+  description: "The agent's commands for a directory, as its provider lists them.",
 })
 
 export const AgentModelList = Schema.Array(AgentModel).annotate({
@@ -836,6 +873,12 @@ export const PromptThreadRequest = Schema.Struct({
           "Ids of attachments previously uploaded to THIS thread (createThreadAttachment), in display order. An id the thread does not own is a 404.",
       }),
   ),
+  when: Schema.optionalKey(
+    Schema.Literals(["queue", "now"]).annotate({
+      description:
+        '"queue" (the default) runs the prompt at the next idle. "now" hands it to the turn ATC is running as a mid-turn message — the provider folds it into the work in progress and it lands in the transcript as that turn\'s next user message — and queues only when no turn of ATC\'s is running (a TUI-driven turn included) or the turn ended first. The response says which: `turnId` present is the turn it joined or started.',
+    }),
+  ),
 })
   .check(
     Schema.makeFilter(
@@ -855,7 +898,8 @@ export const PromptThreadResponse = Schema.Struct({
   promptId: Schema.String.annotate({ description: "The admitted prompt's id." }),
   turnId: Schema.optionalKey(
     Schema.String.annotate({
-      description: "Present when the prompt started a turn at once; absent when it queued.",
+      description:
+        'Present when the prompt started a turn at once or joined the running one (`when: "now"`); absent when it queued.',
     }),
   ),
 }).annotate({
@@ -1644,7 +1688,7 @@ export class V1 extends HttpApiGroup.make("v1")
       .annotate(OpenApi.Identifier, "promptThread")
       .annotate(
         OpenApi.Description,
-        "Prompt the thread. Always admitted: an idle thread starts a turn at once (`turnId` present) and a busy one queues the prompt to run at the next idle (`turnId` absent) — there is no busy error and no lock between surfaces. On a one-process provider (Claude Code) a prompt while the TUI is live takes the thread over: the TUI ends once idle, the turn runs natively, and the TUI relaunches when the queue drains (see openThreadTerminal). " +
+        'Prompt the thread. Always admitted: an idle thread starts a turn at once and a busy one queues the prompt for the next idle — or hands it to the running turn with `when: "now"` (see PromptThreadRequest); `turnId` tells which. There is no busy error and no lock between surfaces. On a one-process provider (Claude Code) a prompt while the TUI is live takes the thread over: the TUI ends once idle, the turn runs natively, and the TUI relaunches when the queue drains (see openThreadTerminal). ' +
           "The turn is server-owned: the client's connection never matters to it. When the prompt would start now and the provider refuses, it is un-admitted (the error means not accepted; nothing stays queued); a prompt queued behind others is admitted regardless. Follow the turn on the per-thread event stream.",
       ),
     HttpApiEndpoint.get("getThreadTranscript", "/threads/:threadId/transcript", {
@@ -1788,6 +1832,21 @@ export class V1 extends HttpApiGroup.make("v1")
         OpenApi.Description,
         "The agent's model catalog as its provider reports it, cached server-side for a short while.",
       ),
+    HttpApiEndpoint.get("listAgentCommands", "/agents/:agentId/commands", {
+      params: { agentId: Schema.String },
+      query: {
+        dir: AbsolutePath.annotate({
+          description: "Directory the commands are resolved in (project and user scopes).",
+        }),
+      },
+      success: AgentCommandList,
+      error: [AgentNotFound, ProviderUnavailable, DirectoryUnavailable, DirectoryCheckTimedOut],
+    })
+      .annotate(OpenApi.Identifier, "listAgentCommands")
+      .annotate(
+        OpenApi.Description,
+        "The slash commands and skills the agent offers in `dir` — answerable with no thread and no live session, so a cold thread and a thread not yet created complete alike. Cached server-side per agent and directory for a short while; an empty list is a real answer. Commands are inserted into a prompt as plain text.",
+      ),
     HttpApiEndpoint.get("subscribeEvents", "/events", {
       success: HttpApiSchema.StreamSse({ data: ResourceChangedEvent }),
     })
@@ -1836,6 +1895,27 @@ export class V1 extends HttpApiGroup.make("v1")
           "dotfolders excluded, symlinks included when they resolve to directories, sorted " +
           "case-insensitively. Omitting `path` lists the server's home directory. Same bounded " +
           "timeout and tagged errors as the health check; nothing is persisted.",
+      ),
+    HttpApiEndpoint.get("searchFiles", "/fs/files", {
+      query: {
+        dir: AbsolutePath.annotate({ description: "Directory tree to search." }),
+        query: Schema.optionalKey(
+          Schema.String.annotate({
+            description:
+              "Filename query (case-insensitive); omitted or empty lists files in path order.",
+          }),
+        ),
+        limit: Schema.optionalKey(
+          integerParam("Entries to return (default 25, at most 200).", 1, 200),
+        ),
+      },
+      success: FsFilesResponse,
+      error: [DirectoryUnavailable, DirectoryCheckTimedOut],
+    })
+      .annotate(OpenApi.Identifier, "searchFiles")
+      .annotate(
+        OpenApi.Description,
+        "Search the files under `dir` by name (`@` mentions): best matches first, with `.git` and every `.gitignore`'s exclusions skipped and the tree capped (see `truncated`). Directory-driven, not project-scoped: pass a thread's working directory, a worktree, or the directory a new thread will use. Same validation and tagged errors as /fs/list; nothing is persisted.",
       ),
   )
   // .prefix only applies to endpoints added above it — add new endpoints

--- a/app-server/src/api/handlers.ts
+++ b/app-server/src/api/handlers.ts
@@ -6,6 +6,7 @@ import { AgentRegistry } from "../agents/agentRegistry.ts"
 import { Events, HEARTBEAT } from "../events/events.ts"
 import { BuildInfo } from "../platform/buildInfo.ts"
 import { Directories } from "../platform/directories.ts"
+import { FileSearch } from "../platform/fileSearch.ts"
 import * as Tailscale from "../platform/tailscale.ts"
 import { Projects } from "../projects/projects.ts"
 import { attachTerminal } from "../terminals/terminalAttach.ts"
@@ -42,6 +43,7 @@ export const V1Handlers = HttpApiBuilder.group(
     const tailscale = yield* Tailscale.Tailscale
     const projects = yield* Projects
     const directories = yield* Directories
+    const fileSearch = yield* FileSearch
     const terminals = yield* Terminals
     const threads = yield* Threads
     const runtime = yield* ThreadRuntime
@@ -76,6 +78,7 @@ export const V1Handlers = HttpApiBuilder.group(
         .handle("deleteProject", ({ params }) => projects.delete(params.projectId))
         .handle("checkDirectory", ({ query }) => directories.check(query.path))
         .handle("listDirectory", ({ query }) => directories.list(query.path))
+        .handle("searchFiles", ({ query }) => fileSearch.search(query))
         .handle("listTerminals", ({ query }) =>
           terminals.list({ projectId: query.projectId, threadId: query.threadId }),
         )
@@ -132,6 +135,9 @@ export const V1Handlers = HttpApiBuilder.group(
         .handle("listAgents", () => agents.list())
         .handle("getAgent", ({ params }) => agents.get(params.agentId))
         .handle("listAgentModels", ({ params }) => agents.models(params.agentId))
+        .handle("listAgentCommands", ({ params, query }) =>
+          agents.commands(params.agentId, query.dir),
+        )
         // handleRaw instead of the typed handler for one reason: this stream
         // emits nothing until the first change, and Bun's fetch (every Bun
         // client, the contract TS client included) does not resolve a

--- a/app-server/src/cli/threads.ts
+++ b/app-server/src/cli/threads.ts
@@ -141,8 +141,13 @@ const threadPrompt = Command.make(
     follow: Flag.boolean("follow").pipe(
       Flag.withDescription("Stream the thread's events (JSON lines) until this prompt's turn ends"),
     ),
+    now: Flag.boolean("now").pipe(
+      Flag.withDescription(
+        "Hand the prompt to the running turn instead of queueing behind it (queues when no turn is running)",
+      ),
+    ),
   },
-  ({ threadId, text, follow }) =>
+  ({ threadId, text, follow, now }) =>
     Cli.withClient("thread prompt", (client) =>
       Effect.gen(function* () {
         // Subscribe BEFORE prompting so no event of the turn is missed.
@@ -151,7 +156,7 @@ const threadPrompt = Command.make(
           : undefined
         const admitted = yield* client.v1.promptThread({
           params: { threadId },
-          payload: { prompt: text },
+          payload: { prompt: text, ...(now ? { when: "now" as const } : {}) },
         })
         // Without --follow the admission is the result; with it, stdout is
         // a pure ThreadEvent stream (the turn.started event names the
@@ -167,7 +172,7 @@ const threadPrompt = Command.make(
     ),
 ).pipe(
   Command.withDescription(
-    "Prompt the thread (queued if a turn is running); --follow streams the thread's events (JSON lines) until this prompt's turn ends",
+    "Prompt the thread (queued if a turn is running, or --now to join it); --follow streams the thread's events (JSON lines) until this prompt's turn ends",
   ),
 )
 

--- a/app-server/src/platform/fileSearch.ts
+++ b/app-server/src/platform/fileSearch.ts
@@ -1,0 +1,283 @@
+import { Cache, Context, Duration, Effect, Exit, Layer } from "effect"
+import ignore from "ignore"
+import * as fs from "node:fs/promises"
+import { join } from "node:path"
+import { DirectoryUnavailable } from "../api/contract.ts"
+import type { DirectoryCheckTimedOut } from "../api/contract.ts"
+import type * as Contract from "../api/contract.ts"
+import { Directories } from "./directories.ts"
+
+// Filename search over one directory tree (ATC-216): what the composer's
+// `@` mention ranks from. Directory-driven, not project-scoped, so it
+// follows a thread's working directory (worktrees included) and a
+// not-yet-created thread's directory chip alike. Pure TypeScript on
+// purpose: no native module in the compiled binary, and at the scale of a
+// capped filename index a readdir walk plus subsequence scoring answers
+// within a frame; the contract hides the engine so it can be swapped.
+//
+//   - The index of a directory is built by one bounded walk (WALK_CAP
+//     entries seen, then `truncated`; READ_CONCURRENCY directories read at
+//     a time), skipping `.git` and everything the tree's `.gitignore` files
+//     exclude — each file's patterns apply to its own subtree and a deeper
+//     rule overrides a shallower one, as git applies them — and is cached
+//     for INDEX_TTL, so a keystroke re-ranks in memory and only the first
+//     query pays the walk. A part of the tree that cannot be read fails the
+//     walk (DirectoryUnavailable), never a partial index; a failed walk is
+//     never cached, so the next query retries.
+//   - Ranking (T3Code's searchRanking): on the basename first — exact,
+//     prefix, word boundary, substring, subsequence — then the same tiers on
+//     the relative path; lower scores win, ties break by path. An empty
+//     query lists the index in path order.
+//   - Nothing is persisted, nothing is watched: freshness is the TTL.
+
+/** Entries (files and directories) one walk looks at; past it the index reports `truncated`. */
+export const WALK_CAP = 50_000
+
+/** How long a built index answers queries before the tree is walked again. */
+export const INDEX_TTL: Duration.Input = "10 seconds"
+
+export type FileMatch = typeof Contract.FsFileEntry.Type
+export type FileSearchResult = typeof Contract.FsFilesResponse.Type
+
+/** Matches returned when the caller names no limit. */
+export const DEFAULT_LIMIT = 25
+
+interface FileIndex {
+  readonly files: ReadonlyArray<FileMatch>
+  readonly truncated: boolean
+}
+
+export class FileSearch extends Context.Service<
+  FileSearch,
+  {
+    /**
+     * The best `limit` (default DEFAULT_LIMIT) matches for `query` (default
+     * none: path order) under `dir`, canonicalized and validated like every
+     * directory the server touches.
+     */
+    readonly search: (options: {
+      readonly dir: string
+      readonly query?: string | undefined
+      readonly limit?: number | undefined
+    }) => Effect.Effect<FileSearchResult, DirectoryUnavailable | DirectoryCheckTimedOut>
+  }
+>()("app-server/FileSearch") {}
+
+/** A gitignore matcher with the subtree (relative to the index root) it governs. */
+interface IgnoreScope {
+  readonly base: string
+  readonly matcher: ReturnType<typeof ignore>
+}
+
+interface WalkDirectory {
+  readonly relative: string
+  readonly scopes: ReadonlyArray<IgnoreScope>
+}
+
+/** Directories read concurrently at once; bounds the walk's fan-out. */
+const READ_CONCURRENCY = 16
+
+/** Errno codes that mean "not there (any more)" — never a failure of the walk. */
+const ABSENT = new Set(["ENOENT", "ENOTDIR", "EISDIR"])
+
+const isAbsent = (error: unknown): boolean =>
+  error instanceof Error && "code" in error && ABSENT.has(String(error.code))
+
+const readIgnoreScope = async (directory: string, base: string): Promise<IgnoreScope | null> => {
+  try {
+    const text = await fs.readFile(join(directory, ".gitignore"), "utf8")
+    return { base, matcher: ignore().add(text) }
+  } catch (error) {
+    if (isAbsent(error)) return null
+    throw error
+  }
+}
+
+/**
+ * Whether the governing `.gitignore` files exclude `relativePath`, as git
+ * decides it: the scopes run root-first and the deepest rule that speaks
+ * wins, so a nested `!keep.log` re-includes what the root ignored. A
+ * directory is tested with a trailing slash (directory-only patterns).
+ */
+const isIgnored = (
+  scopes: ReadonlyArray<IgnoreScope>,
+  relativePath: string,
+  isDirectory: boolean,
+): boolean => {
+  let ignored = false
+  for (const scope of scopes) {
+    const within = scope.base === "" ? relativePath : relativePath.slice(scope.base.length + 1)
+    const verdict = scope.matcher.test(isDirectory ? `${within}/` : within)
+    if (verdict.ignored) ignored = true
+    else if (verdict.unignored) ignored = false
+  }
+  return ignored
+}
+
+/** `fn` over `items`, READ_CONCURRENCY at a time (a recursion, not a loop). */
+const mapBounded = async <A, B>(
+  items: ReadonlyArray<A>,
+  fn: (item: A) => Promise<B>,
+  done: Array<B> = [],
+): Promise<Array<B>> => {
+  if (items.length === 0) return done
+  const batch = await Promise.all(items.slice(0, READ_CONCURRENCY).map(fn))
+  return mapBounded(items.slice(READ_CONCURRENCY), fn, [...done, ...batch])
+}
+
+/**
+ * Walk `root` breadth-first into a file index (see the header): one level
+ * of directories at a time, each level a recursion. Every entry seen —
+ * file or directory — counts against WALK_CAP, so a wide tree of empty
+ * directories ends too; `signal` ends an abandoned walk between levels.
+ */
+const buildIndex = async (root: string, signal: AbortSignal): Promise<FileIndex> => {
+  const files: Array<FileMatch> = []
+  let seen = 0
+  const walkLevel = async (level: ReadonlyArray<WalkDirectory>): Promise<boolean> => {
+    if (level.length === 0) return false
+    if (signal.aborted) throw new Error("the walk was abandoned")
+    const listed = await mapBounded(level, async (directory) => ({
+      directory,
+      dirents: await fs
+        .readdir(directory.relative === "" ? root : join(root, directory.relative), {
+          withFileTypes: true,
+        })
+        .catch((error: unknown) => {
+          // The directory vanished since its parent listed it: nothing to
+          // index. Anything else (permissions, I/O) fails the walk.
+          if (isAbsent(error)) return []
+          throw error
+        }),
+    }))
+    const subdirectories: Array<WalkDirectory> = []
+    for (const { directory, dirents } of listed) {
+      for (const dirent of dirents) {
+        if (dirent.name === ".git") continue
+        if (seen >= WALK_CAP) return true
+        seen += 1
+        const path =
+          directory.relative === "" ? dirent.name : `${directory.relative}/${dirent.name}`
+        if (dirent.isDirectory()) {
+          if (!isIgnored(directory.scopes, path, true)) {
+            subdirectories.push({ relative: path, scopes: directory.scopes })
+          }
+          continue
+        }
+        if (!dirent.isFile() && !dirent.isSymbolicLink()) continue
+        if (isIgnored(directory.scopes, path, false)) continue
+        files.push({ path, name: dirent.name })
+      }
+    }
+    // A subdirectory's own .gitignore governs its subtree from here on.
+    const next = await mapBounded(subdirectories, async (directory) => {
+      const scope = await readIgnoreScope(join(root, directory.relative), directory.relative)
+      return scope === null
+        ? directory
+        : { relative: directory.relative, scopes: [...directory.scopes, scope] }
+    })
+    return walkLevel(next)
+  }
+  const rootScope = await readIgnoreScope(root, "")
+  const truncated = await walkLevel([
+    { relative: "", scopes: rootScope === null ? [] : [rootScope] },
+  ])
+  return { files, truncated }
+}
+
+// --- Ranking (T3Code searchRanking.ts, reduced to the filename case) ---
+
+const lengthPenalty = (value: string, query: string): number =>
+  Math.min(64, Math.max(0, value.length - query.length))
+
+/** Gap-penalized subsequence score; null when `query` is not a subsequence. */
+const subsequenceScore = (value: string, query: string): number | null => {
+  let queryIndex = 0
+  let first = -1
+  let previous = -1
+  let gaps = 0
+  for (let index = 0; index < value.length; index += 1) {
+    if (value[index] !== query[queryIndex]) continue
+    if (first === -1) first = index
+    if (previous !== -1) gaps += index - previous - 1
+    previous = index
+    queryIndex += 1
+    if (queryIndex === query.length) {
+      return first * 2 + gaps * 3 + (index - first + 1 - query.length) + lengthPenalty(value, query)
+    }
+  }
+  return null
+}
+
+const BOUNDARIES = [" ", "-", "_", "/", "."]
+
+/** Tiered score of `query` against `value` (both lowercased): exact, prefix,
+ * word boundary, substring, subsequence — offsets keep the tiers apart. */
+const tieredScore = (value: string, query: string, base: number): number | null => {
+  if (value === query) return base
+  if (value.startsWith(query)) return base + 100 + lengthPenalty(value, query)
+  const boundary = BOUNDARIES.map((marker) => value.indexOf(`${marker}${query}`)).filter(
+    (index) => index !== -1,
+  )
+  if (boundary.length > 0) {
+    return base + 200 + Math.min(...boundary) * 2 + lengthPenalty(value, query)
+  }
+  const index = value.indexOf(query)
+  if (index !== -1) return base + 300 + index * 2 + lengthPenalty(value, query)
+  const fuzzy = subsequenceScore(value, query)
+  return fuzzy === null ? null : base + 400 + fuzzy
+}
+
+/** The name's tiers beat the path's: a match on what the user sees first. */
+const score = (file: FileMatch, query: string): number | null =>
+  tieredScore(file.name.toLowerCase(), query, 0) ??
+  tieredScore(file.path.toLowerCase(), query, 1_000)
+
+const rank = (index: FileIndex, query: string, limit: number): ReadonlyArray<FileMatch> => {
+  const normalized = query.trim().toLowerCase()
+  if (normalized === "") {
+    return index.files.toSorted((a, b) => a.path.localeCompare(b.path, "en")).slice(0, limit)
+  }
+  const scored: Array<{ readonly file: FileMatch; readonly score: number }> = []
+  for (const file of index.files) {
+    const value = score(file, normalized)
+    if (value !== null) scored.push({ file, score: value })
+  }
+  return scored
+    .toSorted((a, b) => a.score - b.score || a.file.path.localeCompare(b.file.path, "en"))
+    .slice(0, limit)
+    .map((entry) => entry.file)
+}
+
+export const layer = Layer.effect(FileSearch)(
+  Effect.gen(function* () {
+    const directories = yield* Directories
+    // One index per canonical directory, shared by concurrent queries; a
+    // failed walk is not kept (zero TTL), so the next query retries.
+    const indexes = yield* Cache.makeWith(
+      (dir: string) =>
+        Effect.tryPromise({
+          try: (signal) => buildIndex(dir, signal),
+          // A walk that cannot read part of the tree is no listing at all —
+          // the same fail-closed answer /fs/list gives.
+          catch: () => new DirectoryUnavailable({ path: dir, state: "inaccessible" }),
+        }),
+      {
+        capacity: 32,
+        timeToLive: (exit) => (Exit.isSuccess(exit) ? INDEX_TTL : Duration.zero),
+      },
+    )
+    return {
+      search: (options) =>
+        Effect.gen(function* () {
+          const dir = yield* directories.canonicalize(options.dir)
+          const index = yield* Cache.get(indexes, dir)
+          return {
+            dir,
+            entries: rank(index, options.query ?? "", options.limit ?? DEFAULT_LIMIT),
+            truncated: index.truncated,
+          }
+        }),
+    } satisfies FileSearch["Service"]
+  }),
+)

--- a/app-server/src/server.ts
+++ b/app-server/src/server.ts
@@ -12,6 +12,7 @@ import * as ClaudeHooks from "./agents/claudeHooks.ts"
 import * as CodexAdapter from "./agents/codexAdapter.ts"
 import * as CodexServer from "./agents/codexServer.ts"
 import * as Directories from "./platform/directories.ts"
+import * as FileSearch from "./platform/fileSearch.ts"
 import * as Events from "./events/events.ts"
 import { V1Handlers } from "./api/handlers.ts"
 import * as LocalTrust from "./api/localTrust.ts"
@@ -152,6 +153,7 @@ export const production = (options: { readonly port: number; readonly hostname?:
     // Attachments serve the handlers, Threads (delete purges blobs), and the
     // runtime (a prompt's images), so it sits below all three.
     Layer.provide(Attachments.layer),
+    Layer.provide(FileSearch.layer),
     Layer.provide(AgentRegistry.layer),
     // Below Terminals (the deepest publisher) so one memoized Events instance
     // serves every domain service, the handlers, and the shutdown drain.

--- a/app-server/src/threads/threadRuntime.ts
+++ b/app-server/src/threads/threadRuntime.ts
@@ -75,7 +75,10 @@ export type QueuedPrompt = typeof Contract.QueuedPrompt.Type
 //     a provider that refuses that immediate start, which un-admits the
 //     prompt so the caller's error means "not accepted". A thread busy
 //     under a TUI (the ledger says so) queues the prompt and drains at the
-//     observed idle: no busy error, no lock between surfaces. A turn runs
+//     observed idle: no busy error, no lock between surfaces. A prompt
+//     marked `now` (ATC-216) is instead handed to the turn running on our
+//     writer — the seam's `steer` — and recorded against that turn; with no
+//     such turn, or one that ended first, it is an ordinary prompt. A turn runs
 //     on a writer connection the runtime holds; client connections never
 //     matter to a run's lifetime. A closing writer stays registered until
 //     its connection has closed, so the next prompt never races it.
@@ -259,14 +262,16 @@ export interface ThreadRuntimeOptions {
 export class ThreadRuntime extends Context.Service<
   ThreadRuntime,
   {
-    /** Admit a prompt; `turnId` present ⇒ it started at once, else queued.
-     * `attachments` are ids of the thread's own uploads (ATC-216); a foreign
-     * or unknown id refuses the prompt before it is admitted. */
+    /** Admit a prompt; `turnId` present ⇒ it started at once (or, with
+     * `when: "now"`, joined the running turn), else queued. `attachments`
+     * are ids of the thread's own uploads (ATC-216); a foreign or unknown
+     * id refuses the prompt before it is admitted. */
     readonly prompt: (
       id: string,
       input: {
         readonly prompt: string
         readonly attachments?: ReadonlyArray<string> | undefined
+        readonly when?: "queue" | "now" | undefined
       },
     ) => Effect.Effect<
       { readonly promptId: string; readonly turnId?: string },
@@ -517,6 +522,44 @@ const make = (options: ThreadRuntimeOptions) =>
           ),
         ),
       )
+
+    /**
+     * Hand an admitted (waiting) prompt to the turn running on the thread's
+     * writer (ATC-216 "now"): the seam's `steer`, under the writer's lock so
+     * the item it produces lands after the Run that owns it, and — in one
+     * uninterruptible step with it — the row stamped started against that
+     * turn, so a provider that took the message never has it delivered
+     * again by the drain. Undefined when no turn of ours runs (a TUI-driven
+     * turn has no writer to hand to) or the turn ended first: the prompt
+     * stays waiting for the ordinary drain.
+     */
+    const steerRunning = (
+      id: string,
+      queued: QueuedPromptRecord,
+      input: TurnInput,
+    ): Effect.Effect<{ readonly promptId: string; readonly turnId: string } | undefined> =>
+      Effect.gen(function* () {
+        const writer = writers.get(id)
+        const run = writer?.run
+        if (writer === undefined || run === undefined || run.finished) return undefined
+        const joined = yield* writer.lock
+          .withPermit(
+            Effect.uninterruptible(
+              writer.connection
+                .steer(input, run.turn)
+                .pipe(Effect.andThen(transcripts.startWaiting(id, queued.id, run.turnId))),
+            ),
+          )
+          .pipe(
+            Effect.catch((error) =>
+              Effect.logDebug("the running turn did not take the prompt; it queues").pipe(
+                Effect.annotateLogs({ threadId: id, reason: error.message }),
+                Effect.as(false),
+              ),
+            ),
+          )
+        return joined ? { promptId: queued.id, turnId: run.turnId } : undefined
+      })
 
     const publishQueue = (threadId: string): Effect.Effect<void> =>
       queuedPrompts(threadId).pipe(
@@ -1610,10 +1653,17 @@ const make = (options: ThreadRuntimeOptions) =>
           // admitted — an unknown id is the caller's error, not a queued
           // prompt that can never start.
           const attachmentIds = input.attachments ?? []
-          yield* attachments.resolve(id, attachmentIds)
+          const resolved = yield* attachments.resolve(id, attachmentIds)
           // Whether THIS prompt is the one an immediate start would run.
           const first = runOf(id) === undefined && Option.isNone(yield* transcripts.peek(id))
           const queued = yield* transcripts.enqueue(id, input.prompt, attachmentIds)
+          if (input.when === "now") {
+            const joined = yield* steerRunning(id, queued, {
+              text: input.prompt,
+              attachments: resolved,
+            })
+            if (joined !== undefined) return joined
+          }
           // The drain runs the OLDEST waiting prompt. When that is ours, a
           // provider that refuses un-admits it (the caller's error means
           // "not accepted"); an older prompt's failure just leaves ours

--- a/app-server/src/threads/transcriptRepository.ts
+++ b/app-server/src/threads/transcriptRepository.ts
@@ -136,10 +136,13 @@ type AttachmentList = NonNullable<UserMessageRecord["attachments"]>
  * holds them — what a re-read must not lose (ATC-216, the header). */
 const attachmentsByTurn = (
   items: ReadonlyArray<ThreadItemRecord>,
-): Map<string, Array<AttachmentList>> => {
-  const byTurn = new Map<string, Array<AttachmentList>>()
+): Map<string, Array<AttachmentList | undefined>> => {
+  // Every prompt of the turn takes a slot, images or not: a turn holds
+  // several prompts once one is steered in ("now"), and the ordinal must
+  // count them all or a later prompt's images land on an earlier one.
+  const byTurn = new Map<string, Array<AttachmentList | undefined>>()
   for (const item of items) {
-    if (item.type !== "userMessage" || item.attachments === undefined) continue
+    if (item.type !== "userMessage") continue
     byTurn.set(item.turnId, [...(byTurn.get(item.turnId) ?? []), item.attachments])
   }
   return byTurn
@@ -265,6 +268,14 @@ export class TranscriptRepository extends Context.Service<
       prompt: string,
       attachmentIds: ReadonlyArray<string>,
     ) => Effect.Effect<QueuedPromptRecord>
+    /** A WAITING prompt the running turn `turnId` took mid-flight (ATC-216
+     * "now"): stamped started against that turn; false when it was not
+     * waiting (unknown, or started meanwhile). */
+    readonly startWaiting: (
+      threadId: string,
+      promptId: string,
+      turnId: string,
+    ) => Effect.Effect<boolean>
     /** Prompts still waiting, oldest first. */
     readonly listWaiting: (threadId: string) => Effect.Effect<ReadonlyArray<QueuedPromptRecord>>
     /** The oldest waiting prompt (None when nothing waits). */
@@ -333,14 +344,13 @@ export const layer = Layer.effect(TranscriptRepository)(
       `,
     })
 
-    // The userMessage items carrying attachments, in transcript order, for
-    // replace's carry-forward.
+    // The stored prompts in transcript order, for replace's carry-forward.
     const attachedItemRows = SqlSchema.findAll({
       Request: Schema.String,
       Result: Schema.Struct({ item: Schema.String }),
       execute: (threadId) => sql`
         SELECT item FROM thread_items
-        WHERE thread_id = ${threadId} AND json_extract(item, '$.attachments') IS NOT NULL
+        WHERE thread_id = ${threadId} AND json_extract(item, '$.type') = 'userMessage'
         ORDER BY ord ASC
       `,
     })
@@ -477,6 +487,20 @@ export const layer = Layer.effect(TranscriptRepository)(
     const insertQueueRow = SqlSchema.void({
       Request: QueueRow,
       execute: (row) => sql`INSERT INTO thread_queue ${sql.insert(row)}`,
+    })
+
+    const startWaitingRows = SqlSchema.findAll({
+      Request: Schema.Struct({
+        thread_id: Schema.String,
+        id: Schema.String,
+        turn_id: Schema.String,
+      }),
+      Result: Schema.Struct({ id: Schema.String }),
+      execute: (request) => sql`
+        UPDATE thread_queue SET started_turn_id = ${request.turn_id}
+        WHERE thread_id = ${request.thread_id} AND id = ${request.id} AND started_turn_id IS NULL
+        RETURNING id
+      `,
     })
 
     const waitingRows = SqlSchema.findAll({
@@ -719,6 +743,11 @@ export const layer = Layer.effect(TranscriptRepository)(
           }
           return insertQueueRow(row).pipe(Effect.as(toQueued(row)))
         }).pipe(Effect.orDie),
+      startWaiting: (threadId, promptId, turnId) =>
+        startWaitingRows({ thread_id: threadId, id: promptId, turn_id: turnId }).pipe(
+          Effect.map((rows) => rows.length > 0),
+          Effect.orDie,
+        ),
       listWaiting: (threadId) =>
         waitingRows(threadId).pipe(
           Effect.map((rows) => rows.map(toQueued)),

--- a/app-server/test/agents/agentRegistry.test.ts
+++ b/app-server/test/agents/agentRegistry.test.ts
@@ -2,6 +2,7 @@ import { assert, describe, it } from "@effect/vitest"
 import { BunHttpServer, BunServices } from "@effect/platform-bun"
 import { Effect, Layer } from "effect"
 import { HttpApiTest } from "effect/unstable/httpapi"
+import { realpathSync } from "node:fs"
 import * as AgentRegistry from "../../src/agents/agentRegistry.ts"
 import * as ClaudeAdapter from "../../src/agents/claudeAdapter.ts"
 import * as CodexAdapter from "../../src/agents/codexAdapter.ts"
@@ -41,6 +42,33 @@ describe("/api/v1/agents", () => {
         yield* client.v1.getAgent({ params: { agentId: "claude-code" } }),
         agents[1],
       )
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("commands come from the adapter per directory and are cached for a while", () =>
+    Effect.gen(function* () {
+      const client = yield* HttpApiTest.groups(Api, ["v1"])
+      kit.fakeAgents.codex.setCommands([{ name: "review", description: "Review the diff" }])
+      const first = yield* client.v1.listAgentCommands({
+        params: { agentId: "codex" },
+        query: { dir: "/tmp" },
+      })
+      assert.deepStrictEqual(first, [{ name: "review", description: "Review the diff" }])
+      // A second ask within the TTL is served from the cache — the adapter
+      // is not probed again — and another directory is its own entry.
+      kit.fakeAgents.codex.setCommands([])
+      const again = yield* client.v1.listAgentCommands({
+        params: { agentId: "codex" },
+        query: { dir: "/tmp" },
+      })
+      assert.deepStrictEqual(again, first)
+      const elsewhere = yield* client.v1.listAgentCommands({
+        params: { agentId: "codex" },
+        query: { dir: "/" },
+      })
+      assert.deepStrictEqual(elsewhere, [])
+      // Canonical paths (macOS resolves /tmp to /private/tmp; Linux does not).
+      assert.deepStrictEqual(kit.fakeAgents.codex.commandReads, [realpathSync("/tmp"), "/"])
     }).pipe(Effect.provide(TestLayer)),
   )
 

--- a/app-server/test/agents/claudeAdapter.test.ts
+++ b/app-server/test/agents/claudeAdapter.test.ts
@@ -131,6 +131,83 @@ describe("ClaudeAdapter", () => {
     }),
   )
 
+  it.live(
+    "steer pushes a message into the running turn and mints its item; a stale turn is a conflict",
+    () =>
+      Effect.gen(function* () {
+        const cwd = workDir()
+        const { fake, layer } = adapterStack({ sessionId: "session-steer" })
+        yield* Effect.gen(function* () {
+          const adapter = yield* ClaudeAdapter.ClaudeAdapter
+          yield* Effect.scoped(
+            Effect.gen(function* () {
+              const { connection, turn } = yield* adapter.createSession({
+                cwd,
+                input: { text: "HANG until told otherwise", attachments: [] },
+                settings: TEST_SETTINGS,
+              })
+              const sink = yield* collectAgentEvents(connection.events)
+              yield* connection.steer({ text: "also check the tests", attachments: [] }, turn)
+              // The SDK child took the message while the first turn still runs.
+              yield* eventually(
+                Effect.sync(() => fake.prompts),
+                (prompts) => prompts.length === 2,
+              )
+              assert.deepStrictEqual(fake.prompts, [
+                "HANG until told otherwise",
+                "also check the tests",
+              ])
+              const messages = sink.filter(
+                (event) => event.type === "itemCompleted" && event.item.type === "userMessage",
+              )
+              assert.lengthOf(messages, 2)
+              assert.isTrue(
+                messages.every(
+                  (event) => event.type === "itemCompleted" && event.item.turnId === turn.turnId,
+                ),
+              )
+              const stale = yield* Effect.flip(
+                connection.steer({ text: "nope", attachments: [] }, { turnId: "some-other-turn" }),
+              )
+              assert.strictEqual(stale._tag, "AgentConflict")
+              yield* connection.interrupt(turn)
+            }),
+          )
+        }).pipe(Effect.provide(layer))
+      }),
+  )
+
+  it.live(
+    "listCommands probes a throwaway child in the directory and reads its initialization",
+    () =>
+      Effect.gen(function* () {
+        const cwd = workDir()
+        const { fake, layer } = adapterStack({
+          commands: [
+            { name: "review", description: "Review the diff", argumentHint: "" },
+            { name: "commit", description: "Commit staged work", argumentHint: "<message>" },
+          ],
+        })
+        yield* Effect.gen(function* () {
+          const adapter = yield* ClaudeAdapter.ClaudeAdapter
+          const commands = yield* adapter.listCommands({ cwd })
+          assert.deepStrictEqual(commands, [
+            { name: "review", description: "Review the diff" },
+            { name: "commit", description: "Commit staged work", argumentHint: "<message>" },
+          ])
+          // The probe ran in the asked directory with the project's settings,
+          // sent no prompt, and was aborted.
+          const spawn = fake.spawns.at(-1) as {
+            cwd?: string
+            settingSources?: ReadonlyArray<string>
+          }
+          assert.strictEqual(spawn.cwd, cwd)
+          assert.deepStrictEqual(spawn.settingSources, ["user", "project", "local"])
+          assert.lengthOf(fake.prompts, 0)
+        }).pipe(Effect.provide(layer))
+      }),
+  )
+
   it.live("create with a lying cwd fails closed", () =>
     Effect.gen(function* () {
       const { layer } = adapterStack({ wrongCwd: true })

--- a/app-server/test/agents/codexAdapter.test.ts
+++ b/app-server/test/agents/codexAdapter.test.ts
@@ -115,6 +115,56 @@ describe("CodexAdapter", () => {
   )
 
   it.live(
+    "steer rides turn/steer into the running turn and echoes as its next item; a stale turn is a conflict",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.scoped(
+            Effect.gen(function* () {
+              const { connection, turn } = yield* adapter.createSession({
+                cwd: sandbox.cwd,
+                input: { text: "HANG on", attachments: [] },
+                settings: TEST_SETTINGS,
+              })
+              const sink = yield* collectAgentEvents(connection.events)
+              yield* connection.steer({ text: "and this too", attachments: [] }, turn)
+              yield* waitForAgentEvent(
+                sink,
+                (event) =>
+                  event.type === "itemCompleted" &&
+                  event.item.type === "userMessage" &&
+                  event.item.text === "and this too" &&
+                  event.item.turnId === turn.turnId,
+              )
+              const stale = yield* Effect.flip(
+                connection.steer({ text: "nope", attachments: [] }, { turnId: "other-turn" }),
+              )
+              assert.strictEqual(stale._tag, "AgentConflict")
+              yield* connection.interrupt(turn)
+            }),
+          ),
+        )
+      }),
+    30_000,
+  )
+
+  it.live(
+    "listCommands lists the shared server's enabled skills for the directory",
+    () =>
+      Effect.gen(function* () {
+        const sandbox = makeCodexSandbox()
+        yield* withAdapter(sandbox, (adapter) =>
+          Effect.gen(function* () {
+            const commands = yield* adapter.listCommands({ cwd: sandbox.cwd })
+            assert.deepStrictEqual(commands, [{ name: "review", description: "Review the diff" }])
+          }),
+        )
+      }),
+    30_000,
+  )
+
+  it.live(
     "resume: exact identity round trip; unknown id fails closed",
     () =>
       Effect.gen(function* () {

--- a/app-server/test/agents/fakeAgentAdapter.ts
+++ b/app-server/test/agents/fakeAgentAdapter.ts
@@ -2,6 +2,7 @@ import { Cause, Deferred, Effect, Queue, Stream } from "effect"
 import type {
   AgentActivity,
   AgentAdapter,
+  AgentCommand,
   AgentConnection,
   AgentEvent,
   AgentModel,
@@ -82,6 +83,10 @@ export interface FakeAgentAdapter {
   readonly closeRequest: (providerSessionId: string, requestId: string) => void
   /** Answers `respond` delivered, in order. */
   readonly answers: Array<{ requestId: string; answer: ThreadRequestAnswer }>
+  /** Script what listCommands returns (default []). */
+  readonly setCommands: (commands: ReadonlyArray<AgentCommand>) => void
+  /** listCommands calls (cwds), in order. */
+  readonly commandReads: Array<string>
   /** Push one item event onto the active connection's feed. */
   readonly emitItem: (
     providerSessionId: string,
@@ -175,6 +180,8 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
   const observers = new Map<string, Set<Queue.Queue<AgentSessionEvent, Cause.Done>>>()
   const checkActivity = new Map<string, AgentActivity>()
   const runningOnResume = new Map<string, string>()
+  let commands: ReadonlyArray<AgentCommand> = []
+  const commandReads: Array<string> = []
   const histories = new Map<string, ReadonlyArray<HistoryTurn>>()
   const historyReads: Array<string> = []
   const answers: FakeAgentAdapter["answers"] = []
@@ -330,6 +337,32 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
           ),
         ),
         startTurn,
+        steer: (input, turn) =>
+          Effect.gen(function* () {
+            yield* requireAvailable
+            yield* requireOpen
+            if (live.activeTurn !== turn.turnId) {
+              return yield* Effect.fail(
+                new AgentConflict({
+                  provider: "codex",
+                  reason: `turn ${turn.turnId} is not the active turn`,
+                }),
+              )
+            }
+            session.inputs.push(input.text)
+            session.attachments.push(input.attachments)
+            // Both real adapters surface the message as the turn's next item.
+            emit(live, {
+              type: "itemCompleted",
+              item: {
+                type: "userMessage",
+                id: `${turn.turnId}:steer-${session.inputs.length}`,
+                turnId: turn.turnId,
+                text: input.text,
+                ...(input.attachments.length > 0 ? { attachments: input.attachments } : {}),
+              },
+            })
+          }),
         interrupt: (turn: AgentTurn) =>
           Effect.gen(function* () {
             yield* requireAvailable
@@ -504,6 +537,13 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
         )
         return Stream.fromQueue(queue)
       }),
+    listCommands: (options) =>
+      requireAvailable.pipe(
+        Effect.map(() => {
+          commandReads.push(options.cwd)
+          return commands
+        }),
+      ),
     listModels: () =>
       Effect.gen(function* () {
         yield* requireAvailable
@@ -637,6 +677,10 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
       histories.set(providerSessionId, turns)
     },
     historyReads,
+    setCommands: (next) => {
+      commands = next
+    },
+    commandReads,
     closeRequest: (providerSessionId, requestId) => {
       const live = requireLive(providerSessionId)
       if (!live.openRequests.delete(requestId)) {

--- a/app-server/test/agents/fakeClaudeQuery.ts
+++ b/app-server/test/agents/fakeClaudeQuery.ts
@@ -1,4 +1,9 @@
-import type { ModelInfo, SDKMessage, SDKUserMessage } from "@anthropic-ai/claude-agent-sdk"
+import type {
+  ModelInfo,
+  SDKMessage,
+  SDKUserMessage,
+  SlashCommand,
+} from "@anthropic-ai/claude-agent-sdk"
 import type { ClaudeQueryFn, ClaudeQueryHandle } from "../../src/agents/claudeAdapter.ts"
 
 // A scripted stand-in for the Agent SDK's query() (the ClaudeQueryFn seam):
@@ -19,8 +24,16 @@ import type { ClaudeQueryFn, ClaudeQueryHandle } from "../../src/agents/claudeAd
 //   "FAILTURN"   — ends with error_max_turns, then the iterator throws
 // Every successful turn ends with a per-block `assistant` text message
 // (`fake: <text>`) before its result, like the SDK's own output.
+//
+// Input is taken off the prompt stream as it arrives (`prompts` records
+// every message, mid-turn ones included — a steer, ATC-216) and runs one
+// turn at a time; a hanging turn holds later input until interrupt() ends
+// it, as the real CLI folds a steer into the model call in progress.
+// initializationResult() answers with the scripted `commands`.
 
 export interface FakeClaudeQueryOptions {
+  /** What initializationResult() lists as slash commands (default []). */
+  readonly commands?: ReadonlyArray<SlashCommand>
   /** session_id for created sessions (resumes echo the resume id). */
   readonly sessionId?: string
   /** Session ids that resume finds; anything else fails closed. */
@@ -343,18 +356,43 @@ export const makeFakeClaudeQuery = (options: FakeClaudeQueryOptions = {}): FakeC
       state("idle")
     }
 
-    // Drain the prompt stream like the real SDK does.
+    // Drain the prompt stream like the real SDK does: input is taken as it
+    // arrives — mid-turn too (a steer, ATC-216) — and runs one turn at a time.
+    const inbox: Array<string> = []
+    let inboxClosed = false
+    // An object field, not a `let`: TypeScript would narrow a let to null in
+    // the closures below.
+    const runner: { wake: (() => void) | null } = { wake: null }
     void (async () => {
       for await (const message of args.prompt) {
         const content = (message as SDKUserMessage).message.content
         prompts.push(content)
         // Keyword behavior keys off the text blocks; image blocks ride along.
-        const text =
+        inbox.push(
           typeof content === "string"
             ? content
-            : content.flatMap((block) => (block.type === "text" ? [block.text] : [])).join("\n")
-        await runTurn(text)
+            : content.flatMap((block) => (block.type === "text" ? [block.text] : [])).join("\n"),
+        )
+        runner.wake?.()
+      }
+      inboxClosed = true
+      runner.wake?.()
+    })()
+    // A hanging turn holds later input (the real CLI folds a steer into the
+    // model call in progress) until interrupt() ends it.
+    void (async () => {
+      for (;;) {
         if (done) return
+        const next = hanging === null ? inbox.shift() : undefined
+        if (next !== undefined) {
+          await runTurn(next)
+          continue
+        }
+        if (inboxClosed && hanging === null) return
+        await new Promise<void>((resolve) => {
+          runner.wake = resolve
+        })
+        runner.wake = null
       }
     })()
 
@@ -378,6 +416,7 @@ export const makeFakeClaudeQuery = (options: FakeClaudeQueryOptions = {}): FakeC
         return Promise.resolve()
       },
       supportedModels: () => Promise.resolve(options.models ?? FAKE_CLAUDE_MODELS),
+      initializationResult: () => Promise.resolve({ commands: [...(options.commands ?? [])] }),
       ...(options.withoutGetSettings === true ? {} : { getSettings }),
       interrupt: () => {
         interrupts.push(hanging ?? "(no hanging turn)")
@@ -391,6 +430,7 @@ export const makeFakeClaudeQuery = (options: FakeClaudeQueryOptions = {}): FakeC
             errors: ["aborted_streaming"],
           })
           finish()
+          runner.wake?.()
         }
         return Promise.resolve({ still_queued: [] })
       },

--- a/app-server/test/api/openapi.test.ts
+++ b/app-server/test/api/openapi.test.ts
@@ -11,6 +11,9 @@ import {
   HttpServerResponse,
 } from "effect/unstable/http"
 import { HttpApi, OpenApi } from "effect/unstable/httpapi"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
 import { Api, DEFAULT_PORT } from "../../src/api/contract.ts"
 import * as ClaudeHooks from "../../src/agents/claudeHooks.ts"
 import { openApiDocument, openApiJson } from "../../src/api/openapi.ts"
@@ -202,9 +205,11 @@ describe("openapi document vs runtime", () => {
       "/api/v1/agents",
       "/api/v1/agents/{agentId}",
       "/api/v1/agents/{agentId}/models",
+      "/api/v1/agents/{agentId}/commands",
       "/api/v1/events",
       "/api/v1/fs/check",
       "/api/v1/fs/list",
+      "/api/v1/fs/files",
     ])
     // The WebSocket attach endpoint is contract-declared but excluded from
     // the document — REST clients cannot represent an upgrade.
@@ -1056,6 +1061,59 @@ describe("openapi document vs runtime", () => {
       // reason is optional (absent when conclusive) — and deliberately not a
       // nullable required field, which the pinned Swift generator would drop.
       assert.sameMembers([...schema.required], ["path", "state", "checkedAt"])
+    }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
+  )
+
+  it.effect("GET /api/v1/fs/files returns the documented ranked listing", () =>
+    Effect.gen(function* () {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "atc-openapi-files-"))
+      fs.mkdirSync(path.join(dir, "src"))
+      fs.writeFileSync(path.join(dir, "src", "main.ts"), "")
+      fs.writeFileSync(path.join(dir, "notes.md"), "")
+      const response = yield* (yield* rawClient).get(
+        `http://127.0.0.1/api/v1/fs/files?dir=${encodeURIComponent(dir)}&query=main&limit=5`,
+      )
+      assert.strictEqual(response.status, 200)
+      const body = (yield* response.json) as Record<string, unknown>
+      assert.strictEqual(body["dir"], fs.realpathSync(dir))
+      assert.deepStrictEqual(body["entries"], [{ path: "src/main.ts", name: "main.ts" }])
+      assert.strictEqual(body["truncated"], false)
+      const ref =
+        operation("/api/v1/fs/files").responses["200"]!.content["application/json"]!.schema
+      assert.deepStrictEqual(ref, { $ref: "#/components/schemas/FsFilesResponse" })
+      const schema = componentSchema("FsFilesResponse")
+      assert.sameMembers([...schema.required], ["dir", "entries", "truncated"])
+      const missing = yield* (yield* rawClient).get(
+        "http://127.0.0.1/api/v1/fs/files?dir=/definitely/not/here",
+      )
+      assert.strictEqual(missing.status, 422)
+      fs.rmSync(dir, { recursive: true, force: true })
+    }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
+  )
+
+  it.effect("GET /api/v1/agents/{agentId}/commands returns the documented list", () =>
+    Effect.gen(function* () {
+      const response = yield* (yield* rawClient).get(
+        "http://127.0.0.1/api/v1/agents/codex/commands?dir=/tmp",
+      )
+      assert.strictEqual(response.status, 200)
+      // The fake adapter lists nothing by default: an empty list is an answer.
+      assert.deepStrictEqual(yield* response.json, [])
+      const ref = operation("/api/v1/agents/{agentId}/commands").responses["200"]!.content[
+        "application/json"
+      ]!.schema
+      assert.deepStrictEqual(ref, { $ref: "#/components/schemas/AgentCommandList" })
+      const command = componentSchema("AgentCommand")
+      assert.sameMembers(Object.keys(command.properties), ["name", "description", "argumentHint"])
+      assert.sameMembers([...command.required], ["name", "description"])
+      const unknown = yield* (yield* rawClient).get(
+        "http://127.0.0.1/api/v1/agents/nope/commands?dir=/tmp",
+      )
+      assert.strictEqual(unknown.status, 404)
+      const badDir = yield* (yield* rawClient).get(
+        "http://127.0.0.1/api/v1/agents/codex/commands?dir=/definitely/not/here",
+      )
+      assert.strictEqual(badDir.status, 422)
     }).pipe(Effect.provide(BunHttpServer.layerHttpServices)),
   )
 

--- a/app-server/test/fixtures/fake-codex-listener.ts
+++ b/app-server/test/fixtures/fake-codex-listener.ts
@@ -37,6 +37,12 @@
 // thread/settings/updated like a TUI change would; model/list serves a
 // small catalog.
 //
+// Steering and skills (ATC-216): turn/steer takes input only while the
+// named turn is the thread's active one (anything else is an invalid
+// request) and echoes it as that turn's next userMessage item, localImage
+// blocks included; skills/list answers one entry per asked cwd with one
+// enabled skill ("review") and one disabled.
+//
 // Env switches (baked into the wrapper script by tests):
 //   FAKE_CODEX_MODE       "ok" (default) | "never-ready" (alive, never binds)
 //   FAKE_CODEX_WRONG_CWD  "start" | "resume" — lie about cwd in that reply
@@ -737,6 +743,59 @@ const handle = (
         })
       }
       return finishTurn(thread, turnId, text)
+    }
+    case "skills/list": {
+      // One entry per asked cwd: an enabled skill and a disabled one.
+      const cwds = (params["cwds"] as Array<string> | undefined) ?? []
+      return respond({
+        data: cwds.map((cwd) => ({
+          cwd,
+          errors: [],
+          skills: [
+            {
+              name: "review",
+              description: "Review the current diff carefully",
+              shortDescription: "Review the diff",
+              enabled: true,
+              path: "/skills/review/SKILL.md",
+              scope: "user",
+            },
+            {
+              name: "hidden",
+              description: "A disabled skill",
+              enabled: false,
+              path: "/skills/hidden/SKILL.md",
+              scope: "user",
+            },
+          ],
+        })),
+      })
+    }
+    case "turn/steer": {
+      const threadId = String(params["threadId"] ?? "")
+      const expectedTurnId = String(params["expectedTurnId"] ?? "")
+      const thread = threads.get(threadId)
+      if (thread === undefined) return respondError(-32600, `unknown thread ${threadId}`)
+      const active = thread.turns.find((turn) => turn.status === "inProgress")
+      if (active === undefined || active.id !== expectedTurnId) {
+        return respondError(-32600, `turn ${expectedTurnId} is not the active turn`)
+      }
+      const input = (params["input"] ?? []) as Array<{
+        type: string
+        text?: string
+        path?: string
+      }>
+      respond({ turnId: active.id })
+      // The real server echoes the steer as the turn's next userMessage item.
+      return emitItem(thread, active.id, "completed", {
+        id: crypto.randomUUID(),
+        type: "userMessage",
+        content: input.map((block) =>
+          block.type === "localImage"
+            ? { type: "localImage", path: block.path }
+            : { type: "text", text: block.text ?? "", text_elements: [] },
+        ),
+      })
     }
     case "turn/interrupt": {
       const threadId = String(params["threadId"] ?? "")

--- a/app-server/test/platform/fileSearch.test.ts
+++ b/app-server/test/platform/fileSearch.test.ts
@@ -1,0 +1,139 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Layer } from "effect"
+import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll } from "vitest"
+import * as Directories from "../../src/platform/directories.ts"
+import * as FileSearch from "../../src/platform/fileSearch.ts"
+import { testAppConfig } from "../testLayers.ts"
+
+// The filename search engine (ATC-216): the walk's exclusions, the ranking
+// tiers, the limit, and the directory validation it shares with /fs/list.
+
+const scratch = mkdtempSync(join(tmpdir(), "atc-file-search-"))
+afterAll(() => rmSync(scratch, { recursive: true, force: true }))
+
+const root = join(scratch, "project")
+for (const directory of [
+  "src/util",
+  "src/generated",
+  "node_modules/dep",
+  ".git",
+  "docs",
+  "build",
+]) {
+  mkdirSync(join(root, directory), { recursive: true })
+}
+writeFileSync(join(root, ".gitignore"), "node_modules/\nbuild\n")
+writeFileSync(join(root, "src", ".gitignore"), "generated/\n")
+for (const file of [
+  "README.md",
+  "app.ts",
+  "src/app.ts",
+  "src/util/helpers.ts",
+  "src/util/help.md",
+  "src/generated/out.ts",
+  "node_modules/dep/index.js",
+  ".git/HEAD",
+  "docs/Helping-Hands.md",
+  "build/app.js",
+  ".env",
+]) {
+  writeFileSync(join(root, file), "x")
+}
+
+const TestLayer = FileSearch.layer.pipe(
+  Layer.provide(Directories.layer.pipe(Layer.provide(testAppConfig({})))),
+)
+
+const paths = (result: FileSearch.FileSearchResult) => result.entries.map((entry) => entry.path)
+
+describe("FileSearch", () => {
+  it.effect("walks the tree minus .git and every .gitignore's exclusions, in path order", () =>
+    Effect.gen(function* () {
+      const search = yield* FileSearch.FileSearch
+      const result = yield* search.search({ dir: root, query: "", limit: 50 })
+      assert.strictEqual(result.dir, realpathSync(root))
+      assert.isFalse(result.truncated)
+      // The .gitignore files themselves are files like any other; the order is
+      // the pinned case-insensitive collation (README after docs).
+      assert.deepStrictEqual(paths(result), [
+        ".env",
+        ".gitignore",
+        "app.ts",
+        "docs/Helping-Hands.md",
+        "README.md",
+        "src/.gitignore",
+        "src/app.ts",
+        "src/util/help.md",
+        "src/util/helpers.ts",
+      ])
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect(
+    "ranks the name's tiers before the path's: exact, prefix, boundary, substring, fuzzy",
+    () =>
+      Effect.gen(function* () {
+        const search = yield* FileSearch.FileSearch
+        const help = yield* search.search({ dir: root, query: "help", limit: 10 })
+        // Prefix on the name (help.md, helpers.ts), then a boundary match
+        // (Helping-Hands.md starts with it too, case-insensitively, but is
+        // longer), then nothing else carries the letters in order.
+        assert.deepStrictEqual(paths(help), [
+          "src/util/help.md",
+          "src/util/helpers.ts",
+          "docs/Helping-Hands.md",
+        ])
+        const app = yield* search.search({ dir: root, query: "app.ts", limit: 10 })
+        // An exact name match beats an equal name deeper in the tree only by path.
+        assert.deepStrictEqual(paths(app), ["app.ts", "src/app.ts"])
+        const fuzzy = yield* search.search({ dir: root, query: "suhl", limit: 10 })
+        // Subsequence on the path: s/u(til)/h(elp)...
+        assert.deepStrictEqual(paths(fuzzy), ["src/util/help.md", "src/util/helpers.ts"])
+        const none = yield* search.search({ dir: root, query: "zzz", limit: 10 })
+        assert.deepStrictEqual(paths(none), [])
+      }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("a nested .gitignore's negation re-includes what the root excluded", () =>
+    Effect.gen(function* () {
+      const nested = join(scratch, "nested")
+      mkdirSync(join(nested, "logs"), { recursive: true })
+      writeFileSync(join(nested, ".gitignore"), "*.log\n")
+      writeFileSync(join(nested, "logs", ".gitignore"), "!keep.log\n")
+      writeFileSync(join(nested, "logs", "keep.log"), "")
+      writeFileSync(join(nested, "logs", "drop.log"), "")
+      writeFileSync(join(nested, "top.log"), "")
+      const search = yield* FileSearch.FileSearch
+      const result = yield* search.search({ dir: nested, query: "" })
+      assert.deepStrictEqual(paths(result), [".gitignore", "logs/.gitignore", "logs/keep.log"])
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("a subtree that cannot be read fails the walk instead of indexing around it", () =>
+    Effect.gen(function* () {
+      const locked = join(scratch, "locked")
+      mkdirSync(join(locked, "secret"), { recursive: true })
+      writeFileSync(join(locked, "open.txt"), "")
+      chmodSync(join(locked, "secret"), 0o000)
+      const search = yield* FileSearch.FileSearch
+      const failure = yield* Effect.flip(search.search({ dir: locked, query: "" }))
+      chmodSync(join(locked, "secret"), 0o755)
+      assert.isTrue(failure._tag === "DirectoryUnavailable" && failure.state === "inaccessible")
+    }).pipe(Effect.provide(TestLayer)),
+  )
+
+  it.effect("the limit caps the ranked list; an unusable directory is the tagged error", () =>
+    Effect.gen(function* () {
+      const search = yield* FileSearch.FileSearch
+      const two = yield* search.search({ dir: root, query: "", limit: 2 })
+      assert.deepStrictEqual(paths(two), [".env", ".gitignore"])
+      const missing = yield* Effect.flip(
+        search.search({ dir: join(scratch, "nope"), query: "", limit: 2 }),
+      )
+      assert.strictEqual(missing._tag, "DirectoryUnavailable")
+    }).pipe(Effect.provide(TestLayer)),
+  )
+})

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -16,6 +16,7 @@ import * as ClaudeHooks from "../src/agents/claudeHooks.ts"
 import * as CodexAdapter from "../src/agents/codexAdapter.ts"
 import { AppConfig } from "../src/platform/config.ts"
 import * as Directories from "../src/platform/directories.ts"
+import * as FileSearch from "../src/platform/fileSearch.ts"
 import * as Events from "../src/events/events.ts"
 import * as Persistence from "../src/platform/persistence.ts"
 import * as ProjectRepository from "../src/projects/projectRepository.ts"
@@ -73,9 +74,10 @@ export const TestTailscaleLayer = Layer.succeed(Tailscale.Tailscale)({
   status: Effect.succeed({ state: "disabled" }),
 })
 
-/** A settled AppConfig for tests that only need a few fields overridden. */
 /** One scratch data directory per test process: attachments write under it. */
 const testDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "atc-test-data-"))
+
+/** A settled AppConfig for tests that only need a few fields overridden. */
 
 export const testAppConfig = (overrides: Partial<AppConfig["Service"]>): Layer.Layer<AppConfig> =>
   Layer.succeed(AppConfig)({
@@ -129,6 +131,7 @@ export const makeTestServiceLayers = (
     | Threads.Threads
     | ThreadRuntime.ThreadRuntime
     | Attachments.Attachments
+    | FileSearch.FileSearch
     | TranscriptRepository.TranscriptRepository
     | Projects.Projects
     | AgentRegistry.AgentRegistry
@@ -157,9 +160,11 @@ export const makeTestServiceLayers = (
     // Merged, not just provided: Threads holds the SqlClient for its
     // settings write-through transaction.
   ).pipe(Layer.provideMerge(Persistence.layerFile(dbFile)))
+  const directories = Directories.layer.pipe(Layer.provide(testAppConfig(configOverrides)))
   const services = Layer.mergeAll(
     base,
-    Directories.layer.pipe(Layer.provide(testAppConfig(configOverrides))),
+    directories,
+    FileSearch.layer.pipe(Layer.provide(directories)),
     Attachments.layer.pipe(
       Layer.provide([base, testAppConfig(configOverrides), BunServices.layer]),
     ),

--- a/app-server/test/threads/threadRuntime.test.ts
+++ b/app-server/test/threads/threadRuntime.test.ts
@@ -214,6 +214,101 @@ describe("ThreadRuntime", () => {
     }).pipe(Effect.scoped, Effect.provide(kit.layer)),
   )
 
+  it.live(
+    "`when: now` joins the running turn as its next message; queues once the turn ended",
+    () =>
+      Effect.gen(function* () {
+        const runtime = yield* ThreadRuntime
+        const threads = yield* Threads
+        const thread = yield* newThread
+        const started = yield* runtime.prompt(thread.id, { prompt: "begin" })
+        const turnId = started.turnId ?? ""
+        const session = [...fake.sessions.values()].find((entry) => entry.inputs.includes("begin"))
+        const providerSessionId = session?.providerSessionId ?? ""
+
+        // Joined: the same turn id, the adapter took the text mid-turn, the
+        // transcript shows it under the running turn, and nothing waits.
+        const joined = yield* runtime.prompt(thread.id, { prompt: "also this", when: "now" })
+        assert.strictEqual(joined.turnId, turnId)
+        assert.deepStrictEqual(session?.inputs, ["begin", "also this"])
+        const page = yield* waitFor(
+          runtime.transcript(thread.id).pipe(Effect.orDie),
+          (current) => current.items.filter((item) => item.type === "userMessage").length === 2,
+        )
+        assert.deepStrictEqual(
+          page.items.flatMap((item) => (item.type === "userMessage" ? [item.turnId] : [])),
+          [turnId, turnId],
+        )
+        assert.deepStrictEqual(yield* runtime.listQueue(thread.id), [])
+
+        // A plain prompt still queues behind the running turn.
+        const queued = yield* runtime.prompt(thread.id, { prompt: "later" })
+        assert.isUndefined(queued.turnId)
+
+        // Once the turn is over, "now" is an ordinary prompt: it queues behind
+        // the waiting one (and starts when the drain reaches it).
+        fake.completeTurn(providerSessionId, "completed")
+        yield* waitFor(
+          Effect.sync(() => session?.inputs ?? []),
+          (inputs) => inputs.includes("later"),
+        )
+        fake.completeTurn(providerSessionId, "completed")
+        // Idle on the ledger, not just a completed turn row: the activity
+        // event trails the turn's end on the feed, and a busy ledger queues.
+        yield* waitFor(
+          threads.get(thread.id).pipe(Effect.orDie),
+          (current) => current.activityState === "idle",
+        )
+        const fresh = yield* runtime.prompt(thread.id, { prompt: "after all", when: "now" })
+        assert.isString(fresh.turnId)
+        assert.notStrictEqual(fresh.turnId, turnId)
+      }).pipe(Effect.scoped, Effect.provide(kit.layer)),
+  )
+
+  it.live("a re-read keeps a steered prompt's images on that prompt, not the turn's first", () =>
+    Effect.gen(function* () {
+      const runtime = yield* ThreadRuntime
+      const attachments = yield* Attachments
+      const thread = yield* newThread
+      const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3])
+      const shot = yield* attachments.create(thread.id, { bytes: png, mediaType: "image/png" })
+      const started = yield* runtime.prompt(thread.id, { prompt: "start" })
+      const turnId = started.turnId ?? ""
+      const session = [...fake.sessions.values()].find((entry) => entry.inputs.includes("start"))
+      const providerSessionId = session?.providerSessionId ?? ""
+      const joined = yield* runtime.prompt(thread.id, {
+        prompt: "and look",
+        attachments: [shot.id],
+        when: "now",
+      })
+      assert.strictEqual(joined.turnId, turnId)
+      yield* waitFor(
+        runtime.transcript(thread.id).pipe(Effect.orDie),
+        (current) => current.items.filter((item) => item.type === "userMessage").length === 2,
+      )
+      fake.completeTurn(providerSessionId, "completed")
+      yield* waitFor(runtime.transcript(thread.id).pipe(Effect.orDie), (current) =>
+        current.turns.every((turn) => turn.status === "completed"),
+      )
+      // History re-numbers both prompts and carries no attachments.
+      fake.setHistory(providerSessionId, [
+        {
+          turn: { id: turnId, status: "completed" },
+          items: [
+            { type: "userMessage", id: "item-1", turnId, text: "start" },
+            { type: "userMessage", id: "item-2", turnId, text: "and look" },
+          ],
+        },
+      ])
+      yield* runtime.reread(thread.id)
+      const page = yield* runtime.transcript(thread.id)
+      const messages = page.items.flatMap((item) =>
+        item.type === "userMessage" ? [item.attachments] : [],
+      )
+      assert.deepStrictEqual(messages, [undefined, [shot]])
+    }).pipe(Effect.scoped, Effect.provide(kit.layer)),
+  )
+
   it.live("a provider re-read keeps a prompt's images where its turn id is stable", () =>
     Effect.gen(function* () {
       const runtime = yield* ThreadRuntime

--- a/macos/ATC/Features/Agents/AgentsStore.swift
+++ b/macos/ATC/Features/Agents/AgentsStore.swift
@@ -4,7 +4,11 @@
 // store refreshes with the SSE-driven cycle like every other list. The
 // per-agent model catalogs (ATC-205) are read on demand — the first Chat of
 // an agent asks for its catalog — and kept for the store's life; the server
-// caches them too, so a re-read is cheap when a view wants one.
+// caches them too, so a re-read is cheap when a view wants one. The
+// per-agent, per-directory command lists (ATC-216) follow the same rule:
+// read when a composer first asks, kept for the store's life, a failed read
+// retried on the next ask — and never shown as an error, since an absent
+// list simply means no `/` suggestions.
 
 import ATCAppServerAPI
 import Foundation
@@ -19,8 +23,17 @@ final class AgentsStore {
     private(set) var models: [AgentID: [AgentModel]] = [:]
     /// The last failed catalog read per agent, until a read succeeds.
     private(set) var modelErrors: [AgentID: String] = [:]
+    /// Command lists by agent and directory, once read (see the header).
+    private(set) var commands: [AgentDirectory: [AgentCommand]] = [:]
     private let refreshState = RefreshState(category: "agents")
     private var modelReads: [AgentID: Task<Void, Never>] = [:]
+    private var commandReads: [AgentDirectory: Task<Void, Never>] = [:]
+
+    /// The key a command list is read for: one agent in one directory.
+    struct AgentDirectory: Hashable {
+        let agent: AgentID
+        let dir: String
+    }
 
     var hasLoadedOnce: Bool { refreshState.hasLoadedOnce }
     var lastError: String? { refreshState.lastError }
@@ -45,6 +58,26 @@ final class AgentsStore {
     /// The agent's catalog, or nil until `loadModels` has read it.
     func models(for id: AgentID) -> [AgentModel]? {
         models[id]
+    }
+
+    /// The agent's commands in `dir`, or nil until `loadCommands` has read them.
+    func commands(for id: AgentID, dir: String) -> [AgentCommand]? {
+        commands[AgentDirectory(agent: id, dir: dir)]
+    }
+
+    /// Read the agent's command list for `dir` once (idempotent while a
+    /// read is in flight or already landed); a failed read is retried on
+    /// the next call.
+    func loadCommands(for id: AgentID, dir: String) {
+        let key = AgentDirectory(agent: id, dir: dir)
+        guard commands[key] == nil, commandReads[key] == nil else { return }
+        commandReads[key] = Task { [weak self] in
+            defer { self?.commandReads[key] = nil }
+            guard let self else { return }
+            commands[key] = try? await client.listAgentCommands(
+                path: .init(agentId: id.rawValue), query: .init(dir: dir)
+            ).ok.body.json
+        }
     }
 
     /// Read the agent's catalog once (idempotent while a read is in flight

--- a/macos/ATC/Features/Agents/AgentsStore.swift
+++ b/macos/ATC/Features/Agents/AgentsStore.swift
@@ -1,14 +1,21 @@
 // Shared domain state for one Connection's agent registry: live-detected
 // availability plus the actionable reason when a provider is missing. The
 // server never persists this — every refresh is a fresh detection — so the
-// store refreshes with the SSE-driven cycle like every other list. The
-// per-agent model catalogs (ATC-205) are read on demand — the first Chat of
-// an agent asks for its catalog — and kept for the store's life; the server
-// caches them too, so a re-read is cheap when a view wants one. The
-// per-agent, per-directory command lists (ATC-216) follow the same rule:
-// read when a composer first asks, kept for the store's life, a failed read
-// retried on the next ask — and never shown as an error, since an absent
-// list simply means no `/` suggestions.
+// store refreshes with the SSE-driven cycle like every other list.
+//
+// The per-agent model catalogs (ATC-205) and per-agent, per-directory
+// command lists (ATC-216) are read on demand and held only for rendering:
+// the server owns their freshness (it caches each for a short while and
+// re-asks the provider lazily, on the next request after expiry), so every
+// ask here re-reads — serving what is held immediately and replacing it
+// when the read lands (stale-while-revalidate). A catalog is asked for when
+// a Chat of the agent appears; a command list whenever a composer's `/`
+// needs suggestions. Neither polls. A failed re-read keeps what is held; a
+// failed first read of a catalog records its error for the picker, while an
+// absent command list is never an error — it simply means no `/`
+// suggestions. Nothing is kept across a URL/token rebuild of the runtime;
+// an SSE reconnect keeps the store, so freshness comes from re-asking, not
+// from reconnecting.
 
 import ATCAppServerAPI
 import Foundation
@@ -65,26 +72,29 @@ final class AgentsStore {
         commands[AgentDirectory(agent: id, dir: dir)]
     }
 
-    /// Read the agent's command list for `dir` once (idempotent while a
-    /// read is in flight or already landed); a failed read is retried on
-    /// the next call.
+    /// Re-read the agent's command list for `dir` (coalesced while a read
+    /// is in flight). The held list stays up until the read lands; a failed
+    /// read keeps it.
     func loadCommands(for id: AgentID, dir: String) {
         let key = AgentDirectory(agent: id, dir: dir)
-        guard commands[key] == nil, commandReads[key] == nil else { return }
+        guard commandReads[key] == nil else { return }
         commandReads[key] = Task { [weak self] in
             defer { self?.commandReads[key] = nil }
             guard let self else { return }
-            commands[key] = try? await client.listAgentCommands(
+            if let fetched = try? await client.listAgentCommands(
                 path: .init(agentId: id.rawValue), query: .init(dir: dir)
-            ).ok.body.json
+            ).ok.body.json {
+                commands[key] = fetched
+            }
         }
     }
 
-    /// Read the agent's catalog once (idempotent while a read is in flight
-    /// or already landed); a failed read records its error and is retried
-    /// on the next call.
+    /// Re-read the agent's catalog (coalesced while a read is in flight).
+    /// The held catalog stays up until the read lands; a failed read keeps
+    /// it and records the error, which the picker shows only while no
+    /// catalog is held.
     func loadModels(for id: AgentID) {
-        guard models[id] == nil, modelReads[id] == nil else { return }
+        guard modelReads[id] == nil else { return }
         modelReads[id] = Task { [weak self] in
             defer { self?.modelReads[id] = nil }
             guard let self else { return }

--- a/macos/ATC/Features/Threads/Chat/ChatComposer.swift
+++ b/macos/ATC/Features/Threads/Chat/ChatComposer.swift
@@ -6,19 +6,28 @@
 // round send button in the corner.
 // Return sends (never mid-IME-composition — a marked-text Return commits the
 // composition), Shift-Return inserts a newline, Escape stops a running turn,
-// and ⌘↑ recalls the last sent prompt into an empty composer. Send is never
-// disabled while connected — the server admits every prompt (idle starts a
-// turn, busy queues it) — and a refused prompt keeps its text with the
-// server's message inline. Stop shows only while the server is driving a
-// turn. The composer autofocuses on appear unless a request is pending (a
-// bar card or an inline row) — answering the agent owns the keyboard until
-// it is done.
+// and ⌘↑/⌘↓ walk the thread's previous prompts (`PromptHistory`). Send is
+// never disabled while connected — the server admits every prompt (idle
+// starts a turn, busy queues it) — and a refused prompt keeps its text with
+// the server's message inline. Stop shows only while the server is driving
+// a turn, and then Return hands the prompt to that turn ("now") while
+// ⌥Return queues it behind; idle, Return is a plain send. The composer
+// autofocuses on appear unless a request is pending (a bar card or an
+// inline row) — answering the agent owns the keyboard until it is done.
 //
 // Images (ATC-216) arrive by paste (the text view declines an image-only
 // pasteboard, so the paste command reaches us), drop, or the Attach button
 // (⌘⇧A); each is fitted to the server's caps at once
 // (`ImageAttachmentEncoder`) and held as bytes until send. A prompt may be
 // images alone.
+//
+// Completions (ATC-216): `@` at a word start lists the thread directory's
+// files (the server ranks them; the query is debounced), `/` at the start
+// lists the agent's commands (filtered here). The list sits inside the
+// card above the text — a popover would take key focus from the editor —
+// and is keyboard-first: ↑/↓ (Ctrl-N/P) move, Return/Tab accept, Esc
+// dismisses; the accepted text replaces the trigger as plain text
+// (`ComposerCompletion`).
 
 import ATCAppServerAPI
 import ATCChat
@@ -34,27 +43,41 @@ struct ChatComposer: View {
     /// The agent's model catalog, nil until read (the chip shows the raw id).
     let models: [AgentModel]?
     let modelsError: String?
-    let showsStop: Bool
+    /// The server is driving a turn: Stop shows, Return joins the turn.
+    let isTurnRunning: Bool
     let error: String?
-    /// ⌘↑ recalls this into an empty composer.
-    let lastSentPrompt: String?
+    /// The thread's previous prompts, newest first (⌘↑/⌘↓).
+    let history: [String]
+    /// The agent's commands in the thread's directory, nil until read.
+    let commands: [AgentCommand]?
     /// A request card is up: don't steal focus from it on appear.
     let yieldsFocus: Bool
     /// Advances whenever the window wants the composer focused.
     let focusRequest: UInt
-    let send: () -> Void
+    /// The server's ranked files for an `@` query (nil: unavailable).
+    let searchFiles: (String) async -> Components.Schemas.FsFilesResponse?
+    /// Ask for the command list (idempotent; `commands` fills in).
+    let loadCommands: () -> Void
+    /// Send the draft; `when` is nil for a plain send while idle.
+    let send: (PromptWhen?) -> Void
     let stop: () -> Void
     let updateSettings: (ThreadSettingsPatch) -> Void
     let reloadModels: () -> Void
 
     @FocusState private var isFocused: Bool
+    @State private var selection: TextSelection?
     @State private var editorHeight: CGFloat = 24
     /// The last image that could not be attached (unreadable, too many).
     @State private var attachmentError: String?
     @State private var isPicking = false
     @State private var isDropTargeted = false
+    @State private var completion: Completion?
+    @State private var fileSearch: Task<Void, Never>?
+    @State private var recall = PromptHistory()
 
     private static let imageTypes: [UTType] = [.image, .fileURL]
+    private static let completionRowHeight: CGFloat = 26
+    private static let completionVisibleRows = 8
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
@@ -69,6 +92,9 @@ struct ChatComposer: View {
                     AttachmentStrip(images: attachments.map { .local($0) }) { image in
                         attachments.removeAll { $0.id.uuidString == image.id }
                     }
+                }
+                if let completion, !completion.items.isEmpty {
+                    completionList(completion)
                 }
                 editor
                 HStack(spacing: Spacing.sm) {
@@ -89,7 +115,7 @@ struct ChatComposer: View {
                         update: updateSettings, reloadModels: reloadModels
                     )
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    if showsStop {
+                    if isTurnRunning {
                         Button(action: stop) {
                             Label("Stop", systemImage: "stop.fill")
                                 .labelStyle(.titleAndIcon)
@@ -101,18 +127,9 @@ struct ChatComposer: View {
                         .background(Surface.raised, in: Capsule())
                         .help("Stop the running turn (Esc)")
                         .transition(.opacity)
+                        sendMenu
                     }
-                    Button(action: send) {
-                        Image(systemName: "arrow.up")
-                            .font(.body.weight(.bold))
-                            .frame(width: 30, height: 30)
-                            .foregroundStyle(canSend ? Color.black : Color.secondary)
-                            .background(canSend ? Color.white : Surface.raised, in: Circle())
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(!canSend)
-                    .help("Send (Return)")
-                    .accessibilityLabel("Send message")
+                    sendButton
                 }
             }
             .padding(Spacing.md)
@@ -138,7 +155,63 @@ struct ChatComposer: View {
             if !yieldsFocus { isFocused = true }
         }
         .onChange(of: focusRequest) { _, _ in isFocused = true }
+        .onChange(of: text) { _, now in
+            // Typing ends a history walk; a step of the walk does not.
+            if let shown = recall.shown, shown != now { recall.reset() }
+            refreshCompletion()
+        }
+        .onChange(of: selection) { _, _ in refreshCompletion() }
+        .onChange(of: commands) { _, _ in
+            if completion?.trigger.kind == .command { refreshCompletion() }
+        }
     }
+
+    // MARK: - Sending
+
+    /// What Return sends: the running turn takes the prompt now, ⌥ queues it
+    /// behind; idle, the plain send.
+    private func whenFor(option: Bool) -> PromptWhen? {
+        guard isTurnRunning else { return nil }
+        return option ? .queue : .now
+    }
+
+    private var sendButton: some View {
+        Button {
+            send(whenFor(option: NSEvent.modifierFlags.contains(.option)))
+        } label: {
+            Image(systemName: "arrow.up")
+                .font(.body.weight(.bold))
+                .frame(width: 30, height: 30)
+                .foregroundStyle(canSend ? Color.black : Color.secondary)
+                .background(canSend ? Color.white : Surface.raised, in: Circle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!canSend)
+        .help(isTurnRunning ? "Send now (Return) · Queue for after (⌥Return)" : "Send (Return)")
+        .accessibilityLabel(isTurnRunning ? "Send now" : "Send message")
+    }
+
+    /// The running turn's alternative, spelled out: a quiet chevron popping
+    /// the two ways a prompt can go.
+    private var sendMenu: some View {
+        PopupMenuButton(
+            entries: [
+                .item(title: "Send now", isSelected: false) { send(.now) },
+                .item(title: "Queue for after", isSelected: false) { send(.queue) },
+            ],
+            appearance: .accessoryBar
+        ) {
+            Image(systemName: "chevron.down")
+                .font(.caption.weight(.semibold))
+                .frame(width: 18, height: 24)
+        }
+        .disabled(!canSend)
+        .help("Send now, or queue for after the turn")
+        .accessibilityLabel("Send options")
+        .transition(.opacity)
+    }
+
+    // MARK: - Attachments
 
     private func attachPicked(_ result: Result<[URL], any Error>) {
         guard case .success(let urls) = result else { return }
@@ -170,6 +243,206 @@ struct ChatComposer: View {
         }
     }
 
+    // MARK: - Completions
+
+    /// One list the composer offers: the trigger it answers and its rows.
+    private struct Completion {
+        let trigger: ComposerCompletion.Trigger
+        var items: [CompletionItem] = []
+        var selectedID: String?
+        var truncated = false
+        /// The rows answer an earlier query and are shown only to avoid a
+        /// flash; they cannot be accepted until the fresh ones land.
+        var stale = false
+    }
+
+    /// A completion with rows on screen — the only state that takes keys
+    /// from the editor (an empty or pending one is invisible and inert).
+    private var hasVisibleCompletion: Bool {
+        !(completion?.items.isEmpty ?? true)
+    }
+
+    private enum CompletionItem: Identifiable {
+        case file(Components.Schemas.FsFileEntry)
+        case command(AgentCommand)
+
+        var id: String {
+            switch self {
+            case .file(let entry): "file:\(entry.path)"
+            case .command(let command): "command:\(command.name)"
+            }
+        }
+
+        /// What acceptance inserts in place of the trigger.
+        var insertion: String {
+            switch self {
+            case .file(let entry): "@\(entry.path)"
+            case .command(let command): "/\(command.name)"
+            }
+        }
+
+        var title: String {
+            switch self {
+            case .file(let entry): entry.name
+            case .command(let command): "/\(command.name)"
+            }
+        }
+
+        var detail: String? {
+            switch self {
+            case .file(let entry): entry.path == entry.name ? nil : entry.path
+            case .command(let command):
+                command.argumentHint.map { "\($0)  \(command.description)" } ?? command.description
+            }
+        }
+
+        var systemImage: String {
+            switch self {
+            case .file: "doc"
+            case .command: "terminal"
+            }
+        }
+    }
+
+    /// The caret: the selection's end, or the text's end when the editor
+    /// reports none.
+    private var caret: String.Index {
+        if case .selection(let range) = selection?.indices, range.upperBound <= text.endIndex {
+            return range.upperBound
+        }
+        return text.endIndex
+    }
+
+    /// Re-derive the list from the text and caret: a command list filters
+    /// in place, a file list asks the server after a short debounce so a
+    /// burst of keystrokes is one request.
+    private func refreshCompletion() {
+        guard let trigger = ComposerCompletion.trigger(in: text, caret: caret) else {
+            dismissCompletion()
+            return
+        }
+        switch trigger.kind {
+        case .command:
+            fileSearch?.cancel()
+            loadCommands()
+            let items = ComposerCompletion.filter(commands ?? [], query: trigger.query).map(CompletionItem.command)
+            setCompletion(trigger: trigger, items: items, truncated: false)
+        case .file:
+            if completion?.trigger != trigger {
+                // Keep the last rows up (stale) while the next query is in
+                // flight; a different kind of trigger starts empty.
+                let previous = completion?.trigger.kind == .file ? completion : nil
+                completion = Completion(
+                    trigger: trigger, items: previous?.items ?? [], selectedID: previous?.selectedID,
+                    truncated: previous?.truncated ?? false, stale: true)
+            }
+            fileSearch?.cancel()
+            fileSearch = Task {
+                try? await Task.sleep(for: .milliseconds(100))
+                guard !Task.isCancelled else { return }
+                let response = await searchFiles(trigger.query)
+                guard !Task.isCancelled, completion?.trigger == trigger else { return }
+                setCompletion(
+                    trigger: trigger, items: (response?.entries ?? []).map(CompletionItem.file),
+                    truncated: response?.truncated ?? false)
+            }
+        }
+    }
+
+    private func setCompletion(trigger: ComposerCompletion.Trigger, items: [CompletionItem], truncated: Bool) {
+        let kept = completion?.selectedID.flatMap { id in items.first { $0.id == id }?.id }
+        completion = Completion(
+            trigger: trigger, items: items, selectedID: kept ?? items.first?.id, truncated: truncated)
+    }
+
+    private func dismissCompletion() {
+        fileSearch?.cancel()
+        fileSearch = nil
+        completion = nil
+    }
+
+    private func moveCompletion(by offset: Int) -> KeyPress.Result {
+        guard let current = completion, !current.items.isEmpty else { return .ignored }
+        completion?.selectedID = SelectionMovement.wrapped(from: current.selectedID, by: offset, in: current.items)
+        return .handled
+    }
+
+    private func acceptCompletion() -> KeyPress.Result {
+        guard hasVisibleCompletion, let current = completion else { return .ignored }
+        // Rows of an earlier query: swallow the key until the fresh ones land.
+        guard !current.stale, let item = current.items.first(where: { $0.id == current.selectedID })
+        else { return .handled }
+        accept(item, for: current.trigger)
+        return .handled
+    }
+
+    private func accept(_ item: CompletionItem, for trigger: ComposerCompletion.Trigger) {
+        let accepted = ComposerCompletion.accept(trigger, in: text, with: item.insertion)
+        dismissCompletion()
+        text = accepted.text
+        selection = TextSelection(range: accepted.caret..<accepted.caret)
+    }
+
+    private func completionList(_ completion: Completion) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 2) {
+                        ForEach(completion.items) { item in
+                            completionRow(item, isSelected: item.id == completion.selectedID)
+                                .id(item.id)
+                                .onTapGesture { accept(item, for: completion.trigger) }
+                        }
+                    }
+                }
+                .frame(
+                    height: Self.completionRowHeight
+                        * CGFloat(min(completion.items.count, Self.completionVisibleRows))
+                )
+                .onChange(of: completion.selectedID) { _, id in
+                    if let id { proxy.scrollTo(id) }
+                }
+            }
+            if completion.truncated {
+                Text("More files than the index holds — type more of the name.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .padding(.horizontal, Spacing.sm)
+            }
+        }
+        .padding(Spacing.xs)
+        .background(Surface.raised, in: RoundedRectangle(cornerRadius: Radius.chip))
+        .accessibilityLabel(completion.trigger.kind == .file ? "File suggestions" : "Command suggestions")
+    }
+
+    private func completionRow(_ item: CompletionItem, isSelected: Bool) -> some View {
+        HStack(spacing: Spacing.sm) {
+            Image(systemName: item.systemImage)
+                .foregroundStyle(.secondary)
+                .frame(width: 16)
+            Text(item.title)
+                .lineLimit(1)
+            if let detail = item.detail {
+                Text(detail)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer(minLength: 0)
+        }
+        .font(.callout)
+        .padding(.horizontal, Spacing.sm)
+        .frame(height: Self.completionRowHeight)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            isSelected ? Color.accentColor.opacity(0.18) : Color.clear,
+            in: RoundedRectangle(cornerRadius: Radius.chip - 2)
+        )
+        .contentShape(Rectangle())
+    }
+
+    // MARK: - Editor
+
     /// A TextEditor sized by the text behind it: it starts three lines tall
     /// (room to type before the controls row), grows with the message, then
     /// scrolls. TextEditor claims every point it is offered, so its height
@@ -188,7 +461,7 @@ struct ChatComposer: View {
                 } action: {
                     editorHeight = $0
                 }
-            TextEditor(text: $text)
+            TextEditor(text: $text, selection: $selection)
                 .font(.body)
                 .scrollContentBackground(.hidden)
                 .scrollIndicators(.never)
@@ -201,28 +474,36 @@ struct ChatComposer: View {
                 }
                 .onKeyPress(.return, phases: .down) { press in
                     guard !press.modifiers.contains(.shift) else { return .ignored }
-                    // Mid-IME composition, Return commits the marked text.
+                    // Mid-IME composition, every key is the input method's.
                     guard !isComposing else { return .ignored }
+                    if hasVisibleCompletion { return acceptCompletion() }
                     guard canSend else { return .handled }
-                    send()
+                    send(whenFor(option: press.modifiers.contains(.option)))
                     return .handled
                 }
+                .onKeyPress(.tab, phases: .down) { _ in
+                    guard !isComposing else { return .ignored }
+                    return acceptCompletion()
+                }
                 .onKeyPress(.escape, phases: .down) { _ in
-                    guard showsStop else { return .ignored }
+                    guard !isComposing else { return .ignored }
+                    if hasVisibleCompletion {
+                        dismissCompletion()
+                        return .handled
+                    }
+                    guard isTurnRunning else { return .ignored }
                     stop()
                     return .handled
                 }
                 .onKeyPress(.upArrow, phases: .down) { press in
-                    // Exactly ⌘↑ — ⌘⇧↑ and friends keep their standard text
-                    // behavior (extend selection to start, …).
-                    guard press.modifiers.subtracting(.capsLock) == .command else {
-                        return .ignored
-                    }
-                    // Recall only into an empty composer; otherwise the text
-                    // view keeps its standard ⌘↑ (caret to start).
-                    guard text.isEmpty, let lastSentPrompt else { return .ignored }
-                    text = lastSentPrompt
-                    return .handled
+                    verticalKey(press, offset: -1)
+                }
+                .onKeyPress(.downArrow, phases: .down) { press in
+                    verticalKey(press, offset: 1)
+                }
+                .onKeyPress(keys: ["n", "p"], phases: .down) { press in
+                    guard press.modifiers == .control else { return .ignored }
+                    return moveCompletion(by: press.key == "n" ? 1 : -1)
                 }
             if text.isEmpty {
                 Text(attachments.isEmpty ? "Message the agent…" : "Add a message, or send the images…")
@@ -232,6 +513,19 @@ struct ChatComposer: View {
                     .allowsHitTesting(false)
             }
         }
+    }
+
+    /// ↑/↓: move the completion while one is up; exactly ⌘↑/⌘↓ walk the
+    /// prompt history (⌘⇧↑ and friends keep their standard text behavior);
+    /// anything else is the text view's.
+    private func verticalKey(_ press: KeyPress, offset: Int) -> KeyPress.Result {
+        if hasVisibleCompletion, press.modifiers.isEmpty { return moveCompletion(by: offset) }
+        guard press.modifiers.subtracting(.capsLock) == .command else { return .ignored }
+        guard let recalled = offset < 0 ? recall.older(from: text, in: history) : recall.newer(in: history)
+        else { return .ignored }
+        text = recalled
+        selection = TextSelection(range: recalled.endIndex..<recalled.endIndex)
+        return .handled
     }
 
     private var canSend: Bool {

--- a/macos/ATC/Features/Threads/Chat/ThreadChatView.swift
+++ b/macos/ATC/Features/Threads/Chat/ThreadChatView.swift
@@ -148,11 +148,14 @@ private struct ChatPane: View {
                     thread: thread,
                     models: agents?.models(for: thread.agentId),
                     modelsError: agents?.modelErrors[thread.agentId],
-                    showsStop: chat.runningTurn != nil,
+                    isTurnRunning: chat.runningTurn != nil,
                     error: chat.promptError,
-                    lastSentPrompt: chat.lastSentPrompt,
+                    history: chat.promptHistory,
+                    commands: agents?.commands(for: thread.agentId, dir: thread.workingDirectory),
                     yieldsFocus: !chat.requests.isEmpty,
                     focusRequest: focusRequest,
+                    searchFiles: searchFiles,
+                    loadCommands: { agents?.loadCommands(for: thread.agentId, dir: thread.workingDirectory) },
                     send: send,
                     stop: { chat.perform { [chat] in try await chat.interrupt() } },
                     updateSettings: { patch in
@@ -268,15 +271,16 @@ private struct ChatPane: View {
 
     /// The draft (text and images) clears the moment the prompt leaves (the
     /// echo row carries it); a refusal restores it in front of whatever was
-    /// typed or attached since, so nothing is ever lost.
-    private func send() {
+    /// typed or attached since, so nothing is ever lost. `when` is the
+    /// composer's choice while a turn runs (now / queue), nil when idle.
+    private func send(when: PromptWhen?) {
         let draft = appModel.draft(for: ref)
         let prompt = draft.text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !prompt.isEmpty || !draft.attachments.isEmpty else { return }
         appModel.setDraft(ComposerDraft(), for: ref)
         followRequest += 1
         Task {
-            guard await !chat.send(prompt, attachments: draft.attachments) else { return }
+            guard await !chat.send(prompt, attachments: draft.attachments, when: when) else { return }
             let since = appModel.draft(for: ref)
             appModel.setDraft(
                 ComposerDraft(
@@ -284,6 +288,16 @@ private struct ChatPane: View {
                     attachments: draft.attachments + since.attachments),
                 for: ref)
         }
+    }
+
+    /// The `@` completion's source: the server's ranking of the thread
+    /// directory's files, a dozen at a time; nil when the read fails (the
+    /// list simply stays empty).
+    private func searchFiles(_ query: String) async -> Components.Schemas.FsFilesResponse? {
+        guard let client = appModel.runtime(id: ref.connectionID)?.client else { return nil }
+        return try? await client.searchFiles(
+            query: .init(dir: thread.workingDirectory, query: query, limit: "12")
+        ).ok.body.json
     }
 
     // MARK: - Status

--- a/macos/ATC/PreviewSupport/PreviewAppServerClient.swift
+++ b/macos/ATC/PreviewSupport/PreviewAppServerClient.swift
@@ -600,6 +600,25 @@ import OpenAPIRuntime
             .ok(.init(body: .json(agents)))
         }
 
+        func listAgentCommands(
+            _ input: Operations.ListAgentCommands.Input
+        ) async throws -> Operations.ListAgentCommands.Output {
+            .ok(
+                .init(
+                    body: .json([
+                        .init(name: "review", description: "Review the current diff"),
+                        .init(name: "commit", description: "Commit staged changes", argumentHint: "<message>"),
+                    ])))
+        }
+
+        func searchFiles(_ input: Operations.SearchFiles.Input) async throws -> Operations.SearchFiles.Output {
+            let files = ["Package.swift", "Sources/App/Main.swift", "Sources/App/Model.swift", "README.md"]
+            let needle = (input.query.query ?? "").lowercased()
+            let entries = files.filter { needle.isEmpty || $0.lowercased().contains(needle) }
+                .map { Components.Schemas.FsFileEntry(path: $0, name: ($0 as NSString).lastPathComponent) }
+            return .ok(.init(body: .json(.init(dir: input.query.dir, entries: entries, truncated: false))))
+        }
+
         func listAgentModels(
             _ input: Operations.ListAgentModels.Input
         ) async throws -> Operations.ListAgentModels.Output {

--- a/macos/ATCTests/AgentsStoreTests.swift
+++ b/macos/ATCTests/AgentsStoreTests.swift
@@ -1,0 +1,75 @@
+import ATCAppServerAPI
+import Foundation
+import Testing
+
+@testable import ATC
+
+/// AgentsStore's on-demand reads: every ask re-reads (the server owns
+/// freshness), the held value stays up until the read lands, and a failed
+/// re-read keeps it.
+@MainActor
+@Suite("AgentsStore")
+struct AgentsStoreTests {
+    private typealias AgentCommand = Components.Schemas.AgentCommand
+
+    @Test("every command ask re-reads, so a newly added skill shows on the next ask")
+    func commandsRevalidateOnEachAsk() async {
+        let client = ScriptableAppServerClient()
+        client.agentCommands = [.claudeCode: [AgentCommand(name: "commit", description: "Commit")]]
+        let store = AgentsStore(client: client)
+
+        store.loadCommands(for: .claudeCode, dir: "/home/dev/app")
+        await settle { store.commands(for: .claudeCode, dir: "/home/dev/app") != nil }
+        #expect(store.commands(for: .claudeCode, dir: "/home/dev/app")?.map(\.name) == ["commit"])
+
+        client.agentCommands = [
+            .claudeCode: [
+                AgentCommand(name: "commit", description: "Commit"),
+                AgentCommand(name: "review", description: "Review"),
+            ]
+        ]
+        store.loadCommands(for: .claudeCode, dir: "/home/dev/app")
+        await settle { store.commands(for: .claudeCode, dir: "/home/dev/app")?.count == 2 }
+        #expect(client.commandListings.count == 2)
+    }
+
+    @Test("a failed re-read keeps the held command list")
+    func failedCommandRereadKeepsHeldList() async {
+        let client = ScriptableAppServerClient()
+        client.agentCommands = [.claudeCode: [AgentCommand(name: "commit", description: "Commit")]]
+        let store = AgentsStore(client: client)
+
+        store.loadCommands(for: .claudeCode, dir: "/home/dev/app")
+        await settle { store.commands(for: .claudeCode, dir: "/home/dev/app") != nil }
+
+        client.shouldFail = true
+        store.loadCommands(for: .claudeCode, dir: "/home/dev/app")
+        // A failed read leaves no trace on the client, so give it a bounded
+        // moment, then prove the store still serves the held list and the
+        // next successful ask goes through (the failure cleared the in-flight
+        // guard).
+        await settle(until: { false }, timeout: .milliseconds(50))
+        #expect(store.commands(for: .claudeCode, dir: "/home/dev/app")?.map(\.name) == ["commit"])
+
+        client.shouldFail = false
+        client.agentCommands = [.claudeCode: []]
+        store.loadCommands(for: .claudeCode, dir: "/home/dev/app")
+        await settle { store.commands(for: .claudeCode, dir: "/home/dev/app")?.isEmpty == true }
+        #expect(client.commandListings.count == 2)
+    }
+
+    @Test("a failed catalog re-read keeps the held catalog")
+    func failedModelRereadKeepsHeldCatalog() async {
+        let client = ScriptableAppServerClient()
+        client.models = [.codex: [Fixtures.model("gpt-5", displayName: "GPT-5")]]
+        let store = AgentsStore(client: client)
+
+        store.loadModels(for: .codex)
+        await settle { store.models(for: .codex) != nil }
+
+        client.shouldFail = true
+        store.loadModels(for: .codex)
+        await settle { store.modelErrors[.codex] != nil }
+        #expect(store.models(for: .codex)?.map(\.value) == ["gpt-5"])
+    }
+}

--- a/macos/ATCTests/ScriptableAppServerClient.swift
+++ b/macos/ATCTests/ScriptableAppServerClient.swift
@@ -54,7 +54,13 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
         /// While set, promptThread fails 503 with this payload.
         var promptThreadFailure: Components.Schemas.ProviderUnavailableJsonEncoding?
         var transcriptReads: [(threadID: String, before: String?)] = []
-        var prompts: [(threadID: String, prompt: String, attachments: [String]?)] = []
+        var prompts: [(threadID: String, prompt: String, attachments: [String]?, when: PromptWhen?)] = []
+        /// What searchFiles answers with (filtered by the query) and the queries asked.
+        var fileSearchEntries: [Components.Schemas.FsFileEntry] = []
+        var fileSearches: [(dir: String, query: String?)] = []
+        /// Command lists by agent, and the (agent, dir) pairs asked for.
+        var agentCommands: [AgentID: [Components.Schemas.AgentCommand]] = [:]
+        var commandListings: [(agentID: String, dir: String)] = []
         /// Uploads received, in order, with the bytes as sent.
         var uploads: [(threadID: String, attachment: Components.Schemas.ThreadAttachment, bytes: Data)] = []
         var answers: [(threadID: String, requestID: String, answer: ThreadRequestAnswer)] = []
@@ -227,7 +233,19 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
     var openThreadTerminalCount: Int { lock.withLock { state.openThreadTerminalCount } }
     var markThreadViewedCount: Int { lock.withLock { state.markThreadViewedCount } }
     var transcriptReads: [(threadID: String, before: String?)] { lock.withLock { state.transcriptReads } }
-    var prompts: [(threadID: String, prompt: String, attachments: [String]?)] { lock.withLock { state.prompts } }
+    var prompts: [(threadID: String, prompt: String, attachments: [String]?, when: PromptWhen?)] {
+        lock.withLock { state.prompts }
+    }
+    var fileSearchEntries: [Components.Schemas.FsFileEntry] {
+        get { lock.withLock { state.fileSearchEntries } }
+        set { lock.withLock { state.fileSearchEntries = newValue } }
+    }
+    var fileSearches: [(dir: String, query: String?)] { lock.withLock { state.fileSearches } }
+    var agentCommands: [AgentID: [Components.Schemas.AgentCommand]] {
+        get { lock.withLock { state.agentCommands } }
+        set { lock.withLock { state.agentCommands = newValue } }
+    }
+    var commandListings: [(agentID: String, dir: String)] { lock.withLock { state.commandListings } }
     var uploads: [(threadID: String, attachment: Components.Schemas.ThreadAttachment, bytes: Data)] {
         lock.withLock { state.uploads }
     }
@@ -693,6 +711,32 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
         return .ok(.init(body: .json(payload)))
     }
 
+    func searchFiles(_ input: Operations.SearchFiles.Input) async throws -> Operations.SearchFiles.Output {
+        try await gate()
+        let dir = input.query.dir
+        let needle = (input.query.query ?? "").lowercased()
+        return mutate { model -> Operations.SearchFiles.Output in
+            model.fileSearches.append((dir, input.query.query))
+            let entries = model.fileSearchEntries.filter { needle.isEmpty || $0.path.lowercased().contains(needle) }
+            return .ok(.init(body: .json(.init(dir: dir, entries: entries, truncated: false))))
+        }
+    }
+
+    func listAgentCommands(_ input: Operations.ListAgentCommands.Input) async throws
+        -> Operations.ListAgentCommands.Output
+    {
+        try await gate()
+        let id = input.path.agentId
+        guard let agentId = AgentID(rawValue: id) else {
+            return .notFound(
+                .init(body: .json(.init(_tag: .agentNotFound, agentId: id, message: "No agent \(id)"))))
+        }
+        return mutate { model -> Operations.ListAgentCommands.Output in
+            model.commandListings.append((id, input.query.dir))
+            return .ok(.init(body: .json(model.agentCommands[agentId] ?? [])))
+        }
+    }
+
     func listAgentModels(_ input: Operations.ListAgentModels.Input) async throws
         -> Operations.ListAgentModels.Output
     {
@@ -794,7 +838,7 @@ nonisolated final class ScriptableAppServerClient: APIProtocol, @unchecked Senda
             guard model.threads.contains(where: { $0.id == id }) else {
                 return .notFound(.init(body: .json(.init(value1: threadNotFound(id)))))
             }
-            model.prompts.append((id, request.prompt, request.attachments))
+            model.prompts.append((id, request.prompt, request.attachments, request.when))
             return .ok(.init(body: .json(.init(promptId: model.nextID("prm"), turnId: model.nextID("turn")))))
         }
     }

--- a/macos/ATCTests/ThreadChatModelTests.swift
+++ b/macos/ATCTests/ThreadChatModelTests.swift
@@ -179,7 +179,6 @@ struct ThreadChatModelTests {
         #expect(await chat.send("do it"))
         #expect(client.prompts.map(\.prompt) == ["do it"])
         #expect(chat.promptError == nil)
-        #expect(chat.lastSentPrompt == "do it")
         // The echo is up (the response named its turn); the real userMessage
         // resolves it.
         #expect(chat.transcript.pendingPrompts.count == 1)
@@ -227,6 +226,24 @@ struct ThreadChatModelTests {
         #expect(await chat.send("again", attachments: [images[0]]) == false)
         #expect(chat.promptError != nil)
         #expect(chat.transcript.pendingPrompts.count == 2)
+    }
+
+    @Test("send passes the when choice through, and the prompt history lists sent prompts newest first")
+    func sendWhenAndHistory() async throws {
+        let harness = try await acquired()
+        let chat = harness.chat
+        let client = harness.test.client
+
+        #expect(await chat.send("nudge", when: .now))
+        #expect(client.prompts.last?.when == .now)
+        #expect(await chat.send("later", when: .queue))
+        #expect(client.prompts.last?.when == .queue)
+        #expect(await chat.send("plain"))
+        #expect(client.prompts.last?.when == nil)
+        // The echoes lead the history (newest first), ahead of the
+        // transcript's user messages; nothing repeats.
+        #expect(Array(chat.promptHistory.prefix(3)) == ["plain", "later", "nudge"])
+        #expect(Set(chat.promptHistory).count == chat.promptHistory.count)
     }
 
     @Test("perform refuses off-live inline and routes failures into actionError, never a throw")

--- a/packages/ATCKit/Sources/ATCAppServerAPI/ServerModels.swift
+++ b/packages/ATCKit/Sources/ATCAppServerAPI/ServerModels.swift
@@ -26,6 +26,9 @@ public typealias ReasoningLevel = Components.Schemas.ReasoningLevel
 public typealias ThreadMode = Components.Schemas.ThreadMode
 public typealias ThreadAccess = Components.Schemas.ThreadAccess
 public typealias AgentModel = Components.Schemas.AgentModel
+public typealias AgentCommand = Components.Schemas.AgentCommand
+/// When a prompt runs: queued for the next idle, or handed to the running turn.
+public typealias PromptWhen = Components.Schemas.PromptThreadRequest.WhenPayload
 
 extension AgentID {
     public var displayName: String {

--- a/packages/ATCKit/Sources/ATCChat/ComposerCompletion.swift
+++ b/packages/ATCKit/Sources/ATCChat/ComposerCompletion.swift
@@ -1,0 +1,86 @@
+// The composer's completions (ATC-216): `@` mentions a file, `/` names a
+// command. Both are plain text in the end — an accepted completion replaces
+// the trigger and what was typed after it with the chosen text and a space;
+// nothing structured survives into the prompt. This type is the pure part:
+// where a trigger is, what an acceptance produces, how commands filter.
+// Views own the fetching and the list.
+//
+//   - `@` triggers at a word start (the start of the text, or after
+//     whitespace) and stays active while the caret follows it with no
+//     whitespace in between — `foo @src/ma|` is a file query "src/ma",
+//     `mail@example|` is not a trigger.
+//   - `/` triggers only at the very start of the text, so a path typed
+//     mid-sentence never opens the command list.
+
+import ATCAppServerAPI
+import Foundation
+
+public nonisolated enum ComposerCompletion {
+    public enum Kind: Equatable, Sendable {
+        case file
+        case command
+    }
+
+    /// An active trigger: what was typed after it, and the span an
+    /// acceptance replaces (the trigger character through the caret).
+    public struct Trigger: Equatable, Sendable {
+        public let kind: Kind
+        public let query: String
+        public let range: Range<String.Index>
+
+        public init(kind: Kind, query: String, range: Range<String.Index>) {
+            self.kind = kind
+            self.query = query
+            self.range = range
+        }
+    }
+
+    /// The trigger the caret sits in, if any (see the header's rules).
+    public static func trigger(in text: String, caret: String.Index) -> Trigger? {
+        guard caret <= text.endIndex else { return nil }
+        // Walk back from the caret to the start of the current word.
+        var start = caret
+        while start > text.startIndex {
+            let previous = text.index(before: start)
+            if text[previous].isWhitespace || text[previous].isNewline { break }
+            start = previous
+        }
+        guard start < caret else { return nil }
+        let word = text[start..<caret]
+        let query = String(word.dropFirst())
+        switch word.first {
+        case "@":
+            return Trigger(kind: .file, query: query, range: start..<caret)
+        case "/" where start == text.startIndex:
+            return Trigger(kind: .command, query: query, range: start..<caret)
+        default:
+            return nil
+        }
+    }
+
+    /// `text` with the trigger's span replaced by `replacement` plus a
+    /// space, and the caret just after it.
+    public static func accept(
+        _ trigger: Trigger, in text: String, with replacement: String
+    ) -> (text: String, caret: String.Index) {
+        let inserted = replacement + " "
+        var result = text
+        result.replaceSubrange(trigger.range, with: inserted)
+        let caret = result.index(trigger.range.lowerBound, offsetBy: inserted.count)
+        return (result, caret)
+    }
+
+    /// Commands matching `query` (case-insensitive): name-prefix matches
+    /// first, then the rest in the provider's order; everything when empty.
+    public static func filter(_ commands: [AgentCommand], query: String) -> [AgentCommand] {
+        let needle = query.lowercased()
+        guard !needle.isEmpty else { return commands }
+        let prefixed = commands.filter { $0.name.lowercased().hasPrefix(needle) }
+        let rest = commands.filter { command in
+            !command.name.lowercased().hasPrefix(needle)
+                && (command.name.lowercased().contains(needle)
+                    || command.description.lowercased().contains(needle))
+        }
+        return prefixed + rest
+    }
+}

--- a/packages/ATCKit/Sources/ATCChat/PromptHistory.swift
+++ b/packages/ATCKit/Sources/ATCChat/PromptHistory.swift
@@ -1,0 +1,67 @@
+// The ⌘↑/⌘↓ walk through a thread's previous prompts (ATC-216): newest
+// first, from the draft the walk started on, and back to it. The prompts
+// are the caller's (the chat model projects them from the transcript); the
+// walk keeps the list it started on and ends the moment the caller's list
+// differs (a prompt landed, a resync), rather than step through shifted
+// indexes. Any edit to the shown text ends the walk too (`reset`), so
+// typing never fights the history.
+
+public nonisolated struct PromptHistory: Equatable, Sendable {
+    /// Position in the prompts while walking; nil at the draft.
+    public private(set) var position: Int?
+    /// The list the walk started on; a different list ends the walk.
+    private var walked: [String] = []
+    /// The draft the walk left, restored when walking back past the newest.
+    private var draft = ""
+    /// The text the last step produced — what the composer shows if the
+    /// user has not typed since.
+    public private(set) var shown: String?
+
+    public init() {}
+
+    /// One step toward older prompts from `current` (the composer text)
+    /// through `prompts` (newest first); nil when there is nothing older,
+    /// or when the list changed under a walk (which ends it).
+    public mutating func older(from current: String, in prompts: [String]) -> String? {
+        guard let position else {
+            guard let first = prompts.first else { return nil }
+            draft = current
+            walked = prompts
+            self.position = 0
+            shown = first
+            return first
+        }
+        guard prompts == walked else {
+            reset()
+            return nil
+        }
+        guard position + 1 < walked.count else { return nil }
+        self.position = position + 1
+        shown = walked[position + 1]
+        return shown
+    }
+
+    /// One step back toward the draft; nil when already at the draft, or
+    /// when the list changed under the walk (which ends it).
+    public mutating func newer(in prompts: [String]) -> String? {
+        guard let position else { return nil }
+        guard prompts == walked else {
+            reset()
+            return nil
+        }
+        if position == 0 {
+            self.position = nil
+            shown = draft
+            return draft
+        }
+        self.position = position - 1
+        shown = walked[position - 1]
+        return shown
+    }
+
+    /// The user typed: the walk is over, the text is theirs.
+    public mutating func reset() {
+        position = nil
+        shown = nil
+    }
+}

--- a/packages/ATCKit/Sources/ATCChat/ThreadChatModel.swift
+++ b/packages/ATCKit/Sources/ATCChat/ThreadChatModel.swift
@@ -82,8 +82,10 @@ public final class ThreadChatModel {
     public private(set) var promptError: String?
     /// The last chat action's failure, shown inline above the composer.
     public private(set) var actionError: String?
-    /// The last prompt this client sent (⌘↑ recalls it into the composer).
-    public private(set) var lastSentPrompt: String?
+    /// The thread's previous prompts, newest first and without repeats —
+    /// what ⌘↑/⌘↓ walk in the composer (ATC-216): the echoes still pending,
+    /// then the transcript's user messages.
+    public private(set) var promptHistory: [String] = []
 
     // What the views observe, projected from `transcript` after each change.
     private(set) var rows: [ChatRowModel] = []
@@ -215,6 +217,18 @@ public final class ThreadChatModel {
         if runningTurn != transcript.runningTurn { runningTurn = transcript.runningTurn }
         if hasMore != transcript.hasMore { hasMore = transcript.hasMore }
         if isLoaded != transcript.isLoaded { isLoaded = transcript.isLoaded }
+        let history = Self.history(of: transcript)
+        if promptHistory != history { promptHistory = history }
+    }
+
+    private static func history(of transcript: ChatTranscript) -> [String] {
+        let pending = transcript.pendingPrompts.reversed().map(\.text)
+        let sent = transcript.items.reversed().compactMap { item -> String? in
+            guard case .userMessage(let message) = item else { return nil }
+            return message.text
+        }
+        var seen: Set<String> = []
+        return (pending + sent).filter { !$0.isEmpty && seen.insert($0).inserted }
     }
 
     // MARK: - Reads
@@ -323,12 +337,15 @@ public final class ThreadChatModel {
 
     /// Prompts the thread, echoing the prompt (and its images) as a pending
     /// row at once. Images upload first; the prompt carries their ids.
+    /// `when` is the server's choice between queueing and joining the
+    /// running turn (ATC-216); nil leaves it to the server's default.
     /// Returns false when the server refused (the error is in `promptError`)
     /// so the composer restores text and images.
     @discardableResult
-    public func send(_ prompt: String, attachments: [PendingAttachment] = []) async -> Bool {
+    public func send(
+        _ prompt: String, attachments: [PendingAttachment] = [], when: PromptWhen? = nil
+    ) async -> Bool {
         promptError = nil
-        if !prompt.isEmpty { lastSentPrompt = prompt }
         let pendingID = transcript.addPending(prompt, attachments: attachments)
         project(.structure)
         do {
@@ -337,7 +354,7 @@ public final class ThreadChatModel {
                 ids.append(try await upload(attachment).id)
             }
             let request = Components.Schemas.PromptThreadRequest(
-                prompt: prompt, attachments: ids.isEmpty ? nil : ids)
+                prompt: prompt, attachments: ids.isEmpty ? nil : ids, when: when)
             switch try await client.promptThread(path: .init(threadId: threadID), body: .json(request)) {
             case .ok(let ok):
                 let response = try ok.body.json

--- a/packages/ATCKit/Tests/ATCChatTests/ComposerCompletionTests.swift
+++ b/packages/ATCKit/Tests/ATCChatTests/ComposerCompletionTests.swift
@@ -1,0 +1,96 @@
+import ATCAppServerAPI
+import Foundation
+import Testing
+
+@testable import ATCChat
+
+/// The composer's pure completion rules: where `@` and `/` trigger, what an
+/// acceptance produces, how commands filter — and the ⌘↑/⌘↓ history walk.
+@Suite("ComposerCompletion")
+struct ComposerCompletionTests {
+    private func trigger(_ text: String, caretOffset: Int? = nil) -> ComposerCompletion.Trigger? {
+        let caret = caretOffset.map { text.index(text.startIndex, offsetBy: $0) } ?? text.endIndex
+        return ComposerCompletion.trigger(in: text, caret: caret)
+    }
+
+    @Test("@ triggers at a word start and carries what follows it")
+    func atTriggers() {
+        #expect(trigger("@")?.kind == .file)
+        #expect(trigger("@src/ma")?.query == "src/ma")
+        #expect(trigger("look at @src/ma")?.query == "src/ma")
+        #expect(trigger("line one\n@ma")?.query == "ma")
+        // Mid-word, or with whitespace after it, `@` is just text.
+        #expect(trigger("mail@example") == nil)
+        #expect(trigger("@src/ma done") == nil)
+        #expect(trigger("plain words") == nil)
+    }
+
+    @Test("/ triggers only at the very start of the text")
+    func slashTriggers() {
+        #expect(trigger("/")?.kind == .command)
+        #expect(trigger("/rev")?.query == "rev")
+        #expect(trigger("see /usr/bin") == nil)
+        #expect(trigger("/review now") == nil)
+    }
+
+    @Test("the trigger follows the caret, not the end of the text")
+    func caretAware() {
+        let text = "@src tail"
+        #expect(trigger(text, caretOffset: 4)?.query == "src")
+        #expect(trigger(text, caretOffset: 9) == nil)
+    }
+
+    @Test("accepting replaces the trigger span with the choice and a space, caret after")
+    func accept() throws {
+        let text = "look at @src/ma please"
+        let caret = text.index(text.startIndex, offsetBy: 15)
+        let found = try #require(ComposerCompletion.trigger(in: text, caret: caret))
+        let accepted = ComposerCompletion.accept(found, in: text, with: "@src/main.swift")
+        #expect(accepted.text == "look at @src/main.swift  please")
+        #expect(accepted.text[..<accepted.caret] == "look at @src/main.swift ")
+    }
+
+    @Test("commands filter by name prefix first, then by name or description substring")
+    func filter() {
+        let commands: [AgentCommand] = [
+            .init(name: "commit", description: "Commit staged changes"),
+            .init(name: "review", description: "Review the diff"),
+            .init(name: "pr-review", description: "Open a pull request review"),
+        ]
+        #expect(ComposerCompletion.filter(commands, query: "").map(\.name) == ["commit", "review", "pr-review"])
+        #expect(ComposerCompletion.filter(commands, query: "rev").map(\.name) == ["review", "pr-review"])
+        #expect(ComposerCompletion.filter(commands, query: "staged").map(\.name) == ["commit"])
+        #expect(ComposerCompletion.filter(commands, query: "zzz").isEmpty)
+    }
+
+    @Test("the history walk goes newest-first from the draft and back to it; an edit ends it")
+    func history() {
+        let prompts = ["third", "second", "first"]
+        var history = PromptHistory()
+        #expect(history.newer(in: prompts) == nil)
+        #expect(history.older(from: "draft", in: prompts) == "third")
+        #expect(history.older(from: "third", in: prompts) == "second")
+        #expect(history.older(from: "second", in: prompts) == "first")
+        #expect(history.older(from: "first", in: prompts) == nil)
+        #expect(history.newer(in: prompts) == "second")
+        #expect(history.newer(in: prompts) == "third")
+        #expect(history.newer(in: prompts) == "draft")
+        #expect(history.newer(in: prompts) == nil)
+        // A walk in progress that the user edits is over: the next ⌘↑
+        // starts again from the edited text.
+        #expect(history.older(from: "draft", in: prompts) == "third")
+        history.reset()
+        #expect(history.shown == nil)
+        #expect(history.older(from: "third edited", in: prompts) == "third")
+        #expect(history.newer(in: prompts) == "third edited")
+        // The list changes under a walk (a prompt landed, a resync): the
+        // walk ends instead of stepping through shifted indexes.
+        #expect(history.older(from: "draft", in: prompts) == "third")
+        #expect(history.older(from: "third", in: prompts) == "second")
+        #expect(history.newer(in: ["fourth"] + prompts) == nil)
+        #expect(history.position == nil)
+        #expect(history.older(from: "draft", in: ["only"]) == "only")
+        #expect(history.older(from: "only", in: []) == nil)
+        #expect(history.position == nil)
+    }
+}


### PR DESCRIPTION
PR B of ATC-216 (Composer as the front door), tracked as ATC-222; stacked on #228 (PR A). The composer learns the three things that make typing the front door: `@` a file, `/` a command, and nudge a running turn — each a server capability first, so the CLI (and iOS, and integrations) get them too.

## Server

- **`GET /fs/files?dir=&query=&limit=`** — filename search over one directory tree, directory-driven (a thread's working directory, a worktree, or a not-yet-created thread's chip). New `FileSearch` service (`platform/fileSearch.ts`): one bounded readdir walk per directory (skips `.git` and every `.gitignore`'s exclusions, each scoped to its own subtree via the `ignore` package; capped with `truncated`), cached 10 s so keystrokes re-rank in memory; T3Code's tiered ranking (exact, prefix, word boundary, substring, subsequence — name first, then path). Pure TypeScript by design; the contract hides the engine.
- **`GET /agents/:agentId/commands?dir=`** — the agent's slash commands / skills for a directory, answerable with no thread and no live session. New seam method `listCommands`: Claude runs T3Code's throwaway probe (a child in `dir` with a never-yielding prompt, read for `initializationResult().commands`, aborted — no API request); Codex asks the shared server's `skills/list` (enabled skills). The registry caches per (agent, canonical dir) for a minute, never caching failures; the TTL is demand-driven (nothing runs at expiry — the provider is re-asked on the next request after it), and it is the one freshness knob: clients re-ask on demand rather than holding a read.
- **`PromptThreadRequest.when: "queue" | "now"`** — `now` hands the prompt to the turn ATC is running via the new seam method `AgentConnection.steer(input, turn)`: Claude pushes into the held query's input stream and mints the `userMessage` item; Codex calls `turn/steer` with `expectedTurnId` and the server echoes the item. The runtime records it as a queue row already stamped with the turn (durable like any prompt, so the PR A attachment carry-forward applies), returns the joined `turnId`, and falls back to an ordinary prompt when no turn of ours runs or the turn ended first (`AgentConflict`). `atc thread prompt --now`.
- Test fixtures grew with the seam: the fake Claude query takes input mid-turn and reports `initializationResult`, the fake Codex listener answers `turn/steer` and `skills/list`, the fake adapter scripts commands.

## macOS / ATCKit

- **`@` files / `/` commands**: a keyboard-first completion list inside the composer's glass card (a popover would steal key focus from the editor). `@` at a word start queries `searchFiles` for the thread's working directory, debounced, keeping the previous rows up (stale, not acceptable) while the next query is in flight and hinting when the index is truncated; `/` at the start filters the agent's commands from `listAgentCommands`, held per (agent, dir) in `AgentsStore` and re-read on every `/` trigger (stale-while-revalidate: the held list renders at once, a failed re-read keeps it — so a skill added or removed on disk shows within the server TTL, with no client timestamp and no polling; the model catalog follows the same rule), an absent list meaning no popover. ↑/↓ (Ctrl-N/P) move, Return/Tab accept, Esc dismisses; an accepted item replaces the trigger as plain text. The pure rules (`ComposerCompletion`: caret-aware triggers, replacement, command filter) live in ATCChat with unit tests. IME composition always wins over completion keys.
- **Nudge vs queue**: while the server drives a turn, Return sends `when: now` and ⌥Return queues; the send button honors ⌥-click and a quiet chevron offers both. Idle, Return is a plain send.
- **Prompt history**: ⌘↑/⌘↓ walk the thread's previous prompts (`PromptHistory` in ATCChat; the chat model projects them from the transcript — pending echoes first, then user messages, newest first, de-duplicated); any edit ends the walk, and a list that changes under a walk ends it rather than guess. The old `lastSentPrompt` is gone.
- Test doubles implement both operations and record `when`; tests cover the completion rules, the history walk, and `send(when:)` pass-through.

## Verification

`mise run -C app-server check`, `kit:test`, `macos:test`, `swift:lint` / `swift:fmt:check`. New coverage: file-search walk/ranking/limit/validation; both endpoints' documented shapes and refusals; runtime `now` (joins the running turn, queues once it ended); Claude steer + command probe; Codex steer + skills; registry command cache; AgentsStore revalidation (re-read on each ask, failed re-read keeps the held list/catalog).

https://claude.ai/code/session_01Rk3dUZMQeQAJBmoeCxrHUp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added slash-command discovery for agents, including command descriptions and argument hints.
  - Added workspace file search with ranked results, filtering, limits, and truncation status.
  - Added inline file and command completions in the chat composer.
  - Added prompt history navigation with keyboard shortcuts.
  - Added options to send prompts immediately during an active turn or queue them.
- **Bug Fixes**
  - Improved handling of prompts sent while a turn is running, including reliable fallback to queueing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
