### PR TITLE
ATC-256 | Projects: resource, canonical-directory identity, required terminal ownership, CLI walk-up resolution

### DIFF
--- a/cmd/atc/main.go
+++ b/cmd/atc/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jeremytondo/atc/internal/config"
 	"github.com/jeremytondo/atc/internal/events"
 	"github.com/jeremytondo/atc/internal/paths"
+	"github.com/jeremytondo/atc/internal/projects"
 	"github.com/jeremytondo/atc/internal/server"
 	"github.com/jeremytondo/atc/internal/service"
 	"github.com/jeremytondo/atc/internal/store"
@@ -36,7 +37,7 @@ import (
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	if err := run(ctx, os.Args[1:], os.Stdout, os.Stderr); err != nil {
+	if err := run(ctx, os.Args[1:], os.Stdin, os.Stdout, os.Stderr); err != nil {
 		// An ExitError's report is already on stdout (e.g. `server status`
 		// exit codes); it only picks the process exit code.
 		var exit *service.ExitError
@@ -48,10 +49,11 @@ func main() {
 	}
 }
 
-// run executes the command tree. It is the seam tests drive: output streams
-// are injected, and errors return here so main owns the exit path.
-func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+// run executes the command tree. It is the seam tests drive: the standard
+// streams are injected, and errors return here so main owns the exit path.
+func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	root := newRootCmd()
+	root.SetIn(stdin)
 	root.SetOut(stdout)
 	root.SetErr(stderr)
 	if args == nil {
@@ -81,8 +83,8 @@ expose on the tailnet without the flag.`,
 			return cmd.Help()
 		},
 	}
-	root.AddCommand(newTerminalCmd(), newAPICmd(), newVersionCmd(), newUpgradeCmd(),
-		newServerCmd(), newChildCmd())
+	root.AddCommand(newTerminalCmd(), newProjectCmd(), newAPICmd(), newVersionCmd(),
+		newUpgradeCmd(), newServerCmd(), newChildCmd())
 	return root
 }
 
@@ -473,18 +475,19 @@ func serverRunUntilCancelled(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
 	hub := events.NewHub(events.DefaultBacklog)
+	projectService := projects.NewService(projects.Options{
+		Repository: database.Projects(),
+		Terminals:  database.Terminals(),
+		Hub:        hub,
+	})
 	terminalService := terminals.NewService(terminals.Options{
 		Repository: database.Terminals(),
 		Adapter:    adapter,
+		Projects:   database.Projects(),
 		MarkerDir:  markerDir,
 		Hub:        hub,
 		Logger:     logger,
-		HomeDir:    home,
 	})
 	if err := terminalService.Load(ctx); err != nil {
 		return err
@@ -498,6 +501,7 @@ func serverRunUntilCancelled(cmd *cobra.Command, _ []string) error {
 		Version:   versionValue,
 		Logger:    logger,
 		Terminals: terminalService,
+		Projects:  projectService,
 		Events:    hub,
 	})
 

--- a/cmd/atc/main.go
+++ b/cmd/atc/main.go
@@ -138,7 +138,7 @@ interrupted), headless runs print a reminder unless --restart or
 			opts := upgrade.Options{
 				Dev:         dev,
 				Restart:     mode,
-				Interactive: stdinIsTerminal(),
+				Interactive: stdinIsTTY(),
 				Version:     version.String(),
 				Stdin:       cmd.InOrStdin(),
 				Stdout:      cmd.OutOrStdout(),
@@ -157,12 +157,6 @@ interrupted), headless runs print a reminder unless --restart or
 	cmd.Flags().Bool("no-restart", false, "never restart the server")
 	cmd.MarkFlagsMutuallyExclusive("restart", "no-restart")
 	return cmd
-}
-
-// stdinIsTerminal gates the restart prompt: only a human at a TTY is asked.
-func stdinIsTerminal() bool {
-	info, err := os.Stdin.Stat()
-	return err == nil && info.Mode()&os.ModeCharDevice != 0
 }
 
 func newServerCmd() *cobra.Command {

--- a/cmd/atc/main_test.go
+++ b/cmd/atc/main_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestRunNoArgsPrintsUsage(t *testing.T) {
 	var stdout, stderr strings.Builder
-	if err := run(context.Background(), nil, &stdout, &stderr); err != nil {
+	if err := run(context.Background(), nil, strings.NewReader(""), &stdout, &stderr); err != nil {
 		t.Fatalf("run() = %v, want nil", err)
 	}
 	if !strings.Contains(stdout.String(), "Usage:") {
@@ -27,7 +27,7 @@ func TestRunNoArgsPrintsUsage(t *testing.T) {
 
 func TestRunVersion(t *testing.T) {
 	var stdout, stderr strings.Builder
-	if err := run(context.Background(), []string{"version"}, &stdout, &stderr); err != nil {
+	if err := run(context.Background(), []string{"version"}, strings.NewReader(""), &stdout, &stderr); err != nil {
 		t.Fatalf("run() = %v, want nil", err)
 	}
 	if strings.TrimSpace(stdout.String()) == "" {
@@ -54,7 +54,7 @@ func TestRunRejectsBadInvocations(t *testing.T) {
 		{"server", "uninstall", "extra"},
 	} {
 		var stdout, stderr strings.Builder
-		if err := run(context.Background(), args, &stdout, &stderr); err == nil {
+		if err := run(context.Background(), args, strings.NewReader(""), &stdout, &stderr); err == nil {
 			t.Errorf("run(%q) = nil, want error", args)
 		}
 	}
@@ -96,7 +96,9 @@ func TestServerRunStopsOnContextCancel(t *testing.T) {
 	var stdout strings.Builder
 	var stderr syncBuffer
 	done := make(chan error, 1)
-	go func() { done <- run(ctx, []string{"server", "run", "--port", "0"}, &stdout, &stderr) }()
+	go func() {
+		done <- run(ctx, []string{"server", "run", "--port", "0"}, strings.NewReader(""), &stdout, &stderr)
+	}()
 
 	// Boot now includes storage migration and the blocking startup
 	// reconcile; wait for the serve log before requesting shutdown.
@@ -124,7 +126,7 @@ func TestServerRunCancelledDuringBoot(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	var stdout, stderr strings.Builder
-	if err := run(ctx, []string{"server", "run", "--port", "0"}, &stdout, &stderr); err != nil {
+	if err := run(ctx, []string{"server", "run", "--port", "0"}, strings.NewReader(""), &stdout, &stderr); err != nil {
 		t.Fatalf("server run with pre-cancelled context = %v, want nil", err)
 	}
 }
@@ -139,7 +141,7 @@ func TestServerRunRejectsInvalidFlagValues(t *testing.T) {
 		"port out of range": {"server", "run", "--port", "70000"},
 	} {
 		var stdout, stderr strings.Builder
-		if err := run(context.Background(), args, &stdout, &stderr); err == nil {
+		if err := run(context.Background(), args, strings.NewReader(""), &stdout, &stderr); err == nil {
 			t.Errorf("%s: run(%q) = nil, want validation error", name, args)
 		}
 	}
@@ -172,7 +174,7 @@ func TestServerStatusNotInstalled(t *testing.T) {
 	}
 
 	var stdout, stderr strings.Builder
-	err := run(context.Background(), []string{"server", "status"}, &stdout, &stderr)
+	err := run(context.Background(), []string{"server", "status"}, strings.NewReader(""), &stdout, &stderr)
 	var exit *service.ExitError
 	if !errors.As(err, &exit) || exit.Code != 2 {
 		t.Fatalf("server status = %v, want ExitError with code 2", err)
@@ -197,14 +199,14 @@ func TestRecoveryCommandsSurviveBrokenConfig(t *testing.T) {
 
 	// status settles config and must surface the parse error.
 	var stdout, stderr strings.Builder
-	if err := run(context.Background(), []string{"server", "status"}, &stdout, &stderr); err == nil || !strings.Contains(err.Error(), "bogus_key") {
+	if err := run(context.Background(), []string{"server", "status"}, strings.NewReader(""), &stdout, &stderr); err == nil || !strings.Contains(err.Error(), "bogus_key") {
 		t.Errorf("server status = %v, want the config parse error", err)
 	}
 
 	// stop and uninstall proceed to their not-installed reports.
 	for _, args := range [][]string{{"server", "stop"}, {"server", "uninstall"}} {
 		var stdout, stderr strings.Builder
-		if err := run(context.Background(), args, &stdout, &stderr); err != nil {
+		if err := run(context.Background(), args, strings.NewReader(""), &stdout, &stderr); err != nil {
 			t.Errorf("run(%q) = %v, want nil despite broken config", args, err)
 		}
 		if !strings.Contains(stdout.String(), "not installed") {
@@ -216,7 +218,7 @@ func TestRecoveryCommandsSurviveBrokenConfig(t *testing.T) {
 	// empty journal).
 	stdout.Reset()
 	stderr.Reset()
-	err := run(context.Background(), []string{"server", "logs"}, &stdout, &stderr)
+	err := run(context.Background(), []string{"server", "logs"}, strings.NewReader(""), &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), "not installed") {
 		t.Errorf("server logs = %v, want a not-installed explanation", err)
 	}
@@ -226,7 +228,7 @@ func TestServerTokenPrintsAndRotates(t *testing.T) {
 	isolateXDG(t)
 	tokenOut := func(args ...string) string {
 		var stdout, stderr strings.Builder
-		if err := run(context.Background(), args, &stdout, &stderr); err != nil {
+		if err := run(context.Background(), args, strings.NewReader(""), &stdout, &stderr); err != nil {
 			t.Fatalf("run(%q) = %v", args, err)
 		}
 		return strings.TrimSpace(stdout.String())

--- a/cmd/atc/project.go
+++ b/cmd/atc/project.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jeremytondo/atc/internal/api"
+	"github.com/jeremytondo/atc/internal/paths"
+)
+
+func newProjectCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "project",
+		Short: "Group work into projects rooted at directories",
+		Args:  cobra.NoArgs,
+		RunE: func(*cobra.Command, []string) error {
+			return fmt.Errorf("usage: atc project <create|get|list|update|delete>")
+		},
+	}
+	cmd.AddCommand(newProjectCreateCmd(), newProjectGetCmd(), newProjectListCmd(),
+		newProjectUpdateCmd(), newProjectDeleteCmd())
+	return cmd
+}
+
+func newProjectCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create [path]",
+		Short: "Create a project rooted at a directory",
+		Long: `Create a project rooted at path. Without a path, the project is rooted at
+the git toplevel when inside a repository, at the current directory
+otherwise. The directory is canonicalized (symlinks resolved) and is the
+project's identity: one project per real folder, immutable after create.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: runWithClient(func(cmd *cobra.Command, args []string, client *api.Client, _ string) error {
+			name, err := cmd.Flags().GetString("name")
+			if err != nil {
+				return err
+			}
+			var directory string
+			if len(args) == 1 {
+				// Canonicalized client-side: a relative path must mean this
+				// process's working directory, never the server's.
+				if directory, err = paths.CanonicalDir(args[0]); err != nil {
+					return err
+				}
+			} else if directory, err = defaultProjectDir(); err != nil {
+				return err
+			}
+			project, err := client.CreateProject(cmd.Context(), api.ProjectCreateParams{
+				Directory: directory, Name: name,
+			})
+			if err != nil {
+				return err
+			}
+			printProject(cmd.OutOrStdout(), project)
+			return nil
+		}),
+	}
+	cmd.Flags().String("name", "", "display name (defaults to the directory basename)")
+	return cmd
+}
+
+func newProjectGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <id>",
+		Short: "Show one project",
+		Args:  cobra.ExactArgs(1),
+		RunE: runWithClient(func(cmd *cobra.Command, args []string, client *api.Client, _ string) error {
+			project, err := client.Project(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			printProject(cmd.OutOrStdout(), project)
+			return nil
+		}),
+	}
+}
+
+func newProjectListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List projects",
+		Args:  cobra.NoArgs,
+		RunE: runWithClient(func(cmd *cobra.Command, _ []string, client *api.Client, _ string) error {
+			projects, err := client.Projects(cmd.Context())
+			if err != nil {
+				return err
+			}
+			out := cmd.OutOrStdout()
+			if len(projects) == 0 {
+				_, err := fmt.Fprintln(out, "no projects")
+				return err
+			}
+			w := tabwriter.NewWriter(out, 2, 8, 2, ' ', 0)
+			_, _ = fmt.Fprintln(w, "ID\tNAME\tDIRECTORY")
+			for _, project := range projects {
+				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", project.ID, project.Name, project.Directory)
+			}
+			return w.Flush()
+		}),
+	}
+}
+
+func newProjectUpdateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a project (name is the only mutable field)",
+		Args:  cobra.ExactArgs(1),
+		RunE: runWithClient(func(cmd *cobra.Command, args []string, client *api.Client, _ string) error {
+			name, err := cmd.Flags().GetString("name")
+			if err != nil {
+				return err
+			}
+			project, err := client.UpdateProject(cmd.Context(), args[0], api.ProjectUpdateParams{Name: name})
+			if err != nil {
+				return err
+			}
+			printProject(cmd.OutOrStdout(), project)
+			return nil
+		}),
+	}
+	cmd.Flags().String("name", "", "new display name")
+	_ = cmd.MarkFlagRequired("name")
+	return cmd
+}
+
+func newProjectDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete an empty project",
+		Long: `Delete a project. Refused while any terminal still belongs to it — delete
+those first; there is no cascade.`,
+		Args: cobra.ExactArgs(1),
+		RunE: runWithClient(func(cmd *cobra.Command, args []string, client *api.Client, _ string) error {
+			if err := client.DeleteProject(cmd.Context(), args[0]); err != nil {
+				return err
+			}
+			_, err := fmt.Fprintf(cmd.OutOrStdout(), "deleted %s\n", args[0])
+			return err
+		}),
+	}
+}
+
+// resolveProjectID finds the project owning the current directory the way
+// git finds a repository (ATC-256): canonicalize the cwd, then walk up —
+// the nearest ancestor (or the directory itself) matching a project's
+// directory wins. On no match, an interactive run is offered a project
+// rooted at the default (git toplevel, else cwd); a non-interactive run
+// refuses with the fixes instead of prompting.
+func resolveProjectID(cmd *cobra.Command, client *api.Client) (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	canonical, err := paths.CanonicalDir(cwd)
+	if err != nil {
+		return "", err
+	}
+	projects, err := client.Projects(cmd.Context())
+	if err != nil {
+		return "", err
+	}
+	byDir := make(map[string]api.Project, len(projects))
+	for _, project := range projects {
+		byDir[project.Directory] = project
+	}
+	for dir := canonical; ; {
+		if project, ok := byDir[dir]; ok {
+			return project.ID, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	if !stdioIsTerminal() {
+		return "", fmt.Errorf("no project contains %s; pass --project <id> or run `atc project create`", canonical)
+	}
+	defaultDir := projectRootFor(canonical)
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "no project contains %s\ncreate a project at %s? [y/N] ", canonical, defaultDir)
+	answer, _ := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
+	switch strings.ToLower(strings.TrimSpace(answer)) {
+	case "y", "yes":
+	default:
+		return "", fmt.Errorf("no project selected; pass --project <id> or run `atc project create`")
+	}
+	project, err := client.CreateProject(cmd.Context(), api.ProjectCreateParams{Directory: defaultDir})
+	if err != nil {
+		return "", err
+	}
+	_, _ = fmt.Fprintf(out, "created project %s at %s\n", project.ID, project.Directory)
+	return project.ID, nil
+}
+
+// defaultProjectDir is where an unspecified project is rooted: the git
+// toplevel when inside a repository, the current directory otherwise.
+func defaultProjectDir() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	canonical, err := paths.CanonicalDir(cwd)
+	if err != nil {
+		return "", err
+	}
+	return projectRootFor(canonical), nil
+}
+
+// projectRootFor walks up from a canonical directory looking for a .git
+// entry (a directory in a normal checkout, a file in linked worktrees);
+// the first hit is the innermost repository's toplevel. Without one the
+// directory is its own root.
+func projectRootFor(canonical string) string {
+	for dir := canonical; ; {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return canonical
+		}
+		dir = parent
+	}
+}
+
+func printProject(out io.Writer, project api.Project) {
+	w := tabwriter.NewWriter(out, 2, 8, 2, ' ', 0)
+	_, _ = fmt.Fprintf(w, "id\t%s\n", project.ID)
+	_, _ = fmt.Fprintf(w, "name\t%s\n", project.Name)
+	_, _ = fmt.Fprintf(w, "directory\t%s\n", project.Directory)
+	_, _ = fmt.Fprintf(w, "created\t%s\n", project.CreatedAt.Format("2006-01-02 15:04:05 MST"))
+	_ = w.Flush()
+}

