### PR TITLE
ATC-260 | Supervisor-backed server lifecycle: start/stop/restart/status/logs/uninstall

### DIFF
--- a/cmd/atc/main.go
+++ b/cmd/atc/main.go
@@ -6,13 +6,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"runtime/debug"
 	"strconv"
 	"sync"
@@ -24,6 +24,7 @@ import (
 	"github.com/jeremytondo/atc/internal/config"
 	"github.com/jeremytondo/atc/internal/paths"
 	"github.com/jeremytondo/atc/internal/server"
+	"github.com/jeremytondo/atc/internal/service"
 	"github.com/jeremytondo/atc/internal/tailscale"
 )
 
@@ -31,6 +32,12 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	if err := run(ctx, os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		// An ExitError's report is already on stdout (e.g. `server status`
+		// exit codes); it only picks the process exit code.
+		var exit *service.ExitError
+		if errors.As(err, &exit) {
+			os.Exit(exit.Code)
+		}
 		fmt.Fprintln(os.Stderr, "atc:", err)
 		os.Exit(1)
 	}
@@ -51,6 +58,9 @@ func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 }
 
 func newRootCmd() *cobra.Command {
+	// Help lists commands in the order they are added, so the advanced
+	// foreground `run` can sit last under `atc server`.
+	cobra.EnableCommandSorting = false
 	root := &cobra.Command{
 		Use:   "atc",
 		Short: "The ATC terminal client and server",
@@ -88,19 +98,134 @@ func newServerCmd() *cobra.Command {
 		Short: "Run and administer the ATC server",
 		Args:  cobra.NoArgs,
 		RunE: func(*cobra.Command, []string) error {
-			return fmt.Errorf("usage: atc server <run|token>")
+			return fmt.Errorf("usage: atc server <start|stop|restart|status|logs|token|uninstall|run>")
 		},
 	}
-	cmd.AddCommand(newServerRunCmd(), newServerTokenCmd())
+	// Display order is deliberate (EnableCommandSorting is off): the
+	// supervised lifecycle first, the advanced foreground primitive last.
+	cmd.AddCommand(newServerStartCmd(), newServerStopCmd(), newServerRestartCmd(),
+		newServerStatusCmd(), newServerLogsCmd(), newServerTokenCmd(),
+		newServerUninstallCmd(), newServerRunCmd())
 	return cmd
+}
+
+// lifecycleOptions settles the configuration the supervised daemon itself
+// will read: config file and defaults only. The unit stamps no ATC_*
+// environment (supervisors start services with a minimal environment), so
+// honoring the invoking shell's ATC_PORT here would probe a port the daemon
+// never serves.
+func lifecycleOptions(cmd *cobra.Command) (service.Options, error) {
+	configPath, err := paths.ConfigFile()
+	if err != nil {
+		return service.Options{}, err
+	}
+	cfg, err := config.Load(configPath, func(string) (string, bool) { return "", false })
+	if err != nil {
+		return service.Options{}, err
+	}
+	return service.Options{
+		Config:  cfg,
+		Version: versionString(),
+		Stdout:  cmd.OutOrStdout(),
+		Stderr:  cmd.ErrOrStderr(),
+	}, nil
+}
+
+func lifecycleCmd(use, short, long string, action func(context.Context, service.Options) error) *cobra.Command {
+	return &cobra.Command{
+		Use:   use,
+		Short: short,
+		Long:  long,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			opts, err := lifecycleOptions(cmd)
+			if err != nil {
+				return err
+			}
+			return action(cmd.Context(), opts)
+		},
+	}
+}
+
+func newServerStartCmd() *cobra.Command {
+	return lifecycleCmd("start",
+		"Register and start the supervised server",
+		`Register the server with the user supervisor (launchd on macOS, systemd user
+units on Linux) and start it. Registration happens on every start: the unit is
+re-rendered from the current binary, so upgrades only need `+"`atc server restart`"+`.
+A healthy running server is left untouched. The first start prints what was
+registered and how to undo it (atc server uninstall).`,
+		service.Start)
+}
+
+func newServerStopCmd() *cobra.Command {
+	return lifecycleCmd("stop",
+		"Stop the supervised server until next login",
+		`Stop the supervised server process. The unit stays installed, so the server
+returns at next login; use `+"`atc server uninstall`"+` to remove it entirely.`,
+		service.Stop)
+}
+
+func newServerRestartCmd() *cobra.Command {
+	return lifecycleCmd("restart",
+		"Restart the supervised server",
+		`Re-render the unit and restart the server process. This is the remedy for
+upgrades, config edits, and client/server version skew.`,
+		service.Restart)
+}
+
+func newServerStatusCmd() *cobra.Command {
+	return lifecycleCmd("status",
+		"Report server health, versions, and API URLs",
+		`Probe the server's health endpoint (the source of truth for liveness), report
+unit state, client and server versions, and ready-to-paste API URLs.
+Exit codes: 0 healthy, 1 installed but not responding, 2 not installed.`,
+		service.Status)
+}
+
+func newServerLogsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "logs",
+		Short: "Show the supervised server's logs",
+		Long: `Show the supervised server's captured output: the systemd journal on Linux,
+the launchd-captured log file on macOS.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			opts, err := lifecycleOptions(cmd)
+			if err != nil {
+				return err
+			}
+			follow, err := cmd.Flags().GetBool("follow")
+			if err != nil {
+				return err
+			}
+			lines, err := cmd.Flags().GetInt("lines")
+			if err != nil {
+				return err
+			}
+			return service.Logs(cmd.Context(), opts, follow, lines)
+		},
+	}
+	cmd.Flags().BoolP("follow", "f", false, "keep printing new log lines as they arrive")
+	cmd.Flags().IntP("lines", "n", 100, "number of recent lines to show")
+	return cmd
+}
+
+func newServerUninstallCmd() *cobra.Command {
+	return lifecycleCmd("uninstall",
+		"Stop the server and remove its registration",
+		`Stop the supervised server and remove its unit. Data is never deleted; the
+config, token, and (on macOS) log files that remain are listed.`,
+		service.Uninstall)
 }
 
 func newServerRunCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run",
-		Short: "Run the ATC server in the foreground",
-		Long: `Run the ATC server in the foreground until SIGINT or SIGTERM. This is the
-permanent foreground primitive a supervisor will exec (ATC-246).`,
+		Short: "Run the ATC server in the foreground (advanced)",
+		Long: `Run the ATC server in the foreground until SIGINT or SIGTERM, logging to
+stderr. This is the primitive the supervised unit execs; most users want
+` + "`atc server start`" + `.`,
 		Args: cobra.NoArgs,
 		RunE: serverRun,
 	}
@@ -198,21 +323,10 @@ func serverRun(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	// JSON lines at the state-dir log (adopted legacy convention; no
-	// rotation, deliberately), mirrored to stderr for the foreground case.
-	logPath, err := paths.LogFile()
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Dir(logPath), 0o700); err != nil {
-		return err
-	}
-	logFile, err := os.OpenFile(logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = logFile.Close() }()
-	logger := slog.New(slog.NewJSONHandler(io.MultiWriter(logFile, stderr), nil))
+	// Supervisor-owned logging (ATC-260): logfmt on stderr only. The
+	// journal captures it on Linux; the LaunchAgent redirects it to the
+	// state-dir log file on macOS; foreground runs see it directly.
+	logger := slog.New(slog.NewTextHandler(stderr, nil))
 
 	// With auth required everywhere, a server that cannot verify tokens
 	// serves nothing but 401s — refuse to start instead (deliberate

--- a/cmd/atc/main.go
+++ b/cmd/atc/main.go
@@ -131,14 +131,26 @@ func lifecycleOptions(cmd *cobra.Command) (service.Options, error) {
 	}, nil
 }
 
-func lifecycleCmd(use, short, long string, action func(context.Context, service.Options) error) *cobra.Command {
+// recoveryOptions builds Options without settling configuration. Stop,
+// logs, and uninstall never consume it, and they must keep working when
+// config.toml is broken — the same condition that can keep the daemon from
+// booting must not block diagnostics, stopping, or the promised total undo.
+func recoveryOptions(cmd *cobra.Command) (service.Options, error) {
+	return service.Options{
+		Version: versionString(),
+		Stdout:  cmd.OutOrStdout(),
+		Stderr:  cmd.ErrOrStderr(),
+	}, nil
+}
+
+func lifecycleCmd(use, short, long string, options func(*cobra.Command) (service.Options, error), action func(context.Context, service.Options) error) *cobra.Command {
 	return &cobra.Command{
 		Use:   use,
 		Short: short,
 		Long:  long,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			opts, err := lifecycleOptions(cmd)
+			opts, err := options(cmd)
 			if err != nil {
 				return err
 			}
@@ -153,9 +165,10 @@ func newServerStartCmd() *cobra.Command {
 		`Register the server with the user supervisor (launchd on macOS, systemd user
 units on Linux) and start it. Registration happens on every start: the unit is
 re-rendered from the current binary, so upgrades only need `+"`atc server restart`"+`.
