### PR TITLE
Chat prose matches T3Code: 14pt type, relaxed leading, heading scale

### DIFF
--- a/macos/ATC/Features/Threads/Chat/ChatComposer.swift
+++ b/macos/ATC/Features/Threads/Chat/ChatComposer.swift
@@ -450,7 +450,8 @@ struct ChatComposer: View {
     private var editor: some View {
         ZStack(alignment: .topLeading) {
             Text(text.isEmpty ? " " : text)
-                .font(.body)
+                .font(Prose.font)
+                .lineSpacing(Prose.lineSpacing)
                 .lineLimit(3...10)
                 .padding(.vertical, Spacing.xs)
                 .padding(.horizontal, Spacing.xs + 1)
@@ -462,7 +463,8 @@ struct ChatComposer: View {
                     editorHeight = $0
                 }
             TextEditor(text: $text, selection: $selection)
-                .font(.body)
+                .font(Prose.font)
+                .lineSpacing(Prose.lineSpacing)
                 .scrollContentBackground(.hidden)
                 .scrollIndicators(.never)
                 .focused($isFocused)
@@ -507,6 +509,8 @@ struct ChatComposer: View {
                 }
             if text.isEmpty {
                 Text(attachments.isEmpty ? "Message the agent…" : "Add a message, or send the images…")
+                    .font(Prose.font)
+                    .lineSpacing(Prose.lineSpacing)
                     .foregroundStyle(.secondary)
                     .padding(.vertical, Spacing.xs)
                     .padding(.horizontal, Spacing.xs + 1)

--- a/packages/ATCKit/Sources/ATCChat/ChatText.swift
+++ b/packages/ATCKit/Sources/ATCChat/ChatText.swift
@@ -16,6 +16,8 @@ struct MarkdownText: View {
 
     var body: some View {
         Text(attributed)
+            .font(Prose.font)
+            .lineSpacing(Prose.lineSpacing)
             .textSelection(.enabled)
             .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/packages/ATCKit/Sources/ATCChat/Markdown/MarkdownBlocksView.swift
+++ b/packages/ATCKit/Sources/ATCChat/Markdown/MarkdownBlocksView.swift
@@ -29,11 +29,12 @@ struct MarkdownBlocksView: View {
     let blocks: [MarkdownBlock]
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.sm) {
+        VStack(alignment: .leading, spacing: Spacing.md) {
             ForEach(blocks) { block in
                 MarkdownBlockView(block: block)
             }
         }
+        .font(Prose.font)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
@@ -45,11 +46,12 @@ private struct MarkdownBlockView: View {
         switch block {
         case .paragraph(_, let text):
             Text(text)
+                .lineSpacing(Prose.lineSpacing)
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
         case .heading(_, let level, let text):
             Text(text)
-                .font(headingFont(level))
+                .font(Prose.heading(level))
                 .foregroundStyle(.primary)
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -66,7 +68,7 @@ private struct MarkdownBlockView: View {
                         .frame(width: 3)
                 }
         case .list(_, let items):
-            VStack(alignment: .leading, spacing: Spacing.xs) {
+            VStack(alignment: .leading, spacing: Spacing.sm) {
                 ForEach(items) { item in
                     HStack(alignment: .firstTextBaseline, spacing: Spacing.sm) {
                         Text(item.marker)
@@ -84,14 +86,6 @@ private struct MarkdownBlockView: View {
         }
     }
 
-    private func headingFont(_ level: Int) -> Font {
-        switch level {
-        case 1: .title2.weight(.semibold)
-        case 2: .title3.weight(.semibold)
-        case 3: .headline
-        default: .subheadline.weight(.semibold)
-        }
-    }
 }
 
 /// A fenced code block: language label and copy button above monospaced,

--- a/packages/ATCKit/Sources/ATCDesign/DesignTokens.swift
+++ b/packages/ATCKit/Sources/ATCDesign/DesignTokens.swift
@@ -34,6 +34,31 @@ public enum Spacing {
     public static let xxl: CGFloat = 32
 }
 
+/// Chat prose — assistant text and the user's own messages. Sized to T3Code's
+/// chat (14px at a ~1.6 line-height) rather than the 13pt system body: one
+/// point up keeps it a clear step above the 12pt `.callout` chrome (tool
+/// rows, chips, captions) without drifting from the system scale. Headings
+/// land on system styles where one fits (`.title2` 17, `.title3` 15) and on
+/// the prose size for h4+, so a heading never reads smaller than its body.
+public enum Prose {
+    public static let size: CGFloat = 14
+    public static let font = Font.system(size: size)
+    /// Extra points between wrapped lines, on top of the font's natural
+    /// ~17pt line box — together they land at T3Code's 1.625 ratio.
+    public static let lineSpacing: CGFloat = 6
+
+    /// The font for a markdown heading at `level` (1-based; 4 and deeper
+    /// share the prose size in semibold).
+    public static func heading(_ level: Int) -> Font {
+        switch level {
+        case 1: .system(size: 20, weight: .semibold)
+        case 2: .title2.weight(.semibold)
+        case 3: .title3.weight(.semibold)
+        default: font.weight(.semibold)
+        }
+    }
+}
+
 /// Corner radii: small controls, chip controls, cards, and floating panels.
 /// Text pills use `Capsule`.
 public enum Radius {


### PR DESCRIPTION
## Summary

Chat threads rendered prose at the 13pt system body with the font's natural line height, which read noticeably denser than T3Code's chat (14px `text-sm` at `leading-relaxed`, 1.625). This makes `Prose` in `ATCDesign` the chat's type scale and applies it to assistant text, user messages, and the composer.

| | Before | Now | T3Code |
|---|---|---|---|
| Prose (assistant + user messages) | `.body` 13 | **14** | 14 |
| Composer editor | `.body` 13 | **14** | 14 |
| Line spacing | 0 | **+6** (17pt box → 23 ≈ 1.625×) | 1.625× |
| Paragraph gap / list-item gap | sm 8 / xs 4 | **md 12 / sm 8** | ~16 / ~8 visual |
| h1 / h2 / h3 / h4+ | 17 / 15 / 13 / 11 | **20 / title2 17 / title3 15 / 14** semibold | 20 / 18 / 16 / 14 |
| Tool rows, chips, captions | `.callout` 12 | unchanged | 12 |

Why the ratios hold:
- Chrome stays at the system 12pt `.callout`, so prose is the same 14:12 step above tool rows and chips that T3Code uses.
- Headings snap to system styles where one fits (`.title2`, `.title3`); h1 is an explicit 20 because the next style up is `.title` at 22. h4+ is prose-size semibold. This also fixes a latent scale bug: h3 was `.headline` (13) and h4 `.subheadline` (11), smaller than the prose they labelled.
- The paragraph gap stops at `Spacing.md` rather than a numerically exact ~15pt so it never exceeds the 12pt gap between messages.
- The composer moves with prose (type at the size you read), matching T3Code's 14px prompt default.

`MarkdownBlocksView` applies `Prose.font` once at its root; list markers and quotes inherit it, and only headings, code blocks, and table cells override.

## Test plan

- [x] `mise run swift:fmt:check`
- [x] `mise run kit:test` — 74/74
- [x] `mise run macos:build`
- [ ] Open a chat thread and compare against T3Code side by side

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved chat text readability with consistent prose typography.
  * Updated markdown paragraphs with clearer line spacing and block spacing.
  * Refined heading styles across multiple heading levels.
  * Increased spacing between list items for easier scanning.
  * Standardized the appearance of text in the message composer and rendered markdown content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->