### PR TITLE
ATC-249 | Restore reference checkout task

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Tools and tasks are managed by [mise](https://mise.jdx.dev) via
 
 - `mise run build` — build a static `atc` binary into `bin/`
 - `mise run check` — build, lint, vet, and test (CI runs the same task)
+- `mise run refs` — fetch read-only T3 Code, OpenCode, and zmx source into `repos/`
 - `mise tasks` — list all tasks
 
 ## Repository status

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Tools and tasks are managed by [mise](https://mise.jdx.dev) via
 
 - `mise run build` — build a static `atc` binary into `bin/`
 - `mise run check` — build, lint, vet, and test (CI runs the same task)
-- `mise run refs` — fetch read-only T3 Code, OpenCode, and zmx source into `repos/`
+- `mise run refs` — fetch read-only T3 Code, Herdr, Agent Client Protocol,
+  and zmx v0.6.0 source into `repos/`
 - `mise tasks` — list all tasks
 
 ## Repository status

--- a/mise.toml
+++ b/mise.toml
@@ -37,3 +37,20 @@ depends = ["build", "lint", "vet", "test"]
 [tasks.clean]
 description = "Remove build artifacts"
 run = "rm -rf bin"
+
+[tasks.refs]
+description = "Fetch read-only reference source into repos/ (gitignored); delete a checkout and re-run to update"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+clone() {
+  if [ -d "repos/$1" ]; then
+    echo "repos/$1 already present; delete it and re-run to update"
+  else
+    git clone --depth 1 "${@:2}" "repos/$1"
+  fi
+}
+clone t3code https://github.com/pingdotgg/t3code.git
+clone opencode https://github.com/sst/opencode.git
+clone zmx --branch 'v0.6.0' https://github.com/neurosnap/zmx.git
+"""

--- a/mise.toml
+++ b/mise.toml
@@ -51,6 +51,7 @@ clone() {
   fi
 }
 clone t3code https://github.com/pingdotgg/t3code.git
-clone opencode https://github.com/sst/opencode.git
+clone herdr https://github.com/herdrdev/herdr.git
+clone agent-client-protocol https://github.com/agentclientprotocol/agent-client-protocol.git
 clone zmx --branch 'v0.6.0' https://github.com/neurosnap/zmx.git
 """


### PR DESCRIPTION
## Summary

- restore `mise run refs` for read-only local reference checkouts
- fetch T3 Code, Herdr, the Agent Client Protocol specification, and zmx v0.6.0
- document the task while keeping archived Effect/App Server tooling absent

## Testing

- `mise tasks validate`
- `mise task info refs`
- `mise run --dry-run --skip-tools refs`
- `mise run check`
- `git diff --check`

## Dependency

This is a stacked PR targeting #242 because ATC-249 builds on the root `mise.toml` introduced by ATC-248.