### PR TITLE
Thread runtime split: ThreadRuntime drives chat, ThreadObserver follows tui; the TUI hand-off is gone (ATC-226)

### DIFF
--- a/app-server/src/agents/agentAdapter.ts
+++ b/app-server/src/agents/agentAdapter.ts
@@ -390,9 +390,9 @@ export interface AgentAdapter {
    * one session. Without it (Claude) each process holds the session in
    * memory: the hooks feed dies silently with the TUI (a busy state must
    * re-derive through checkSession), and two live processes FORK the
-   * session — so the Thread runtime keeps one live process per thread
-   * (its surface-ownership rules, threadRuntime.ts) and keeps that one
-   * process's writer connection resident across native turns (ATC-207).
+   * session — so ATC's process is the only process ATC runs on a chat
+   * thread (ATC-224), and the Thread runtime keeps that process's writer
+   * connection resident across its turns (ATC-207).
    */
   readonly sharedServer: boolean
   /**

--- a/app-server/src/platform/keyedLock.ts
+++ b/app-server/src/platform/keyedLock.ts
@@ -1,0 +1,25 @@
+import { Effect, Semaphore } from "effect"
+
+/**
+ * Per-key serialization: one permit per key, created on first use. `release`
+ * drops a key's lock (a deleted row's) — a waiter still queued on it just
+ * finds the row gone.
+ */
+export const makeKeyedLock = () => {
+  const locks = new Map<string, Semaphore.Semaphore>()
+  return {
+    withLock:
+      (key: string) =>
+      <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
+        Effect.suspend(() => {
+          const existing = locks.get(key)
+          if (existing !== undefined) return existing.withPermit(effect)
+          const lock = Semaphore.makeUnsafe(1)
+          locks.set(key, lock)
+          return lock.withPermit(effect)
+        }),
+    release: (key: string): void => {
+      locks.delete(key)
+    },
+  }
+}

--- a/app-server/src/server.ts
+++ b/app-server/src/server.ts
@@ -28,6 +28,7 @@ import * as AttachmentRepository from "./threads/attachmentRepository.ts"
 import * as Attachments from "./threads/attachments.ts"
 import * as ThreadRepository from "./threads/threadRepository.ts"
 import * as ThreadNaming from "./threads/threadNaming.ts"
+import * as ThreadObserver from "./threads/threadObserver.ts"
 import * as ThreadRuntime from "./threads/threadRuntime.ts"
 import * as Threads from "./threads/threads.ts"
 import * as ThreadTui from "./threads/threadTui.ts"
@@ -140,12 +141,14 @@ export const production = (options: { readonly port: number; readonly hostname?:
     // server-info handler and the optional trust allowlist read one instance.
     Layer.provideMerge(Tailscale.layer),
     // Projects sits above Threads (its delete cascades through them), which
-    // sits above the ThreadRuntime (activity ledger, transcript, turns,
-    // observation, TUI ownership); ThreadTui and Terminals serve both, and
-    // ThreadNaming serves Threads and the runtime — each provide feeds
+    // sits above the ThreadObserver (tui threads' feeds) and the
+    // ThreadRuntime (activity ledger, transcript, turns) the observer feeds;
+    // ThreadTui and Terminals serve all of them, and ThreadNaming serves
+    // Threads, the observer, and the runtime — each provide feeds
     // everything composed so far.
     Layer.provide(Projects.layer),
     Layer.provide(Threads.layer),
+    Layer.provide(ThreadObserver.layer),
     Layer.provide(ThreadRuntime.layer),
     Layer.provide(ThreadTui.layer),
     Layer.provide(Terminals.layer),

--- a/app-server/src/threads/threadObserver.ts
+++ b/app-server/src/threads/threadObserver.ts
@@ -1,0 +1,274 @@
+import { Cause, Context, Effect, Exit, Layer, Option, Scope, Stream } from "effect"
+import { AgentRegistry } from "../agents/agentRegistry.ts"
+import { isBusyActivity } from "../agents/agentAdapter.ts"
+import type { AgentActivity, AgentAdapter, AgentSessionEvent } from "../agents/agentAdapter.ts"
+import { isAgentId } from "../api/contract.ts"
+import type {
+  ProviderSessionConflict,
+  ProviderUnavailable,
+  ThreadNotFound,
+  ZmxUnavailable,
+} from "../api/contract.ts"
+import { makeKeyedLock } from "../platform/keyedLock.ts"
+import { ThreadNaming } from "./threadNaming.ts"
+import { ThreadRepository } from "./threadRepository.ts"
+import type { ThreadRecord } from "./threadRepository.ts"
+import { ThreadRuntime } from "./threadRuntime.ts"
+import { ThreadTui } from "./threadTui.ts"
+import { TranscriptRepository } from "./transcriptRepository.ts"
+
+// The Thread observer (ATC-226): how ATC follows a tui thread — one whose
+// driver is the provider TUI in a terminal ATC launched. Its feed is the
+// adapter's normalized subscription, drained into the runtime's ledger,
+// transcript copy, and settings row, and into ThreadNaming. A chat thread
+// is never observed: every entry point is a no-op for it. Invariants:
+//
+//   - One observation per thread, once per provider session, demand-driven
+//     (`observe` on every read that finds a live terminal, and at launch):
+//     a superseded session's subscription never keeps driving the thread,
+//     and a feed that ends on its own releases its claim so the next read
+//     re-subscribes instead of trusting a dead stream. The idle work a
+//     feed spawns lives in its scope: `unobserve` ends both.
+//   - The observed busy→idle drop is a turn's end: the copy is re-read
+//     wholesale (`runtime.reread`). Re-reads serialize per thread, and a
+//     terminal ends only with its last turn on disk: a close while idle
+//     re-reads first (a read that fails fails the close), a close while
+//     busy waits for the idle and ends the terminal once the re-read of
+//     THAT idle has landed — a newer idle in between (the TUI worked again
+//     meanwhile) re-arms the wait for its own re-read, and a read that
+//     fails leaves the terminal running (nothing can re-read a TUI that is
+//     gone). Showing the terminal again calls the close off.
+//   - Nothing relaunches a terminal that ended: the next open does. At
+//     startup, a tui thread whose copy still holds a running turn is
+//     re-read once (the TUI may have worked while ATC was down).
+
+export class ThreadObserver extends Context.Service<
+  ThreadObserver,
+  {
+    /** Start (once) the thread's session observation. */
+    readonly observe: (record: ThreadRecord) => Effect.Effect<void>
+    /** End the thread's observation and the idle work it spawned. */
+    readonly unobserve: (id: string) => Effect.Effect<void>
+    /** Whether the record's current session is under observation. */
+    readonly observing: (record: ThreadRecord) => Effect.Effect<boolean>
+    /** One activity observation into the runtime's ledger — the feed's, or
+     * a read's re-derivation — with the header's idle rule on top. */
+    readonly noteActivity: (record: ThreadRecord, activity: AgentActivity) => Effect.Effect<void>
+    /** A client stopped showing the terminal: end it now when idle (its
+     * last turn re-read first), at its observed idle when busy. */
+    readonly closeTui: (
+      record: ThreadRecord,
+    ) => Effect.Effect<
+      void,
+      ThreadNotFound | ProviderUnavailable | ProviderSessionConflict | ZmxUnavailable
+    >
+    /** A client opens the terminal: a close waiting on the idle is called
+     * off first, and any idle work in flight has finished. */
+    readonly cancelPendingClose: (id: string) => Effect.Effect<void>
+  }
+>()("app-server/ThreadObserver") {}
+
+export const layer = Layer.effect(ThreadObserver)(
+  Effect.gen(function* () {
+    const registry = yield* AgentRegistry
+    const repository = yield* ThreadRepository
+    const transcripts = yield* TranscriptRepository
+    const runtime = yield* ThreadRuntime
+    const naming = yield* ThreadNaming
+    const tui = yield* ThreadTui
+    const serviceScope = yield* Effect.scope
+
+    const adapterFor = (record: ThreadRecord): AgentAdapter | undefined =>
+      isAgentId(record.agentId) ? registry.adapterFor(record.agentId) : undefined
+
+    /** The observed session per thread; the child scope closes it and the
+     * idle work it spawned. */
+    interface Observation {
+      readonly providerSessionId: string
+      readonly scope: Scope.Closeable
+    }
+    const observed = new Map<string, Observation>()
+    /** Threads whose terminal ends at the next observed idle. */
+    const closeAtIdle = new Set<string>()
+    /** Idle edges seen per thread: a re-read knows whether a newer idle
+     * has landed since the one that started it. */
+    const idleEdges = new Map<string, number>()
+    const idleLock = makeKeyedLock()
+
+    const busy = (id: string): Effect.Effect<boolean> =>
+      runtime.activity(id).pipe(Effect.map((activity) => isBusyActivity(activity ?? "unknown")))
+
+    const endLinked = (record: ThreadRecord): Effect.Effect<void, ZmxUnavailable> =>
+      Effect.gen(function* () {
+        const linked = yield* tui.linked(record)
+        if (linked === undefined) return
+        yield* tui.end(linked.id)
+      })
+
+    /** The idle's re-read, then the close it gates (the header). */
+    const observedIdle = (record: ThreadRecord, edge: number): Effect.Effect<void> =>
+      idleLock.withLock(record.id)(
+        Effect.gen(function* () {
+          const settled = yield* runtime.reread(record.id).pipe(
+            Effect.as(true),
+            Effect.catch((error) =>
+              Effect.logDebug("re-read after observed idle failed").pipe(
+                Effect.annotateLogs({ threadId: record.id, reason: error.message }),
+                Effect.as(false),
+              ),
+            ),
+          )
+          if (!settled || !closeAtIdle.has(record.id)) return
+          // A newer idle (or a turn in progress) since this one: its own
+          // re-read is the gate now.
+          if (idleEdges.get(record.id) !== edge || (yield* busy(record.id))) return
+          closeAtIdle.delete(record.id)
+          yield* endLinked(record).pipe(
+            Effect.catch((error) =>
+              Effect.logWarning("the closed TUI could not be ended at its idle").pipe(
+                Effect.annotateLogs({ threadId: record.id, reason: error.message }),
+              ),
+            ),
+          )
+        }),
+      )
+
+    const noteActivity = (record: ThreadRecord, activity: AgentActivity): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        const { previous } = yield* runtime.noteActivity(record, activity)
+        if (record.kind !== "tui") return
+        if (previous === undefined || !isBusyActivity(previous) || activity !== "idle") return
+        const edge = (idleEdges.get(record.id) ?? 0) + 1
+        idleEdges.set(record.id, edge)
+        // Forked (the drain must never wait on the provider), into the
+        // observation's scope when one holds the thread so `unobserve`
+        // ends it too.
+        yield* observedIdle(record, edge).pipe(
+          Effect.forkIn(observed.get(record.id)?.scope ?? serviceScope),
+        )
+      })
+
+    // The idle lock entry stays (bounded by thread ids): idle work forked
+    // outside the observation (a discovered idle) may still hold it.
+    const unobserve = (id: string): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        closeAtIdle.delete(id)
+        idleEdges.delete(id)
+        const observation = observed.get(id)
+        if (observation === undefined) return
+        observed.delete(id)
+        yield* Scope.close(observation.scope, Exit.void)
+      })
+
+    const drain = (record: ThreadRecord, event: AgentSessionEvent): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        if (event.type === "userPrompt") return yield* naming.notePrompt(record, event.text)
+        if (event.type === "settings") return yield* runtime.adoptSettings(record, event.settings)
+        if (event.type === "activity") return yield* noteActivity(record, event.activity)
+        yield* runtime.recordObservedItem(record.id, event)
+      })
+
+    const observe = (record: ThreadRecord): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        if (record.kind !== "tui") return
+        const adapter = adapterFor(record)
+        const providerSessionId = record.providerSessionId
+        if (adapter === undefined || providerSessionId === undefined) return
+        const existing = observed.get(record.id)
+        if (existing?.providerSessionId === providerSessionId) return
+        if (existing !== undefined) yield* unobserve(record.id)
+        // The re-check, unsafe fork, and claim are ONE synchronous step:
+        // concurrent first reads of the same live thread (sidebar list +
+        // detail get at relaunch) race exactly here, and a loser that
+        // proceeded would leak its adapter subscription until shutdown.
+        // Whoever claimed during the unobserve above wins, whatever
+        // session it observes — the next read re-checks and heals.
+        if (observed.get(record.id) !== undefined) return
+        const child = Scope.forkUnsafe(serviceScope)
+        const observation: Observation = { providerSessionId, scope: child }
+        observed.set(record.id, observation)
+        const releaseClaim = Effect.gen(function* () {
+          if (observed.get(record.id) !== observation) return
+          observed.delete(record.id)
+          yield* Scope.close(child, Exit.void)
+        })
+        yield* Effect.gen(function* () {
+          // The subscription is established HERE, before the caller
+          // proceeds — only the drain loop is forked. An unavailable
+          // evidence source yields an empty feed: `unknown` on reads,
+          // never a guess or a crash.
+          const stream = yield* adapter
+            .observeSession({ providerSessionId, providerMetadata: record.providerMetadata })
+            .pipe(
+              Effect.catchTag("AgentUnavailable", () =>
+                Effect.succeed(Stream.empty as Stream.Stream<AgentSessionEvent>),
+              ),
+              Scope.provide(child),
+            )
+          yield* stream.pipe(
+            Stream.runForEach((event) => drain(record, event)),
+            // An ended observation also ends the refinement's wait — its
+            // turn-end evidence is gone, so the catch-up must not park
+            // forever.
+            Effect.ensuring(naming.noteFeedEnded(record).pipe(Effect.andThen(releaseClaim))),
+            Effect.forkIn(child),
+          )
+        }).pipe(
+          // A caller interrupted (a dropped read) or failing before the
+          // drain fiber arms must not leave a claim with no consumer — that
+          // would freeze the thread's activity until shutdown.
+          Effect.onExit((exit) => (exit._tag === "Failure" ? releaseClaim : Effect.void)),
+        )
+      })
+
+    // Startup: the tui threads whose copy still holds a running turn.
+    yield* Effect.forEach(
+      yield* transcripts.threadsNeedingAttention(),
+      (id) =>
+        Effect.gen(function* () {
+          const record = yield* repository.get(id)
+          if (Option.isNone(record) || record.value.kind !== "tui") return
+          yield* runtime
+            .reread(id)
+            .pipe(
+              Effect.catch((error) =>
+                Effect.logWarning("startup re-read failed").pipe(
+                  Effect.annotateLogs({ threadId: id, reason: error.message }),
+                ),
+              ),
+            )
+        }),
+      { concurrency: 4 },
+    ).pipe(
+      Effect.catchCause((cause) =>
+        Effect.logWarning("startup tui re-read failed").pipe(
+          Effect.annotateLogs({ cause: Cause.pretty(cause) }),
+        ),
+      ),
+      Effect.forkScoped,
+    )
+
+    return {
+      observe,
+      unobserve,
+      observing: (record) =>
+        Effect.sync(() => observed.get(record.id)?.providerSessionId === record.providerSessionId),
+      noteActivity,
+      closeTui: (record) =>
+        Effect.gen(function* () {
+          if (record.kind !== "tui") return
+          if (yield* busy(record.id)) {
+            closeAtIdle.add(record.id)
+            return
+          }
+          closeAtIdle.delete(record.id)
+          yield* idleLock.withLock(record.id)(
+            runtime.reread(record.id).pipe(Effect.andThen(endLinked(record))),
+          )
+        }),
+      // Under the idle lock: an idle's re-read and close in flight finish
+      // first, so the caller's own linked check sees the outcome.
+      cancelPendingClose: (id) => idleLock.withLock(id)(Effect.sync(() => closeAtIdle.delete(id))),
+    }
+  }),
+)

