### PR TITLE
ATC-266 | Restructure constructors to idiomatic Go: required deps as parameters, optionals defaulted

### DIFF
--- a/cmd/atc/main.go
+++ b/cmd/atc/main.go
@@ -355,11 +355,7 @@ func serverRun(cmd *cobra.Command, _ []string) error {
 
 	version := versionString()
 	logger.Info("server starting", "version", version, "pid", os.Getpid())
-	handler := server.NewHandler(server.Options{
-		Version: version,
-		Verify:  store.Verify,
-		Logger:  logger,
-	})
+	handler := server.NewHandler(store.Verify, version, logger)
 
 	listener, err := net.Listen("tcp", net.JoinHostPort(cfg.Bind, strconv.Itoa(cfg.Port)))
 	if err != nil {
@@ -371,11 +367,7 @@ func serverRun(cmd *cobra.Command, _ []string) error {
 	// child before the process exits.
 	var exposure sync.WaitGroup
 	if cfg.Tailscale {
-		supervisor := &tailscale.Supervisor{
-			Executable: tailscaleExecutable,
-			Port:       listener.Addr().(*net.TCPAddr).Port,
-			Logger:     logger,
-		}
+		supervisor := tailscale.NewSupervisor(tailscaleExecutable, listener.Addr().(*net.TCPAddr).Port, logger)
 		exposure.Go(func() { supervisor.Run(ctx) })
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,4 +1,4 @@
-// Package server is the ATC HTTP chassis (ATC-259): a Huma v2 API mounted
+// Package server is the ATC HTTP server (ATC-259): a Huma v2 API mounted
 // on a standard http.ServeMux, fronted by transport-level middleware for
 // auth and version headers.
 //
@@ -29,17 +29,6 @@ const (
 	ServerVersionHeader = "Atc-Server-Version"
 )
 
-// Options configures the chassis.
-type Options struct {
-	// Version is the server build identity, sent on every response.
-	Version string
-	// Verify reports whether an Authorization header value presents the
-	// current bearer token (authtoken.Store.Verify in production).
-	Verify func(authorization string) bool
-	// Logger receives request-level events. Required.
-	Logger *slog.Logger
-}
-
 // HealthOutput doubles as the response contract and its documentation; the
 // generated OpenAPI schema is derived from it.
 type HealthOutput struct {
@@ -50,13 +39,26 @@ type HealthOutput struct {
 }
 
 // NewHandler builds the /v1 API surface plus /openapi.json and /docs.
+// verify reports whether an Authorization header value presents the
+// current bearer token (authtoken.Store.Verify in production). version is
+// the server build identity, sent on every response. A nil logger
+// discards request-level events.
+//
 // Middleware order (outermost first): version headers, then auth, then
 // routing — headers appear on every response including 401s, and
 // unauthenticated callers cannot probe which routes exist.
-func NewHandler(opts Options) http.Handler {
+func NewHandler(verify func(authorization string) bool, version string, logger *slog.Logger) http.Handler {
+	if verify == nil {
+		// Without auth the server would panic on the first request; fail
+		// at construction instead.
+		panic("server.NewHandler: verify must not be nil")
+	}
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
 	mux := http.NewServeMux()
 
-	config := huma.DefaultConfig("ATC API", opts.Version)
+	config := huma.DefaultConfig("ATC API", version)
 	config.Components.SecuritySchemes = map[string]*huma.SecurityScheme{
 		"bearerAuth": {Type: "http", Scheme: "bearer"},
 	}
@@ -74,26 +76,26 @@ func NewHandler(opts Options) http.Handler {
 	}, func(ctx context.Context, _ *struct{}) (*HealthOutput, error) {
 		out := &HealthOutput{}
 		out.Body.Status = "ok"
-		out.Body.Version = opts.Version
+		out.Body.Version = version
 		return out, nil
 	})
 
-	return withVersionHeaders(opts, withAuth(opts, mux))
+	return withVersionHeaders(version, logger, withAuth(verify, mux))
 }
 
-func withVersionHeaders(opts Options, next http.Handler) http.Handler {
+func withVersionHeaders(version string, logger *slog.Logger, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(ServerVersionHeader, opts.Version)
-		if client := r.Header.Get(ClientVersionHeader); client != "" && client != opts.Version {
-			opts.Logger.Debug("client version skew", "client", client, "server", opts.Version)
+		w.Header().Set(ServerVersionHeader, version)
+		if client := r.Header.Get(ClientVersionHeader); client != "" && client != version {
+			logger.Debug("client version skew", "client", client, "server", version)
 		}
 		next.ServeHTTP(w, r)
 	})
 }
 
-func withAuth(opts Options, next http.Handler) http.Handler {
+func withAuth(verify func(authorization string) bool, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !opts.Verify(r.Header.Get("Authorization")) {
+		if !verify(r.Header.Get("Authorization")) {
 			w.Header().Set("WWW-Authenticate", `Bearer realm="atc"`)
 			// Same RFC 7807 shape Huma uses for its own errors, so clients
 			// see one error contract regardless of which layer rejected.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -14,12 +14,12 @@ const (
 	testVersion = "v1.2.3-test"
 )
 
+func testVerify(authorization string) bool {
+	return authorization == "Bearer "+testToken
+}
+
 func newHandler() http.Handler {
-	return NewHandler(Options{
-		Version: testVersion,
-		Verify:  func(authorization string) bool { return authorization == "Bearer "+testToken },
-		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
-	})
+	return NewHandler(testVerify, testVersion, slog.New(slog.NewTextHandler(io.Discard, nil)))
 }
 
 func get(handler http.Handler, path string, token bool) *httptest.ResponseRecorder {
@@ -71,6 +71,20 @@ func TestServerVersionHeaderOnEveryResponse(t *testing.T) {
 		if got := rec.Header().Get(ServerVersionHeader); got != testVersion {
 			t.Errorf("%s: %s = %q, want %q", name, ServerVersionHeader, got, testVersion)
 		}
+	}
+}
+
+// A nil logger must default to discard: the skew log on a version-skewed
+// request was previously a latent nil dereference.
+func TestNilLoggerDefaultsToDiscard(t *testing.T) {
+	handler := NewHandler(testVerify, testVersion, nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	req.Header.Set(ClientVersionHeader, "v0.0.0-skewed")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("skewed request with nil logger: got %d, want 200", rec.Code)
 	}
 }
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,5 +1,5 @@
 // Package service manages the supervised ATC server (ATC-260, the ATC-246
-// lifecycle family on the ATC-259 chassis): a user-scope launchd
+// lifecycle family on the ATC-259 server): a user-scope launchd
 // LaunchAgent on macOS, a systemd user unit on Linux. Supervisor-only —
 // there is no pidfile family. The unit execs `atc server run`, keeping the
 // daemon structurally unable to call back into the supervisor.

--- a/internal/tailscale/tailscale.go
+++ b/internal/tailscale/tailscale.go
@@ -66,17 +66,27 @@ func ResolveExecutable(configured string) (string, error) {
 // Supervisor exposes the loopback listener over the tailnet. Same port,
 // same API, the bearer token doing the auth work.
 type Supervisor struct {
-	// Executable is the resolved tailscale CLI path (ResolveExecutable).
-	Executable string
-	// Port is the bound listener port; serve fronts localhost:Port at
-	// https://<node>:Port.
-	Port   int
-	Logger *slog.Logger
+	// executable is the resolved tailscale CLI path (ResolveExecutable).
+	executable string
+	// port is the bound listener port; serve fronts localhost:port at
+	// https://<node>:port.
+	port   int
+	logger *slog.Logger
 
 	// readyTimeout and waitDelay shrink the readiness and kill delays in
 	// tests; zero means the production values.
 	readyTimeout time.Duration
 	waitDelay    time.Duration
+}
+
+// NewSupervisor builds a Supervisor for the resolved tailscale CLI path
+// (ResolveExecutable) fronting the bound listener port. A nil logger
+// discards supervision events.
+func NewSupervisor(executable string, port int, logger *slog.Logger) *Supervisor {
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+	return &Supervisor{executable: executable, port: port, logger: logger}
 }
 
 // Run supervises exposure until ctx is cancelled. It never returns an
@@ -91,7 +101,7 @@ func (s *Supervisor) Run(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
-		s.Logger.Warn("tailscale exposure failed", "error", err)
+		s.logger.Warn("tailscale exposure failed", "error", err)
 		if time.Since(started) > healthyRunReset {
 			delay = retryBaseDelay
 		}
@@ -120,7 +130,7 @@ func (s *Supervisor) attempt(ctx context.Context) error {
 // attempted against a running backend, so the retry loop reports "logged
 // out" instead of an opaque serve failure.
 func (s *Supervisor) preflight(ctx context.Context) (string, error) {
-	return DNSName(ctx, s.Executable)
+	return DNSName(ctx, s.executable)
 }
 
 // DNSName asks tailscaled for its state and this node's DNS name, reported
@@ -178,8 +188,8 @@ func (s *Supervisor) serve(ctx context.Context, dnsName string) error {
 	// readiness-timeout path depends on that — see below.
 	serveCtx, cancelServe := context.WithCancel(ctx)
 	defer cancelServe()
-	cmd := exec.CommandContext(serveCtx, s.Executable,
-		"serve", fmt.Sprintf("--https=%d", s.Port), fmt.Sprintf("localhost:%d", s.Port))
+	cmd := exec.CommandContext(serveCtx, s.executable,
+		"serve", fmt.Sprintf("--https=%d", s.port), fmt.Sprintf("localhost:%d", s.port))
 	cmd.Env = cliEnv()
 	// Graceful stop: interrupt on ctx cancel so serve tears its route
 	// down, SIGKILL only if it lingers past WaitDelay.
@@ -258,7 +268,7 @@ func (s *Supervisor) serve(ctx context.Context, dnsName string) error {
 		return fmt.Errorf("tailscale serve did not become ready within %s", readyTimeout)
 	}
 
-	s.Logger.Info("tailscale serving", "url", fmt.Sprintf("https://%s:%d", dnsName, s.Port))
+	s.logger.Info("tailscale serving", "url", fmt.Sprintf("https://%s:%d", dnsName, s.port))
 	err = <-exited
 	if ctx.Err() != nil {
 		return ctx.Err()

--- a/internal/tailscale/tailscale_test.go
+++ b/internal/tailscale/tailscale_test.go
@@ -22,11 +22,7 @@ func fake(t *testing.T, script string, logs io.Writer) *Supervisor {
 	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script+"\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	return &Supervisor{
-		Executable: path,
-		Port:       7331,
-		Logger:     slog.New(slog.NewTextHandler(logs, nil)),
-	}
+	return NewSupervisor(path, 7331, slog.New(slog.NewTextHandler(logs, nil)))
 }
 
 func waitFor(t *testing.T, what string, cond func() bool) {
@@ -50,12 +46,12 @@ func TestResolveExecutableNotFound(t *testing.T) {
 
 func TestResolveExecutableCustomPath(t *testing.T) {
 	s := fake(t, "exit 0", io.Discard)
-	resolved, err := ResolveExecutable(s.Executable)
+	resolved, err := ResolveExecutable(s.executable)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resolved != s.Executable {
-		t.Errorf("resolved %q, want %q", resolved, s.Executable)
+	if resolved != s.executable {
+		t.Errorf("resolved %q, want %q", resolved, s.executable)
 	}
 }
 
@@ -154,6 +150,21 @@ func TestServeFailureCarriesStderr(t *testing.T) {
 	err := s.serve(context.Background(), "host.tailnet.ts.net")
 	if err == nil || !strings.Contains(err.Error(), "serve not permitted") {
 		t.Errorf("err = %v, want stderr detail", err)
+	}
+}
+
+// A nil logger must default to discard: Run logs every failed attempt and
+// previously dereferenced the logger unguarded.
+func TestNilLoggerDefaultsToDiscard(t *testing.T) {
+	s := NewSupervisor(fake(t, "exit 1", io.Discard).executable, 7331, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	done := make(chan struct{})
+	go func() { s.Run(ctx); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not stop after cancellation")
 	}
 }
 


### PR DESCRIPTION
Implements [ATC-266](https://linear.app/elevenideas/issue/ATC-266/restructure-constructors-to-idiomatic-go-required-deps-as-parameters).

## What changed

- **`internal/server`**: the `Options` struct is gone. `NewHandler(verify, version, logger)` takes everything positionally — `verify` is the one true requirement (nil panics at construction with a clear message instead of on the first request), a nil `logger` defaults to `slog.DiscardHandler`, and `version` is just a string. The middleware helpers now take the specific values they use.
- **`internal/tailscale`**: `Supervisor` fields are unexported; construction goes through `NewSupervisor(executable, port, logger)` with the same nil-logger-to-discard default. The test-only `readyTimeout`/`waitDelay` knobs are unchanged.
- **Call sites and tests** updated; each package gains a `TestNilLoggerDefaultsToDiscard` exercising the paths that were latent nil-dereference panics (the version-skew log in the server, the retry-failure log in the supervisor).
- **"Chassis" retired** from the three production comments (`server.go` package doc, the removed `Options` doc, `internal/service` package doc). It survives only under `experiments/`, which stays untouched per AGENTS.md.

Nothing added to AGENTS.md — once the constructors follow the ecosystem norm, the code is the documentation.

## Verification

`mise check` passes: build, golangci-lint (0 issues), and all tests under the race detector.