### PR TITLE
Text hierarchy: three tiers derived from the system label color

### DIFF
--- a/macos/ATC/Commands/CommandFeedbackViews.swift
+++ b/macos/ATC/Commands/CommandFeedbackViews.swift
@@ -78,7 +78,7 @@ struct CommandSequenceHintView: View {
             if case .unavailable(let reason) = availability {
                 Text(reason)
                     .font(.caption)
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(.secondary)
             }
         }
         .foregroundStyle(availability.isAvailable ? .primary : .secondary)

--- a/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
+++ b/macos/ATC/Features/CommandPalette/CommandPaletteView.swift
@@ -242,7 +242,7 @@ struct CommandPaletteView: View {
         if case .unavailable(let reason) = availability {
             Text(reason)
                 .font(.caption2)
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(.secondary)
         }
     }
 

--- a/macos/ATC/Features/Dashboard/DashboardView.swift
+++ b/macos/ATC/Features/Dashboard/DashboardView.swift
@@ -79,7 +79,7 @@ struct DashboardView: View {
                 Text(section.connectionName)
                     .font(.title3.weight(.semibold))
                 Text(section.contextLabel)
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(.secondary)
                 Spacer()
                 if reachability == .unreachable {
                     Button("Retry", systemImage: "arrow.clockwise") {
@@ -131,7 +131,7 @@ struct DashboardView: View {
 
             Text(card.project.defaultWorkingDirectory)
                 .font(.caption.monospaced())
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(.secondary)
                 .lineLimit(1)
                 .truncationMode(.head)
 
@@ -173,7 +173,7 @@ struct DashboardView: View {
         HStack(spacing: Spacing.md) {
             Text("No projects yet")
                 .font(.callout)
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(.secondary)
             Spacer()
             Button("New Project", systemImage: "plus") {
                 windowState.isCreateProjectPresented = true

--- a/macos/ATC/Features/Navigator/NavigatorSidebar.swift
+++ b/macos/ATC/Features/Navigator/NavigatorSidebar.swift
@@ -332,7 +332,7 @@ struct NavigatorSidebar: View {
                 if !terminal.isLive {
                     Text("Ended")
                         .font(.caption)
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(.secondary)
                 }
                 if let shortcutLabel {
                     Spacer(minLength: Spacing.sm)
@@ -368,7 +368,7 @@ struct NavigatorSidebar: View {
     private func emptyLabel(_ title: String) -> some View {
         Text(title)
             .font(.caption)
-            .foregroundStyle(.tertiary)
+            .foregroundStyle(.secondary)
             .padding(.horizontal, NavigatorMetrics.contentHorizontalPadding)
             .frame(minHeight: NavigatorMetrics.rowHeight, alignment: .leading)
             .navigatorListRow()

--- a/macos/ATC/Features/Threads/Chat/ChatComposer.swift
+++ b/macos/ATC/Features/Threads/Chat/ChatComposer.swift
@@ -406,7 +406,7 @@ struct ChatComposer: View {
             if completion.truncated {
                 Text("More files than the index holds — type more of the name.")
                     .font(.caption)
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(.secondary)
                     .padding(.horizontal, Spacing.sm)
             }
         }
@@ -507,7 +507,7 @@ struct ChatComposer: View {
                 }
             if text.isEmpty {
                 Text(attachments.isEmpty ? "Message the agent…" : "Add a message, or send the images…")
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(.secondary)
                     .padding(.vertical, Spacing.xs)
                     .padding(.horizontal, Spacing.xs + 1)
                     .allowsHitTesting(false)

--- a/macos/ATC/Features/Threads/ThreadCard.swift
+++ b/macos/ATC/Features/Threads/ThreadCard.swift
@@ -57,7 +57,7 @@ struct ThreadCard: View {
                     if let directory = item.distinctWorkingDirectory {
                         Text(directory)
                             .font(.caption.monospaced())
-                            .foregroundStyle(.tertiary)
+                            .foregroundStyle(.secondary)
                             .lineLimit(1)
                             .truncationMode(.head)
                     }

--- a/packages/ATCKit/Package.swift
+++ b/packages/ATCKit/Package.swift
@@ -81,6 +81,11 @@ let package = Package(
             swiftSettings: uiTargetSwiftSettings
         ),
         .testTarget(
+            name: "ATCDesignTests",
+            dependencies: ["ATCDesign"],
+            swiftSettings: uiTargetSwiftSettings
+        ),
+        .testTarget(
             name: "ATCAppServerTransportTests",
             dependencies: ["ATCAppServerTransport"]
         ),

--- a/packages/ATCKit/Sources/ATCChat/ChatItemRows.swift
+++ b/packages/ATCKit/Sources/ATCChat/ChatItemRows.swift
@@ -93,6 +93,7 @@ struct ChatNodeView: View {
             }
         case .assistantText(let text):
             MarkdownBlocksView(blocks: node.box.markdownBlocks(text: text.text, complete: text.complete))
+                .foregroundStyle(TextColor.body)
                 .copyable(text.text)
         case .compaction:
             ChatDividerRow(label: "Context compacted")
@@ -207,7 +208,7 @@ struct ChatDividerRow: View {
             Rectangle().fill(Surface.chipBorder).frame(height: 1)
             Text(label)
                 .font(.caption)
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(.secondary)
                 .fixedSize()
             Rectangle().fill(Surface.chipBorder).frame(height: 1)
         }
@@ -223,7 +224,7 @@ struct TimestampCaption: View {
     var body: some View {
         Text(date, style: .time)
             .font(.caption2)
-            .foregroundStyle(.tertiary)
+            .foregroundStyle(.secondary)
     }
 }
 

--- a/packages/ATCKit/Sources/ATCChat/ChatText.swift
+++ b/packages/ATCKit/Sources/ATCChat/ChatText.swift
@@ -35,6 +35,7 @@ struct DetailBlock: View {
     var body: some View {
         Text(text)
             .font(.callout.monospaced())
+            .foregroundStyle(.secondary)
             .textSelection(.enabled)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(Spacing.sm)

--- a/packages/ATCKit/Sources/ATCChat/Markdown/MarkdownBlocksView.swift
+++ b/packages/ATCKit/Sources/ATCChat/Markdown/MarkdownBlocksView.swift
@@ -50,6 +50,7 @@ private struct MarkdownBlockView: View {
         case .heading(_, let level, let text):
             Text(text)
                 .font(headingFont(level))
+                .foregroundStyle(.primary)
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.top, level <= 2 ? Spacing.xs : 0)

--- a/packages/ATCKit/Sources/ATCDesign/DesignTokens.swift
+++ b/packages/ATCKit/Sources/ATCDesign/DesignTokens.swift
@@ -59,6 +59,21 @@ public enum Surface {
     public static let cardBorder = Color.white.opacity(0.08)
 }
 
+/// The text hierarchy. Three tiers, one rule: the user's own words, headings,
+/// and control labels are `primary`; prose to be read is `body`; context about
+/// the prose — metadata, placeholders, tool detail — is `secondary`. All three
+/// derive from the system label color so Increase Contrast still lifts them.
+/// On the canvas they measure ~13:1, ~11:1, and ~6:1; `.tertiary` (2.2:1) and
+/// `.quaternary` fall below the 4.5:1 floor here, so they are reserved for
+/// non-text — dividers, fills, and disabled glyphs — never for readable text.
+public enum TextColor {
+    public static let primary = Color.primary
+    /// Long-form assistant prose, one step below headings so a screen of text
+    /// does not glare. Matches the prose tier T3Code and Codex desktop use.
+    public static let body = Color.primary.opacity(0.9)
+    public static let secondary = Color.secondary
+}
+
 /// Opacity applied to unavailable content.
 public enum Dimming {
     public static let unavailable: Double = 0.5

--- a/packages/ATCKit/Tests/ATCDesignTests/TextColorTests.swift
+++ b/packages/ATCKit/Tests/ATCDesignTests/TextColorTests.swift
@@ -1,0 +1,71 @@
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import ATCDesign
+
+/// The text ladder's two invariants, measured the way the app renders them
+/// (dark appearance, composited over the real surfaces): every readable tier
+/// clears the HIG's 4.5:1 floor, and the tiers stay in order, so a tier cannot
+/// drift dim or swap places without a failing test.
+@Suite("Text tiers")
+struct TextColorTests {
+    private let tiers: [(name: String, color: Color)] = [
+        ("primary", TextColor.primary),
+        ("body", TextColor.body),
+        ("secondary", TextColor.secondary),
+    ]
+
+    @Test("every text tier clears 4.5:1 on the canvas and on a card")
+    func contrast() {
+        let canvas = composite(resolve(AppColors.canvas), over: (0, 0, 0))
+        let card = composite(resolve(Surface.card), over: canvas)
+        for tier in tiers {
+            let ink = resolve(tier.color)
+            #expect(contrast(composite(ink, over: canvas), canvas) >= 4.5, "\(tier.name) on canvas")
+            #expect(contrast(composite(ink, over: card), card) >= 4.5, "\(tier.name) on card")
+        }
+    }
+
+    @Test("tiers descend in brightness: primary > body > secondary")
+    func ordering() {
+        let canvas = composite(resolve(AppColors.canvas), over: (0, 0, 0))
+        let luminances = tiers.map { luminance(composite(resolve($0.color), over: canvas)) }
+        #expect(luminances == luminances.sorted(by: >))
+        #expect(Set(luminances).count == tiers.count)
+    }
+
+    // MARK: - Color math (sRGB, WCAG 2.x relative luminance)
+
+    private typealias RGBA = (r: Double, g: Double, b: Double, a: Double)
+    private typealias RGB = (r: Double, g: Double, b: Double)
+
+    private func resolve(_ color: Color) -> RGBA {
+        var resolved: RGBA = (0, 0, 0, 0)
+        NSAppearance(named: .darkAqua)!.performAsCurrentDrawingAppearance {
+            let ns = NSColor(color).usingColorSpace(.sRGB)!
+            resolved = (ns.redComponent, ns.greenComponent, ns.blueComponent, ns.alphaComponent)
+        }
+        return resolved
+    }
+
+    private func composite(_ top: RGBA, over bottom: RGB) -> RGB {
+        (
+            top.r * top.a + bottom.r * (1 - top.a),
+            top.g * top.a + bottom.g * (1 - top.a),
+            top.b * top.a + bottom.b * (1 - top.a)
+        )
+    }
+
+    private func luminance(_ c: RGB) -> Double {
+        func channel(_ v: Double) -> Double {
+            v <= 0.03928 ? v / 12.92 : pow((v + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * channel(c.r) + 0.7152 * channel(c.g) + 0.0722 * channel(c.b)
+    }
+
+    private func contrast(_ a: RGB, _ b: RGB) -> Double {
+        let (la, lb) = (luminance(a), luminance(b))
+        return (max(la, lb) + 0.05) / (min(la, lb) + 0.05)
+    }
+}


### PR DESCRIPTION
## Why

A thread full of text glared: assistant prose, code blocks, tool/command output, tables, and tool-row titles all rendered at the top label tier (`.primary`, white @ 85% → `#DBDBDB`, 13.3:1 on the canvas). Meanwhile placeholders, timestamps, working-dir paths, and the turn divider sat at `.tertiary` (white @ 25% → `#4E4E50`, **2.2:1**), below the HIG's 4.5:1 floor.

T3Code keeps only headings and the user's own prompt at full strength; prose sits a step down (`foreground/80`), code another, and tool output is fully muted. This PR adopts the same shape, derived from the system label color per the HIG ("use the system-provided label colors"; "avoid hard-coding system color values").

## What

**`ATCDesign.TextColor`** (`DesignTokens.swift`) — the ladder, documented where design intent already lives:

| Tier | Value | On `#141416` | Use |
|---|---|---|---|
| `primary` | `.primary` | `#DBDBDB`, 13.3:1 | Headings, the user's words, composer input, control labels |
| `body` | `.primary.opacity(0.9)` → white @ 76% | `#C7C7C7`, 10.8:1 | Long-form assistant prose, lists, tables, code (until highlighting lands) |
| `secondary` | `.secondary` | `#959596`, 6.1:1 | Metadata, timestamps, placeholders, tool detail/output |

`.tertiary` / `.quaternary` are reserved for non-text (dividers, fills, disabled glyphs).

**Sweep**
- Transcript: assistant markdown → `body`; headings pin back to `primary`; `DetailBlock` (command output, diffs, JSON) → `secondary`; timestamps and divider `.tertiary` → `.secondary`. User bubbles and tool-row titles stay `primary`.
- Composer: placeholder and completion note `.tertiary` → `.secondary` (matches `NSColor.placeholderTextColor`, which is 55%).
- Chrome: readable `.tertiary` text in ThreadCard, NavigatorSidebar, Dashboard, CommandPalette, CommandFeedback → `.secondary`. Disabled-state and decorative uses keep `.tertiary`.

**Guard** — new `ATCDesignTests` suite resolves each tier in dark appearance, composites over `AppColors.canvas` and `Surface.card`, and asserts ≥ 4.5:1 plus strict primary > body > secondary ordering.

## Verified

- `mise run kit:test` (74 tests incl. the new suite), `macos:test`, `macos:build`, `swift:lint`, `swift:fmt:check` — all green.
- Launched the dev build against the local server and eyeballed a tool-heavy thread: prose visibly a step under headings/bold/user prompt; placeholder and timestamps legible.

## Not in scope

- Tool-row verb/argument split (T3 dims the argument): titles are server-composed strings, so that is a contract change.
- Line height: T3 prose is 14px @ 1.625; ours is 13pt default leading. Separate small follow-up if wanted.

https://claude.ai/code/session_01CFbTwhuC9jC5xbHVW6ffso

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text hierarchy and readability across command hints, search results, dashboards, navigation, chat, threads, and empty states.
  * Standardized headings, details, timestamps, labels, and supporting text with clearer foreground contrast.
  * Introduced consistent primary, body, and secondary text color treatments across the macOS interface.
* **Tests**
  * Added accessibility-focused checks to verify text contrast and visual hierarchy across light and dark appearances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->