### PR TITLE
ATC-271 | terminal: add create --attach and a TTY guard on attach

### DIFF
--- a/cmd/atc/terminal.go
+++ b/cmd/atc/terminal.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -95,14 +96,26 @@ func newTerminalCreateCmd() *cobra.Command {
 		Use:   "create",
 		Short: "Create a terminal and start its session",
 		Long: `Create a terminal and start its session immediately. The session survives
-disconnects and ATC server restarts; attach with ` + "`atc terminal attach <id>`" + `.
+disconnects and ATC server restarts; attach with ` + "`atc terminal attach <id>`" + `,
+or pass ` + "`--attach`" + ` to attach immediately.
 With --app the command runs through your login shell (profile and rc files
 loaded); without it you get a plain interactive shell.`,
 		Args: cobra.NoArgs,
-		RunE: runWithClient(func(cmd *cobra.Command, _ []string, client *api.Client, _ string) error {
+		RunE: runWithClient(func(cmd *cobra.Command, _ []string, client *api.Client, baseURL string) error {
 			flags := cmd.Flags()
+			attach, err := flags.GetBool("attach")
+			if err != nil {
+				return err
+			}
+			if attach {
+				if err := attachPreflight(baseURL); err != nil {
+					return err
+				}
+				if _, err := exec.LookPath("zmx"); err != nil {
+					return fmt.Errorf("zmx executable not found on PATH; install zmx to attach")
+				}
+			}
 			params := api.TerminalCreateParams{}
-			var err error
 			if params.Name, err = flags.GetString("name"); err != nil {
 				return err
 			}
@@ -117,12 +130,18 @@ loaded); without it you get a plain interactive shell.`,
 				return err
 			}
 			printTerminal(cmd.OutOrStdout(), terminal)
+			if attach {
+				if err := attachSession(terminal); err != nil {
+					return fmt.Errorf("%w; the terminal was created; retry with: atc terminal attach %s", err, terminal.ID)
+				}
+			}
 			return nil
 		}),
 	}
 	cmd.Flags().String("name", "", "display name (defaults from --app, else \"Shell\")")
 	cmd.Flags().String("dir", "", "working directory (defaults to the server user's home)")
 	cmd.Flags().String("app", "", "command to run through your shell; omit for a plain shell")
+	cmd.Flags().Bool("attach", false, "attach to the terminal after creation")
 	return cmd
 }
 
@@ -218,8 +237,8 @@ the session's socket lives on the server's machine. The terminal must be
 running — attach never resurrects or creates sessions.`,
 		Args: cobra.ExactArgs(1),
 		RunE: runWithClient(func(cmd *cobra.Command, args []string, client *api.Client, baseURL string) error {
-			if !isLoopback(baseURL) {
-				return fmt.Errorf("atc terminal attach is local-only (the session socket lives on the server's machine); this client targets %s", baseURL)
+			if err := attachPreflight(baseURL); err != nil {
+				return err
 			}
 			// The API check keeps zmx's attach-auto-creates behavior from
 			// resurrecting anything: only a verified-running session is
@@ -228,30 +247,55 @@ running — attach never resurrects or creates sessions.`,
 			if err != nil {
 				return err
 			}
-			if terminal.Status != api.TerminalRunning {
-				return fmt.Errorf("terminal %s is %s, not running", terminal.ID, terminal.Status)
-			}
-			socketDir, err := paths.TerminalSocketDir()
-			if err != nil {
-				return err
-			}
-			// A loopback URL does not prove the server shares this
-			// process's namespace (an SSH-forwarded remote server, a
-			// different XDG_STATE_HOME). A session the API calls running
-			// must have its socket here; anything else would hand the TTY
-			// to zmx's auto-create.
-			if _, err := os.Stat(filepath.Join(socketDir, terminal.ID)); err != nil {
-				return fmt.Errorf("terminal %s has no session socket under %s — the server appears to be remote (an SSH-forwarded port?) or running with a different state directory", terminal.ID, socketDir)
-			}
-			executable, argv, env, err := zmx.AttachCommand(socketDir, terminal.ID)
-			if err != nil {
-				return err
-			}
-			// Exec replaces this process: the user's real TTY belongs to
-			// zmx until detach.
-			return syscall.Exec(executable, argv, env)
+			return attachSession(terminal)
 		}),
 	}
+}
+
+// stdioIsTerminal reports whether stdin and stdout are both real TTYs.
+// It is a variable so tests, which never have a TTY, can force it.
+var stdioIsTerminal = func() bool {
+	stdin, err := os.Stdin.Stat()
+	if err != nil || stdin.Mode()&os.ModeCharDevice == 0 {
+		return false
+	}
+	stdout, err := os.Stdout.Stat()
+	return err == nil && stdout.Mode()&os.ModeCharDevice != 0
+}
+
+func attachPreflight(baseURL string) error {
+	if !stdioIsTerminal() {
+		return fmt.Errorf("attaching requires an interactive terminal (stdin and stdout must be TTYs)")
+	}
+	if !isLoopback(baseURL) {
+		return fmt.Errorf("atc terminal attach is local-only (the session socket lives on the server's machine); this client targets %s", baseURL)
+	}
+	return nil
+}
+
+func attachSession(terminal api.Terminal) error {
+	if terminal.Status != api.TerminalRunning {
+		return fmt.Errorf("terminal %s is %s, not running", terminal.ID, terminal.Status)
+	}
+	socketDir, err := paths.TerminalSocketDir()
+	if err != nil {
+		return err
+	}
+	// A loopback URL does not prove the server shares this
+	// process's namespace (an SSH-forwarded remote server, a
+	// different XDG_STATE_HOME). A session the API calls running
+	// must have its socket here; anything else would hand the TTY
+	// to zmx's auto-create.
+	if _, err := os.Stat(filepath.Join(socketDir, terminal.ID)); err != nil {
+		return fmt.Errorf("terminal %s has no session socket under %s — the server appears to be remote (an SSH-forwarded port?) or running with a different state directory", terminal.ID, socketDir)
+	}
+	executable, argv, env, err := zmx.AttachCommand(socketDir, terminal.ID)
+	if err != nil {
+		return err
+	}
+	// Exec replaces this process: the user's real TTY belongs to
+	// zmx until detach.
+	return syscall.Exec(executable, argv, env)
 }
 
 func isLoopback(baseURL string) bool {

--- a/cmd/atc/terminal_test.go
+++ b/cmd/atc/terminal_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -90,6 +91,22 @@ func runCLI(t *testing.T, args ...string) (string, string, error) {
 	return stdout.String(), stderr.String(), err
 }
 
+func forceTTY(t *testing.T) {
+	t.Helper()
+	prev := stdioIsTerminal
+	stdioIsTerminal = func() bool { return true }
+	t.Cleanup(func() { stdioIsTerminal = prev })
+}
+
+func installFakeZmx(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "zmx"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+}
+
 func TestTerminalCLILifecycle(t *testing.T) {
 	adapter := startTestServer(t)
 
@@ -152,9 +169,80 @@ func TestTerminalGetUnknownIsError(t *testing.T) {
 	}
 }
 
+func TestTerminalCreateAttachWithoutTTYCreatesNothing(t *testing.T) {
+	startTestServer(t)
+	_, _, err := runCLI(t, "terminal", "create", "--attach")
+	if err == nil || !strings.Contains(err.Error(), "stdin and stdout must be TTYs") {
+		t.Errorf("create attach without TTY = %v, want a TTY refusal", err)
+	}
+	stdout, _, listErr := runCLI(t, "terminal", "list")
+	if listErr != nil || !strings.Contains(stdout, "no terminals") {
+		t.Errorf("list after TTY refusal = %q, %v", stdout, listErr)
+	}
+}
+
+func TestTerminalCreateAttachRemoteCreatesNothing(t *testing.T) {
+	forceTTY(t)
+	t.Setenv("ATC_SERVER", "http://100.64.0.5:7331")
+	t.Setenv("ATC_TOKEN", cliTestToken)
+
+	_, _, err := runCLI(t, "terminal", "create", "--attach")
+	if err == nil || !strings.Contains(err.Error(), "local-only") {
+		t.Errorf("remote create attach = %v, want the local-only refusal", err)
+	}
+}
+
+func TestTerminalCreateAttachMissingZmxCreatesNothing(t *testing.T) {
+	forceTTY(t)
+	startTestServer(t)
+	t.Setenv("PATH", "")
+
+	_, _, err := runCLI(t, "terminal", "create", "--attach")
+	if err == nil || err.Error() != "zmx executable not found on PATH; install zmx to attach" {
+		t.Errorf("create attach without zmx = %v", err)
+	}
+	stdout, _, listErr := runCLI(t, "terminal", "list")
+	if listErr != nil || !strings.Contains(stdout, "no terminals") {
+		t.Errorf("list after zmx refusal = %q, %v", stdout, listErr)
+	}
+}
+
+func TestTerminalCreateAttachMissingSocketKeepsTerminal(t *testing.T) {
+	forceTTY(t)
+	installFakeZmx(t)
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	startTestServer(t)
+
+	stdout, _, err := runCLI(t, "terminal", "create", "--attach")
+	id := regexp.MustCompile(`term-[a-z2-9]{5}`).FindString(stdout)
+	if id == "" || !strings.Contains(stdout, "running") {
+		t.Fatalf("create attach output does not show the created terminal:\n%s", stdout)
+	}
+	if err == nil || !strings.Contains(err.Error(), "has no session socket") {
+		t.Fatalf("create attach without socket = %v, want the missing-socket refusal", err)
+	}
+	if !strings.Contains(err.Error(), "the terminal was created; retry with: atc terminal attach "+id) {
+		t.Errorf("create attach error has no retry instruction: %v", err)
+	}
+	stdout, _, getErr := runCLI(t, "terminal", "get", id)
+	if getErr != nil || !strings.Contains(stdout, id) {
+		t.Errorf("get created terminal = %q, %v", stdout, getErr)
+	}
+}
+
+func TestTerminalAttachWithoutTTY(t *testing.T) {
+	t.Setenv("ATC_SERVER", "http://100.64.0.5:7331")
+	t.Setenv("ATC_TOKEN", cliTestToken)
+	_, _, err := runCLI(t, "terminal", "attach", "term-zzzzz")
+	if err == nil || !strings.Contains(err.Error(), "stdin and stdout must be TTYs") {
+		t.Errorf("attach without TTY = %v, want a TTY refusal", err)
+	}
+}
+
 // Attach is local-only: against a non-loopback server it refuses before
 // touching anything.
 func TestAttachRemoteFailsClearly(t *testing.T) {
+	forceTTY(t)
 	t.Setenv("ATC_SERVER", "http://100.64.0.5:7331")
 	t.Setenv("ATC_TOKEN", cliTestToken)
 	_, _, err := runCLI(t, "terminal", "attach", "term-zzzzz")
@@ -165,6 +253,7 @@ func TestAttachRemoteFailsClearly(t *testing.T) {
 
 // Attach never resurrects: anything but running refuses before zmx runs.
 func TestAttachRefusesNonRunning(t *testing.T) {
+	forceTTY(t)
 	// Defense in depth: if a regression ever let attach proceed, an empty
 	// PATH fails the zmx lookup and an isolated state dir keeps even that
 	// failure away from the developer's real sessions.


### PR DESCRIPTION
Implements [ATC-271](https://linear.app/elevenideas/issue/ATC-271/create-and-attach-to-a-terminal-with-one-cli-command): create and attach to a terminal with one CLI command.

## What

- `atc terminal create --attach` creates the terminal exactly as plain create, prints the normal output block (so the ID stays in scrollback after detach), then hands the TTY to the existing attach path (exec of `zmx attach`).
- Pre-flight before anything is created: stdin/stdout are real TTYs, the client targets a loopback server, and `zmx` is on `PATH`. Any failure exits with an error and creates nothing.
- Attach failure after a successful create keeps the terminal, exits non-zero, and names the retry command: `the terminal was created; retry with: atc terminal attach term-xxxxx`.
- Plain `terminal attach` is hardened with the same TTY check, refusing before any other work.

## How

- The attach preconditions and exec handoff are factored into shared helpers — `attachPreflight` (TTY, then loopback) and `attachSession` (running check, socket check, `zmx.AttachCommand`, `syscall.Exec`) — so `attach` and `create --attach` cannot drift.
- The zmx-on-`PATH` check is create-`--attach`-only: plain attach keeps its existing lookup inside `zmx.AttachCommand` after the status and socket checks (it has no created resource to protect, and the empty-`PATH` defense in `TestAttachRefusesNonRunning` keeps landing on the "not running" refusal).
- No readiness wait/poll: create's synchronous settle verification is the only wait; a terminal that isn't `running` after create fails attachment immediately.
- The TTY probe is a package-level func var (`stdioIsTerminal`) checking the real `os.Stdin`/`os.Stdout` — attach hands over the process's real TTY, and the var is the seam that lets the non-TTY test harness force it.

## Tests

Through the existing CLI seam (real command tree, real server chassis, fake session adapter):

- `create --attach` pre-flight refusals create no terminal: non-TTY stdio (the harness's natural state), non-loopback server, missing zmx.
- Post-create failure (missing session socket under an isolated `XDG_STATE_HOME`): terminal kept, error names the retry command, create block still printed.
- Plain `attach` refuses without a TTY, before the loopback check.
- Existing attach refusal tests updated to force a TTY past the new guard.

`mise check` passes (build, lint, sqlc diff, `go test -race ./...`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `--attach` option to create a terminal and connect to it immediately.
  * Shared attachment behavior across terminal creation and the existing attach command.
  * Provides a retry command when automatic attachment fails.

* **Bug Fixes**
  * Added validation for interactive terminals, local connections, required tools, session availability, and terminal running status.
  * Prevents unsupported remote or non-interactive attachment attempts.
  * Preserves newly created terminals when attachment cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->