--- a/app-server/src/threads/threadRuntime.ts
+++ b/app-server/src/threads/threadRuntime.ts
@@ -21,7 +21,6 @@ import type {
   AgentConnection,
   AgentEvent,
   AgentItemEvent,
-  AgentSessionEvent,
   AgentTurn,
   ProviderSettings,
   ThreadAttachment,
@@ -43,16 +42,14 @@ import {
   ThreadKindMismatch,
   ThreadNotFound,
 } from "../api/contract.ts"
-import type { ZmxUnavailable } from "../api/contract.ts"
 import { Events } from "../events/events.ts"
-import type { Terminal } from "../terminals/terminals.ts"
+import { makeKeyedLock } from "../platform/keyedLock.ts"
 import { Attachments } from "./attachments.ts"
 import { ThreadNaming } from "./threadNaming.ts"
 import { requireKind, ThreadRepository } from "./threadRepository.ts"
 import type { ThreadRecord } from "./threadRepository.ts"
 import { applyProviderSettings } from "./threadSettings.ts"
 import type { ThreadSettings } from "./threadSettings.ts"
-import { ThreadTui } from "./threadTui.ts"
 import { TranscriptRepository } from "./transcriptRepository.ts"
 import type { QueuedPromptRecord, TranscriptChange, TurnSource } from "./transcriptRepository.ts"
 
@@ -61,104 +58,53 @@ export type ThreadTranscript = typeof Contract.ThreadTranscript.Type
 export type QueuedPrompt = typeof Contract.QueuedPrompt.Type
 
 // The Thread runtime (ATC-193): the server-owned run, and everything live
-// about a thread's provider session. It drives a thread's conversation
+// about a chat thread's provider session. It drives a thread's conversation
 // through the AgentAdapter seam with no Terminal involved — prompts, the
 // durable prompt queue, the turn loop, parked provider requests, the
-// transcript projection with its per-thread event stream, the observation
-// of TUI-driven sessions, and the live activity ledger every surface reads.
-// Every surface (macOS, CLI, Linear) is a client of this one service;
-// nothing here is provider-specific beyond the seam's `sharedServer`
-// capability. Invariants:
+// transcript with its per-thread event stream, and the live activity
+// ledger every surface reads. Every surface (macOS, CLI, Linear) is a
+// client of this one service; nothing here is provider-specific beyond the
+// seam's `sharedServer` capability. A tui thread is never driven here —
+// prompt, interrupt, answer, and the queue refuse it (ThreadKindMismatch,
+// ATC-224); the ThreadObserver follows it through the seams at the end of
+// the service. Invariants:
 //
-//   - Thread kinds (ATC-224): a chat thread is driven only by this
-//     runtime's own writer — prompt, interrupt, answer, and the queue
-//     refuse a tui thread (ThreadKindMismatch) — and is NEVER observed or
-//     re-read: `observe` is a no-op on it, no re-read trigger (idle,
-//     startup, a failed connection, a TUI end) ever replaces its
-//     transcript, and `snapshot.invalidated` never reaches its stream. Its
-//     transcript is ATC's append-only record of the turns ATC drove. A tui
-//     thread is the converse: observed and re-read as the bullets below
-//     say, never prompted. A chat thread whose confirmed provider session
-//     is gone (AgentResumeFailed on resume, or on Claude's first turn
-//     after it) is not stuck: the turn starts a fresh session, the
-//     transcript is kept, and one `notice` item opens the turn. A Codex
-//     chat thread mid-turn in another Codex client refuses the prompt
-//     (un-admitted, ProviderSessionConflict) — nothing queues behind a
-//     turn ATC cannot see. The ownership and observation bullets below
-//     therefore apply to tui threads only (ATC-226 removes them).
 //   - A prompt is admitted, always: it lands in the queue (durable), and if
 //     the thread is idle it starts a turn at once — the one exception being
 //     a provider that refuses that immediate start, which un-admits the
-//     prompt so the caller's error means "not accepted". A thread busy
-//     under a TUI (the ledger says so) queues the prompt and drains at the
-//     observed idle: no busy error, no lock between surfaces. A prompt
-//     marked `now` (ATC-216) is instead handed to the turn running on our
-//     writer — the seam's `steer` — and recorded against that turn; with no
-//     such turn, or one that ended first, it is an ordinary prompt. A turn runs
-//     on a writer connection the runtime holds; client connections never
+//     prompt so the caller's error means "not accepted" (a Codex thread
+//     mid-turn in another Codex client is the case that matters: nothing
+//     queues behind a turn ATC cannot see). A prompt marked `now`
+//     (ATC-216) is instead handed to the turn running on our writer — the
+//     seam's `steer` — and recorded against that turn; with no such turn,
+//     or one that ended first, it is an ordinary prompt. A turn runs on a
+//     writer connection the runtime holds; client connections never
 //     matter to a run's lifetime. A closing writer stays registered until
 //     its connection has closed, so the next prompt never races it.
 //   - Connection lifetime is not turn lifetime (ATC-207): the Run ends at
 //     turn end, the writer need not. A one-process provider's writer stays
 //     resident after a successful turn — the next prompt starts on it
 //     rather than re-spawning and resuming — and while held its feed owns
-//     the ledger; it must close before another process takes the session
-//     (the TUI hand-off), it closes when the provider ends it, on release
-//     and shutdown, and idle residency is bounded (`armIdleClose`). A
-//     shared-server provider's connection is a cheap subscription that
-//     coexists with its TUI: it holds nothing between turns, as before.
-//     A turn the provider starts by itself on a held one-process
-//     connection (Claude's root loop woken by a finished background task)
-//     is ATC's run: adopted at its turnStarted, ended by `finish` like a
-//     prompted turn, its requests answerable; a prompt admitted meanwhile
-//     waits for it (the connection refuses a second turn) and drains at
-//     its end. On a shared server the same event is another writer's turn
-//     and stays observed.
-//   - One live process per thread (ATC-203), on a provider whose sessions
-//     live in one process at a time (`sharedServer: false` — Claude; two
-//     live processes fork the session). The native side owns the thread by
-//     default; the TUI owns it only while clients want it: `tuiWanted` is a
-//     per-thread, last-writer-wins mark — openTui sets it, closeTui clears
-//     it, and a TUI found live at a thread's first observation (no client
-//     has spoken for it yet — after a restart) is wanted until a client
-//     says otherwise. It is deliberately not per-client presence
-//     (single user; a client that quits without closing leaves the TUI in
-//     charge until the next close, nothing worse). A native turn against a
-//     live TUI queues while the TUI is busy (the ledger), then ENDS the TUI
-//     and resumes the session itself; when the run ends with the queue
-//     drained and the TUI still wanted, the TUI is relaunched. The ledger
-//     is the only liveness evidence Claude offers (checkSession is
-//     `unknown`), so `unknown` — a TUI observed since a restart that has
-//     not spoken yet — is taken as idle: the settle gate below is the
-//     remaining guard, and a queue that could otherwise never drain is the
-//     worse failure. A TUI open
-//     during a native run is refused (ThreadBusy) and happens at the run's
-//     end instead, and no native turn starts while a TUI launch is in
-//     flight. Closing the TUI ends it at once when idle, at its next
-//     observed idle when busy. A TUI ends only after its last turn is on
-//     disk — `endTui`: the settled re-read (the adapter's readHistory)
-//     first, then the kill; a read that fails leaves the TUI alive (the
-//     prompt stays queued / the close fails retryably) rather than guess.
-//     While a writer is held, observed activity is ignored: the ended TUI's
-//     own SessionEnd must not read as the native turn's end. A
-//     shared-server provider (Codex) needs none of this — its TUI and
-//     native connection coexist — and its observation keeps writing the
-//     ledger between runs as before.
-//   - Observation is per thread and demand-driven: `observe` starts (once
-//     per provider session) the adapter's normalized subscription for a
-//     TUI-driven session and drains it into the ledger, the transcript copy
-//     (observed items), and ThreadNaming; `unobserve` ends it. A superseded
-//     session's subscription must never keep driving the thread, and a
-//     feed that ends on its own releases its claim so the next read
-//     re-subscribes instead of trusting a dead stream.
-//   - The transcript copy is a projection of provider history, never the
-//     authority: `seq` (allocated by the repository) orders durable changes
-//     and replays them (subscribe after=seq); a re-read (`readHistory`)
-//     replaces the copy wholesale and bumps snapshotVersion — triggered at
-//     startup for threads mid-work, when a TUI-driven thread goes idle, and
-//     before a TUI is ended (its last turn), never for a turn ATC drove
-//     itself. An empty history never replaces the copy (a swept Claude
-//     transcript keeps ATC's copy readable).
+//     the ledger; it closes when the provider ends it, on release and
+//     shutdown, and idle residency is bounded (`armIdleClose`). A
+//     shared-server provider's connection is a cheap subscription: it
+//     holds nothing between turns. A turn the provider starts by itself on
+//     a held one-process connection (Claude's root loop woken by a finished
+//     background task) is ATC's run: adopted at its turnStarted, ended by
+//     `finish` like a prompted turn, its requests answerable; a prompt
+//     admitted meanwhile waits for it (the connection refuses a second
+//     turn) and drains at its end.
+//   - A chat thread's transcript is ATC's own append-only record of the
+//     turns it drove: never re-read from the provider, never replaced —
+//     not at idle, not when a connection fails, not at startup — so
+//     `snapshot.invalidated` never reaches a chat thread's stream, and a
+//     turn run on the session from outside ATC leaves no trace here. Only
+//     a tui thread's copy is ever replaced (`reread`, the observer's
+//     trigger), and only its subscribers are ever told to refetch.
+//   - A confirmed provider session the provider no longer has
+//     (AgentResumeFailed on the resume, or on Claude's first turn after it)
+//     never bricks the thread: the turn starts a fresh session, the
+//     transcript is kept, and one `notice` item opens the turn.
 //   - Provider requests park in memory until answered through
 //     `answerRequest`; they die with their turn or the process (a re-run
 //     turn re-asks). Answers are validated against the request here, so
@@ -167,37 +113,29 @@ export type QueuedPrompt = typeof Contract.QueuedPrompt.Type
 //     settings (re-read under the start lock, so a change made while a
 //     prompt waited is what the turn runs with); the adapter pushes only
 //     what differs from the live session. The provider's own word on its
-//     session settings — the seam's `settings` events, on the writer feed
-//     and the observation feed alike — is adopted into the row as it
-//     arrives (provider state wins), which is how a change made in a TUI or
-//     another provider client shows up here — except that a report merely
+//     session settings — the seam's `settings` events — is adopted into
+//     the row as it arrives (provider state wins), except that a report merely
 //     confirming what the writer's last turn pushed is not news
 //     (applyProviderSettings): a confirmation that lands after the user
 //     changed a setting again must not roll that change back.
 //   - The activity ledger is the one place live activity lives (the
-//     observation drain and threads.ts's demand-driven re-derivation feed
-//     it too): a first busy confirms the thread, a busy→idle drop stamps
+//     observer feeds it too): a first busy confirms the thread, a busy→idle drop stamps
 //     last_finished_at (unread, ATC-160), and every transition publishes
 //     the thread as updated. Turn end forces idle (the turn is done; ATC-160
 //     stamps it); a resident connection's later evidence — background work
 //     re-busying the thread, then its idle — applies on top, and a
 //     connection that ends forces idle again, since nothing can report on
-//     it any more. While the runtime holds a writer on a thread, its ledger
-//     entry is authoritative: never re-derived, and observed activity is
-//     ignored. The ledger also feeds ThreadNaming every busy/idle edge,
+//     it any more. The ledger also feeds ThreadNaming every busy/idle edge,
 //     whichever surface produced it (ATC-202).
-//   - Startup: threads with a running turn re-read history (their status
-//     is whatever the provider says); a turn still running on a shared
-//     provider server (Codex) is reattached and followed to its end, any
+//   - Startup: a chat thread with a turn still running on a shared
+//     provider server (Codex) is reattached and followed to its end; any
 //     other still-running turn is marked interrupted; then queues drain.
-//     A provider that is unavailable at startup leaves prompts queued —
-//     the next prompt on that thread retries the drain.
+//     A provider that is unavailable at startup leaves prompts queued — the
+//     next prompt on that thread retries the drain.
 //   - Live-only events (text.delta, request.*, queue.updated) carry no seq
 //     and are never replayed; a replay re-sends changed rows as
 //     item.updated / turn.started|completed with the row's current state,
-//     in seq order. A subscriber rejoining from before the latest
-//     replacement gets snapshot.invalidated instead — the deleted rows
-//     cannot be replayed, so it refetches.
+//     in seq order.
 //   - Streamed text is durable while it streams (ATC-214): deltas stay
 //     live-only, and on a throttle the writer persists the text so far as
 //     an item.updated partial (complete stays false), so a reconnect, a
@@ -345,15 +283,15 @@ export class ThreadRuntime extends Context.Service<
       id: string,
       after?: number | undefined,
     ) => Effect.Effect<Stream.Stream<ThreadEvent>, ThreadNotFound>