-A healthy running server is left untouched. The first start prints what was
-registered and how to undo it (atc server uninstall).`,
-		service.Start)
+A healthy server running the current unit is left untouched; a changed unit
+bounces it. The first start prints what was registered and how to undo it
+(atc server uninstall).`,
+		lifecycleOptions, service.Start)
 }
 
 func newServerStopCmd() *cobra.Command {
@@ -163,7 +176,7 @@ func newServerStopCmd() *cobra.Command {
 		"Stop the supervised server until next login",
 		`Stop the supervised server process. The unit stays installed, so the server
 returns at next login; use `+"`atc server uninstall`"+` to remove it entirely.`,
-		service.Stop)
+		recoveryOptions, service.Stop)
 }
 
 func newServerRestartCmd() *cobra.Command {
@@ -171,7 +184,7 @@ func newServerRestartCmd() *cobra.Command {
 		"Restart the supervised server",
 		`Re-render the unit and restart the server process. This is the remedy for
 upgrades, config edits, and client/server version skew.`,
-		service.Restart)
+		lifecycleOptions, service.Restart)
 }
 
 func newServerStatusCmd() *cobra.Command {
@@ -180,7 +193,7 @@ func newServerStatusCmd() *cobra.Command {
 		`Probe the server's health endpoint (the source of truth for liveness), report
 unit state, client and server versions, and ready-to-paste API URLs.
 Exit codes: 0 healthy, 1 installed but not responding, 2 not installed.`,
-		service.Status)
+		lifecycleOptions, service.Status)
 }
 
 func newServerLogsCmd() *cobra.Command {
@@ -191,7 +204,7 @@ func newServerLogsCmd() *cobra.Command {
 the launchd-captured log file on macOS.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			opts, err := lifecycleOptions(cmd)
+			opts, err := recoveryOptions(cmd)
 			if err != nil {
 				return err
 			}
@@ -216,7 +229,7 @@ func newServerUninstallCmd() *cobra.Command {
 		"Stop the server and remove its registration",
 		`Stop the supervised server and remove its unit. Data is never deleted; the
 config, token, and (on macOS) log files that remain are listed.`,
-		service.Uninstall)
+		recoveryOptions, service.Uninstall)
 }
 
 func newServerRunCmd() *cobra.Command {

--- a/cmd/atc/main_test.go
+++ b/cmd/atc/main_test.go
@@ -2,9 +2,16 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/jeremytondo/atc/internal/service"
 )
 
 func TestRunNoArgsPrintsUsage(t *testing.T) {
@@ -36,6 +43,12 @@ func TestRunRejectsBadInvocations(t *testing.T) {
 		{"server", "run", "extra"},
 		{"server", "token", "frobnicate"},
 		{"server", "token", "rotate", "extra"},
+		{"server", "start", "extra"},
+		{"server", "stop", "extra"},
+		{"server", "restart", "extra"},
+		{"server", "status", "extra"},
+		{"server", "logs", "extra"},
+		{"server", "uninstall", "extra"},
 	} {
 		var stdout, stderr strings.Builder
 		if err := run(context.Background(), args, &stdout, &stderr); err == nil {
@@ -87,6 +100,43 @@ func TestServerRunRejectsInvalidFlagValues(t *testing.T) {
 		if err := run(context.Background(), args, &stdout, &stderr); err == nil {
 			t.Errorf("%s: run(%q) = nil, want validation error", name, args)
 		}
+	}
+}
+
+// closedPort finds a port nothing is listening on, so the status probe
+// cannot accidentally reach a real server running on the developer machine.
+func closedPort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return port
+}
+
+func TestServerStatusNotInstalled(t *testing.T) {
+	isolateXDG(t)
+	configDir := filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "atc")
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	content := fmt.Sprintf("port = %d\n", closedPort(t))
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr strings.Builder
+	err := run(context.Background(), []string{"server", "status"}, &stdout, &stderr)
+	var exit *service.ExitError
+	if !errors.As(err, &exit) || exit.Code != 2 {
+		t.Fatalf("server status = %v, want ExitError with code 2", err)
+	}
+	if !strings.Contains(stdout.String(), "not installed") {
+		t.Errorf("stdout = %q, want a not-installed report", stdout.String())
 	}
 }
 

--- a/cmd/atc/main_test.go
+++ b/cmd/atc/main_test.go
@@ -140,6 +140,46 @@ func TestServerStatusNotInstalled(t *testing.T) {
 	}
 }
 
