### PR TITLE
Improve rolling dev release guidance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,10 +101,35 @@ jobs:
           # below. Editing the release cannot do this — target_commitish is
           # ignored once a tag exists.
           git push --force origin "$GITHUB_SHA:refs/tags/dev"
+          short_sha=${GITHUB_SHA:0:7}
+          printf -v notes '%s\n' \
+            'The latest development build of ATC. It may be unstable.' \
+            '' \
+            '### Install on a new machine' \
+            '' \
+            '```sh' \
+            'curl -fsSL https://raw.githubusercontent.com/jeremytondo/atc/main/install.sh | env ATC_VERSION=dev sh' \
+            '```' \
+            '' \
+            '### Update an existing installation' \
+            '' \
+            '```sh' \
+            'atc upgrade --dev' \
+            '```' \
+            '' \
+            'To return to the latest production release:' \
+            '' \
+            '```sh' \
+            'atc upgrade' \
+            '```' \
+            '' \
+            "Current build: \`v${version}\` from [\`${GITHUB_REF_NAME}@${short_sha}\`](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})." \
+            '' \
+            'The `dev` tag and attached downloads are replaced whenever a new development build is published.'
           if ! gh release view dev >/dev/null 2>&1; then
-            gh release create dev --prerelease --title "dev (rolling)" \
-              --notes "Rolling development build."
+            gh release create dev --prerelease \
+              --title "ATC development build (rolling)" --notes "$notes"
           fi
           gh release upload dev dist/*.tar.gz dist/checksums.txt --clobber
           gh release edit dev --prerelease \
-            --notes "Rolling development build; every dev cut clobbers these assets and moves the dev tag. Current: v${version} (${GITHUB_REF_NAME}@${GITHUB_SHA}). Install with \`atc upgrade --dev\`."
+            --title "ATC development build (rolling)" --notes "$notes"

--- a/README.md
+++ b/README.md
@@ -14,9 +14,15 @@ curl -fsSL https://raw.githubusercontent.com/jeremytondo/atc/main/install.sh | s
 ```
 
 Installs the latest release into `~/.local/bin` (override with
-`ATC_INSTALL_DIR`, pin a tag with `ATC_VERSION`). Supported platforms:
-macOS arm64, Linux amd64/arm64. After the first install the binary keeps
-itself current:
+`ATC_INSTALL_DIR`, select a tag with `ATC_VERSION`). To install the rolling
+development build directly on a new machine:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/jeremytondo/atc/main/install.sh | env ATC_VERSION=dev sh
+```
+
+Supported platforms: macOS arm64, Linux amd64/arm64. After the first install
+the binary keeps itself current:
 
 - `atc upgrade` — move to the latest production release
 - `atc upgrade --dev` — install the current rolling dev build

--- a/install.sh
+++ b/install.sh
@@ -3,14 +3,14 @@
 # release, verifies it against checksums.txt, and installs it to
 # ~/.local/bin on macOS and Linux alike. First install only: after this,
 # `atc upgrade` owns staying current (and `atc upgrade --dev` moves a
-# machine onto the rolling dev build — there is deliberately no dev knob
-# here).
+# machine onto the rolling dev build). Set ATC_VERSION=dev to install the
+# rolling dev build directly on a new machine.
 #
 #   curl -fsSL https://raw.githubusercontent.com/jeremytondo/atc/main/install.sh | sh
 #
 # Knobs:
 #   ATC_INSTALL_DIR  install directory (default: ~/.local/bin)
-#   ATC_VERSION      pin a release tag (e.g. v0.1.0) instead of the latest
+#   ATC_VERSION      release tag (e.g. immutable v0.1.0 or rolling dev)
 set -eu
 
 REPO="jeremytondo/atc"


### PR DESCRIPTION
## Summary

- give the rolling `dev` prerelease a descriptive, human-facing title
- lead release notes with fresh install, update, and return-to-production commands
- document `ATC_VERSION=dev` as the supported direct installation path
- retain build provenance and explain that the rolling downloads are replaced

## Validation

- `mise run check`
- `sh -n install.sh`