-    /** Replace the copy with provider history (see the header's rules; a
-     * no-op on a chat thread). No route calls this — the triggers are
-     * internal; it exists for tests and manual repair. */
+
+    // --- The seams threads.ts and the observer consume --------------------
+
+    /** Replace a tui thread's copy with provider history (the header's
+     * rules; a no-op on a chat thread). The observer's idle re-read and
+     * startup are the triggers; no route calls this. */
     readonly reread: (
       id: string,
     ) => Effect.Effect<void, ThreadNotFound | ProviderUnavailable | ProviderSessionConflict>
-
-    // --- The seams threads.ts consumes -------------------------------------
-
     /** The ledger's current activity for a thread (undefined = no evidence). */
     readonly activity: (id: string) => Effect.Effect<AgentActivity | undefined>
     /** Whether the runtime holds a live writer on the thread — a turn in
@@ -365,41 +303,18 @@ export class ThreadRuntime extends Context.Service<
       record: ThreadRecord,
       activity: AgentActivity,
     ) => Effect.Effect<{ readonly previous: AgentActivity | undefined }>
-    /** The thread went idle under observation: re-read unless the busy was
-     * ours, end a TUI no client shows, drain the queue. */
-    readonly observedIdle: (record: ThreadRecord) => Effect.Effect<void>
-    /** Start (once) the thread's session observation — call it whenever a
-     * TUI is live or being launched on the record's session. A no-op on a
-     * chat thread (the header). */
-    readonly observe: (record: ThreadRecord) => Effect.Effect<void>
-    /** End the thread's observation (a superseded session, a put-away). */
-    readonly unobserve: (id: string) => Effect.Effect<void>
-    /** Whether the record's current session is under observation. */
-    readonly observing: (record: ThreadRecord) => Effect.Effect<boolean>
-    /**
-     * A client shows the TUI (openThreadTerminal, tui threads only): mark
-     * it wanted, then launch under the ownership rules — the live linked
-     * terminal is returned as-is (checked again once the launch claim is
-     * held, so an automatic relaunch and an explicit open can never both
-     * launch), and no native turn starts while the launch is in flight.
-     */
-    readonly openTui: <E, R>(
+    /** An item of a tui thread's turn, from the observer's feed, into the
+     * copy (and onto the thread's stream). */
+    readonly recordObservedItem: (threadId: string, event: AgentItemEvent) => Effect.Effect<void>
+    /** A provider settings report from the observer's feed, adopted over
+     * the row as it stands (the header's settings bullet). */
+    readonly adoptSettings: (
       record: ThreadRecord,
-      launch: Effect.Effect<Terminal, E, R>,
-    ) => Effect.Effect<Terminal, E, R>
-    /**
-     * A client stopped showing the TUI (closeThreadTerminal): the native
-     * side takes the thread back on a one-process provider — an idle TUI
-     * ends now (its last turn on disk first — a failed read fails the close
-     * retryably and leaves the TUI running), a busy one at its observed
-     * idle. A shared-server provider's TUI keeps running.
-     */
-    readonly closeTui: (
-      record: ThreadRecord,
-    ) => Effect.Effect<void, ProviderUnavailable | ProviderSessionConflict | ZmxUnavailable>
-    /** Release the run, the observation, the surface marks, and the thread's
-     * event streams (archive/delete): the connection closes, its turn is
-     * recorded interrupted, and the provider keeps its own state. */
+      reported: ProviderSettings,
+    ) => Effect.Effect<void>
+    /** Release the run and the thread's event streams (archive/delete): the
+     * connection closes, its turn is recorded interrupted, and the provider
+     * keeps its own state. */
     readonly release: (id: string) => Effect.Effect<void>
   }
 >()("app-server/ThreadRuntime") {}
@@ -412,10 +327,8 @@ const make = (options: ThreadRuntimeOptions) =>
     const registry = yield* AgentRegistry
     const events = yield* Events
     const naming = yield* ThreadNaming
-    const tui = yield* ThreadTui
-    // Writers, observations, and their drain fibers outlive their
-    // originating requests; they live in the service scope so shutdown
-    // releases every connection and subscription.
+    // Writers and their drain fibers outlive their originating requests;
+    // they live in the service scope so shutdown releases every connection.
     const serviceScope = yield* Effect.scope
     const residentIdleTimeout = options.residentIdleTimeout ?? "10 minutes"
     const streamingFlushInterval = options.streamingFlushInterval ?? "250 millis"
@@ -425,33 +338,10 @@ const make = (options: ThreadRuntimeOptions) =>
     const runOf = (id: string): Run | undefined => writers.get(id)?.run
     const hubs = new Map<string, Set<Queue.Queue<ThreadEvent, Cause.Done>>>()
     const liveActivity = new Map<string, AgentActivity>()
-    /** The observed session per thread; the child scope closes it. */
-    interface Observation {
-      readonly providerSessionId: string
-      readonly scope: Scope.Closeable
-    }
-    const observed = new Map<string, Observation>()
-    /** Threads whose clients want the TUI (the header's ownership rule). */
-    const tuiWanted = new Set<string>()
-    /** Threads whose TUI want is settled — a client said open or close, or
-     * a live TUI was adopted at first observation. Only an unsettled
-     * thread's observation may mark the TUI wanted: a feed that ends and is
-     * re-observed must not undo an explicit close. */
-    const tuiSettled = new Set<string>()
-    /** Threads with a TUI launch in flight: no native turn starts meanwhile. */
-    const tuiOpening = new Set<string>()
     // Threads the startup pass has not settled yet: their prompts wait.
     const recovering = new Set(yield* transcripts.threadsNeedingAttention())
     /** Per-thread serialization of "is a run active → start the next prompt". */
-    const startLocks = new Map<string, Semaphore.Semaphore>()
-    const withStartLock =
-      (id: string) =>
-      <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
-        Effect.suspend(() => {
-          const lock = startLocks.get(id) ?? Semaphore.makeUnsafe(1)
-          startLocks.set(id, lock)
-          return lock.withPermit(effect)
-        })
+    const withStartLock = makeKeyedLock().withLock
 
     const adapterFor = (record: ThreadRecord): AgentAdapter | undefined =>
       isAgentId(record.agentId) ? registry.adapterFor(record.agentId) : undefined
@@ -472,7 +362,7 @@ const make = (options: ThreadRuntimeOptions) =>
     const isBusy = isBusyActivity
 
     /** The thread's provider keeps a session in one process at a time (the
-     * header's ownership rule applies); an unknown agent needs no hand-off. */
+     * header's residency rule applies). */
     const oneProcess = (record: ThreadRecord): boolean => adapterFor(record)?.sharedServer === false
 
     // --- Per-thread event hub -------------------------------------------------
@@ -558,9 +448,8 @@ const make = (options: ThreadRuntimeOptions) =>
      * the item it produces lands after the Run that owns it, and — in one
      * uninterruptible step with it — the row stamped started against that
      * turn, so a provider that took the message never has it delivered
