### PR TITLE
ATC-273 | cli: extract client construction, project resolution, and attach into internal/cli

### DIFF
--- a/cmd/atc/main.go
+++ b/cmd/atc/main.go
@@ -19,7 +19,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/jeremytondo/atc/internal/api"
 	"github.com/jeremytondo/atc/internal/authtoken"
+	"github.com/jeremytondo/atc/internal/cli"
 	"github.com/jeremytondo/atc/internal/config"
 	"github.com/jeremytondo/atc/internal/events"
 	"github.com/jeremytondo/atc/internal/paths"
@@ -88,6 +90,19 @@ expose on the tailnet without the flag.`,
 	return root
 }
 
+// runWithClient wraps an API-backed command body with the shared client
+// construction and error path — every terminal/project/api command starts
+// the same way.
+func runWithClient(body func(cmd *cobra.Command, args []string, client *api.Client, baseURL string) error) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		client, baseURL, err := cli.NewClient(cmd.ErrOrStderr())
+		if err != nil {
+			return err
+		}
+		return body(cmd, args, client, baseURL)
+	}
+}
+
 func newVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
@@ -138,7 +153,7 @@ interrupted), headless runs print a reminder unless --restart or
 			opts := upgrade.Options{
 				Dev:         dev,
 				Restart:     mode,
-				Interactive: stdinIsTTY(),
+				Interactive: cli.StdinIsTTY(),
 				Version:     version.String(),
 				Stdin:       cmd.InOrStdin(),
 				Stdout:      cmd.OutOrStdout(),

--- a/cmd/atc/main.go
+++ b/cmd/atc/main.go
@@ -90,6 +90,14 @@ expose on the tailnet without the flag.`,
 	return root
 }
 
+// stdioIsTerminal and stdinIsTTY are this binary's TTY detection, held in
+// variables so tests, which never have a TTY, can force them. The cli
+// package takes the results as explicit arguments and holds no such state.
+var (
+	stdioIsTerminal = cli.StdioIsTerminal
+	stdinIsTTY      = cli.StdinIsTTY
+)
+
 // runWithClient wraps an API-backed command body with the shared client
 // construction and error path — every terminal/project/api command starts
 // the same way.
