### PR TITLE
Fix macOS release resource bundle naming

### DIFF
--- a/scripts/release-macos.sh
+++ b/scripts/release-macos.sh
@@ -310,7 +310,9 @@ run_step "Generate App Server API sources" "01-generate-api" \
 XCODE_OVERRIDES=(
   "ARCHS=arm64"
   "ONLY_ACTIVE_ARCH=NO"
-  "PRODUCT_NAME=$APP_NAME"
+  # Command-line build settings apply to every target. Overriding PRODUCT_NAME
+  # here renames SwiftPM resource bundles while Xcode still copies their
+  # package-derived names.
   "PRODUCT_BUNDLE_IDENTIFIER=$BUNDLE_ID"
   "DEVELOPMENT_TEAM=$ATC_TEAM_ID"
   # Release CI imports this long-lived identity into an isolated keychain.

--- a/scripts/release-test.sh
+++ b/scripts/release-test.sh
@@ -412,6 +412,10 @@ set -e
 grep -Fq -- \
   "<CODE_SIGN_STYLE=Manual> <CODE_SIGN_IDENTITY=Developer ID Application: Test (337D6CNU4E)>" \
   "$tool_log"
+if grep -Fq '<PRODUCT_NAME=atc>' "$tool_log"; then
+  echo "release builds must not globally rename SwiftPM resource bundle targets" >&2
+  exit 1
+fi
 if grep -Eq -- '-allowProvisioningUpdates|-authenticationKey(Path|ID|IssuerID)' "$tool_log"; then
   echo "release builds must not let Xcode create or update signing assets" >&2
   exit 1


### PR DESCRIPTION
## Summary

- stop globally overriding PRODUCT_NAME during macOS release archives
- preserve SwiftPM resource bundle names expected by Xcode
- add a release-tooling regression check for the harmful override

## Root cause

The release archive passed PRODUCT_NAME=atc on the xcodebuild command line. Command-line build settings apply to every target, so SwiftPM produced ATCChat's resources as atc.bundle while the app copy phase still expected ATCKit_ATCChat.bundle.

## Verification

- mise run release:check
- unsigned arm64 Release build via XcodeBuildMCP
- verified ATCKit_ATCChat.bundle and both chat fixtures in the built app
- mise run check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS release builds to preserve correct Swift package resource-bundle names.
  * Added validation to prevent release configurations from applying unsupported global product-name overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->