### PR TITLE
ATC-263 | Lint and test conventions: golangci-lint in mise check, testing doctrine in AGENTS.md

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+# Enumerated linter set (ATC-263): never inherit defaults, so a golangci-lint
+# upgrade cannot silently move the bar. Each addition earns its way in.
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - errorlint
+    - govet
+    - ineffassign
+    - nolintlint
+    - staticcheck
+    - unused
+  settings:
+    nolintlint:
+      # Any //nolint must name the linter it silences and carry a reason.
+      require-explanation: true
+      require-specific: true
+
+formatters:
+  enable:
+    - gofmt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,20 @@ reading the implementation. READMEs cover how to run a thing, where its data
 lives, and which task to use. They should point to generated references and
 `--help` rather than enumerate details that can drift.
 
+## Testing
+
+- Use the stdlib `testing` package, with go-cmp for structural diffs
+  (`cmp.Diff` against a full want value; see `internal/config` for the
+  pattern).
+- No assertion or mocking frameworks. Test doubles are hand-written fakes
+  behind the interfaces the code already defines.
+- The race detector stays on (`mise test` runs it).
+- Use table tests where they clarify a set of cases, not as ritual.
+- Tests are serial by default. Add `t.Parallel()` deliberately, when a
+  package's tests become slow enough to pay for it — cross-package
+  parallelism from `go test ./...` already carries the wall-clock win for a
+  tree of many small packages.
+
 ## Experiments and Reference Source
 
 Everything under `experiments/` is historical research material, not

--- a/cmd/atc/main.go
+++ b/cmd/atc/main.go
@@ -76,8 +76,8 @@ func newVersionCmd() *cobra.Command {
 		Short: "Print the atc version",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			fmt.Fprintln(cmd.OutOrStdout(), versionString())
-			return nil
+			_, err := fmt.Fprintln(cmd.OutOrStdout(), versionString())
+			return err
 		},
 	}
 }
@@ -143,8 +143,10 @@ func printToken(stdout io.Writer, issue func(*authtoken.Store) (string, error)) 
 	if err != nil {
 		return err
 	}
-	fmt.Fprintln(stdout, token)
-	return nil
+	// A failed or truncated write matters here: the printed token is the
+	// credential the user pastes into a remote client.
+	_, err = fmt.Fprintln(stdout, token)
+	return err
 }
 
 // serverRun runs the server in the foreground until the command context is
