### PR TITLE
Claude: open background-task wake turns on the feed; the runtime holds them as its run

### DIFF
--- a/app-server/src/agents/claudeAdapter.ts
+++ b/app-server/src/agents/claudeAdapter.ts
@@ -89,6 +89,12 @@ import * as Subprocess from "../platform/subprocess.ts"
 //     (level snapshot); what the feed carries is always the reducer's
 //     aggregate, so a root Stop with live background work stays `working`
 //     and the last SubagentStop lands the `idle` transition.
+//   - A background task's notification wakes the root loop into a turn of
+//     the SDK's own (probed 2026-08-21): no `user` message is echoed, the
+//     UserPromptSubmit hook carries the notification text, and the turn
+//     ends with an ordinary `result`. It is opened on the feed like a
+//     client turn (`beginWakeTurn`) so its output and requests are not
+//     lost; startTurn refuses while it runs, as for any active turn.
 //   - Known residual: the SDK stream carries no correlation between a
 //     `result` and the input that caused it, so a background wake-turn's
 //     held result flushing just after a client startTurn is paired with
@@ -972,7 +978,17 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
             [
               {
                 hooks: [
-                  (input: { hook_event_name: string }) => {
+                  (input: { hook_event_name: string; prompt?: unknown }) => {
+                    // A prompt submitted with no turn of ours open is the
+                    // SDK waking the root loop (see beginWakeTurn).
+                    if (
+                      input.hook_event_name === "UserPromptSubmit" &&
+                      session.activeTurn === null &&
+                      !session.closed &&
+                      typeof input.prompt === "string"
+                    ) {
+                      beginWakeTurn(session, input.prompt)
+                    }
                     const activity = session.tracker.update(
                       input.hook_event_name,
                       input as unknown as Record<string, unknown>,
@@ -1303,6 +1319,30 @@ export const layerWith = (adapterOptions: ClaudeAdapterOptions) =>
         })
         session.pushInput(userMessage(content))
         return turnId
+      }
+
+      /**
+       * A turn the provider started on its own: a background task finished
+       * and its notification woke the root loop (probed 2026-08-21, SDK
+       * 0.3.235 — the notification is never echoed as a `user` message on
+       * the stream; the in-process UserPromptSubmit hook is what carries
+       * its text, after `session_state_changed: running` and before the
+       * turn's output). Opened exactly like a client turn, so its items,
+       * requests and result flow through the same paths — without this
+       * every block is dropped for want of an active turn and its
+       * canUseTool asks are denied unseen. Only ever opened with no turn
+       * active: a notification that lands mid-turn is that turn's input.
+       */
+      const beginWakeTurn = (session: LiveSession, prompt: string): void => {
+        const turnId = `claude-turn-${crypto.randomUUID()}`
+        session.activeTurn = turnId
+        emit(session, { type: "turnStarted", turnId })
+        emitItem(session, "itemCompleted", {
+          type: "userMessage",
+          id: `${turnId}:prompt`,
+          turnId,
+          text: prompt,
+        })
       }
 
       /** The bounded transcript read behind both readers (getSessionMessages). */

--- a/app-server/src/threads/threadRuntime.ts
+++ b/app-server/src/threads/threadRuntime.ts
@@ -91,6 +91,13 @@ export type QueuedPrompt = typeof Contract.QueuedPrompt.Type
 //     and shutdown, and idle residency is bounded (`armIdleClose`). A
 //     shared-server provider's connection is a cheap subscription that
 //     coexists with its TUI: it holds nothing between turns, as before.
+//     A turn the provider starts by itself on a held one-process
+//     connection (Claude's root loop woken by a finished background task)
+//     is ATC's run: adopted at its turnStarted, ended by `finish` like a
+//     prompted turn, its requests answerable; a prompt admitted meanwhile
+//     waits for it (the connection refuses a second turn) and drains at
+//     its end. On a shared server the same event is another writer's turn
+//     and stays observed.
 //   - One live process per thread (ATC-203), on a provider whose sessions
 //     live in one process at a time (`sharedServer: false` — Claude; two
 //     live processes fork the session). The native side owns the thread by
@@ -641,7 +648,7 @@ const make = (options: ThreadRuntimeOptions) =>
      * latch its close completes: the scope closes in the service scope —
      * the drain fiber, the connection, the process behind it — and the
      * writer deregisters once that is done (a prompt admitted meanwhile
-     * queues rather than racing the connection). One close per writer,
+     * waits out the latch rather than racing the connection). One close per writer,
      * shared by every caller: a second Scope.close of a closing scope
      * returns before the first's finalizers are done, and a TUI must not
      * launch on a process still shutting down.
@@ -914,16 +921,22 @@ const make = (options: ThreadRuntimeOptions) =>
           })
         case "settings":
           return adoptSettings(record, event.settings, writer.pushed)