--- a/cmd/atc/project.go
+++ b/cmd/atc/project.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"text/tabwriter"
@@ -35,8 +36,10 @@ func newProjectCreateCmd() *cobra.Command {
 		Short: "Create a project rooted at a directory",
 		Long: `Create a project rooted at path. Without a path, the project is rooted at
 the git toplevel when inside a repository, at the current directory
-otherwise. The directory is canonicalized (symlinks resolved) and is the
-project's identity: one project per real folder, immutable after create.`,
+otherwise. The server canonicalizes the directory (symlinks resolved) and
+it is the project's identity: one project per real folder, immutable after
+create. A relative path is resolved against this shell's directory; the
+directory itself must exist on the server's machine.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: runWithClient(func(cmd *cobra.Command, args []string, client *api.Client, _ string) error {
 			name, err := cmd.Flags().GetString("name")
@@ -45,9 +48,11 @@ project's identity: one project per real folder, immutable after create.`,
 			}
 			var directory string
 			if len(args) == 1 {
-				// Canonicalized client-side: a relative path must mean this
-				// process's working directory, never the server's.
-				if directory, err = paths.CanonicalDir(args[0]); err != nil {
+				// Absolutized client-side so a relative path means this
+				// process's working directory, never the server's — but
+				// only absolutized: existence and canonicalization are the
+				// server's, whose filesystem the directory lives on.
+				if directory, err = filepath.Abs(args[0]); err != nil {
 					return err
 				}
 			} else if directory, err = defaultProjectDir(); err != nil {
@@ -148,6 +153,15 @@ those first; there is no cascade.`,
 	}
 }
 
+// stdinIsTTY gates the create-offer prompt: a question is only asked of a
+// human on an interactive stdin. Stdout deliberately does not matter — a
+// redirected stdout still deserves the prompt (on stderr) rather than a
+// refusal. A variable so tests, which never have a TTY, can force it.
+var stdinIsTTY = func() bool {
+	info, err := os.Stdin.Stat()
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
+}
+
 // resolveProjectID finds the project owning the current directory the way
 // git finds a repository (ATC-256): canonicalize the cwd, then walk up —
 // the nearest ancestor (or the directory itself) matching a project's
@@ -155,11 +169,7 @@ those first; there is no cascade.`,
 // rooted at the default (git toplevel, else cwd); a non-interactive run
 // refuses with the fixes instead of prompting.
 func resolveProjectID(cmd *cobra.Command, client *api.Client) (string, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	canonical, err := paths.CanonicalDir(cwd)
+	canonical, err := paths.CanonicalDir(".")
 	if err != nil {
 		return "", err
 	}
@@ -167,13 +177,13 @@ func resolveProjectID(cmd *cobra.Command, client *api.Client) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	byDir := make(map[string]api.Project, len(projects))
+	byDir := make(map[string]string, len(projects))
 	for _, project := range projects {
-		byDir[project.Directory] = project
+		byDir[project.Directory] = project.ID
 	}
 	for dir := canonical; ; {
-		if project, ok := byDir[dir]; ok {
-			return project.ID, nil
+		if id, ok := byDir[dir]; ok {
+			return id, nil
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
@@ -182,12 +192,14 @@ func resolveProjectID(cmd *cobra.Command, client *api.Client) (string, error) {
 		dir = parent
 	}
 
-	if !stdioIsTerminal() {
+	if !stdinIsTTY() {
 		return "", fmt.Errorf("no project contains %s; pass --project <id> or run `atc project create`", canonical)
 	}
 	defaultDir := projectRootFor(canonical)
-	out := cmd.OutOrStdout()
-	_, _ = fmt.Fprintf(out, "no project contains %s\ncreate a project at %s? [y/N] ", canonical, defaultDir)
+	// The conversation goes to stderr: stdout stays the command's
+	// redirectable output (the created terminal).
+	console := cmd.ErrOrStderr()
+	_, _ = fmt.Fprintf(console, "no project contains %s\ncreate a project at %s? [y/N] ", canonical, defaultDir)
 	answer, _ := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
 	switch strings.ToLower(strings.TrimSpace(answer)) {
 	case "y", "yes":
@@ -198,39 +210,34 @@ func resolveProjectID(cmd *cobra.Command, client *api.Client) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	_, _ = fmt.Fprintf(out, "created project %s at %s\n", project.ID, project.Directory)
+	_, _ = fmt.Fprintf(console, "created project %s at %s\n", project.ID, project.Directory)
 	return project.ID, nil
 }
 
 // defaultProjectDir is where an unspecified project is rooted: the git
 // toplevel when inside a repository, the current directory otherwise.
 func defaultProjectDir() (string, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	canonical, err := paths.CanonicalDir(cwd)
+	canonical, err := paths.CanonicalDir(".")
 	if err != nil {
 		return "", err
 	}
 	return projectRootFor(canonical), nil
 }
 
-// projectRootFor walks up from a canonical directory looking for a .git
-// entry (a directory in a normal checkout, a file in linked worktrees);
-// the first hit is the innermost repository's toplevel. Without one the
-// directory is its own root.
+// projectRootFor asks git for the toplevel of the repository containing
+// the canonical directory — git itself is the authority on what counts as
+// a repository (a stray or malformed .git entry is not one). Outside a
+// repository, or without git installed, the directory is its own root.
 func projectRootFor(canonical string) string {
-	for dir := canonical; ; {
-		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return canonical
-		}
-		dir = parent
+	output, err := exec.Command("git", "-C", canonical, "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return canonical
 	}
+	toplevel, err := paths.CanonicalDir(strings.TrimSpace(string(output)))
+	if err != nil {
+		return canonical
+	}
+	return toplevel
 }
 
 func printProject(out io.Writer, project api.Project) {

--- a/cmd/atc/project_test.go
+++ b/cmd/atc/project_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -26,6 +27,18 @@ func mkdirAll(t *testing.T, dir string) string {
 		t.Fatal(err)
 	}
 	return dir
+}
+
+// gitInit makes dir a real git repository — toplevel detection asks git
+// itself, so a bare .git entry would not count.
+func gitInit(t *testing.T, dir string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	if out, err := exec.Command("git", "init", "-q", dir).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
 }
 
 func TestProjectCLILifecycle(t *testing.T) {
@@ -172,20 +185,24 @@ func TestTerminalCreateOffersProjectAtGitToplevel(t *testing.T) {
 	forceTTY(t)
 	startTestServer(t)
 	repo := t.TempDir()
-	mkdirAll(t, filepath.Join(repo, ".git"))
+	gitInit(t, repo)
 	sub := mkdirAll(t, filepath.Join(repo, "pkg"))
 
 	t.Chdir(sub)
-	stdout, _, err := runCLIInput(t, "y\n", "terminal", "create")
+	stdout, stderr, err := runCLIInput(t, "y\n", "terminal", "create")
 	if err != nil {
 		t.Fatal(err)
 	}
+	// The conversation rides stderr; stdout carries the created terminal.
 	toplevel := canonical(t, repo)
-	if !strings.Contains(stdout, "create a project at "+toplevel+"?") {
-		t.Errorf("offer does not name the git toplevel:\n%s", stdout)
+	if !strings.Contains(stderr, "create a project at "+toplevel+"?") {
+		t.Errorf("offer does not name the git toplevel:\n%s", stderr)
 	}
-	if !strings.Contains(stdout, "created project proj-") || !strings.Contains(stdout, "running") {
-		t.Errorf("accepting the offer did not create project and terminal:\n%s", stdout)
+	if !strings.Contains(stderr, "created project proj-") {
+		t.Errorf("accepting the offer did not report the created project:\n%s", stderr)
+	}
+	if !strings.Contains(stdout, "running") {
+		t.Errorf("accepting the offer did not create the terminal:\n%s", stdout)
 	}
 	if listOut, _, err := runCLI(t, "project", "list"); err != nil || !strings.Contains(listOut, toplevel) {
 		t.Errorf("project list = %q, %v; want the toplevel project", listOut, err)
@@ -215,7 +232,7 @@ func TestTerminalCreateOfferDeclinedCreatesNothing(t *testing.T) {
 func TestProjectCreateDefaultPath(t *testing.T) {
 	startTestServer(t)
 	repo := t.TempDir()
-	mkdirAll(t, filepath.Join(repo, ".git"))
+	gitInit(t, repo)
 	sub := mkdirAll(t, filepath.Join(repo, "pkg"))
 
 	t.Chdir(sub)

--- a/cmd/atc/project_test.go
+++ b/cmd/atc/project_test.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jeremytondo/atc/internal/paths"
+)
+
+// canonical mirrors the CLI's own canonicalization so assertions compare
+// like with like (t.TempDir may sit behind symlinks, e.g. /tmp).
+func canonical(t *testing.T, dir string) string {
+	t.Helper()
+	resolved, err := paths.CanonicalDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resolved
+}
+
+func mkdirAll(t *testing.T, dir string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestProjectCLILifecycle(t *testing.T) {
+	startTestServer(t)
+	dir := t.TempDir()
+
+	stdout, _, err := runCLI(t, "project", "create", dir, "--name", "atc")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	id := projectIDFormat.FindString(stdout)
+	if id == "" || !strings.Contains(stdout, "atc") || !strings.Contains(stdout, canonical(t, dir)) {
+		t.Fatalf("create output:\n%s", stdout)
+	}
+
+	stdout, _, err = runCLI(t, "project", "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, id) || !strings.Contains(stdout, "atc") || !strings.Contains(stdout, canonical(t, dir)) {
+		t.Errorf("list output:\n%s", stdout)
+	}
+
+	if stdout, _, err = runCLI(t, "project", "update", id, "--name", "renamed"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "renamed") {
+		t.Errorf("update output:\n%s", stdout)
+	}
+
+	if stdout, _, err = runCLI(t, "project", "get", id); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, id) || !strings.Contains(stdout, "renamed") {
+		t.Errorf("get output:\n%s", stdout)
+	}
+
+	if stdout, _, err = runCLI(t, "project", "delete", id); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "deleted "+id) {
+		t.Errorf("delete output:\n%s", stdout)
+	}
+	if stdout, _, err = runCLI(t, "project", "list"); err != nil || !strings.Contains(stdout, "no projects") {
+		t.Errorf("list after delete = %q, %v", stdout, err)
+	}
+}
+
+func TestProjectDeleteRefusedWhileNotEmpty(t *testing.T) {
+	startTestServer(t)
+	projectID := createProjectCLI(t, t.TempDir())
+	if _, _, err := runCLI(t, "terminal", "create", "--project", projectID); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := runCLI(t, "project", "delete", projectID)
+	if err == nil || !strings.Contains(err.Error(), "terminal") {
+		t.Fatalf("delete non-empty project = %v, want a refusal naming what remains", err)
+	}
+}
+
+// The nearest ancestor wins: with projects at A and A/B, a terminal
+// created from A/B/sub belongs to A/B.
+func TestTerminalCreateResolvesNearestProject(t *testing.T) {
+	startTestServer(t)
+	root := t.TempDir()
+	outer := mkdirAll(t, filepath.Join(root, "a"))
+	inner := mkdirAll(t, filepath.Join(root, "a", "b"))
+	sub := mkdirAll(t, filepath.Join(root, "a", "b", "sub"))
+	outerID := createProjectCLI(t, outer)
+	innerID := createProjectCLI(t, inner)
+
+	t.Chdir(sub)
+	stdout, _, err := runCLI(t, "terminal", "create")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, innerID) || strings.Contains(stdout, outerID) {
+		t.Errorf("terminal did not land in the nearest project %s:\n%s", innerID, stdout)
+	}
+	if !strings.Contains(stdout, canonical(t, inner)) {
+		t.Errorf("terminal directory is not the project's:\n%s", stdout)
+	}
+}
+
+// A symlinked spelling of the cwd resolves to the same project: the walk
+// compares canonical forms only.
+func TestTerminalCreateSymlinkedCwdResolves(t *testing.T) {
+	startTestServer(t)
+	real := t.TempDir()
+	projectID := createProjectCLI(t, real)
+	link := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(link)
+	stdout, _, err := runCLI(t, "terminal", "create")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, projectID) {
+		t.Errorf("symlinked cwd did not resolve to %s:\n%s", projectID, stdout)
+	}
+}
+
+// --project skips resolution entirely, even when the cwd sits inside a
+// different project.
+func TestTerminalCreateProjectFlagSkipsResolution(t *testing.T) {
+	startTestServer(t)
+	here := t.TempDir()
+	elsewhere := t.TempDir()
+	hereID := createProjectCLI(t, here)
+	elsewhereID := createProjectCLI(t, elsewhere)
+
+	t.Chdir(here)
+	stdout, _, err := runCLI(t, "terminal", "create", "--project", elsewhereID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, elsewhereID) || strings.Contains(stdout, hereID) {
+		t.Errorf("--project did not win over the cwd:\n%s", stdout)
+	}
+}
+
+// Without a TTY, no match is a refusal naming the fixes — never a prompt.
+func TestTerminalCreateNoMatchWithoutTTYRefuses(t *testing.T) {
+	startTestServer(t)
+	t.Chdir(t.TempDir())
+
+	_, _, err := runCLI(t, "terminal", "create")
+	if err == nil || !strings.Contains(err.Error(), "--project") || !strings.Contains(err.Error(), "atc project create") {
+		t.Fatalf("no-match without TTY = %v, want a refusal naming --project and atc project create", err)
+	}
+	stdout, _, listErr := runCLI(t, "terminal", "list")
+	if listErr != nil || !strings.Contains(stdout, "no terminals") {
+		t.Errorf("list after refusal = %q, %v", stdout, listErr)
+	}
+}
+
+// With a TTY and no match, the CLI offers a project rooted at the git
+// toplevel; accepting creates the project and the terminal in one go.
+func TestTerminalCreateOffersProjectAtGitToplevel(t *testing.T) {
+	forceTTY(t)
+	startTestServer(t)
+	repo := t.TempDir()
+	mkdirAll(t, filepath.Join(repo, ".git"))
+	sub := mkdirAll(t, filepath.Join(repo, "pkg"))
+
+	t.Chdir(sub)
+	stdout, _, err := runCLIInput(t, "y\n", "terminal", "create")
+	if err != nil {
+		t.Fatal(err)
+	}
+	toplevel := canonical(t, repo)
+	if !strings.Contains(stdout, "create a project at "+toplevel+"?") {
+		t.Errorf("offer does not name the git toplevel:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "created project proj-") || !strings.Contains(stdout, "running") {
+		t.Errorf("accepting the offer did not create project and terminal:\n%s", stdout)
+	}
+	if listOut, _, err := runCLI(t, "project", "list"); err != nil || !strings.Contains(listOut, toplevel) {
+		t.Errorf("project list = %q, %v; want the toplevel project", listOut, err)
+	}
+}
+
+// Declining the offer refuses the command and creates nothing.
+func TestTerminalCreateOfferDeclinedCreatesNothing(t *testing.T) {
+	forceTTY(t)
+	startTestServer(t)
+	t.Chdir(t.TempDir())
+
+	_, _, err := runCLIInput(t, "n\n", "terminal", "create")
+	if err == nil || !strings.Contains(err.Error(), "no project selected") {
+		t.Fatalf("declined offer = %v, want a refusal", err)
+	}
+	if stdout, _, err := runCLI(t, "project", "list"); err != nil || !strings.Contains(stdout, "no projects") {
+		t.Errorf("project list after decline = %q, %v", stdout, err)
+	}
+	if stdout, _, err := runCLI(t, "terminal", "list"); err != nil || !strings.Contains(stdout, "no terminals") {
+		t.Errorf("terminal list after decline = %q, %v", stdout, err)
+	}
+}
+
+// `atc project create` without a path defaults to the git toplevel when
+// inside a repository, the current directory otherwise.
+func TestProjectCreateDefaultPath(t *testing.T) {
+	startTestServer(t)
+	repo := t.TempDir()
+	mkdirAll(t, filepath.Join(repo, ".git"))
+	sub := mkdirAll(t, filepath.Join(repo, "pkg"))
+
+	t.Chdir(sub)
+	stdout, _, err := runCLI(t, "project", "create")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, canonical(t, repo)) {
+		t.Errorf("create output does not root at the toplevel:\n%s", stdout)
+	}
+
+	plain := canonical(t, t.TempDir())
+	// The walk honestly finds any ancestor repo (a stray /tmp/.git on a
+	// developer machine, say); only a truly repo-free cwd tests this case.
+	if projectRootFor(plain) != plain {
+		t.Skipf("an ancestor of %s is a git repository; skipping the no-repo case", plain)
+	}
+	t.Chdir(plain)
+	stdout, _, err = runCLI(t, "project", "create")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, plain) {
+		t.Errorf("create outside a repo does not root at the cwd:\n%s", stdout)
+	}
+}

--- a/cmd/atc/terminal.go
+++ b/cmd/atc/terminal.go
@@ -95,8 +95,11 @@ func newTerminalCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a terminal and start its session",
-		Long: `Create a terminal and start its session immediately. The session survives
-disconnects and ATC server restarts; attach with ` + "`atc terminal attach <id>`" + `,
+		Long: `Create a terminal and start its session immediately. The terminal lands in
+the project owning the current directory (found by walking up, the way git
+finds a repository) and starts in that project's directory; pass --project
+to pick one explicitly. The session survives disconnects and ATC server
+restarts; attach with ` + "`atc terminal attach <id>`" + `,
 or pass ` + "`--attach`" + ` to attach immediately.
 With --app the command runs through your login shell (profile and rc files
 loaded); without it you get a plain interactive shell.`,
@@ -119,11 +122,16 @@ loaded); without it you get a plain interactive shell.`,
 			if params.Name, err = flags.GetString("name"); err != nil {
 				return err
 			}
-			if params.Directory, err = flags.GetString("dir"); err != nil {
-				return err
-			}
 			if params.App, err = flags.GetString("app"); err != nil {
 				return err
+			}
+			if params.ProjectID, err = flags.GetString("project"); err != nil {
+				return err
+			}
+			if params.ProjectID == "" {
+				if params.ProjectID, err = resolveProjectID(cmd, client); err != nil {
+					return err
+				}
 			}
 			terminal, err := client.CreateTerminal(cmd.Context(), params)
 			if err != nil {
@@ -139,7 +147,7 @@ loaded); without it you get a plain interactive shell.`,
 		}),
 	}
 	cmd.Flags().String("name", "", "display name (defaults from --app, else \"Shell\")")
-	cmd.Flags().String("dir", "", "working directory (defaults to the server user's home)")
+	cmd.Flags().String("project", "", "project the terminal belongs to (defaults to the project owning the current directory)")
 	cmd.Flags().String("app", "", "command to run through your shell; omit for a plain shell")
 	cmd.Flags().Bool("attach", false, "attach to the terminal after creation")
 	return cmd
@@ -162,14 +170,19 @@ func newTerminalGetCmd() *cobra.Command {
 }
 
 func newTerminalListCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List terminals with their statuses",
-		Long: `List every terminal. Exited and missing terminals stay listed — an exit you
-never saw is information, not garbage — until you delete them.`,
+		Long: `List every terminal (pass --project to scope to one project). Exited and
+missing terminals stay listed — an exit you never saw is information, not
+garbage — until you delete them.`,
 		Args: cobra.NoArgs,
 		RunE: runWithClient(func(cmd *cobra.Command, _ []string, client *api.Client, _ string) error {
-			terminals, err := client.Terminals(cmd.Context())
+			project, err := cmd.Flags().GetString("project")
+			if err != nil {
+				return err
+			}
+			terminals, err := client.Terminals(cmd.Context(), project)
 			if err != nil {
 				return err
 			}
@@ -179,13 +192,15 @@ never saw is information, not garbage — until you delete them.`,
 				return err
 			}
 			w := tabwriter.NewWriter(out, 2, 8, 2, ' ', 0)
-			_, _ = fmt.Fprintln(w, "ID\tSTATUS\tNAME\tDIRECTORY")
+			_, _ = fmt.Fprintln(w, "ID\tSTATUS\tNAME\tPROJECT\tDIRECTORY")
 			for _, terminal := range terminals {
-				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", terminal.ID, statusLabel(terminal), terminal.Name, terminal.Directory)
+				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", terminal.ID, statusLabel(terminal), terminal.Name, terminal.ProjectID, terminal.Directory)
 			}
 			return w.Flush()
 		}),
 	}
+	cmd.Flags().String("project", "", "only terminals belonging to this project")
+	return cmd
 }
 
 func newTerminalUpdateCmd() *cobra.Command {
@@ -323,6 +338,7 @@ func printTerminal(out io.Writer, terminal api.Terminal) {
 	_, _ = fmt.Fprintf(w, "id\t%s\n", terminal.ID)
 	_, _ = fmt.Fprintf(w, "name\t%s\n", terminal.Name)
 	_, _ = fmt.Fprintf(w, "status\t%s\n", statusLabel(terminal))
+	_, _ = fmt.Fprintf(w, "project\t%s\n", terminal.ProjectID)
 	_, _ = fmt.Fprintf(w, "directory\t%s\n", terminal.Directory)
 	if terminal.App != "" {
 		_, _ = fmt.Fprintf(w, "app\t%s\n", terminal.App)
@@ -342,7 +358,7 @@ error status.
 
 Examples:
   atc api /v1/terminals
-  atc api -X POST -d '{"app":"hx"}' /v1/terminals
+  atc api -X POST -d '{"projectId":"proj-x7k2f","app":"hx"}' /v1/terminals
   atc api /v1/events`,
 		Args: cobra.ExactArgs(1),
 		RunE: runWithClient(func(cmd *cobra.Command, args []string, client *api.Client, _ string) error {

--- a/cmd/atc/terminal_test.go
+++ b/cmd/atc/terminal_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/jeremytondo/atc/internal/events"
+	"github.com/jeremytondo/atc/internal/projects"
 	"github.com/jeremytondo/atc/internal/server"
 	"github.com/jeremytondo/atc/internal/store"
 	"github.com/jeremytondo/atc/internal/terminals"
@@ -66,15 +67,21 @@ func startTestServer(t *testing.T) *cliAdapter {
 	service := terminals.NewService(terminals.Options{
 		Repository: db.Terminals(),
 		Adapter:    adapter,
+		Projects:   db.Projects(),
 		MarkerDir:  t.TempDir(),
 		Hub:        hub,
 		Logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
-		HomeDir:    "/home/tester",
+	})
+	projectService := projects.NewService(projects.Options{
+		Repository: db.Projects(),
+		Terminals:  db.Terminals(),
+		Hub:        hub,
 	})
 	handler := server.NewHandler(server.Options{
 		Verify:    func(authorization string) bool { return authorization == "Bearer "+cliTestToken },
 		Version:   "v0.0.0-test",
 		Terminals: service,
+		Projects:  projectService,
 		Events:    hub,
 	})
 	srv := httptest.NewServer(handler)
@@ -86,9 +93,31 @@ func startTestServer(t *testing.T) *cliAdapter {
 
 func runCLI(t *testing.T, args ...string) (string, string, error) {
 	t.Helper()
+	return runCLIInput(t, "", args...)
+}
+
+// runCLIInput drives the CLI with stdin content — the create-offer prompt.
+func runCLIInput(t *testing.T, input string, args ...string) (string, string, error) {
+	t.Helper()
 	var stdout, stderr strings.Builder
-	err := run(context.Background(), args, &stdout, &stderr)
+	err := run(context.Background(), args, strings.NewReader(input), &stdout, &stderr)
 	return stdout.String(), stderr.String(), err
+}
+
+var projectIDFormat = regexp.MustCompile(`proj-[a-z2-9]{5}`)
+
+// createProjectCLI registers a project rooted at dir and returns its id.
+func createProjectCLI(t *testing.T, dir string) string {
+	t.Helper()
+	stdout, _, err := runCLI(t, "project", "create", dir)
+	if err != nil {
+		t.Fatalf("project create: %v", err)
+	}
+	id := projectIDFormat.FindString(stdout)
+	if id == "" {
+		t.Fatalf("project create output has no id:\n%s", stdout)
+	}
+	return id
 }
 
 func forceTTY(t *testing.T) {
@@ -109,8 +138,11 @@ func installFakeZmx(t *testing.T) {
 
 func TestTerminalCLILifecycle(t *testing.T) {
 	adapter := startTestServer(t)
+	// --project skips cwd resolution entirely; the cwd (this repo) owns no
+	// project on the test server.
+	projectID := createProjectCLI(t, t.TempDir())
 
-	stdout, _, err := runCLI(t, "terminal", "create", "--app", "hx", "--dir", "/proj")
+	stdout, _, err := runCLI(t, "terminal", "create", "--app", "hx", "--project", projectID)
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -126,8 +158,9 @@ func TestTerminalCLILifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// IDs beside names and statuses — the list contract.
-	if !strings.Contains(stdout, id) || !strings.Contains(stdout, "hx") || !strings.Contains(stdout, "running") {
+	// IDs beside names, statuses, and projects — the list contract.
+	if !strings.Contains(stdout, id) || !strings.Contains(stdout, "hx") ||
+		!strings.Contains(stdout, "running") || !strings.Contains(stdout, projectID) {
 		t.Errorf("list output:\n%s", stdout)
 	}
 
@@ -213,7 +246,8 @@ func TestTerminalCreateAttachMissingSocketKeepsTerminal(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	startTestServer(t)
 
-	stdout, _, err := runCLI(t, "terminal", "create", "--attach")
+	projectID := createProjectCLI(t, t.TempDir())
+	stdout, _, err := runCLI(t, "terminal", "create", "--attach", "--project", projectID)
 	id := regexp.MustCompile(`term-[a-z2-9]{5}`).FindString(stdout)
 	if id == "" || !strings.Contains(stdout, "running") {
 		t.Fatalf("create attach output does not show the created terminal:\n%s", stdout)
@@ -261,7 +295,8 @@ func TestAttachRefusesNonRunning(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 
 	adapter := startTestServer(t)
-	stdout, _, err := runCLI(t, "terminal", "create")
+	projectID := createProjectCLI(t, t.TempDir())
+	stdout, _, err := runCLI(t, "terminal", "create", "--project", projectID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -271,7 +306,7 @@ func TestAttachRefusesNonRunning(t *testing.T) {
 	adapter.mu.Lock()
 	delete(adapter.sessions, id)
 	adapter.mu.Unlock()
-	if _, _, err := runCLI(t, "terminal", "create", "--name", "other"); err != nil {
+	if _, _, err := runCLI(t, "terminal", "create", "--name", "other", "--project", projectID); err != nil {
 		t.Fatal(err)
 	}
 
@@ -295,7 +330,8 @@ func TestAPICommand(t *testing.T) {
 	}
 
 	// POST with a body creates a terminal through the raw gateway.
-	stdout, _, err = runCLI(t, "api", "-d", `{"app":"hx"}`, "/v1/terminals")
+	projectID := createProjectCLI(t, t.TempDir())
+	stdout, _, err = runCLI(t, "api", "-d", `{"app":"hx","projectId":"`+projectID+`"}`, "/v1/terminals")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/atc/terminal_test.go
+++ b/cmd/atc/terminal_test.go
@@ -122,9 +122,10 @@ func createProjectCLI(t *testing.T, dir string) string {
 
 func forceTTY(t *testing.T) {
 	t.Helper()
-	prev := stdioIsTerminal
+	prevStdio, prevStdin := stdioIsTerminal, stdinIsTTY
 	stdioIsTerminal = func() bool { return true }
-	t.Cleanup(func() { stdioIsTerminal = prev })
+	stdinIsTTY = func() bool { return true }
+	t.Cleanup(func() { stdioIsTerminal, stdinIsTTY = prevStdio, prevStdin })
 }
 
 func installFakeZmx(t *testing.T) {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -73,10 +74,15 @@ func (c *Client) Terminal(ctx context.Context, id string) (Terminal, error) {
 	return terminal, err
 }
 
-// Terminals lists every terminal, exited and missing ones included.
-func (c *Client) Terminals(ctx context.Context) ([]Terminal, error) {
+// Terminals lists every terminal, exited and missing ones included. A
+// non-empty projectID filters to that project's terminals.
+func (c *Client) Terminals(ctx context.Context, projectID string) ([]Terminal, error) {
+	path := "/v1/terminals"
+	if projectID != "" {
+		path += "?project=" + url.QueryEscape(projectID)
+	}
 	var list TerminalList
-	err := c.do(ctx, http.MethodGet, "/v1/terminals", nil, &list)
+	err := c.do(ctx, http.MethodGet, path, nil, &list)
 	return list.Terminals, err
 }
 
@@ -90,6 +96,40 @@ func (c *Client) UpdateTerminal(ctx context.Context, id string, params TerminalU
 // DeleteTerminal stops the session best-effort and removes the record.
 func (c *Client) DeleteTerminal(ctx context.Context, id string) error {
 	return c.do(ctx, http.MethodDelete, "/v1/terminals/"+id, nil, nil)
+}
+
+// CreateProject registers a project rooted at a directory.
+func (c *Client) CreateProject(ctx context.Context, params ProjectCreateParams) (Project, error) {
+	var project Project
+	err := c.do(ctx, http.MethodPost, "/v1/projects", params, &project)
+	return project, err
+}
+
+// Project fetches one project by ID.
+func (c *Client) Project(ctx context.Context, id string) (Project, error) {
+	var project Project
+	err := c.do(ctx, http.MethodGet, "/v1/projects/"+id, nil, &project)
+	return project, err
+}
+
+// Projects lists every project.
+func (c *Client) Projects(ctx context.Context) ([]Project, error) {
+	var list ProjectList
+	err := c.do(ctx, http.MethodGet, "/v1/projects", nil, &list)
+	return list.Projects, err
+}
+
+// UpdateProject renames a project; name is the only mutable field.
+func (c *Client) UpdateProject(ctx context.Context, id string, params ProjectUpdateParams) (Project, error) {
+	var project Project
+	err := c.do(ctx, http.MethodPatch, "/v1/projects/"+id, params, &project)
+	return project, err
+}
+
+// DeleteProject removes an empty project; a project that still holds
+// terminals is refused.
+func (c *Client) DeleteProject(ctx context.Context, id string) error {
+	return c.do(ctx, http.MethodDelete, "/v1/projects/"+id, nil, nil)
 }
 
 // Raw performs one authenticated request over the contract and returns the

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -197,12 +197,12 @@ func TestTransportErrorIsNotAProblem(t *testing.T) {
 // method, path, and body round-trip is what there is to verify.
 func TestTerminalMethods(t *testing.T) {
 	type call struct {
-		Method, Path, Body string
+		Method, Path, Query, Body string
 	}
 	var got call
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
-		got = call{Method: r.Method, Path: r.URL.Path, Body: strings.TrimSpace(string(body))}
+		got = call{Method: r.Method, Path: r.URL.Path, Query: r.URL.RawQuery, Body: strings.TrimSpace(string(body))}
 		switch r.URL.Path {
 		case "/v1/terminals":
 			if r.Method == http.MethodPost {
@@ -222,20 +222,27 @@ func TestTerminalMethods(t *testing.T) {
 	client := NewClient(srv.URL, testToken, testClientVersion, nil, nil)
 	ctx := context.Background()
 
-	terminal, err := client.CreateTerminal(ctx, TerminalCreateParams{App: "hx", Directory: "/proj"})
+	terminal, err := client.CreateTerminal(ctx, TerminalCreateParams{ProjectID: "proj-x7k2f", App: "hx"})
 	if err != nil || terminal.ID != "term-x7k2f" {
 		t.Fatalf("CreateTerminal = %+v, %v", terminal, err)
 	}
-	want := call{http.MethodPost, "/v1/terminals", `{"directory":"/proj","app":"hx"}`}
+	want := call{http.MethodPost, "/v1/terminals", "", `{"projectId":"proj-x7k2f","app":"hx"}`}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("create request (-want +got):\n%s", diff)
 	}
 
-	if _, err := client.Terminals(ctx); err != nil {
+	if _, err := client.Terminals(ctx, ""); err != nil {
 		t.Fatal(err)
 	}
 	if got.Method != http.MethodGet || got.Path != "/v1/terminals" {
 		t.Errorf("list request = %+v", got)
+	}
+
+	if _, err := client.Terminals(ctx, "proj-x7k2f"); err != nil {
+		t.Fatal(err)
+	}
+	if got.Query != "project=proj-x7k2f" {
+		t.Errorf("filtered list query = %q", got.Query)
 	}
 
 	if _, err := client.Terminal(ctx, "term-x7k2f"); err != nil {
@@ -248,12 +255,74 @@ func TestTerminalMethods(t *testing.T) {
 	if _, err := client.UpdateTerminal(ctx, "term-x7k2f", TerminalUpdateParams{Name: "build"}); err != nil {
 		t.Fatal(err)
 	}
-	want = call{http.MethodPatch, "/v1/terminals/term-x7k2f", `{"name":"build"}`}
+	want = call{http.MethodPatch, "/v1/terminals/term-x7k2f", "", `{"name":"build"}`}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("update request (-want +got):\n%s", diff)
 	}
 
 	if err := client.DeleteTerminal(ctx, "term-x7k2f"); err != nil {
+		t.Fatal(err)
+	}
+	if got.Method != http.MethodDelete {
+		t.Errorf("delete method = %q", got.Method)
+	}
+}
+
+func TestProjectMethods(t *testing.T) {
+	type call struct {
+		Method, Path, Body string
+	}
+	var got call
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		got = call{Method: r.Method, Path: r.URL.Path, Body: strings.TrimSpace(string(body))}
+		switch {
+		case r.URL.Path == "/v1/projects" && r.Method == http.MethodPost:
+			_ = json.NewEncoder(w).Encode(Project{ID: "proj-x7k2f"})
+		case r.URL.Path == "/v1/projects":
+			_ = json.NewEncoder(w).Encode(ProjectList{Projects: []Project{{ID: "proj-x7k2f"}}})
+		case r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			_ = json.NewEncoder(w).Encode(Project{ID: "proj-x7k2f"})
+		}
+	}))
+	defer srv.Close()
+	client := NewClient(srv.URL, testToken, testClientVersion, nil, nil)
+	ctx := context.Background()
+
+	project, err := client.CreateProject(ctx, ProjectCreateParams{Directory: "/proj", Name: "p"})
+	if err != nil || project.ID != "proj-x7k2f" {
+		t.Fatalf("CreateProject = %+v, %v", project, err)
+	}
+	want := call{http.MethodPost, "/v1/projects", `{"directory":"/proj","name":"p"}`}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("create request (-want +got):\n%s", diff)
+	}
+
+	if _, err := client.Projects(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if got.Method != http.MethodGet || got.Path != "/v1/projects" {
+		t.Errorf("list request = %+v", got)
+	}
+
+	if _, err := client.Project(ctx, "proj-x7k2f"); err != nil {
+		t.Fatal(err)
+	}
+	if got.Path != "/v1/projects/proj-x7k2f" {
+		t.Errorf("get path = %q", got.Path)
+	}
+
+	if _, err := client.UpdateProject(ctx, "proj-x7k2f", ProjectUpdateParams{Name: "renamed"}); err != nil {
+		t.Fatal(err)
+	}
+	want = call{http.MethodPatch, "/v1/projects/proj-x7k2f", `{"name":"renamed"}`}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("update request (-want +got):\n%s", diff)
+	}
+
+	if err := client.DeleteProject(ctx, "proj-x7k2f"); err != nil {
 		t.Fatal(err)
 	}
 	if got.Method != http.MethodDelete {

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -11,6 +11,9 @@ const (
 	EventTerminalCreated = "terminal.created"
 	EventTerminalUpdated = "terminal.updated"
 	EventTerminalDeleted = "terminal.deleted"
+	EventProjectCreated  = "project.created"
+	EventProjectUpdated  = "project.updated"
+	EventProjectDeleted  = "project.deleted"
 	EventResync          = "resync"
 )
 
@@ -31,6 +34,15 @@ type TerminalUpdatedEvent struct{ ChangeEvent }
 
 // TerminalDeletedEvent is the terminal.deleted payload.
 type TerminalDeletedEvent struct{ ChangeEvent }
+
+// ProjectCreatedEvent is the project.created payload.
+type ProjectCreatedEvent struct{ ChangeEvent }
+
+// ProjectUpdatedEvent is the project.updated payload.
+type ProjectUpdatedEvent struct{ ChangeEvent }
+
+// ProjectDeletedEvent is the project.deleted payload.
+type ProjectDeletedEvent struct{ ChangeEvent }
 
 // ResyncEvent tells a reconnecting client its cursor has fallen off the
 // backlog: refetch snapshots once, then resume from the live stream.

--- a/internal/api/project.go
+++ b/internal/api/project.go
@@ -1,0 +1,34 @@
+package api
+
+import "time"
+
+// Project is the /v1/projects resource (ATC-256): ATC's unit of
+// organization. Everything belongs to exactly one project; the directory
+// answers where new things in the project start, asked once at create
+// time.
+type Project struct {
+	ID string `json:"id" doc:"Server-minted identifier."`
+	// Name is editable and deliberately not unique; the canonical
+	// directory is the identity.
+	Name      string    `json:"name" doc:"Display name; the only mutable field. Not required to be unique."`
+	Directory string    `json:"directory" doc:"Canonical absolute directory (symlinks resolved) the project is rooted at. Unique across projects. Immutable."`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// ProjectCreateParams is the POST /v1/projects request body.
+type ProjectCreateParams struct {
+	Directory string `json:"directory" minLength:"1" doc:"Directory the project is rooted at. Canonicalized by the server; must exist and be a directory."`
+	Name      string `json:"name,omitempty" doc:"Display name; defaults to the basename of the canonical directory."`
+}
+
+// ProjectUpdateParams is the PATCH /v1/projects/{id} request body. Name is
+// the only mutable field; unknown or immutable fields are rejected.
+type ProjectUpdateParams struct {
+	Name string `json:"name" minLength:"1" doc:"New display name."`
+}
+
+// ProjectList is the GET /v1/projects response body.
+type ProjectList struct {
+	Projects []Project `json:"projects"`
+}

--- a/internal/api/terminal.go
+++ b/internal/api/terminal.go
@@ -24,7 +24,8 @@ const (
 type Terminal struct {
 	ID        string         `json:"id" doc:"Server-minted identifier; also the zmx session name."`
 	Name      string         `json:"name" doc:"Display name; the only mutable field."`
-	Directory string         `json:"directory" doc:"Working directory the session started in. Immutable."`
+	ProjectID string         `json:"projectId" doc:"Project the terminal belongs to. Immutable; terminals never move between projects."`
+	Directory string         `json:"directory" doc:"Working directory the session started in, copied from the project at create time. Immutable."`
 	App       string         `json:"app,omitempty" doc:"Command launched in the session; empty means a plain shell. Immutable."`
 	Status    TerminalStatus `json:"status" enum:"running,exited,unreachable,missing" doc:"Server-owned session state."`
 	ExitCode  *int           `json:"exitCode,omitempty" doc:"Recorded exit evidence: exit code, 128+signal for signal deaths, 127 for launch failure. Omitted while running and for ATC-initiated stops."`
@@ -32,11 +33,12 @@ type Terminal struct {
 	UpdatedAt time.Time      `json:"updatedAt"`
 }
 
-// TerminalCreateParams is the POST /v1/terminals request body. Every field
-// is optional.
+// TerminalCreateParams is the POST /v1/terminals request body. The project
+// is required (ATC-256) and supplies the working directory; everything
+// else is optional.
 type TerminalCreateParams struct {
+	ProjectID string `json:"projectId" minLength:"1" doc:"Project the terminal belongs to; its directory becomes the terminal's working directory."`
 	Name      string `json:"name,omitempty" doc:"Display name; defaults from app, else \"Shell\"."`
-	Directory string `json:"directory,omitempty" doc:"Working directory; defaults to the server user's home."`
 	App       string `json:"app,omitempty" doc:"Free-form command run through the user's shell; empty starts a plain interactive shell."`
 }
 

--- a/internal/ids/ids.go
+++ b/internal/ids/ids.go
@@ -1,0 +1,40 @@
+// Package ids mints ATC's public identifiers (ATC-251): a type prefix
+// plus a fixed-length 5-character random suffix. The alphabet is
+// lowercase, excludes the ambiguous glyphs (0/o, 1/l/i) and all vowels —
+// so an ID can never spell a word. Fixed length makes IDs prefix-free,
+// which keeps zmx's trailing-* prefix matching safe to type. The format
+// is permanent: it appears in un-versioned surfaces (zmx list) and must
+// never be reformatted.
+package ids
+
+import "crypto/rand"
+
+const (
+	// SuffixLength is the fixed random-suffix length of every public ID.
+	SuffixLength = 5
+	alphabet     = "23456789bcdfghjkmnpqrstvwxyz"
+)
+
+// New mints one candidate ID with the given type prefix; the caller
+// collision-checks it against the database and re-rolls.
+func New(prefix string) string {
+	suffix := make([]byte, SuffixLength)
+	// Rejection sampling keeps the distribution uniform: 256 is not a
+	// multiple of 28, so bytes past the largest full multiple re-roll.
+	limit := byte(256 - 256%len(alphabet))
+	for i := 0; i < len(suffix); {
+		var buf [16]byte
+		rand.Read(buf[:])
+		for _, b := range buf {
+			if i == len(suffix) {
+				break
+			}
+			if b >= limit {
+				continue
+			}
+			suffix[i] = alphabet[int(b)%len(alphabet)]
+			i++
+		}
+	}
+	return prefix + string(suffix)
+}

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -9,12 +9,40 @@
 //	state   $XDG_STATE_HOME/atc/atc.log       (~/.local/state/atc/atc.log)
 //	state   $XDG_STATE_HOME/atc/terminals     (~/.local/state/atc/terminals)
 //	state   $XDG_STATE_HOME/atc/exits         (~/.local/state/atc/exits)
+//
+// It also owns CanonicalDir, the one rule for canonicalizing user-supplied
+// directories (ATC-256) — project identity and CLI project resolution must
+// agree on it exactly.
 package paths
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
+
+// CanonicalDir resolves path to the canonical form ATC stores and compares
+// (ATC-256): absolute, cleaned, symlinks resolved. It fails when the path
+// does not exist or is not a directory (symlink resolution already
+// requires existence; this is one check, not two).
+func CanonicalDir(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%s is not a directory", path)
+	}
+	return resolved, nil
+}
 
 // ConfigFile is the TOML configuration file the server reads.
 func ConfigFile() (string, error) {

--- a/internal/projects/projects.go
+++ b/internal/projects/projects.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -31,21 +32,14 @@ var (
 	// ErrDirectoryInvalid wraps a create directory that cannot be
 	// canonicalized: it does not exist or is not a directory.
 	ErrDirectoryInvalid = errors.New("invalid project directory")
-	// ErrDirectoryTaken reports a create whose canonical directory already
-	// belongs to a project.
+	// ErrDirectoryTaken reports a create whose directory already belongs to
+	// a project — same canonical form or the same real folder.
 	ErrDirectoryTaken = errors.New("directory already belongs to a project")
+	// ErrNotEmpty refuses a delete while terminals still belong to the
+	// project; the wrapped message reports what remains. There is no
+	// cascade and no --force.
+	ErrNotEmpty = errors.New("project is not empty")
 )
-
-// NotEmptyError refuses a delete while terminals still belong to the
-// project, reporting what remains. There is no cascade and no --force.
-type NotEmptyError struct {
-	TerminalIDs []string
-}
-
-func (e *NotEmptyError) Error() string {
-	return fmt.Sprintf("project still has %d terminal(s): %s",
-		len(e.TerminalIDs), strings.Join(e.TerminalIDs, ", "))
-}
 
 // resource is the event-payload resource kind.
 const resource = "project"
@@ -108,13 +102,28 @@ func (s *Service) Create(ctx context.Context, params api.ProjectCreateParams) (a
 
 	s.ops.Lock()
 	defer s.ops.Unlock()
-	// Uniqueness compares canonical forms only; a symlinked spelling of a
-	// claimed folder is the same project. ops serializes the check against
-	// the insert, and the schema's UNIQUE backstops external writers.
-	if _, taken, err := s.repository.GetByDirectory(ctx, canonical); err != nil {
+	// One project per real folder: a symlinked spelling canonicalizes to
+	// the claimed string, and a differently-spelled path to the same folder
+	// (a case-insensitive filesystem) is caught by filesystem identity.
+	// ops serializes the check against the insert, and the schema's UNIQUE
+	// backstops external writers.
+	info, err := os.Stat(canonical)
+	if err != nil {
+		return api.Project{}, fmt.Errorf("%w: %w", ErrDirectoryInvalid, err)
+	}
+	existing, err := s.repository.List(ctx)
+	if err != nil {
 		return api.Project{}, err
-	} else if taken {
-		return api.Project{}, fmt.Errorf("%w: %s", ErrDirectoryTaken, canonical)
+	}
+	for _, project := range existing {
+		if project.Directory == canonical {
+			return api.Project{}, fmt.Errorf("%w: %s", ErrDirectoryTaken, canonical)
+		}
+		// A project whose folder is gone cannot be the same folder; its
+		// canonical string above is still its claim.
+		if projectInfo, err := os.Stat(project.Directory); err == nil && os.SameFile(info, projectInfo) {
+			return api.Project{}, fmt.Errorf("%w: %s is %s", ErrDirectoryTaken, canonical, project.Directory)
+		}
 	}
 	// Insertion is the collision check: a taken ID inserts nothing and
 	// re-rolls, with no check-then-insert window.
@@ -157,24 +166,17 @@ func (s *Service) List(ctx context.Context) ([]api.Project, error) {
 	return projects, nil
 }
 
-// UpdateName renames the project — the only mutable field.
+// UpdateName renames the project — the only mutable field. The rename
+// returns the committed row in one repository operation, so a committed
+// write can never surface as an error with its event unpublished.
 func (s *Service) UpdateName(ctx context.Context, id, name string) (api.Project, error) {
 	s.ops.Lock()
 	defer s.ops.Unlock()
-	ok, err := s.repository.UpdateName(ctx, id, name, s.now())
+	record, ok, err := s.repository.UpdateName(ctx, id, name, s.now())
 	if err != nil {
 		return api.Project{}, err
 	}
 	if !ok {
-		return api.Project{}, ErrNotFound
-	}
-	record, ok, err := s.repository.Get(ctx, id)
-	if err != nil {
-		return api.Project{}, err
-	}
-	if !ok {
-		// The row updated but is gone — impossible while ops serializes
-		// mutations, and never worth answering with a zero value.
 		return api.Project{}, ErrNotFound
 	}
 	s.hub.Publish(api.EventProjectUpdated, resource, id)
@@ -192,9 +194,15 @@ func (s *Service) Delete(ctx context.Context, id string) error {
 		return err
 	}
 	if len(terminalIDs) > 0 {
-		return &NotEmptyError{TerminalIDs: terminalIDs}
+		return fmt.Errorf("%w: %d terminal(s) remain: %s",
+			ErrNotEmpty, len(terminalIDs), strings.Join(terminalIDs, ", "))
 	}
 	deleted, err := s.repository.Delete(ctx, id)
+	if errors.Is(err, store.ErrForeignKeyViolation) {
+		// A terminal create slipped in after the empty check; the foreign
+		// key kept the state consistent, so answer with the refusal.
+		return fmt.Errorf("%w: a terminal was just created in it", ErrNotEmpty)
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/projects/projects.go
+++ b/internal/projects/projects.go
@@ -1,0 +1,216 @@
+// Package projects is the Projects domain (ATC-256): the resource behind
+// /v1/projects, ATC's unit of organization. A project carries a name and
+// a canonical directory; the directory is the identity (unique, immutable)
+// and answers where new things in the project start. Presentation —
+// grouping, scoping views — belongs to UIs; the API only provides filters.
+//
+// Unlike terminals, projects have no external backend and no derived
+// status, so the service is a thin policy layer over the repository: no
+// in-memory view, no reconciliation.
+package projects
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jeremytondo/atc/internal/api"
+	"github.com/jeremytondo/atc/internal/events"
+	"github.com/jeremytondo/atc/internal/ids"
+	"github.com/jeremytondo/atc/internal/paths"
+	"github.com/jeremytondo/atc/internal/store"
+)
+
+var (
+	// ErrNotFound reports an id with no record; the API layer maps it to 404.
+	ErrNotFound = errors.New("project not found")
+	// ErrDirectoryInvalid wraps a create directory that cannot be
+	// canonicalized: it does not exist or is not a directory.
+	ErrDirectoryInvalid = errors.New("invalid project directory")
+	// ErrDirectoryTaken reports a create whose canonical directory already
+	// belongs to a project.
+	ErrDirectoryTaken = errors.New("directory already belongs to a project")
+)
+
+// NotEmptyError refuses a delete while terminals still belong to the
+// project, reporting what remains. There is no cascade and no --force.
+type NotEmptyError struct {
+	TerminalIDs []string
+}
+
+func (e *NotEmptyError) Error() string {
+	return fmt.Sprintf("project still has %d terminal(s): %s",
+		len(e.TerminalIDs), strings.Join(e.TerminalIDs, ", "))
+}
+
+// resource is the event-payload resource kind.
+const resource = "project"
+
+const idPrefix = "proj-"
+
+// Options wires a Service. Now defaults to time.Now.
+type Options struct {
+	Repository *store.Projects
+	// Terminals is read for the delete-refusal check: a project with
+	// terminals is never deleted.
+	Terminals *store.Terminals
+	Hub       *events.Hub
+	Now       func() time.Time
+}
+
+// Service owns project policy: canonical-directory identity, name
+// defaulting, and the refuse-when-non-empty delete. ops serializes each
+// mutation's commit so check-then-write sequences (directory uniqueness,
+// the empty check) cannot interleave.
+type Service struct {
+	repository *store.Projects
+	terminals  *store.Terminals
+	hub        *events.Hub
+	now        func() time.Time
+
+	ops sync.Mutex
+}
+
+func NewService(opts Options) *Service {
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	return &Service{
+		repository: opts.Repository,
+		terminals:  opts.Terminals,
+		hub:        opts.Hub,
+		now:        opts.Now,
+	}
+}
+
+// Create canonicalizes the directory (absolute, cleaned, symlinks
+// resolved — the canonical form is what directory means everywhere),
+// defaults the name from its basename, and persists the record. The path
+// must exist and be a directory; the canonical form must be unclaimed.
+func (s *Service) Create(ctx context.Context, params api.ProjectCreateParams) (api.Project, error) {
+	canonical, err := paths.CanonicalDir(params.Directory)
+	if err != nil {
+		return api.Project{}, fmt.Errorf("%w: %w", ErrDirectoryInvalid, err)
+	}
+	name := params.Name
+	if name == "" {
+		name = filepath.Base(canonical)
+	}
+	now := s.now()
+	record := store.ProjectRecord{
+		Name: name, Directory: canonical,
+		CreatedAt: now, UpdatedAt: now,
+	}
+
+	s.ops.Lock()
+	defer s.ops.Unlock()
+	// Uniqueness compares canonical forms only; a symlinked spelling of a
+	// claimed folder is the same project. ops serializes the check against
+	// the insert, and the schema's UNIQUE backstops external writers.
+	if _, taken, err := s.repository.GetByDirectory(ctx, canonical); err != nil {
+		return api.Project{}, err
+	} else if taken {
+		return api.Project{}, fmt.Errorf("%w: %s", ErrDirectoryTaken, canonical)
+	}
+	// Insertion is the collision check: a taken ID inserts nothing and
+	// re-rolls, with no check-then-insert window.
+	for {
+		record.ID = ids.New(idPrefix)
+		inserted, err := s.repository.Insert(ctx, record)
+		if err != nil {
+			return api.Project{}, err
+		}
+		if inserted {
+			break
+		}
+	}
+	s.hub.Publish(api.EventProjectCreated, resource, record.ID)
+	return project(record), nil
+}
+
+// Get serves one project.
+func (s *Service) Get(ctx context.Context, id string) (api.Project, error) {
+	record, ok, err := s.repository.Get(ctx, id)
+	if err != nil {
+		return api.Project{}, err
+	}
+	if !ok {
+		return api.Project{}, ErrNotFound
+	}
+	return project(record), nil
+}
+
+// List serves every project in creation order.
+func (s *Service) List(ctx context.Context) ([]api.Project, error) {
+	records, err := s.repository.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	projects := make([]api.Project, 0, len(records))
+	for _, record := range records {
+		projects = append(projects, project(record))
+	}
+	return projects, nil
+}
+
+// UpdateName renames the project — the only mutable field.
+func (s *Service) UpdateName(ctx context.Context, id, name string) (api.Project, error) {
+	s.ops.Lock()
+	defer s.ops.Unlock()
+	ok, err := s.repository.UpdateName(ctx, id, name, s.now())
+	if err != nil {
+		return api.Project{}, err
+	}
+	if !ok {
+		return api.Project{}, ErrNotFound
+	}
+	record, ok, err := s.repository.Get(ctx, id)
+	if err != nil {
+		return api.Project{}, err
+	}
+	if !ok {
+		// The row updated but is gone — impossible while ops serializes
+		// mutations, and never worth answering with a zero value.
+		return api.Project{}, ErrNotFound
+	}
+	s.hub.Publish(api.EventProjectUpdated, resource, id)
+	return project(record), nil
+}
+
+// Delete removes an empty project. While any terminal still belongs to it
+// the delete is refused with what remains; the schema's foreign key
+// backstops the race against a concurrent terminal create.
+func (s *Service) Delete(ctx context.Context, id string) error {
+	s.ops.Lock()
+	defer s.ops.Unlock()
+	terminalIDs, err := s.terminals.ListIDsByProject(ctx, id)
+	if err != nil {
+		return err
+	}
+	if len(terminalIDs) > 0 {
+		return &NotEmptyError{TerminalIDs: terminalIDs}
+	}
+	deleted, err := s.repository.Delete(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !deleted {
+		return ErrNotFound
+	}
+	s.hub.Publish(api.EventProjectDeleted, resource, id)
+	return nil
+}
+
+func project(record store.ProjectRecord) api.Project {
+	return api.Project{
+		ID:        record.ID,
+		Name:      record.Name,
+		Directory: record.Directory,
+		CreatedAt: record.CreatedAt,
+		UpdatedAt: record.UpdatedAt,
+	}
+}

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -89,6 +89,9 @@ func registerEvents(humaAPI huma.API, hub *events.Hub, heartbeat time.Duration) 
 		api.EventTerminalCreated: api.TerminalCreatedEvent{},
 		api.EventTerminalUpdated: api.TerminalUpdatedEvent{},
 		api.EventTerminalDeleted: api.TerminalDeletedEvent{},
+		api.EventProjectCreated:  api.ProjectCreatedEvent{},
+		api.EventProjectUpdated:  api.ProjectUpdatedEvent{},
+		api.EventProjectDeleted:  api.ProjectDeletedEvent{},
 		api.EventResync:          api.ResyncEvent{},
 	}, func(ctx context.Context, input *eventsInput, send sse.Sender) {
 		after, hasCursor := uint64(0), false
@@ -157,6 +160,12 @@ func sendChange(send sse.Sender, change events.Change) error {
 		data = api.TerminalUpdatedEvent{ChangeEvent: body}
 	case api.EventTerminalDeleted:
 		data = api.TerminalDeletedEvent{ChangeEvent: body}
+	case api.EventProjectCreated:
+		data = api.ProjectCreatedEvent{ChangeEvent: body}
+	case api.EventProjectUpdated:
+		data = api.ProjectUpdatedEvent{ChangeEvent: body}
+	case api.EventProjectDeleted:
+		data = api.ProjectDeletedEvent{ChangeEvent: body}
 	default:
 		// An unmapped type would panic Huma's type lookup; drop it loudly
 		// in tests via the OpenAPI event map instead.

--- a/internal/server/projects.go
+++ b/internal/server/projects.go
@@ -1,0 +1,119 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"github.com/jeremytondo/atc/internal/api"
+	"github.com/jeremytondo/atc/internal/projects"
+)
+
+// The five standard verbs on /v1/projects — exactly these, mirroring the
+// terminals surface (ATC-256). Handlers are thin Huma wrappers around the
+// shared wire structs; policy lives in the projects service.
+
+type projectOutput struct {
+	Body api.Project
+}
+
+type projectListOutput struct {
+	Body api.ProjectList
+}
+
+type projectIDInput struct {
+	ID string `path:"id" doc:"Project identifier."`
+}
+
+func registerProjects(humaAPI huma.API, service *projects.Service) {
+	huma.Register(humaAPI, huma.Operation{
+		OperationID:   "create-project",
+		Method:        http.MethodPost,
+		Path:          "/v1/projects",
+		Summary:       "Create a project",
+		Description:   "Canonicalizes the directory (absolute, cleaned, symlinks resolved) and stores the canonical form; the path must exist and be a directory, and its canonical form must not already belong to a project.",
+		DefaultStatus: http.StatusCreated,
+	}, func(ctx context.Context, input *struct {
+		Body api.ProjectCreateParams
+	}) (*projectOutput, error) {
+		project, err := service.Create(ctx, input.Body)
+		if err != nil {
+			return nil, mapProjectError(err)
+		}
+		return &projectOutput{Body: project}, nil
+	})
+
+	huma.Register(humaAPI, huma.Operation{
+		OperationID: "list-projects",
+		Method:      http.MethodGet,
+		Path:        "/v1/projects",
+		Summary:     "List projects",
+	}, func(ctx context.Context, _ *struct{}) (*projectListOutput, error) {
+		list, err := service.List(ctx)
+		if err != nil {
+			return nil, mapProjectError(err)
+		}
+		return &projectListOutput{Body: api.ProjectList{Projects: list}}, nil
+	})
+
+	huma.Register(humaAPI, huma.Operation{
+		OperationID: "get-project",
+		Method:      http.MethodGet,
+		Path:        "/v1/projects/{id}",
+		Summary:     "Get a project",
+	}, func(ctx context.Context, input *projectIDInput) (*projectOutput, error) {
+		project, err := service.Get(ctx, input.ID)
+		if err != nil {
+			return nil, mapProjectError(err)
+		}
+		return &projectOutput{Body: project}, nil
+	})
+
+	huma.Register(humaAPI, huma.Operation{
+		OperationID: "update-project",
+		Method:      http.MethodPatch,
+		Path:        "/v1/projects/{id}",
+		Summary:     "Update a project",
+		Description: "Name is the only mutable field; unknown or immutable fields are rejected.",
+	}, func(ctx context.Context, input *struct {
+		ID   string `path:"id" doc:"Project identifier."`
+		Body api.ProjectUpdateParams
+	}) (*projectOutput, error) {
+		project, err := service.UpdateName(ctx, input.ID, input.Body.Name)
+		if err != nil {
+			return nil, mapProjectError(err)
+		}
+		return &projectOutput{Body: project}, nil
+	})
+
+	huma.Register(humaAPI, huma.Operation{
+		OperationID:   "delete-project",
+		Method:        http.MethodDelete,
+		Path:          "/v1/projects/{id}",
+		Summary:       "Delete a project",
+		Description:   "Refused while any terminal still belongs to the project, reporting what remains. No cascade.",
+		DefaultStatus: http.StatusNoContent,
+	}, func(ctx context.Context, input *projectIDInput) (*struct{}, error) {
+		if err := service.Delete(ctx, input.ID); err != nil {
+			return nil, mapProjectError(err)
+		}
+		return nil, nil
+	})
+}
+
+func mapProjectError(err error) error {
+	var notEmpty *projects.NotEmptyError
+	switch {
+	case errors.Is(err, projects.ErrNotFound):
+		return huma.Error404NotFound("project not found")
+	case errors.Is(err, projects.ErrDirectoryInvalid):
+		return huma.Error422UnprocessableEntity(err.Error())
+	case errors.Is(err, projects.ErrDirectoryTaken):
+		return huma.Error409Conflict(err.Error())
+	case errors.As(err, &notEmpty):
+		return huma.Error409Conflict(err.Error())
+	}
+	return err
+}

--- a/internal/server/projects.go
+++ b/internal/server/projects.go
@@ -104,7 +104,6 @@ func registerProjects(humaAPI huma.API, service *projects.Service) {
 }
 
 func mapProjectError(err error) error {
-	var notEmpty *projects.NotEmptyError
 	switch {
 	case errors.Is(err, projects.ErrNotFound):
 		return huma.Error404NotFound("project not found")
@@ -112,7 +111,7 @@ func mapProjectError(err error) error {
 		return huma.Error422UnprocessableEntity(err.Error())
 	case errors.Is(err, projects.ErrDirectoryTaken):
 		return huma.Error409Conflict(err.Error())
-	case errors.As(err, &notEmpty):
+	case errors.Is(err, projects.ErrNotEmpty):
 		return huma.Error409Conflict(err.Error())
 	}
 	return err

--- a/internal/server/projects_test.go
+++ b/internal/server/projects_test.go
@@ -1,0 +1,205 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/jeremytondo/atc/internal/api"
+)
+
+func decodeProject(t *testing.T, rec *httptest.ResponseRecorder) api.Project {
+	t.Helper()
+	var project api.Project
+	if err := json.Unmarshal(rec.Body.Bytes(), &project); err != nil {
+		t.Fatalf("decoding %q: %v", rec.Body, err)
+	}
+	return project
+}
+
+func TestProjectCRUDOverTheWire(t *testing.T) {
+	f := newFixture(t)
+	dir := t.TempDir()
+
+	created := f.createProject(t, dir)
+	// The name defaults to the basename of the canonical directory.
+	if created.Name != filepath.Base(created.Directory) || created.Directory == "" {
+		t.Fatalf("created = %+v", created)
+	}
+	if !strings.HasPrefix(created.ID, "proj-") {
+		t.Fatalf("id = %q, want the proj- prefix", created.ID)
+	}
+
+	rec := f.request(t, http.MethodGet, "/v1/projects/"+created.ID, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get: got %d", rec.Code)
+	}
+	if diff := cmp.Diff(created, decodeProject(t, rec)); diff != "" {
+		t.Errorf("get (-created +got):\n%s", diff)
+	}
+
+	rec = f.request(t, http.MethodGet, "/v1/projects", "")
+	var list api.ProjectList
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatal(err)
+	}
+	// The fixture project plus this one, in creation order.
+	if len(list.Projects) != 2 || list.Projects[1].ID != created.ID {
+		t.Errorf("list = %+v", list)
+	}
+
+	rec = f.request(t, http.MethodPatch, "/v1/projects/"+created.ID, `{"name":"renamed"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("update: got %d; body %s", rec.Code, rec.Body)
+	}
+	if got := decodeProject(t, rec); got.Name != "renamed" {
+		t.Errorf("updated name = %q", got.Name)
+	}
+
+	// Immutable and unknown fields are rejected by schema.
+	for name, body := range map[string]string{
+		"immutable directory": `{"name":"x","directory":"/elsewhere"}`,
+		"unknown field":       `{"name":"x","frobnicate":true}`,
+		"missing name":        `{}`,
+	} {
+		rec := f.request(t, http.MethodPatch, "/v1/projects/"+created.ID, body)
+		if rec.Code != http.StatusUnprocessableEntity {
+			t.Errorf("%s: got %d, want 422; body %s", name, rec.Code, rec.Body)
+		}
+	}
+
+	rec = f.request(t, http.MethodDelete, "/v1/projects/"+created.ID, "")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("delete: got %d; body %s", rec.Code, rec.Body)
+	}
+	if rec := f.request(t, http.MethodGet, "/v1/projects/"+created.ID, ""); rec.Code != http.StatusNotFound {
+		t.Errorf("get after delete: got %d, want 404", rec.Code)
+	}
+}
+
+func TestProjectCreateValidation(t *testing.T) {
+	f := newFixture(t)
+
+	// A path that does not exist (or is a file) cannot become a project.
+	rec := f.request(t, http.MethodPost, "/v1/projects", `{"directory":"/no/such/dir"}`)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("nonexistent dir: got %d, want 422; body %s", rec.Code, rec.Body)
+	}
+	file := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(file, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	body, _ := json.Marshal(api.ProjectCreateParams{Directory: file})
+	if rec := f.request(t, http.MethodPost, "/v1/projects", string(body)); rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("file path: got %d, want 422; body %s", rec.Code, rec.Body)
+	}
+
+	// A symlinked spelling of a claimed folder is the same canonical
+	// directory: uniqueness compares canonical forms only.
+	link := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(f.projectDir, link); err != nil {
+		t.Fatal(err)
+	}
+	body, _ = json.Marshal(api.ProjectCreateParams{Directory: link})
+	rec = f.request(t, http.MethodPost, "/v1/projects", string(body))
+	if rec.Code != http.StatusConflict {
+		t.Errorf("symlinked duplicate: got %d, want 409; body %s", rec.Code, rec.Body)
+	}
+
+	// An explicit name wins over the basename default, and names are not
+	// required to be unique.
+	other := t.TempDir()
+	body, _ = json.Marshal(api.ProjectCreateParams{Directory: other, Name: "custom"})
+	rec = f.request(t, http.MethodPost, "/v1/projects", string(body))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("named create: got %d; body %s", rec.Code, rec.Body)
+	}
+	if got := decodeProject(t, rec); got.Name != "custom" {
+		t.Errorf("name = %q, want custom", got.Name)
+	}
+}
+
+func TestProjectDeleteRefusedWhileTerminalsRemain(t *testing.T) {
+	f := newFixture(t)
+	created := decodeTerminal(t, f.request(t, http.MethodPost, "/v1/terminals",
+		f.createTerminalBody(t, api.TerminalCreateParams{})))
+
+	rec := f.request(t, http.MethodDelete, "/v1/projects/"+f.projectID, "")
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("delete non-empty: got %d, want 409; body %s", rec.Code, rec.Body)
+	}
+	// The refusal reports what remains.
+	if !strings.Contains(rec.Body.String(), created.ID) {
+		t.Errorf("refusal does not name the terminal: %s", rec.Body)
+	}
+
+	if rec := f.request(t, http.MethodDelete, "/v1/terminals/"+created.ID, ""); rec.Code != http.StatusNoContent {
+		t.Fatalf("delete terminal: got %d", rec.Code)
+	}
+	if rec := f.request(t, http.MethodDelete, "/v1/projects/"+f.projectID, ""); rec.Code != http.StatusNoContent {
+		t.Errorf("delete emptied project: got %d; body %s", rec.Code, rec.Body)
+	}
+}
+
+// The ATC-256 terminal-create contract: projectId is required, must name a
+// known project, and the project's directory must exist at that moment.
+func TestTerminalCreateProjectContract(t *testing.T) {
+	f := newFixture(t)
+
+	if rec := f.request(t, http.MethodPost, "/v1/terminals", `{}`); rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("missing projectId: got %d, want 422; body %s", rec.Code, rec.Body)
+	}
+	if rec := f.request(t, http.MethodPost, "/v1/terminals", `{"projectId":"proj-zzzzz"}`); rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("unknown project: got %d, want 422; body %s", rec.Code, rec.Body)
+	}
+	// The directory parameter is gone from create.
+	if rec := f.request(t, http.MethodPost, "/v1/terminals",
+		`{"projectId":"`+f.projectID+`","directory":"/elsewhere"}`); rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("directory param: got %d, want 422; body %s", rec.Code, rec.Body)
+	}
+
+	// The project's folder vanishing after project creation refuses the
+	// create, and no terminal row is written.
+	if err := os.RemoveAll(f.projectDir); err != nil {
+		t.Fatal(err)
+	}
+	rec := f.request(t, http.MethodPost, "/v1/terminals", f.createTerminalBody(t, api.TerminalCreateParams{}))
+	if rec.Code != http.StatusConflict {
+		t.Errorf("vanished directory: got %d, want 409; body %s", rec.Code, rec.Body)
+	}
+	if rec := f.request(t, http.MethodGet, "/v1/terminals", ""); !strings.Contains(rec.Body.String(), `"terminals":[]`) {
+		t.Errorf("refused create left a terminal: %s", rec.Body)
+	}
+}
+
+func TestTerminalListProjectFilter(t *testing.T) {
+	f := newFixture(t)
+	other := f.createProject(t, t.TempDir())
+
+	mine := decodeTerminal(t, f.request(t, http.MethodPost, "/v1/terminals",
+		f.createTerminalBody(t, api.TerminalCreateParams{})))
+	theirs := decodeTerminal(t, f.request(t, http.MethodPost, "/v1/terminals",
+		f.createTerminalBody(t, api.TerminalCreateParams{ProjectID: other.ID})))
+
+	var list api.TerminalList
+	rec := f.request(t, http.MethodGet, "/v1/terminals?project="+other.ID, "")
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Terminals) != 1 || list.Terminals[0].ID != theirs.ID {
+		t.Errorf("filtered list = %+v, want only %s", list, theirs.ID)
+	}
+	rec = f.request(t, http.MethodGet, "/v1/terminals", "")
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Terminals) != 2 {
+		t.Errorf("unfiltered list = %+v, want both %s and %s", list, mine.ID, theirs.ID)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/jeremytondo/atc/internal/api"
 	"github.com/jeremytondo/atc/internal/events"
+	"github.com/jeremytondo/atc/internal/projects"
 	"github.com/jeremytondo/atc/internal/terminals"
 )
 
