### PR TITLE
ATC-276 | terminals: rename app to command across the API

### DIFF
--- a/cmd/atc/terminal.go
+++ b/cmd/atc/terminal.go
@@ -51,7 +51,7 @@ finds a repository) and starts in that project's directory; pass --project
 to pick one explicitly. The session survives disconnects and ATC server
 restarts; attach with ` + "`atc terminal attach <id>`" + `,
 or pass ` + "`--attach`" + ` to attach immediately.
-With --app the command runs through your login shell (profile and rc files
+With --command it runs through your login shell (profile and rc files
 loaded); without it you get a plain interactive shell.`,
 		Args: cobra.NoArgs,
 		RunE: runWithClient(func(cmd *cobra.Command, _ []string, client *api.Client, baseURL string) error {
@@ -76,7 +76,7 @@ loaded); without it you get a plain interactive shell.`,
 			if params.Name, err = flags.GetString("name"); err != nil {
 				return err
 			}
-			if params.App, err = flags.GetString("app"); err != nil {
+			if params.Command, err = flags.GetString("command"); err != nil {
 				return err
 			}
 			if params.ProjectID, err = flags.GetString("project"); err != nil {
@@ -100,9 +100,9 @@ loaded); without it you get a plain interactive shell.`,
 			return nil
 		}),
 	}
-	cmd.Flags().String("name", "", "display name (defaults from --app, else \"Shell\")")
+	cmd.Flags().String("name", "", "display name (defaults from --command, else \"Shell\")")
 	cmd.Flags().String("project", "", "project the terminal belongs to (defaults to the project owning the current directory)")
-	cmd.Flags().String("app", "", "command to run through your shell; omit for a plain shell")
+	cmd.Flags().String("command", "", "command to run through your shell; omit for a plain shell")
 	cmd.Flags().Bool("attach", false, "attach to the terminal after creation")
 	return cmd
 }
@@ -239,8 +239,8 @@ func printTerminal(out io.Writer, terminal api.Terminal) {
 	_, _ = fmt.Fprintf(w, "status\t%s\n", statusLabel(terminal))
 	_, _ = fmt.Fprintf(w, "project\t%s\n", terminal.ProjectID)
 	_, _ = fmt.Fprintf(w, "directory\t%s\n", terminal.Directory)
-	if terminal.App != "" {
-		_, _ = fmt.Fprintf(w, "app\t%s\n", terminal.App)
+	if terminal.Command != "" {
+		_, _ = fmt.Fprintf(w, "command\t%s\n", terminal.Command)
 	}
 	_, _ = fmt.Fprintf(w, "created\t%s\n", terminal.CreatedAt.Format("2006-01-02 15:04:05 MST"))
 	_ = w.Flush()
@@ -257,7 +257,7 @@ error status.
 
 Examples:
   atc api /v1/terminals
-  atc api -X POST -d '{"projectId":"proj-x7k2f","app":"hx"}' /v1/terminals
+  atc api -X POST -d '{"projectId":"proj-x7k2f","command":"hx"}' /v1/terminals
   atc api /v1/events`,
 		Args: cobra.ExactArgs(1),
 		RunE: runWithClient(func(cmd *cobra.Command, args []string, client *api.Client, _ string) error {
@@ -325,7 +325,7 @@ func newChildCmd() *cobra.Command {
 			if opts.Directory, err = flags.GetString("dir"); err != nil {
 				return err
 			}
-			if opts.App, err = flags.GetString("app"); err != nil {
+			if opts.Command, err = flags.GetString("command"); err != nil {
 				return err
 			}
 			if code := wrapper.Run(opts); code != 0 {
@@ -337,7 +337,7 @@ func newChildCmd() *cobra.Command {
 	cmd.Flags().String("marker", "", "exit marker file path")
 	cmd.Flags().String("id", "", "terminal id")
 	cmd.Flags().String("dir", "", "working directory")
-	cmd.Flags().String("app", "", "command to run through the shell")
+	cmd.Flags().String("command", "", "command to run through the shell")
 	_ = cmd.MarkFlagRequired("marker")
 	_ = cmd.MarkFlagRequired("id")
 	_ = cmd.MarkFlagRequired("dir")

--- a/cmd/atc/terminal_test.go
+++ b/cmd/atc/terminal_test.go
@@ -143,7 +143,7 @@ func TestTerminalCLILifecycle(t *testing.T) {
 	// project on the test server.
 	projectID := createProjectCLI(t, t.TempDir())
 
-	stdout, _, err := runCLI(t, "terminal", "create", "--app", "hx", "--project", projectID)
+	stdout, _, err := runCLI(t, "terminal", "create", "--command", "hx", "--project", projectID)
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -332,7 +332,7 @@ func TestAPICommand(t *testing.T) {
 
 	// POST with a body creates a terminal through the raw gateway.
 	projectID := createProjectCLI(t, t.TempDir())
-	stdout, _, err = runCLI(t, "api", "-d", `{"app":"hx","projectId":"`+projectID+`"}`, "/v1/terminals")
+	stdout, _, err = runCLI(t, "api", "-d", `{"command":"hx","projectId":"`+projectID+`"}`, "/v1/terminals")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -222,11 +222,11 @@ func TestTerminalMethods(t *testing.T) {
 	client := NewClient(srv.URL, testToken, testClientVersion, nil, nil)
 	ctx := context.Background()
 
-	terminal, err := client.CreateTerminal(ctx, TerminalCreateParams{ProjectID: "proj-x7k2f", App: "hx"})
+	terminal, err := client.CreateTerminal(ctx, TerminalCreateParams{ProjectID: "proj-x7k2f", Command: "hx"})
 	if err != nil || terminal.ID != "term-x7k2f" {
 		t.Fatalf("CreateTerminal = %+v, %v", terminal, err)
 	}
-	want := call{http.MethodPost, "/v1/terminals", "", `{"projectId":"proj-x7k2f","app":"hx"}`}
+	want := call{http.MethodPost, "/v1/terminals", "", `{"projectId":"proj-x7k2f","command":"hx"}`}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("create request (-want +got):\n%s", diff)
 	}

--- a/internal/api/terminal.go
+++ b/internal/api/terminal.go
@@ -26,7 +26,7 @@ type Terminal struct {
 	Name      string         `json:"name" doc:"Display name; the only mutable field."`
 	ProjectID string         `json:"projectId" doc:"Project the terminal belongs to. Immutable; terminals never move between projects."`
 	Directory string         `json:"directory" doc:"Working directory the session started in, copied from the project at create time. Immutable."`
-	App       string         `json:"app,omitempty" doc:"Command launched in the session; empty means a plain shell. Immutable."`
+	Command   string         `json:"command,omitempty" doc:"Command launched in the session; empty means a plain shell. Immutable."`
 	Status    TerminalStatus `json:"status" enum:"running,exited,unreachable,missing" doc:"Server-owned session state."`
 	ExitCode  *int           `json:"exitCode,omitempty" doc:"Recorded exit evidence: exit code, 128+signal for signal deaths, 127 for launch failure. Omitted while running and for ATC-initiated stops."`
 	CreatedAt time.Time      `json:"createdAt"`
@@ -38,8 +38,8 @@ type Terminal struct {
 // else is optional.
 type TerminalCreateParams struct {
 	ProjectID string `json:"projectId" minLength:"1" doc:"Project the terminal belongs to; its directory becomes the terminal's working directory."`
-	Name      string `json:"name,omitempty" doc:"Display name; defaults from app, else \"Shell\"."`
-	App       string `json:"app,omitempty" doc:"Free-form command run through the user's shell; empty starts a plain interactive shell."`
+	Name      string `json:"name,omitempty" doc:"Display name; defaults from command, else \"Shell\"."`
+	Command   string `json:"command,omitempty" doc:"Free-form command run through the user's shell; empty starts a plain interactive shell."`
 }
 
 // TerminalUpdateParams is the PATCH /v1/terminals/{id} request body. Name

--- a/internal/server/terminals.go
+++ b/internal/server/terminals.go
@@ -33,7 +33,7 @@ func registerTerminals(humaAPI huma.API, service *terminals.Service) {
 		Method:        http.MethodPost,
 		Path:          "/v1/terminals",
 		Summary:       "Create a terminal",
-		Description:   "Persists the record, starts the session, and waits a short verification window; a fast-failing app returns exited with its evidence.",
+		Description:   "Persists the record, starts the session, and waits a short verification window; a fast-failing command returns exited with its evidence.",
 		DefaultStatus: http.StatusCreated,
 	}, func(ctx context.Context, input *struct {
 		Body api.TerminalCreateParams

--- a/internal/server/terminals_test.go
+++ b/internal/server/terminals_test.go
@@ -212,7 +212,7 @@ func decodeTerminal(t *testing.T, rec *httptest.ResponseRecorder) api.Terminal {
 func TestTerminalCRUDOverTheWire(t *testing.T) {
 	f := newFixture(t)
 
-	rec := f.request(t, http.MethodPost, "/v1/terminals", f.createTerminalBody(t, api.TerminalCreateParams{App: "hx"}))
+	rec := f.request(t, http.MethodPost, "/v1/terminals", f.createTerminalBody(t, api.TerminalCreateParams{Command: "hx"}))
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("create: got %d, want 201; body %s", rec.Code, rec.Body)
 	}
@@ -263,7 +263,7 @@ func TestUpdateRejectsUnknownAndImmutableFields(t *testing.T) {
 	created := decodeTerminal(t, f.request(t, http.MethodPost, "/v1/terminals", f.createTerminalBody(t, api.TerminalCreateParams{})))
 	for name, body := range map[string]string{
 		"immutable directory": `{"name":"x","directory":"/elsewhere"}`,
-		"immutable app":       `{"app":"vim"}`,
+		"immutable command":   `{"command":"vim"}`,
 		"unknown field":       `{"name":"x","frobnicate":true}`,
 		"missing name":        `{}`,
 	} {
@@ -274,13 +274,13 @@ func TestUpdateRejectsUnknownAndImmutableFields(t *testing.T) {
 	}
 }
 
-func TestCreateWithFailingApp(t *testing.T) {
+func TestCreateWithFailingCommand(t *testing.T) {
 	f := newFixture(t)
 	f.adapter.onCreate = func(id string, _ terminals.CreateSpec) error {
 		writeExitMarker(t, f.markers, id, 127)
 		return errors.New("client exited before the session settled")
 	}
-	rec := f.request(t, http.MethodPost, "/v1/terminals", f.createTerminalBody(t, api.TerminalCreateParams{App: "no-such-tool"}))
+	rec := f.request(t, http.MethodPost, "/v1/terminals", f.createTerminalBody(t, api.TerminalCreateParams{Command: "no-such-tool"}))
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("got %d; body %s", rec.Code, rec.Body)
 	}

--- a/internal/store/gen/models.go
+++ b/internal/store/gen/models.go
@@ -21,7 +21,7 @@ type Terminal struct {
 	ProjectID       string
 	Name            string
 	Directory       string
-	App             sql.NullString
+	Command         sql.NullString
 	CreatedAt       string
 	UpdatedAt       string
 	StopRequestedAt sql.NullString

--- a/internal/store/gen/queries.sql.go
+++ b/internal/store/gen/queries.sql.go
@@ -81,7 +81,7 @@ func (q *Queries) InsertProject(ctx context.Context, arg InsertProjectParams) (i
 
 const insertTerminal = `-- name: InsertTerminal :execrows
 
-INSERT INTO terminals (id, project_id, name, directory, app, created_at, updated_at)
+INSERT INTO terminals (id, project_id, name, directory, command, created_at, updated_at)
 VALUES (?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (id) DO NOTHING
 `
@@ -91,7 +91,7 @@ type InsertTerminalParams struct {
 	ProjectID string
 	Name      string
 	Directory string
-	App       sql.NullString
+	Command   sql.NullString
 	CreatedAt string
 	UpdatedAt string
 }
@@ -108,7 +108,7 @@ func (q *Queries) InsertTerminal(ctx context.Context, arg InsertTerminalParams) 
 		arg.ProjectID,
 		arg.Name,
 		arg.Directory,
-		arg.App,
+		arg.Command,
 		arg.CreatedAt,
 		arg.UpdatedAt,
 	)
@@ -180,7 +180,7 @@ func (q *Queries) ListTerminalIDsByProject(ctx context.Context, projectID string
 }
 
 const listTerminals = `-- name: ListTerminals :many
-SELECT id, project_id, name, directory, app, created_at, updated_at, stop_requested_at, exited_at, exit_code FROM terminals ORDER BY created_at, id
+SELECT id, project_id, name, directory, command, created_at, updated_at, stop_requested_at, exited_at, exit_code FROM terminals ORDER BY created_at, id
 `
 
 func (q *Queries) ListTerminals(ctx context.Context) ([]Terminal, error) {
@@ -197,7 +197,7 @@ func (q *Queries) ListTerminals(ctx context.Context) ([]Terminal, error) {
 			&i.ProjectID,
 			&i.Name,
 			&i.Directory,
-			&i.App,
+			&i.Command,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.StopRequestedAt,

--- a/internal/store/migrations/00003_rename_app_to_command.sql
+++ b/internal/store/migrations/00003_rename_app_to_command.sql
@@ -1,0 +1,5 @@
+-- Rename terminals.app to command (ATC-276): the field holds a free-form
+-- command run through the user's shell — a dev server or build script is
+-- not an "app". NULL still means a plain interactive shell.
+-- +goose Up
+ALTER TABLE terminals RENAME COLUMN app TO command;

--- a/internal/store/queries.sql
+++ b/internal/store/queries.sql
@@ -6,7 +6,7 @@
 -- inserts zero rows and the caller re-rolls, with no check-then-insert
 -- window.
 -- name: InsertTerminal :execrows
-INSERT INTO terminals (id, project_id, name, directory, app, created_at, updated_at)
+INSERT INTO terminals (id, project_id, name, directory, command, created_at, updated_at)
 VALUES (?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (id) DO NOTHING;
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -37,7 +37,7 @@ func TestTerminalsRoundTrip(t *testing.T) {
 
 	records := []TerminalRecord{
 		{ID: "term-aaaaa", ProjectID: "proj-aaaaa", Name: "Shell", Directory: "/home/x", CreatedAt: at(0), UpdatedAt: at(0)},
-		{ID: "term-bbbbb", ProjectID: "proj-aaaaa", Name: "hx", Directory: "/home/x/proj", App: "hx .", CreatedAt: at(1), UpdatedAt: at(1)},
+		{ID: "term-bbbbb", ProjectID: "proj-aaaaa", Name: "hx", Directory: "/home/x/proj", Command: "hx .", CreatedAt: at(1), UpdatedAt: at(1)},
 	}
 	for _, record := range records {
 		if ok, err := terminals.Insert(ctx, record); err != nil || !ok {

--- a/internal/store/terminals.go
+++ b/internal/store/terminals.go
@@ -19,9 +19,9 @@ type TerminalRecord struct {
 	ProjectID string
 	Name      string
 	Directory string
-	// App is the free-form command the terminal was created with; empty
-	// means a plain interactive shell.
-	App       string
+	// Command is the free-form command the terminal was created with;
+	// empty means a plain interactive shell.
+	Command   string
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	// StopRequestedAt is the persisted stop intent (set before the kill is
@@ -50,7 +50,7 @@ func (t *Terminals) Insert(ctx context.Context, record TerminalRecord) (bool, er
 		ProjectID: record.ProjectID,
 		Name:      record.Name,
 		Directory: record.Directory,
-		App:       nullString(record.App),
+		Command:   nullString(record.Command),
 		CreatedAt: formatTime(record.CreatedAt),
 		UpdatedAt: formatTime(record.UpdatedAt),
 	})
@@ -124,7 +124,7 @@ func recordFrom(row gen.Terminal) (TerminalRecord, error) {
 		ProjectID: row.ProjectID,
 		Name:      row.Name,
 		Directory: row.Directory,
-		App:       row.App.String,
+		Command:   row.Command.String,
 	}
 	var err error
 	if record.CreatedAt, err = parseTime(row.CreatedAt); err != nil {

--- a/internal/terminals/service.go
+++ b/internal/terminals/service.go
@@ -317,7 +317,7 @@ func (s *Service) reconcile(ctx context.Context, reap bool) {
 // Create validates the required project reference, copies its directory,
 // mints the ID, persists the record before starting the session (no
 // orphan window), starts it, and waits a short verification window so the
-// common case returns running and a fast-failing app returns exited with
+// common case returns running and a fast-failing command returns exited with
 // real evidence. Failures after the record exists surface through the
 // normal status machinery — there is no separate launch-error path.
 func (s *Service) Create(ctx context.Context, params api.TerminalCreateParams) (api.Terminal, error) {
@@ -336,7 +336,7 @@ func (s *Service) Create(ctx context.Context, params api.TerminalCreateParams) (
 
 	name := params.Name
 	if name == "" {
-		name = params.App
+		name = params.Command
 	}
 	if name == "" {
 		name = "Shell"
@@ -344,7 +344,7 @@ func (s *Service) Create(ctx context.Context, params api.TerminalCreateParams) (
 
 	now := s.now()
 	record := store.TerminalRecord{
-		ProjectID: project.ID, Name: name, Directory: project.Directory, App: params.App,
+		ProjectID: project.ID, Name: name, Directory: project.Directory, Command: params.Command,
 		CreatedAt: now, UpdatedAt: now,
 	}
 	s.ops.Lock()
@@ -380,7 +380,7 @@ func (s *Service) Create(ctx context.Context, params api.TerminalCreateParams) (
 	s.hub.Publish(api.EventTerminalCreated, resource, record.ID)
 	s.ops.Unlock()
 
-	if err := s.adapter.Create(ctx, record.ID, CreateSpec{Directory: record.Directory, App: params.App}); err != nil {
+	if err := s.adapter.Create(ctx, record.ID, CreateSpec{Directory: record.Directory, Command: params.Command}); err != nil {
 		// The record stays: the session may have been born after the
 		// client gave up, and the status machinery reports the truth.
 		s.logger.Warn("session create failed", "terminal", record.ID, "error", err)
@@ -550,7 +550,7 @@ func (e *entry) terminal() api.Terminal {
 		Name:      e.record.Name,
 		ProjectID: e.record.ProjectID,
 		Directory: e.record.Directory,
-		App:       e.record.App,
+		Command:   e.record.Command,
 		Status:    e.status,
 		CreatedAt: e.record.CreatedAt,
 		UpdatedAt: e.record.UpdatedAt,

--- a/internal/terminals/service_test.go
+++ b/internal/terminals/service_test.go
@@ -201,7 +201,7 @@ func TestCreateHappyPath(t *testing.T) {
 		}
 	}
 
-	terminal, err := f.create(ctx, api.TerminalCreateParams{App: "hx"})
+	terminal, err := f.create(ctx, api.TerminalCreateParams{Command: "hx"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,7 +212,7 @@ func TestCreateHappyPath(t *testing.T) {
 		t.Error("session started before the record was persisted")
 	}
 	want := terminal
-	want.Name, want.ProjectID, want.Directory, want.App, want.Status = "hx", f.projectID, f.projectDir, "hx", api.TerminalRunning
+	want.Name, want.ProjectID, want.Directory, want.Command, want.Status = "hx", f.projectID, f.projectDir, "hx", api.TerminalRunning
 	if diff := cmp.Diff(want, terminal); diff != "" {
 		t.Errorf("terminal (-want +got):\n%s", diff)
 	}
@@ -224,20 +224,20 @@ func TestCreateDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if terminal.Name != "Shell" || terminal.Directory != f.projectDir || terminal.App != "" {
-		t.Errorf("defaults = %q %q %q, want Shell %q \"\"", terminal.Name, terminal.Directory, terminal.App, f.projectDir)
+	if terminal.Name != "Shell" || terminal.Directory != f.projectDir || terminal.Command != "" {
+		t.Errorf("defaults = %q %q %q, want Shell %q \"\"", terminal.Name, terminal.Directory, terminal.Command, f.projectDir)
 	}
 }
 
-// A fast-failing app never becomes a session; the wrapper's marker is the
-// evidence and create reports exited with it — no separate error path.
-func TestCreateFastFailingApp(t *testing.T) {
+// A fast-failing command never becomes a session; the wrapper's marker is
+// the evidence and create reports exited with it — no separate error path.
+func TestCreateFastFailingCommand(t *testing.T) {
 	f := newFixture(t)
 	f.adapter.createErr = errors.New("client exited before the session settled")
 	f.adapter.onCreate = func(id string, _ CreateSpec) {
 		plantExitMarker(t, f.markers, id, 127, true)
 	}
-	terminal, err := f.create(context.Background(), api.TerminalCreateParams{App: "no-such-tool"})
+	terminal, err := f.create(context.Background(), api.TerminalCreateParams{Command: "no-such-tool"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -335,7 +335,7 @@ func TestReconcileDecisionTable(t *testing.T) {
 func TestExitedIsStickyAndStaysListed(t *testing.T) {
 	f := newFixture(t)
 	ctx := context.Background()
-	terminal, err := f.create(ctx, api.TerminalCreateParams{App: "build"})
+	terminal, err := f.create(ctx, api.TerminalCreateParams{Command: "build"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/terminals/terminals.go
+++ b/internal/terminals/terminals.go
@@ -48,9 +48,9 @@ type CreateSpec struct {
 	// Directory the workload starts in (the wrapper chdirs; a bad
 	// directory surfaces as launch-failure evidence, not a create error).
 	Directory string
-	// App is the free-form command run through the user's shell; empty
+	// Command is the free-form command run through the user's shell; empty
 	// starts a plain interactive login shell.
-	App string
+	Command string
 }
 
 // Adapter is the session backend seam. Implementations own every backend

--- a/internal/terminals/wrapper/wrapper.go
+++ b/internal/terminals/wrapper/wrapper.go
@@ -4,12 +4,12 @@
 // process supervision in the containerd-shim/tini shape. zmx remains the
 // sole durable supervisor; the wrapper only records.
 //
-// Shell invocation (decided in the spec): with no app it execs $SHELL
+// Shell invocation (decided in the spec): with no command it execs $SHELL
 // (fallback /bin/sh) with the traditional login convention
 // (argv[0] = "-zsh") — byte-for-byte what zmx does for a hand-opened
-// session. With an app it runs $SHELL -i -l -c "<app>", so profile and rc
-// files load before the app, exactly as if the user had opened a terminal
-// and typed it. App exit (or shell exit) ends the terminal.
+// session. With a command it runs $SHELL -i -l -c "<command>", so profile
+// and rc files load before the command, exactly as if the user had opened
+// a terminal and typed it. Command exit (or shell exit) ends the terminal.
 package wrapper
 
 import (
@@ -36,9 +36,9 @@ type Options struct {
 	TerminalID string
 	// Directory the workload starts in.
 	Directory string
-	// App is the free-form command to run through the shell; empty starts
-	// a plain interactive login shell.
-	App string
+	// Command is the free-form command to run through the shell; empty
+	// starts a plain interactive login shell.
+	Command string
 }
 
 // Run supervises the workload and returns the wrapper's own exit code
@@ -53,11 +53,11 @@ func Run(opts Options) int {
 		shell = "/bin/sh"
 	}
 	var cmd *exec.Cmd
-	if opts.App == "" {
+	if opts.Command == "" {
 		cmd = exec.Command(shell)
 		cmd.Args = []string{"-" + filepath.Base(shell)}
 	} else {
-		cmd = exec.Command(shell, "-i", "-l", "-c", opts.App)
+		cmd = exec.Command(shell, "-i", "-l", "-c", opts.Command)
 	}
 	cmd.Dir = opts.Directory
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr

--- a/internal/terminals/wrapper/wrapper_test.go
+++ b/internal/terminals/wrapper/wrapper_test.go
@@ -24,11 +24,11 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func runWrapper(t *testing.T, app string, directory string) (int, *exitmarker.Marker) {
+func runWrapper(t *testing.T, command string, directory string) (int, *exitmarker.Marker) {
 	t.Helper()
 	dir := t.TempDir()
 	path := exitmarker.Path(dir, "term-aaaaa")
-	code := Run(Options{MarkerPath: path, TerminalID: "term-aaaaa", Directory: directory, App: app})
+	code := Run(Options{MarkerPath: path, TerminalID: "term-aaaaa", Directory: directory, Command: command})
 	marker, err := exitmarker.Read(dir, "term-aaaaa")
 	if err != nil {
 		t.Fatal(err)
@@ -36,7 +36,7 @@ func runWrapper(t *testing.T, app string, directory string) (int, *exitmarker.Ma
 	return code, marker
 }
 
-func TestAppExitCodeRecorded(t *testing.T) {
+func TestCommandExitCodeRecorded(t *testing.T) {
 	t.Setenv("SHELL", "/bin/sh")
 	code, marker := runWrapper(t, "exit 3", t.TempDir())
 	if code != 3 {
@@ -83,13 +83,13 @@ func TestForwardsSignalsToChild(t *testing.T) {
 	ready := filepath.Join(t.TempDir(), "ready")
 	// The backgrounded sleep must not inherit the test's output pipes, or
 	// an orphan holds go test's stdout open for the full 30 seconds.
-	app := "trap 'exit 42' HUP; : > " + ready + "; sleep 30 >/dev/null 2>&1 & wait"
+	command := "trap 'exit 42' HUP; : > " + ready + "; sleep 30 >/dev/null 2>&1 & wait"
 
 	dir := t.TempDir()
 	path := exitmarker.Path(dir, "term-aaaaa")
 	done := make(chan int, 1)
 	go func() {
-		done <- Run(Options{MarkerPath: path, TerminalID: "term-aaaaa", Directory: "/", App: app})
+		done <- Run(Options{MarkerPath: path, TerminalID: "term-aaaaa", Directory: "/", Command: command})
 	}()
 
 	deadline := time.Now().Add(5 * time.Second)
@@ -117,29 +117,29 @@ func TestForwardsSignalsToChild(t *testing.T) {
 	}
 }
 
-// The exact shell argv is the fidelity contract: a plain terminal gets the
-// traditional login convention (argv[0] = "-shell", nothing else); an app
-// gets `$SHELL -i -l -c "<app>"`.
+// The exact shell argv is the fidelity contract: a plain terminal gets
+// the traditional login convention (argv[0] = "-shell", nothing else); a
+// command gets `$SHELL -i -l -c "<command>"`.
 func TestShellInvocation(t *testing.T) {
 	self, err := os.Executable()
 	if err != nil {
 		t.Fatal(err)
 	}
 	for name, tc := range map[string]struct {
-		app  string
-		want func() []string
+		command string
+		want    func() []string
 	}{
 		"plain shell": {"", func() []string {
 			return []string{"-" + filepath.Base(self)}
 		}},
-		"app": {"hx .", func() []string {
+		"command": {"hx .", func() []string {
 			return []string{self, "-i", "-l", "-c", "hx ."}
 		}},
 	} {
 		record := filepath.Join(t.TempDir(), "argv")
 		t.Setenv("SHELL", self)
 		t.Setenv("WRAPPER_TEST_RECORD", record)
-		code, marker := runWrapper(t, tc.app, "/")
+		code, marker := runWrapper(t, tc.command, "/")
 		if code != 0 || !marker.Exited() {
 			t.Fatalf("%s: Run = %d, marker %+v", name, code, marker)
 		}

--- a/internal/terminals/zmx/zmx.go
+++ b/internal/terminals/zmx/zmx.go
@@ -240,8 +240,8 @@ func (a *Adapter) Create(ctx context.Context, id string, spec terminals.CreateSp
 
 	argv := []string{"attach", id, a.wrapper, "__child",
 		"--marker", exitmarker.Path(a.markerDir, id), "--id", id, "--dir", spec.Directory}
-	if spec.App != "" {
-		argv = append(argv, "--app", spec.App)
+	if spec.Command != "" {
+		argv = append(argv, "--command", spec.Command)
 	}
 	cmd := exec.Command(executable, argv...)
 	cmd.Env = Env(a.socketDir, true)

--- a/internal/terminals/zmx/zmx_test.go
+++ b/internal/terminals/zmx/zmx_test.go
@@ -20,17 +20,17 @@ import (
 
 // TestMain doubles as the wrapper executable for the real-zmx integration
 // tests: re-exec'd as `<test-binary> __child --marker … --id … --dir …
-// [--app …]`, it runs the real wrapper exactly the way cmd/atc does.
+// [--command …]`, it runs the real wrapper exactly the way cmd/atc does.
 func TestMain(m *testing.M) {
 	if len(os.Args) > 1 && os.Args[1] == "__child" {
 		flags := flag.NewFlagSet("__child", flag.ExitOnError)
 		marker := flags.String("marker", "", "")
 		id := flags.String("id", "", "")
 		dir := flags.String("dir", "", "")
-		app := flags.String("app", "", "")
+		command := flags.String("command", "", "")
 		_ = flags.Parse(os.Args[2:])
 		os.Exit(wrapper.Run(wrapper.Options{
-			MarkerPath: *marker, TerminalID: *id, Directory: *dir, App: *app,
+			MarkerPath: *marker, TerminalID: *id, Directory: *dir, Command: *command,
 		}))
 	}
 	os.Exit(m.Run())
@@ -181,7 +181,7 @@ func TestRealZmxLifecycle(t *testing.T) {
 	}
 
 	t.Setenv("SHELL", "/bin/sh")
-	if err := adapter.Create(ctx, id, terminals.CreateSpec{Directory: "/", App: "sleep 60"}); err != nil {
+	if err := adapter.Create(ctx, id, terminals.CreateSpec{Directory: "/", Command: "sleep 60"}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	sessions, err := adapter.Inventory(ctx)
@@ -203,7 +203,7 @@ func TestRealZmxLifecycle(t *testing.T) {
 		}
 		if marker != nil {
 			if marker.Exited() {
-				t.Fatalf("marker = %+v, want un-exited while the app runs", marker)
+				t.Fatalf("marker = %+v, want un-exited while the command runs", marker)
 			}
 			break
 		}


### PR DESCRIPTION
Renames the terminal create parameter `app` to `command` everywhere it surfaces. The field always held a free-form string run through the user's shell — a dev server or build script fits, so "app" was misleadingly narrow — and zmx itself calls this a command (`attach <name> [command...]`), as do tmux, docker, and systemd for the same shape.

Covered surfaces:
- HTTP API: `app` → `command` on the terminal resource and create params
- CLI: `atc terminal create --command`, `atc api` example, `get` output row
- Wrapper: `atc __child --command` flag and `wrapper.Options.Command`
- zmx adapter: `CreateSpec.Command`, argv it hands the wrapper
- Store: `terminals.command` column via migration 00003 (`ALTER TABLE ... RENAME COLUMN`, data preserved), sqlc regenerated
- All comments, doc strings, and test names

Empty still means a plain interactive shell. `mise run check` passes (build, lint, generate-check, race tests).

Closes ATC-276.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Renamed the terminal launch field from `app` to `command` across the API and CLI.
  - Updated terminal creation examples, help text, output labels, and request payloads to use `command`.
  - Existing integrations using the `app` field must migrate to `command`.

- **Bug Fixes**
  - Preserved interactive shell behavior when no command is supplied.
  - Continued supporting command execution, failure reporting, and exit-status handling with the updated terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->