@@ -153,7 +161,7 @@ interrupted), headless runs print a reminder unless --restart or
 			opts := upgrade.Options{
 				Dev:         dev,
 				Restart:     mode,
-				Interactive: cli.StdinIsTTY(),
+				Interactive: stdinIsTTY(),
 				Version:     version.String(),
 				Stdin:       cmd.InOrStdin(),
 				Stdout:      cmd.OutOrStdout(),

--- a/cmd/atc/project.go
+++ b/cmd/atc/project.go
@@ -1,19 +1,15 @@
 package main
 
 import (
-	"bufio"
 	"fmt"
 	"io"
-	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 
 	"github.com/jeremytondo/atc/internal/api"
-	"github.com/jeremytondo/atc/internal/paths"
+	"github.com/jeremytondo/atc/internal/cli"
 )
 
 func newProjectCmd() *cobra.Command {
@@ -55,7 +51,7 @@ directory itself must exist on the server's machine.`,
 				if directory, err = filepath.Abs(args[0]); err != nil {
 					return err
 				}
-			} else if directory, err = defaultProjectDir(); err != nil {
+			} else if directory, err = cli.DefaultProjectDir(); err != nil {
 				return err
 			}
 			project, err := client.CreateProject(cmd.Context(), api.ProjectCreateParams{
@@ -151,93 +147,6 @@ those first; there is no cascade.`,
 			return err
 		}),
 	}
-}
-
-// stdinIsTTY gates the create-offer prompt: a question is only asked of a
-// human on an interactive stdin. Stdout deliberately does not matter — a
-// redirected stdout still deserves the prompt (on stderr) rather than a
-// refusal. A variable so tests, which never have a TTY, can force it.
-var stdinIsTTY = func() bool {
-	info, err := os.Stdin.Stat()
-	return err == nil && info.Mode()&os.ModeCharDevice != 0
-}
-
-// resolveProjectID finds the project owning the current directory the way
-// git finds a repository (ATC-256): canonicalize the cwd, then walk up —
-// the nearest ancestor (or the directory itself) matching a project's
-// directory wins. On no match, an interactive run is offered a project
-// rooted at the default (git toplevel, else cwd); a non-interactive run
-// refuses with the fixes instead of prompting.
-func resolveProjectID(cmd *cobra.Command, client *api.Client) (string, error) {
-	canonical, err := paths.CanonicalDir(".")
-	if err != nil {
-		return "", err
-	}
-	projects, err := client.Projects(cmd.Context())
-	if err != nil {
-		return "", err
-	}
-	byDir := make(map[string]string, len(projects))
-	for _, project := range projects {
-		byDir[project.Directory] = project.ID
-	}
-	for dir := canonical; ; {
-		if id, ok := byDir[dir]; ok {
-			return id, nil
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			break
-		}
-		dir = parent
-	}
-
-	if !stdinIsTTY() {
-		return "", fmt.Errorf("no project contains %s; pass --project <id> or run `atc project create`", canonical)
-	}
-	defaultDir := projectRootFor(canonical)
-	// The conversation goes to stderr: stdout stays the command's
-	// redirectable output (the created terminal).
-	console := cmd.ErrOrStderr()
-	_, _ = fmt.Fprintf(console, "no project contains %s\ncreate a project at %s? [y/N] ", canonical, defaultDir)
-	answer, _ := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
-	switch strings.ToLower(strings.TrimSpace(answer)) {
-	case "y", "yes":
-	default:
-		return "", fmt.Errorf("no project selected; pass --project <id> or run `atc project create`")
-	}
-	project, err := client.CreateProject(cmd.Context(), api.ProjectCreateParams{Directory: defaultDir})
-	if err != nil {
-		return "", err
-	}
-	_, _ = fmt.Fprintf(console, "created project %s at %s\n", project.ID, project.Directory)
-	return project.ID, nil
-}
-
-// defaultProjectDir is where an unspecified project is rooted: the git
-// toplevel when inside a repository, the current directory otherwise.
-func defaultProjectDir() (string, error) {
-	canonical, err := paths.CanonicalDir(".")
-	if err != nil {
-		return "", err
-	}
-	return projectRootFor(canonical), nil
-}
-
-// projectRootFor asks git for the toplevel of the repository containing
-// the canonical directory — git itself is the authority on what counts as
-// a repository (a stray or malformed .git entry is not one). Outside a
-// repository, or without git installed, the directory is its own root.
-func projectRootFor(canonical string) string {
-	output, err := exec.Command("git", "-C", canonical, "rev-parse", "--show-toplevel").Output()
-	if err != nil {
-		return canonical
-	}
-	toplevel, err := paths.CanonicalDir(strings.TrimSpace(string(output)))
-	if err != nil {
-		return canonical
-	}
-	return toplevel
 }
 
 func printProject(out io.Writer, project api.Project) {

--- a/cmd/atc/project_test.go
+++ b/cmd/atc/project_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jeremytondo/atc/internal/cli"
 	"github.com/jeremytondo/atc/internal/paths"
 )
 
@@ -247,7 +248,7 @@ func TestProjectCreateDefaultPath(t *testing.T) {
 	plain := canonical(t, t.TempDir())
 	// The walk honestly finds any ancestor repo (a stray /tmp/.git on a
 	// developer machine, say); only a truly repo-free cwd tests this case.
-	if projectRootFor(plain) != plain {
+	if cli.ProjectRootFor(plain) != plain {
 		t.Skipf("an ancestor of %s is a git repository; skipping the no-repo case", plain)
 	}
 	t.Chdir(plain)

--- a/cmd/atc/project_test.go
+++ b/cmd/atc/project_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jeremytondo/atc/internal/cli"
 	"github.com/jeremytondo/atc/internal/paths"
 )
 
@@ -246,9 +245,10 @@ func TestProjectCreateDefaultPath(t *testing.T) {
 	}
 
 	plain := canonical(t, t.TempDir())
-	// The walk honestly finds any ancestor repo (a stray /tmp/.git on a
+	// The default honestly finds any ancestor repo (a stray /tmp/.git on a
 	// developer machine, say); only a truly repo-free cwd tests this case.
-	if cli.ProjectRootFor(plain) != plain {
+	// git itself is the probe, the same authority the CLI consults.
+	if exec.Command("git", "-C", plain, "rev-parse", "--show-toplevel").Run() == nil {
 		t.Skipf("an ancestor of %s is a git repository; skipping the no-repo case", plain)
 	}
 	t.Chdir(plain)

--- a/cmd/atc/terminal.go
+++ b/cmd/atc/terminal.go
@@ -3,79 +3,17 @@ package main
 import (
 	"fmt"
 	"io"
-	"net"
-	"net/url"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
-	"syscall"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 
 	"github.com/jeremytondo/atc/internal/api"
-	"github.com/jeremytondo/atc/internal/authtoken"
-	"github.com/jeremytondo/atc/internal/config"
-	"github.com/jeremytondo/atc/internal/paths"
+	"github.com/jeremytondo/atc/internal/cli"
 	"github.com/jeremytondo/atc/internal/service"
-	"github.com/jeremytondo/atc/internal/version"
 	"github.com/jeremytondo/atc/internal/wrapper"
-	"github.com/jeremytondo/atc/internal/zmx"
 )
-
-// newAPIClient builds the shared API client every CLI command speaks
-// through — never server internals. The server URL comes from ATC_SERVER
-// (a remote client's paste-once setup) or the settled local config port;
-// the token from ATC_TOKEN or the local token file. Version skew prints
-// one stderr warning line with the restart remedy.
-func newAPIClient(cmd *cobra.Command) (*api.Client, string, error) {
-	baseURL := os.Getenv("ATC_SERVER")
-	if baseURL == "" {
-		configPath, err := paths.ConfigFile()
-		if err != nil {
-			return nil, "", err
-		}
-		cfg, err := config.Load(configPath, os.LookupEnv)
-		if err != nil {
-			return nil, "", err
-		}
-		baseURL = fmt.Sprintf("http://127.0.0.1:%d", cfg.Port)
-	}
-	token := os.Getenv("ATC_TOKEN")
-	if token == "" {
-		tokenPath, err := paths.AuthTokenFile()
-		if err != nil {
-			return nil, "", err
-		}
-		if token, err = (&authtoken.Store{Path: tokenPath}).Ensure(); err != nil {
-			return nil, "", err
-		}
-	}
-	stderr := cmd.ErrOrStderr()
-	clientVersion := version.String()
-	warned := false
-	onServerVersion := func(serverVersion string) {
-		if serverVersion != clientVersion && !warned {
-			warned = true
-			_, _ = fmt.Fprintf(stderr, "atc: server is %s, client is %s; run `atc server restart`\n", serverVersion, clientVersion)
-		}
-	}
-	return api.NewClient(baseURL, token, clientVersion, nil, onServerVersion), baseURL, nil
-}
-
-// runWithClient wraps an API-backed command body with the shared client
-// construction and error path — every terminal/api command starts the same
-// way.
-func runWithClient(body func(cmd *cobra.Command, args []string, client *api.Client, baseURL string) error) func(*cobra.Command, []string) error {
-	return func(cmd *cobra.Command, args []string) error {
-		client, baseURL, err := newAPIClient(cmd)
-		if err != nil {
-			return err
-		}
-		return body(cmd, args, client, baseURL)
-	}
-}
 
 func newTerminalCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -111,7 +49,7 @@ loaded); without it you get a plain interactive shell.`,
 				return err
 			}
 			if attach {
-				if err := attachPreflight(baseURL); err != nil {
+				if err := cli.AttachPreflight(baseURL); err != nil {
 					return err
 				}
 				if _, err := exec.LookPath("zmx"); err != nil {
@@ -129,7 +67,7 @@ loaded); without it you get a plain interactive shell.`,
 				return err
 			}
 			if params.ProjectID == "" {
-				if params.ProjectID, err = resolveProjectID(cmd, client); err != nil {
+				if params.ProjectID, err = cli.ResolveProjectID(cmd.Context(), client, cmd.InOrStdin(), cmd.ErrOrStderr()); err != nil {
 					return err
 				}
 			}
@@ -139,7 +77,7 @@ loaded); without it you get a plain interactive shell.`,
 			}
 			printTerminal(cmd.OutOrStdout(), terminal)
 			if attach {
-				if err := attachSession(terminal); err != nil {
+				if err := cli.AttachSession(terminal); err != nil {
 					return fmt.Errorf("%w; the terminal was created; retry with: atc terminal attach %s", err, terminal.ID)
 				}
 			}
@@ -252,7 +190,7 @@ the session's socket lives on the server's machine. The terminal must be
 running — attach never resurrects or creates sessions.`,
 		Args: cobra.ExactArgs(1),
 		RunE: runWithClient(func(cmd *cobra.Command, args []string, client *api.Client, baseURL string) error {
-			if err := attachPreflight(baseURL); err != nil {
+			if err := cli.AttachPreflight(baseURL); err != nil {
 				return err
 			}
 			// The API check keeps zmx's attach-auto-creates behavior from
@@ -262,68 +200,9 @@ running — attach never resurrects or creates sessions.`,
 			if err != nil {
 				return err
 			}
-			return attachSession(terminal)
+			return cli.AttachSession(terminal)
 		}),
 	}
-}
-
-// stdioIsTerminal reports whether stdin and stdout are both real TTYs.
-// It is a variable so tests, which never have a TTY, can force it.
-var stdioIsTerminal = func() bool {
-	stdin, err := os.Stdin.Stat()
-	if err != nil || stdin.Mode()&os.ModeCharDevice == 0 {
-		return false
-	}
-	stdout, err := os.Stdout.Stat()
-	return err == nil && stdout.Mode()&os.ModeCharDevice != 0
-}
-
-func attachPreflight(baseURL string) error {
-	if !stdioIsTerminal() {
-		return fmt.Errorf("attaching requires an interactive terminal (stdin and stdout must be TTYs)")
-	}
-	if !isLoopback(baseURL) {
-		return fmt.Errorf("atc terminal attach is local-only (the session socket lives on the server's machine); this client targets %s", baseURL)
-	}
-	return nil
-}
-
-func attachSession(terminal api.Terminal) error {
-	if terminal.Status != api.TerminalRunning {
-		return fmt.Errorf("terminal %s is %s, not running", terminal.ID, terminal.Status)
-	}
-	socketDir, err := paths.TerminalSocketDir()
-	if err != nil {
-		return err
-	}
-	// A loopback URL does not prove the server shares this
-	// process's namespace (an SSH-forwarded remote server, a
-	// different XDG_STATE_HOME). A session the API calls running
-	// must have its socket here; anything else would hand the TTY
-	// to zmx's auto-create.
-	if _, err := os.Stat(filepath.Join(socketDir, terminal.ID)); err != nil {
-		return fmt.Errorf("terminal %s has no session socket under %s — the server appears to be remote (an SSH-forwarded port?) or running with a different state directory", terminal.ID, socketDir)
-	}
-	executable, argv, env, err := zmx.AttachCommand(socketDir, terminal.ID)
-	if err != nil {
-		return err
-	}
-	// Exec replaces this process: the user's real TTY belongs to
-	// zmx until detach.
-	return syscall.Exec(executable, argv, env)
-}
-
-func isLoopback(baseURL string) bool {
-	parsed, err := url.Parse(baseURL)
-	if err != nil {
-		return false
-	}
-	host := parsed.Hostname()
-	if host == "localhost" {
-		return true
-	}
-	ip := net.ParseIP(host)
-	return ip != nil && ip.IsLoopback()
 }
 
 func statusLabel(terminal api.Terminal) string {

--- a/cmd/atc/terminal.go
+++ b/cmd/atc/terminal.go
@@ -49,7 +49,7 @@ loaded); without it you get a plain interactive shell.`,
 				return err
 			}
 			if attach {
-				if err := cli.AttachPreflight(baseURL); err != nil {
+				if err := cli.AttachPreflight(baseURL, stdioIsTerminal()); err != nil {
 					return err
 				}
 				if _, err := exec.LookPath("zmx"); err != nil {
@@ -67,7 +67,7 @@ loaded); without it you get a plain interactive shell.`,
 				return err
 			}
 			if params.ProjectID == "" {
-				if params.ProjectID, err = cli.ResolveProjectID(cmd.Context(), client, cmd.InOrStdin(), cmd.ErrOrStderr()); err != nil {
+				if params.ProjectID, err = cli.ResolveProjectID(cmd.Context(), client, cmd.InOrStdin(), cmd.ErrOrStderr(), stdinIsTTY()); err != nil {
 					return err
 				}
 			}
@@ -190,7 +190,7 @@ the session's socket lives on the server's machine. The terminal must be
 running — attach never resurrects or creates sessions.`,
 		Args: cobra.ExactArgs(1),
 		RunE: runWithClient(func(cmd *cobra.Command, args []string, client *api.Client, baseURL string) error {
-			if err := cli.AttachPreflight(baseURL); err != nil {
+			if err := cli.AttachPreflight(baseURL, stdioIsTerminal()); err != nil {
 				return err
 			}
 			// The API check keeps zmx's attach-auto-creates behavior from

--- a/cmd/atc/terminal_test.go
+++ b/cmd/atc/terminal_test.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/jeremytondo/atc/internal/cli"
 	"github.com/jeremytondo/atc/internal/events"
 	"github.com/jeremytondo/atc/internal/projects"
 	"github.com/jeremytondo/atc/internal/server"
@@ -122,10 +123,10 @@ func createProjectCLI(t *testing.T, dir string) string {
 
 func forceTTY(t *testing.T) {
 	t.Helper()
-	prevStdio, prevStdin := stdioIsTerminal, stdinIsTTY
-	stdioIsTerminal = func() bool { return true }
-	stdinIsTTY = func() bool { return true }
-	t.Cleanup(func() { stdioIsTerminal, stdinIsTTY = prevStdio, prevStdin })
+	prevStdio, prevStdin := cli.StdioIsTerminal, cli.StdinIsTTY
+	cli.StdioIsTerminal = func() bool { return true }
+	cli.StdinIsTTY = func() bool { return true }
+	t.Cleanup(func() { cli.StdioIsTerminal, cli.StdinIsTTY = prevStdio, prevStdin })
 }
 
 func installFakeZmx(t *testing.T) {

--- a/cmd/atc/terminal_test.go
+++ b/cmd/atc/terminal_test.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/jeremytondo/atc/internal/cli"
 	"github.com/jeremytondo/atc/internal/events"
 	"github.com/jeremytondo/atc/internal/projects"
 	"github.com/jeremytondo/atc/internal/server"
@@ -123,10 +122,10 @@ func createProjectCLI(t *testing.T, dir string) string {
 
 func forceTTY(t *testing.T) {
 	t.Helper()
-	prevStdio, prevStdin := cli.StdioIsTerminal, cli.StdinIsTTY
-	cli.StdioIsTerminal = func() bool { return true }
-	cli.StdinIsTTY = func() bool { return true }
-	t.Cleanup(func() { cli.StdioIsTerminal, cli.StdinIsTTY = prevStdio, prevStdin })
+	prevStdio, prevStdin := stdioIsTerminal, stdinIsTTY
+	stdioIsTerminal = func() bool { return true }
+	stdinIsTTY = func() bool { return true }
+	t.Cleanup(func() { stdioIsTerminal, stdinIsTTY = prevStdio, prevStdin })
 }
 
 func installFakeZmx(t *testing.T) {

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -13,9 +13,11 @@ import (
 	"github.com/jeremytondo/atc/internal/zmx"
 )
 
-// StdioIsTerminal reports whether stdin and stdout are both real TTYs.
-// It is a variable so tests, which never have a TTY, can force it.
-var StdioIsTerminal = func() bool {
+// StdioIsTerminal reports whether this process's stdin and stdout are both
+// real TTYs. Callers pass the result (or their own knowledge) into
+// AttachPreflight, so the check stays an explicit capability rather than
+// package state.
+func StdioIsTerminal() bool {
 	stdin, err := os.Stdin.Stat()
 	if err != nil || stdin.Mode()&os.ModeCharDevice == 0 {
 		return false
@@ -25,10 +27,10 @@ var StdioIsTerminal = func() bool {
 }
 
 // AttachPreflight refuses attach attempts that can never succeed: a
-// non-interactive stdio pair, or a non-loopback server (the session socket
-// lives on the server's machine).
-func AttachPreflight(baseURL string) error {
-	if !StdioIsTerminal() {
+// non-interactive stdio pair (stdioIsTerminal, supplied by the caller), or
+// a non-loopback server (the session socket lives on the server's machine).
+func AttachPreflight(baseURL string, stdioIsTerminal bool) error {
+	if !stdioIsTerminal {
 		return fmt.Errorf("attaching requires an interactive terminal (stdin and stdout must be TTYs)")
 	}
 	if !isLoopback(baseURL) {

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/jeremytondo/atc/internal/api"
+	"github.com/jeremytondo/atc/internal/paths"
+	"github.com/jeremytondo/atc/internal/zmx"
+)
+
+// StdioIsTerminal reports whether stdin and stdout are both real TTYs.
+// It is a variable so tests, which never have a TTY, can force it.
+var StdioIsTerminal = func() bool {
+	stdin, err := os.Stdin.Stat()
+	if err != nil || stdin.Mode()&os.ModeCharDevice == 0 {
+		return false
+	}
+	stdout, err := os.Stdout.Stat()
+	return err == nil && stdout.Mode()&os.ModeCharDevice != 0
+}
+
+// AttachPreflight refuses attach attempts that can never succeed: a
+// non-interactive stdio pair, or a non-loopback server (the session socket
+// lives on the server's machine).
+func AttachPreflight(baseURL string) error {
+	if !StdioIsTerminal() {
+		return fmt.Errorf("attaching requires an interactive terminal (stdin and stdout must be TTYs)")
+	}
+	if !isLoopback(baseURL) {
+		return fmt.Errorf("atc terminal attach is local-only (the session socket lives on the server's machine); this client targets %s", baseURL)
+	}
+	return nil
+}
+
+// AttachSession hands this process's TTY over to the terminal's running
+// session. On success it never returns: the process is replaced by zmx
+// until detach.
+func AttachSession(terminal api.Terminal) error {
+	if terminal.Status != api.TerminalRunning {
+		return fmt.Errorf("terminal %s is %s, not running", terminal.ID, terminal.Status)
+	}
+	socketDir, err := paths.TerminalSocketDir()
+	if err != nil {
+		return err
+	}
+	// A loopback URL does not prove the server shares this
+	// process's namespace (an SSH-forwarded remote server, a
+	// different XDG_STATE_HOME). A session the API calls running
+	// must have its socket here; anything else would hand the TTY
+	// to zmx's auto-create.
+	if _, err := os.Stat(filepath.Join(socketDir, terminal.ID)); err != nil {
+		return fmt.Errorf("terminal %s has no session socket under %s — the server appears to be remote (an SSH-forwarded port?) or running with a different state directory", terminal.ID, socketDir)
+	}
+	executable, argv, env, err := zmx.AttachCommand(socketDir, terminal.ID)
+	if err != nil {
+		return err
+	}
+	// Exec replaces this process: the user's real TTY belongs to
+	// zmx until detach.
+	return syscall.Exec(executable, argv, env)
+}
+
+func isLoopback(baseURL string) bool {
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return false
+	}
+	host := parsed.Hostname()
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 
 	"github.com/jeremytondo/atc/internal/api"
 	"github.com/jeremytondo/atc/internal/authtoken"
@@ -47,11 +48,15 @@ func NewClient(stderr io.Writer) (*api.Client, string, error) {
 		}
 	}
 	clientVersion := version.String()
-	warned := false
+	// The callback runs on whichever goroutine issued the request, and the
+	// client supports concurrent calls — Once keeps the warning single and
+	// race-free.
+	var warn sync.Once
 	onServerVersion := func(serverVersion string) {
-		if serverVersion != clientVersion && !warned {
-			warned = true
-			_, _ = fmt.Fprintf(stderr, "atc: server is %s, client is %s; run `atc server restart`\n", serverVersion, clientVersion)
+		if serverVersion != clientVersion {
+			warn.Do(func() {
+				_, _ = fmt.Fprintf(stderr, "atc: server is %s, client is %s; run `atc server restart`\n", serverVersion, clientVersion)
+			})
 		}
 	}
 	return api.NewClient(baseURL, token, clientVersion, nil, onServerVersion), baseURL, nil

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -1,0 +1,58 @@
+// Package cli implements the client-side behavior ATC's user-facing
+// clients share: constructing the authenticated API client, resolving the
+// project that owns the current directory, and handing a TTY to a running
+// session. cmd/atc stays cobra wiring over this package; the TUI (ATC-258)
+// will drive the same behavior without going through cobra.
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/jeremytondo/atc/internal/api"
+	"github.com/jeremytondo/atc/internal/authtoken"
+	"github.com/jeremytondo/atc/internal/config"
+	"github.com/jeremytondo/atc/internal/paths"
+	"github.com/jeremytondo/atc/internal/version"
+)
+
+// NewClient builds the shared API client every client command speaks
+// through — never server internals. It returns the client and the base URL
+// it settled on. The server URL comes from ATC_SERVER (a remote client's
+// paste-once setup) or the settled local config port; the token from
+// ATC_TOKEN or the local token file. Version skew prints one warning line
+// on stderr with the restart remedy.
+func NewClient(stderr io.Writer) (*api.Client, string, error) {
+	baseURL := os.Getenv("ATC_SERVER")
+	if baseURL == "" {
+		configPath, err := paths.ConfigFile()
+		if err != nil {
+			return nil, "", err
+		}
+		cfg, err := config.Load(configPath, os.LookupEnv)
+		if err != nil {
+			return nil, "", err
+		}
+		baseURL = fmt.Sprintf("http://127.0.0.1:%d", cfg.Port)
+	}
+	token := os.Getenv("ATC_TOKEN")
+	if token == "" {
+		tokenPath, err := paths.AuthTokenFile()
+		if err != nil {
+			return nil, "", err
+		}
+		if token, err = (&authtoken.Store{Path: tokenPath}).Ensure(); err != nil {
+			return nil, "", err
+		}
+	}
+	clientVersion := version.String()
+	warned := false
+	onServerVersion := func(serverVersion string) {
+		if serverVersion != clientVersion && !warned {
+			warned = true
+			_, _ = fmt.Fprintf(stderr, "atc: server is %s, client is %s; run `atc server restart`\n", serverVersion, clientVersion)
+		}
+	}
+	return api.NewClient(baseURL, token, clientVersion, nil, onServerVersion), baseURL, nil
+}

--- a/internal/cli/client_test.go
+++ b/internal/cli/client_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/jeremytondo/atc/internal/api"
+)
+
+// syncWriter is a strings.Builder safe for the concurrent writes a racy
+// warning path would attempt, so the race detector watches the warning
+// state itself rather than the test buffer.
+type syncWriter struct {
+	mu sync.Mutex
+	b  strings.Builder
+}
+
+func (w *syncWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.b.Write(p)
+}
+
+func (w *syncWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.b.String()
+}
+
+// The version-skew warning fires once even when concurrent requests
+// deliver the server version simultaneously — the callback runs on each
+// request's goroutine, and the client supports concurrent use.
+func TestNewClientVersionSkewWarnsOnceUnderConcurrency(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(api.ServerVersionHeader, "v9.9.9-skewed")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","version":"v9.9.9-skewed"}`))
+	}))
+	defer srv.Close()
+	t.Setenv("ATC_SERVER", srv.URL)
+	t.Setenv("ATC_TOKEN", "atc_cli-test-token")
+
+	var stderr syncWriter
+	client, baseURL, err := NewClient(&stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if baseURL != srv.URL {
+		t.Fatalf("baseURL = %q, want ATC_SERVER %q", baseURL, srv.URL)
+	}
+
+	var requests sync.WaitGroup
+	for range 8 {
+		requests.Go(func() {
+			if _, err := client.Health(context.Background()); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+	requests.Wait()
+
+	if got := strings.Count(stderr.String(), "run `atc server restart`"); got != 1 {
+		t.Errorf("skew warning printed %d times, want exactly once:\n%s", got, stderr.String())
+	}
+}

--- a/internal/cli/project.go
+++ b/internal/cli/project.go
@@ -1,0 +1,101 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/jeremytondo/atc/internal/api"
+	"github.com/jeremytondo/atc/internal/paths"
+)
+
+// StdinIsTTY gates the create-offer prompt: a question is only asked of a
+// human on an interactive stdin. Stdout deliberately does not matter — a
+// redirected stdout still deserves the prompt (on stderr) rather than a
+// refusal. A variable so tests, which never have a TTY, can force it.
+var StdinIsTTY = func() bool {
+	info, err := os.Stdin.Stat()
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
+}
+
+// ResolveProjectID finds the project owning the current directory the way
+// git finds a repository (ATC-256): canonicalize the cwd, then walk up —
+// the nearest ancestor (or the directory itself) matching a project's
+// directory wins. On no match, an interactive run is offered a project
+// rooted at the default (git toplevel, else cwd) on stderr; a
+// non-interactive run refuses with the fixes instead of prompting.
+func ResolveProjectID(ctx context.Context, client *api.Client, stdin io.Reader, stderr io.Writer) (string, error) {
+	canonical, err := paths.CanonicalDir(".")
+	if err != nil {
+		return "", err
+	}
+	projects, err := client.Projects(ctx)
+	if err != nil {
+		return "", err
+	}
+	byDir := make(map[string]string, len(projects))
+	for _, project := range projects {
+		byDir[project.Directory] = project.ID
+	}
+	for dir := canonical; ; {
+		if id, ok := byDir[dir]; ok {
+			return id, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	if !StdinIsTTY() {
+		return "", fmt.Errorf("no project contains %s; pass --project <id> or run `atc project create`", canonical)
+	}
+	defaultDir := ProjectRootFor(canonical)
+	// The conversation goes to stderr: stdout stays the command's
+	// redirectable output (the created terminal).
+	_, _ = fmt.Fprintf(stderr, "no project contains %s\ncreate a project at %s? [y/N] ", canonical, defaultDir)
+	answer, _ := bufio.NewReader(stdin).ReadString('\n')
+	switch strings.ToLower(strings.TrimSpace(answer)) {
+	case "y", "yes":
+	default:
+		return "", fmt.Errorf("no project selected; pass --project <id> or run `atc project create`")
+	}
+	project, err := client.CreateProject(ctx, api.ProjectCreateParams{Directory: defaultDir})
+	if err != nil {
+		return "", err
+	}
+	_, _ = fmt.Fprintf(stderr, "created project %s at %s\n", project.ID, project.Directory)
+	return project.ID, nil
+}
+
+// DefaultProjectDir is where an unspecified project is rooted: the git
+// toplevel when inside a repository, the current directory otherwise.
+func DefaultProjectDir() (string, error) {
+	canonical, err := paths.CanonicalDir(".")
+	if err != nil {
+		return "", err
+	}
+	return ProjectRootFor(canonical), nil
+}
+
+// ProjectRootFor asks git for the toplevel of the repository containing
+// the canonical directory — git itself is the authority on what counts as
+// a repository (a stray or malformed .git entry is not one). Outside a
+// repository, or without git installed, the directory is its own root.
+func ProjectRootFor(canonical string) string {
+	output, err := exec.Command("git", "-C", canonical, "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return canonical
+	}
+	toplevel, err := paths.CanonicalDir(strings.TrimSpace(string(output)))
+	if err != nil {
+		return canonical
+	}
+	return toplevel
+}

--- a/internal/cli/project.go
+++ b/internal/cli/project.go
@@ -14,11 +14,10 @@ import (
 	"github.com/jeremytondo/atc/internal/paths"
 )
 
-// StdinIsTTY gates the create-offer prompt: a question is only asked of a
-// human on an interactive stdin. Stdout deliberately does not matter — a
-// redirected stdout still deserves the prompt (on stderr) rather than a
-// refusal. A variable so tests, which never have a TTY, can force it.
-var StdinIsTTY = func() bool {
+// StdinIsTTY reports whether this process's stdin is a real TTY. Callers
+// pass the result (or their own knowledge) into ResolveProjectID, so the
+// check stays an explicit capability rather than package state.
+func StdinIsTTY() bool {
 	info, err := os.Stdin.Stat()
 	return err == nil && info.Mode()&os.ModeCharDevice != 0
 }
@@ -26,10 +25,12 @@ var StdinIsTTY = func() bool {
 // ResolveProjectID finds the project owning the current directory the way
 // git finds a repository (ATC-256): canonicalize the cwd, then walk up —
 // the nearest ancestor (or the directory itself) matching a project's
-// directory wins. On no match, an interactive run is offered a project
-// rooted at the default (git toplevel, else cwd) on stderr; a
-// non-interactive run refuses with the fixes instead of prompting.
-func ResolveProjectID(ctx context.Context, client *api.Client, stdin io.Reader, stderr io.Writer) (string, error) {
+// directory wins. On no match, an interactive run (stdinIsTTY — a question
+// is only asked of a human; stdout deliberately does not matter, since a
+// redirected stdout still deserves the prompt on stderr) is offered a
+// project rooted at the default (git toplevel, else cwd); a non-interactive
+// run refuses with the fixes instead of prompting.
+func ResolveProjectID(ctx context.Context, client *api.Client, stdin io.Reader, stderr io.Writer, stdinIsTTY bool) (string, error) {
 	canonical, err := paths.CanonicalDir(".")
 	if err != nil {
 		return "", err
@@ -53,10 +54,10 @@ func ResolveProjectID(ctx context.Context, client *api.Client, stdin io.Reader, 
 		dir = parent
 	}
 
-	if !StdinIsTTY() {
+	if !stdinIsTTY {
 		return "", fmt.Errorf("no project contains %s; pass --project <id> or run `atc project create`", canonical)
 	}
-	defaultDir := ProjectRootFor(canonical)
+	defaultDir := projectRootFor(canonical)
 	// The conversation goes to stderr: stdout stays the command's
 	// redirectable output (the created terminal).
 	_, _ = fmt.Fprintf(stderr, "no project contains %s\ncreate a project at %s? [y/N] ", canonical, defaultDir)
@@ -81,14 +82,14 @@ func DefaultProjectDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return ProjectRootFor(canonical), nil
+	return projectRootFor(canonical), nil
 }
 
-// ProjectRootFor asks git for the toplevel of the repository containing
+// projectRootFor asks git for the toplevel of the repository containing
 // the canonical directory — git itself is the authority on what counts as
 // a repository (a stray or malformed .git entry is not one). Outside a
 // repository, or without git installed, the directory is its own root.
-func ProjectRootFor(canonical string) string {
+func projectRootFor(canonical string) string {
 	output, err := exec.Command("git", "-C", canonical, "rev-parse", "--show-toplevel").Output()
 	if err != nil {
 		return canonical


### PR DESCRIPTION
Client-side behavior had accumulated in `cmd/atc` (the ATC-256 walk-up resolution, the ATC-271 attach machinery, and the API-client connection policy), leaving real functionality unreachable outside `package main`. This moves it into a new `internal/cli` package and reduces `cmd/atc` to cobra wiring, flag parsing, and output formatting.

Linear: [ATC-273](https://linear.app/elevenideas/issue/ATC-273/extract-client-side-cli-logic-from-cmdatc-into-internalcli)

## What moved

- **`internal/cli/client.go`** — `NewClient`: the shared API client and its connection policy (ATC_SERVER / ATC_TOKEN over the settled local config port and token file, plus the one-line version-skew warning). Was `newAPIClient` in `cmd/atc/terminal.go`.
- **`internal/cli/project.go`** — `ResolveProjectID` (canonical-cwd walk-up, nearest ancestor wins, TTY create-offer prompt on no match), `DefaultProjectDir`, and `ProjectRootFor` (git-authoritative toplevel). Was in `cmd/atc/project.go`.
- **`internal/cli/attach.go`** — `AttachPreflight` (TTY and loopback checks), `AttachSession` (running-status check, socket validation, the `syscall.Exec` handover), and the `isLoopback` helper. Was in `cmd/atc/terminal.go`.

The `stdinIsTTY` / `stdioIsTerminal` test seams moved with their consumers as `cli.StdinIsTTY` / `cli.StdioIsTerminal`.

## What stayed

- `cmd/atc` keeps the command tree, flag definitions and parsing, help text, tabwriter printers, and the `runWithClient` wrapper (now over `cli.NewClient`).
- The server composition root stays in `main.go` — main is the conventional home for wiring the store, adapter, services, and listener together, and nothing else needs to reuse it.
- The CLI tests stay in `cmd/atc` unchanged apart from the seam references: they exercise the full command surface through `run()`, which is the contract they cover.

No behavior changes; this is a pure move. Motivation beyond tidiness: the TUI (ATC-258) needs exactly this client-side behavior and could not reach it inside `package main`.

`mise run check` passes (build, golangci-lint, sqlc diff, `go test -race ./...`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added streamlined terminal attachment support for interactive sessions.
  - Added automatic project-directory selection when no path is specified.
  - Added shared CLI setup for server connection and authentication.

- **Bug Fixes**
  - Terminal attachment now validates interactive use and permits only local server connections.
  - Added a single warning when client and server versions differ, including during concurrent requests.
  - Improved project detection and Git repository handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->