@@ -42,6 +43,7 @@ type Options struct {
 	Version   string
 	Logger    *slog.Logger
 	Terminals *terminals.Service
+	Projects  *projects.Service
 	Events    *events.Hub
 	// HeartbeatInterval paces SSE heartbeats; zero means the default.
 	HeartbeatInterval time.Duration
@@ -87,6 +89,9 @@ func NewHandler(opts Options) http.Handler {
 
 	if opts.Terminals != nil {
 		registerTerminals(humaAPI, opts.Terminals)
+	}
+	if opts.Projects != nil {
+		registerProjects(humaAPI, opts.Projects)
 	}
 	if opts.Events != nil {
 		registerEvents(humaAPI, opts.Events, opts.HeartbeatInterval)

--- a/internal/server/terminals.go
+++ b/internal/server/terminals.go
@@ -50,9 +50,11 @@ func registerTerminals(humaAPI huma.API, service *terminals.Service) {
 		Method:      http.MethodGet,
 		Path:        "/v1/terminals",
 		Summary:     "List terminals",
-		Description: "Served from the reconciled in-memory view; exited and missing terminals stay listed until deleted.",
-	}, func(ctx context.Context, _ *struct{}) (*terminalListOutput, error) {
-		return &terminalListOutput{Body: api.TerminalList{Terminals: service.List()}}, nil
+		Description: "Served from the reconciled in-memory view; exited and missing terminals stay listed until deleted. Unfiltered, returns every terminal.",
+	}, func(ctx context.Context, input *struct {
+		Project string `query:"project" doc:"Only terminals belonging to this project."`
+	}) (*terminalListOutput, error) {
+		return &terminalListOutput{Body: api.TerminalList{Terminals: service.List(input.Project)}}, nil
 	})
 
 	huma.Register(humaAPI, huma.Operation{
@@ -101,8 +103,13 @@ func registerTerminals(humaAPI huma.API, service *terminals.Service) {
 }
 
 func mapError(err error) error {
-	if errors.Is(err, terminals.ErrNotFound) {
+	switch {
+	case errors.Is(err, terminals.ErrNotFound):
 		return huma.Error404NotFound("terminal not found")
+	case errors.Is(err, terminals.ErrProjectUnknown):
+		return huma.Error422UnprocessableEntity(err.Error())
+	case errors.Is(err, terminals.ErrProjectDirectoryMissing):
+		return huma.Error409Conflict(err.Error())
 	}
 	return err
 }

--- a/internal/server/terminals_test.go
+++ b/internal/server/terminals_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jeremytondo/atc/internal/api"
 	"github.com/jeremytondo/atc/internal/events"
 	"github.com/jeremytondo/atc/internal/exitmarker"
+	"github.com/jeremytondo/atc/internal/projects"
 	"github.com/jeremytondo/atc/internal/store"
 	"github.com/jeremytondo/atc/internal/terminals"
 )
@@ -76,13 +77,17 @@ func (a *fakeAdapter) Kill(_ context.Context, id string) error {
 }
 
 // fixture is a full chassis over fakes: real store in a temp dir, real
-// hub, fake adapter, fake clock — the server's existing test seam.
+// hub, fake adapter, fake clock — the server's existing test seam. One
+// project rooted at a real temp directory exists for terminals to belong
+// to.
 type fixture struct {
-	handler http.Handler
-	adapter *fakeAdapter
-	hub     *events.Hub
-	service *terminals.Service
-	markers string
+	handler    http.Handler
+	adapter    *fakeAdapter
+	hub        *events.Hub
+	service    *terminals.Service
+	markers    string
+	projectID  string
+	projectDir string
 }
 
 func newFixture(t *testing.T) *fixture {
@@ -103,29 +108,79 @@ func newFixture(t *testing.T) *fixture {
 	}
 	clock.now = time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
 	markers := t.TempDir()
+	now := func() time.Time {
+		clock.Lock()
+		defer clock.Unlock()
+		clock.now = clock.now.Add(time.Millisecond)
+		return clock.now
+	}
 	service := terminals.NewService(terminals.Options{
 		Repository: db.Terminals(),
 		Adapter:    adapter,
+		Projects:   db.Projects(),
 		MarkerDir:  markers,
 		Hub:        hub,
 		Logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
-		Now: func() time.Time {
-			clock.Lock()
-			defer clock.Unlock()
-			clock.now = clock.now.Add(time.Millisecond)
-			return clock.now
-		},
-		HomeDir: "/home/tester",
+		Now:        now,
+	})
+	projectService := projects.NewService(projects.Options{
+		Repository: db.Projects(),
+		Terminals:  db.Terminals(),
+		Hub:        hub,
+		Now:        now,
 	})
 	handler := NewHandler(Options{
 		Verify:            testVerify,
 		Version:           testVersion,
 		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
 		Terminals:         service,
+		Projects:          projectService,
 		Events:            hub,
 		HeartbeatInterval: 50 * time.Millisecond,
 	})
-	return &fixture{handler: handler, adapter: adapter, hub: hub, service: service, markers: markers}
+	f := &fixture{handler: handler, adapter: adapter, hub: hub, service: service, markers: markers}
+	// Planted through the repository, not the API: the fixture project must
+	// not consume an event sequence number the SSE assertions rely on.
+	f.projectDir = t.TempDir()
+	f.projectID = "proj-fixtr"
+	if ok, err := db.Projects().Insert(context.Background(), store.ProjectRecord{
+		ID: f.projectID, Name: "fixture", Directory: f.projectDir,
+		CreatedAt: now(), UpdatedAt: now(),
+	}); err != nil || !ok {
+		t.Fatalf("planting fixture project = %v, %v", ok, err)
+	}
+	return f
+}
+
+// createProject registers a project over the wire and returns it.
+func (f *fixture) createProject(t *testing.T, dir string) api.Project {
+	t.Helper()
+	body, err := json.Marshal(api.ProjectCreateParams{Directory: dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := f.request(t, http.MethodPost, "/v1/projects", string(body))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create project: got %d; body %s", rec.Code, rec.Body)
+	}
+	var project api.Project
+	if err := json.Unmarshal(rec.Body.Bytes(), &project); err != nil {
+		t.Fatal(err)
+	}
+	return project
+}
+
+// createTerminalBody is a create request body against the fixture project.
+func (f *fixture) createTerminalBody(t *testing.T, params api.TerminalCreateParams) string {
+	t.Helper()
+	if params.ProjectID == "" {
+		params.ProjectID = f.projectID
+	}
+	body, err := json.Marshal(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(body)
 }
 
 // request drives the handler with the test token and returns the recorder.
@@ -157,12 +212,13 @@ func decodeTerminal(t *testing.T, rec *httptest.ResponseRecorder) api.Terminal {
 func TestTerminalCRUDOverTheWire(t *testing.T) {
 	f := newFixture(t)
 
-	rec := f.request(t, http.MethodPost, "/v1/terminals", `{"app":"hx","directory":"/proj"}`)
+	rec := f.request(t, http.MethodPost, "/v1/terminals", f.createTerminalBody(t, api.TerminalCreateParams{App: "hx"}))
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("create: got %d, want 201; body %s", rec.Code, rec.Body)
 	}
 	created := decodeTerminal(t, rec)
-	if created.Status != api.TerminalRunning || created.Name != "hx" || created.Directory != "/proj" {
+	if created.Status != api.TerminalRunning || created.Name != "hx" ||
+		created.ProjectID != f.projectID || created.Directory != f.projectDir {
 		t.Fatalf("created = %+v", created)
 	}
 
@@ -204,7 +260,7 @@ func TestTerminalCRUDOverTheWire(t *testing.T) {
 // schema, so the contract cannot silently widen.
 func TestUpdateRejectsUnknownAndImmutableFields(t *testing.T) {
 	f := newFixture(t)
-	created := decodeTerminal(t, f.request(t, http.MethodPost, "/v1/terminals", `{}`))
+	created := decodeTerminal(t, f.request(t, http.MethodPost, "/v1/terminals", f.createTerminalBody(t, api.TerminalCreateParams{})))
 	for name, body := range map[string]string{
 		"immutable directory": `{"name":"x","directory":"/elsewhere"}`,
 		"immutable app":       `{"app":"vim"}`,
@@ -224,7 +280,7 @@ func TestCreateWithFailingApp(t *testing.T) {
 		writeExitMarker(t, f.markers, id, 127)
 		return errors.New("client exited before the session settled")
 	}
-	rec := f.request(t, http.MethodPost, "/v1/terminals", `{"app":"no-such-tool"}`)
+	rec := f.request(t, http.MethodPost, "/v1/terminals", f.createTerminalBody(t, api.TerminalCreateParams{App: "no-such-tool"}))
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("got %d; body %s", rec.Code, rec.Body)
 	}
@@ -236,7 +292,7 @@ func TestCreateWithFailingApp(t *testing.T) {
 
 func TestDeleteUnderUnreachableBackend(t *testing.T) {
 	f := newFixture(t)
-	created := decodeTerminal(t, f.request(t, http.MethodPost, "/v1/terminals", `{}`))
+	created := decodeTerminal(t, f.request(t, http.MethodPost, "/v1/terminals", f.createTerminalBody(t, api.TerminalCreateParams{})))
 	f.adapter.mu.Lock()
 	f.adapter.killErr = errors.New("session still present after inventory passes")
 	f.adapter.invErr = errors.New("zmx down")

--- a/internal/store/gen/models.go
+++ b/internal/store/gen/models.go
@@ -8,8 +8,17 @@ import (
 	"database/sql"
 )
 
+type Project struct {
+	ID        string
+	Name      string
+	Directory string
+	CreatedAt string
+	UpdatedAt string
+}
+
 type Terminal struct {
 	ID              string
+	ProjectID       string
 	Name            string
 	Directory       string
 	App             sql.NullString

--- a/internal/store/gen/queries.sql.go
+++ b/internal/store/gen/queries.sql.go
@@ -10,6 +10,18 @@ import (
 	"database/sql"
 )
 
+const deleteProject = `-- name: DeleteProject :execrows
+DELETE FROM projects WHERE id = ?
+`
+
+func (q *Queries) DeleteProject(ctx context.Context, id string) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteProject, id)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const deleteTerminal = `-- name: DeleteTerminal :execrows
 DELETE FROM terminals WHERE id = ?
 `
@@ -22,15 +34,79 @@ func (q *Queries) DeleteTerminal(ctx context.Context, id string) (int64, error) 
 	return result.RowsAffected()
 }
 
+const getProject = `-- name: GetProject :one
+SELECT id, name, directory, created_at, updated_at FROM projects WHERE id = ?
+`
+
+func (q *Queries) GetProject(ctx context.Context, id string) (Project, error) {
+	row := q.db.QueryRowContext(ctx, getProject, id)
+	var i Project
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.Directory,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getProjectByDirectory = `-- name: GetProjectByDirectory :one
+SELECT id, name, directory, created_at, updated_at FROM projects WHERE directory = ?
+`
+
+// The canonical-directory uniqueness pre-check on project create.
+func (q *Queries) GetProjectByDirectory(ctx context.Context, directory string) (Project, error) {
+	row := q.db.QueryRowContext(ctx, getProjectByDirectory, directory)
+	var i Project
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.Directory,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const insertProject = `-- name: InsertProject :execrows
+INSERT INTO projects (id, name, directory, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT (id) DO NOTHING
+`
+
+type InsertProjectParams struct {
+	ID        string
+	Name      string
+	Directory string
+	CreatedAt string
+	UpdatedAt string
+}
+
+func (q *Queries) InsertProject(ctx context.Context, arg InsertProjectParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, insertProject,
+		arg.ID,
+		arg.Name,
+		arg.Directory,
+		arg.CreatedAt,
+		arg.UpdatedAt,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const insertTerminal = `-- name: InsertTerminal :execrows
 
-INSERT INTO terminals (id, name, directory, app, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?)
+INSERT INTO terminals (id, project_id, name, directory, app, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (id) DO NOTHING
 `
 
 type InsertTerminalParams struct {
 	ID        string
+	ProjectID string
 	Name      string
 	Directory string
 	App       sql.NullString
@@ -38,14 +114,16 @@ type InsertTerminalParams struct {
 	UpdatedAt string
 }
 
-// Terminals repository queries (sqlc input). Nothing outside a repository
-// speaks SQL; internal/store/terminals.go is the only consumer.
+// Repository queries (sqlc input). Nothing outside a repository speaks
+// SQL; internal/store/terminals.go and internal/store/projects.go are the
+// only consumers.
 // Insertion doubles as the mint-time ID collision check: a conflicting id
 // inserts zero rows and the caller re-rolls, with no check-then-insert
 // window.
 func (q *Queries) InsertTerminal(ctx context.Context, arg InsertTerminalParams) (int64, error) {
 	result, err := q.db.ExecContext(ctx, insertTerminal,
 		arg.ID,
+		arg.ProjectID,
 		arg.Name,
 		arg.Directory,
 		arg.App,
@@ -58,8 +136,69 @@ func (q *Queries) InsertTerminal(ctx context.Context, arg InsertTerminalParams) 
 	return result.RowsAffected()
 }
 
+const listProjects = `-- name: ListProjects :many
+SELECT id, name, directory, created_at, updated_at FROM projects ORDER BY created_at, id
+`
+
+func (q *Queries) ListProjects(ctx context.Context) ([]Project, error) {
+	rows, err := q.db.QueryContext(ctx, listProjects)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Project
+	for rows.Next() {
+		var i Project
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.Directory,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listTerminalIDsByProject = `-- name: ListTerminalIDsByProject :many
+SELECT id FROM terminals WHERE project_id = ? ORDER BY created_at, id
+`
+
+// The project-empty check behind project delete's refusal.
+func (q *Queries) ListTerminalIDsByProject(ctx context.Context, projectID string) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, listTerminalIDsByProject, projectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listTerminals = `-- name: ListTerminals :many
-SELECT id, name, directory, app, created_at, updated_at, stop_requested_at, exited_at, exit_code FROM terminals ORDER BY created_at, id
+SELECT id, project_id, name, directory, app, created_at, updated_at, stop_requested_at, exited_at, exit_code FROM terminals ORDER BY created_at, id
 `
 
 func (q *Queries) ListTerminals(ctx context.Context) ([]Terminal, error) {
@@ -73,6 +212,7 @@ func (q *Queries) ListTerminals(ctx context.Context) ([]Terminal, error) {
 		var i Terminal
 		if err := rows.Scan(
 			&i.ID,
+			&i.ProjectID,
 			&i.Name,
 			&i.Directory,
 			&i.App,
@@ -134,6 +274,24 @@ type RecordTerminalStopIntentParams struct {
 
 func (q *Queries) RecordTerminalStopIntent(ctx context.Context, arg RecordTerminalStopIntentParams) (int64, error) {
 	result, err := q.db.ExecContext(ctx, recordTerminalStopIntent, arg.StopRequestedAt, arg.UpdatedAt, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const updateProjectName = `-- name: UpdateProjectName :execrows
+UPDATE projects SET name = ?, updated_at = ? WHERE id = ?
+`
+
+type UpdateProjectNameParams struct {
+	Name      string
+	UpdatedAt string
+	ID        string
+}
+
+func (q *Queries) UpdateProjectName(ctx context.Context, arg UpdateProjectNameParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, updateProjectName, arg.Name, arg.UpdatedAt, arg.ID)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/store/gen/queries.sql.go
+++ b/internal/store/gen/queries.sql.go
@@ -51,24 +51,6 @@ func (q *Queries) GetProject(ctx context.Context, id string) (Project, error) {
 	return i, err
 }
 
-const getProjectByDirectory = `-- name: GetProjectByDirectory :one
-SELECT id, name, directory, created_at, updated_at FROM projects WHERE directory = ?
-`
-
-// The canonical-directory uniqueness pre-check on project create.
-func (q *Queries) GetProjectByDirectory(ctx context.Context, directory string) (Project, error) {
-	row := q.db.QueryRowContext(ctx, getProjectByDirectory, directory)
-	var i Project
-	err := row.Scan(
-		&i.ID,
-		&i.Name,
-		&i.Directory,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-	)
-	return i, err
-}
-
 const insertProject = `-- name: InsertProject :execrows
 INSERT INTO projects (id, name, directory, created_at, updated_at)
 VALUES (?, ?, ?, ?, ?)
@@ -280,8 +262,8 @@ func (q *Queries) RecordTerminalStopIntent(ctx context.Context, arg RecordTermin
 	return result.RowsAffected()
 }
 
-const updateProjectName = `-- name: UpdateProjectName :execrows
-UPDATE projects SET name = ?, updated_at = ? WHERE id = ?
+const updateProjectName = `-- name: UpdateProjectName :one
+UPDATE projects SET name = ?, updated_at = ? WHERE id = ? RETURNING id, name, directory, created_at, updated_at
 `
 
 type UpdateProjectNameParams struct {
@@ -290,12 +272,20 @@ type UpdateProjectNameParams struct {
 	ID        string
 }
 
-func (q *Queries) UpdateProjectName(ctx context.Context, arg UpdateProjectNameParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, updateProjectName, arg.Name, arg.UpdatedAt, arg.ID)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected()
+// RETURNING makes the mutation and the read one operation: a rename either
+// fails with nothing committed or returns the committed row, so the caller
+// can never observe a committed write as an error.
+func (q *Queries) UpdateProjectName(ctx context.Context, arg UpdateProjectNameParams) (Project, error) {
+	row := q.db.QueryRowContext(ctx, updateProjectName, arg.Name, arg.UpdatedAt, arg.ID)
+	var i Project
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.Directory,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
 }
 
 const updateTerminalName = `-- name: UpdateTerminalName :execrows

--- a/internal/store/migrations/00002_projects.sql
+++ b/internal/store/migrations/00002_projects.sql
@@ -1,0 +1,41 @@
+-- Projects (ATC-256): ATC's unit of organization. Everything belongs to
+-- exactly one project; the canonical directory is the identity and the
+-- answer to where new things in the project start. Timestamps are
+-- fixed-width RFC 3339 UTC text (store.TimeFormat).
+-- +goose Up
+CREATE TABLE projects (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    -- Canonical form only: absolute, cleaned, symlinks resolved.
+    directory TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+) STRICT;
+
+-- Breaking reset (ATC-256): pre-existing terminal rows do not survive.
+-- Terminals are recreated with a required project reference; no
+-- assignment logic, no seeded default project.
+DROP TABLE terminals;
+CREATE TABLE terminals (
+    id TEXT PRIMARY KEY,
+    -- The FK is the backstop behind the domain checks: a terminal can
+    -- never reference a missing project, and a project with terminals
+    -- can never be deleted.
+    project_id TEXT NOT NULL REFERENCES projects (id),
+    name TEXT NOT NULL,
+    -- Copied from the project at create time; immutable.
+    directory TEXT NOT NULL,
+    -- NULL means a plain interactive shell.
+    app TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    -- Stop intent, persisted before the kill is attempted, so a deliberate
+    -- termination stays distinguishable even when the wrapper never writes
+    -- its exit marker.
+    stop_requested_at TEXT,
+    -- Exit evidence copied from the wrapper's marker file. exit_code is
+    -- NULL when the stop was ATC-initiated (a kill is not a meaningful
+    -- program result) or when the marker carried none.
+    exited_at TEXT,
+    exit_code INTEGER
+) STRICT;

--- a/internal/store/projects.go
+++ b/internal/store/projects.go
@@ -1,0 +1,119 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jeremytondo/atc/internal/store/gen"
+)
+
+// ProjectRecord is one projects row in domain terms. Directory is the
+// canonical form (paths.CanonicalDir) — the domain canonicalizes before
+// the repository ever sees a path.
+type ProjectRecord struct {
+	ID        string
+	Name      string
+	Directory string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// Projects is the repository for project records. Reads go to the read
+// pool, mutations to the single-writer pool.
+type Projects struct {
+	reads  *gen.Queries
+	writes *gen.Queries
+}
+
+// Insert persists a new record; false reports an ID collision (the caller
+// re-rolls). A duplicate directory surfaces as the UNIQUE constraint error
+// — the domain pre-checks it and this is the backstop.
+func (p *Projects) Insert(ctx context.Context, record ProjectRecord) (bool, error) {
+	n, err := p.writes.InsertProject(ctx, gen.InsertProjectParams{
+		ID:        record.ID,
+		Name:      record.Name,
+		Directory: record.Directory,
+		CreatedAt: formatTime(record.CreatedAt),
+		UpdatedAt: formatTime(record.UpdatedAt),
+	})
+	return n > 0, err
+}
+
+// Get returns one record by ID; false means no such record.
+func (p *Projects) Get(ctx context.Context, id string) (ProjectRecord, bool, error) {
+	row, err := p.reads.GetProject(ctx, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ProjectRecord{}, false, nil
+	}
+	if err != nil {
+		return ProjectRecord{}, false, err
+	}
+	record, err := projectFrom(row)
+	return record, err == nil, err
+}
+
+// GetByDirectory returns the record owning a canonical directory; false
+// means none does.
+func (p *Projects) GetByDirectory(ctx context.Context, directory string) (ProjectRecord, bool, error) {
+	row, err := p.reads.GetProjectByDirectory(ctx, directory)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ProjectRecord{}, false, nil
+	}
+	if err != nil {
+		return ProjectRecord{}, false, err
+	}
+	record, err := projectFrom(row)
+	return record, err == nil, err
+}
+
+// List returns every record in creation order.
+func (p *Projects) List(ctx context.Context) ([]ProjectRecord, error) {
+	rows, err := p.reads.ListProjects(ctx)
+	if err != nil {
+		return nil, err
+	}
+	records := make([]ProjectRecord, 0, len(rows))
+	for _, row := range rows {
+		record, err := projectFrom(row)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	return records, nil
+}
+
+// UpdateName renames the project; false means no such record.
+func (p *Projects) UpdateName(ctx context.Context, id, name string, at time.Time) (bool, error) {
+	n, err := p.writes.UpdateProjectName(ctx, gen.UpdateProjectNameParams{
+		Name: name, UpdatedAt: formatTime(at), ID: id,
+	})
+	return n > 0, err
+}
+
+// Delete removes the record; false means no such record. A project that
+// still owns terminals fails on the foreign key — the domain refuses
+// first and this is the backstop.
+func (p *Projects) Delete(ctx context.Context, id string) (bool, error) {
+	n, err := p.writes.DeleteProject(ctx, id)
+	return n > 0, err
+}
+
+func projectFrom(row gen.Project) (ProjectRecord, error) {
+	record := ProjectRecord{
+		ID:        row.ID,
+		Name:      row.Name,
+		Directory: row.Directory,
+	}
+	var err error
+	if record.CreatedAt, err = parseTime(row.CreatedAt); err != nil {
+		return ProjectRecord{}, fmt.Errorf("project %s created_at: %w", row.ID, err)
+	}
+	if record.UpdatedAt, err = parseTime(row.UpdatedAt); err != nil {
+		return ProjectRecord{}, fmt.Errorf("project %s updated_at: %w", row.ID, err)
+	}
+	return record, nil
+}

--- a/internal/store/projects.go
+++ b/internal/store/projects.go
@@ -55,20 +55,6 @@ func (p *Projects) Get(ctx context.Context, id string) (ProjectRecord, bool, err
 	return record, err == nil, err
 }
 
-// GetByDirectory returns the record owning a canonical directory; false
-// means none does.
-func (p *Projects) GetByDirectory(ctx context.Context, directory string) (ProjectRecord, bool, error) {
-	row, err := p.reads.GetProjectByDirectory(ctx, directory)
-	if errors.Is(err, sql.ErrNoRows) {
-		return ProjectRecord{}, false, nil
-	}
-	if err != nil {
-		return ProjectRecord{}, false, err
-	}
-	record, err := projectFrom(row)
-	return record, err == nil, err
-}
-
 // List returns every record in creation order.
 func (p *Projects) List(ctx context.Context) ([]ProjectRecord, error) {
 	rows, err := p.reads.ListProjects(ctx)
@@ -86,20 +72,29 @@ func (p *Projects) List(ctx context.Context) ([]ProjectRecord, error) {
 	return records, nil
 }
 
-// UpdateName renames the project; false means no such record.
-func (p *Projects) UpdateName(ctx context.Context, id, name string, at time.Time) (bool, error) {
-	n, err := p.writes.UpdateProjectName(ctx, gen.UpdateProjectNameParams{
+// UpdateName renames the project and returns the committed row in the
+// same operation (RETURNING), so a committed rename can never surface as
+// an error; false means no such record.
+func (p *Projects) UpdateName(ctx context.Context, id, name string, at time.Time) (ProjectRecord, bool, error) {
+	row, err := p.writes.UpdateProjectName(ctx, gen.UpdateProjectNameParams{
 		Name: name, UpdatedAt: formatTime(at), ID: id,
 	})
-	return n > 0, err
+	if errors.Is(err, sql.ErrNoRows) {
+		return ProjectRecord{}, false, nil
+	}
+	if err != nil {
+		return ProjectRecord{}, false, err
+	}
+	record, err := projectFrom(row)
+	return record, err == nil, err
 }
 
 // Delete removes the record; false means no such record. A project that
-// still owns terminals fails on the foreign key — the domain refuses
-// first and this is the backstop.
+// still owns terminals fails with ErrForeignKeyViolation — the domain
+// refuses first and this is the backstop.
 func (p *Projects) Delete(ctx context.Context, id string) (bool, error) {
 	n, err := p.writes.DeleteProject(ctx, id)
-	return n > 0, err
+	return n > 0, foreignKeyError(err)
 }
 
 func projectFrom(row gen.Project) (ProjectRecord, error) {

--- a/internal/store/projects_test.go
+++ b/internal/store/projects_test.go
@@ -1,0 +1,176 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pressly/goose/v3"
+)
+
+func TestProjectsRoundTrip(t *testing.T) {
+	s, _ := openStore(t)
+	ctx := context.Background()
+	projects := s.Projects()
+
+	records := []ProjectRecord{
+		{ID: "proj-aaaaa", Name: "atc", Directory: "/home/x/atc", CreatedAt: at(0), UpdatedAt: at(0)},
+		{ID: "proj-bbbbb", Name: "notes", Directory: "/home/x/notes", CreatedAt: at(1), UpdatedAt: at(1)},
+	}
+	for _, record := range records {
+		if ok, err := projects.Insert(ctx, record); err != nil || !ok {
+			t.Fatalf("Insert = %v, %v; want true", ok, err)
+		}
+	}
+
+	got, err := projects.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(records, got); diff != "" {
+		t.Errorf("List() mismatch (-want +got):\n%s", diff)
+	}
+
+	// Insertion is the ID collision check: a conflicting id inserts
+	// nothing and reports false.
+	ok, err := projects.Insert(ctx, ProjectRecord{
+		ID: "proj-aaaaa", Name: "impostor", Directory: "/elsewhere", CreatedAt: at(9), UpdatedAt: at(9),
+	})
+	if err != nil || ok {
+		t.Fatalf("Insert(id collision) = %v, %v; want false", ok, err)
+	}
+
+	// The directory UNIQUE constraint is the backstop behind the domain's
+	// pre-check: a fresh id claiming a taken directory errors.
+	if _, err := projects.Insert(ctx, ProjectRecord{
+		ID: "proj-ccccc", Name: "dup", Directory: "/home/x/atc", CreatedAt: at(9), UpdatedAt: at(9),
+	}); err == nil {
+		t.Fatal("Insert(duplicate directory) succeeded, want a constraint error")
+	}
+
+	record, found, err := projects.Get(ctx, "proj-aaaaa")
+	if err != nil || !found || record.Name != "atc" {
+		t.Errorf("Get = %+v, %v, %v", record, found, err)
+	}
+	if _, found, err := projects.Get(ctx, "proj-zzzzz"); err != nil || found {
+		t.Errorf("Get(absent) = %v, %v; want false", found, err)
+	}
+	record, found, err = projects.GetByDirectory(ctx, "/home/x/notes")
+	if err != nil || !found || record.ID != "proj-bbbbb" {
+		t.Errorf("GetByDirectory = %+v, %v, %v", record, found, err)
+	}
+	if _, found, err := projects.GetByDirectory(ctx, "/nowhere"); err != nil || found {
+		t.Errorf("GetByDirectory(absent) = %v, %v; want false", found, err)
+	}
+
+	if ok, err := projects.UpdateName(ctx, "proj-aaaaa", "renamed", at(2)); err != nil || !ok {
+		t.Fatalf("UpdateName = %v, %v; want true", ok, err)
+	}
+	if ok, err := projects.UpdateName(ctx, "proj-zzzzz", "x", at(2)); err != nil || ok {
+		t.Fatalf("UpdateName(absent) = %v, %v; want false", ok, err)
+	}
+	record, _, err = projects.Get(ctx, "proj-aaaaa")
+	if err != nil || record.Name != "renamed" || !record.UpdatedAt.Equal(at(2)) {
+		t.Errorf("after rename = %+v, %v", record, err)
+	}
+
+	if ok, err := projects.Delete(ctx, "proj-bbbbb"); err != nil || !ok {
+		t.Fatalf("Delete = %v, %v; want true", ok, err)
+	}
+	if ok, err := projects.Delete(ctx, "proj-bbbbb"); err != nil || ok {
+		t.Fatalf("second Delete = %v, %v; want false", ok, err)
+	}
+}
+
+func TestTerminalsByProjectAndDeleteBackstop(t *testing.T) {
+	s, _ := openStore(t)
+	ctx := context.Background()
+	insertProject(t, s, "proj-aaaaa", "/a")
+	insertProject(t, s, "proj-bbbbb", "/b")
+	terminals := s.Terminals()
+	for i, terminal := range []TerminalRecord{
+		{ID: "term-aaaaa", ProjectID: "proj-aaaaa", Name: "one", Directory: "/a"},
+		{ID: "term-bbbbb", ProjectID: "proj-aaaaa", Name: "two", Directory: "/a"},
+		{ID: "term-ccccc", ProjectID: "proj-bbbbb", Name: "three", Directory: "/b"},
+	} {
+		terminal.CreatedAt, terminal.UpdatedAt = at(i), at(i)
+		if ok, err := terminals.Insert(ctx, terminal); err != nil || !ok {
+			t.Fatalf("Insert = %v, %v; want true", ok, err)
+		}
+	}
+
+	got, err := terminals.ListIDsByProject(ctx, "proj-aaaaa")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff([]string{"term-aaaaa", "term-bbbbb"}, got); diff != "" {
+		t.Errorf("ListIDsByProject (-want +got):\n%s", diff)
+	}
+
+	// A terminal can never reference a missing project.
+	if _, err := terminals.Insert(ctx, TerminalRecord{
+		ID: "term-ddddd", ProjectID: "proj-zzzzz", Name: "stray", Directory: "/",
+		CreatedAt: at(9), UpdatedAt: at(9),
+	}); err == nil {
+		t.Error("Insert(unknown project) succeeded, want a foreign-key error")
+	}
+	// And a project with terminals can never be deleted — the backstop
+	// behind the domain's refuse-when-non-empty check.
+	if _, err := s.Projects().Delete(ctx, "proj-aaaaa"); err == nil {
+		t.Error("Delete(project with terminals) succeeded, want a foreign-key error")
+	}
+}
+
+// The ATC-256 migration is a breaking reset: pre-migration terminal rows
+// are gone afterwards, and the new schema requires project_id.
+func TestProjectsMigrationResetsTerminals(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "atc.db")
+
+	// A database at the pre-projects schema with one legacy terminal row.
+	db, err := sql.Open("sqlite", "file:"+path+"?"+pragmas)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
+	fsys, err := fs.Sub(migrations, "migrations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider, err := goose.NewProvider(goose.DialectSQLite3, db, fsys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := provider.UpTo(ctx, 1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO terminals (id, name, directory, created_at, updated_at) VALUES ('term-aaaaa', 'Shell', '/', '2026-08-27T12:00:00.000000000Z', '2026-08-27T12:00:00.000000000Z')`,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := Open(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = s.Close() }()
+	records, err := s.Terminals().List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 0 {
+		t.Errorf("legacy terminal rows survived the reset: %+v", records)
+	}
+	if _, err := s.Terminals().Insert(ctx, TerminalRecord{
+		ID: "term-bbbbb", Name: "Shell", Directory: "/", CreatedAt: at(0), UpdatedAt: at(0),
+	}); err == nil {
+		t.Error("Insert without a project succeeded; the schema must require project_id")
+	}
+}

--- a/internal/store/projects_test.go
+++ b/internal/store/projects_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"io/fs"
 	"path/filepath"
 	"testing"
@@ -58,23 +59,14 @@ func TestProjectsRoundTrip(t *testing.T) {
 	if _, found, err := projects.Get(ctx, "proj-zzzzz"); err != nil || found {
 		t.Errorf("Get(absent) = %v, %v; want false", found, err)
 	}
-	record, found, err = projects.GetByDirectory(ctx, "/home/x/notes")
-	if err != nil || !found || record.ID != "proj-bbbbb" {
-		t.Errorf("GetByDirectory = %+v, %v, %v", record, found, err)
-	}
-	if _, found, err := projects.GetByDirectory(ctx, "/nowhere"); err != nil || found {
-		t.Errorf("GetByDirectory(absent) = %v, %v; want false", found, err)
-	}
 
-	if ok, err := projects.UpdateName(ctx, "proj-aaaaa", "renamed", at(2)); err != nil || !ok {
-		t.Fatalf("UpdateName = %v, %v; want true", ok, err)
+	// The rename returns the committed row in the same operation.
+	renamed, ok, err := projects.UpdateName(ctx, "proj-aaaaa", "renamed", at(2))
+	if err != nil || !ok || renamed.Name != "renamed" || !renamed.UpdatedAt.Equal(at(2)) {
+		t.Fatalf("UpdateName = %+v, %v, %v", renamed, ok, err)
 	}
-	if ok, err := projects.UpdateName(ctx, "proj-zzzzz", "x", at(2)); err != nil || ok {
+	if _, ok, err := projects.UpdateName(ctx, "proj-zzzzz", "x", at(2)); err != nil || ok {
 		t.Fatalf("UpdateName(absent) = %v, %v; want false", ok, err)
-	}
-	record, _, err = projects.Get(ctx, "proj-aaaaa")
-	if err != nil || record.Name != "renamed" || !record.UpdatedAt.Equal(at(2)) {
-		t.Errorf("after rename = %+v, %v", record, err)
 	}
 
 	if ok, err := projects.Delete(ctx, "proj-bbbbb"); err != nil || !ok {
@@ -110,17 +102,18 @@ func TestTerminalsByProjectAndDeleteBackstop(t *testing.T) {
 		t.Errorf("ListIDsByProject (-want +got):\n%s", diff)
 	}
 
-	// A terminal can never reference a missing project.
+	// A terminal can never reference a missing project, and the violation
+	// is typed so the domain can answer with its own error.
 	if _, err := terminals.Insert(ctx, TerminalRecord{
 		ID: "term-ddddd", ProjectID: "proj-zzzzz", Name: "stray", Directory: "/",
 		CreatedAt: at(9), UpdatedAt: at(9),
-	}); err == nil {
-		t.Error("Insert(unknown project) succeeded, want a foreign-key error")
+	}); !errors.Is(err, ErrForeignKeyViolation) {
+		t.Errorf("Insert(unknown project) = %v, want ErrForeignKeyViolation", err)
 	}
 	// And a project with terminals can never be deleted — the backstop
 	// behind the domain's refuse-when-non-empty check.
-	if _, err := s.Projects().Delete(ctx, "proj-aaaaa"); err == nil {
-		t.Error("Delete(project with terminals) succeeded, want a foreign-key error")
+	if _, err := s.Projects().Delete(ctx, "proj-aaaaa"); !errors.Is(err, ErrForeignKeyViolation) {
+		t.Errorf("Delete(project with terminals) = %v, want ErrForeignKeyViolation", err)
 	}
 }
 

--- a/internal/store/queries.sql
+++ b/internal/store/queries.sql
@@ -40,15 +40,14 @@ ON CONFLICT (id) DO NOTHING;
 -- name: GetProject :one
 SELECT * FROM projects WHERE id = ?;
 
--- The canonical-directory uniqueness pre-check on project create.
--- name: GetProjectByDirectory :one
-SELECT * FROM projects WHERE directory = ?;
-
 -- name: ListProjects :many
 SELECT * FROM projects ORDER BY created_at, id;
 
--- name: UpdateProjectName :execrows
-UPDATE projects SET name = ?, updated_at = ? WHERE id = ?;
+-- RETURNING makes the mutation and the read one operation: a rename either
+-- fails with nothing committed or returns the committed row, so the caller
+-- can never observe a committed write as an error.
+-- name: UpdateProjectName :one
+UPDATE projects SET name = ?, updated_at = ? WHERE id = ? RETURNING *;
 
 -- name: DeleteProject :execrows
 DELETE FROM projects WHERE id = ?;

--- a/internal/store/queries.sql
+++ b/internal/store/queries.sql
@@ -1,16 +1,21 @@
--- Terminals repository queries (sqlc input). Nothing outside a repository
--- speaks SQL; internal/store/terminals.go is the only consumer.
+-- Repository queries (sqlc input). Nothing outside a repository speaks
+-- SQL; internal/store/terminals.go and internal/store/projects.go are the
+-- only consumers.
 
 -- Insertion doubles as the mint-time ID collision check: a conflicting id
 -- inserts zero rows and the caller re-rolls, with no check-then-insert
 -- window.
 -- name: InsertTerminal :execrows
-INSERT INTO terminals (id, name, directory, app, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?)
+INSERT INTO terminals (id, project_id, name, directory, app, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (id) DO NOTHING;
 
 -- name: ListTerminals :many
 SELECT * FROM terminals ORDER BY created_at, id;
+
+-- The project-empty check behind project delete's refusal.
+-- name: ListTerminalIDsByProject :many
+SELECT id FROM terminals WHERE project_id = ? ORDER BY created_at, id;
 
 -- name: UpdateTerminalName :execrows
 UPDATE terminals SET name = ?, updated_at = ? WHERE id = ?;
@@ -26,3 +31,24 @@ WHERE id = ? AND exited_at IS NULL;
 
 -- name: DeleteTerminal :execrows
 DELETE FROM terminals WHERE id = ?;
+
+-- name: InsertProject :execrows
+INSERT INTO projects (id, name, directory, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT (id) DO NOTHING;
+
+-- name: GetProject :one
+SELECT * FROM projects WHERE id = ?;
+
+-- The canonical-directory uniqueness pre-check on project create.
+-- name: GetProjectByDirectory :one
+SELECT * FROM projects WHERE directory = ?;
+
+-- name: ListProjects :many
+SELECT * FROM projects ORDER BY created_at, id;
+
+-- name: UpdateProjectName :execrows
+UPDATE projects SET name = ?, updated_at = ? WHERE id = ?;
+
+-- name: DeleteProject :execrows
+DELETE FROM projects WHERE id = ?;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -18,6 +18,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/pressly/goose/v3"
@@ -172,6 +173,23 @@ func (s *Store) Terminals() *Terminals {
 // Projects returns the projects repository.
 func (s *Store) Projects() *Projects {
 	return &Projects{reads: gen.New(s.reads), writes: gen.New(s.writes)}
+}
+
+// ErrForeignKeyViolation marks a write the schema's foreign keys refused —
+// the database-level backstop behind the domains' own referential checks
+// (terminal create racing a project delete, and vice versa). Domain
+// services translate it to their typed errors instead of surfacing a raw
+// constraint failure.
+var ErrForeignKeyViolation = errors.New("foreign key constraint violated")
+
+// foreignKeyError wraps a driver error in ErrForeignKeyViolation when it
+// is a foreign-key constraint failure; anything else passes through. The
+// driver exposes constraint failures only through the message text.
+func foreignKeyError(err error) error {
+	if err != nil && strings.Contains(err.Error(), "FOREIGN KEY constraint failed") {
+		return fmt.Errorf("%w: %w", ErrForeignKeyViolation, err)
+	}
+	return err
 }
 
 func formatTime(t time.Time) string {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -169,6 +169,11 @@ func (s *Store) Terminals() *Terminals {
 	return &Terminals{reads: gen.New(s.reads), writes: gen.New(s.writes)}
 }
 
+// Projects returns the projects repository.
+func (s *Store) Projects() *Projects {
+	return &Projects{reads: gen.New(s.reads), writes: gen.New(s.writes)}
+}
+
 func formatTime(t time.Time) string {
 	return t.UTC().Format(TimeFormat)
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -33,10 +33,11 @@ func TestTerminalsRoundTrip(t *testing.T) {
 	s, _ := openStore(t)
 	ctx := context.Background()
 	terminals := s.Terminals()
+	insertProject(t, s, "proj-aaaaa", "/home/x")
 
 	records := []TerminalRecord{
-		{ID: "term-aaaaa", Name: "Shell", Directory: "/home/x", CreatedAt: at(0), UpdatedAt: at(0)},
-		{ID: "term-bbbbb", Name: "hx", Directory: "/home/x/proj", App: "hx .", CreatedAt: at(1), UpdatedAt: at(1)},
+		{ID: "term-aaaaa", ProjectID: "proj-aaaaa", Name: "Shell", Directory: "/home/x", CreatedAt: at(0), UpdatedAt: at(0)},
+		{ID: "term-bbbbb", ProjectID: "proj-aaaaa", Name: "hx", Directory: "/home/x/proj", App: "hx .", CreatedAt: at(1), UpdatedAt: at(1)},
 	}
 	for _, record := range records {
 		if ok, err := terminals.Insert(ctx, record); err != nil || !ok {
@@ -55,7 +56,7 @@ func TestTerminalsRoundTrip(t *testing.T) {
 	// Insertion is the ID collision check: a conflicting id inserts
 	// nothing and reports false, leaving the existing record untouched.
 	ok, err := terminals.Insert(ctx, TerminalRecord{
-		ID: "term-aaaaa", Name: "impostor", Directory: "/", CreatedAt: at(9), UpdatedAt: at(9),
+		ID: "term-aaaaa", ProjectID: "proj-aaaaa", Name: "impostor", Directory: "/", CreatedAt: at(9), UpdatedAt: at(9),
 	})
 	if err != nil || ok {
 		t.Fatalf("Insert(collision) = %v, %v; want false", ok, err)
@@ -73,8 +74,9 @@ func TestTerminalsMutations(t *testing.T) {
 	s, _ := openStore(t)
 	ctx := context.Background()
 	terminals := s.Terminals()
+	insertProject(t, s, "proj-aaaaa", "/")
 
-	record := TerminalRecord{ID: "term-aaaaa", Name: "Shell", Directory: "/", CreatedAt: at(0), UpdatedAt: at(0)}
+	record := TerminalRecord{ID: "term-aaaaa", ProjectID: "proj-aaaaa", Name: "Shell", Directory: "/", CreatedAt: at(0), UpdatedAt: at(0)}
 	if ok, err := terminals.Insert(ctx, record); err != nil || !ok {
 		t.Fatalf("Insert = %v, %v; want true", ok, err)
 	}
@@ -96,7 +98,7 @@ func TestTerminalsMutations(t *testing.T) {
 	// updated_at carries the observation time, not the exit time.
 	stopAt, exitAt := at(2), at(3)
 	want := []TerminalRecord{{
-		ID: "term-aaaaa", Name: "build watcher", Directory: "/",
+		ID: "term-aaaaa", ProjectID: "proj-aaaaa", Name: "build watcher", Directory: "/",
 		CreatedAt: at(0), UpdatedAt: at(4),
 		StopRequestedAt: &stopAt, ExitedAt: &exitAt, ExitCode: &code,
 	}}
@@ -166,8 +168,25 @@ func TestOpenIsIdempotentAndBacksUpBeforeMigration(t *testing.T) {
 }
 
 func terminalsInsertOne(ctx context.Context, s *Store) error {
+	if _, err := s.Projects().Insert(ctx, ProjectRecord{
+		ID: "proj-aaaaa", Name: "root", Directory: "/", CreatedAt: at(0), UpdatedAt: at(0),
+	}); err != nil {
+		return err
+	}
 	_, err := s.Terminals().Insert(ctx, TerminalRecord{
-		ID: "term-aaaaa", Name: "Shell", Directory: "/", CreatedAt: at(0), UpdatedAt: at(0),
+		ID: "term-aaaaa", ProjectID: "proj-aaaaa", Name: "Shell", Directory: "/", CreatedAt: at(0), UpdatedAt: at(0),
 	})
 	return err
+}
+
+// insertProject plants an owning project — the schema requires every
+// terminal to reference one.
+func insertProject(t *testing.T, s *Store, id, directory string) {
+	t.Helper()
+	ok, err := s.Projects().Insert(context.Background(), ProjectRecord{
+		ID: id, Name: "p", Directory: directory, CreatedAt: at(0), UpdatedAt: at(0),
+	})
+	if err != nil || !ok {
+		t.Fatalf("insertProject = %v, %v", ok, err)
+	}
 }

--- a/internal/store/terminals.go
+++ b/internal/store/terminals.go
@@ -41,8 +41,9 @@ type Terminals struct {
 }
 
 // Insert persists a new record; false reports an ID collision (the caller
-// re-rolls). Create persists before starting the session, so a record
-// exists for every session ATC ever starts.
+// re-rolls), and a vanished project surfaces as ErrForeignKeyViolation.
+// Create persists before starting the session, so a record exists for
+// every session ATC ever starts.
 func (t *Terminals) Insert(ctx context.Context, record TerminalRecord) (bool, error) {
 	n, err := t.writes.InsertTerminal(ctx, gen.InsertTerminalParams{
 		ID:        record.ID,
@@ -53,7 +54,7 @@ func (t *Terminals) Insert(ctx context.Context, record TerminalRecord) (bool, er
 		CreatedAt: formatTime(record.CreatedAt),
 		UpdatedAt: formatTime(record.UpdatedAt),
 	})
-	return n > 0, err
+	return n > 0, foreignKeyError(err)
 }
 
 // ListIDsByProject returns the IDs of the project's terminals in creation

--- a/internal/store/terminals.go
+++ b/internal/store/terminals.go
@@ -13,7 +13,10 @@ import (
 // nullable facts, time.Time for the text timestamps. The SQL row shape
 // never leaves this package.
 type TerminalRecord struct {
-	ID        string
+	ID string
+	// ProjectID is the owning project; required, immutable, and enforced
+	// by the schema's foreign key.
+	ProjectID string
 	Name      string
 	Directory string
 	// App is the free-form command the terminal was created with; empty
@@ -43,6 +46,7 @@ type Terminals struct {
 func (t *Terminals) Insert(ctx context.Context, record TerminalRecord) (bool, error) {
 	n, err := t.writes.InsertTerminal(ctx, gen.InsertTerminalParams{
 		ID:        record.ID,
+		ProjectID: record.ProjectID,
 		Name:      record.Name,
 		Directory: record.Directory,
 		App:       nullString(record.App),
@@ -50,6 +54,12 @@ func (t *Terminals) Insert(ctx context.Context, record TerminalRecord) (bool, er
 		UpdatedAt: formatTime(record.UpdatedAt),
 	})
 	return n > 0, err
+}
+
+// ListIDsByProject returns the IDs of the project's terminals in creation
+// order — the project-empty check behind project delete's refusal.
+func (t *Terminals) ListIDsByProject(ctx context.Context, projectID string) ([]string, error) {
+	return t.reads.ListTerminalIDsByProject(ctx, projectID)
 }
 
 // List returns every record in creation order.
@@ -110,6 +120,7 @@ func (t *Terminals) Delete(ctx context.Context, id string) (bool, error) {
 func recordFrom(row gen.Terminal) (TerminalRecord, error) {
 	record := TerminalRecord{
 		ID:        row.ID,
+		ProjectID: row.ProjectID,
 		Name:      row.Name,
 		Directory: row.Directory,
 		App:       row.App.String,

--- a/internal/terminals/id.go
+++ b/internal/terminals/id.go
@@ -1,42 +1,18 @@
 package terminals
 
-import "crypto/rand"
+import "github.com/jeremytondo/atc/internal/ids"
 
-// The ATC-wide public ID scheme (ATC-251): type prefix plus a fixed-length
-// 5-character random suffix. The alphabet is lowercase, excludes the
-// ambiguous glyphs (0/o, 1/l/i) and all vowels — so an ID can never spell
-// a word. Fixed length makes IDs prefix-free, which keeps zmx's trailing-*
-// prefix matching safe to type. The format is permanent: it appears in
-// un-versioned surfaces (zmx list) and must never be reformatted.
+// Terminal IDs use the ATC-wide public ID scheme (internal/ids) with the
+// terminal type prefix.
 const (
-	idPrefix       = "term-"
-	idSuffixLength = 5
-	idAlphabet     = "23456789bcdfghjkmnpqrstvwxyz"
+	idPrefix = "term-"
 	// IDLength is the fixed byte length of every terminal ID — what the
 	// zmx adapter budgets socket paths against.
-	IDLength = len(idPrefix) + idSuffixLength
+	IDLength = len(idPrefix) + ids.SuffixLength
 )
 
 // randomID mints one candidate ID; the caller collision-checks it against
 // the database and re-rolls.
 func randomID() string {
-	suffix := make([]byte, idSuffixLength)
-	// Rejection sampling keeps the distribution uniform: 256 is not a
-	// multiple of 28, so bytes past the largest full multiple re-roll.
-	limit := byte(256 - 256%len(idAlphabet))
-	for i := 0; i < len(suffix); {
-		var buf [16]byte
-		rand.Read(buf[:])
-		for _, b := range buf {
-			if i == len(suffix) {
-				break
-			}
-			if b >= limit {
-				continue
-			}
-			suffix[i] = idAlphabet[int(b)%len(idAlphabet)]
-			i++
-		}
-	}
-	return idPrefix + string(suffix)
+	return ids.New(idPrefix)
 }

--- a/internal/terminals/service.go
+++ b/internal/terminals/service.go
@@ -89,6 +89,12 @@ type entry struct {
 }
 
 func NewService(opts Options) *Service {
+	if opts.Projects == nil {
+		// A nil projects repository would panic on the first create request
+		// rather than at boot; fail at construction instead (the
+		// server.NewHandler Verify precedent).
+		panic("terminals.NewService: Projects must not be nil")
+	}
 	if opts.Now == nil {
 		opts.Now = time.Now
 	}

--- a/internal/terminals/service.go
+++ b/internal/terminals/service.go
@@ -347,6 +347,13 @@ func (s *Service) Create(ctx context.Context, params api.TerminalCreateParams) (
 	for {
 		record.ID = randomID()
 		inserted, err := s.repository.Insert(ctx, record)
+		if errors.Is(err, store.ErrForeignKeyViolation) {
+			// The project was deleted between the lookup above and this
+			// insert; the foreign key kept the state consistent, so answer
+			// as if the lookup had missed.
+			s.ops.Unlock()
+			return api.Terminal{}, fmt.Errorf("%w %q", ErrProjectUnknown, params.ProjectID)
+		}
 		if err != nil {
 			s.ops.Unlock()
 			return api.Terminal{}, err

--- a/internal/terminals/service.go
+++ b/internal/terminals/service.go
@@ -3,7 +3,9 @@ package terminals
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"os"
 	"sort"
 	"sync"
 	"time"
@@ -17,6 +19,16 @@ import (
 // ErrNotFound reports an id with no record; the API layer maps it to 404.
 var ErrNotFound = errors.New("terminal not found")
 
+// ErrProjectUnknown rejects a create naming a project with no record.
+var ErrProjectUnknown = errors.New("unknown project")
+
+// ErrProjectDirectoryMissing refuses a create whose project directory does
+// not exist at that moment (the project folder was deleted after project
+// creation). This deliberately reverses the domain's previous skip-the-
+// existence-check choice (ATC-256); the launch-failure path remains as the
+// backstop for races.
+var ErrProjectDirectoryMissing = errors.New("project directory does not exist")
+
 // resource is the event-payload resource kind.
 const resource = "terminal"
 
@@ -24,13 +36,14 @@ const resource = "terminal"
 type Options struct {
 	Repository *store.Terminals
 	Adapter    Adapter
+	// Projects is read on create: the required project reference is
+	// validated and its directory copied (ATC-256).
+	Projects *store.Projects
 	// MarkerDir is where wrappers record exit evidence.
 	MarkerDir string
 	Hub       *events.Hub
 	Logger    *slog.Logger
 	Now       func() time.Time
-	// HomeDir is the default directory for created terminals.
-	HomeDir string
 }
 
 // Service owns the in-memory view and the reconciliation that keeps it
@@ -51,11 +64,11 @@ type Options struct {
 type Service struct {
 	repository *store.Terminals
 	adapter    Adapter
+	projects   *store.Projects
 	markerDir  string
 	hub        *events.Hub
 	logger     *slog.Logger
 	now        func() time.Time
-	home       string
 	// verifyInterval is VerifyInterval in production; tests shrink it.
 	verifyInterval time.Duration
 
@@ -85,11 +98,11 @@ func NewService(opts Options) *Service {
 	return &Service{
 		repository:     opts.Repository,
 		adapter:        opts.Adapter,
+		projects:       opts.Projects,
 		markerDir:      opts.MarkerDir,
 		hub:            opts.Hub,
 		logger:         opts.Logger,
 		now:            opts.Now,
-		home:           opts.HomeDir,
 		verifyInterval: VerifyInterval,
 		view:           make(map[string]*entry),
 		settling:       make(map[string]struct{}),
@@ -295,12 +308,26 @@ func (s *Service) reconcile(ctx context.Context, reap bool) {
 	}
 }
 
-// Create mints the ID, persists the record before starting the session (no
+// Create validates the required project reference, copies its directory,
+// mints the ID, persists the record before starting the session (no
 // orphan window), starts it, and waits a short verification window so the
 // common case returns running and a fast-failing app returns exited with
-// real evidence. Failures surface through the normal status machinery —
-// there is no separate launch-error path.
+// real evidence. Failures after the record exists surface through the
+// normal status machinery — there is no separate launch-error path.
 func (s *Service) Create(ctx context.Context, params api.TerminalCreateParams) (api.Terminal, error) {
+	project, ok, err := s.projects.Get(ctx, params.ProjectID)
+	if err != nil {
+		return api.Terminal{}, err
+	}
+	if !ok {
+		return api.Terminal{}, fmt.Errorf("%w %q", ErrProjectUnknown, params.ProjectID)
+	}
+	// The project's directory must exist right now; a vanished folder
+	// refuses the create before any record is written.
+	if info, err := os.Stat(project.Directory); err != nil || !info.IsDir() {
+		return api.Terminal{}, fmt.Errorf("%w: %s", ErrProjectDirectoryMissing, project.Directory)
+	}
+
 	name := params.Name
 	if name == "" {
 		name = params.App
@@ -308,14 +335,10 @@ func (s *Service) Create(ctx context.Context, params api.TerminalCreateParams) (
 	if name == "" {
 		name = "Shell"
 	}
-	directory := params.Directory
-	if directory == "" {
-		directory = s.home
-	}
 
 	now := s.now()
 	record := store.TerminalRecord{
-		Name: name, Directory: directory, App: params.App,
+		ProjectID: project.ID, Name: name, Directory: project.Directory, App: params.App,
 		CreatedAt: now, UpdatedAt: now,
 	}
 	s.ops.Lock()
@@ -344,7 +367,7 @@ func (s *Service) Create(ctx context.Context, params api.TerminalCreateParams) (
 	s.hub.Publish(api.EventTerminalCreated, resource, record.ID)
 	s.ops.Unlock()
 
-	if err := s.adapter.Create(ctx, record.ID, CreateSpec{Directory: directory, App: params.App}); err != nil {
+	if err := s.adapter.Create(ctx, record.ID, CreateSpec{Directory: record.Directory, App: params.App}); err != nil {
 		// The record stays: the session may have been born after the
 		// client gave up, and the status machinery reports the truth.
 		s.logger.Warn("session create failed", "terminal", record.ID, "error", err)
@@ -400,12 +423,17 @@ func (s *Service) Get(id string) (api.Terminal, error) {
 	return e.terminal(), nil
 }
 
-// List serves every terminal from the in-memory view in creation order.
-func (s *Service) List() []api.Terminal {
+// List serves terminals from the in-memory view in creation order. A
+// non-empty projectID filters to that project's terminals; empty returns
+// everything (the API imposes no scoping — presentation belongs to UIs).
+func (s *Service) List(projectID string) []api.Terminal {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	terminals := make([]api.Terminal, 0, len(s.view))
 	for _, e := range s.view {
+		if projectID != "" && e.record.ProjectID != projectID {
+			continue
+		}
 		terminals = append(terminals, e.terminal())
 	}
 	sort.Slice(terminals, func(i, j int) bool {
@@ -507,6 +535,7 @@ func (e *entry) terminal() api.Terminal {
 	terminal := api.Terminal{
 		ID:        e.record.ID,
 		Name:      e.record.Name,
+		ProjectID: e.record.ProjectID,
 		Directory: e.record.Directory,
 		App:       e.record.App,
 		Status:    e.status,

--- a/internal/terminals/service_test.go
+++ b/internal/terminals/service_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sync"
@@ -103,13 +104,16 @@ func (a *fakeAdapter) setInvErr(err error) {
 }
 
 // fixture wires a Service over a real temp-file store, the fake adapter, a
-// real marker directory, and a fake clock.
+// real marker directory, and a fake clock, with one project (rooted at a
+// real temp directory) for terminals to belong to.
 type fixture struct {
-	service *Service
-	adapter *fakeAdapter
-	hub     *events.Hub
-	markers string
-	clock   *fakeClock
+	service    *Service
+	adapter    *fakeAdapter
+	hub        *events.Hub
+	markers    string
+	clock      *fakeClock
+	projectID  string
+	projectDir string
 }
 
 type fakeClock struct {
@@ -134,17 +138,33 @@ func newFixture(t *testing.T) *fixture {
 	adapter := newFakeAdapter()
 	markers := t.TempDir()
 	clock := &fakeClock{now: time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)}
+	projectDir := t.TempDir()
+	projectID := "proj-aaaaa"
+	if ok, err := s.Projects().Insert(context.Background(), store.ProjectRecord{
+		ID: projectID, Name: "p", Directory: projectDir, CreatedAt: clock.Now(), UpdatedAt: clock.Now(),
+	}); err != nil || !ok {
+		t.Fatalf("planting project = %v, %v", ok, err)
+	}
 	service := NewService(Options{
 		Repository: s.Terminals(),
 		Adapter:    adapter,
+		Projects:   s.Projects(),
 		MarkerDir:  markers,
 		Hub:        events.NewHub(64),
 		Logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
 		Now:        clock.Now,
-		HomeDir:    "/home/tester",
 	})
 	service.verifyInterval = time.Millisecond
-	return &fixture{service: service, adapter: adapter, hub: service.hub, markers: markers, clock: clock}
+	return &fixture{service: service, adapter: adapter, hub: service.hub, markers: markers,
+		clock: clock, projectID: projectID, projectDir: projectDir}
+}
+
+// create is Create against the fixture's project.
+func (f *fixture) create(ctx context.Context, params api.TerminalCreateParams) (api.Terminal, error) {
+	if params.ProjectID == "" {
+		params.ProjectID = f.projectID
+	}
+	return f.service.Create(ctx, params)
 }
 
 func plantExitMarker(t *testing.T, dir, id string, code int, exited bool) {
@@ -181,7 +201,7 @@ func TestCreateHappyPath(t *testing.T) {
 		}
 	}
 
-	terminal, err := f.service.Create(ctx, api.TerminalCreateParams{App: "hx", Directory: "/proj"})
+	terminal, err := f.create(ctx, api.TerminalCreateParams{App: "hx"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +212,7 @@ func TestCreateHappyPath(t *testing.T) {
 		t.Error("session started before the record was persisted")
 	}
 	want := terminal
-	want.Name, want.Directory, want.App, want.Status = "hx", "/proj", "hx", api.TerminalRunning
+	want.Name, want.ProjectID, want.Directory, want.App, want.Status = "hx", f.projectID, f.projectDir, "hx", api.TerminalRunning
 	if diff := cmp.Diff(want, terminal); diff != "" {
 		t.Errorf("terminal (-want +got):\n%s", diff)
 	}
@@ -200,12 +220,12 @@ func TestCreateHappyPath(t *testing.T) {
 
 func TestCreateDefaults(t *testing.T) {
 	f := newFixture(t)
-	terminal, err := f.service.Create(context.Background(), api.TerminalCreateParams{})
+	terminal, err := f.create(context.Background(), api.TerminalCreateParams{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if terminal.Name != "Shell" || terminal.Directory != "/home/tester" || terminal.App != "" {
-		t.Errorf("defaults = %q %q %q, want Shell /home/tester \"\"", terminal.Name, terminal.Directory, terminal.App)
+	if terminal.Name != "Shell" || terminal.Directory != f.projectDir || terminal.App != "" {
+		t.Errorf("defaults = %q %q %q, want Shell %q \"\"", terminal.Name, terminal.Directory, terminal.App, f.projectDir)
 	}
 }
 
@@ -217,7 +237,7 @@ func TestCreateFastFailingApp(t *testing.T) {
 	f.adapter.onCreate = func(id string, _ CreateSpec) {
 		plantExitMarker(t, f.markers, id, 127, true)
 	}
-	terminal, err := f.service.Create(context.Background(), api.TerminalCreateParams{App: "no-such-tool"})
+	terminal, err := f.create(context.Background(), api.TerminalCreateParams{App: "no-such-tool"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -234,7 +254,7 @@ func TestCreateFastFailingApp(t *testing.T) {
 func TestCreateNeverSettles(t *testing.T) {
 	f := newFixture(t)
 	f.adapter.createErr = errors.New("session never settled")
-	terminal, err := f.service.Create(context.Background(), api.TerminalCreateParams{})
+	terminal, err := f.create(context.Background(), api.TerminalCreateParams{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -269,7 +289,7 @@ func TestReconcileDecisionTable(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			f := newFixture(t)
 			ctx := context.Background()
-			terminal, err := f.service.Create(ctx, api.TerminalCreateParams{})
+			terminal, err := f.create(ctx, api.TerminalCreateParams{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -315,7 +335,7 @@ func TestReconcileDecisionTable(t *testing.T) {
 func TestExitedIsStickyAndStaysListed(t *testing.T) {
 	f := newFixture(t)
 	ctx := context.Background()
-	terminal, err := f.service.Create(ctx, api.TerminalCreateParams{App: "build"})
+	terminal, err := f.create(ctx, api.TerminalCreateParams{App: "build"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -331,7 +351,7 @@ func TestExitedIsStickyAndStaysListed(t *testing.T) {
 	f.adapter.setInvErr(nil)
 	f.service.Reconcile(ctx)
 
-	list := f.service.List()
+	list := f.service.List("")
 	if len(list) != 1 || list[0].Status != api.TerminalExited || list[0].ExitCode == nil || *list[0].ExitCode != 3 {
 		t.Errorf("list = %+v, want one exited terminal with code 3", list)
 	}
@@ -340,7 +360,7 @@ func TestExitedIsStickyAndStaysListed(t *testing.T) {
 func TestUpdateName(t *testing.T) {
 	f := newFixture(t)
 	ctx := context.Background()
-	terminal, err := f.service.Create(ctx, api.TerminalCreateParams{})
+	terminal, err := f.create(ctx, api.TerminalCreateParams{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -362,7 +382,7 @@ func TestUpdateName(t *testing.T) {
 func TestDeleteBestEffortAndOrphanReaping(t *testing.T) {
 	f := newFixture(t)
 	ctx := context.Background()
-	terminal, err := f.service.Create(ctx, api.TerminalCreateParams{})
+	terminal, err := f.create(ctx, api.TerminalCreateParams{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -426,7 +446,7 @@ func TestDeleteAbsentIsNotFound(t *testing.T) {
 func TestSecondDeleteIsNotFound(t *testing.T) {
 	f := newFixture(t)
 	ctx := context.Background()
-	terminal, err := f.service.Create(ctx, api.TerminalCreateParams{})
+	terminal, err := f.create(ctx, api.TerminalCreateParams{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -459,7 +479,7 @@ func TestSecondDeleteIsNotFound(t *testing.T) {
 // user's intent, once durable, must not be abandoned by a disconnect.
 func TestDeleteSurvivesCancelledContext(t *testing.T) {
 	f := newFixture(t)
-	terminal, err := f.service.Create(context.Background(), api.TerminalCreateParams{})
+	terminal, err := f.create(context.Background(), api.TerminalCreateParams{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -478,7 +498,7 @@ func TestDeleteSurvivesCancelledContext(t *testing.T) {
 func TestStaleMarkerFromEarlierIncarnationIgnored(t *testing.T) {
 	f := newFixture(t)
 	ctx := context.Background()
-	terminal, err := f.service.Create(ctx, api.TerminalCreateParams{})
+	terminal, err := f.create(ctx, api.TerminalCreateParams{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -506,11 +526,11 @@ func TestStaleMarkerFromEarlierIncarnationIgnored(t *testing.T) {
 func TestLoadRebuildsView(t *testing.T) {
 	f := newFixture(t)
 	ctx := context.Background()
-	running, err := f.service.Create(ctx, api.TerminalCreateParams{Name: "keep"})
+	running, err := f.create(ctx, api.TerminalCreateParams{Name: "keep"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	gone, err := f.service.Create(ctx, api.TerminalCreateParams{Name: "gone"})
+	gone, err := f.create(ctx, api.TerminalCreateParams{Name: "gone"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -520,11 +540,11 @@ func TestLoadRebuildsView(t *testing.T) {
 	restarted := NewService(Options{
 		Repository: f.service.repository,
 		Adapter:    f.adapter,
+		Projects:   f.service.projects,
 		MarkerDir:  f.markers,
 		Hub:        events.NewHub(64),
 		Logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
 		Now:        f.clock.Now,
-		HomeDir:    "/home/tester",
 	})
 	if err := restarted.Load(ctx); err != nil {
 		t.Fatal(err)
@@ -532,7 +552,7 @@ func TestLoadRebuildsView(t *testing.T) {
 	restarted.Reconcile(ctx)
 
 	byName := map[string]api.TerminalStatus{}
-	for _, terminal := range restarted.List() {
+	for _, terminal := range restarted.List("") {
 		byName[terminal.Name] = terminal.Status
 	}
 	want := map[string]api.TerminalStatus{"keep": api.TerminalRunning, "gone": api.TerminalMissing}
@@ -549,7 +569,7 @@ func TestEventsEmitted(t *testing.T) {
 	sub := f.hub.Subscribe(0, false)
 	defer sub.Close()
 
-	terminal, err := f.service.Create(ctx, api.TerminalCreateParams{})
+	terminal, err := f.create(ctx, api.TerminalCreateParams{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -581,5 +601,64 @@ func TestEventsEmitted(t *testing.T) {
 	}
 	if diff := cmp.Diff(want, types); diff != "" {
 		t.Errorf("event types (-want +got):\n%s", diff)
+	}
+}
+
+// The ATC-256 create contract: the project must exist, and its directory
+// must exist at that moment — refused before any record is written.
+func TestCreateRequiresLiveProject(t *testing.T) {
+	f := newFixture(t)
+	ctx := context.Background()
+
+	if _, err := f.service.Create(ctx, api.TerminalCreateParams{ProjectID: "proj-zzzzz"}); !errors.Is(err, ErrProjectUnknown) {
+		t.Errorf("Create(unknown project) = %v, want ErrProjectUnknown", err)
+	}
+
+	if err := os.RemoveAll(f.projectDir); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.create(ctx, api.TerminalCreateParams{}); !errors.Is(err, ErrProjectDirectoryMissing) {
+		t.Errorf("Create(vanished directory) = %v, want ErrProjectDirectoryMissing", err)
+	}
+
+	// Refused means refused: no terminal row was written and nothing is
+	// listed.
+	records, err := f.service.repository.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 0 || len(f.service.List("")) != 0 {
+		t.Errorf("refused creates left records: %+v", records)
+	}
+}
+
+// List's project filter scopes the view; unfiltered returns everything.
+func TestListFiltersByProject(t *testing.T) {
+	f := newFixture(t)
+	ctx := context.Background()
+	otherDir := t.TempDir()
+	if ok, err := f.service.projects.Insert(ctx, store.ProjectRecord{
+		ID: "proj-bbbbb", Name: "other", Directory: otherDir,
+		CreatedAt: f.clock.Now(), UpdatedAt: f.clock.Now(),
+	}); err != nil || !ok {
+		t.Fatalf("planting project = %v, %v", ok, err)
+	}
+	mine, err := f.create(ctx, api.TerminalCreateParams{Name: "mine"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	other, err := f.service.Create(ctx, api.TerminalCreateParams{ProjectID: "proj-bbbbb", Name: "other"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if all := f.service.List(""); len(all) != 2 {
+		t.Errorf("unfiltered list = %+v, want both terminals", all)
+	}
+	filtered := f.service.List("proj-bbbbb")
+	if len(filtered) != 1 || filtered[0].ID != other.ID {
+		t.Errorf("filtered list = %+v, want only %s", filtered, other.ID)
+	}
+	if other.Directory != otherDir || mine.Directory != f.projectDir {
+		t.Errorf("directories not copied from projects: %q %q", mine.Directory, other.Directory)
 	}
 }


### PR DESCRIPTION
Implements [ATC-256](https://linear.app/elevenideas/issue/ATC-256/projects): projects become ATC's unit of organization, mirroring the terminals domain stack end to end.

## Projects domain
- `/v1/projects` with the five standard verbs; wire structs and typed client methods in `internal/api`; `project.created/updated/deleted` change events.
- Canonical paths are the identity: on create the directory is made absolute, cleaned, and symlink-resolved (`paths.CanonicalDir`, new), must exist and be a directory, and the canonical form is unique across projects and immutable. Name defaults from the basename, is editable, and is not unique.
- Delete refuses while any terminal belongs to the project and reports what remains; the schema's foreign key backstops the races.
- New `00002_projects.sql` migration: `projects` table plus a breaking reset of `terminals` with required `project_id` (pre-existing terminal rows do not survive, per spec).

## Terminal changes
- `project_id` is required on create; unknown projects are rejected (422) and the directory parameter (`--dir`) is removed — a terminal's directory is copied from its project and immutable.
- Create now refuses (409, no row written) when the project's folder no longer exists, deliberately reversing ATC-251's skip-the-check choice; the launch-failure path remains the backstop.
- Terminal list gains an optional project filter (`?project=`, CLI `--project`); unfiltered still returns everything.

## CLI
- `atc project create|get|list|update|delete` mirroring the terminal commands.
- `atc terminal create` resolves the project by canonicalizing the cwd and walking up, nearest ancestor wins; `--project` skips resolution. On no match: interactive runs are offered a project rooted at the git toplevel (else cwd), non-interactive runs refuse naming `--project` and `atc project create`.
- The terminal ID minting scheme moved to `internal/ids` so both domains share it.

## Tests
- API-contract tests for project CRUD/validation (symlinked-duplicate 409, name defaulting, delete-refusal reporting the terminal) and the terminal create contract.
- CLI walk-up tests with temp trees: nested projects, symlinked cwd, no-TTY refusal, `--project` bypass, accept/decline of the create offer.
- Store tests for the projects repository and the reset migration (legacy rows gone, `project_id` required).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added project management through the CLI and API, including create, view, list, rename, and delete operations.
  * Terminals are now associated with projects and inherit their configured directories.
  * Added project-based terminal filtering and project details in terminal output.
  * Added automatic project discovery from the current directory, including Git repository support.
* **Bug Fixes**
  * Prevented deletion of projects that still contain terminals.
  * Added validation for missing or invalid project directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->