### PR TITLE
ATC-264 | Shared /v1 contract: internal/api wire structs, typed Problem, hand-written api.Client

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,0 +1,26 @@
+// Package api is the /v1 wire contract and its Go client (ATC-264). The
+// structs here are the single source of truth for the API shape: the
+// server's Huma handlers wrap them (the served OpenAPI document derives
+// from these same definitions), and every in-repo Go consumer imports
+// them, so a contract change that breaks a consumer is a compile error.
+// The validation/doc tags are Huma's; they are inert to clients.
+//
+// The package is deliberately stdlib-only, which keeps a later promotion
+// out of internal/ for third-party Go consumers cheap. Codegen exists only
+// across language boundaries: external consumers generate from the served
+// /openapi.json, never from a checked-in artifact and never in this repo.
+package api
+
+// Version headers ride both ways on every request/response — the entire
+// skew handshake (ATC-247 §6). They live here, not in the server, so
+// client-side code never imports server internals.
+const (
+	ClientVersionHeader = "Atc-Client-Version"
+	ServerVersionHeader = "Atc-Server-Version"
+)
+
+// Health is the GET /v1/health response body.
+type Health struct {
+	Status  string `json:"status" enum:"ok" doc:"Liveness state of the server."`
+	Version string `json:"version" doc:"Version of the running server binary."`
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -9,9 +9,10 @@ import (
 	"strings"
 )
 
-// Errors from a misbehaving peer are capped rather than trusted to be
-// small.
-const maxProblemBody = 1 << 20
+// Bodies from a misbehaving peer are read to a cap, never to EOF: problem
+// documents larger than this are truncated, and a response still streaming
+// past it forfeits connection reuse instead of blocking the call.
+const maxBodyRead = 1 << 20
 
 // Client is the typed /v1 client every in-repo Go consumer speaks through;
 // TUI and CLI commands use it and never touch server internals. One
@@ -19,10 +20,11 @@ const maxProblemBody = 1 << 20
 // Atc-Server-Version on every exchange, so the skew handshake lives in
 // exactly one place; each operation is a small typed method over it.
 type Client struct {
-	baseURL    string
-	token      string
-	version    string
-	httpClient *http.Client
+	baseURL         string
+	token           string
+	version         string
+	httpClient      *http.Client
+	onServerVersion func(version string)
 }
 
 // NewClient returns a client for the server at baseURL (scheme and
@@ -30,16 +32,21 @@ type Client struct {
 // tokenless probing — the server's version still comes back on the typed
 // error of the resulting 401. version is the client build identity, for
 // skew reporting. A nil httpClient defaults to a plain http.Client; pass
-// one to set timeouts or transports.
-func NewClient(baseURL, token, version string, httpClient *http.Client) *Client {
+// one to set timeouts or transports. onServerVersion, when non-nil, is
+// invoked with the Atc-Server-Version header of every response that
+// carries one — success or failure — which is how callers observe the
+// server's side of the skew handshake without the client holding mutable
+// last-response state; it runs on the calling goroutine.
+func NewClient(baseURL, token, version string, httpClient *http.Client, onServerVersion func(version string)) *Client {
 	if httpClient == nil {
 		httpClient = &http.Client{}
 	}
 	return &Client{
-		baseURL:    strings.TrimSuffix(baseURL, "/"),
-		token:      token,
-		version:    version,
-		httpClient: httpClient,
+		baseURL:         strings.TrimSuffix(baseURL, "/"),
+		token:           token,
+		version:         version,
+		httpClient:      httpClient,
+		onServerVersion: onServerVersion,
 	}
 }
 
@@ -50,8 +57,11 @@ func (c *Client) Health(ctx context.Context) (Health, error) {
 	return health, err
 }
 
-// do is the single request path. A non-2xx response returns *Problem; any
-// other error means no usable HTTP response arrived at all.
+// do is the single request path. Any HTTP response that is not a decodable
+// success returns *Problem — the server's own problem document when it
+// sent one, a synthesized one otherwise — so a *Problem uniformly means
+// "the server answered". Any other error means no usable HTTP response
+// arrived at all.
 func (c *Client) do(ctx context.Context, method, path string, out any) error {
 	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, nil)
 	if err != nil {
@@ -66,16 +76,29 @@ func (c *Client) do(ctx context.Context, method, path string, out any) error {
 		return fmt.Errorf("%s %s: %w", method, path, err)
 	}
 	defer func() {
-		// Drain so the keep-alive connection is reusable.
-		_, _ = io.Copy(io.Discard, resp.Body)
+		// Drain a bounded amount so healthy keep-alive connections are
+		// reusable; a peer still streaming past the cap loses reuse, not
+		// the caller's time.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxBodyRead))
 		_ = resp.Body.Close()
 	}()
+	serverVersion := resp.Header.Get(ServerVersionHeader)
+	if c.onServerVersion != nil && serverVersion != "" {
+		c.onServerVersion(serverVersion)
+	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return problemFrom(resp)
+		return problemFrom(resp, serverVersion)
 	}
 	if out != nil {
-		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
-			return fmt.Errorf("decoding %s %s response: %w", method, path, err)
+		if err := json.NewDecoder(io.LimitReader(resp.Body, maxBodyRead)).Decode(out); err != nil {
+			// The server answered; a body we cannot decode must not look
+			// like a transport failure to callers branching on *Problem.
+			return &Problem{
+				Title:         "malformed response body",
+				Status:        resp.StatusCode,
+				Detail:        fmt.Sprintf("decoding %s %s response: %v", method, path, err),
+				ServerVersion: serverVersion,
+			}
 		}
 	}
 	return nil
@@ -85,12 +108,15 @@ func (c *Client) do(ctx context.Context, method, path string, out any) error {
 // a problem document (a proxy's error page, some other process on the
 // port) degrades to the status line instead of failing the decode — the
 // caller still gets a typed error with the right status.
-func problemFrom(resp *http.Response) *Problem {
+func problemFrom(resp *http.Response, serverVersion string) *Problem {
 	problem := &Problem{}
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxProblemBody))
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBodyRead))
 	if err := json.Unmarshal(body, problem); err != nil || problem.Status == 0 {
-		*problem = Problem{Title: http.StatusText(resp.StatusCode), Status: resp.StatusCode}
+		*problem = Problem{Title: http.StatusText(resp.StatusCode)}
 	}
-	problem.ServerVersion = resp.Header.Get(ServerVersionHeader)
+	// The wire status member is advisory; callers branch on what the
+	// transport actually said, immune to a lying or rewritten body.
+	problem.Status = resp.StatusCode
+	problem.ServerVersion = serverVersion
 	return problem
 }

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Errors from a misbehaving peer are capped rather than trusted to be
+// small.
+const maxProblemBody = 1 << 20
+
+// Client is the typed /v1 client every in-repo Go consumer speaks through;
+// TUI and CLI commands use it and never touch server internals. One
+// request path sets the bearer token and Atc-Client-Version and reads
+// Atc-Server-Version on every exchange, so the skew handshake lives in
+// exactly one place; each operation is a small typed method over it.
+type Client struct {
+	baseURL    string
+	token      string
+	version    string
+	httpClient *http.Client
+}
+
+// NewClient returns a client for the server at baseURL (scheme and
+// authority, e.g. "http://127.0.0.1:4779"). token may be empty for
+// tokenless probing — the server's version still comes back on the typed
+// error of the resulting 401. version is the client build identity, for
+// skew reporting. A nil httpClient defaults to a plain http.Client; pass
+// one to set timeouts or transports.
+func NewClient(baseURL, token, version string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+	return &Client{
+		baseURL:    strings.TrimSuffix(baseURL, "/"),
+		token:      token,
+		version:    version,
+		httpClient: httpClient,
+	}
+}
+
+// Health reports the server's liveness and build version.
+func (c *Client) Health(ctx context.Context) (Health, error) {
+	var health Health
+	err := c.do(ctx, http.MethodGet, "/v1/health", &health)
+	return health, err
+}
+
+// do is the single request path. A non-2xx response returns *Problem; any
+// other error means no usable HTTP response arrived at all.
+func (c *Client) do(ctx context.Context, method, path string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, nil)
+	if err != nil {
+		return fmt.Errorf("building %s %s request: %w", method, path, err)
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	req.Header.Set(ClientVersionHeader, c.version)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s %s: %w", method, path, err)
+	}
+	defer func() {
+		// Drain so the keep-alive connection is reusable.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return problemFrom(resp)
+	}
+	if out != nil {
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			return fmt.Errorf("decoding %s %s response: %w", method, path, err)
+		}
+	}
+	return nil
+}
+
+// problemFrom turns a non-2xx response into a *Problem. A body that is not
+// a problem document (a proxy's error page, some other process on the
+// port) degrades to the status line instead of failing the decode — the
+// caller still gets a typed error with the right status.
+func problemFrom(resp *http.Response) *Problem {
+	problem := &Problem{}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxProblemBody))
+	if err := json.Unmarshal(body, problem); err != nil || problem.Status == 0 {
+		*problem = Problem{Title: http.StatusText(resp.StatusCode), Status: resp.StatusCode}
+	}
+	problem.ServerVersion = resp.Header.Get(ServerVersionHeader)
+	return problem
+}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1,0 +1,145 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+const (
+	testToken         = "atc_test-token"
+	testClientVersion = "v1.2.3-client"
+	testServerVersion = "v1.2.3-server"
+)
+
+// testServer answers /v1/health the way the real chassis does: version
+// header on every response, 401s included, problem+json on rejection.
+func testServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(ServerVersionHeader, testServerVersion)
+		if r.Header.Get("Authorization") != "Bearer "+testToken {
+			w.Header().Set("Content-Type", "application/problem+json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(Problem{
+				Title:  "Unauthorized",
+				Status: http.StatusUnauthorized,
+				Detail: "invalid or missing bearer token",
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(Health{Status: "ok", Version: testServerVersion})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestHealth(t *testing.T) {
+	srv := testServer(t)
+	client := NewClient(srv.URL, testToken, testClientVersion, nil)
+	health, err := client.Health(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := Health{Status: "ok", Version: testServerVersion}
+	if diff := cmp.Diff(want, health); diff != "" {
+		t.Errorf("Health() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestRequestCarriesTokenAndClientVersion(t *testing.T) {
+	var authorization, clientVersion string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorization = r.Header.Get("Authorization")
+		clientVersion = r.Header.Get(ClientVersionHeader)
+		_ = json.NewEncoder(w).Encode(Health{Status: "ok"})
+	}))
+	defer srv.Close()
+
+	if _, err := NewClient(srv.URL, testToken, testClientVersion, nil).Health(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if authorization != "Bearer "+testToken {
+		t.Errorf("Authorization = %q, want bearer token", authorization)
+	}
+	if clientVersion != testClientVersion {
+		t.Errorf("%s = %q, want %q", ClientVersionHeader, clientVersion, testClientVersion)
+	}
+}
+
+// A tokenless client (the probe) must not send an empty Authorization
+// header, and must still learn the server version from the 401's typed
+// error — the contract that lets `atc upgrade` verify a swap without
+// credentials.
+func TestTokenlessProbeReadsVersionOffUnauthorized(t *testing.T) {
+	srv := testServer(t)
+	_, err := NewClient(srv.URL, "", testClientVersion, nil).Health(context.Background())
+	problem, ok := errors.AsType[*Problem](err)
+	if !ok {
+		t.Fatalf("err = %v, want *Problem", err)
+	}
+	if problem.Status != http.StatusUnauthorized {
+		t.Errorf("Status = %d, want 401", problem.Status)
+	}
+	if problem.ServerVersion != testServerVersion {
+		t.Errorf("ServerVersion = %q, want %q", problem.ServerVersion, testServerVersion)
+	}
+	if got, want := problem.Error(), "invalid or missing bearer token (HTTP 401)"; got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+// A non-problem error body (a proxy page, some other process on the port)
+// degrades to the status line; the caller still gets a typed error.
+func TestNonProblemBodyDegradesToStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("<html>nope</html>"))
+	}))
+	defer srv.Close()
+
+	_, err := NewClient(srv.URL, testToken, testClientVersion, nil).Health(context.Background())
+	problem, ok := errors.AsType[*Problem](err)
+	if !ok {
+		t.Fatalf("err = %v, want *Problem", err)
+	}
+	want := &Problem{Title: "Bad Gateway", Status: http.StatusBadGateway}
+	if diff := cmp.Diff(want, problem); diff != "" {
+		t.Errorf("problem mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// Only an HTTP response becomes a *Problem; transport failure stays a
+// plain error so "responding" and "rejected" remain distinguishable.
+func TestTransportErrorIsNotAProblem(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	srv.Close() // nothing listening anymore
+
+	_, err := NewClient(srv.URL, testToken, testClientVersion, nil).Health(context.Background())
+	if err == nil {
+		t.Fatal("want an error from a dead server")
+	}
+	if problem, ok := errors.AsType[*Problem](err); ok {
+		t.Errorf("transport failure decoded as *Problem: %v", problem)
+	}
+}
+
+func TestProblemErrorFallbacks(t *testing.T) {
+	for name, tc := range map[string]struct {
+		problem Problem
+		want    string
+	}{
+		"detail":      {Problem{Title: "Unauthorized", Status: 401, Detail: "bad token"}, "bad token (HTTP 401)"},
+		"title":       {Problem{Title: "Unauthorized", Status: 401}, "Unauthorized (HTTP 401)"},
+		"status only": {Problem{Status: 502}, "Bad Gateway (HTTP 502)"},
+	} {
+		if got := tc.problem.Error(); got != tc.want {
+			t.Errorf("%s: Error() = %q, want %q", name, got, tc.want)
+		}
+	}
+}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -41,7 +41,7 @@ func testServer(t *testing.T) *httptest.Server {
 
 func TestHealth(t *testing.T) {
 	srv := testServer(t)
-	client := NewClient(srv.URL, testToken, testClientVersion, nil)
+	client := NewClient(srv.URL, testToken, testClientVersion, nil, nil)
 	health, err := client.Health(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -61,7 +61,7 @@ func TestRequestCarriesTokenAndClientVersion(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if _, err := NewClient(srv.URL, testToken, testClientVersion, nil).Health(context.Background()); err != nil {
+	if _, err := NewClient(srv.URL, testToken, testClientVersion, nil, nil).Health(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if authorization != "Bearer "+testToken {
@@ -78,7 +78,7 @@ func TestRequestCarriesTokenAndClientVersion(t *testing.T) {
 // credentials.
 func TestTokenlessProbeReadsVersionOffUnauthorized(t *testing.T) {
 	srv := testServer(t)
-	_, err := NewClient(srv.URL, "", testClientVersion, nil).Health(context.Background())
+	_, err := NewClient(srv.URL, "", testClientVersion, nil, nil).Health(context.Background())
 	problem, ok := errors.AsType[*Problem](err)
 	if !ok {
 		t.Fatalf("err = %v, want *Problem", err)
@@ -94,6 +94,68 @@ func TestTokenlessProbeReadsVersionOffUnauthorized(t *testing.T) {
 	}
 }
 
+// The Atc-Server-Version header is reported to the callback on every
+// response that carries one, success and rejection alike — the client's
+// half of the skew handshake.
+func TestServerVersionCallbackOnEveryResponse(t *testing.T) {
+	srv := testServer(t)
+	for name, token := range map[string]string{"success": testToken, "unauthorized": ""} {
+		var reported string
+		client := NewClient(srv.URL, token, testClientVersion, nil,
+			func(version string) { reported = version })
+		_, _ = client.Health(context.Background())
+		if reported != testServerVersion {
+			t.Errorf("%s: callback got %q, want %q", name, reported, testServerVersion)
+		}
+	}
+}
+
+// A 2xx whose body cannot be decoded is still an HTTP response: it must
+// surface as *Problem carrying the real status and server version, not as
+// a plain error a caller would mistake for "nothing answered".
+func TestMalformedSuccessBodyIsAProblem(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(ServerVersionHeader, testServerVersion)
+		_, _ = w.Write([]byte("<html>not json</html>"))
+	}))
+	defer srv.Close()
+
+	_, err := NewClient(srv.URL, testToken, testClientVersion, nil, nil).Health(context.Background())
+	problem, ok := errors.AsType[*Problem](err)
+	if !ok {
+		t.Fatalf("err = %v, want *Problem", err)
+	}
+	if problem.Status != http.StatusOK {
+		t.Errorf("Status = %d, want 200", problem.Status)
+	}
+	if problem.ServerVersion != testServerVersion {
+		t.Errorf("ServerVersion = %q, want %q", problem.ServerVersion, testServerVersion)
+	}
+}
+
+// The problem body's status member is advisory; branching trusts what the
+// transport actually said, immune to a lying or rewritten body.
+func TestProblemStatusComesFromTransport(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(Problem{Title: "Server Error", Status: http.StatusInternalServerError, Detail: "lying body"})
+	}))
+	defer srv.Close()
+
+	_, err := NewClient(srv.URL, "", testClientVersion, nil, nil).Health(context.Background())
+	problem, ok := errors.AsType[*Problem](err)
+	if !ok {
+		t.Fatalf("err = %v, want *Problem", err)
+	}
+	if problem.Status != http.StatusUnauthorized {
+		t.Errorf("Status = %d, want the transport's 401", problem.Status)
+	}
+	if problem.Detail != "lying body" {
+		t.Errorf("Detail = %q, want the body's fields retained", problem.Detail)
+	}
+}
+
 // A non-problem error body (a proxy page, some other process on the port)
 // degrades to the status line; the caller still gets a typed error.
 func TestNonProblemBodyDegradesToStatus(t *testing.T) {
@@ -103,7 +165,7 @@ func TestNonProblemBodyDegradesToStatus(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := NewClient(srv.URL, testToken, testClientVersion, nil).Health(context.Background())
+	_, err := NewClient(srv.URL, testToken, testClientVersion, nil, nil).Health(context.Background())
 	problem, ok := errors.AsType[*Problem](err)
 	if !ok {
 		t.Fatalf("err = %v, want *Problem", err)
@@ -120,7 +182,7 @@ func TestTransportErrorIsNotAProblem(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	srv.Close() // nothing listening anymore
 
-	_, err := NewClient(srv.URL, testToken, testClientVersion, nil).Health(context.Background())
+	_, err := NewClient(srv.URL, testToken, testClientVersion, nil, nil).Health(context.Background())
 	if err == nil {
 		t.Fatal("want an error from a dead server")
 	}

--- a/internal/api/problem.go
+++ b/internal/api/problem.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Problem is the RFC 7807 error body every non-2xx response carries: Huma
+// emits it for routing and validation errors, and the server's auth
+// middleware deliberately mimics the same shape, so callers see one error
+// contract regardless of which layer rejected. Defined fresh rather than
+// importing Huma's model to keep this package stdlib-only.
+//
+// Callers branch with errors.As when they care which failure it was and
+// print the error when they don't.
+type Problem struct {
+	Title  string        `json:"title"`
+	Status int           `json:"status"`
+	Detail string        `json:"detail,omitempty"`
+	Errors []ErrorDetail `json:"errors,omitempty"`
+
+	// ServerVersion is the Atc-Server-Version response header, carried on
+	// the error so a tokenless probe reads the server's version off a 401.
+	ServerVersion string `json:"-"`
+}
+
+// ErrorDetail is one Huma validation failure inside a Problem.
+type ErrorDetail struct {
+	Message  string `json:"message,omitempty"`
+	Location string `json:"location,omitempty"`
+	Value    any    `json:"value,omitempty"`
+}
+
+func (p *Problem) Error() string {
+	message := p.Detail
+	if message == "" {
+		message = p.Title
+	}
+	if message == "" {
+		message = http.StatusText(p.Status)
+	}
+	return fmt.Sprintf("%s (HTTP %d)", message, p.Status)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,22 +20,15 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humago"
+
+	"github.com/jeremytondo/atc/internal/api"
 )
 
-// Version headers both ways on every request/response — the entire skew
-// handshake (ATC-247 §6).
-const (
-	ClientVersionHeader = "Atc-Client-Version"
-	ServerVersionHeader = "Atc-Server-Version"
-)
-
-// HealthOutput doubles as the response contract and its documentation; the
-// generated OpenAPI schema is derived from it.
+// HealthOutput is Huma routing machinery around the shared body; the
+// contract itself is api.Health (ATC-264), from which the OpenAPI schema
+// is derived. Wrappers like this stay server-side, never in internal/api.
 type HealthOutput struct {
-	Body struct {
-		Status  string `json:"status" enum:"ok" doc:"Liveness state of the server."`
-		Version string `json:"version" doc:"Version of the running server binary."`
-	}
+	Body api.Health
 }
 
 // NewHandler builds the /v1 API surface plus /openapi.json and /docs.
@@ -65,19 +58,16 @@ func NewHandler(verify func(authorization string) bool, version string, logger *
 	// Declared globally so the generated document tells adapter authors
 	// every operation needs the token; enforcement is the middleware's.
 	config.Security = []map[string][]string{{"bearerAuth": {}}}
-	api := humago.New(mux, config)
+	humaAPI := humago.New(mux, config)
 
-	huma.Register(api, huma.Operation{
+	huma.Register(humaAPI, huma.Operation{
 		OperationID: "get-health",
 		Method:      http.MethodGet,
 		Path:        "/v1/health",
 		Summary:     "Server liveness",
 		Description: "Source of truth for whether the server is up; `atc server status` probes this first.",
 	}, func(ctx context.Context, _ *struct{}) (*HealthOutput, error) {
-		out := &HealthOutput{}
-		out.Body.Status = "ok"
-		out.Body.Version = version
-		return out, nil
+		return &HealthOutput{Body: api.Health{Status: "ok", Version: version}}, nil
 	})
 
 	return withVersionHeaders(version, logger, withAuth(verify, mux))
@@ -85,8 +75,8 @@ func NewHandler(verify func(authorization string) bool, version string, logger *
 
 func withVersionHeaders(version string, logger *slog.Logger, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(ServerVersionHeader, version)
-		if client := r.Header.Get(ClientVersionHeader); client != "" && client != version {
+		w.Header().Set(api.ServerVersionHeader, version)
+		if client := r.Header.Get(api.ClientVersionHeader); client != "" && client != version {
 			logger.Debug("client version skew", "client", client, "server", version)
 		}
 		next.ServeHTTP(w, r)
@@ -97,14 +87,15 @@ func withAuth(verify func(authorization string) bool, next http.Handler) http.Ha
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !verify(r.Header.Get("Authorization")) {
 			w.Header().Set("WWW-Authenticate", `Bearer realm="atc"`)
-			// Same RFC 7807 shape Huma uses for its own errors, so clients
-			// see one error contract regardless of which layer rejected.
+			// Same RFC 7807 shape Huma uses for its own errors, emitted from
+			// the shared struct, so clients see one error contract regardless
+			// of which layer rejected.
 			w.Header().Set("Content-Type", "application/problem+json")
 			w.WriteHeader(http.StatusUnauthorized)
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"title":  "Unauthorized",
-				"status": http.StatusUnauthorized,
-				"detail": "invalid or missing bearer token",
+			_ = json.NewEncoder(w).Encode(api.Problem{
+				Title:  "Unauthorized",
+				Status: http.StatusUnauthorized,
+				Detail: "invalid or missing bearer token",
 			})
 			return
 		}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/jeremytondo/atc/internal/api"
 )
 
 const (
@@ -47,10 +49,9 @@ func TestHealthWithToken(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("got %d, want 200; body: %s", rec.Code, rec.Body)
 	}
-	var body struct {
-		Status  string `json:"status"`
-		Version string `json:"version"`
-	}
+	// Decoding into the shared contract type is the point of ATC-264: the
+	// wire body and api.Health are one definition.
+	var body api.Health
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decoding %q: %v", rec.Body, err)
 	}
@@ -68,8 +69,8 @@ func TestServerVersionHeaderOnEveryResponse(t *testing.T) {
 		"unauthorized": get(handler, "/v1/health", false),
 		"not found":    get(handler, "/v1/nope", true),
 	} {
-		if got := rec.Header().Get(ServerVersionHeader); got != testVersion {
-			t.Errorf("%s: %s = %q, want %q", name, ServerVersionHeader, got, testVersion)
+		if got := rec.Header().Get(api.ServerVersionHeader); got != testVersion {
+			t.Errorf("%s: %s = %q, want %q", name, api.ServerVersionHeader, got, testVersion)
 		}
 	}
 }
@@ -80,7 +81,7 @@ func TestNilLoggerDefaultsToDiscard(t *testing.T) {
 	handler := NewHandler(testVerify, testVersion, nil)
 	req := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
 	req.Header.Set("Authorization", "Bearer "+testToken)
-	req.Header.Set(ClientVersionHeader, "v0.0.0-skewed")
+	req.Header.Set(api.ClientVersionHeader, "v0.0.0-skewed")
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {

--- a/internal/service/probe.go
+++ b/internal/service/probe.go
@@ -7,6 +7,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -18,10 +19,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jeremytondo/atc/internal/api"
 	"github.com/jeremytondo/atc/internal/authtoken"
 	"github.com/jeremytondo/atc/internal/config"
 	"github.com/jeremytondo/atc/internal/paths"
-	"github.com/jeremytondo/atc/internal/server"
 )
 
 // Health-gate contract (ATC-260, carried from legacy): 15s total, 150ms
@@ -40,27 +41,20 @@ type probeOutcome struct {
 }
 
 func probeOnce(ctx context.Context, opts Options, token string) probeOutcome {
-	url := "http://" + probeAddr(opts.Config) + "/v1/health"
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return probeOutcome{}
+	client := api.NewClient("http://"+probeAddr(opts.Config), token, opts.Version,
+		&http.Client{Timeout: probeTimeout})
+	health, err := client.Health(ctx)
+	if err == nil {
+		return probeOutcome{responding: true, healthy: true, serverVersion: health.Version}
 	}
-	if token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
+	problem, ok := errors.AsType[*api.Problem](err)
+	if !ok {
+		return probeOutcome{} // no HTTP response at all
 	}
-	req.Header.Set(server.ClientVersionHeader, opts.Version)
-	client := &http.Client{Timeout: probeTimeout}
-	resp, err := client.Do(req)
-	if err != nil {
-		return probeOutcome{}
-	}
-	defer func() { _ = resp.Body.Close() }()
-	_, _ = io.Copy(io.Discard, resp.Body)
 	return probeOutcome{
 		responding:    true,
-		healthy:       resp.StatusCode == http.StatusOK,
-		unauthorized:  resp.StatusCode == http.StatusUnauthorized,
-		serverVersion: resp.Header.Get(server.ServerVersionHeader),
+		unauthorized:  problem.Status == http.StatusUnauthorized,
+		serverVersion: problem.ServerVersion,
 	}
 }
 

--- a/internal/service/probe.go
+++ b/internal/service/probe.go
@@ -41,20 +41,24 @@ type probeOutcome struct {
 }
 
 func probeOnce(ctx context.Context, opts Options, token string) probeOutcome {
+	var serverVersion string
 	client := api.NewClient("http://"+probeAddr(opts.Config), token, opts.Version,
-		&http.Client{Timeout: probeTimeout})
-	health, err := client.Health(ctx)
+		&http.Client{Timeout: probeTimeout},
+		func(version string) { serverVersion = version })
+	_, err := client.Health(ctx)
 	if err == nil {
-		return probeOutcome{responding: true, healthy: true, serverVersion: health.Version}
+		return probeOutcome{responding: true, healthy: true, serverVersion: serverVersion}
 	}
+	// Any *Problem means an HTTP response arrived — including a 2xx whose
+	// body was not decodable; anything else means nothing answered.
 	problem, ok := errors.AsType[*api.Problem](err)
 	if !ok {
-		return probeOutcome{} // no HTTP response at all
+		return probeOutcome{}
 	}
 	return probeOutcome{
 		responding:    true,
 		unauthorized:  problem.Status == http.StatusUnauthorized,
-		serverVersion: problem.ServerVersion,
+		serverVersion: serverVersion,
 	}
 }
 


### PR DESCRIPTION
Implements the decided record in [ATC-264](https://linear.app/elevenideas/issue/ATC-264/explore-and-decide-how-client-and-server-share-the-v1-api-contract): the Go structs are the single source of truth for the /v1 API shape, shared directly with every in-repo Go consumer.

## What changed

**New `internal/api` package** — the wire contract and its client, deliberately stdlib-only so a later promotion out of `internal/` for third-party Go consumers stays cheap:
- `Health` wire struct with Huma's validation/doc tags (inert to clients), plus the `Atc-Client-Version`/`Atc-Server-Version` header constants moved out of `internal/server` so client code never imports the server.
- Typed RFC 7807 `Problem` error (with `ErrorDetail` for Huma validation failures). It carries `ServerVersion` from the response header, so a tokenless probe reads the server's version off a 401. Callers branch with `errors.AsType` when they care and print the error when they don't.
- Hand-written `api.Client`: one shared request path sets the bearer token and client-version header and returns `*Problem` for any non-2xx — the skew handshake (ATC-247 §6) lives in exactly one place. A non-problem error body (proxy page, wrong process on the port) degrades to a synthesized problem with the right status. `Health(ctx)` is the first typed operation.

**`internal/server` rewired to wrap the shared structs** — `HealthOutput` wraps `api.Health` (named body types become reusable OpenAPI components), and the auth middleware's 401 body is now an encoded `api.Problem` instead of an ad-hoc map, making the one-error-contract claim structural.

**Probe migrated onto `api.Client`** — `probeOnce` in `internal/service` branches on `errors.AsType[*api.Problem]`, retiring the `service → server` import the ticket called out as the drift-shaped smell. `internal/server` is now imported only by `cmd/atc/main.go`.

## Verification

- `mise run check` green: build, golangci-lint, `go test -race ./...`.
- New tests cover the success path, header emission, the tokenless-401-carries-version contract, non-problem body degradation, and transport-error-vs-problem distinguishability; the server health test now decodes directly into `api.Health`.
- `go list -deps ./internal/api` confirms the package is stdlib-only.