+// A config.toml the server refuses to load must not block the recovery
+// commands: stop, logs, and uninstall never consume configuration, and they
+// are the diagnostics and the undo for exactly that broken state.
+func TestRecoveryCommandsSurviveBrokenConfig(t *testing.T) {
+	isolateXDG(t)
+	configDir := filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "atc")
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte("bogus_key = true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// status settles config and must surface the parse error.
+	var stdout, stderr strings.Builder
+	if err := run(context.Background(), []string{"server", "status"}, &stdout, &stderr); err == nil || !strings.Contains(err.Error(), "bogus_key") {
+		t.Errorf("server status = %v, want the config parse error", err)
+	}
+
+	// stop and uninstall proceed to their not-installed reports.
+	for _, args := range [][]string{{"server", "stop"}, {"server", "uninstall"}} {
+		var stdout, stderr strings.Builder
+		if err := run(context.Background(), args, &stdout, &stderr); err != nil {
+			t.Errorf("run(%q) = %v, want nil despite broken config", args, err)
+		}
+		if !strings.Contains(stdout.String(), "not installed") {
+			t.Errorf("run(%q) stdout = %q, want a not-installed report", args, stdout.String())
+		}
+	}
+
+	// logs reports the uninstalled state rather than a config error (or an
+	// empty journal).
+	stdout.Reset()
+	stderr.Reset()
+	err := run(context.Background(), []string{"server", "logs"}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "not installed") {
+		t.Errorf("server logs = %v, want a not-installed explanation", err)
+	}
+}
+
 func TestServerTokenPrintsAndRotates(t *testing.T) {
 	isolateXDG(t)
 	tokenOut := func(args ...string) string {

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -23,7 +23,10 @@ func AuthTokenFile() (string, error) {
 	return resolve("XDG_DATA_HOME", []string{".local", "share"}, "auth-token")
 }
 
-// LogFile is the server's JSON-lines log.
+// LogFile is where the macOS LaunchAgent captures the supervised server's
+// output (launchd has no journal, so the unit redirects both streams here).
+// The server itself logs only to stderr (ATC-260); on Linux the systemd
+// journal owns capture and this file is unused.
 func LogFile() (string, error) {
 	return resolve("XDG_STATE_HOME", []string{".local", "state"}, "atc.log")
 }

--- a/internal/service/lifecycle.go
+++ b/internal/service/lifecycle.go
@@ -48,6 +48,13 @@ func startOrRestart(ctx context.Context, opts Options, bounce bool) error {
 	if err != nil {
 		return err
 	}
+	content, err := renderUnit()
+	if err != nil {
+		return err
+	}
+	existing, readErr := os.ReadFile(unitFile)
+	firstRun := errors.Is(readErr, fs.ErrNotExist)
+	unchanged := readErr == nil && string(existing) == content
 
 	supervised := supervisorRunning(ctx)
 	if !supervised && portAnswering(opts.Config) {
@@ -55,26 +62,28 @@ func startOrRestart(ctx context.Context, opts Options, bounce bool) error {
 		// foreground `atc server run`.
 		return fmt.Errorf("something is already serving on port %d (a foreground `atc server run`?); stop it first", opts.Config.Port)
 	}
-	if supervised && !bounce && probeOnce(ctx, opts, token).healthy {
-		if err := rewriteUnit(ctx, unitFile); err != nil {
-			return err
+	if supervised && !bounce && unchanged && probeOnce(ctx, opts, token).healthy {
+		// Idempotent: healthy and running the current unit — leave the
+		// process untouched. enable still runs so an active-but-disabled
+		// unit returns at next login.
+		if runtime.GOOS == "linux" {
+			if err := runSupervisor(ctx, "systemctl", "--user", "enable", UnitName); err != nil {
+				return err
+			}
 		}
 		say(opts.Stdout, "%s is already running and healthy: %s\n", UnitName, loopbackURL(opts.Config.Port))
 		return nil
 	}
+	// A supervised daemon whose unit changed must be bounced onto the new
+	// one: daemon-reload alone leaves the running process (and launchd's
+	// loaded job) on the stale configuration.
+	if supervised && !unchanged {
+		bounce = true
+	}
 
-	_, statErr := os.Stat(unitFile)
-	firstRun := errors.Is(statErr, fs.ErrNotExist)
-	if err := writeUnit(unitFile); err != nil {
+	if err := writeUnit(unitFile, content); err != nil {
 		return err
 	}
-	if firstRun {
-		// Consent-after-the-fact (ATC-246 grill decision): no prompt, no
-		// TTY branch — identical interactive or scripted. Honest because
-		// uninstall is one cheap, total undo.
-		say(opts.Stderr, "%s", firstRunNotice(runtime.GOOS, unitFile))
-	}
-
 	if runtime.GOOS == "linux" {
 		if err := runSupervisor(ctx, "systemctl", "--user", "daemon-reload"); err != nil {
 			return err
@@ -94,14 +103,23 @@ func startOrRestart(ctx context.Context, opts Options, bounce bool) error {
 		// so every path that (re)starts the process unloads first and
 		// bootstraps the freshly rendered unit. (`kickstart -k` would bounce
 		// the process but leave launchd running the stale configuration —
-		// the healthy-and-untouched case already returned above.)
+		// the healthy-and-current case already returned above.)
 		if launchdLoadedDomain(ctx) != "" {
-			launchdUnload(ctx)
+			if err := launchdUnload(ctx); err != nil {
+				return err
+			}
 		}
 		// Loading starts it (RunAtLoad).
 		if err := launchdBootstrap(ctx, unitFile); err != nil {
 			return err
 		}
+	}
+	if firstRun {
+		// Consent-after-the-fact (ATC-246 grill decision): no prompt, no
+		// TTY branch — identical interactive or scripted. Honest because
+		// uninstall is one cheap, total undo. Printed only after the
+		// supervisor accepted the unit, so the notice reports a fact.
+		say(opts.Stderr, "%s", firstRunNotice(runtime.GOOS, unitFile))
 	}
 
 	if err := awaitHealthy(ctx, opts, token); err != nil {
@@ -113,18 +131,6 @@ func startOrRestart(ctx context.Context, opts Options, bounce bool) error {
 		verb = "restarted"
 	}
 	say(opts.Stdout, "%s %s: %s\n", verb, UnitName, loopbackURL(opts.Config.Port))
-	return nil
-}
-
-// rewriteUnit refreshes the unit without touching the process, keeping
-// systemd's loaded view in sync on Linux.
-func rewriteUnit(ctx context.Context, unitFile string) error {
-	if err := writeUnit(unitFile); err != nil {
-		return err
-	}
-	if runtime.GOOS == "linux" {
-		return runSupervisor(ctx, "systemctl", "--user", "daemon-reload")
-	}
 	return nil
 }
 
@@ -148,7 +154,9 @@ func Stop(ctx context.Context, opts Options) error {
 			say(opts.Stdout, "%s is not running\n", UnitName)
 			return nil
 		}
-		launchdBootout(ctx)
+		if err := launchdUnload(ctx); err != nil {
+			return err
+		}
 	} else {
 		if err := requireSystemctl(); err != nil {
 			return err
@@ -173,18 +181,25 @@ func Uninstall(ctx context.Context, opts Options) error {
 	if err != nil {
 		return err
 	}
-	if runtime.GOOS == "darwin" {
-		launchdBootout(ctx)
-	} else if requireSystemctl() == nil {
-		// Non-zero here means "not loaded/enabled", an expected state.
-		exitCode(ctx, "systemctl", "--user", "disable", "--now", UnitName)
-	}
 	_, statErr := os.Stat(unitFile)
 	existed := statErr == nil
+	if runtime.GOOS == "darwin" {
+		if err := launchdUnload(ctx); err != nil {
+			return err
+		}
+	} else if existed && requireSystemctl() == nil {
+		// Surfaced, not ignored: proceeding past a failed disable/stop
+		// would remove the unit under a still-running daemon and defeat
+		// uninstall as the total undo. (On an installed unit, disable and
+		// stop are both no-op successes when already disabled/inactive.)
+		if err := runSupervisor(ctx, "systemctl", "--user", "disable", "--now", UnitName); err != nil {
+			return err
+		}
+	}
 	if err := os.Remove(unitFile); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
-	if runtime.GOOS == "linux" && requireSystemctl() == nil {
+	if existed && runtime.GOOS == "linux" && requireSystemctl() == nil {
 		exitCode(ctx, "systemctl", "--user", "daemon-reload")
 	}
 	say(opts.Stdout, "%s", uninstallReport(existed, remainingFiles()))

--- a/internal/service/lifecycle.go
+++ b/internal/service/lifecycle.go
@@ -1,0 +1,250 @@
+package service
+
+// The lifecycle commands: start (registration folded in), restart, stop,
+// uninstall. Start and restart share one path — verify supervisor, one
+// pre-flight port probe, (re)render the unit, start, health-gate — and
+// differ only in whether they bounce a running process.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/jeremytondo/atc/internal/paths"
+)
+
+// Start registers and starts the supervised server; there is no separate
+// install command. Idempotent: a healthy running server is left untouched,
+// though the unit is still re-rendered so it can never go stale.
+func Start(ctx context.Context, opts Options) error {
+	return startOrRestart(ctx, opts, false)
+}
+
+// Restart is the same path as Start — re-render, health gate, same failure
+// diagnostics — but always bounces the process. The remedy for upgrades,
+// config edits, and version skew.
+func Restart(ctx context.Context, opts Options) error {
+	return startOrRestart(ctx, opts, true)
+}
+
+func startOrRestart(ctx context.Context, opts Options, bounce bool) error {
+	if err := supported(); err != nil {
+		return err
+	}
+	if runtime.GOOS == "linux" {
+		if err := requireSystemctl(); err != nil {
+			return err
+		}
+	}
+	unitFile, err := UnitPath()
+	if err != nil {
+		return err
+	}
+	token, err := ensureToken()
+	if err != nil {
+		return err
+	}
+
+	supervised := supervisorRunning(ctx)
+	if !supervised && portAnswering(opts.Config) {
+		// An ATC responder that is not the supervised unit is a stray
+		// foreground `atc server run`.
+		return fmt.Errorf("something is already serving on port %d (a foreground `atc server run`?); stop it first", opts.Config.Port)
+	}
+	if supervised && !bounce && probeOnce(ctx, opts, token).healthy {
+		if err := rewriteUnit(ctx, unitFile); err != nil {
+			return err
+		}
+		say(opts.Stdout, "%s is already running and healthy: %s\n", UnitName, loopbackURL(opts.Config.Port))
+		return nil
+	}
+
+	_, statErr := os.Stat(unitFile)
+	firstRun := errors.Is(statErr, fs.ErrNotExist)
+	if err := writeUnit(unitFile); err != nil {
+		return err
+	}
+	if firstRun {
+		// Consent-after-the-fact (ATC-246 grill decision): no prompt, no
+		// TTY branch — identical interactive or scripted. Honest because
+		// uninstall is one cheap, total undo.
+		say(opts.Stderr, "%s", firstRunNotice(runtime.GOOS, unitFile))
+	}
+
+	if runtime.GOOS == "linux" {
+		if err := runSupervisor(ctx, "systemctl", "--user", "daemon-reload"); err != nil {
+			return err
+		}
+		if err := runSupervisor(ctx, "systemctl", "--user", "enable", UnitName); err != nil {
+			return err
+		}
+		verb := "start"
+		if bounce {
+			verb = "restart"
+		}
+		if err := runSupervisor(ctx, "systemctl", "--user", verb, UnitName); err != nil {
+			return err
+		}
+	} else {
+		// Bootstrap is the only launchd operation that (re)reads the plist,
+		// so every path that (re)starts the process unloads first and
+		// bootstraps the freshly rendered unit. (`kickstart -k` would bounce
+		// the process but leave launchd running the stale configuration —
+		// the healthy-and-untouched case already returned above.)
+		if launchdLoadedDomain(ctx) != "" {
+			launchdUnload(ctx)
+		}
+		// Loading starts it (RunAtLoad).
+		if err := launchdBootstrap(ctx, unitFile); err != nil {
+			return err
+		}
+	}
+
+	if err := awaitHealthy(ctx, opts, token); err != nil {
+		printLastLogs(ctx, opts.Stderr)
+		return err
+	}
+	verb := "started"
+	if bounce {
+		verb = "restarted"
+	}
+	say(opts.Stdout, "%s %s: %s\n", verb, UnitName, loopbackURL(opts.Config.Port))
+	return nil
+}
+
+// rewriteUnit refreshes the unit without touching the process, keeping
+// systemd's loaded view in sync on Linux.
+func rewriteUnit(ctx context.Context, unitFile string) error {
+	if err := writeUnit(unitFile); err != nil {
+		return err
+	}
+	if runtime.GOOS == "linux" {
+		return runSupervisor(ctx, "systemctl", "--user", "daemon-reload")
+	}
+	return nil
+}
+
+// Stop stops the supervised process; "stop" means "until next login" on
+// both platforms — the unit stays installed and enabled. Uninstall is the
+// way out.
+func Stop(ctx context.Context, opts Options) error {
+	if err := supported(); err != nil {
+		return err
+	}
+	unitFile, err := UnitPath()
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(unitFile); errors.Is(err, fs.ErrNotExist) {
+		say(opts.Stdout, "%s is not installed; nothing to stop\n", UnitName)
+		return nil
+	}
+	if runtime.GOOS == "darwin" {
+		if launchdLoadedDomain(ctx) == "" {
+			say(opts.Stdout, "%s is not running\n", UnitName)
+			return nil
+		}
+		launchdBootout(ctx)
+	} else {
+		if err := requireSystemctl(); err != nil {
+			return err
+		}
+		// stop with no disable; already a no-op success on an inactive unit.
+		if err := runSupervisor(ctx, "systemctl", "--user", "stop", UnitName); err != nil {
+			return err
+		}
+	}
+	say(opts.Stdout, "stopped %s (still installed; returns at next login)\n", UnitName)
+	return nil
+}
+
+// Uninstall stops the server and removes the unit — the one total undo for
+// start's registration. No purge: the leftovers are predictable XDG paths,
+// reported so nothing is hidden.
+func Uninstall(ctx context.Context, opts Options) error {
+	if err := supported(); err != nil {
+		return err
+	}
+	unitFile, err := UnitPath()
+	if err != nil {
+		return err
+	}
+	if runtime.GOOS == "darwin" {
+		launchdBootout(ctx)
+	} else if requireSystemctl() == nil {
+		// Non-zero here means "not loaded/enabled", an expected state.
+		exitCode(ctx, "systemctl", "--user", "disable", "--now", UnitName)
+	}
+	_, statErr := os.Stat(unitFile)
+	existed := statErr == nil
+	if err := os.Remove(unitFile); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	if runtime.GOOS == "linux" && requireSystemctl() == nil {
+		exitCode(ctx, "systemctl", "--user", "daemon-reload")
+	}
+	say(opts.Stdout, "%s", uninstallReport(existed, remainingFiles()))
+	return nil
+}
+
+func loopbackURL(port int) string {
+	return fmt.Sprintf("http://127.0.0.1:%d", port)
+}
+
+// firstRunNotice replaces the ATC-246 consent prompt (2026-08-25 grill):
+// printed to stderr when no unit existed before this start.
+func firstRunNotice(goos, unitFile string) string {
+	notice := fmt.Sprintf("registered %s (%s)\n", UnitName, unitFile) +
+		"the server now starts automatically at every login and restarts if it exits\n" +
+		"undo at any time with `atc server uninstall`\n"
+	if goos == "linux" {
+		notice += "headless machines: run `loginctl enable-linger` once so the server outlives logins\n"
+	}
+	return notice
+}
+
+type remainingFile struct{ label, path string }
+
+// remainingFiles lists what uninstall leaves behind, filtered to files that
+// actually exist: config, token, and on macOS the captured log file.
+func remainingFiles() []remainingFile {
+	var files []remainingFile
+	add := func(label string, path string, err error) {
+		if err != nil {
+			return
+		}
+		if _, statErr := os.Stat(path); statErr == nil {
+			files = append(files, remainingFile{label, path})
+		}
+	}
+	configPath, err := paths.ConfigFile()
+	add("config", configPath, err)
+	tokenPath, err := paths.AuthTokenFile()
+	add("token", tokenPath, err)
+	if runtime.GOOS == "darwin" {
+		logPath, err := paths.LogFile()
+		add("logs", logPath, err)
+	}
+	return files
+}
+
+func uninstallReport(existed bool, remaining []remainingFile) string {
+	var b strings.Builder
+	if existed {
+		fmt.Fprintf(&b, "uninstalled %s\n", UnitName)
+	} else {
+		fmt.Fprintf(&b, "%s was not installed; nothing removed\n", UnitName)
+	}
+	if len(remaining) == 0 {
+		return b.String()
+	}
+	b.WriteString("left in place (uninstall never deletes data):\n")
+	for _, f := range remaining {
+		fmt.Fprintf(&b, "  %s: %s\n", f.label, f.path)
+	}
+	return b.String()
+}

--- a/internal/service/lifecycle_test.go
+++ b/internal/service/lifecycle_test.go
@@ -1,0 +1,81 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/jeremytondo/atc/internal/config"
+)
+
+func TestFirstRunNotice(t *testing.T) {
+	linux := firstRunNotice("linux", "/home/ab/.config/systemd/user/atc.server.service")
+	wantLinux := "registered atc.server (/home/ab/.config/systemd/user/atc.server.service)\n" +
+		"the server now starts automatically at every login and restarts if it exits\n" +
+		"undo at any time with `atc server uninstall`\n" +
+		"headless machines: run `loginctl enable-linger` once so the server outlives logins\n"
+	if diff := cmp.Diff(wantLinux, linux); diff != "" {
+		t.Errorf("linux notice mismatch (-want +got):\n%s", diff)
+	}
+
+	darwin := firstRunNotice("darwin", "/Users/ab/Library/LaunchAgents/atc.server.plist")
+	wantDarwin := "registered atc.server (/Users/ab/Library/LaunchAgents/atc.server.plist)\n" +
+		"the server now starts automatically at every login and restarts if it exits\n" +
+		"undo at any time with `atc server uninstall`\n"
+	if diff := cmp.Diff(wantDarwin, darwin); diff != "" {
+		t.Errorf("darwin notice mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestUninstallReport(t *testing.T) {
+	got := uninstallReport(true, []remainingFile{
+		{"config", "/home/ab/.config/atc/config.toml"},
+		{"token", "/home/ab/.local/share/atc/auth-token"},
+	})
+	want := "uninstalled atc.server\n" +
+		"left in place (uninstall never deletes data):\n" +
+		"  config: /home/ab/.config/atc/config.toml\n" +
+		"  token: /home/ab/.local/share/atc/auth-token\n"
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("uninstallReport mismatch (-want +got):\n%s", diff)
+	}
+
+	got = uninstallReport(false, nil)
+	want = "atc.server was not installed; nothing removed\n"
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("empty uninstallReport mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestProbeAddr(t *testing.T) {
+	for name, tc := range map[string]struct {
+		bind string
+		want string
+	}{
+		"loopback":      {"127.0.0.1", "127.0.0.1:7331"},
+		"wildcard v4":   {"0.0.0.0", "127.0.0.1:7331"},
+		"wildcard v6":   {"::", "127.0.0.1:7331"},
+		"specific bind": {"192.168.1.20", "192.168.1.20:7331"},
+	} {
+		got := probeAddr(config.Config{Port: 7331, Bind: tc.bind})
+		if got != tc.want {
+			t.Errorf("%s: probeAddr = %q, want %q", name, got, tc.want)
+		}
+	}
+}
+
+func TestTailLines(t *testing.T) {
+	for name, tc := range map[string]struct {
+		text  string
+		count int
+		want  string
+	}{
+		"shorter than count":  {"a\nb\n", 5, "a\nb"},
+		"trimmed to count":    {"a\nb\nc\nd\n", 2, "c\nd"},
+		"no trailing newline": {"a\nb", 1, "b"},
+	} {
+		if got := tailLines(tc.text, tc.count); got != tc.want {
+			t.Errorf("%s: tailLines = %q, want %q", name, got, tc.want)
+		}
+	}
+}

--- a/internal/service/logs.go
+++ b/internal/service/logs.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+
+	"github.com/jeremytondo/atc/internal/paths"
+)
+
+// Logs shows the supervisor-captured server output: the journal on Linux, a
+// tail of the launchd-redirected log file on macOS.
+func Logs(ctx context.Context, opts Options, follow bool, lines int) error {
+	if err := supported(); err != nil {
+		return err
+	}
+	if runtime.GOOS == "linux" {
+		if _, err := exec.LookPath("journalctl"); err != nil {
+			return errors.New("journalctl not found: no supervisor captures logs on this machine; foreground `atc server run` logs to stderr")
+		}
+		args := []string{"--user", "-u", UnitName, "--no-pager", "-n", strconv.Itoa(lines)}
+		if follow {
+			args = append(args, "-f")
+		}
+		return stream(ctx, opts, "journalctl", args...)
+	}
+	logFile, err := paths.LogFile()
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(logFile); errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("no log file at %s; `atc server start` creates it (foreground `atc server run` logs to stderr)", logFile)
+	}
+	args := []string{"-n", strconv.Itoa(lines)}
+	if follow {
+		args = append(args, "-f")
+	}
+	return stream(ctx, opts, "tail", append(args, logFile)...)
+}
+
+// stream runs a log tool with its output attached to ours; cancellation
+// (^C on --follow) is a clean exit, not an error.
+func stream(ctx context.Context, opts Options, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdout = opts.Stdout
+	cmd.Stderr = opts.Stderr
+	err := cmd.Run()
+	if ctx.Err() != nil {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("%s failed: %w", name, err)
+	}
+	return nil
+}

--- a/internal/service/logs.go
+++ b/internal/service/logs.go
@@ -23,6 +23,16 @@ func Logs(ctx context.Context, opts Options, follow bool, lines int) error {
 		if _, err := exec.LookPath("journalctl"); err != nil {
 			return errors.New("journalctl not found: no supervisor captures logs on this machine; foreground `atc server run` logs to stderr")
 		}
+		// An installed unit is what makes the journal worth consulting; on
+		// a never-supervised machine an empty journal would masquerade as
+		// "no recent output".
+		unitFile, err := UnitPath()
+		if err != nil {
+			return err
+		}
+		if _, err := os.Stat(unitFile); errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("%s is not installed, so no supervised logs exist; foreground `atc server run` logs to stderr", UnitName)
+		}
 		args := []string{"--user", "-u", UnitName, "--no-pager", "-n", strconv.Itoa(lines)}
 		if follow {
 			args = append(args, "-f")

--- a/internal/service/probe.go
+++ b/internal/service/probe.go
@@ -1,0 +1,146 @@
+package service
+
+// Health probing: GET /v1/health is the source of truth for liveness. The
+// server version rides the Atc-Server-Version header on every response,
+// 401s included, so liveness and version detection never require a valid
+// token even though health itself does.
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jeremytondo/atc/internal/authtoken"
+	"github.com/jeremytondo/atc/internal/config"
+	"github.com/jeremytondo/atc/internal/paths"
+	"github.com/jeremytondo/atc/internal/server"
+)
+
+// Health-gate contract (ATC-260, carried from legacy): 15s total, 150ms
+// interval, 1s per probe.
+const (
+	healthGateTimeout  = 15 * time.Second
+	healthGateInterval = 150 * time.Millisecond
+	probeTimeout       = time.Second
+)
+
+type probeOutcome struct {
+	responding    bool // any HTTP response at all
+	healthy       bool // authenticated 200
+	unauthorized  bool
+	serverVersion string
+}
+
+func probeOnce(ctx context.Context, opts Options, token string) probeOutcome {
+	url := "http://" + probeAddr(opts.Config) + "/v1/health"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return probeOutcome{}
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	req.Header.Set(server.ClientVersionHeader, opts.Version)
+	client := &http.Client{Timeout: probeTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return probeOutcome{}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return probeOutcome{
+		responding:    true,
+		healthy:       resp.StatusCode == http.StatusOK,
+		unauthorized:  resp.StatusCode == http.StatusUnauthorized,
+		serverVersion: resp.Header.Get(server.ServerVersionHeader),
+	}
+}
+
+// awaitHealthy gates start/restart success on the daemon answering
+// /v1/health with the local token.
+func awaitHealthy(ctx context.Context, opts Options, token string) error {
+	deadline := time.Now().Add(healthGateTimeout)
+	for {
+		if probeOnce(ctx, opts, token).healthy {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("the server did not become healthy within %s", healthGateTimeout)
+		}
+		select {
+		case <-time.After(healthGateInterval):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// portAnswering is the pre-flight conflict check before starting an
+// unsupervised port: anything accepting a TCP connection there means
+// something else is already serving.
+func portAnswering(cfg config.Config) bool {
+	conn, err := net.DialTimeout("tcp", probeAddr(cfg), probeTimeout)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// ensureToken mints the credential when absent so the health gate can
+// authenticate on a fresh install — the same token the daemon will enforce.
+func ensureToken() (string, error) {
+	tokenPath, err := paths.AuthTokenFile()
+	if err != nil {
+		return "", err
+	}
+	return (&authtoken.Store{Path: tokenPath}).Ensure()
+}
+
+// printLastLogs shows the daemon's most recent output after a health-gate
+// failure — diagnose, don't guess. Journal on Linux, the launchd-captured
+// file on macOS.
+func printLastLogs(ctx context.Context, stderr io.Writer) {
+	if logs := lastLogLines(ctx, 15); logs != "" {
+		say(stderr, "last server log lines:\n%s\n", logs)
+	} else {
+		say(stderr, "no server logs were found; try `atc server logs`\n")
+	}
+}
+
+func lastLogLines(ctx context.Context, count int) string {
+	if runtime.GOOS == "linux" {
+		out, err := exec.CommandContext(ctx, "journalctl",
+			"--user", "-u", UnitName, "-n", strconv.Itoa(count), "--no-pager").Output()
+		if err != nil {
+			return ""
+		}
+		return strings.TrimSpace(string(out))
+	}
+	logFile, err := paths.LogFile()
+	if err != nil {
+		return ""
+	}
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		return ""
+	}
+	return tailLines(string(data), count)
+}
+
+// tailLines keeps the last count lines of text.
+func tailLines(text string, count int) string {
+	lines := strings.Split(strings.TrimRight(text, "\n"), "\n")
+	if len(lines) > count {
+		lines = lines[len(lines)-count:]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -44,7 +44,9 @@ const UnitName = "atc.server"
 // file and default layers only — the supervised daemon runs with a minimal
 // environment where ATC_* variables do not exist, so probing a port taken
 // from the invoking shell's environment would target a server that will
-// never serve it.
+// never serve it. Stop, Logs, and Uninstall never consume Config; their
+// callers leave it zero so a broken config.toml cannot block diagnostics,
+// stopping, or the total undo.
 type Options struct {
 	Config config.Config
 	// Version is the client build identity, for skew reporting.
@@ -140,28 +142,38 @@ func launchdBootstrap(ctx context.Context, unitFile string) error {
 	return runSupervisor(ctx, "launchctl", "bootstrap", domains[len(domains)-1], unitFile)
 }
 
-// launchdBootout unloads the agent from every domain; failures mean "not
-// loaded there", an expected state.
-func launchdBootout(ctx context.Context) {
+// launchdUnload boots the agent out of every domain it is loaded in and
+// confirms launchd forgot the label — bootstrapping again while the old
+// instance is still winding down fails, and reporting "stopped" while the
+// job survives would be a lie. Success is judged by observation (the label
+// gone from every domain) rather than bootout's exit status alone; a label
+// still loaded at the deadline is a failure carrying the supervisor's own
+// diagnostic. Domains proven absent are skipped, not "ignored on error".
+func launchdUnload(ctx context.Context) error {
+	var bootoutErr error
 	for _, domain := range launchdDomains() {
-		exitCode(ctx, "launchctl", "bootout", domain+"/"+UnitName)
+		if exitCode(ctx, "launchctl", "print", domain+"/"+UnitName) != 0 {
+			continue // not loaded there
+		}
+		if err := runSupervisor(ctx, "launchctl", "bootout", domain+"/"+UnitName); err != nil {
+			bootoutErr = err
+		}
 	}
-}
-
-// launchdUnload boots the agent out of every domain and waits until launchd
-// forgets the label — bootstrapping again while the old instance is still
-// winding down fails. On timeout it returns anyway and lets the bootstrap's
-// own error surface.
-func launchdUnload(ctx context.Context) {
-	launchdBootout(ctx)
 	deadline := time.Now().Add(5 * time.Second)
-	for launchdLoadedDomain(ctx) != "" && time.Now().Before(deadline) {
+	for launchdLoadedDomain(ctx) != "" {
+		if time.Now().After(deadline) {
+			if bootoutErr != nil {
+				return fmt.Errorf("%s is still loaded: %w", UnitName, bootoutErr)
+			}
+			return fmt.Errorf("%s is still loaded after bootout", UnitName)
+		}
 		select {
 		case <-time.After(100 * time.Millisecond):
 		case <-ctx.Done():
-			return
+			return ctx.Err()
 		}
 	}
+	return nil
 }
 
 // supervisorRunning reports whether the supervised daemon is under active

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,0 +1,188 @@
+// Package service manages the supervised ATC server (ATC-260, the ATC-246
+// lifecycle family on the ATC-259 chassis): a user-scope launchd
+// LaunchAgent on macOS, a systemd user unit on Linux. Supervisor-only —
+// there is no pidfile family. The unit execs `atc server run`, keeping the
+// daemon structurally unable to call back into the supervisor.
+//
+// Registration is folded into start: every start re-renders the unit from
+// os.Executable() and the installing shell's PATH, so the unit can never go
+// stale — upgrades are `atc server restart`. Hand-editing the generated
+// unit is unsupported for the same reason.
+//
+// Logging is supervisor-owned: the server writes logfmt lines to stderr
+// only. systemd's journal captures them on Linux; on macOS the LaunchAgent
+// redirects both streams to the state-dir log file (launchd has no
+// journal).
+//
+// Boundaries (deliberate): unit rendering and message formatting are pure
+// and fully tested; launchctl/systemctl/journalctl invocations stay thin
+// and untested.
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jeremytondo/atc/internal/config"
+)
+
+// UnitName is the launchd label / systemd unit name, and the unit file
+// basename (legacy convention, tag legacy-product-2026-08).
+const UnitName = "atc.server"
+
+// Options carries what every lifecycle command needs. Config must hold the
+// file and default layers only — the supervised daemon runs with a minimal
+// environment where ATC_* variables do not exist, so probing a port taken
+// from the invoking shell's environment would target a server that will
+// never serve it.
+type Options struct {
+	Config config.Config
+	// Version is the client build identity, for skew reporting.
+	Version string
+	Stdout  io.Writer
+	Stderr  io.Writer
+}
+
+// ExitError requests a specific process exit code after the command already
+// reported its state on stdout; main exits with Code without printing more.
+type ExitError struct{ Code int }
+
+func (e *ExitError) Error() string { return fmt.Sprintf("exit code %d", e.Code) }
+
+// say writes a user-facing message; a failed write to the user's own
+// terminal has no better remedy than the message it would have carried.
+func say(w io.Writer, format string, args ...any) {
+	_, _ = fmt.Fprintf(w, format, args...)
+}
+
+func supported() error {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		return fmt.Errorf("unsupported platform %s (launchd on macOS, systemd user units on Linux)", runtime.GOOS)
+	}
+	return nil
+}
+
+// requireSystemctl is the Linux pre-flight: without a systemd user manager
+// there is no supervisor family at all, only the foreground primitive.
+func requireSystemctl() error {
+	if _, err := exec.LookPath("systemctl"); err != nil {
+		return fmt.Errorf("systemctl not found: this machine cannot supervise the server; run `atc server run` in the foreground instead")
+	}
+	return nil
+}
+
+// runSupervisor executes one supervisor command; a failure surfaces the
+// tool's own stderr as one diagnostic (thin and untested by design).
+func runSupervisor(ctx context.Context, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if detail := strings.TrimSpace(stderr.String()); detail != "" {
+			return fmt.Errorf("%s %s failed: %s", name, strings.Join(args, " "), detail)
+		}
+		return fmt.Errorf("%s %s failed: %w", name, strings.Join(args, " "), err)
+	}
+	return nil
+}
+
+// exitCode runs a command whose non-zero exit is an expected state, not a
+// failure; -1 means the command could not run at all.
+func exitCode(ctx context.Context, name string, args ...string) int {
+	cmd := exec.CommandContext(ctx, name, args...)
+	if err := cmd.Run(); err != nil {
+		var exit *exec.ExitError
+		if errors.As(err, &exit) {
+			return exit.ExitCode()
+		}
+		return -1
+	}
+	return 0
+}
+
+// launchdDomains lists the domains an agent may live in: gui first (normal
+// console login), user as the ssh/headless fallback — the gui domain does
+// not exist without an Aqua session.
+func launchdDomains() []string {
+	uid := os.Getuid()
+	return []string{fmt.Sprintf("gui/%d", uid), fmt.Sprintf("user/%d", uid)}
+}
+
+// launchdLoadedDomain is the domain the agent is currently loaded in, or "".
+func launchdLoadedDomain(ctx context.Context) string {
+	for _, domain := range launchdDomains() {
+		if exitCode(ctx, "launchctl", "print", domain+"/"+UnitName) == 0 {
+			return domain
+		}
+	}
+	return ""
+}
+
+// launchdBootstrap loads the unit into the first domain that accepts it,
+// surfacing only the last domain's failure.
+func launchdBootstrap(ctx context.Context, unitFile string) error {
+	domains := launchdDomains()
+	for _, domain := range domains[:len(domains)-1] {
+		if exitCode(ctx, "launchctl", "bootstrap", domain, unitFile) == 0 {
+			return nil
+		}
+	}
+	return runSupervisor(ctx, "launchctl", "bootstrap", domains[len(domains)-1], unitFile)
+}
+
+// launchdBootout unloads the agent from every domain; failures mean "not
+// loaded there", an expected state.
+func launchdBootout(ctx context.Context) {
+	for _, domain := range launchdDomains() {
+		exitCode(ctx, "launchctl", "bootout", domain+"/"+UnitName)
+	}
+}
+
+// launchdUnload boots the agent out of every domain and waits until launchd
+// forgets the label — bootstrapping again while the old instance is still
+// winding down fails. On timeout it returns anyway and lets the bootstrap's
+// own error surface.
+func launchdUnload(ctx context.Context) {
+	launchdBootout(ctx)
+	deadline := time.Now().Add(5 * time.Second)
+	for launchdLoadedDomain(ctx) != "" && time.Now().Before(deadline) {
+		select {
+		case <-time.After(100 * time.Millisecond):
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// supervisorRunning reports whether the supervised daemon is under active
+// management: unit loaded on macOS (KeepAlive keeps a loaded agent's
+// process alive), unit active on Linux.
+func supervisorRunning(ctx context.Context) bool {
+	if runtime.GOOS == "darwin" {
+		return launchdLoadedDomain(ctx) != ""
+	}
+	return exitCode(ctx, "systemctl", "--user", "is-active", "--quiet", UnitName) == 0
+}
+
+// probeAddr is where a local client reaches the server: the bind address,
+// with wildcard binds reached via loopback.
+func probeAddr(cfg config.Config) string {
+	return net.JoinHostPort(probeHost(cfg.Bind), strconv.Itoa(cfg.Port))
+}
+
+func probeHost(bind string) string {
+	if ip := net.ParseIP(bind); ip != nil && ip.IsUnspecified() {
+		return "127.0.0.1"
+	}
+	return bind
+}

--- a/internal/service/status.go
+++ b/internal/service/status.go
@@ -1,0 +1,182 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/jeremytondo/atc/internal/config"
+	"github.com/jeremytondo/atc/internal/tailscale"
+)
+
+// Status reports liveness (the health probe is the source of truth), unit
+// state as supplementary, client and server versions with skew flagged, and
+// ready-to-paste API URLs. Exit codes: 0 healthy, 1 installed but not
+// responding, 2 not installed.
+func Status(ctx context.Context, opts Options) error {
+	if err := supported(); err != nil {
+		return err
+	}
+	unitFile, err := UnitPath()
+	if err != nil {
+		return err
+	}
+	token, err := ensureToken()
+	if err != nil {
+		return err
+	}
+	probe := probeOnce(ctx, opts, token)
+
+	info := statusInfo{
+		unitFile:      unitFile,
+		responding:    probe.responding,
+		healthy:       probe.healthy,
+		unauthorized:  probe.unauthorized,
+		clientVersion: opts.Version,
+		serverVersion: probe.serverVersion,
+		port:          opts.Config.Port,
+		bind:          opts.Config.Bind,
+		tailscale:     opts.Config.Tailscale,
+	}
+	if _, statErr := os.Stat(unitFile); statErr == nil {
+		info.installed = true
+		info.supervisor = supervisorState(ctx)
+	}
+	if hostname, hostErr := os.Hostname(); hostErr == nil {
+		info.hostname = hostname
+	}
+	if opts.Config.Tailscale {
+		info.tailnetDNS, info.tailnetProblem = tailnetDNS(ctx, opts.Config)
+	}
+
+	report, code := renderStatus(info)
+	say(opts.Stdout, "%s", report)
+	if code != 0 {
+		return &ExitError{Code: code}
+	}
+	return nil
+}
+
+// supervisorState is the supplementary unit-state string shown next to the
+// unit path (thin supervisor queries, untested by design).
+func supervisorState(ctx context.Context) string {
+	if runtime.GOOS == "darwin" {
+		if domain := launchdLoadedDomain(ctx); domain != "" {
+			return "loaded in " + domain
+		}
+		return "not loaded"
+	}
+	if requireSystemctl() != nil {
+		return "systemctl unavailable"
+	}
+	// is-active prints the state and exits non-zero for anything but
+	// "active" — the printed word is the interesting part either way.
+	out, _ := exec.CommandContext(ctx, "systemctl", "--user", "is-active", UnitName).Output()
+	if state := strings.TrimSpace(string(out)); state != "" {
+		return state
+	}
+	return "unknown"
+}
+
+func tailnetDNS(ctx context.Context, cfg config.Config) (dns, problem string) {
+	executable, err := tailscale.ResolveExecutable(cfg.TailscaleExecutable)
+	if err != nil {
+		return "", err.Error()
+	}
+	dns, err = tailscale.DNSName(ctx, executable)
+	if err != nil {
+		return "", err.Error()
+	}
+	return dns, ""
+}
+
+type statusInfo struct {
+	installed      bool
+	unitFile       string
+	supervisor     string // supplementary unit state; "" when not installed
+	responding     bool
+	healthy        bool
+	unauthorized   bool
+	clientVersion  string
+	serverVersion  string // "" when no response carried one
+	port           int
+	bind           string
+	hostname       string
+	tailscale      bool
+	tailnetDNS     string
+	tailnetProblem string
+}
+
+// renderStatus formats the report and picks the exit code. Pure and fully
+// tested; the headline states liveness first, everything else supports it.
+func renderStatus(s statusInfo) (string, int) {
+	var b strings.Builder
+	code := 0
+	switch {
+	case s.healthy && s.installed:
+		fmt.Fprintf(&b, "%s: running and healthy\n", UnitName)
+	case s.healthy:
+		fmt.Fprintf(&b, "%s: healthy, but not installed — likely a foreground `atc server run`\n", UnitName)
+	case !s.installed:
+		code = 2
+		fmt.Fprintf(&b, "%s: not installed; `atc server start` registers and starts it\n", UnitName)
+	case s.unauthorized:
+		code = 1
+		fmt.Fprintf(&b, "%s: responding but rejected the local token; `atc server restart`, then `atc server token rotate` if it persists\n", UnitName)
+	case s.responding:
+		code = 1
+		fmt.Fprintf(&b, "%s: responding but unhealthy; try `atc server logs`\n", UnitName)
+	default:
+		code = 1
+		fmt.Fprintf(&b, "%s: installed but not responding; try `atc server logs` or `atc server restart`\n", UnitName)
+	}
+	if s.installed {
+		fmt.Fprintf(&b, "  unit: %s (%s)\n", s.unitFile, s.supervisor)
+	}
+	fmt.Fprintf(&b, "  client: %s\n", s.clientVersion)
+	switch {
+	case s.serverVersion == "" && !s.responding:
+		b.WriteString("  server: unknown (not responding)\n")
+	case s.serverVersion == "":
+		b.WriteString("  server: unknown\n")
+	case s.serverVersion != s.clientVersion:
+		fmt.Fprintf(&b, "  server: %s — differs from client %s; `atc server restart` updates it\n", s.serverVersion, s.clientVersion)
+	default:
+		fmt.Fprintf(&b, "  server: %s\n", s.serverVersion)
+	}
+	for _, url := range apiURLs(s) {
+		fmt.Fprintf(&b, "  %s\n", url)
+	}
+	b.WriteString("  token: `atc server token` prints the bearer token remote clients use\n")
+	return b.String(), code
+}
+
+// apiURLs builds the ready-to-paste URLs the configuration serves: loopback
+// always, a LAN form when bound wider, the tailnet URL when exposure is on.
+func apiURLs(s statusInfo) []string {
+	urls := []string{fmt.Sprintf("api: http://127.0.0.1:%d", s.port)}
+	ip := net.ParseIP(s.bind)
+	loopback := s.bind == "localhost" || (ip != nil && ip.IsLoopback())
+	if !loopback {
+		host := s.bind
+		if ip != nil && ip.IsUnspecified() {
+			host = s.hostname
+		}
+		if host != "" {
+			urls = append(urls, "api (lan): http://"+net.JoinHostPort(host, strconv.Itoa(s.port)))
+		}
+	}
+	if s.tailscale {
+		if s.tailnetDNS != "" {
+			urls = append(urls, fmt.Sprintf("api (tailnet): https://%s:%d", s.tailnetDNS, s.port))
+		} else {
+			urls = append(urls, fmt.Sprintf("api (tailnet): unavailable (%s)", s.tailnetProblem))
+		}
+	}
+	return urls
+}

--- a/internal/service/status_test.go
+++ b/internal/service/status_test.go
@@ -1,0 +1,177 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// healthyInfo is the baseline every case mutates: installed, supervised,
+// healthy, versions in agreement, loopback-only bind.
+func healthyInfo() statusInfo {
+	return statusInfo{
+		installed:     true,
+		unitFile:      "/home/ab/.config/systemd/user/atc.server.service",
+		supervisor:    "active",
+		responding:    true,
+		healthy:       true,
+		clientVersion: "v1.2.3",
+		serverVersion: "v1.2.3",
+		port:          7331,
+		bind:          "127.0.0.1",
+		hostname:      "workstation",
+	}
+}
+
+func TestRenderStatus(t *testing.T) {
+	for name, tc := range map[string]struct {
+		info     func() statusInfo
+		want     string
+		wantCode int
+	}{
+		"healthy": {
+			info: healthyInfo,
+			want: "atc.server: running and healthy\n" +
+				"  unit: /home/ab/.config/systemd/user/atc.server.service (active)\n" +
+				"  client: v1.2.3\n" +
+				"  server: v1.2.3\n" +
+				"  api: http://127.0.0.1:7331\n" +
+				"  token: `atc server token` prints the bearer token remote clients use\n",
+			wantCode: 0,
+		},
+		"version skew flags a restart": {
+			info: func() statusInfo {
+				s := healthyInfo()
+				s.serverVersion = "v1.2.2"
+				return s
+			},
+			want: "atc.server: running and healthy\n" +
+				"  unit: /home/ab/.config/systemd/user/atc.server.service (active)\n" +
+				"  client: v1.2.3\n" +
+				"  server: v1.2.2 — differs from client v1.2.3; `atc server restart` updates it\n" +
+				"  api: http://127.0.0.1:7331\n" +
+				"  token: `atc server token` prints the bearer token remote clients use\n",
+			wantCode: 0,
+		},
+		"installed but not responding": {
+			info: func() statusInfo {
+				s := healthyInfo()
+				s.responding = false
+				s.healthy = false
+				s.serverVersion = ""
+				s.supervisor = "failed"
+				return s
+			},
+			want: "atc.server: installed but not responding; try `atc server logs` or `atc server restart`\n" +
+				"  unit: /home/ab/.config/systemd/user/atc.server.service (failed)\n" +
+				"  client: v1.2.3\n" +
+				"  server: unknown (not responding)\n" +
+				"  api: http://127.0.0.1:7331\n" +
+				"  token: `atc server token` prints the bearer token remote clients use\n",
+			wantCode: 1,
+		},
+		"not installed": {
+			info: func() statusInfo {
+				s := healthyInfo()
+				s.installed = false
+				s.supervisor = ""
+				s.responding = false
+				s.healthy = false
+				s.serverVersion = ""
+				return s
+			},
+			want: "atc.server: not installed; `atc server start` registers and starts it\n" +
+				"  client: v1.2.3\n" +
+				"  server: unknown (not responding)\n" +
+				"  api: http://127.0.0.1:7331\n" +
+				"  token: `atc server token` prints the bearer token remote clients use\n",
+			wantCode: 2,
+		},
+		"healthy foreground server without a unit": {
+			info: func() statusInfo {
+				s := healthyInfo()
+				s.installed = false
+				s.supervisor = ""
+				return s
+			},
+			want: "atc.server: healthy, but not installed — likely a foreground `atc server run`\n" +
+				"  client: v1.2.3\n" +
+				"  server: v1.2.3\n" +
+				"  api: http://127.0.0.1:7331\n" +
+				"  token: `atc server token` prints the bearer token remote clients use\n",
+			wantCode: 0,
+		},
+		"responding but rejecting the token": {
+			info: func() statusInfo {
+				s := healthyInfo()
+				s.healthy = false
+				s.unauthorized = true
+				return s
+			},
+			want: "atc.server: responding but rejected the local token; `atc server restart`, then `atc server token rotate` if it persists\n" +
+				"  unit: /home/ab/.config/systemd/user/atc.server.service (active)\n" +
+				"  client: v1.2.3\n" +
+				"  server: v1.2.3\n" +
+				"  api: http://127.0.0.1:7331\n" +
+				"  token: `atc server token` prints the bearer token remote clients use\n",
+			wantCode: 1,
+		},
+		"wildcard bind adds the LAN url and tailnet url": {
+			info: func() statusInfo {
+				s := healthyInfo()
+				s.bind = "0.0.0.0"
+				s.tailscale = true
+				s.tailnetDNS = "machine.tail1234.ts.net"
+				return s
+			},
+			want: "atc.server: running and healthy\n" +
+				"  unit: /home/ab/.config/systemd/user/atc.server.service (active)\n" +
+				"  client: v1.2.3\n" +
+				"  server: v1.2.3\n" +
+				"  api: http://127.0.0.1:7331\n" +
+				"  api (lan): http://workstation:7331\n" +
+				"  api (tailnet): https://machine.tail1234.ts.net:7331\n" +
+				"  token: `atc server token` prints the bearer token remote clients use\n",
+			wantCode: 0,
+		},
+		"specific bind address is the LAN host": {
+			info: func() statusInfo {
+				s := healthyInfo()
+				s.bind = "192.168.1.20"
+				return s
+			},
+			want: "atc.server: running and healthy\n" +
+				"  unit: /home/ab/.config/systemd/user/atc.server.service (active)\n" +
+				"  client: v1.2.3\n" +
+				"  server: v1.2.3\n" +
+				"  api: http://127.0.0.1:7331\n" +
+				"  api (lan): http://192.168.1.20:7331\n" +
+				"  token: `atc server token` prints the bearer token remote clients use\n",
+			wantCode: 0,
+		},
+		"tailnet exposure unavailable states why": {
+			info: func() statusInfo {
+				s := healthyInfo()
+				s.tailscale = true
+				s.tailnetProblem = "tailscale is logged out (BackendState NeedsLogin)"
+				return s
+			},
+			want: "atc.server: running and healthy\n" +
+				"  unit: /home/ab/.config/systemd/user/atc.server.service (active)\n" +
+				"  client: v1.2.3\n" +
+				"  server: v1.2.3\n" +
+				"  api: http://127.0.0.1:7331\n" +
+				"  api (tailnet): unavailable (tailscale is logged out (BackendState NeedsLogin))\n" +
+				"  token: `atc server token` prints the bearer token remote clients use\n",
+			wantCode: 0,
+		},
+	} {
+		got, code := renderStatus(tc.info())
+		if diff := cmp.Diff(tc.want, got); diff != "" {
+			t.Errorf("%s: renderStatus mismatch (-want +got):\n%s", name, diff)
+		}
+		if code != tc.wantCode {
+			t.Errorf("%s: exit code = %d, want %d", name, code, tc.wantCode)
+		}
+	}
+}

--- a/internal/service/unit.go
+++ b/internal/service/unit.go
@@ -25,13 +25,38 @@ func unitArgs(executable string) []string {
 
 var xmlEscaper = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", `"`, "&quot;")
 
+// unitEnv is the environment stamped into the unit as ordered name/value
+// pairs. Supervisors start services with a minimal environment, so the unit
+// carries the installing shell's PATH (without it the daemon could not
+// resolve the tools it shells out to) plus any XDG overrides that move the
+// paths package: the daemon must resolve the same config, token, and state
+// files as the CLI that installed and health-gated it.
+func unitEnv() [][2]string {
+	pathEnv := os.Getenv("PATH")
+	if pathEnv == "" {
+		pathEnv = "/usr/local/bin:/usr/bin:/bin"
+	}
+	env := [][2]string{{"PATH", pathEnv}}
+	for _, name := range []string{"XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME"} {
+		if value := os.Getenv(name); value != "" {
+			env = append(env, [2]string{name, value})
+		}
+	}
+	return env
+}
+
 // launchAgentPlist renders the macOS unit. KeepAlive relaunches the server
 // whenever it exits; launchd redirects both streams to logFile because it
 // has no journal.
-func launchAgentPlist(args []string, logFile, pathEnv string) string {
+func launchAgentPlist(args []string, logFile string, env [][2]string) string {
 	var lines strings.Builder
 	for _, arg := range args {
 		fmt.Fprintf(&lines, "    <string>%s</string>\n", xmlEscaper.Replace(arg))
+	}
+	var envLines strings.Builder
+	for _, pair := range env {
+		fmt.Fprintf(&envLines, "    <key>%s</key>\n    <string>%s</string>\n",
+			xmlEscaper.Replace(pair[0]), xmlEscaper.Replace(pair[1]))
 	}
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -44,9 +69,7 @@ func launchAgentPlist(args []string, logFile, pathEnv string) string {
 %s  </array>
   <key>EnvironmentVariables</key>
   <dict>
-    <key>PATH</key>
-    <string>%s</string>
-  </dict>
+%s  </dict>
   <key>RunAtLoad</key>
   <true/>
   <key>KeepAlive</key>
@@ -57,7 +80,7 @@ func launchAgentPlist(args []string, logFile, pathEnv string) string {
   <string>%s</string>
 </dict>
 </plist>
-`, UnitName, lines.String(), xmlEscaper.Replace(pathEnv),
+`, UnitName, lines.String(), envLines.String(),
 		xmlEscaper.Replace(logFile), xmlEscaper.Replace(logFile))
 }
 
@@ -68,10 +91,14 @@ var unitValueEscaper = strings.NewReplacer(`\`, `\\`, `"`, `\"`, "%", "%%")
 
 // systemdUnit renders the Linux unit: Restart=always with backoff, output
 // left to the journal's default capture (no log file of our own).
-func systemdUnit(args []string, pathEnv string) string {
+func systemdUnit(args []string, env [][2]string) string {
 	quoted := make([]string, len(args))
 	for i, arg := range args {
 		quoted[i] = `"` + unitValueEscaper.Replace(arg) + `"`
+	}
+	var envLines strings.Builder
+	for _, pair := range env {
+		fmt.Fprintf(&envLines, "Environment=\"%s=%s\"\n", pair[0], unitValueEscaper.Replace(pair[1]))
 	}
 	return fmt.Sprintf(`[Unit]
 Description=ATC server
@@ -79,13 +106,12 @@ Description=ATC server
 [Service]
 Type=simple
 ExecStart=%s
-Environment="PATH=%s"
-Restart=always
+%sRestart=always
 RestartSec=5
 
 [Install]
 WantedBy=default.target
-`, strings.Join(quoted, " "), unitValueEscaper.Replace(pathEnv))
+`, strings.Join(quoted, " "), envLines.String())
 }
 
 // UnitPath is where this platform's unit file lives: the LaunchAgents
@@ -110,30 +136,35 @@ func unitPath(goos, xdgConfigHome, home string) string {
 	return filepath.Join(configHome, "systemd", "user", UnitName+".service")
 }
 
-// writeUnit renders and installs the unit for this platform. Every start
-// runs it, so the unit always reflects the current binary and PATH.
-func writeUnit(unitFile string) error {
+// renderUnit produces the unit content for this platform from the current
+// binary and environment. Start compares it against the installed file to
+// decide whether the running daemon must be bounced onto it.
+func renderUnit() (string, error) {
 	executable, err := os.Executable()
 	if err != nil {
-		return err
+		return "", err
 	}
-	pathEnv := os.Getenv("PATH")
-	if pathEnv == "" {
-		pathEnv = "/usr/local/bin:/usr/bin:/bin"
+	if runtime.GOOS == "darwin" {
+		logFile, err := paths.LogFile()
+		if err != nil {
+			return "", err
+		}
+		return launchAgentPlist(unitArgs(executable), logFile, unitEnv()), nil
 	}
-	var content string
+	return systemdUnit(unitArgs(executable), unitEnv()), nil
+}
+
+// writeUnit installs rendered unit content, creating the directories the
+// unit depends on (launchd creates its log file, but not the directory).
+func writeUnit(unitFile, content string) error {
 	if runtime.GOOS == "darwin" {
 		logFile, err := paths.LogFile()
 		if err != nil {
 			return err
 		}
-		// launchd creates the log file itself, but not its directory.
 		if err := os.MkdirAll(filepath.Dir(logFile), 0o700); err != nil {
 			return err
 		}
-		content = launchAgentPlist(unitArgs(executable), logFile, pathEnv)
-	} else {
-		content = systemdUnit(unitArgs(executable), pathEnv)
 	}
 	if err := os.MkdirAll(filepath.Dir(unitFile), 0o755); err != nil {
 		return err

--- a/internal/service/unit.go
+++ b/internal/service/unit.go
@@ -1,0 +1,142 @@
+package service
+
+// Unit rendering and placement: pure functions plus the one writer that
+// stamps them onto disk. The rendered unit execs `atc server run` via the
+// absolute binary path from os.Executable(); the installing shell's PATH is
+// the only environment stamped in — supervisors start services with a
+// minimal environment, and without PATH the daemon could not resolve the
+// tools it shells out to. Everything else belongs in config.toml.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/jeremytondo/atc/internal/paths"
+)
+
+// unitArgs is the exec line the supervisor runs. os.Executable(), no dev
+// special case: registering a `go run` binary is unsupported and undetected.
+func unitArgs(executable string) []string {
+	return []string{executable, "server", "run"}
+}
+
+var xmlEscaper = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", `"`, "&quot;")
+
+// launchAgentPlist renders the macOS unit. KeepAlive relaunches the server
+// whenever it exits; launchd redirects both streams to logFile because it
+// has no journal.
+func launchAgentPlist(args []string, logFile, pathEnv string) string {
+	var lines strings.Builder
+	for _, arg := range args {
+		fmt.Fprintf(&lines, "    <string>%s</string>\n", xmlEscaper.Replace(arg))
+	}
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>%s</string>
+  <key>ProgramArguments</key>
+  <array>
+%s  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>%s</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>%s</string>
+  <key>StandardErrorPath</key>
+  <string>%s</string>
+</dict>
+</plist>
+`, UnitName, lines.String(), xmlEscaper.Replace(pathEnv),
+		xmlEscaper.Replace(logFile), xmlEscaper.Replace(logFile))
+}
+
+// unitValueEscaper escapes a double-quoted systemd unit value: unit files
+// C-unescape inside double quotes and expand % specifiers everywhere, so
+// both need escaping along with the quotes themselves.
+var unitValueEscaper = strings.NewReplacer(`\`, `\\`, `"`, `\"`, "%", "%%")
+
+// systemdUnit renders the Linux unit: Restart=always with backoff, output
+// left to the journal's default capture (no log file of our own).
+func systemdUnit(args []string, pathEnv string) string {
+	quoted := make([]string, len(args))
+	for i, arg := range args {
+		quoted[i] = `"` + unitValueEscaper.Replace(arg) + `"`
+	}
+	return fmt.Sprintf(`[Unit]
+Description=ATC server
+
+[Service]
+Type=simple
+ExecStart=%s
+Environment="PATH=%s"
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+`, strings.Join(quoted, " "), unitValueEscaper.Replace(pathEnv))
+}
+
+// UnitPath is where this platform's unit file lives: the LaunchAgents
+// folder on macOS, systemd's own user-unit config home on Linux (systemd's
+// convention, not an atc path — hence the direct XDG_CONFIG_HOME read).
+func UnitPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return unitPath(runtime.GOOS, os.Getenv("XDG_CONFIG_HOME"), home), nil
+}
+
+func unitPath(goos, xdgConfigHome, home string) string {
+	if goos == "darwin" {
+		return filepath.Join(home, "Library", "LaunchAgents", UnitName+".plist")
+	}
+	configHome := xdgConfigHome
+	if configHome == "" {
+		configHome = filepath.Join(home, ".config")
+	}
+	return filepath.Join(configHome, "systemd", "user", UnitName+".service")
+}
+
+// writeUnit renders and installs the unit for this platform. Every start
+// runs it, so the unit always reflects the current binary and PATH.
+func writeUnit(unitFile string) error {
+	executable, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	pathEnv := os.Getenv("PATH")
+	if pathEnv == "" {
+		pathEnv = "/usr/local/bin:/usr/bin:/bin"
+	}
+	var content string
+	if runtime.GOOS == "darwin" {
+		logFile, err := paths.LogFile()
+		if err != nil {
+			return err
+		}
+		// launchd creates the log file itself, but not its directory.
+		if err := os.MkdirAll(filepath.Dir(logFile), 0o700); err != nil {
+			return err
+		}
+		content = launchAgentPlist(unitArgs(executable), logFile, pathEnv)
+	} else {
+		content = systemdUnit(unitArgs(executable), pathEnv)
+	}
+	if err := os.MkdirAll(filepath.Dir(unitFile), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(unitFile, []byte(content), 0o644)
+}

--- a/internal/service/unit_test.go
+++ b/internal/service/unit_test.go
@@ -10,7 +10,10 @@ func TestLaunchAgentPlist(t *testing.T) {
 	got := launchAgentPlist(
 		[]string{`/Users/a b/bin/atc<&>"`, "server", "run"},
 		"/Users/ab/.local/state/atc/atc.log",
-		`/usr/local/bin:/odd"<path>&`,
+		[][2]string{
+			{"PATH", `/usr/local/bin:/odd"<path>&`},
+			{"XDG_STATE_HOME", "/Users/ab/state"},
+		},
 	)
 	want := `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -28,6 +31,8 @@ func TestLaunchAgentPlist(t *testing.T) {
   <dict>
     <key>PATH</key>
     <string>/usr/local/bin:/odd&quot;&lt;path&gt;&amp;</string>
+    <key>XDG_STATE_HOME</key>
+    <string>/Users/ab/state</string>
   </dict>
   <key>RunAtLoad</key>
   <true/>
@@ -48,7 +53,10 @@ func TestLaunchAgentPlist(t *testing.T) {
 func TestSystemdUnit(t *testing.T) {
 	got := systemdUnit(
 		[]string{`/home/a b/bin/100% "atc"\x`, "server", "run"},
-		`/usr/bin:/50% "quoted"\path`,
+		[][2]string{
+			{"PATH", `/usr/bin:/50% "quoted"\path`},
+			{"XDG_CONFIG_HOME", "/home/ab/cfg"},
+		},
 	)
 	want := `[Unit]
 Description=ATC server
@@ -57,6 +65,7 @@ Description=ATC server
 Type=simple
 ExecStart="/home/a b/bin/100%% \"atc\"\\x" "server" "run"
 Environment="PATH=/usr/bin:/50%% \"quoted\"\\path"
+Environment="XDG_CONFIG_HOME=/home/ab/cfg"
 Restart=always
 RestartSec=5
 
@@ -65,6 +74,24 @@ WantedBy=default.target
 `
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("systemdUnit mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// The daemon must resolve the same config, token, and state files as the
+// CLI that installed it, so shell XDG overrides ride along with PATH; unset
+// ones are omitted.
+func TestUnitEnvStampsXDGOverrides(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin")
+	t.Setenv("XDG_CONFIG_HOME", "/custom/config")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_STATE_HOME", "/custom/state")
+	want := [][2]string{
+		{"PATH", "/usr/bin"},
+		{"XDG_CONFIG_HOME", "/custom/config"},
+		{"XDG_STATE_HOME", "/custom/state"},
+	}
+	if diff := cmp.Diff(want, unitEnv()); diff != "" {
+		t.Errorf("unitEnv mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/service/unit_test.go
+++ b/internal/service/unit_test.go
@@ -1,0 +1,100 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestLaunchAgentPlist(t *testing.T) {
+	got := launchAgentPlist(
+		[]string{`/Users/a b/bin/atc<&>"`, "server", "run"},
+		"/Users/ab/.local/state/atc/atc.log",
+		`/usr/local/bin:/odd"<path>&`,
+	)
+	want := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>atc.server</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/a b/bin/atc&lt;&amp;&gt;&quot;</string>
+    <string>server</string>
+    <string>run</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/usr/local/bin:/odd&quot;&lt;path&gt;&amp;</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/Users/ab/.local/state/atc/atc.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/ab/.local/state/atc/atc.log</string>
+</dict>
+</plist>
+`
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("launchAgentPlist mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestSystemdUnit(t *testing.T) {
+	got := systemdUnit(
+		[]string{`/home/a b/bin/100% "atc"\x`, "server", "run"},
+		`/usr/bin:/50% "quoted"\path`,
+	)
+	want := `[Unit]
+Description=ATC server
+
+[Service]
+Type=simple
+ExecStart="/home/a b/bin/100%% \"atc\"\\x" "server" "run"
+Environment="PATH=/usr/bin:/50%% \"quoted\"\\path"
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+`
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("systemdUnit mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestUnitPath(t *testing.T) {
+	for name, tc := range map[string]struct {
+		goos, xdg, home string
+		want            string
+	}{
+		"darwin": {
+			goos: "darwin", xdg: "/ignored", home: "/Users/ab",
+			want: "/Users/ab/Library/LaunchAgents/atc.server.plist",
+		},
+		"linux with XDG_CONFIG_HOME": {
+			goos: "linux", xdg: "/custom/config", home: "/home/ab",
+			want: "/custom/config/systemd/user/atc.server.service",
+		},
+		"linux default": {
+			goos: "linux", xdg: "", home: "/home/ab",
+			want: "/home/ab/.config/systemd/user/atc.server.service",
+		},
+	} {
+		if got := unitPath(tc.goos, tc.xdg, tc.home); got != tc.want {
+			t.Errorf("%s: unitPath = %q, want %q", name, got, tc.want)
+		}
+	}
+}
+
+func TestUnitArgs(t *testing.T) {
+	want := []string{"/opt/atc", "server", "run"}
+	if diff := cmp.Diff(want, unitArgs("/opt/atc")); diff != "" {
+		t.Errorf("unitArgs mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/internal/tailscale/tailscale.go
+++ b/internal/tailscale/tailscale.go
@@ -116,13 +116,21 @@ func (s *Supervisor) attempt(ctx context.Context) error {
 	return s.serve(ctx, dnsName)
 }
 
-// preflight asks tailscaled for its state and this node's DNS name; serve
-// is only attempted against a running backend, so the retry loop reports
-// "logged out" instead of an opaque serve failure.
+// preflight asks tailscaled for this node's DNS name; serve is only
+// attempted against a running backend, so the retry loop reports "logged
+// out" instead of an opaque serve failure.
 func (s *Supervisor) preflight(ctx context.Context) (string, error) {
+	return DNSName(ctx, s.Executable)
+}
+
+// DNSName asks tailscaled for its state and this node's DNS name, reported
+// only for a running backend so callers see "logged out" instead of an
+// opaque failure. The serve supervisor preflights with it, and `atc server
+// status` uses it to print the paste-ready tailnet URL.
+func DNSName(ctx context.Context, executable string) (string, error) {
 	statusCtx, cancel := context.WithTimeout(ctx, statusTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(statusCtx, s.Executable, "status", "--json")
+	cmd := exec.CommandContext(statusCtx, executable, "status", "--json")
 	cmd.Env = cliEnv()
 	out, err := cmd.Output()
 	if statusCtx.Err() != nil && ctx.Err() == nil {


### PR DESCRIPTION
Implements the ATC-246 lifecycle family on the ATC-259 chassis — supervisor-only, one family, no pidfile code. Closes ATC-260.

## What's here

New `internal/service` package plus the `atc server` command wiring:

- **`start`** — registration folded in: verifies `systemctl` on Linux (clear pointer to `atc server run` otherwise), pre-flight-probes the configured port when the unit isn't already supervised ("something is already serving on port N; stop it first"), re-renders the unit from `os.Executable()` + the installing shell's PATH on every start, starts via the supervisor, and health-gates (15 s / 150 ms, authenticated `GET /v1/health`). Gate timeout prints the daemon's last log lines. Idempotent: a healthy running server is left untouched (unit still re-rendered).
- **First-run notice** to stderr when no unit existed — what was registered, that it runs at every login, the `uninstall` undo, and the `loginctl enable-linger` hint on Linux. No prompt, no TTY branch.
- **`restart`** — start's path, always bouncing: `systemctl --user restart` on Linux; **bootout → wait for launchd to forget the label → bootstrap** on macOS. Amended from the ticket's original `kickstart -k` (recorded on ATC-260): bootstrap is the only launchd operation that re-reads the plist, so kickstart would bounce the process onto the stale unit and break the "never goes stale" guarantee.
- **`stop`** — supervisor stop, no disable: "stopped atc.server (still installed; returns at next login)".
- **`status`** — health probe first (source of truth; server version readable via the `Atc-Server-Version` header even on 401), unit state supplementary, client/server versions with skew flagged and a restart hint, paste-ready loopback/LAN/tailnet URLs, exit codes 0/1/2.
- **`logs`** — `journalctl --user -u atc.server` on Linux, tail of the log file on macOS, with `-f`/`-n`; unsupervised boxes get pointed at foreground `atc server run` stderr.
- **`uninstall`** — stop, remove the unit, list the config/token/(macOS) log files left behind. No purge.
- **`run`** demoted: listed last under `atc server`, labeled advanced (command sorting disabled).

## Chassis change (per ticket)

`server run` now logs slog **text** (logfmt) to stderr only and no longer opens `~/.local/state/atc/atc.log` — journal captures on Linux, the LaunchAgent's `StandardOutPath`/`StandardErrorPath` redirect captures on macOS.

## Design notes

- Lifecycle commands settle config from **file + defaults only** (no `ATC_*` env): the supervised daemon never sees shell env, so honoring `ATC_PORT` here would probe a port the daemon never serves.
- `tailscale.DNSName` exported so `status` can print the tailnet URL; the serve supervisor's preflight now wraps it.
- Boundaries per ticket: unit rendering and message formatting pure and fully tested (golden `cmp.Diff` strings, XML/systemd escaping); `launchctl`/`systemctl`/`journalctl` calls thin and untested by design.

## Testing

- `mise run check` green (build, golangci-lint, race-detector tests).
- Smoke-tested on Linux with isolated XDG state: help ordering, `status` exit codes against a live foreground server, stop/uninstall messages, the start conflict pre-flight (no unit written), journal-backed `logs`.
- Not exercised here: the real `systemctl`/`launchctl` start–stop–restart cycle (needs a login session / a Mac). Worth watching on first Mac use that bootout→bootstrap stays under the 15 s health gate.