-     * again by the drain. Undefined when no turn of ours runs (a TUI-driven
-     * turn has no writer to hand to) or the turn ended first: the prompt
-     * stays waiting for the ordinary drain.
+     * again by the drain. Undefined when no turn of ours runs or the turn
+     * ended first: the prompt stays waiting for the ordinary drain.
      */
     const steerRunning = (
       id: string,
@@ -675,8 +564,8 @@ const make = (options: ThreadRuntimeOptions) =>
      * writer deregisters once that is done (a prompt admitted meanwhile
      * waits out the latch rather than racing the connection). One close per writer,
      * shared by every caller: a second Scope.close of a closing scope
-     * returns before the first's finalizers are done, and a TUI must not
-     * launch on a process still shutting down.
+     * returns before the first's finalizers are done, and the next prompt
+     * must not resume on a process still shutting down.
      */
     const beginClose = (id: string, writer: Writer): Effect.Effect<Deferred.Deferred<void>> =>
       Effect.suspend(() => {
@@ -704,8 +593,7 @@ const make = (options: ThreadRuntimeOptions) =>
     /**
      * Close the writer from one of its own fibers (the drain, the idle
      * timer): the close begins now; the wait for it, then `then`, then the
-     * next queued prompt (on a fresh connection) and a wanted TUI's return
-     * run in the service scope. Uninterruptible from the begin to the fork:
+     * next queued prompt (on a fresh connection) run in the service scope. Uninterruptible from the begin to the fork:
      * the close interrupts this very fiber, and the continuation is what
      * starts a prompt admitted during the close.
      */
@@ -720,7 +608,6 @@ const make = (options: ThreadRuntimeOptions) =>
             Deferred.await(closing).pipe(
               Effect.andThen(then),
               Effect.andThen(startNextLogged(id)),
-              Effect.andThen(relaunchTui(id)),
               Effect.forkIn(serviceScope),
             ),
           ),
@@ -762,11 +649,12 @@ const make = (options: ThreadRuntimeOptions) =>
 
     /**
      * End a run: the turn row takes its outcome, parked requests close, and
-     * the Run leaves the writer. A shared-server provider's writer drops
+     * the Run leaves the writer. Callers hold the writer's lock (every
+     * caller is the drain): the final flush below runs unsynchronized. A shared-server provider's writer drops
      * with it (nothing is held between turns), forcing the ledger idle —
      * nothing can report on it any more. A one-process provider's stays
-     * resident — the next queued prompt starts on it (or a wanted TUI
-     * takes over), the idle timer bounds it — and the ledger takes the
+     * resident — the next queued prompt starts on it, the idle timer
+     * bounds it — and the ledger takes the
      * connection's own snapshot: idle, or the background work that outlives
      * the turn, whose idle then lands on this same feed.
      */
@@ -806,10 +694,7 @@ const make = (options: ThreadRuntimeOptions) =>
         }
         yield* noteActivity(record, yield* writer.connection.activity)
         yield* armIdleClose(record, writer)
-        yield* startNextLogged(record.id).pipe(
-          Effect.andThen(relaunchTui(record.id)),
-          Effect.forkIn(serviceScope),
-        )
+        yield* startNextLogged(record.id).pipe(Effect.forkIn(serviceScope))
       })
 
     /**
@@ -951,38 +836,31 @@ const make = (options: ThreadRuntimeOptions) =>
           // A turn ATC did not start. On a one-process provider the held
           // connection IS the session's only process, so the turn is ours
           // to run (the provider woke itself: the header's provider-started
-          // bullet); on a shared server it is another writer's — a TUI
-          // mid-run — and only observed.
+          // bullet). On a shared server it is another client's — a chat
+          // thread's transcript takes nothing from it (the header).
           if (run === undefined && oneProcess(record)) {
             return adoptTurn(record, writer, { turnId: event.turnId })
           }
-          return recordTurn(
-            record.id,
-            { id: event.turnId, status: "running", startedAt: new Date().toISOString() },
-            "observed",
+          return Effect.logDebug("a turn another client started on the session is ignored").pipe(
+            Effect.annotateLogs({ threadId: record.id, turnId: event.turnId }),
           )
         }
         case "turnCompleted":
           return run !== undefined && event.turnId === run.turnId
             ? finish(record, writer, run, event.outcome, event.detail)
-            : recordTurn(
-                record.id,
-                { id: event.turnId, status: event.outcome, endedAt: new Date().toISOString() },
-                "observed",
-              )
+            : Effect.void
       }
     }
 
     /**
      * The feed ended on its own — cleanly (the provider ended the session:
      * a non-success turn on Claude, a resident child that exited) or with
-     * a failure (transport loss). With a run still open ATC no longer
-     * knows how that turn is doing — the provider may still be running it
-     * — so the run is dropped without guessing an outcome and the
-     * provider's history re-read for the truth (a turn history still calls
-     * running is the startup pass's job if the provider stays
-     * unreachable). Either way nothing can report on the connection any
-     * more: the writer drops, and the next prompt resumes afresh.
+     * a failure (transport loss). With a run still open the turn ends
+     * failed, with the reason, and the text streamed so far is kept (the
+     * last flush, as `finish` does); the transcript takes only what ATC
+     * saw (the header), nothing is re-read. Either way nothing can report
+     * on the connection any more: the writer drops, and the next prompt
+     * resumes afresh.
      */
     const writerEnded = (
       record: ThreadRecord,
@@ -1001,51 +879,32 @@ const make = (options: ThreadRuntimeOptions) =>
         run.finished = true
         writer.run = undefined
         closeRequests(record.id, run)
-        // A chat thread's transcript takes only what ATC saw (the header):
-        // the text streamed so far is kept (the last flush, as `finish`
-        // does), the turn ends failed with the reason, and nothing is
-        // re-read.
-        if (record.kind === "chat") {
-          yield* writer.lock.withPermit(
-            Effect.forEach([...writer.streaming.keys()], (itemId) =>
-              flushStreaming(record, writer, itemId),
-            ),
-          )
-          writer.streaming.clear()
-          yield* recordTurn(
-            record.id,
-            {
-              id: run.turnId,
-              status: "failed",
-              error: `the provider connection ended mid-turn: ${reason ?? "the feed ended"}`,
-              endedAt: new Date().toISOString(),
-            },
-            "native",
-          )
-          yield* noteActivity(record, "idle")
-          yield* naming.noteFeedEnded(record)
-          return yield* dropWriter(record.id, writer)
-        }
-        yield* noteActivity(record, "unknown")
+        yield* writer.lock.withPermit(
+          Effect.forEach([...writer.streaming.keys()], (itemId) =>
+            flushStreaming(record, writer, itemId),
+          ),
+        )
+        writer.streaming.clear()
+        yield* recordTurn(
+          record.id,
+          {
+            id: run.turnId,
+            status: "failed",
+            error: `the provider connection ended mid-turn: ${reason ?? "the feed ended"}`,
+            endedAt: new Date().toISOString(),
+          },
+          "native",
+        )
+        yield* noteActivity(record, "idle")
         yield* naming.noteFeedEnded(record)
-        yield* Effect.logWarning("the turn's connection failed; re-reading provider history").pipe(
+        yield* Effect.logWarning("the turn's connection ended before the turn did").pipe(
           Effect.annotateLogs({
             threadId: record.id,
             turnId: run.turnId,
             reason: reason ?? "the feed ended without a turn end",
           }),
         )
-        yield* dropWriter(
-          record.id,
-          writer,
-          rereadRecord(record).pipe(
-            Effect.catch((error) =>
-              Effect.logWarning("re-read after a failed connection failed").pipe(
-                Effect.annotateLogs({ threadId: record.id, reason: error.message }),
-              ),
-            ),
-          ),
-        )
+        yield* dropWriter(record.id, writer)
       })
 
     /**
@@ -1233,12 +1092,9 @@ const make = (options: ThreadRuntimeOptions) =>
 
     /**
      * Start the oldest waiting prompt if the thread can take one: no turn
-     * running, not recovering, not archived, and — unless a resident writer
-     * is held (its feed is the ledger; the connection takes a turn whenever
-     * no turn is on it) — not busy under another surface (the ledger's word:
-     * a TUI turn in progress queues us until the observed idle drains).
-     * A resident writer takes the turn without reopening the session; one
-     * the provider has ended since closes here and a fresh resume follows.
+     * running, not recovering, not archived. A resident writer takes the
+     * turn without reopening the session; one the provider has ended since
+     * closes here and a fresh resume follows.
      * Under the per-thread start lock, with the record re-read inside it,
      * so two prompts cannot both start and an archive or delete that won
      * the lock first is honored.
@@ -1263,8 +1119,6 @@ const make = (options: ThreadRuntimeOptions) =>
           const found = yield* repository.get(id)
           if (Option.isNone(found) || found.value.archivedAt !== undefined) return Option.none()
           const record = found.value
-          if (held === undefined && isBusy(liveActivity.get(id) ?? "unknown")) return Option.none()
-          if (tuiOpening.has(id)) return Option.none()
           const next = yield* transcripts.peek(id)
           if (Option.isNone(next)) return Option.none()
           const adapter = yield* requireAdapter(record)
@@ -1278,13 +1132,6 @@ const make = (options: ThreadRuntimeOptions) =>
               return reused
             }
             yield* closeWriter(id, held)
-          }
-          // Native wins (the header's ownership rule): a live TUI on a
-          // one-process provider ends before this turn resumes the session
-          // — unless it turns out busy, in which case the observed idle
-          // drains this prompt.
-          if (!adapter.sharedServer && (yield* takeOverTui(record)) === "busy") {
-            return Option.none()
           }
           const opened = yield* openWriter(record, adapter, input)
           // The adopted record predates this turn's confirm (a fresh
@@ -1426,299 +1273,14 @@ const make = (options: ThreadRuntimeOptions) =>
         ),
       )
 
-    // --- Surface ownership (the header's one-process rule) ---------------------------
-
-    /**
-     * End the thread's TUI terminal, its last turn on disk first: the
-     * settled re-read is the gate (Claude appends the assistant line after
-     * the Stop hook that reported idle) — and it lands the turn in the copy
-     * — then the kill. A read that fails leaves the TUI alive: unverified
-     * is not "on disk". So does a TUI that went busy during the read (a
-     * prompt typed into it meanwhile): "busy", and it keeps the thread
-     * until its idle.
-     */
-    const endTui = (
-      record: ThreadRecord,
-      terminalId: string,
-    ): Effect.Effect<
-      "ended" | "busy",
-      ProviderUnavailable | ProviderSessionConflict | ZmxUnavailable
-    > =>
-      Effect.gen(function* () {
-        yield* rereadRecord(record)
-        if (isBusy(liveActivity.get(record.id) ?? "unknown")) return "busy"
-        yield* tui.end(terminalId)
-        return "ended"
-      })
-
-    /** A native turn is about to start on a one-process provider: a live
-     * TUI (idle — the caller checked the ledger) ends first. "busy" when
-     * it is not idle after all: the turn waits for the observed idle. */
-    const takeOverTui = (
-      record: ThreadRecord,
-    ): Effect.Effect<"taken" | "busy", ProviderUnavailable | ProviderSessionConflict> =>
-      Effect.gen(function* () {
-        const linked = yield* tui.linked(record)
-        if (linked === undefined) return "taken"
-        const outcome = yield* endTui(record, linked.id).pipe(
-          Effect.catchTag("ZmxUnavailable", (error) =>
-            Effect.fail(
-              new ProviderUnavailable({
-                agentId: record.agentId,
-                reason: `the thread's TUI could not be ended: ${error.message}`,
-              }),
-            ),
-          ),
-        )
-        return outcome === "ended" ? "taken" : "busy"
-      })
-
-    /**
-     * The TUI takes the session over from a resident writer between turns:
-     * the connection (and the process behind it) is gone before the TUI's
-     * starts, and so is whatever it was doing — the ledger drops to idle,
-     * because nothing can report on it any more (a stale busy would queue
-     * every later native prompt behind work that no longer exists).
-     */
-    const handOff = (record: ThreadRecord, writer: Writer): Effect.Effect<void> =>
-      closeWriter(record.id, writer).pipe(Effect.andThen(noteActivity(record, "idle")))
-
-    /**
-     * The native side is done (no turn running, nothing queued): a TUI
-     * clients still want comes back on the thread's confirmed session — a
-     * resident writer closes first (one live process). Best-effort — a
-     * failed relaunch is logged, and the next open launches it. Under the
-     * start lock so it cannot interleave with a prompt starting.
-     */
-    const relaunchTui = (id: string): Effect.Effect<void> =>
-      withStartLock(id)(
-        Effect.gen(function* () {
-          const held = writers.get(id)
-          if (!tuiWanted.has(id) || held?.run !== undefined || tuiOpening.has(id)) return
-          const found = yield* repository.get(id)
-          if (Option.isNone(found) || found.value.archivedAt !== undefined) return
-          const record = found.value
-          const adapter = adapterFor(record)
-          if (adapter === undefined || adapter.sharedServer) return
-          if (record.providerSessionId === undefined || record.confirmedAt === undefined) return
-          // A waiting prompt drains first (or stays queued on a provider
-          // failure); the TUI comes back only once the queue is empty.
-          if (Option.isSome(yield* transcripts.peek(id))) return
-          if ((yield* tui.linked(record)) !== undefined) return
-          if (held !== undefined) yield* handOff(record, held)
-          const { record: current } = yield* tui.reopen(record, adapter)
-          yield* observe(current)
-          yield* events.publish({ resource: "thread", id, change: "updated" })
-        }).pipe(
-          Effect.catch((error) =>
-            Effect.logWarning("the TUI could not be relaunched; the next open launches it").pipe(
-              Effect.annotateLogs({ threadId: id, reason: error.message }),
-            ),
-          ),
-        ),
-      )
-
-    const openTui: ThreadRuntime["Service"]["openTui"] = (record, launch) =>
-      Effect.gen(function* () {
-        tuiWanted.add(record.id)
-        tuiSettled.add(record.id)
-        // The refusal, the linked re-check, the resident writer's close,
-        // and the launch claim are one step under the start lock: a prompt
-        // cannot start a run between them, and a relaunch (which holds the
-        // lock while it launches) is seen as the live terminal it produced.
-        const claimed = yield* withStartLock(record.id)(
-          Effect.gen(function* () {
-            const held = writers.get(record.id)
-            const linked = yield* tui.linked(record)
-            if (linked !== undefined) return linked
-            if (!oneProcess(record)) return undefined
-            if (held !== undefined) yield* handOff(record, held)
-            tuiOpening.add(record.id)
-            return undefined
-          }),
-        )
-        if (claimed !== undefined) return claimed
-        if (!oneProcess(record)) return yield* launch
-        return yield* launch.pipe(
-          Effect.ensuring(
-            Effect.sync(() => tuiOpening.delete(record.id)).pipe(
-              // Prompts that queued behind the launch drain now (native
-              // wins: they take the fresh TUI over).
-              Effect.andThen(startNextLogged(record.id)),
-            ),
-          ),
-        )
-      })
-
-    // Under the start lock: a relaunch in flight finishes first (and is
-    // then ended here), and none starts once the mark is gone.
-    const closeTui: ThreadRuntime["Service"]["closeTui"] = (record) =>
-      withStartLock(record.id)(
-        Effect.gen(function* () {
-          tuiWanted.delete(record.id)
-          tuiSettled.add(record.id)
-          if (!oneProcess(record)) return
-          // Busy: the observed idle ends it (observedIdle below).
-          if (isBusy(liveActivity.get(record.id) ?? "unknown")) return
-          const linked = yield* tui.linked(record)
-          if (linked === undefined) return
-          yield* endTui(record, linked.id)
-        }),
-      )
-
-    // --- Observation of TUI-driven sessions ---------------------------------------
-
-    /**
-     * The thread went idle under observation — a TUI turn's end (a native
-     * turn's own idle never comes this way: observed activity is ignored
-     * while the runtime drives): re-read the provider's history before the
-     * queue drains, so the next turn's live items survive it; then end a
-     * TUI no client wants any more (a Chat switch while it was busy) — the
-     * settled read that just landed is its on-disk gate, so a failed read
-     * leaves it running; then drain. The read and the end hold the start
-     * lock: a prompt admitted meanwhile starts after them, so the replaced
-     * copy can never wipe a native turn's fresh rows.
-     */
-    const observedIdle = (record: ThreadRecord): Effect.Effect<void> =>
-      withStartLock(record.id)(
-        Effect.gen(function* () {
-          if (writers.has(record.id)) return
-          const settled = yield* rereadRecord(record).pipe(
-            Effect.as(true),
-            Effect.catch((error) =>
-              Effect.logDebug("re-read after observed idle failed").pipe(
-                Effect.annotateLogs({ threadId: record.id, reason: error.message }),
-                Effect.as(false),
-              ),
-            ),
-          )
-          if (!settled || !oneProcess(record) || tuiWanted.has(record.id)) return
-          // A prompt typed into the TUI while the read was in flight keeps
-          // the thread (the rule endTui applies); its own idle ends it.
-          if (isBusy(liveActivity.get(record.id) ?? "unknown")) return
-          const linked = yield* tui.linked(record)
-          if (linked === undefined) return
-          yield* tui
-            .end(linked.id)
-            .pipe(
-              Effect.catch((error) =>
-                Effect.logWarning("the closed TUI could not be ended at its idle").pipe(
-                  Effect.annotateLogs({ threadId: record.id, reason: error.message }),
-                ),
-              ),
-            )
-        }),
-      ).pipe(Effect.andThen(startNextLogged(record.id)))
-
-    const unobserve = (id: string): Effect.Effect<void> =>
-      Effect.gen(function* () {
-        // The ledger entry goes with the observation — unless the runtime
-        // holds a writer on the thread, whose own evidence stays authoritative.
-        if (!writers.has(id)) liveActivity.delete(id)
-        tuiWanted.delete(id)
-        tuiSettled.delete(id)
-        const observation = observed.get(id)
-        if (observation === undefined) return
-        observed.delete(id)
-        yield* Scope.close(observation.scope, Exit.void)
-      })
-
-    const drainObserved = (record: ThreadRecord, event: AgentSessionEvent): Effect.Effect<void> =>
-      Effect.gen(function* () {
-        if (event.type === "userPrompt") return yield* naming.notePrompt(record, event.text)
-        // While the runtime holds a writer, its feed already carries every
-        // item, every activity edge, and every settings report; the observer
-        // copy of a shared server's fan-out would double the items, and a
-        // one-process provider's dead TUI can only report its own SessionEnd.
-        if (writers.has(record.id)) return
-        if (event.type === "settings")
-          return yield* adoptSettings(record, event.settings, undefined)
-        if (event.type !== "activity") return yield* recordItem(record.id, event)
-        const { previous } = yield* noteActivity(record, event.activity)
-        // The busy→idle drop is the turn's end (forked: the drain must never
-        // wait on the provider).
-        if (previous !== undefined && isBusy(previous) && event.activity === "idle") {
-          yield* observedIdle(record).pipe(Effect.forkIn(serviceScope))
-        }
-      })
-
-    /**
-     * Start (once) the thread's normalized session subscription. A TUI is
-     * live or launching whenever this is called, so the FIRST observation
-     * of a thread no client has spoken for marks the TUI wanted (a live TUI
-     * found after a restart stays in charge until a client says otherwise).
-     */
-    const observe = (record: ThreadRecord): Effect.Effect<void> =>
-      Effect.gen(function* () {
-        // A chat thread is never observed (the header), whatever a read
-        // finds linked to it.
-        if (record.kind !== "tui") return
-        const adapter = adapterFor(record)
-        const providerSessionId = record.providerSessionId
-        if (adapter === undefined || providerSessionId === undefined) return
-        const existing = observed.get(record.id)
-        if (existing?.providerSessionId === providerSessionId) return
-        // A superseded session's subscription must never keep driving the
-        // thread (its feed would confirm a session it never saw).
-        if (existing !== undefined) yield* unobserve(record.id)
-        // The re-check, unsafe fork, and claim are ONE synchronous step:
-        // concurrent first reads of the same live thread (sidebar list +
-        // detail get at relaunch) race exactly here, and a loser that
-        // proceeded would leak its adapter subscription until shutdown.
-        // Whoever claimed during the unobserve above wins, whatever
-        // session it observes — the next read re-checks and heals.
-        if (observed.get(record.id) !== undefined) return
-        const child = Scope.forkUnsafe(serviceScope)
-        const observation: Observation = { providerSessionId, scope: child }
-        observed.set(record.id, observation)
-        if (!tuiSettled.has(record.id)) {
-          tuiWanted.add(record.id)
-          tuiSettled.add(record.id)
-        }
-        const releaseClaim = Effect.gen(function* () {
-          if (observed.get(record.id) !== observation) return
-          observed.delete(record.id)
-          yield* Scope.close(child, Exit.void)
-        })
-        yield* Effect.gen(function* () {
-          // The subscription is established HERE, before the caller
-          // proceeds — only the drain loop is forked. An unavailable
-          // evidence source yields an empty feed: `unknown` on reads,
-          // never a guess or a crash.
-          const stream = yield* adapter
-            .observeSession({ providerSessionId, providerMetadata: record.providerMetadata })
-            .pipe(
-              Effect.catchTag("AgentUnavailable", () =>
-                Effect.succeed(Stream.empty as Stream.Stream<AgentSessionEvent>),
-              ),
-              Scope.provide(child),
-            )
-          yield* stream.pipe(
-            Stream.runForEach((event) => drainObserved(record, event)),
-            // A feed that ends on its own must not pin the entry (the next
-            // read re-subscribes instead of trusting a dead stream) nor
-            // leak its child scope into the service scope. An ended
-            // observation also ends the refinement's wait — its turn-end
-            // evidence is gone, so the catch-up must not park forever.
-            Effect.ensuring(naming.noteFeedEnded(record).pipe(Effect.andThen(releaseClaim))),
-            Effect.forkIn(child),
-          )
-        }).pipe(
-          // A caller interrupted (a dropped read) or failing before the
-          // drain fiber arms must not leave a claim with no consumer — that
-          // would freeze the thread's activity until shutdown.
-          Effect.onExit((exit) => (exit._tag === "Failure" ? releaseClaim : Effect.void)),
-        )
-      })
-
     // --- Startup ---------------------------------------------------------------------
 
     /**
      * Follow a turn still running on a shared provider server after a
      * restart: resume the session and drain its feed to the turn's end.
-     * A session that is already idle has nothing to follow — the copy is
-     * re-read once more, and a turn history still calls running is marked
-     * interrupted.
+     * A session that is already idle has nothing to follow: the turn is
+     * marked interrupted (whatever it emitted while ATC was down is not in
+     * the transcript, by design).
      */
     const reattach = (record: ThreadRecord, turn: ThreadTurn): Effect.Effect<void> =>
       Effect.gen(function* () {
@@ -1735,12 +1297,7 @@ const make = (options: ThreadRuntimeOptions) =>
           .pipe(Scope.provide(scope))
         if (!isBusy(yield* connection.activity)) {
           yield* Scope.close(scope, Exit.void)
-          yield* rereadRecord(record)
-          const still = (yield* transcripts.runningTurns(record.id)).find(
-            (entry) => entry.id === turn.id,
-          )
-          if (still !== undefined) yield* markInterrupted(record, still)
-          return
+          return yield* markInterrupted(record, turn)
         }
         // The turn's own pushed baseline died with the old process, so the
         // provider's first report after reattach is adopted as its word —
@@ -1777,21 +1334,14 @@ const make = (options: ThreadRuntimeOptions) =>
           const found = yield* repository.get(id)
           if (Option.isNone(found)) return
           const record = found.value
+          // A tui thread is the observer's to settle.
+          if (record.kind !== "chat") return
           const running = yield* transcripts.runningTurns(id)
           if (running.length === 0) return
-          yield* rereadRecord(record).pipe(
-            Effect.catch((error) =>
-              Effect.logWarning("startup re-read failed").pipe(
-                Effect.annotateLogs({ threadId: id, reason: error.message }),
-              ),
-            ),
-          )
-          const still = yield* transcripts.runningTurns(id)
           const adapter = adapterFor(record)
-          for (const turn of still) {
-            // A shared provider server (the observation-outlives-TUI shape)
-            // keeps running our turn across ATC's restart; anything else
-            // died with the process.
+          for (const turn of running) {
+            // A shared provider server keeps running our turn across ATC's
+            // restart; anything else died with the process.
             yield* adapter?.sharedServer === true
               ? reattach(record, turn)
               : markInterrupted(record, turn)
@@ -2019,19 +1569,12 @@ const make = (options: ThreadRuntimeOptions) =>
       activity: (id) => Effect.sync(() => liveActivity.get(id)),
       hasWriter: (id) => Effect.sync(() => writers.has(id)),
       noteActivity,
-      observedIdle,
-      observe,
-      unobserve,
-      observing: (record) =>
-        Effect.sync(() => observed.get(record.id)?.providerSessionId === record.providerSessionId),
-      openTui,
-      closeTui,
+      recordObservedItem: recordItem,
+      adoptSettings: (record, reported) => adoptSettings(record, reported, undefined),
       release: (id) =>
         withStartLock(id)(
           Effect.gen(function* () {
             const writer = writers.get(id)
-            liveActivity.delete(id)
-            yield* unobserve(id)
             const found = yield* repository.get(id)
             const run = writer?.run
             if (run !== undefined && !run.finished) {
@@ -2045,6 +1588,9 @@ const make = (options: ThreadRuntimeOptions) =>
               }
             }
             if (writer !== undefined) yield* closeWriter(id, writer)
+            // After the close: a late event on the feed can no longer
+            // re-insert the entry.
+            liveActivity.delete(id)
             // Subscribers of a thread being put away or deleted are done.
             for (const queue of hubs.get(id) ?? []) Queue.endUnsafe(queue)
             hubs.delete(id)

--- a/app-server/src/threads/threadTui.ts
+++ b/app-server/src/threads/threadTui.ts
@@ -13,11 +13,10 @@ import type { Terminal } from "../terminals/terminals.ts"
 import { ThreadRepository } from "./threadRepository.ts"
 import type { ThreadRecord } from "./threadRepository.ts"
 
-// A thread's TUI terminal (ATC-124 / ATC-203): the one place a Terminal is
-// found, launched, or ended on a thread's behalf, shared by the Threads
-// domain (open, archive, delete) and the ThreadRuntime (the one-process
-// hand-off between a TUI and a native turn) so both launch and end a TUI
-// the same way. Invariants:
+// A tui thread's terminal (ATC-124): the one place a Terminal is found,
+// launched, or ended on a thread's behalf, shared by the Threads domain
+// (open, archive, delete) and the ThreadObserver (ending a TUI at its
+// observed idle) so both launch and end a TUI the same way. Invariants:
 //
 //   - Every launch scrubs the nested-session markers uniformly
 //     (agentAdapter.ts NESTED_SESSION_ENV_VARIABLES): inherited from a

--- a/app-server/src/threads/threads.ts
+++ b/app-server/src/threads/threads.ts
@@ -1,4 +1,4 @@
-import { Context, Duration, Effect, Layer, Option, Schedule, Semaphore } from "effect"
+import { Context, Duration, Effect, Layer, Option, Schedule } from "effect"
 import { AgentRegistry } from "../agents/agentRegistry.ts"
 import type {
   AgentActivity,
@@ -34,11 +34,13 @@ import type {
 import { SqlClient } from "effect/unstable/sql"
 import { Events } from "../events/events.ts"
 import { Directories } from "../platform/directories.ts"
+import { makeKeyedLock } from "../platform/keyedLock.ts"
 import { ProjectRepository } from "../projects/projectRepository.ts"
 import { Terminals } from "../terminals/terminals.ts"
 import type { Terminal } from "../terminals/terminals.ts"
 import { ThreadNaming } from "./threadNaming.ts"
 import { Attachments } from "./attachments.ts"
+import { ThreadObserver } from "./threadObserver.ts"
 import { requireKind, ThreadRepository } from "./threadRepository.ts"
 import type { ThreadRecord } from "./threadRepository.ts"
 import { ThreadRuntime } from "./threadRuntime.ts"
@@ -56,10 +58,10 @@ export type Thread = typeof Contract.Thread.Type
 //     registry's adapterFor). Every provider difference is translated
 //     inside adapters; the same columns are persisted at the same points
 //     in the same flow for every agent.
-//   - `create` is local-only: the durable row, no provider call. Identity
-//     establishment is one internal transition (`materialize`, below) with
-//     openTerminal as its first caller; the runtime's first prompt is the
-//     second caller, with identical persistence.
+//   - `create` is local-only: the durable row, no provider call. A tui
+//     thread's identity is established by `materialize` (below) during
+//     openTerminal; a chat thread's by the runtime's first prompt, with
+//     the same persistence.
 //   - A thread has one driver for life — its `kind` (ATC-224): a chat
 //     thread is driven by the runtime's own process and has no terminal
 //     (openTerminal / closeTerminal refuse ThreadKindMismatch, and a read
@@ -75,26 +77,21 @@ export type Thread = typeof Contract.Thread.Type
 //     no history to protect yet. A terminal that ended is never relaunched
 //     by the server: the next open relaunches it.
 //   - workingDirectory is validated, canonicalized, and immutable.
-//   - activityState is in-memory evidence, never persisted, and lives in
-//     the ThreadRuntime's activity ledger — fed by its observation of a
-//     TUI-driven session (started here on demand: `runtime.observe`
-//     whenever a read finds a live linked TUI, or an open launches one) and
-//     by its native turns, one set of rules (first busy confirms, busy→idle
-//     stamps the finish, every transition publishes). `unknown` when there
-//     is no evidence; a busy state whose driver is gone re-derives
-//     demand-driven from the adapter's reconciliation check on read, unless
-//     the runtime is driving the thread (its evidence is authoritative) or a
-//     shared-server observation still covers it. The confirmed marker is
-//     persisted at the FIRST busy signal — a submitted prompt is already
-//     durable provider history worth protecting — the same signal for every
-//     provider.
+//   - activityState is in-memory evidence, never persisted: the
+//     ThreadRuntime's ledger, fed by the runtime's own turns and by the
+//     ThreadObserver (observation starts here on demand — `observer.observe`
+//     whenever a read finds a live linked TUI, or an open launches one).
+//     `unknown` when there is no evidence; a busy state whose driver is gone
+//     re-derives demand-driven from the adapter's reconciliation check on
+//     read, unless the runtime is driving the thread (its evidence is
+//     authoritative) or a shared-server observation still covers it.
 //   - The unread overlay (ATC-160) is derived, never stored as a flag:
 //     last_finished_at is stamped at the observed busy→idle drop — the
 //     ledger and the driver-gone re-derivation alike — last_viewed_at by
 //     markViewed, and archived rows are never unread. The activity
 //     vocabulary is untouched; "Done" is client-side display translation.
 //   - Auto-naming lives in ThreadNaming (ATC-155/190/202), fed by the
-//     runtime's observation and turns.
+//     observer's feed and the runtime's turns.
 //   - Settings (ATC-205) are stored state the runtime hands to the adapter
 //     at every turn start; a change here never touches a provider — it
 //     takes effect at the next turn, and a turn in flight is never
@@ -107,8 +104,8 @@ export type Thread = typeof Contract.Thread.Type
 //   - archived threads are never pinned: pin refuses archived records, and
 //     archive clears the pin in the same repository write so no client can
 //     observe or restore an archived pin.
-//   - archive suspends the thread's runtime (ATC-157): the live linked TUI
-//     terminal is killed (the terminals confirmed-kill rules) and
+//   - archive suspends the thread's runtime and observation (ATC-157): the
+//     live linked TUI terminal is killed (the terminals confirmed-kill rules) and
 //     adapter-owned session resources are released before archivedAt is
 //     written, so an archived thread consumes no zmx session while the
 //     provider conversation survives for an exact resume after unarchive.
@@ -194,7 +191,7 @@ export class Threads extends Context.Service<
       | TerminalLaunchFailed
     >
     /** End a tui thread's terminal: at once when idle, at its observed
-     * idle when busy (`runtime.closeTui`). */
+     * idle when busy (`observer.closeTui`). */
     readonly closeTerminal: (
       id: string,
     ) => Effect.Effect<
@@ -219,34 +216,22 @@ export const layerWith = (options: ThreadsOptions) =>
       const registry = yield* AgentRegistry
       const events = yield* Events
       const runtime = yield* ThreadRuntime
+      const observer = yield* ThreadObserver
       const naming = yield* ThreadNaming
       const tui = yield* ThreadTui
       // No SQL is written here: the client is held for `withTransaction`
       // alone, so the settings write and its defaults write-through commit
       // together (both repositories run on this one client).
       const sql = yield* SqlClient.SqlClient
-      // Forked work (a discovered finish's re-read) outlives its request;
-      // it lives in the service's own scope.
-      const serviceScope = yield* Effect.scope
       const identityTimeout = options.identityTimeout ?? "30 seconds"
       const launchWatchInterval = options.launchWatchInterval ?? "500 millis"
 
       /** Threads with an openTerminal in flight — the one-open guard. */
       const opening = new Set<string>()
-      /**
-       * Per-thread lifecycle serialization (the header's serialization
-       * bullet). Entries are dropped when the thread row is deleted; a
-       * waiter still queued on a dropped semaphore just finds the row gone.
-       */
-      const lifecycleLocks = new Map<string, Semaphore.Semaphore>()
-      const withLifecycleLock =
-        (id: string) =>
-        <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
-          Effect.suspend(() => {
-            const lock = lifecycleLocks.get(id) ?? Semaphore.makeUnsafe(1)
-            lifecycleLocks.set(id, lock)
-            return lock.withPermit(effect)
-          })
+      /** Per-thread lifecycle serialization (the header's serialization
+       * bullet); a deleted thread's entry is dropped. */
+      const lifecycleLock = makeKeyedLock()
+      const withLifecycleLock = lifecycleLock.withLock
 
       const adapterFor = (record: ThreadRecord): AgentAdapter | undefined =>
         isAgentId(record.agentId) ? registry.adapterFor(record.agentId) : undefined
@@ -296,7 +281,7 @@ export const layerWith = (options: ThreadsOptions) =>
           // so their busy states must still re-derive below (for Codex the
           // re-derivation costs paginated provider walks; skipping it here
           // is what keeps the listing hot path off the provider).
-          if (adapter?.sharedServer === true && (yield* runtime.observing(record))) {
+          if (adapter?.sharedServer === true && (yield* observer.observing(record))) {
             return { activity: live, record }
           }
           const providerSessionId = record.providerSessionId
@@ -308,17 +293,14 @@ export const layerWith = (options: ThreadsOptions) =>
                   .pipe(Effect.orElseSucceed(() => "unknown" as const))
           // The ledger stamps a finish discovered here (the busy snapshot
           // was real evidence and the check says the turn is over) and
-          // publishes the change to every subscriber. Loop-safe: the busy
-          // snapshot is gone, so the next event-triggered read returns at
-          // the short-circuit above without publishing. The record is
-          // re-read so the discovering response itself presents the thread
-          // unread — never a stale `unread: false` racing the refetch.
-          yield* runtime.noteActivity(record, checked)
-          if (checked === "idle") {
-            // A turn ended under observation, discovered here: the same
-            // moment the drain loop reports (re-read, drain the queue).
-            yield* runtime.observedIdle(record).pipe(Effect.forkIn(serviceScope))
-          }
+          // publishes the change to every subscriber — through the
+          // observer, whose idle rule (the re-read) applies to a discovered
+          // idle as to a reported one. Loop-safe: the busy snapshot is
+          // gone, so the next event-triggered read returns at the
+          // short-circuit above without publishing. The record is re-read
+          // so the discovering response itself presents the thread unread —
+          // never a stale `unread: false` racing the refetch.
+          yield* observer.noteActivity(record, checked)
           const current =
             checked === "idle"
               ? yield* repository.get(record.id).pipe(Effect.map(Option.getOrElse(() => record)))
@@ -366,7 +348,7 @@ export const layerWith = (options: ThreadsOptions) =>
           // the superseded session, and a read subscribing to it could
           // confirm a session the thread no longer references — the open's
           // own observe covers the fresh identity.
-          if (linked !== undefined && !opening.has(record.id)) yield* runtime.observe(record)
+          if (linked !== undefined && !opening.has(record.id)) yield* observer.observe(record)
           const resolved = yield* resolveActivity(record, linked?.id)
           return toThread(resolved.record, linked?.id, resolved.activity)
         })
@@ -451,7 +433,7 @@ export const layerWith = (options: ThreadsOptions) =>
             // feed (it must never confirm the successor) and release its
             // adapter resources before minting the replacement.
             if (record.providerSessionId !== undefined) {
-              yield* runtime.unobserve(record.id)
+              yield* observer.unobserve(record.id)
               yield* adapter.releaseSession({
                 providerSessionId: record.providerSessionId,
                 providerMetadata: record.providerMetadata,
@@ -492,7 +474,7 @@ export const layerWith = (options: ThreadsOptions) =>
                       identity.providerMetadata ?? null,
                     )
                     adopted = true
-                    yield* runtime.observe(updated)
+                    yield* observer.observe(updated)
                   }),
                 ).pipe(
                   Effect.onExit((exit) =>
@@ -520,7 +502,7 @@ export const layerWith = (options: ThreadsOptions) =>
       const reopen = (record: ThreadRecord, adapter: AgentAdapter) =>
         Effect.gen(function* () {
           const launched = yield* tui.reopen(record, adapter)
-          yield* runtime.observe(launched.record)
+          yield* observer.observe(launched.record)
           return launched.terminal
         })
 
@@ -565,13 +547,9 @@ export const layerWith = (options: ThreadsOptions) =>
                       ),
                   }),
                 )
-          // The runtime's ownership rules wrap the launch (the header) —
-          // including the last "already live" check, so a relaunch the
-          // runtime made while this caller waited is returned, never
-          // doubled.
-          return yield* runtime.openTui(record, launch).pipe(
-            // The open changed the thread (linked terminal, and possibly
-            // provider identity); the idempotent return above changed nothing.
+          // The open changed the thread (linked terminal, and possibly
+          // provider identity); the idempotent return above changed nothing.
+          return yield* launch.pipe(
             Effect.tap(() => events.publish({ resource: "thread", id, change: "updated" })),
           )
         })
@@ -587,12 +565,13 @@ export const layerWith = (options: ThreadsOptions) =>
             return yield* Effect.fail(new ThreadArchived({ threadId: id }))
           }
           yield* requireKind(record, "tui")
+          // A close waiting on the idle is called off by any open, and its
+          // in-flight idle work settles before the linked check below.
+          yield* observer.cancelPendingClose(id)
           const linked = yield* tui.linked(record)
           if (linked !== undefined) {
-            if (!opening.has(id)) yield* runtime.observe(record)
-            // Already live — still an open: the TUI is wanted again (a
-            // pending Chat hand-off is called off).
-            return yield* runtime.openTui(record, Effect.succeed(linked))
+            if (!opening.has(id)) yield* observer.observe(record)
+            return linked
           }
           if (opening.has(id)) {
             return yield* Effect.fail(
@@ -617,7 +596,7 @@ export const layerWith = (options: ThreadsOptions) =>
           Effect.gen(function* () {
             const record = yield* repository.require(id)
             yield* requireKind(record, "tui")
-            yield* runtime.closeTui(record)
+            yield* observer.closeTui(record)
             return yield* assembleAlone(record)
           }),
         )
@@ -626,10 +605,11 @@ export const layerWith = (options: ThreadsOptions) =>
         withLifecycleLock(id)(
           Effect.gen(function* () {
             const record = yield* repository.require(id)
-            // The runtime first: it waits out a TUI relaunch in flight and
-            // forbids another, so the kill below sees every terminal.
-            // Confirmed-kill rules live in Terminals.delete; a terminal that
-            // vanished since the lookup is already the goal state.
+            // Observation and run first, so nothing reports on the thread
+            // while it goes. Confirmed-kill rules live in Terminals.delete;
+            // a terminal that vanished since the lookup is already the goal
+            // state.
+            yield* observer.unobserve(id)
             yield* runtime.release(id)
             const linked = yield* tui.linked(record)
             if (linked !== undefined) yield* tui.end(linked.id)
@@ -651,7 +631,7 @@ export const layerWith = (options: ThreadsOptions) =>
             // The rows cascaded with the thread; the bytes on disk are ours
             // to remove (ATC-216).
             yield* attachments.purge(id)
-            lifecycleLocks.delete(id)
+            lifecycleLock.release(id)
             yield* events.publish({ resource: "thread", id, change: "deleted" })
             yield* Effect.forEach(orphaned, (terminal) =>
               events.publish({ resource: "terminal", id: terminal.id, change: "updated" }),
@@ -834,10 +814,8 @@ export const layerWith = (options: ThreadsOptions) =>
               if (isBusy((yield* resolveActivity(record, linked?.id)).activity)) {
                 return yield* Effect.fail(new ThreadBusy({ threadId: id }))
               }
-              // Suspend the runtime first: it waits out a TUI relaunch in
-              // flight and forbids another, so the kill sees every terminal
-              // (its run and observation are gone either way — the busy
-              // check above already found nothing running). Then the
+              // Suspend observation and the runtime first (the busy check
+              // above already found nothing running). Then the
               // confirmed-kill rules of Terminals.delete: a kill that cannot
               // verify death fails ZmxUnavailable and the thread stays
               // active (a re-archive converges); a terminal that vanished
@@ -846,6 +824,7 @@ export const layerWith = (options: ThreadsOptions) =>
               // plumbing; the next tuiLaunch recreates it). The provider
               // conversation itself is untouched, so unarchive + open
               // resumes it exactly.
+              yield* observer.unobserve(id)
               yield* runtime.release(id)
               const live = yield* tui.linked(record)
               if (live !== undefined) yield* tui.end(live.id)

--- a/app-server/test/agents/claudeTui.smoke.test.ts
+++ b/app-server/test/agents/claudeTui.smoke.test.ts
@@ -22,11 +22,13 @@ import { claudeAdapterLayer, collectAgentEvents, waitForAgentEvent } from "./age
 //     and must report the exact minted id through its own hook delivery,
 //     before any prompt is typed. A possible first-run trust dialog is
 //     answered with Enter.
-//   - The one-process hand-off (ATC-203): a native SDK turn, then a TUI
+//   - Session continuity across processes: a native SDK turn, then a TUI
 //     turn on the same session (`--resume`) once the SDK process is gone,
 //     then — the TUI ended after its last turn is on disk — a native turn
 //     again that must answer with the context of BOTH earlier turns. One
-//     conversation, one leaf; getSessionMessages agrees.
+//     conversation, one leaf; getSessionMessages agrees. (ATC never hands
+//     a thread between the two any more — ATC-224 — but the adapter's
+//     resume must still hold for a user doing it by hand.)
 
 /** Cheap real-provider settings for the smoke turns (a real, small model). */
 const SMOKE_SETTINGS = { model: "haiku", mode: "chat", access: "supervised" } as const

--- a/app-server/test/agents/fakeAgentAdapter.ts
+++ b/app-server/test/agents/fakeAgentAdapter.ts
@@ -111,6 +111,13 @@ export interface FakeAgentAdapter {
   readonly emitActivity: (providerSessionId: string, activity: AgentActivity) => void
   /** Push one userPrompt event to every observer of `providerSessionId`. */
   readonly emitUserPrompt: (providerSessionId: string, text: string) => void
+  /** Push one item event to every observer of `providerSessionId` (the
+   * TUI's turn, as a shared server fans it out). */
+  readonly emitObservedItem: (
+    providerSessionId: string,
+    phase: "itemStarted" | "itemUpdated" | "itemCompleted",
+    item: ThreadItem,
+  ) => void
   /** generateTitle calls observed, in order. */
   readonly titleRequests: Array<{
     cwd: string
@@ -725,6 +732,11 @@ export const makeFakeAgentAdapter = (options: FakeAgentAdapterOptions = {}): Fak
     emitUserPrompt: (providerSessionId, text) => {
       for (const queue of observers.get(providerSessionId) ?? []) {
         Queue.offerUnsafe(queue, { type: "userPrompt", text })
+      }
+    },
+    emitObservedItem: (providerSessionId, phase, item) => {
+      for (const queue of observers.get(providerSessionId) ?? []) {
+        Queue.offerUnsafe(queue, { type: phase, item })
       }
     },
     emitSettings: (providerSessionId, settings) => {

--- a/app-server/test/testLayers.ts
+++ b/app-server/test/testLayers.ts
@@ -30,6 +30,7 @@ import * as AttachmentRepository from "../src/threads/attachmentRepository.ts"
 import * as Attachments from "../src/threads/attachments.ts"
 import * as ThreadRepository from "../src/threads/threadRepository.ts"
 import * as ThreadNaming from "../src/threads/threadNaming.ts"
+import * as ThreadObserver from "../src/threads/threadObserver.ts"
 import * as ThreadRuntime from "../src/threads/threadRuntime.ts"
 import * as ThreadTui from "../src/threads/threadTui.ts"
 import * as TranscriptRepository from "../src/threads/transcriptRepository.ts"
@@ -130,6 +131,7 @@ export const makeTestServiceLayers = (
     | Terminals.Terminals
     | Threads.Threads
     | ThreadRuntime.ThreadRuntime
+    | ThreadObserver.ThreadObserver
     | Attachments.Attachments
     | FileSearch.FileSearch
     | TranscriptRepository.TranscriptRepository
@@ -187,10 +189,22 @@ export const makeTestServiceLayers = (
   )
   const threadTui = ThreadTui.layer.pipe(Layer.provide([services, terminals]))
   const runtime = ThreadRuntime.layerWith(threadOptions).pipe(
-    Layer.provide([services, registry, eventsLayer, naming, threadTui]),
+    Layer.provide([services, registry, eventsLayer, naming]),
+  )
+  const observer = ThreadObserver.layer.pipe(
+    Layer.provide([services, registry, naming, threadTui, runtime]),
   )
   const threads = Threads.layerWith(threadOptions).pipe(
-    Layer.provide([services, terminals, registry, eventsLayer, runtime, naming, threadTui]),
+    Layer.provide([
+      services,
+      terminals,
+      registry,
+      eventsLayer,
+      runtime,
+      observer,
+      naming,
+      threadTui,
+    ]),
   )
   return {
     fake,
@@ -204,6 +218,7 @@ export const makeTestServiceLayers = (
       TestAuthTokenLayer,
       Layer.succeed(Tailscale.Tailscale)({ status: Effect.succeed(tailscaleStatus) }),
       runtime,
+      observer,
       threads,
       Projects.layer.pipe(Layer.provide([services, terminals, threads, eventsLayer])),
     ),

--- a/app-server/test/threads/threadKinds.test.ts
+++ b/app-server/test/threads/threadKinds.test.ts
@@ -1,6 +1,6 @@
 import { assert, describe, it } from "@effect/vitest"
 import { BunHttpServer } from "@effect/platform-bun"
-import { Effect, Layer, Option, Stream } from "effect"
+import { Effect, Layer, Stream } from "effect"
 import { HttpApiTest } from "effect/unstable/httpapi"
 import { mkdtempSync, realpathSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
@@ -15,7 +15,6 @@ import { ThreadRepository } from "../../src/threads/threadRepository.ts"
 import { TranscriptRepository } from "../../src/threads/transcriptRepository.ts"
 import { ThreadRuntime } from "../../src/threads/threadRuntime.ts"
 import type { ThreadEvent } from "../../src/threads/threadRuntime.ts"
-import { Threads } from "../../src/threads/threads.ts"
 import { TestBuildInfoLayer } from "../testBuildInfo.ts"
 import { eventually, makeTestServiceLayers } from "../testLayers.ts"
 
@@ -363,31 +362,6 @@ describe("thread kinds", () => {
       const started = yield* runtime.prompt(thread.id, { prompt: "now" })
       assert.isString(started.turnId)
       fake.completeTurn(sessionId, "completed")
-    }).pipe(Effect.provide(TestLayer)),
-  )
-
-  it.live("a tui thread is observed and re-read as before", () =>
-    Effect.gen(function* () {
-      const { client, create } = yield* setup
-      const threads = yield* Threads
-      const repository = yield* ThreadRepository
-      const tui = yield* create("tui")
-      const terminal = yield* client.v1.openThreadTerminal({ params: { threadId: tui.id } })
-      const sessionId = Option.getOrThrow(yield* repository.get(tui.id)).providerSessionId ?? ""
-      assert.strictEqual(fake.observerCount(sessionId), 1)
-      fake.emitActivity(sessionId, "working")
-      yield* waitFor(
-        threads.get(tui.id).pipe(Effect.orDie),
-        (current) => current.activityState === "working",
-      )
-      const read = yield* client.v1.getThread({ params: { threadId: tui.id } })
-      assert.strictEqual(read.linkedTerminalId, terminal.id)
-      fake.emitActivity(sessionId, "idle")
-      yield* waitFor(
-        threads.get(tui.id).pipe(Effect.orDie),
-        (current) => current.activityState === "idle" && current.unread,
-      )
-      yield* client.v1.deleteThread({ params: { threadId: tui.id } })
     }).pipe(Effect.provide(TestLayer)),
   )
 })

--- a/app-server/test/threads/threadObserver.test.ts
+++ b/app-server/test/threads/threadObserver.test.ts
@@ -1,0 +1,191 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Option } from "effect"
+import { mkdtempSync, realpathSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll } from "vitest"
+import { sessionNameForTerminalId } from "../../src/terminals/terminalAdapter.ts"
+import { ThreadRepository } from "../../src/threads/threadRepository.ts"
+import { ThreadRuntime } from "../../src/threads/threadRuntime.ts"
+import { Threads } from "../../src/threads/threads.ts"
+import { Projects } from "../../src/projects/projects.ts"
+import { eventually, makeTestServiceLayers } from "../testLayers.ts"
+
+// The Thread observer (ATC-226) through the fake adapters and the uniform
+// seam only: a tui thread's terminal feed drives the ledger and the
+// transcript copy (re-read at its idle), closing the terminal ends it now
+// when idle and at its next idle when busy — after that turn's re-read —
+// and showing it again calls the close off. Nothing here is ever driven by
+// the runtime, and nothing relaunches a terminal by itself.
+
+const scratch = mkdtempSync(join(tmpdir(), "atc-observer-"))
+afterAll(() => rmSync(scratch, { recursive: true, force: true }))
+const realDir = realpathSync(scratch)
+
+const kit = makeTestServiceLayers()
+const fake = kit.fakeAgents.codex
+
+const terminalAlive = (terminalId: string): boolean =>
+  kit.fake.sessions.has(sessionNameForTerminalId(terminalId))
+
+const waitFor = <A>(read: Effect.Effect<A>, predicate: (value: A) => boolean) =>
+  eventually(read, predicate, { attempts: 400, interval: "10 millis" })
+
+/** A tui thread with its terminal open and its session observed. */
+const openedThread = Effect.gen(function* () {
+  const projects = yield* Projects
+  const threads = yield* Threads
+  const repository = yield* ThreadRepository
+  const project = yield* projects.create({ name: "Observer", defaultWorkingDirectory: realDir })
+  const thread = yield* threads.create({ projectId: project.id, agentId: "codex", kind: "tui" })
+  const terminal = yield* threads.openTerminal(thread.id)
+  const sessionId = Option.getOrThrow(yield* repository.get(thread.id)).providerSessionId ?? ""
+  return { threadId: thread.id, terminal, sessionId }
+})
+
+describe("ThreadObserver", () => {
+  it.live("the observed idle re-reads the copy; nothing relaunches an ended terminal", () =>
+    Effect.gen(function* () {
+      const threads = yield* Threads
+      const runtime = yield* ThreadRuntime
+      const { threadId, terminal, sessionId } = yield* openedThread
+      assert.strictEqual(fake.observerCount(sessionId), 1)
+
+      fake.setHistory(sessionId, [
+        {
+          turn: { id: "tui-turn", status: "completed" },
+          items: [{ type: "userMessage", id: "t1", turnId: "tui-turn", text: "typed" }],
+        },
+      ])
+      fake.emitActivity(sessionId, "working")
+      fake.emitActivity(sessionId, "idle")
+      const page = yield* waitFor(
+        runtime.transcript(threadId).pipe(Effect.orDie),
+        (current) => current.snapshotVersion === 1,
+      )
+      assert.deepStrictEqual(
+        page.items.map((item) => item.id),
+        ["t1"],
+      )
+      const read = yield* threads.get(threadId)
+      assert.strictEqual(read.activityState, "idle")
+      assert.isTrue(read.unread)
+
+      // The TUI's own items land in the copy as they happen.
+      fake.emitObservedItem(sessionId, "itemCompleted", {
+        type: "assistantText",
+        id: "o1",
+        turnId: "tui-turn",
+        text: "seen live",
+        complete: true,
+      })
+      yield* waitFor(runtime.transcript(threadId).pipe(Effect.orDie), (current) =>
+        current.items.some((item) => item.id === "o1"),
+      )
+
+      // The TUI exits on its own: the thread unlinks, and stays unlinked.
+      kit.fake.sessions.delete(sessionNameForTerminalId(terminal.id))
+      yield* waitFor(
+        threads.get(threadId).pipe(Effect.orDie),
+        (current) => current.linkedTerminalId === undefined,
+      )
+    }).pipe(Effect.provide(kit.layer)),
+  )
+
+  it.live("closing ends an idle terminal now, a busy one after its idle's re-read", () =>
+    Effect.gen(function* () {
+      const threads = yield* Threads
+      const runtime = yield* ThreadRuntime
+      const { threadId, terminal } = yield* openedThread
+
+      const closed = yield* threads.closeTerminal(threadId)
+      assert.isUndefined(closed.linkedTerminalId)
+      assert.isFalse(terminalAlive(terminal.id))
+
+      // Reopened (an unconfirmed session re-materializes: a fresh identity),
+      // then closed while busy: it stays until its idle.
+      const reopened = yield* threads.openTerminal(threadId)
+      const repository = yield* ThreadRepository
+      const session = Option.getOrThrow(yield* repository.get(threadId)).providerSessionId ?? ""
+      fake.emitActivity(session, "working")
+      yield* waitFor(
+        threads.get(threadId).pipe(Effect.orDie),
+        (current) => current.activityState === "working",
+      )
+      const stillOpen = yield* threads.closeTerminal(threadId)
+      assert.strictEqual(stillOpen.linkedTerminalId, reopened.id)
+      assert.isTrue(terminalAlive(reopened.id))
+      fake.setHistory(session, [
+        {
+          turn: { id: "last-turn", status: "completed" },
+          items: [{ type: "userMessage", id: "l1", turnId: "last-turn", text: "last" }],
+        },
+      ])
+      fake.emitActivity(session, "idle")
+      yield* waitFor(
+        Effect.sync(() => terminalAlive(reopened.id)),
+        (alive) => !alive,
+      )
+      // Its last turn landed in the copy before the kill.
+      const page = yield* runtime.transcript(threadId)
+      assert.deepStrictEqual(
+        page.items.map((item) => item.id),
+        ["l1"],
+      )
+    }).pipe(Effect.provide(kit.layer)),
+  )
+
+  it.live("a close left pending when the terminal died never ends the next one", () =>
+    Effect.gen(function* () {
+      const threads = yield* Threads
+      const repository = yield* ThreadRepository
+      const { threadId, terminal, sessionId } = yield* openedThread
+      fake.emitActivity(sessionId, "working")
+      yield* waitFor(
+        threads.get(threadId).pipe(Effect.orDie),
+        (current) => current.activityState === "working",
+      )
+      yield* threads.closeTerminal(threadId)
+      // The busy TUI dies before its idle; the user opens a new one.
+      kit.fake.sessions.delete(sessionNameForTerminalId(terminal.id))
+      yield* waitFor(
+        threads.get(threadId).pipe(Effect.orDie),
+        (current) => current.linkedTerminalId === undefined,
+      )
+      const next = yield* threads.openTerminal(threadId)
+      const session = Option.getOrThrow(yield* repository.get(threadId)).providerSessionId ?? ""
+      fake.emitActivity(session, "working")
+      fake.emitActivity(session, "idle")
+      yield* waitFor(
+        threads.get(threadId).pipe(Effect.orDie),
+        (current) => current.activityState === "idle",
+      )
+      assert.isTrue(terminalAlive(next.id))
+      yield* threads.closeTerminal(threadId)
+      assert.isFalse(terminalAlive(next.id))
+    }).pipe(Effect.provide(kit.layer)),
+  )
+
+  it.live("showing the terminal again before the idle calls a pending close off", () =>
+    Effect.gen(function* () {
+      const threads = yield* Threads
+      const { threadId, terminal, sessionId } = yield* openedThread
+      fake.emitActivity(sessionId, "working")
+      yield* waitFor(
+        threads.get(threadId).pipe(Effect.orDie),
+        (current) => current.activityState === "working",
+      )
+      yield* threads.closeTerminal(threadId)
+      const shownAgain = yield* threads.openTerminal(threadId)
+      assert.strictEqual(shownAgain.id, terminal.id)
+      fake.emitActivity(sessionId, "idle")
+      yield* waitFor(
+        threads.get(threadId).pipe(Effect.orDie),
+        (current) => current.activityState === "idle",
+      )
+      assert.isTrue(terminalAlive(terminal.id))
+      yield* threads.closeTerminal(threadId)
+      assert.isFalse(terminalAlive(terminal.id))
+    }).pipe(Effect.provide(kit.layer)),
+  )
+})

--- a/app-server/test/threads/threadResidency.test.ts
+++ b/app-server/test/threads/threadResidency.test.ts
@@ -15,8 +15,8 @@ import { eventually, makeTestServiceLayers } from "../testLayers.ts"
 // uniform seam only: on a one-process provider the connection a native
 // turn opened outlives the turn — the next prompt starts on it, its feed
 // keeps driving the ledger between turns — and closes only at a lifecycle
-// boundary (TUI hand-off, the provider ending it, release, the idle
-// timeout). A shared-server provider still holds nothing between turns.
+// boundary (the provider ending it, release, the idle timeout). A
+// shared-server provider still holds nothing between turns.
 
 const scratch = mkdtempSync(join(tmpdir(), "atc-residency-"))
 afterAll(() => rmSync(scratch, { recursive: true, force: true }))

--- a/macos/ATC/AppModel.swift
+++ b/macos/ATC/AppModel.swift
@@ -457,9 +457,9 @@ final class AppModel {
     }
 
     /// Stops interaction for terminals the latest successful refresh says
-    /// are ended, keeping the controller and its surface registered — the
-    /// final frame stays visible under the relaunch affordance, and only
-    /// LRU eviction or teardown releases it. A terminal deleted outright is
+    /// are ended, keeping the controller and its surface registered (a
+    /// standalone terminal keeps its final frame; a tui thread shows its
+    /// Reopen empty state) — only LRU eviction or teardown releases it. A terminal deleted outright is
     /// fully disconnected. Failed refreshes are deliberately ignored so
     /// connection loss never manufactures a lifecycle transition.
     func reconcileTerminalLifecycle() {

--- a/macos/ATC/Features/Terminal/TerminalPane.swift
+++ b/macos/ATC/Features/Terminal/TerminalPane.swift
@@ -30,7 +30,7 @@ struct TerminalPane: View {
 
 /// Phase-driven banner floating over the terminal. An authoritative end is
 /// deliberately quiet here — the thread content area owns that state, because
-/// only it can offer the relaunch.
+/// only it can offer Reopen.
 struct TerminalStatusBanner: View {
     let controller: TerminalSessionController
 

--- a/macos/ATC/Features/Threads/ThreadContentView.swift
+++ b/macos/ATC/Features/Threads/ThreadContentView.swift
@@ -3,9 +3,8 @@
 // sidebar navigation; every other state draws over it.
 //
 // A thread's `kind` decides what it shows (ATC-224): a chat thread draws
-// `ThreadChatView` over the pane (its terminal, if a stale one is linked,
-// stays hidden); a tui thread shows its terminal with the status banners
-// over it. A tui thread whose terminal ended shows an empty state with a
+// `ThreadChatView` over the pane; a tui thread shows its terminal with the
+// status banners over it. A tui thread whose terminal ended shows an empty state with a
 // Reopen button as the whole view — never a relaunch on its own; reopening
 // is just `openThread` again, and the server's open is idempotent.
 

--- a/macos/ATC/WindowState.swift
+++ b/macos/ATC/WindowState.swift
@@ -351,8 +351,8 @@ final class WindowState {
     }
 
     /// Keeps the displayed tui thread's terminal mapping and attach current:
-    /// adopt the server's linked terminal when it differs (a relaunch made
-    /// a new one), and reattach a live terminal that lost its controller.
+    /// adopt the server's linked terminal when it differs (another client
+    /// reopened it), and reattach a live terminal that lost its controller.
     /// A chat thread has no terminal (the server never links one).
     private func reconcileThreadTerminal(_ ref: ThreadRef, thread: ATCThread, in appModel: AppModel) {
         guard thread.kind == .tui else {
@@ -373,8 +373,8 @@ final class WindowState {
             }
             return
         }
-        // No live linked terminal server-side. Keep an ended controller's
-        // final frame (the relaunch affordance renders over it); drop the
+        // No live linked terminal server-side. Keep an ended controller
+        // registered (the Reopen empty state stands in for it); drop the
         // mapping only when nothing is retained for it anymore.
         if let terminalRef = threadTerminals[ref], appModel.terminals[terminalRef] == nil {
             threadTerminals[ref] = nil

--- a/macos/CONTEXT.md
+++ b/macos/CONTEXT.md
@@ -29,22 +29,19 @@ exited simply relaunches when opened in TUI.
 _Avoid_: Session, conversation
 
 **Chat**:
-One of the two views of a Thread, and the default: the Thread's transcript
-and a composer, driven natively through the App Server with no Terminal
-involved. Chat and TUI show the same conversation; which one a Thread is
-shown in is remembered for the app session and shared by every window. The
-App Server owns a Thread by default: switching a Claude Code Thread to Chat
-hands it back (its TUI ends once the current turn is on disk), and a Chat
-prompt sent while its TUI is live takes over the same way — the TUI comes
-back when the prompt is done. Codex Threads need no hand-off.
-_Avoid_: Native mode, transcript view
+One of the two kinds of Thread, chosen when the Thread is created and kept
+for life (the New Thread sheet picks it; General settings hold the
+default): the Thread's transcript and a composer, driven through the App
+Server with no Terminal involved. Its transcript is the App Server's own
+record; nothing the agent does outside atc shows up in it.
+_Avoid_: Native mode, transcript view, Chat mode
 
 **TUI**:
-The other view of a Thread: its provider TUI running in the linked Terminal.
-Opening a Thread in TUI launches or reuses that Terminal; while the App
-Server is driving a turn on a Claude Code Thread, the TUI opens once that
-turn ends.
-_Avoid_: Terminal mode, terminal view
+The other kind of Thread: its provider TUI running in the linked Terminal,
+launched or reused when the Thread is opened and never prompted from atc. A
+TUI Thread whose Terminal ended shows an empty state with Reopen; nothing
+relaunches it on its own.
+_Avoid_: Terminal mode, terminal view, TUI mode
 
 **Terminal**:
 A server-owned zmx-backed process. A Thread's TUI runs in a linked Terminal

--- a/packages/ATCKit/Sources/ATCAppServerAPI/ServerModels.swift
+++ b/packages/ATCKit/Sources/ATCAppServerAPI/ServerModels.swift
@@ -49,7 +49,7 @@ extension AgentID {
 }
 
 extension ThreadKind {
-    /// The user-facing names are the two thread views' (ATC-224).
+    /// The user-facing names of the two thread kinds (ATC-224).
     public var displayName: String {
         switch self {
         case .chat: "Chat"


### PR DESCRIPTION
PR 2 of 2 for ATC-224 (this is ATC-226). **Stacked on #235** (base `atc-225-thread-kinds`); no contract change. Merge #235 first, then retarget this PR to `main` and merge.

The runtime no longer knows about terminals. `ThreadRuntime` drives chat threads only — queue, turn loop, parked requests, settings push, durable partials, seq replay, the activity ledger, the per-thread event hub — and exposes a few seams the observer uses (`reread`, `noteActivity`, `recordObservedItem`, `adoptSettings`, `activity`, `hasWriter`, `release`). Everything a tui thread needs lives in the new `ThreadObserver`:

- the demand-driven, once-per-session subscription drained into the ledger, the transcript copy (observed items), the settings row, and naming; a feed that ends releases its claim so the next read re-subscribes;
- the re-read at the observed busy→idle drop (serialized per thread), and the tui startup re-read for a thread whose copy still holds a running turn;
- `closeTui`: ends the terminal now when idle, or at its next observed idle when busy — after that idle's re-read has landed, with a newer idle in between re-arming the wait for its own re-read (an idle-edge generation), and a failed read leaving the terminal running; `cancelPendingClose` on every open, serialized with in-flight idle work so the open's linked check sees the outcome;
- idle work is forked into the observation's scope, so `unobserve` (archive/delete) ends it.

Deleted from the runtime: `tuiWanted` / `tuiSettled` / `tuiOpening`, `takeOverTui`, `handOff`, `relaunchTui`, `endTui` and the settle gate, `openTui` / `closeTui`, observation, the "observed" turn rows a writer feed recorded for foreign turns (ignored with a debug log now), the busy-under-another-surface check in `startNext`, and the chat-thread startup re-read (chat: reattach on a shared server, else mark interrupted). The runtime header no longer mentions ownership, hand-off, the settle gate, or re-reads of its own. `threads.ts` launches the terminal directly and calls the observer; archive/delete `unobserve` before `release`. The three hand-rolled keyed semaphores became `platform/keyedLock.ts`.

Layers: `ThreadObserver` sits between `Threads` and `ThreadRuntime` (`server.ts`, `test/testLayers.ts`).

## Verification

`mise run -C app-server check` green: 514 tests. New `threadObserver.test.ts` covers the idle re-read + observed items + no relaunch after the terminal exits, close-now vs close-at-idle (with the last turn landing before the kill), a pending close surviving a terminal death never ending the next terminal, and reopening before the idle cancelling a pending close. The fake adapter gained `emitObservedItem`. Two adversarial Codex reviews (correctness, simplicity) were run and their actionable findings applied; not applied: the pre-existing stale-busy-after-dead-feed case in `resolveActivity` (unchanged by this PR).

https://claude.ai/code/session_01DEDRJttGjwZkLJ82FbBqT8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live observation of terminal-backed agent sessions, including transcript updates, activity tracking, and session cleanup.
  * Added automatic terminal closure handling for idle or ended sessions, with support for canceling pending closures.
  * Improved recovery and handling of interrupted or disconnected conversations.

* **Bug Fixes**
  * Preserved streamed partial responses when connections are interrupted.
  * Improved thread lifecycle coordination and terminal state consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->