### PR TITLE
Improve GitHub release names and notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # GoReleaser derives changelogs and previous tags from history.
+          # GoReleaser derives versions and GitHub-native release notes from
+          # the complete tag history.
           fetch-depth: 0
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       - name: Cut production release
@@ -95,6 +96,7 @@ jobs:
         run: |
           goreleaser release --snapshot --clean
           version=$(jq -r .version dist/metadata.json)
+          title="ATC Dev v${version} (rolling)"
           # Move the fixed dev tag to the built commit before touching the
           # release: the release page's source provenance (and GitHub's
           # generated source archives) must match the binaries uploaded
@@ -128,8 +130,8 @@ jobs:
             'The `dev` tag and attached downloads are replaced whenever a new development build is published.'
           if ! gh release view dev >/dev/null 2>&1; then
             gh release create dev --prerelease \
-              --title "ATC development build (rolling)" --notes "$notes"
+              --title "$title" --notes "$notes"
           fi
           gh release upload dev dist/*.tar.gz dist/checksums.txt --clobber
           gh release edit dev --prerelease \
-            --title "ATC development build (rolling)" --notes "$notes"
+            --title "$title" --notes "$notes"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,6 +41,9 @@ checksum:
   name_template: checksums.txt
 
 release:
+  # Keep the immutable tag machine-oriented while giving the GitHub release a
+  # recognizable product title.
+  name_template: "ATC v{{ .Version }}"
   # Retry safety (release.yml resumes a tag whose release is incomplete): a
   # rerun over a partially published release must overwrite its assets
   # instead of failing on name collisions.
@@ -53,4 +56,7 @@ snapshot:
   version_template: "{{ incpatch .Version }}-dev.{{ .ShortCommit }}"
 
 changelog:
-  use: git
+  # GitHub's native notes list merged PRs instead of every implementation
+  # commit. PR titles provide the summary; their links lead to the detailed
+  # descriptions and validation notes.
+  use: github-native


### PR DESCRIPTION
## Summary

- name production releases `ATC vX.X.X` while keeping their `vX.X.X` tags unchanged
- name the rolling prerelease `ATC Dev vX.X.X-dev.<short SHA> (rolling)`
- replace raw commit changelogs with GitHub-native notes built from merged PR titles, links, contributors, and the full comparison

PR titles provide the concise release summary; each entry links to the PR description for implementation details and validation.

## Validation

- `goreleaser check`
- `mise run check`