@@ -209,7 +211,7 @@ func serverRun(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	defer logFile.Close()
+	defer func() { _ = logFile.Close() }()
 	logger := slog.New(slog.NewJSONHandler(io.MultiWriter(logFile, stderr), nil))
 
 	// With auth required everywhere, a server that cannot verify tokens

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 )
 
 require (
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,12 @@ go 1.26.7
 
 require (
 	github.com/danielgtaylor/huma/v2 v2.39.1
+	github.com/google/go-cmp v0.7.0
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/spf13/cobra v1.10.2
 )
 
 require (
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/fxamacker/cbor/v2 v2.9.2 h1:X4Ksno9+x3cz0TZv69ec1hxP/+tymuR8PXQJyDwfh
 github.com/fxamacker/cbor/v2 v2.9.2/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/go-chi/chi/v5 v5.3.1 h1:3j4HZLGZQ3JpMCrPJF/Jl3mYJfWLKBfNJ6quurUGCf8=
 github.com/go-chi/chi/v5 v5.3.1/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/internal/authtoken/authtoken.go
+++ b/internal/authtoken/authtoken.go
@@ -74,17 +74,17 @@ func (s Store) writeTemp(token string) (string, error) {
 	}
 	temp := f.Name()
 	if err := f.Chmod(0o600); err != nil {
-		f.Close()
-		os.Remove(temp)
+		_ = f.Close()
+		_ = os.Remove(temp)
 		return "", err
 	}
 	if _, err := f.WriteString(token + "\n"); err != nil {
-		f.Close()
-		os.Remove(temp)
+		_ = f.Close()
+		_ = os.Remove(temp)
 		return "", err
 	}
 	if err := f.Close(); err != nil {
-		os.Remove(temp)
+		_ = os.Remove(temp)
 		return "", err
 	}
 	return temp, nil
@@ -118,7 +118,7 @@ func (s Store) Ensure() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer os.Remove(temp)
+	defer func() { _ = os.Remove(temp) }()
 	if err := os.Link(temp, s.Path); errors.Is(err, fs.ErrExist) {
 		// A concurrent Ensure won the install. Adopt its token — it is
 		// complete by the invariant above; when it still cannot be read
@@ -150,7 +150,7 @@ func (s Store) Rotate() (string, error) {
 		return "", err
 	}
 	if err := os.Rename(temp, s.Path); err != nil {
-		os.Remove(temp)
+		_ = os.Remove(temp)
 		return "", err
 	}
 	return token, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func noEnv(string) (string, bool) { return "", false }
@@ -54,8 +56,9 @@ func TestEnvBeatsFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Port != 9001 || cfg.Bind != "::1" {
-		t.Errorf("cfg = %+v, want env values 9001/::1", cfg)
+	want := Config{Port: 9001, Bind: "::1", TailscaleExecutable: "tailscale"}
+	if diff := cmp.Diff(want, cfg); diff != "" {
+		t.Errorf("Load mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,6 @@
 [tools]
 go = "1.26.7"
+golangci-lint = "2.13.1"
 
 [tasks.build]
 description = "Build a static atc binary into bin/"
@@ -9,30 +10,13 @@ run = "CGO_ENABLED=0 go build -o bin/atc ./cmd/atc"
 description = "Run tests with the race detector"
 run = "go test -race ./..."
 
-# gofmt has no module awareness, so scope it to the root module's packages;
-# this keeps experiments/ and repos/ out without a hand-maintained list.
 [tasks.lint]
-description = "Check gofmt on root-module packages"
-shell = "bash -c"
-run = '''
-{% raw %}
-set -euo pipefail
-unformatted="$(go list -f '{{.Dir}}' ./... | while IFS= read -r dir; do gofmt -l "$dir" || exit 1; done)"
-if [ -n "$unformatted" ]; then
-  echo "gofmt required on:"
-  echo "$unformatted"
-  exit 1
-fi
-{% endraw %}
-'''
-
-[tasks.vet]
-description = "Run go vet"
-run = "go vet ./..."
+description = "Run golangci-lint (includes gofmt and go vet)"
+run = "golangci-lint run ./..."
 
 [tasks.check]
-description = "Build, lint, vet, and test"
-depends = ["build", "lint", "vet", "test"]
+description = "Build, lint, and test"
+depends = ["build", "lint", "test"]
 
 [tasks.clean]
 description = "Remove build artifacts"


### PR DESCRIPTION
Closes the last domain-agnostic Foundation gap from the stack review ([ATC-263](https://linear.app/elevenideas/issue/ATC-263)): deeper static analysis in `mise check` and recorded testing conventions, so every domain package is born under the final bar.

## What changed

- **golangci-lint 2.13.1**, pinned in `mise.toml`, with a v2 `.golangci.yml` that never inherits defaults: `errcheck`, `errorlint`, `govet`, `ineffassign`, `nolintlint` (must name the linter and carry a reason), `staticcheck`, `unused`, plus the `gofmt` formatter. An upgrade can never silently move the bar.
- **Task consolidation**: `lint` is now `golangci-lint run ./...` (replacing the hand-rolled bash gofmt loop), the standalone `vet` task is deleted, and `check` = build + lint + race tests. `experiments/` subtrees are separate modules, so `./...` never sees them.
- **errcheck sweep** (8 findings): `atc version` and `atc server token` now propagate write errors — a truncated token print is a credential the user pastes elsewhere. The six best-effort cleanup paths in `authtoken` and the log-file close get explicit `_ =` discards.
- **go-cmp v0.7.0** added now, not on first use, with `TestEnvBeatsFile` in `internal/config` retrofitted as the live full-struct `cmp.Diff` example.
- **Testing doctrine** in AGENTS.md: stdlib `testing` + go-cmp, no assertion/mocking frameworks (hand-written fakes), race detector stays on, table tests where they clarify, and serial-by-default `t.Parallel()` (settles ATC-266 item 2).

Per decision 6, the lint tool choice is not recorded in AGENTS.md — `mise.toml` and the config are self-documenting.

## Gate proven

A transient unchecked-error violation made `mise run check` exit 1 with errcheck naming the line; removed, the tree is clean under the enumerated set and `mise run check` is green (build, lint, race tests).