-        case "turnStarted":
-          // Another writer's turn on a connection we hold (a TUI mid-run on
-          // a shared server): observed, not ours.
-          return event.turnId === run?.turnId
-            ? Effect.void
-            : recordTurn(
-                record.id,
-                { id: event.turnId, status: "running", startedAt: new Date().toISOString() },
-                "observed",
-              )
+        case "turnStarted": {
+          if (event.turnId === run?.turnId) return Effect.void
+          // A turn ATC did not start. On a one-process provider the held
+          // connection IS the session's only process, so the turn is ours
+          // to run (the provider woke itself: the header's provider-started
+          // bullet); on a shared server it is another writer's — a TUI
+          // mid-run — and only observed.
+          if (run === undefined && oneProcess(record)) {
+            return adoptTurn(record, writer, { turnId: event.turnId })
+          }
+          return recordTurn(
+            record.id,
+            { id: event.turnId, status: "running", startedAt: new Date().toISOString() },
+            "observed",
+          )
+        }
         case "turnCompleted":
           return run !== undefined && event.turnId === run.turnId
             ? finish(record, writer, run, event.outcome, event.detail)
@@ -1109,10 +1122,15 @@ const make = (options: ThreadRuntimeOptions) =>
     > =>
       withStartLock(id)(
         Effect.gen(function* () {
-          const held = writers.get(id)
-          if (held?.run !== undefined || held?.closing !== undefined || recovering.has(id)) {
-            return Option.none()
-          }
+          const registered = writers.get(id)
+          if (registered?.run !== undefined || recovering.has(id)) return Option.none()
+          // A writer mid-close (a shared-server turn just ended, the idle
+          // timer fired): wait out its latch here, under the lock, and
+          // resume afresh — so the caller's own call starts its prompt and
+          // is answered with the turn, rather than "queued" for a start the
+          // close's continuation makes moments later.
+          if (registered?.closing !== undefined) yield* Deferred.await(registered.closing)
+          const held = registered?.closing === undefined ? registered : undefined
           const found = yield* repository.get(id)
           if (Option.isNone(found) || found.value.archivedAt !== undefined) return Option.none()
           const record = found.value
@@ -1125,6 +1143,7 @@ const make = (options: ThreadRuntimeOptions) =>
           const input = yield* turnInputOf(record.id, next.value)
           if (held !== undefined) {
             const reused = yield* startOnWriter(record, held, next.value, input)
+            if (reused === "busy") return Option.none()
             if (Option.isSome(reused)) {
               yield* naming.notePrompt(record, prompt)
               return reused
@@ -1164,17 +1183,22 @@ const make = (options: ThreadRuntimeOptions) =>
      * Start the prompt on a resident writer. Under the writer's lock (the
      * drain waits) and uninterruptibly: the turn's first events must find
      * its Run registered, and a turn started with no Run to end it would
-     * hold the connection for good. `none` when the connection would not
-     * take the turn — the provider ended it since (the seam: a closed or
-     * over connection refuses control calls) — so the caller closes it and
-     * resumes afresh.
+     * hold the connection for good. "busy" when the connection is in a
+     * turn of its own we have not seen yet (AgentConflict: the provider
+     * woke itself — its turnStarted is behind this lock and will be
+     * adopted next, and its end drains the queue), so the prompt simply
+     * waits. `none` when the connection would not take the turn — the
+     * provider ended it since (the seam: a closed or over connection
+     * refuses control calls) — so the caller closes it and resumes afresh.
      */
     const startOnWriter = (
       record: ThreadRecord,
       writer: Writer,
       queued: QueuedPromptRecord,
       input: TurnInput,
-    ): Effect.Effect<Option.Option<{ readonly promptId: string; readonly turnId: string }>> =>
+    ): Effect.Effect<
+      Option.Option<{ readonly promptId: string; readonly turnId: string }> | "busy"
+    > =>
       writer.lock.withPermit(
         Effect.uninterruptible(
           Effect.gen(function* () {
@@ -1183,6 +1207,14 @@ const make = (options: ThreadRuntimeOptions) =>
             yield* registerRun(record, writer, queued, turn)
             return Option.some({ promptId: queued.id, turnId: turn.turnId })
           }).pipe(
+            Effect.catchTag("AgentConflict", (error) =>
+              Effect.logDebug(
+                "the resident connection is mid-turn on its own; the prompt waits",
+              ).pipe(
+                Effect.annotateLogs({ threadId: record.id, reason: error.reason }),
+                Effect.as("busy" as const),
+              ),
+            ),
             Effect.catch((error) =>
               Effect.logDebug("the resident connection refused the turn; resuming afresh").pipe(
                 Effect.annotateLogs({ threadId: record.id, reason: error.message }),
@@ -1213,6 +1245,31 @@ const make = (options: ThreadRuntimeOptions) =>
         const seq = yield* transcripts.beginTurn(record.id, queued.id, row)
         publish(record.id, { type: "turn.started", seq, turn: row })
         yield* publishQueue(record.id)
+        yield* holdRun(writer, turn)
+      })
+
+    /**
+     * A turn the provider started on a held one-process connection (the
+     * header's provider-started bullet) becomes ATC's Run: no prompt of
+     * ours behind it, so only the turn row is recorded, then it is held
+     * like any other — its requests park here, `finish` ends it and
+     * drains the queue. Under the writer's lock (the drain is), so it
+     * never races a start on this connection.
+     */
+    const adoptTurn = (
+      record: ThreadRecord,
+      writer: Writer,
+      turn: AgentTurn,
+    ): Effect.Effect<void> =>
+      recordTurn(
+        record.id,
+        { id: turn.turnId, status: "running", startedAt: new Date().toISOString() },
+        "native",
+      ).pipe(Effect.andThen(holdRun(writer, turn)))
+
+    /** The Run on the writer, its row already recorded. */
+    const holdRun = (writer: Writer, turn: AgentTurn): Effect.Effect<void> =>
+      Effect.gen(function* () {
         // A resident writer's idle timer stands down: the turn is what it
         // was waiting for (interruptible while it waits for the start lock
         // this caller may hold, so this never deadlocks).
@@ -1686,6 +1743,13 @@ const make = (options: ThreadRuntimeOptions) =>
           // stands — and one that queued is published here, waiting.
           if (Option.isSome(started) && started.value.promptId === queued.id) {
             return { promptId: queued.id, turnId: started.value.turnId }
+          }
+          // A turn's end forks its own drain (finish); when that drain won
+          // the start lock with this very prompt, the prompt has started —
+          // answer with its turn rather than a wait that is already over.
+          const startedMeanwhile = yield* transcripts.startedTurn(id, queued.id)
+          if (Option.isSome(startedMeanwhile)) {
+            return { promptId: queued.id, turnId: startedMeanwhile.value }
           }
           yield* publishQueue(id)
           return { promptId: queued.id }

--- a/app-server/src/threads/transcriptRepository.ts
+++ b/app-server/src/threads/transcriptRepository.ts
@@ -280,6 +280,11 @@ export class TranscriptRepository extends Context.Service<
     readonly listWaiting: (threadId: string) => Effect.Effect<ReadonlyArray<QueuedPromptRecord>>
     /** The oldest waiting prompt (None when nothing waits). */
     readonly peek: (threadId: string) => Effect.Effect<Option.Option<QueuedPromptRecord>>
+    /** The turn a prompt was started against (None while it waits, or unknown). */
+    readonly startedTurn: (
+      threadId: string,
+      promptId: string,
+    ) => Effect.Effect<Option.Option<string>>
     /** Remove a WAITING prompt; false when unknown or already started. */
     readonly deleteWaiting: (threadId: string, promptId: string) => Effect.Effect<boolean>
   }
@@ -510,6 +515,15 @@ export const layer = Layer.effect(TranscriptRepository)(
         SELECT * FROM thread_queue
         WHERE thread_id = ${threadId} AND started_turn_id IS NULL
         ORDER BY queued_at ASC, id ASC
+      `,
+    })
+
+    const startedTurnRows = SqlSchema.findAll({
+      Request: Schema.Struct({ thread_id: Schema.String, id: Schema.String }),
+      Result: Schema.Struct({ started_turn_id: Schema.String }),
+      execute: (request) => sql`
+        SELECT started_turn_id FROM thread_queue
+        WHERE thread_id = ${request.thread_id} AND id = ${request.id} AND started_turn_id IS NOT NULL
       `,
     })
 
@@ -756,6 +770,11 @@ export const layer = Layer.effect(TranscriptRepository)(
       peek: (threadId) =>
         waitingRows(threadId).pipe(
           Effect.map((rows) => Option.fromNullishOr(rows[0]).pipe(Option.map(toQueued))),
+          Effect.orDie,
+        ),
+      startedTurn: (threadId, promptId) =>
+        startedTurnRows({ thread_id: threadId, id: promptId }).pipe(
+          Effect.map((rows) => Option.fromNullishOr(rows[0]?.started_turn_id)),
           Effect.orDie,
         ),
       deleteWaiting: (threadId, promptId) =>

--- a/app-server/test/agents/claudeAdapter.test.ts
+++ b/app-server/test/agents/claudeAdapter.test.ts
@@ -15,7 +15,7 @@ import {
 } from "./agentTestKit.ts"
 import { eventually } from "../testLayers.ts"
 import { trackTempDir } from "../blackbox.ts"
-import { FAKE_CLAUDE_MODELS, makeFakeClaudeQuery } from "./fakeClaudeQuery.ts"
+import { FAKE_CLAUDE_MODELS, WAKE_NOTIFICATION, makeFakeClaudeQuery } from "./fakeClaudeQuery.ts"
 import type { FakeClaudeQueryOptions } from "./fakeClaudeQuery.ts"
 
 // Claude adapter tests over the scripted query() seam (fakeClaudeQuery.ts):
@@ -977,6 +977,67 @@ describe("ClaudeAdapter", () => {
           providerMetadata: launch.providerMetadata,
         })
         assert.strictEqual(relaunch.providerMetadata, launch.providerMetadata)
+      }).pipe(Effect.provide(layer))
+    }),
+  )
+
+  it.live("a finished background task wakes the root loop into a turn of the feed's own", () =>
+    Effect.gen(function* () {
+      const cwd = workDir()
+      const { fake, layer } = adapterStack()
+      yield* Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter.ClaudeAdapter
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            const { connection, turn } = yield* adapter.createSession({
+              cwd,
+              input: { text: "WAKEQ when done", attachments: [] },
+              settings: TEST_SETTINGS,
+            })
+            const sink = yield* collectAgentEvents(connection.events)
+            yield* waitForAgentEvent(
+              sink,
+              (event) => event.type === "turnCompleted" && event.turnId === turn.turnId,
+            )
+            // The woken turn opens on the feed with the notification as its
+            // prompt, and its question reaches the consumer like any other.
+            yield* waitForAgentEvent(
+              sink,
+              (event) => event.type === "requestOpened" && event.request.kind === "question",
+            )
+            const woken = sink.find(
+              (event) => event.type === "turnStarted" && event.turnId !== turn.turnId,
+            )
+            if (woken?.type !== "turnStarted") return assert.fail("expected a woken turn")
+            const opened = sink.find((event) => event.type === "requestOpened")
+            if (opened?.type !== "requestOpened") return assert.fail("expected a request")
+            assert.strictEqual(opened.request.turnId, woken.turnId)
+            yield* connection.respond(opened.request.id, {
+              kind: "question",
+              answers: { q0: ["yes"] },
+            })
+            yield* waitForAgentEvent(
+              sink,
+              (event) => event.type === "turnCompleted" && event.turnId === woken.turnId,
+            )
+            const items = sink.flatMap((event) =>
+              event.type === "itemCompleted" && event.item.turnId === woken.turnId
+                ? [event.item]
+                : [],
+            )
+            assert.deepStrictEqual(
+              items.map((item) => [item.type, "text" in item ? item.text : undefined]),
+              [
+                ["userMessage", WAKE_NOTIFICATION],
+                ["assistantText", "fake: woke"],
+              ],
+            )
+            assert.strictEqual(
+              (fake.decisions.at(-1)?.result as { behavior?: string } | undefined)?.behavior,
+              "allow",
+            )
+          }),
+        )
       }).pipe(Effect.provide(layer))
     }),
   )

--- a/app-server/test/agents/fakeAgentAdapter.ts
+++ b/app-server/test/agents/fakeAgentAdapter.ts
@@ -65,6 +65,11 @@ export interface FakeAgentAdapter {
   readonly seedRunningTurn: (providerSessionId: string, turnId: string) => void
   /** Complete the active turn of `providerSessionId` with `outcome`. */
   readonly completeTurn: (providerSessionId: string, outcome: AgentTurnOutcome) => void
+  /** The provider starts a turn by itself on the live connection (a Claude
+   * root loop woken by a finished background task): turnStarted and the
+   * notification as its first userMessage, no startTurn. Returns the turn id;
+   * `completeTurn` ends it like any other. */
+  readonly startProviderTurn: (providerSessionId: string, text: string) => string
   /** End the live connection of `providerSessionId` from the provider's
    * side (its feed ends cleanly, control calls refuse) — a Claude session
    * ending after a non-success turn, a resident child that exited. */
@@ -626,6 +631,21 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
       runningOnResume.set(providerSessionId, turnId)
     },
     completeTurn: (providerSessionId, outcome) => finishTurn(providerSessionId, outcome),
+    startProviderTurn: (providerSessionId, text) => {
+      const live = requireLive(providerSessionId)
+      if (live.activeTurn !== null) {
+        throw new Error(`fake adapter: turn ${live.activeTurn} is still active`)
+      }
+      const turnId = `fake-wake-${nextTurnId++}-${instance}`
+      live.activeTurn = turnId
+      emit(live, { type: "turnStarted", turnId })
+      emit(live, {
+        type: "itemCompleted",
+        item: { type: "userMessage", id: `${turnId}:prompt`, turnId, text },
+      })
+      setActivity(live, "working")
+      return turnId
+    },
     endConnection: (providerSessionId) =>
       closeConnection(providerSessionId, requireLive(providerSessionId)),
     isConnected: (providerSessionId) => connections.has(providerSessionId),

--- a/app-server/test/agents/fakeClaudeQuery.ts
+++ b/app-server/test/agents/fakeClaudeQuery.ts
@@ -22,6 +22,12 @@ import type { ClaudeQueryFn, ClaudeQueryHandle } from "../../src/agents/claudeAd
 //                  per-block `assistant` message with the same message id
 //   "TOOL"       — emits a Read tool_use block and its tool_result
 //   "FAILTURN"   — ends with error_max_turns, then the iterator throws
+//   "WAKE"       — after the turn's result, a background task "finishes":
+//                  the root loop wakes into a turn of the SDK's own (probed
+//                  2026-08-21) — no user message on the stream, the
+//                  UserPromptSubmit hook carries WAKE_NOTIFICATION, then
+//                  the usual output, Stop and result; "WAKEQ" also asks
+//                  a question (canUseTool) inside that woken turn
 // Every successful turn ends with a per-block `assistant` text message
 // (`fake: <text>`) before its result, like the SDK's own output.
 //
@@ -55,6 +61,11 @@ export interface FakeClaudeQueryOptions {
   /** Leave getSettings() undeclared on the handle (an SDK that dropped it). */
   readonly withoutGetSettings?: boolean
 }
+
+/** The prompt the UserPromptSubmit hook carries for a woken turn (the CLI's
+ * task-notification shape, trimmed). */
+export const WAKE_NOTIFICATION =
+  "<task-notification>\n<task-id>fake-task</task-id>\n<status>completed</status>\n</task-notification>"
 
 /** The catalog shape recorded from the CLI (2026-08-18), trimmed. */
 export const FAKE_CLAUDE_MODELS: ReadonlyArray<ModelInfo> = [
@@ -153,6 +164,15 @@ export const makeFakeClaudeQuery = (options: FakeClaudeQueryOptions = {}): FakeC
       done = true
       wake?.()
     }
+    let drainedWaiters: Array<() => void> = []
+    /** Resolves once the consumer has taken (and, being synchronous per
+     * message, handled) everything pushed so far — the real SDK's timing
+     * for evidence that lands well after a turn's result, such as a
+     * background task finishing seconds later. */
+    const whenDrained = (): Promise<void> =>
+      output.length === 0 && wake !== null
+        ? Promise.resolve()
+        : new Promise((resolve) => drainedWaiters.push(resolve))
     const state = (value: string): void => {
       if (options.stateEvents === false) return
       push({
@@ -354,6 +374,48 @@ export const makeFakeClaudeQuery = (options: FakeClaudeQueryOptions = {}): FakeC
         result: `fake: ${text}`,
       })
       state("idle")
+      if (text.includes("WAKE")) await wakeTurn(text.includes("WAKEQ"))
+    }
+
+    /** The woken turn (see the header's WAKE entry). */
+    const wakeTurn = async (ask: boolean): Promise<void> => {
+      await whenDrained()
+      state("running")
+      await fireHook("UserPromptSubmit", { prompt: WAKE_NOTIFICATION })
+      const messageId = `msg_fake_${nextMessage++}`
+      if (ask) {
+        const input = {
+          questions: [
+            {
+              question: "Keep going?",
+              header: "Next",
+              options: [
+                { label: "yes", description: "continue" },
+                { label: "no", description: "stop" },
+              ],
+              multiSelect: false,
+            },
+          ],
+        }
+        state("requires_action")
+        const result = await args.options.canUseTool?.("AskUserQuestion", input, {
+          signal: new AbortController().signal,
+          requestId: "fake-request-wake",
+          toolUseID: "fake-tool-use-wake",
+        })
+        decisions.push({ toolName: "AskUserQuestion", result })
+        state("running")
+      }
+      await fireHook("Stop")
+      assistant(messageId, { type: "text", text: "fake: woke" })
+      push({
+        type: "result",
+        subtype: "success",
+        session_id: sessionId,
+        is_error: false,
+        result: "fake: woke",
+      })
+      state("idle")
     }
 
     // Drain the prompt stream like the real SDK does: input is taken as it
@@ -451,6 +513,9 @@ export const makeFakeClaudeQuery = (options: FakeClaudeQueryOptions = {}): FakeC
                   wake = null
                   resolve()
                 }
+                const waiters = drainedWaiters
+                drainedWaiters = []
+                for (const waiter of waiters) waiter()
               })
             }
           },

--- a/app-server/test/threads/threadResidency.test.ts
+++ b/app-server/test/threads/threadResidency.test.ts
@@ -300,4 +300,55 @@ describe("Resident writer connections", () => {
         }).pipe(Effect.provide(fastKit.layer))
       }),
   )
+
+  it.live("a turn the provider starts on a resident connection is ATC's run", () =>
+    Effect.gen(function* () {
+      const runtime = yield* ThreadRuntime
+      const threads = yield* Threads
+      const { threadId, sessionId } = yield* settledThread(kit, "claude-code")
+      const transcript = runtime.transcript(threadId).pipe(Effect.orDie)
+
+      // The provider wakes itself: the turn lands as ours, with its prompt.
+      const wakeId = claude.startProviderTurn(
+        sessionId,
+        "<task-notification>done</task-notification>",
+      )
+      yield* waitFor(transcript, (current) =>
+        current.turns.some((turn) => turn.id === wakeId && turn.status === "running"),
+      )
+      const midway = yield* transcript
+      assert.deepStrictEqual(
+        midway.items.filter((item) => item.turnId === wakeId).map((item) => item.type),
+        ["userMessage"],
+      )
+      assert.strictEqual((yield* threads.get(threadId)).activityState, "working")
+
+      // Its requests park with the run and are answerable.
+      const requestId = claude.openRequest(sessionId, "question")
+      yield* waitFor(runtime.listRequests(threadId).pipe(Effect.orDie), (list) =>
+        list.some((request) => request.id === requestId),
+      )
+      // A prompt admitted meanwhile waits: the connection is mid-turn.
+      const later = yield* runtime.prompt(threadId, { prompt: "after" })
+      assert.isUndefined(later.turnId)
+      assert.deepStrictEqual(claude.sessions.get(sessionId)?.inputs, ["first"])
+
+      yield* runtime.answerRequest(threadId, requestId, {
+        kind: "question",
+        answers: { q0: ["A"] },
+      })
+      assert.deepStrictEqual(claude.answers.at(-1)?.requestId, requestId)
+      claude.completeTurn(sessionId, "completed")
+      yield* waitFor(transcript, (current) =>
+        current.turns.some((turn) => turn.id === wakeId && turn.status === "completed"),
+      )
+      // Its end drains the queue onto the same connection.
+      yield* waitFor(
+        Effect.sync(() => claude.sessions.get(sessionId)?.inputs ?? []),
+        (inputs) => inputs.includes("after"),
+      )
+      assert.strictEqual(opened(claude, sessionId), 1)
+      claude.completeTurn(sessionId, "completed")
+    }).pipe(Effect.provide(kit.layer)),
+  )
 })


### PR DESCRIPTION
## Why

A finished background task (a subagent, a backgrounded shell) wakes Claude's root loop into a turn the SDK starts by itself. The adapter dropped every block of such a turn — there was no client `startTurn`, so `activeTurn` was `null` (`claudeAdapter.ts` `handleAssistantMessage` / `handleStreamEvent`) — and `canUseTool` denied its asks unseen. In Chat that read as: thread goes working → idle with no new content, and an `AskUserQuestion` the model tried to raise "couldn't be shown". The content only appeared after a history re-read (e.g. a TUI open/close), which is how this surfaced on 2026-08-21.

Probed against SDK 0.3.235 / CLI 2.1.238: the notification is never echoed as a `user` message on the stream; the in-process **UserPromptSubmit hook** carries its text, after `session_state_changed: running`, and the turn ends with an ordinary `result`.

## What

- **Adapter**: `beginWakeTurn` opens a turn from that hook when no turn of ours is active — `turnStarted` plus the notification as the turn's `userMessage` — so items, requests and the result flow through the existing paths. A notification landing mid-turn stays that turn's input.
- **Runtime**: a `turnStarted` ATC did not issue, on a held one-process connection, is adopted as ATC's Run (`adoptTurn` / `holdRun`): its requests park and are answerable, `finish` ends it and drains the queue, and a prompt that races it gets `AgentConflict` → the prompt waits ("busy") instead of the writer being closed under the wake turn. Shared-server turns (a Codex TUI mid-run) stay observed as before.
- **`prompt()` truthfulness** (also fixes a pre-existing flaky test): two windows in which a prompt started without its caller's call making the start, so `prompt` answered "queued" with no `turnId`:
  1. On a shared-server provider the writer drops after every turn; until the forked scope close finishes it stays registered as *closing*, and `startNext` answered `none`. It now waits out the close latch under the start lock (the same pattern `closeWriter` already uses) and resumes afresh, so the caller's own call starts the turn.
  2. On a one-process provider the turn-end drain can win the start lock with the caller's prompt. `prompt` now reads the queue row's `started_turn_id` (`TranscriptRepository.startedTurn`) and reports the turn.

  This is the race behind `"when: now … queues once the turn ended"` failing in CI — it failed the same way on the `atc-222-composer` run at 03:44Z today, before this branch existed (Linux closes the connection slower than the test's next call; macOS wins the race).
- **Fakes and tests**: `fakeClaudeQuery` `WAKE` / `WAKEQ` stage the probed shape (with a drained-wait so the hook lands after the consumer handled the result, as in the real SDK); `fakeAgentAdapter.startProviderTurn` stages it at the seam. Adapter test covers the woken turn's items and its question; runtime test covers adoption, requests, queue wait and drain on the resident connection.

Follow-up (not here): the notification renders as a plain user bubble with the `<task-notification>` XML, which matches what a history re-read already shows; a dedicated rendering can come with ATC-217's item work.

## Verification

`mise run -C app-server check` green (514 tests) on each push.

https://claude.ai/code/session_01Rk3dUZMQeQAJBmoeCxrHUp