### PR TITLE
ATC-261 | Shipping: GoReleaser release workflow, dev/production channels, install.sh, and atc upgrade

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+
+# One workflow, one input (ATC-261). patch/minor/major cut an immutable
+# production release: the next version is computed from the remote's
+# authoritative tags and stamped onto the head of the dispatched ref, so a
+# cut is safe from any machine regardless of checkout state. dev refreshes
+# the single rolling `dev` prerelease (GoReleaser snapshot + asset clobber)
+# and can be dispatched from any branch.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "patch/minor/major cut a production release from this ref; dev refreshes the rolling dev build"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - dev
+
+concurrency: release
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # GoReleaser derives changelogs and previous tags from history.
+          fetch-depth: 0
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+      - name: Cut production release
+        if: inputs.bump != 'dev'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          BUMP: ${{ inputs.bump }}
+        run: |
+          git fetch --tags --force origin
+          latest=$(git tag --list 'v*' | { grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true; } | sort -V | tail -n1)
+          latest=${latest:-v0.0.0}
+          IFS=. read -r major minor patch <<<"${latest#v}"
+          case "$BUMP" in
+            major) next="v$((major + 1)).0.0" ;;
+            minor) next="v${major}.$((minor + 1)).0" ;;
+            patch) next="v${major}.${minor}.$((patch + 1))" ;;
+          esac
+          echo "cutting $next (previous: $latest) from $GITHUB_SHA"
+          git tag "$next"
+          git push origin "$next"
+          goreleaser release --clean
+      - name: Refresh dev build
+        if: inputs.bump == 'dev'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          goreleaser release --snapshot --clean
+          version=$(jq -r .version dist/metadata.json)
+          if ! gh release view dev >/dev/null 2>&1; then
+            gh release create dev --prerelease --title "dev (rolling)" \
+              --notes "Rolling development build." --target "$GITHUB_SHA"
+          fi
+          gh release upload dev dist/*.tar.gz dist/checksums.txt --clobber
+          gh release edit dev --prerelease \
+            --notes "Rolling development build; every dev cut clobbers these assets. Current: v${version} (${GITHUB_REF_NAME}@${GITHUB_SHA}). Install with \`atc upgrade --dev\`."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,17 @@
 name: Release
 
-# One workflow, one input (ATC-261). patch/minor/major cut an immutable
-# production release: the next version is computed from the remote's
-# authoritative tags and stamped onto the head of the dispatched ref, so a
-# cut is safe from any machine regardless of checkout state. dev refreshes
-# the single rolling `dev` prerelease (GoReleaser snapshot + asset clobber)
-# and can be dispatched from any branch.
+# One workflow, one input (ATC-261). patch/minor/major cut a production
+# release: the next version is computed from the remote's authoritative
+# tags and stamped onto the head of the dispatched ref, so a cut is safe
+# from any machine regardless of checkout state. dev refreshes the single
+# rolling `dev` prerelease (GoReleaser snapshot + asset clobber) and can be
+# dispatched from any branch.
+#
+# Production immutability is a convention — tags and completed releases are
+# never moved, edited, or deleted — not GitHub's enforced immutable-release
+# setting: that setting is repository-wide and would prevent the rolling
+# dev prerelease from clobbering its assets, so it stays off (ATC-261
+# review decision, amended in the Linear record).
 
 on:
   workflow_dispatch:
@@ -44,20 +50,43 @@ jobs:
         if: inputs.bump != 'dev'
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
           BUMP: ${{ inputs.bump }}
         run: |
           git fetch --tags --force origin
           latest=$(git tag --list 'v*' | { grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true; } | sort -V | tail -n1)
-          latest=${latest:-v0.0.0}
-          IFS=. read -r major minor patch <<<"${latest#v}"
-          case "$BUMP" in
-            major) next="v$((major + 1)).0.0" ;;
-            minor) next="v${major}.$((minor + 1)).0" ;;
-            patch) next="v${major}.${minor}.$((patch + 1))" ;;
-          esac
-          echo "cutting $next (previous: $latest) from $GITHUB_SHA"
-          git tag "$next"
-          git push origin "$next"
+
+          # Retry safety: a failed run can leave the newest tag with no
+          # release, or a partial one. Resume that tag rather than bumping
+          # past it — a failed publication must never advance the version
+          # chain. Complete means all four assets (three archives plus
+          # checksums.txt); reruns overwrite partial uploads via
+          # replace_existing_artifacts in .goreleaser.yaml.
+          next=""
+          if [ -n "$latest" ]; then
+            assets=$(gh release view "$latest" --json assets --jq '.assets | length' 2>/dev/null || echo 0)
+            if [ "$assets" -lt 4 ]; then
+              tagged=$(git rev-parse "${latest}^{commit}")
+              if [ "$tagged" != "$GITHUB_SHA" ]; then
+                echo "::error::$latest has no complete release and points at $tagged, not this ref's head $GITHUB_SHA; re-dispatch from that commit, or delete the tag to abandon that version"
+                exit 1
+              fi
+              next="$latest"
+              echo "resuming $next: its tag exists without a complete release"
+            fi
+          fi
+          if [ -z "$next" ]; then
+            latest=${latest:-v0.0.0}
+            IFS=. read -r major minor patch <<<"${latest#v}"
+            case "$BUMP" in
+              major) next="v$((major + 1)).0.0" ;;
+              minor) next="v${major}.$((minor + 1)).0" ;;
+              patch) next="v${major}.${minor}.$((patch + 1))" ;;
+            esac
+            echo "cutting $next (previous: $latest) from $GITHUB_SHA"
+            git tag "$next"
+            git push origin "$next"
+          fi
           goreleaser release --clean
       - name: Refresh dev build
         if: inputs.bump == 'dev'
@@ -66,10 +95,16 @@ jobs:
         run: |
           goreleaser release --snapshot --clean
           version=$(jq -r .version dist/metadata.json)
+          # Move the fixed dev tag to the built commit before touching the
+          # release: the release page's source provenance (and GitHub's
+          # generated source archives) must match the binaries uploaded
+          # below. Editing the release cannot do this — target_commitish is
+          # ignored once a tag exists.
+          git push --force origin "$GITHUB_SHA:refs/tags/dev"
           if ! gh release view dev >/dev/null 2>&1; then
             gh release create dev --prerelease --title "dev (rolling)" \
-              --notes "Rolling development build." --target "$GITHUB_SHA"
+              --notes "Rolling development build."
           fi
           gh release upload dev dist/*.tar.gz dist/checksums.txt --clobber
           gh release edit dev --prerelease \
-            --notes "Rolling development build; every dev cut clobbers these assets. Current: v${version} (${GITHUB_REF_NAME}@${GITHUB_SHA}). Install with \`atc upgrade --dev\`."
+            --notes "Rolling development build; every dev cut clobbers these assets and moves the dev tag. Current: v${version} (${GITHUB_REF_NAME}@${GITHUB_SHA}). Install with \`atc upgrade --dev\`."

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,50 @@
+# GoReleaser configuration (ATC-261): one static build, three targets,
+# tar.gz + checksums.txt. Asset names are version-independent so the
+# releases/latest/download URLs stay static and the rolling dev prerelease
+# can clobber them in place; internal/upgrade mirrors this naming.
+version: 2
+
+project_name: atc
+
+git:
+  # Neither the archived product's dev tags nor the rolling dev prerelease
+  # tag may feed version computation; the v0.0.x production tags stay
+  # visible so bumps and changelogs chain from them.
+  ignore_tags:
+    - dev
+    - dev-20260813-073333
+    - dev-20260813-074116
+    - legacy-product-2026-08
+
+builds:
+  - main: ./cmd/atc
+    env:
+      - CGO_ENABLED=0
+    # darwin/amd64 is deliberately absent; install.sh and `atc upgrade`
+    # both name the unsupported platform instead of 404ing.
+    targets:
+      - darwin_arm64
+      - linux_amd64
+      - linux_arm64
+    ldflags:
+      # The stamp that makes a build claim a release-shaped version; local
+      # builds stay on the buildinfo fallback (internal/version).
+      - -s -w -X github.com/jeremytondo/atc/internal/version.Version=v{{ .Version }}
+
+archives:
+  - formats: [tar.gz]
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - README.md
+
+checksum:
+  name_template: checksums.txt
+
+snapshot:
+  # Dev-channel version: last production tag with the patch auto-bumped,
+  # plus the short sha. Claims ordering only (above the last release, below
+  # the next); two dev builds are compared for equality, never for age.
+  version_template: "{{ incpatch .Version }}-dev.{{ .ShortCommit }}"
+
+changelog:
+  use: git

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,6 +40,12 @@ archives:
 checksum:
   name_template: checksums.txt
 
+release:
+  # Retry safety (release.yml resumes a tag whose release is incomplete): a
+  # rerun over a partially published release must overwrite its assets
+  # instead of failing on name collisions.
+  replace_existing_artifacts: true
+
 snapshot:
   # Dev-channel version: last production tag with the patch auto-bumped,
   # plus the short sha. Claims ordering only (above the last release, below

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,20 +1,15 @@
 # ATC Agent Instructions
 
-ATC is being rebuilt in Go under
-[ATC-243](https://linear.app/elevenideas/issue/ATC-243). The active tree is
+## Current Rebuild Notes
+
+ATC is being rebuilt in Go under [ATC-243](https://linear.app/elevenideas/issue/ATC-243). The active tree is
 the rebuild's scaffold: a single Go module at the repository root with one
 entrypoint, `cmd/atc`, plus the research archive under `experiments/`. The
 superseded product is preserved at the `legacy-product-2026-08` tag.
 
-## Recorded Decisions
+## Core Principles
 
-Recorded decisions — charters and decided records in Linear — capture the
-best understanding at the time, not permanent truth. When the work surfaces
-evidence that a prior decision is wrong or improvable, challenge it openly
-and propose amending the record; do not follow it blindly or deviate from it
-silently.
-
-## Core Priorities
+It's important we maintain the following core principles as we iterate on ATC:
 
 - Performance
 - Reliability
@@ -23,6 +18,14 @@ silently.
 
 If a tradeoff is required, choose correctness and robustness over short-term
 convenience.
+
+## Recorded Decisions
+
+Recorded decisions and rules capture the
+best understanding at the time, not permanent truth. When the work surfaces
+evidence that a prior decision is wrong or improvable, challenge it openly
+and propose amending the record; do not follow it blindly or deviate from it
+silently.
 
 ## Maintainability
 
@@ -62,7 +65,7 @@ Everything under `experiments/` is historical research material, not
 production source:
 
 - Read findings before code.
-- Treat findings as evidence, not decisions; ATC-243 takes precedence.
+- Treat findings as evidence, not decisions
 - Do not import, extend, or make production depend on experiment code.
 - Do not rewrite old findings. Capture new evidence in a new experiment.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,14 +6,6 @@ the rebuild's scaffold: a single Go module at the repository root with one
 entrypoint, `cmd/atc`, plus the research archive under `experiments/`. The
 superseded product is preserved at the `legacy-product-2026-08` tag.
 
-Do not create packages ahead of need — `internal/` grows only when real
-code lands in it.
-
-ATC-243 is the source of truth for the rebuild. Do not restore or extend the
-archived TypeScript App Server, macOS app, packages, workflows, or release
-tooling in the active tree. Compatibility with legacy state and configuration
-is a separate implementation decision tracked by ATC-245.
-
 ## Recorded Decisions
 
 Recorded decisions — charters and decided records in Linear — capture the

--- a/README.md
+++ b/README.md
@@ -7,6 +7,24 @@ The active tree holds the Go scaffold for the rebuild: a single Go module
 rooted at the repository with one entrypoint, [`cmd/atc`](cmd/atc/). Run
 `atc help` (or a bare `atc`) for the command reference.
 
+## Installing and upgrading
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/jeremytondo/atc/main/install.sh | sh
+```
+
+Installs the latest release into `~/.local/bin` (override with
+`ATC_INSTALL_DIR`, pin a tag with `ATC_VERSION`). Supported platforms:
+macOS arm64, Linux amd64/arm64. After the first install the binary keeps
+itself current:
+
+- `atc upgrade` — move to the latest production release
+- `atc upgrade --dev` — install the current rolling dev build
+
+Releases are cut by the [Release workflow](.github/workflows/release.yml):
+`mise run release:patch|minor|major|dev`, `gh workflow run release.yml`, or
+the Actions "Run workflow" button.
+
 ## Building and testing
 
 Tools and tasks are managed by [mise](https://mise.jdx.dev) via
@@ -29,5 +47,5 @@ Tools and tasks are managed by [mise](https://mise.jdx.dev) via
   that may inform the rebuild. They are evidence, not production code or
   settled architecture.
 
-Existing GitHub releases are artifacts of the archived product and should not
-be treated as builds of the new implementation.
+GitHub releases `v0.0.x` and older are artifacts of the archived product;
+the rebuild's releases start at `v0.1.0`.

--- a/cmd/atc/main.go
+++ b/cmd/atc/main.go
@@ -13,7 +13,6 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"runtime/debug"
 	"strconv"
 	"sync"
 	"syscall"
@@ -26,6 +25,8 @@ import (
 	"github.com/jeremytondo/atc/internal/server"
 	"github.com/jeremytondo/atc/internal/service"
 	"github.com/jeremytondo/atc/internal/tailscale"
+	"github.com/jeremytondo/atc/internal/upgrade"
+	"github.com/jeremytondo/atc/internal/version"
 )
 
 func main() {
@@ -76,7 +77,7 @@ expose on the tailnet without the flag.`,
 			return cmd.Help()
 		},
 	}
-	root.AddCommand(newVersionCmd(), newServerCmd())
+	root.AddCommand(newVersionCmd(), newUpgradeCmd(), newServerCmd())
 	return root
 }
 
@@ -86,10 +87,75 @@ func newVersionCmd() *cobra.Command {
 		Short: "Print the atc version",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			_, err := fmt.Fprintln(cmd.OutOrStdout(), versionString())
+			_, err := fmt.Fprintln(cmd.OutOrStdout(), version.String())
 			return err
 		},
 	}
+}
+
+func newUpgradeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Replace this binary with the latest release",
+		Long: `Download the latest production release, verify its checksum, and atomically
+replace this binary. A machine running a dev build is moved to the latest
+production release even when that is semver-backwards; with --dev, the
+current rolling dev build is installed unconditionally instead.
+
+A server left running the old version is never restarted silently:
+interactive runs are asked (terminals persist; in-flight agent turns are
+interrupted), headless runs print a reminder unless --restart or
+--no-restart pre-answers.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			flags := cmd.Flags()
+			dev, err := flags.GetBool("dev")
+			if err != nil {
+				return err
+			}
+			always, err := flags.GetBool("restart")
+			if err != nil {
+				return err
+			}
+			never, err := flags.GetBool("no-restart")
+			if err != nil {
+				return err
+			}
+			mode := upgrade.RestartAsk
+			if always {
+				mode = upgrade.RestartAlways
+			}
+			if never {
+				mode = upgrade.RestartNever
+			}
+			opts := upgrade.Options{
+				Dev:         dev,
+				Restart:     mode,
+				Interactive: stdinIsTerminal(),
+				Version:     version.String(),
+				Stdin:       cmd.InOrStdin(),
+				Stdout:      cmd.OutOrStdout(),
+				Stderr:      cmd.ErrOrStderr(),
+			}
+			// A broken config.toml must not block the swap — the new binary
+			// may be the fix. Only the post-swap server check needs it.
+			if opts.Service, err = lifecycleOptions(cmd); err != nil {
+				opts.ConfigErr = err
+			}
+			return upgrade.Run(cmd.Context(), opts)
+		},
+	}
+	cmd.Flags().Bool("dev", false, "install the current rolling dev build (always reinstalls)")
+	cmd.Flags().Bool("restart", false, "restart a server left on the old version, without asking")
+	cmd.Flags().Bool("no-restart", false, "never restart the server")
+	cmd.MarkFlagsMutuallyExclusive("restart", "no-restart")
+	return cmd
+}
+
+// stdinIsTerminal gates the restart prompt: only a human at a TTY is asked.
+func stdinIsTerminal() bool {
+	info, err := os.Stdin.Stat()
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
 }
 
 func newServerCmd() *cobra.Command {
@@ -125,7 +191,7 @@ func lifecycleOptions(cmd *cobra.Command) (service.Options, error) {
 	}
 	return service.Options{
 		Config:  cfg,
-		Version: versionString(),
+		Version: version.String(),
 		Stdout:  cmd.OutOrStdout(),
 		Stderr:  cmd.ErrOrStderr(),
 	}, nil
@@ -137,7 +203,7 @@ func lifecycleOptions(cmd *cobra.Command) (service.Options, error) {
 // booting must not block diagnostics, stopping, or the promised total undo.
 func recoveryOptions(cmd *cobra.Command) (service.Options, error) {
 	return service.Options{
-		Version: versionString(),
+		Version: version.String(),
 		Stdout:  cmd.OutOrStdout(),
 		Stderr:  cmd.ErrOrStderr(),
 	}, nil
@@ -353,9 +419,9 @@ func serverRun(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	version := versionString()
-	logger.Info("server starting", "version", version, "pid", os.Getpid())
-	handler := server.NewHandler(store.Verify, version, logger)
+	versionValue := version.String()
+	logger.Info("server starting", "version", versionValue, "pid", os.Getpid())
+	handler := server.NewHandler(store.Verify, versionValue, logger)
 
 	listener, err := net.Listen("tcp", net.JoinHostPort(cfg.Bind, strconv.Itoa(cfg.Port)))
 	if err != nil {
@@ -374,36 +440,4 @@ func serverRun(cmd *cobra.Command, _ []string) error {
 	serveErr := server.Serve(ctx, listener, handler, logger)
 	exposure.Wait()
 	return serveErr
-}
-
-// versionString resolves the binary's version from embedded build info.
-// Released builds carry the module version; source builds fall back to the
-// VCS revision. The value is a build identity suitable for client/server
-// skew comparison, with one limit: builds without VCS metadata all report
-// "devel" and cannot be told apart.
-func versionString() string {
-	info, ok := debug.ReadBuildInfo()
-	if !ok {
-		return "unknown"
-	}
-	version := info.Main.Version
-	if version != "" && version != "(devel)" {
-		return version
-	}
-	revision, dirty := "", false
-	for _, setting := range info.Settings {
-		switch setting.Key {
-		case "vcs.revision":
-			revision = setting.Value
-		case "vcs.modified":
-			dirty = setting.Value == "true"
-		}
-	}
-	if revision == "" {
-		return "devel"
-	}
-	if dirty {
-		return "devel-" + revision + "-dirty"
-	}
-	return "devel-" + revision
 }

--- a/cmd/atc/main_test.go
+++ b/cmd/atc/main_test.go
@@ -38,6 +38,8 @@ func TestRunRejectsBadInvocations(t *testing.T) {
 	for _, args := range [][]string{
 		{"frobnicate"},
 		{"version", "extra"},
+		{"upgrade", "extra"},
+		{"upgrade", "--restart", "--no-restart"},
 		{"server"},
 		{"server", "frobnicate"},
 		{"server", "run", "extra"},

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# ATC first-install script (ATC-261). Downloads the latest production
+# release, verifies it against checksums.txt, and installs it to
+# ~/.local/bin on macOS and Linux alike. First install only: after this,
+# `atc upgrade` owns staying current (and `atc upgrade --dev` moves a
+# machine onto the rolling dev build — there is deliberately no dev knob
+# here).
+#
+#   curl -fsSL https://raw.githubusercontent.com/jeremytondo/atc/main/install.sh | sh
+#
+# Knobs:
+#   ATC_INSTALL_DIR  install directory (default: ~/.local/bin)
+#   ATC_VERSION      pin a release tag (e.g. v0.1.0) instead of the latest
+set -eu
+
+REPO="jeremytondo/atc"
+INSTALL_DIR="${ATC_INSTALL_DIR:-$HOME/.local/bin}"
+
+fail() {
+    echo "install.sh: $*" >&2
+    exit 1
+}
+
+os=$(uname -s)
+arch=$(uname -m)
+case "$os/$arch" in
+Darwin/arm64) platform="darwin_arm64" ;;
+Linux/x86_64) platform="linux_amd64" ;;
+Linux/aarch64 | Linux/arm64) platform="linux_arm64" ;;
+Darwin/x86_64) fail "atc has no build for Intel macOS (darwin/amd64); supported: darwin/arm64, linux/amd64, linux/arm64" ;;
+*) fail "atc has no build for $os/$arch; supported: darwin/arm64, linux/amd64, linux/arm64" ;;
+esac
+
+asset="atc_${platform}.tar.gz"
+if [ -n "${ATC_VERSION:-}" ]; then
+    base="https://github.com/$REPO/releases/download/$ATC_VERSION"
+else
+    base="https://github.com/$REPO/releases/latest/download"
+fi
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+echo "downloading $base/$asset"
+curl -fsSL -o "$tmp/$asset" "$base/$asset" || fail "download failed: $base/$asset"
+curl -fsSL -o "$tmp/checksums.txt" "$base/checksums.txt" || fail "download failed: $base/checksums.txt"
+
+if command -v sha256sum >/dev/null 2>&1; then
+    got=$(sha256sum "$tmp/$asset" | cut -d' ' -f1)
+elif command -v shasum >/dev/null 2>&1; then
+    got=$(shasum -a 256 "$tmp/$asset" | cut -d' ' -f1)
+else
+    fail "neither sha256sum nor shasum is available to verify the download"
+fi
+want=$(awk -v asset="$asset" '$2 == asset { print $1 }' "$tmp/checksums.txt")
+[ -n "$want" ] || fail "$asset has no entry in checksums.txt"
+[ "$got" = "$want" ] || fail "checksum mismatch for $asset: checksums.txt says $want, the download is $got"
+
+tar -xzf "$tmp/$asset" -C "$tmp" atc || fail "could not extract atc from $asset"
+mkdir -p "$INSTALL_DIR" || fail "cannot create $INSTALL_DIR"
+mv -f "$tmp/atc" "$INSTALL_DIR/atc" || fail "cannot write to $INSTALL_DIR (this script never invokes sudo; set ATC_INSTALL_DIR to a writable directory)"
+
+echo "installed atc $("$INSTALL_DIR/atc" version) to $INSTALL_DIR/atc"
+
+case ":$PATH:" in
+*":$INSTALL_DIR:"*) ;;
+*) echo "note: $INSTALL_DIR is not on your PATH; add it with e.g.  export PATH=\"$INSTALL_DIR:\$PATH\"" ;;
+esac

--- a/install.sh
+++ b/install.sh
@@ -57,10 +57,14 @@ want=$(awk -v asset="$asset" '$2 == asset { print $1 }' "$tmp/checksums.txt")
 [ "$got" = "$want" ] || fail "checksum mismatch for $asset: checksums.txt says $want, the download is $got"
 
 tar -xzf "$tmp/$asset" -C "$tmp" atc || fail "could not extract atc from $asset"
+# Prove the downloaded binary runs on this machine before installing it; a
+# bare `echo "$(...)"` would mask its failure.
+version=$("$tmp/atc" version) || fail "downloaded binary failed to run"
+[ -n "$version" ] || fail "downloaded binary printed no version"
 mkdir -p "$INSTALL_DIR" || fail "cannot create $INSTALL_DIR"
 mv -f "$tmp/atc" "$INSTALL_DIR/atc" || fail "cannot write to $INSTALL_DIR (this script never invokes sudo; set ATC_INSTALL_DIR to a writable directory)"
 
-echo "installed atc $("$INSTALL_DIR/atc" version) to $INSTALL_DIR/atc"
+echo "installed atc $version to $INSTALL_DIR/atc"
 
 case ":$PATH:" in
 *":$INSTALL_DIR:"*) ;;

--- a/internal/service/probe.go
+++ b/internal/service/probe.go
@@ -64,6 +64,14 @@ func probeOnce(ctx context.Context, opts Options, token string) probeOutcome {
 	}
 }
 
+// Probe reports whether a server answers on the configured address and the
+// version it claims. Tokenless: the Atc-Server-Version header rides every
+// response, 401s included. This is `atc upgrade`'s post-swap check.
+func Probe(ctx context.Context, opts Options) (responding bool, serverVersion string) {
+	outcome := probeOnce(ctx, opts, "")
+	return outcome.responding, outcome.serverVersion
+}
+
 // awaitHealthy gates start/restart success on the daemon answering
 // /v1/health with the local token.
 func awaitHealthy(ctx context.Context, opts Options, token string) error {

--- a/internal/upgrade/archive.go
+++ b/internal/upgrade/archive.go
@@ -1,0 +1,66 @@
+package upgrade
+
+// Checksum verification and archive extraction: pure functions over the
+// downloaded bytes, fully tested.
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+)
+
+// verifyChecksum checks the downloaded archive against its entry in
+// GoReleaser's checksums.txt (lines of "<sha256>  <asset>").
+func verifyChecksum(archive, checksums []byte, asset string) error {
+	want, err := expectedChecksum(checksums, asset)
+	if err != nil {
+		return err
+	}
+	got := fmt.Sprintf("%x", sha256.Sum256(archive))
+	if got != want {
+		return fmt.Errorf("checksum mismatch for %s: checksums.txt says %s, the download is %s", asset, want, got)
+	}
+	return nil
+}
+
+func expectedChecksum(checksums []byte, asset string) (string, error) {
+	for line := range strings.Lines(string(checksums)) {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[1] == asset {
+			return fields[0], nil
+		}
+	}
+	return "", fmt.Errorf("%s has no entry in checksums.txt", asset)
+}
+
+// extractBinary returns the atc executable member of a release tar.gz.
+func extractBinary(archive []byte) ([]byte, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(archive))
+	if err != nil {
+		return nil, fmt.Errorf("bad release archive: %w", err)
+	}
+	defer func() { _ = gz.Close() }()
+	reader := tar.NewReader(gz)
+	for {
+		header, err := reader.Next()
+		if errors.Is(err, io.EOF) {
+			return nil, fmt.Errorf("release archive has no %q member", binaryName)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("bad release archive: %w", err)
+		}
+		if header.Typeflag == tar.TypeReg && path.Base(header.Name) == binaryName {
+			binary, err := io.ReadAll(reader)
+			if err != nil {
+				return nil, fmt.Errorf("bad release archive: %w", err)
+			}
+			return binary, nil
+		}
+	}
+}

--- a/internal/upgrade/github.go
+++ b/internal/upgrade/github.go
@@ -1,0 +1,95 @@
+package upgrade
+
+// Release discovery and download. Tokenless by design: the public
+// releases/latest redirect names the production channel head, and asset
+// URLs are static per tag. No GitHub API.
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+)
+
+// assetURL is the tokenless download URL for one asset of one release.
+func assetURL(tag, asset string) string {
+	return fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", repo, tag, asset)
+}
+
+// assetName maps a platform to its release archive, mirroring the
+// .goreleaser.yaml name_template. Unsupported platforms fail with a named
+// diagnostic, never a bare 404.
+func assetName(goos, goarch string) (string, error) {
+	switch goos + "/" + goarch {
+	case "darwin/arm64", "linux/amd64", "linux/arm64":
+		return fmt.Sprintf("%s_%s_%s.tar.gz", binaryName, goos, goarch), nil
+	}
+	return "", fmt.Errorf("no atc release build for %s/%s (supported: darwin/arm64, linux/amd64, linux/arm64)", goos, goarch)
+}
+
+// latestProductionTag resolves the production channel head from the
+// releases/latest redirect — GitHub's own rolling "latest non-prerelease"
+// pointer, so the dev prerelease can never be selected.
+func latestProductionTag(ctx context.Context) (string, error) {
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	address := fmt.Sprintf("https://github.com/%s/releases/latest", repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, address, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("cannot reach github.com to find the latest release: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return tagFromLocation(resp.Header.Get("Location"))
+}
+
+// tagFromLocation extracts the release tag from the releases/latest
+// redirect target, e.g. .../releases/tag/v0.1.0 → v0.1.0.
+func tagFromLocation(location string) (string, error) {
+	parsed, err := url.Parse(location)
+	if err != nil {
+		return "", fmt.Errorf("unexpected releases/latest redirect %q: %w", location, err)
+	}
+	dir, tag := path.Split(parsed.Path)
+	if !strings.HasSuffix(dir, "/releases/tag/") || tag == "" {
+		return "", fmt.Errorf("no production release found (releases/latest redirected to %q)", location)
+	}
+	return tag, nil
+}
+
+// fetch downloads one release asset fully into memory (release archives
+// are a few megabytes).
+func fetch(ctx context.Context, address string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, address, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("%s does not exist — has this release been published?", address)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("download of %s failed: HTTP %d", address, resp.StatusCode)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("download of %s failed: %w", address, err)
+	}
+	return data, nil
+}

--- a/internal/upgrade/messages.go
+++ b/internal/upgrade/messages.go
@@ -1,0 +1,38 @@
+package upgrade
+
+// User-facing message rendering: pure and tested. The output always states
+// what actually happened — including the deliberate semver-backwards move
+// from a dev build to production.
+
+import "fmt"
+
+func upToDateMessage(version string) string {
+	return fmt.Sprintf("atc %s is already up to date", version)
+}
+
+func replacedMessage(oldVersion, newVersion, target string) string {
+	if oldVersion == newVersion {
+		return fmt.Sprintf("reinstalled %s at %s", newVersion, target)
+	}
+	return fmt.Sprintf("replaced %s with %s at %s", oldVersion, newVersion, target)
+}
+
+// staleServerLine is the one clear line a headless (or declined) run gets;
+// the state stays loud afterwards in `atc server status` and skew warnings.
+func staleServerLine(serverVersion string) string {
+	return fmt.Sprintf("server still on %s — run `atc server restart` or pass --restart", versionOrUnknown(serverVersion))
+}
+
+// restartPrompt carries the ATC-246 risk summary: terminals persist (zmx
+// owns them durably); in-flight agent turns served over the API are
+// interrupted. Default yes.
+func restartPrompt(serverVersion string) string {
+	return fmt.Sprintf("server is still on %s; restart it now? terminals persist, but any in-flight agent turns are interrupted [Y/n] ", versionOrUnknown(serverVersion))
+}
+
+func versionOrUnknown(version string) string {
+	if version == "" {
+		return "an unknown version"
+	}
+	return version
+}

--- a/internal/upgrade/swap.go
+++ b/internal/upgrade/swap.go
@@ -1,0 +1,63 @@
+package upgrade
+
+// The binary swap: stage beside the real target (same filesystem), then an
+// atomic rename. Split so the caller can prove the staged binary runs
+// before anything is replaced.
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// executablePath resolves where this process's binary really lives —
+// symlinks resolved so the rename lands on the actual file rather than
+// replacing a symlink.
+func executablePath() (string, error) {
+	executable, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(executable)
+}
+
+// stage writes the new binary to a temp file in target's directory with the
+// executable mode set, returning its path.
+func stage(target string, binary []byte) (string, error) {
+	dir := filepath.Dir(target)
+	tmp, err := os.CreateTemp(dir, ".atc-upgrade-*")
+	if err != nil {
+		return "", writeDiagnostic(dir, err)
+	}
+	_, err = tmp.Write(binary)
+	if err == nil {
+		err = tmp.Chmod(0o755)
+	}
+	if closeErr := tmp.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		_ = os.Remove(tmp.Name())
+		return "", err
+	}
+	return tmp.Name(), nil
+}
+
+// promote atomically replaces target with the staged binary.
+func promote(staged, target string) error {
+	if err := os.Rename(staged, target); err != nil {
+		return writeDiagnostic(filepath.Dir(target), err)
+	}
+	return nil
+}
+
+// writeDiagnostic names the remedy for an unwritable install directory; atc
+// never invokes sudo.
+func writeDiagnostic(dir string, err error) error {
+	if errors.Is(err, fs.ErrPermission) {
+		return fmt.Errorf("cannot write to %s (atc never invokes sudo): fix the directory's ownership or reinstall atc somewhere writable: %w", dir, err)
+	}
+	return err
+}

--- a/internal/upgrade/upgrade.go
+++ b/internal/upgrade/upgrade.go
@@ -1,0 +1,239 @@
+// Package upgrade implements atc's self-upgrade from GitHub releases
+// (ATC-261). The channel is stateless — a machine has no channel identity:
+// plain `atc upgrade` moves it to the latest production release (even when
+// that is semver-backwards from a dev build, and it says so), while
+// `--dev` unconditionally reinstalls the current rolling dev build.
+//
+// Discovery uses no GitHub API and no tokens: the releases/latest redirect
+// names the production tag, and the fixed `dev` prerelease has a stable
+// download URL. The swap is checksum-verified and atomic: the new binary is
+// staged beside the resolved os.Executable() (same filesystem), proved
+// runnable, then renamed over the target. sudo is never invoked.
+//
+// A running server is never restarted silently. Interactive runs are asked
+// (default yes); headless runs without --restart leave the server alone and
+// say exactly what to do next — the skew stays loud in `atc server status`
+// and on every subsequent command.
+//
+// Boundaries (deliberate): asset naming, checksum verification, archive
+// extraction, message rendering, and the restart policy are pure and
+// tested; HTTP fetches and process invocations stay thin and untested.
+package upgrade
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/jeremytondo/atc/internal/service"
+)
+
+const (
+	// repo is the GitHub repository releases are served from.
+	repo = "jeremytondo/atc"
+	// devTag is the fixed tag of the rolling dev prerelease; its assets are
+	// clobbered by every dev cut.
+	devTag = "dev"
+	// checksumsAsset is GoReleaser's checksum file, one per release.
+	checksumsAsset = "checksums.txt"
+	// binaryName is the executable member inside each release archive.
+	binaryName = "atc"
+)
+
+// RestartMode is how upgrade treats a server left running the old version
+// after the swap: ask (the default; only a human at a TTY is actually
+// asked), or the --restart / --no-restart pre-answers for scripts.
+type RestartMode int
+
+const (
+	RestartAsk RestartMode = iota
+	RestartAlways
+	RestartNever
+)
+
+// Options carries one upgrade invocation's settled inputs.
+type Options struct {
+	// Dev selects the rolling dev build and disables the staleness
+	// short-circuit: --dev always reinstalls ("make this machine match the
+	// shelf").
+	Dev     bool
+	Restart RestartMode
+	// Interactive gates the restart prompt; headless runs never prompt.
+	Interactive bool
+	// Version is the running client's build identity.
+	Version string
+	// Service carries the settled config for post-swap server probing and
+	// restart. ConfigErr, when non-nil, is why it could not be settled: the
+	// swap still proceeds and only the server check is skipped, so a broken
+	// config.toml can never block getting a new binary.
+	Service   service.Options
+	ConfigErr error
+	Stdin     io.Reader
+	Stdout    io.Writer
+	Stderr    io.Writer
+}
+
+// Run downloads the selected build, verifies and installs it over this
+// binary, and then deals with a server still running the old version.
+func Run(ctx context.Context, opts Options) error {
+	asset, err := assetName(runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return err
+	}
+
+	tag := devTag
+	if opts.Dev {
+		say(opts.Stdout, "downloading the current dev build...\n")
+	} else {
+		if tag, err = latestProductionTag(ctx); err != nil {
+			return err
+		}
+		if tag == opts.Version {
+			say(opts.Stdout, "%s\n", upToDateMessage(opts.Version))
+			return nil
+		}
+		say(opts.Stdout, "downloading %s...\n", tag)
+	}
+
+	archive, err := fetch(ctx, assetURL(tag, asset))
+	if err != nil {
+		return err
+	}
+	sums, err := fetch(ctx, assetURL(tag, checksumsAsset))
+	if err != nil {
+		return err
+	}
+	if err := verifyChecksum(archive, sums, asset); err != nil {
+		return err
+	}
+	binary, err := extractBinary(archive)
+	if err != nil {
+		return err
+	}
+
+	target, err := executablePath()
+	if err != nil {
+		return err
+	}
+	staged, err := stage(target, binary)
+	if err != nil {
+		return err
+	}
+	// A no-op after the promoting rename; cleanup for every earlier exit.
+	defer func() { _ = os.Remove(staged) }()
+	newVersion, err := binaryVersion(ctx, staged)
+	if err != nil {
+		return err
+	}
+	if err := promote(staged, target); err != nil {
+		return err
+	}
+	say(opts.Stdout, "%s\n", replacedMessage(opts.Version, newVersion, target))
+
+	return checkServer(ctx, opts, newVersion)
+}
+
+// checkServer handles the post-swap server via the existing handshake: not
+// running means done; a server on any other version than the one just
+// installed is restarted or deliberately left, per the policy matrix. It
+// never returns a failure for an unrestarted server — that state is loud on
+// every later command.
+func checkServer(ctx context.Context, opts Options, newVersion string) error {
+	if opts.ConfigErr != nil {
+		say(opts.Stderr, "cannot check the running server (%v); run `atc server restart` if one is running\n", opts.ConfigErr)
+		return nil
+	}
+	responding, serverVersion := service.Probe(ctx, opts.Service)
+	if !responding {
+		return nil
+	}
+	if serverVersion == newVersion {
+		say(opts.Stdout, "server is already running %s\n", newVersion)
+		return nil
+	}
+	action := decideRestart(opts.Restart, opts.Interactive)
+	if action == actionAsk && promptYes(opts.Stdin, opts.Stdout, restartPrompt(serverVersion)) {
+		action = actionRestart
+	}
+	if action == actionRestart {
+		return restartServer(ctx, opts, newVersion)
+	}
+	say(opts.Stdout, "%s\n", staleServerLine(serverVersion))
+	return nil
+}
+
+// restartServer bounces the supervised server with the same path `atc
+// server restart` uses; the unit re-renders from this executable, which now
+// holds the new binary.
+func restartServer(ctx context.Context, opts Options, newVersion string) error {
+	svc := opts.Service
+	svc.Version = newVersion
+	return service.Restart(ctx, svc)
+}
+
+type restartAction int
+
+const (
+	actionSkip restartAction = iota
+	actionAsk
+	actionRestart
+)
+
+// decideRestart is the ATC-261 policy matrix: explicit flags win; a human
+// at a TTY is asked (default yes); headless runs never restart — community
+// consensus reserves auto-restart for provably-cheap interruption, and
+// ATC's mid-turn agent threads are not that.
+func decideRestart(mode RestartMode, interactive bool) restartAction {
+	switch {
+	case mode == RestartAlways:
+		return actionRestart
+	case mode == RestartNever:
+		return actionSkip
+	case interactive:
+		return actionAsk
+	default:
+		return actionSkip
+	}
+}
+
+// promptYes asks a default-yes question on the user's terminal.
+func promptYes(in io.Reader, out io.Writer, prompt string) bool {
+	say(out, "%s", prompt)
+	line, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && line == "" {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "", "y", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+// binaryVersion runs the staged binary's `version` command — proof the
+// download executes on this machine before it replaces anything, and the
+// only way to learn a dev build's stamped version.
+func binaryVersion(ctx context.Context, path string) (string, error) {
+	out, err := exec.CommandContext(ctx, path, "version").Output()
+	if err != nil {
+		return "", fmt.Errorf("downloaded binary failed to run: %w", err)
+	}
+	version := strings.TrimSpace(string(out))
+	if version == "" {
+		return "", errors.New("downloaded binary printed no version")
+	}
+	return version, nil
+}
+
+// say writes a user-facing message; a failed write to the user's own
+// terminal has no better remedy than the message it would have carried.
+func say(w io.Writer, format string, args ...any) {
+	_, _ = fmt.Fprintf(w, format, args...)
+}

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -1,0 +1,225 @@
+package upgrade
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAssetName(t *testing.T) {
+	for _, tt := range []struct {
+		goos, goarch string
+		want         string
+	}{
+		{"darwin", "arm64", "atc_darwin_arm64.tar.gz"},
+		{"linux", "amd64", "atc_linux_amd64.tar.gz"},
+		{"linux", "arm64", "atc_linux_arm64.tar.gz"},
+	} {
+		got, err := assetName(tt.goos, tt.goarch)
+		if err != nil || got != tt.want {
+			t.Errorf("assetName(%s, %s) = %q, %v, want %q", tt.goos, tt.goarch, got, err, tt.want)
+		}
+	}
+}
+
+// Unsupported platforms get a named diagnostic — never a bare 404.
+func TestAssetNameUnsupported(t *testing.T) {
+	for _, tt := range []struct{ goos, goarch string }{
+		{"darwin", "amd64"},
+		{"windows", "amd64"},
+	} {
+		_, err := assetName(tt.goos, tt.goarch)
+		if err == nil || !strings.Contains(err.Error(), tt.goos+"/"+tt.goarch) {
+			t.Errorf("assetName(%s, %s) = %v, want an error naming the platform", tt.goos, tt.goarch, err)
+		}
+	}
+}
+
+func TestTagFromLocation(t *testing.T) {
+	tag, err := tagFromLocation("https://github.com/jeremytondo/atc/releases/tag/v0.1.0")
+	if err != nil || tag != "v0.1.0" {
+		t.Errorf("tagFromLocation() = %q, %v, want v0.1.0", tag, err)
+	}
+}
+
+func TestTagFromLocationRejectsNonReleaseTargets(t *testing.T) {
+	// The releases page itself is where GitHub lands when no release exists.
+	for _, location := range []string{"", "https://github.com/jeremytondo/atc/releases"} {
+		if tag, err := tagFromLocation(location); err == nil {
+			t.Errorf("tagFromLocation(%q) = %q, want an error", location, tag)
+		}
+	}
+}
+
+func checksumsFor(name string, data []byte) []byte {
+	return fmt.Appendf(nil, "%x  %s\n%x  other.tar.gz\n", sha256.Sum256(data), name, sha256.Sum256([]byte("other")))
+}
+
+func TestVerifyChecksum(t *testing.T) {
+	archive := []byte("release bytes")
+	sums := checksumsFor("atc_linux_amd64.tar.gz", archive)
+	if err := verifyChecksum(archive, sums, "atc_linux_amd64.tar.gz"); err != nil {
+		t.Errorf("verifyChecksum() = %v, want nil", err)
+	}
+	if err := verifyChecksum([]byte("tampered"), sums, "atc_linux_amd64.tar.gz"); err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Errorf("verifyChecksum(tampered) = %v, want a mismatch error", err)
+	}
+	if err := verifyChecksum(archive, sums, "atc_darwin_arm64.tar.gz"); err == nil || !strings.Contains(err.Error(), "no entry") {
+		t.Errorf("verifyChecksum(missing asset) = %v, want a no-entry error", err)
+	}
+}
+
+// releaseArchive builds a GoReleaser-shaped tar.gz: the binary plus a
+// README, as the archives config produces.
+func releaseArchive(t *testing.T, members map[string][]byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, data := range members {
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o755, Size: int64(len(data))}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func TestExtractBinary(t *testing.T) {
+	archive := releaseArchive(t, map[string][]byte{
+		"README.md": []byte("docs"),
+		"atc":       []byte("the binary"),
+	})
+	binary, err := extractBinary(archive)
+	if err != nil || string(binary) != "the binary" {
+		t.Errorf("extractBinary() = %q, %v, want the binary member", binary, err)
+	}
+}
+
+func TestExtractBinaryMissingMember(t *testing.T) {
+	archive := releaseArchive(t, map[string][]byte{"README.md": []byte("docs")})
+	if _, err := extractBinary(archive); err == nil || !strings.Contains(err.Error(), `"atc"`) {
+		t.Errorf("extractBinary() = %v, want a missing-member error", err)
+	}
+	if _, err := extractBinary([]byte("not a gzip")); err == nil {
+		t.Error("extractBinary(garbage) = nil, want an error")
+	}
+}
+
+func TestStageAndPromoteReplacesTarget(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "atc")
+	if err := os.WriteFile(target, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	staged, err := stage(target, []byte("new"))
+	if err != nil {
+		t.Fatalf("stage() = %v", err)
+	}
+	if filepath.Dir(staged) != dir {
+		t.Errorf("staged in %s, want beside the target in %s", filepath.Dir(staged), dir)
+	}
+	info, err := os.Stat(staged)
+	if err != nil || info.Mode().Perm() != 0o755 {
+		t.Errorf("staged mode = %v, %v, want 0755", info.Mode(), err)
+	}
+	if err := promote(staged, target); err != nil {
+		t.Fatalf("promote() = %v", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil || string(got) != "new" {
+		t.Errorf("target after promote = %q, %v, want the new binary", got, err)
+	}
+}
+
+func TestStageUnwritableDirectoryNamesTheRemedy(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root ignores directory permissions")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+	_, err := stage(filepath.Join(dir, "atc"), []byte("new"))
+	if err == nil || !strings.Contains(err.Error(), "never invokes sudo") {
+		t.Errorf("stage() = %v, want the unwritable-directory diagnostic", err)
+	}
+}
+
+func TestDecideRestart(t *testing.T) {
+	for _, tt := range []struct {
+		mode        RestartMode
+		interactive bool
+		want        restartAction
+	}{
+		{RestartAlways, false, actionRestart},
+		{RestartAlways, true, actionRestart},
+		{RestartNever, true, actionSkip},
+		{RestartNever, false, actionSkip},
+		{RestartAsk, true, actionAsk},
+		// Headless with no flag never restarts: interruption is not
+		// provably cheap.
+		{RestartAsk, false, actionSkip},
+	} {
+		if got := decideRestart(tt.mode, tt.interactive); got != tt.want {
+			t.Errorf("decideRestart(%v, %v) = %v, want %v", tt.mode, tt.interactive, got, tt.want)
+		}
+	}
+}
+
+func TestPromptYesDefaultsYes(t *testing.T) {
+	for input, want := range map[string]bool{
+		"\n":    true,
+		"y\n":   true,
+		"YES\n": true,
+		"n\n":   false,
+		"no\n":  false,
+		"":      false, // closed stdin cannot consent
+	} {
+		var out strings.Builder
+		if got := promptYes(strings.NewReader(input), &out, "restart? "); got != want {
+			t.Errorf("promptYes(%q) = %v, want %v", input, got, want)
+		}
+		if out.String() != "restart? " {
+			t.Errorf("prompt output = %q", out.String())
+		}
+	}
+}
+
+func TestMessages(t *testing.T) {
+	if got := upToDateMessage("v0.1.1"); got != "atc v0.1.1 is already up to date" {
+		t.Errorf("upToDateMessage() = %q", got)
+	}
+	// The walk-back from dev to production states both versions plainly.
+	if got := replacedMessage("v0.1.2-dev.3cf5189", "v0.1.1", "/home/u/.local/bin/atc"); got != "replaced v0.1.2-dev.3cf5189 with v0.1.1 at /home/u/.local/bin/atc" {
+		t.Errorf("replacedMessage() = %q", got)
+	}
+	if got := replacedMessage("v0.1.1", "v0.1.1", "/b/atc"); !strings.HasPrefix(got, "reinstalled v0.1.1") {
+		t.Errorf("replacedMessage(same) = %q, want a reinstall report", got)
+	}
+	if got := staleServerLine("v0.1.0"); !strings.Contains(got, "v0.1.0") || !strings.Contains(got, "atc server restart") || !strings.Contains(got, "--restart") {
+		t.Errorf("staleServerLine() = %q, want the version and both remedies", got)
+	}
+	if got := staleServerLine(""); !strings.Contains(got, "an unknown version") {
+		t.Errorf("staleServerLine(\"\") = %q", got)
+	}
+	prompt := restartPrompt("v0.1.0")
+	if !strings.Contains(prompt, "terminals persist") || !strings.Contains(prompt, "[Y/n]") {
+		t.Errorf("restartPrompt() = %q, want the risk summary and a default-yes prompt", prompt)
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,49 @@
+// Package version resolves the binary's build identity (ATC-261).
+//
+// Version is stamped by the release workflow via `-ldflags -X` (see
+// .goreleaser.yaml); only workflow-built binaries ever claim a
+// vX.Y.Z-shaped version. That property is what makes client/server skew
+// detection and `atc upgrade`'s staleness comparison trustworthy: local
+// builds deliberately stay on the buildinfo fallback (devel-<sha>) instead
+// of `git describe`-style release-shaped names.
+package version
+
+import "runtime/debug"
+
+// Version is the release identity stamped at build time. Empty in every
+// non-workflow build.
+var Version string
+
+// String returns the build identity used everywhere a version is shown or
+// compared. Released builds carry the stamped version; source builds fall
+// back to the VCS revision. One limit: builds without VCS metadata all
+// report "devel" and cannot be told apart.
+func String() string {
+	if Version != "" {
+		return Version
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+	version := info.Main.Version
+	if version != "" && version != "(devel)" {
+		return version
+	}
+	revision, dirty := "", false
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			revision = setting.Value
+		case "vcs.modified":
+			dirty = setting.Value == "true"
+		}
+	}
+	if revision == "" {
+		return "devel"
+	}
+	if dirty {
+		return "devel-" + revision + "-dirty"
+	}
+	return "devel-" + revision
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,9 +3,9 @@
 // Version is stamped by the release workflow via `-ldflags -X` (see
 // .goreleaser.yaml); only workflow-built binaries ever claim a
 // vX.Y.Z-shaped version. That property is what makes client/server skew
-// detection and `atc upgrade`'s staleness comparison trustworthy: local
-// builds deliberately stay on the buildinfo fallback (devel-<sha>) instead
-// of `git describe`-style release-shaped names.
+// detection and `atc upgrade`'s staleness comparison trustworthy, so every
+// unstamped build — including `go install ...@vX.Y.Z`, whose buildinfo
+// carries the module version — resolves to a devel identity instead.
 package version
 
 import "runtime/debug"
@@ -15,20 +15,25 @@ import "runtime/debug"
 var Version string
 
 // String returns the build identity used everywhere a version is shown or
-// compared. Released builds carry the stamped version; source builds fall
-// back to the VCS revision. One limit: builds without VCS metadata all
-// report "devel" and cannot be told apart.
+// compared.
 func String() string {
-	if Version != "" {
-		return Version
-	}
 	info, ok := debug.ReadBuildInfo()
+	return resolve(Version, info, ok)
+}
+
+// resolve is the pure resolution order: the workflow stamp wins, then VCS
+// metadata (devel-<sha>, devel-<sha>-dirty), then devel/unknown.
+// info.Main.Version is deliberately ignored — `go install ...@vX.Y.Z`
+// embeds it, and a non-workflow build claiming a release-shaped version
+// would break the "only workflow builds" invariant and make `atc upgrade`
+// short-circuit. One limit: builds without VCS metadata all report "devel"
+// and cannot be told apart.
+func resolve(stamped string, info *debug.BuildInfo, ok bool) string {
+	if stamped != "" {
+		return stamped
+	}
 	if !ok {
 		return "unknown"
-	}
-	version := info.Main.Version
-	if version != "" && version != "(devel)" {
-		return version
 	}
 	revision, dirty := "", false
 	for _, setting := range info.Settings {

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,19 @@
+package version
+
+import "testing"
+
+func TestStringPrefersStampedVersion(t *testing.T) {
+	defer func(previous string) { Version = previous }(Version)
+	Version = "v0.1.0"
+	if got := String(); got != "v0.1.0" {
+		t.Errorf("String() = %q, want the stamped version", got)
+	}
+}
+
+func TestStringFallbackIsNeverEmpty(t *testing.T) {
+	defer func(previous string) { Version = previous }(Version)
+	Version = ""
+	if String() == "" {
+		t.Error("String() = \"\", want a buildinfo-derived identity")
+	}
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,19 +1,48 @@
 package version
 
-import "testing"
+import (
+	"runtime/debug"
+	"testing"
+)
 
-func TestStringPrefersStampedVersion(t *testing.T) {
-	defer func(previous string) { Version = previous }(Version)
-	Version = "v0.1.0"
-	if got := String(); got != "v0.1.0" {
-		t.Errorf("String() = %q, want the stamped version", got)
+func TestResolve(t *testing.T) {
+	// The shape `go install github.com/jeremytondo/atc/cmd/atc@v0.1.0`
+	// embeds: a release-shaped module version with no workflow stamp.
+	goInstall := &debug.BuildInfo{Main: debug.Module{Version: "v0.1.0"}}
+	vcs := &debug.BuildInfo{
+		Main: debug.Module{Version: "(devel)"},
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "3cf5189"},
+			{Key: "vcs.modified", Value: "false"},
+		},
+	}
+	dirty := &debug.BuildInfo{
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "3cf5189"},
+			{Key: "vcs.modified", Value: "true"},
+		},
+	}
+	for name, tt := range map[string]struct {
+		stamped string
+		info    *debug.BuildInfo
+		ok      bool
+		want    string
+	}{
+		"stamp wins":             {"v0.2.0", vcs, true, "v0.2.0"},
+		"go install stays devel": {"", goInstall, true, "devel"},
+		"vcs revision":           {"", vcs, true, "devel-3cf5189"},
+		"dirty tree marked":      {"", dirty, true, "devel-3cf5189-dirty"},
+		"no vcs metadata":        {"", &debug.BuildInfo{}, true, "devel"},
+		"no build info":          {"", nil, false, "unknown"},
+	} {
+		if got := resolve(tt.stamped, tt.info, tt.ok); got != tt.want {
+			t.Errorf("%s: resolve(%q, ...) = %q, want %q", name, tt.stamped, got, tt.want)
+		}
 	}
 }
 
-func TestStringFallbackIsNeverEmpty(t *testing.T) {
-	defer func(previous string) { Version = previous }(Version)
-	Version = ""
+func TestStringIsNeverEmpty(t *testing.T) {
 	if String() == "" {
-		t.Error("String() = \"\", want a buildinfo-derived identity")
+		t.Error("String() = \"\", want a build identity")
 	}
 }

--- a/mise.toml
+++ b/mise.toml
@@ -21,7 +21,7 @@ depends = ["build", "lint", "test"]
 
 [tasks.install]
 description = "Build a static atc binary into ~/.local/bin"
-run = "CGO_ENABLED=0 go build -o ~/.local/bin/atc ./cmd/atc"
+run = "mkdir -p ~/.local/bin && CGO_ENABLED=0 go build -o ~/.local/bin/atc ./cmd/atc"
 
 [tasks."release:patch"]
 description = "Dispatch the release workflow to cut a patch release"

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,7 @@
 [tools]
 go = "1.26.7"
 golangci-lint = "2.13.1"
+goreleaser = "2.17.1"
 
 [tasks.build]
 description = "Build a static atc binary into bin/"
@@ -17,6 +18,26 @@ run = "golangci-lint run ./..."
 [tasks.check]
 description = "Build, lint, and test"
 depends = ["build", "lint", "test"]
+
+[tasks.install]
+description = "Build a static atc binary into ~/.local/bin"
+run = "CGO_ENABLED=0 go build -o ~/.local/bin/atc ./cmd/atc"
+
+[tasks."release:patch"]
+description = "Dispatch the release workflow to cut a patch release"
+run = "gh workflow run release.yml -f bump=patch"
+
+[tasks."release:minor"]
+description = "Dispatch the release workflow to cut a minor release"
+run = "gh workflow run release.yml -f bump=minor"
+
+[tasks."release:major"]
+description = "Dispatch the release workflow to cut a major release"
+run = "gh workflow run release.yml -f bump=major"
+
+[tasks."release:dev"]
+description = "Dispatch the release workflow to refresh the rolling dev build from main (use `gh workflow run release.yml -f bump=dev --ref <branch>` for a branch)"
+run = "gh workflow run release.yml -f bump=dev"
 
 [tasks.clean]
 description = "Remove build artifacts"


### PR DESCRIPTION
Implements [ATC-261](https://linear.app/elevenideas/issue/ATC-261) per the 2026-08-25 grill record.

## What's here

**Versioning** — new `internal/version` package: `Version` stamped via `-ldflags -X` by the release workflow only; the buildinfo `devel-<sha>`/`devel-<sha>-dirty` fallback stays for local builds, so only workflow builds ever claim a release-shaped version. `cmd/atc` now uses it everywhere `versionString()` was.

**GoReleaser** (`.goreleaser.yaml`) — CGO-free static builds for darwin/arm64, linux/amd64, linux/arm64; one tar.gz per target (binary + README) with **version-independent asset names** (`atc_<os>_<arch>.tar.gz`) so `releases/latest/download` URLs are static and the dev channel can clobber in place; `checksums.txt`; snapshot versioning `{{ incpatch .Version }}-dev.{{ .ShortCommit }}`; legacy and `dev` tags excluded from version computation (the `v0.0.x` tags stay visible so the first `minor` cut lands on v0.1.0).

**Release workflow** (`release.yml`) — `workflow_dispatch` with a single `bump` choice (`patch|minor|major|dev`). Production: computes the next version from the remote's tags, tags the dispatched ref's head, publishes an immutable release (stateless — safe from any machine). Dev: GoReleaser snapshot + `gh release upload --clobber` onto the rolling `dev` prerelease (created on first use, notes updated with the current build). `contents: write` scoped to the release job.

**install.sh** — first install only; OS/arch detection with named failures (Intel Macs get a real message, not a 404), checksum verification, `~/.local/bin` on both platforms, `ATC_INSTALL_DIR`/`ATC_VERSION` knobs, PATH hint. No dev knob by design.

**`atc upgrade`** — stateless channel: plain upgrade moves to latest production (short-circuits on version match; the dev→production walk-back is stated plainly), `--dev` always reinstalls. Tokenless discovery via the `releases/latest` redirect and the fixed `dev` tag. Swap: checksum verify → extract → stage beside the resolved `os.Executable()` → prove the staged binary runs (`version`) → atomic rename; unwritable dirs get a named diagnostic, never sudo. Post-swap: probe via the existing handshake; interactive runs are asked with the ATC-246 risk summary (default yes), **headless runs never restart** without `--restart`, `--no-restart` pre-answers the other way. A broken config.toml skips only the server check, never the swap.

**Conveniences** — mise: `goreleaser` tool, `install` task (local build into `~/.local/bin`), `release:patch|minor|major|dev` wrappers; README install/upgrade section.

## Verification

- `mise run check` green (build, golangci-lint, tests with race detector).
- `goreleaser check` + a full local `goreleaser release --snapshot --clean`: all three targets built, archives named `atc_<os>_<arch>.tar.gz` containing `atc` + README, snapshot version computed as `0.0.5-dev.15c7f1b`, and the extracted binary reports the stamped `v0.0.5-dev.15c7f1b`.
- Pure logic tested: asset naming (incl. named unsupported-platform diagnostics), redirect tag parsing, checksum verify, tar extraction, stage/promote with the unwritable-dir diagnostic, the restart policy matrix, prompt semantics, message rendering.

## Notes

- GoReleaser pinned at 2.17.1: mise's aqua backend fails GitHub artifact-attestation verification on 2.18.0 (recent releases are signed with GitHub's new `dotcom.releases.github.com` identity, which aqua doesn't expect yet).
- The archives ship `README.md` only — the repo has no LICENSE file to include.
- Until v0.1.0 exists, `releases/latest` still points at the archived product's v0.0.4; `atc upgrade` on this branch would fail there with the named "has this release been published?" diagnostic. Self-heals at the first production cut.

## After merge (the ticket's done-when)

1. `mise run release:minor` → cuts **v0.1.0**.
2. `mise run release:dev` → first rolling dev build.
3. `curl -fsSL .../install.sh | sh` on a machine, then one `atc upgrade` against a later release end-to-end.