### PR TITLE
ATC-254 | agents: catalog, launch, and the atc agent CLI family

### DIFF
--- a/cmd/atc/agent.go
+++ b/cmd/atc/agent.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jeremytondo/atc/internal/api"
+	"github.com/jeremytondo/atc/internal/cli"
+)
+
+// The atc agent family (ATC-254): the catalog reads plus launch — the one
+// human-facing way to start an agent TUI. Commands speak only the shared
+// API client; the server owns resolution, probing, and composition.
+
+func newAgentCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "agent",
+		Short: "See and launch the coding agents ATC works with",
+		Args:  cobra.NoArgs,
+		RunE: func(*cobra.Command, []string) error {
+			return fmt.Errorf("usage: atc agent <list|get|launch>")
+		},
+	}
+	cmd.AddCommand(newAgentListCmd(), newAgentGetCmd(), newAgentLaunchCmd())
+	return cmd
+}
+
+func newAgentListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List agents with per-capability availability",
+		Long: `List the agents this ATC server can work with. Availability is probed
+against the server's machine on every call: an unavailable capability
+names how to install the missing tool (see ` + "`atc agent get <id>`" + `).`,
+		Args: cobra.NoArgs,
+		RunE: runWithClient(func(cmd *cobra.Command, _ []string, client *api.Client, _ string) error {
+			agents, err := client.Agents(cmd.Context())
+			if err != nil {
+				return err
+			}
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 2, 8, 2, ' ', 0)
+			_, _ = fmt.Fprintln(w, "ID\tNAME\tCAPABILITIES")
+			for _, agent := range agents {
+				capabilities := make([]string, 0, len(agent.Capabilities))
+				for _, capability := range agent.Capabilities {
+					capabilities = append(capabilities, fmt.Sprintf("%s (%s)", capability.Capability, availabilityLabel(capability.Available)))
+				}
+				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", agent.ID, agent.Name, strings.Join(capabilities, ", "))
+			}
+			return w.Flush()
+		}),
+	}
+}
+
+func newAgentGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <id>",
+		Short: "Show one agent, including how to install it",
+		Args:  cobra.ExactArgs(1),
+		RunE: runWithClient(func(cmd *cobra.Command, args []string, client *api.Client, _ string) error {
+			agent, err := client.Agent(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			printAgent(cmd.OutOrStdout(), agent)
+			return nil
+		}),
+	}
+}
+
+func newAgentLaunchCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "launch <id>",
+		Short: "Launch an agent TUI in a new terminal",
+		Long: `Launch the agent's TUI in a managed terminal — the terminal lands in the
+project owning the current directory (pass --project to pick one) and
+starts in that project's directory. The session survives disconnects and
+server restarts; attach with ` + "`atc terminal attach <id>`" + `, or pass
+` + "`--attach`" + ` to attach immediately. The server resolves the launch
+command; a missing agent binary is refused with its install hint before
+anything is created.`,
+		Args: cobra.ExactArgs(1),
+		RunE: runWithClient(func(cmd *cobra.Command, args []string, client *api.Client, baseURL string) error {
+			flags := cmd.Flags()
+			attach, err := flags.GetBool("attach")
+			if err != nil {
+				return err
+			}
+			var attacher cli.SessionAttacher
+			if attach {
+				if err := cli.AttachPreflight(baseURL, stdioIsTerminal()); err != nil {
+					return err
+				}
+				if attacher, err = newSessionAttacher(); err != nil {
+					return err
+				}
+				if err := attacher.Preflight(); err != nil {
+					return err
+				}
+			}
+			params := api.AgentLaunchParams{}
+			if params.Name, err = flags.GetString("name"); err != nil {
+				return err
+			}
+			if params.ProjectID, err = flags.GetString("project"); err != nil {
+				return err
+			}
+			if params.ProjectID == "" {
+				if params.ProjectID, err = cli.ResolveProjectID(cmd.Context(), client, cmd.InOrStdin(), cmd.ErrOrStderr(), stdinIsTTY()); err != nil {
+					return err
+				}
+			}
+			terminal, err := client.LaunchAgent(cmd.Context(), args[0], params)
+			if err != nil {
+				return err
+			}
+			printTerminal(cmd.OutOrStdout(), terminal)
+			if attach {
+				if err := cli.AttachSession(terminal, attacher); err != nil {
+					return fmt.Errorf("%w; the terminal was created; retry with: atc terminal attach %s", err, terminal.ID)
+				}
+			}
+			return nil
+		}),
+	}
+	cmd.Flags().String("name", "", "display name (defaults to the agent's display name)")
+	cmd.Flags().String("project", "", "project the terminal belongs to (defaults to the project owning the current directory)")
+	cmd.Flags().Bool("attach", false, "attach to the terminal after launch")
+	return cmd
+}
+
+func availabilityLabel(available bool) string {
+	if available {
+		return "available"
+	}
+	return "unavailable"
+}
+
+func printAgent(out io.Writer, agent api.Agent) {
+	w := tabwriter.NewWriter(out, 2, 8, 2, ' ', 0)
+	_, _ = fmt.Fprintf(w, "id\t%s\n", agent.ID)
+	_, _ = fmt.Fprintf(w, "name\t%s\n", agent.Name)
+	for _, capability := range agent.Capabilities {
+		_, _ = fmt.Fprintf(w, "%s\t%s\tinstall: %s\n", capability.Capability, availabilityLabel(capability.Available), capability.InstallHint)
+	}
+	_ = w.Flush()
+}

--- a/cmd/atc/agent.go
+++ b/cmd/atc/agent.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -9,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/jeremytondo/atc/internal/api"
-	"github.com/jeremytondo/atc/internal/cli"
 )
 
 // The atc agent family (ATC-254): the catalog reads plus launch — the one
@@ -35,7 +35,7 @@ func newAgentListCmd() *cobra.Command {
 		Short: "List agents with per-capability availability",
 		Long: `List the agents this ATC server can work with. Availability is probed
 against the server's machine on every call: an unavailable capability
-names how to install the missing tool (see ` + "`atc agent get <id>`" + `).`,
+names how to install the missing tool.`,
 		Args: cobra.NoArgs,
 		RunE: runWithClient(func(cmd *cobra.Command, _ []string, client *api.Client, _ string) error {
 			agents, err := client.Agents(cmd.Context())
@@ -47,7 +47,11 @@ names how to install the missing tool (see ` + "`atc agent get <id>`" + `).`,
 			for _, agent := range agents {
 				capabilities := make([]string, 0, len(agent.Capabilities))
 				for _, capability := range agent.Capabilities {
-					capabilities = append(capabilities, fmt.Sprintf("%s (%s)", capability.Capability, availabilityLabel(capability.Available)))
+					label := fmt.Sprintf("%s (%s)", capability.Capability, availabilityLabel(capability.Available))
+					if !capability.Available {
+						label = fmt.Sprintf("%s (unavailable; install: %s)", capability.Capability, capability.InstallHint)
+					}
+					capabilities = append(capabilities, label)
 				}
 				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", agent.ID, agent.Name, strings.Join(capabilities, ", "))
 			}
@@ -85,46 +89,9 @@ command; a missing agent binary is refused with its install hint before
 anything is created.`,
 		Args: cobra.ExactArgs(1),
 		RunE: runWithClient(func(cmd *cobra.Command, args []string, client *api.Client, baseURL string) error {
-			flags := cmd.Flags()
-			attach, err := flags.GetBool("attach")
-			if err != nil {
-				return err
-			}
-			var attacher cli.SessionAttacher
-			if attach {
-				if err := cli.AttachPreflight(baseURL, stdioIsTerminal()); err != nil {
-					return err
-				}
-				if attacher, err = newSessionAttacher(); err != nil {
-					return err
-				}
-				if err := attacher.Preflight(); err != nil {
-					return err
-				}
-			}
-			params := api.AgentLaunchParams{}
-			if params.Name, err = flags.GetString("name"); err != nil {
-				return err
-			}
-			if params.ProjectID, err = flags.GetString("project"); err != nil {
-				return err
-			}
-			if params.ProjectID == "" {
-				if params.ProjectID, err = cli.ResolveProjectID(cmd.Context(), client, cmd.InOrStdin(), cmd.ErrOrStderr(), stdinIsTTY()); err != nil {
-					return err
-				}
-			}
-			terminal, err := client.LaunchAgent(cmd.Context(), args[0], params)
-			if err != nil {
-				return err
-			}
-			printTerminal(cmd.OutOrStdout(), terminal)
-			if attach {
-				if err := cli.AttachSession(terminal, attacher); err != nil {
-					return fmt.Errorf("%w; the terminal was created; retry with: atc terminal attach %s", err, terminal.ID)
-				}
-			}
-			return nil
+			return createAndMaybeAttach(cmd, client, baseURL, func(ctx context.Context, projectID, name string) (api.Terminal, error) {
+				return client.LaunchAgent(ctx, args[0], api.AgentLaunchParams{ProjectID: projectID, Name: name})
+			})
 		}),
 	}
 	cmd.Flags().String("name", "", "display name (defaults to the agent's display name)")

--- a/cmd/atc/agent_test.go
+++ b/cmd/atc/agent_test.go
@@ -19,8 +19,10 @@ func TestAgentListCLI(t *testing.T) {
 		!strings.Contains(stdout, "tui (available)") {
 		t.Errorf("list output missing claude's availability:\n%s", stdout)
 	}
-	if !strings.Contains(stdout, "codex") || !strings.Contains(stdout, "tui (unavailable)") {
-		t.Errorf("list output missing codex's unavailability:\n%s", stdout)
+	// The acceptance bar: an unavailable capability names its install
+	// command right in the list.
+	if !strings.Contains(stdout, "codex") || !strings.Contains(stdout, "tui (unavailable; install: npm install -g @openai/codex)") {
+		t.Errorf("list output missing codex's unavailability and install hint:\n%s", stdout)
 	}
 }
 

--- a/cmd/atc/agent_test.go
+++ b/cmd/atc/agent_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The test server's catalog is the shipped one with claude's binary
+// available and codex's missing (see startTestServer).
+
+func TestAgentListCLI(t *testing.T) {
+	startTestServer(t)
+	stdout, _, err := runCLI(t, "agent", "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "claude") || !strings.Contains(stdout, "Claude Code") ||
+		!strings.Contains(stdout, "tui (available)") {
+		t.Errorf("list output missing claude's availability:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "codex") || !strings.Contains(stdout, "tui (unavailable)") {
+		t.Errorf("list output missing codex's unavailability:\n%s", stdout)
+	}
+}
+
+func TestAgentGetCLI(t *testing.T) {
+	startTestServer(t)
+	stdout, _, err := runCLI(t, "agent", "get", "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Entry details include the install hint whether or not it is needed.
+	if !strings.Contains(stdout, "codex") || !strings.Contains(stdout, "unavailable") ||
+		!strings.Contains(stdout, "npm install -g @openai/codex") {
+		t.Errorf("get output:\n%s", stdout)
+	}
+
+	if _, _, err := runCLI(t, "agent", "get", "nonexistent"); err == nil || !strings.Contains(err.Error(), "404") {
+		t.Errorf("get unknown = %v, want a 404 problem", err)
+	}
+}
+
+func TestAgentLaunchCLI(t *testing.T) {
+	startTestServer(t)
+	projectID := createProjectCLI(t, t.TempDir())
+
+	stdout, _, err := runCLI(t, "agent", "launch", "claude", "--project", projectID)
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	id := regexp.MustCompile(`term-[a-z2-9]{5}`).FindString(stdout)
+	if id == "" || !strings.Contains(stdout, "running") {
+		t.Fatalf("launch output has no running terminal:\n%s", stdout)
+	}
+	if !regexp.MustCompile(`(?m)^agent\s+claude$`).MatchString(stdout) || !strings.Contains(stdout, "Claude Code") {
+		t.Errorf("launch output missing the agent label or default name:\n%s", stdout)
+	}
+
+	// The terminal is a normal terminal from here: listed, labeled, deletable.
+	stdout, _, err = runCLI(t, "terminal", "list")
+	if err != nil || !strings.Contains(stdout, id) {
+		t.Errorf("terminal list = %q, %v", stdout, err)
+	}
+}
+
+func TestAgentLaunchUnavailableCLI(t *testing.T) {
+	startTestServer(t)
+	projectID := createProjectCLI(t, t.TempDir())
+
+	_, _, err := runCLI(t, "agent", "launch", "codex", "--project", projectID)
+	if err == nil || !strings.Contains(err.Error(), `"codex"`) ||
+		!strings.Contains(err.Error(), "npm install -g @openai/codex") {
+		t.Errorf("launch unavailable = %v, want the command and its install hint", err)
+	}
+	stdout, _, listErr := runCLI(t, "terminal", "list")
+	if listErr != nil || !strings.Contains(stdout, "no terminals") {
+		t.Errorf("a refused launch left a terminal: %q, %v", stdout, listErr)
+	}
+}
+
+// Launch --attach shares terminal create's preflights: a non-TTY refusal
+// happens before anything is created.
+func TestAgentLaunchAttachWithoutTTYCreatesNothing(t *testing.T) {
+	startTestServer(t)
+	_, _, err := runCLI(t, "agent", "launch", "claude", "--attach")
+	if err == nil || !strings.Contains(err.Error(), "stdin and stdout must be TTYs") {
+		t.Errorf("launch attach without TTY = %v, want a TTY refusal", err)
+	}
+	stdout, _, listErr := runCLI(t, "terminal", "list")
+	if listErr != nil || !strings.Contains(stdout, "no terminals") {
+		t.Errorf("list after TTY refusal = %q, %v", stdout, listErr)
+	}
+}

--- a/cmd/atc/main.go
+++ b/cmd/atc/main.go
@@ -19,6 +19,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/jeremytondo/atc/internal/agents"
+	"github.com/jeremytondo/atc/internal/agents/claude"
+	"github.com/jeremytondo/atc/internal/agents/codex"
 	"github.com/jeremytondo/atc/internal/api"
 	"github.com/jeremytondo/atc/internal/authtoken"
 	"github.com/jeremytondo/atc/internal/cli"
@@ -85,7 +88,7 @@ expose on the tailnet without the flag.`,
 			return cmd.Help()
 		},
 	}
-	root.AddCommand(newTerminalCmd(), newProjectCmd(), newAPICmd(), newVersionCmd(),
+	root.AddCommand(newAgentCmd(), newTerminalCmd(), newProjectCmd(), newAPICmd(), newVersionCmd(),
 		newUpgradeCmd(), newServerCmd(), newChildCmd())
 	return root
 }
@@ -513,12 +516,24 @@ func serverRunUntilCancelled(cmd *cobra.Command, _ []string) error {
 	// observes pre-reconcile state (legacy's rule).
 	terminalService.Reconcile(ctx)
 
+	// The agent catalog: one registration line per built-in agent; a
+	// duplicate id fails the boot.
+	catalog, err := agents.NewCatalog(claude.Entry(), codex.Entry())
+	if err != nil {
+		return err
+	}
+	agentService := agents.NewService(agents.Options{
+		Catalog:   catalog,
+		Terminals: terminalService,
+	})
+
 	handler := server.NewHandler(server.Options{
 		Verify:    tokens.Verify,
 		Version:   versionValue,
 		Logger:    logger,
 		Terminals: terminalService,
 		Projects:  projectService,
+		Agents:    agentService,
 		Events:    hub,
 	})
 

--- a/cmd/atc/main.go
+++ b/cmd/atc/main.go
@@ -516,16 +516,15 @@ func serverRunUntilCancelled(cmd *cobra.Command, _ []string) error {
 	// observes pre-reconcile state (legacy's rule).
 	terminalService.Reconcile(ctx)
 
-	// The agent catalog: one registration line per built-in agent; a
-	// duplicate id fails the boot.
-	catalog, err := agents.NewCatalog(claude.Entry(), codex.Entry())
+	// One registration line per built-in agent; a duplicate id fails the
+	// boot.
+	agentService, err := agents.NewService(agents.Options{
+		Entries:   []agents.Entry{claude.Entry(), codex.Entry()},
+		Terminals: terminalService,
+	})
 	if err != nil {
 		return err
 	}
-	agentService := agents.NewService(agents.Options{
-		Catalog:   catalog,
-		Terminals: terminalService,
-	})
 
 	handler := server.NewHandler(server.Options{
 		Verify:    tokens.Verify,

--- a/cmd/atc/terminal.go
+++ b/cmd/atc/terminal.go
@@ -242,6 +242,9 @@ func printTerminal(out io.Writer, terminal api.Terminal) {
 	if terminal.Command != "" {
 		_, _ = fmt.Fprintf(w, "command\t%s\n", terminal.Command)
 	}
+	if terminal.Agent != "" {
+		_, _ = fmt.Fprintf(w, "agent\t%s\n", terminal.Agent)
+	}
 	_, _ = fmt.Fprintf(w, "created\t%s\n", terminal.CreatedAt.Format("2006-01-02 15:04:05 MST"))
 	_ = w.Flush()
 }

--- a/cmd/atc/terminal.go
+++ b/cmd/atc/terminal.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -55,49 +56,13 @@ With --command it runs through your login shell (profile and rc files
 loaded); without it you get a plain interactive shell.`,
 		Args: cobra.NoArgs,
 		RunE: runWithClient(func(cmd *cobra.Command, _ []string, client *api.Client, baseURL string) error {
-			flags := cmd.Flags()
-			attach, err := flags.GetBool("attach")
+			command, err := cmd.Flags().GetString("command")
 			if err != nil {
 				return err
 			}
-			var attacher cli.SessionAttacher
-			if attach {
-				if err := cli.AttachPreflight(baseURL, stdioIsTerminal()); err != nil {
-					return err
-				}
-				if attacher, err = newSessionAttacher(); err != nil {
-					return err
-				}
-				if err := attacher.Preflight(); err != nil {
-					return err
-				}
-			}
-			params := api.TerminalCreateParams{}
-			if params.Name, err = flags.GetString("name"); err != nil {
-				return err
-			}
-			if params.Command, err = flags.GetString("command"); err != nil {
-				return err
-			}
-			if params.ProjectID, err = flags.GetString("project"); err != nil {
-				return err
-			}
-			if params.ProjectID == "" {
-				if params.ProjectID, err = cli.ResolveProjectID(cmd.Context(), client, cmd.InOrStdin(), cmd.ErrOrStderr(), stdinIsTTY()); err != nil {
-					return err
-				}
-			}
-			terminal, err := client.CreateTerminal(cmd.Context(), params)
-			if err != nil {
-				return err
-			}
-			printTerminal(cmd.OutOrStdout(), terminal)
-			if attach {
-				if err := cli.AttachSession(terminal, attacher); err != nil {
-					return fmt.Errorf("%w; the terminal was created; retry with: atc terminal attach %s", err, terminal.ID)
-				}
-			}
-			return nil
+			return createAndMaybeAttach(cmd, client, baseURL, func(ctx context.Context, projectID, name string) (api.Terminal, error) {
+				return client.CreateTerminal(ctx, api.TerminalCreateParams{ProjectID: projectID, Name: name, Command: command})
+			})
 		}),
 	}
 	cmd.Flags().String("name", "", "display name (defaults from --command, else \"Shell\")")
@@ -105,6 +70,55 @@ loaded); without it you get a plain interactive shell.`,
 	cmd.Flags().String("command", "", "command to run through your shell; omit for a plain shell")
 	cmd.Flags().Bool("attach", false, "attach to the terminal after creation")
 	return cmd
+}
+
+// createAndMaybeAttach is the workflow shared by terminal create and
+// agent launch: attach preflights run before anything is created, the
+// project defaults from the current directory, and a failed attach after
+// a successful create reports the terminal and the retry remedy. create
+// performs the API call with the resolved project and name flags.
+func createAndMaybeAttach(cmd *cobra.Command, client *api.Client, baseURL string, create func(ctx context.Context, projectID, name string) (api.Terminal, error)) error {
+	flags := cmd.Flags()
+	attach, err := flags.GetBool("attach")
+	if err != nil {
+		return err
+	}
+	var attacher cli.SessionAttacher
+	if attach {
+		if err := cli.AttachPreflight(baseURL, stdioIsTerminal()); err != nil {
+			return err
+		}
+		if attacher, err = newSessionAttacher(); err != nil {
+			return err
+		}
+		if err := attacher.Preflight(); err != nil {
+			return err
+		}
+	}
+	name, err := flags.GetString("name")
+	if err != nil {
+		return err
+	}
+	projectID, err := flags.GetString("project")
+	if err != nil {
+		return err
+	}
+	if projectID == "" {
+		if projectID, err = cli.ResolveProjectID(cmd.Context(), client, cmd.InOrStdin(), cmd.ErrOrStderr(), stdinIsTTY()); err != nil {
+			return err
+		}
+	}
+	terminal, err := create(cmd.Context(), projectID, name)
+	if err != nil {
+		return err
+	}
+	printTerminal(cmd.OutOrStdout(), terminal)
+	if attach {
+		if err := cli.AttachSession(terminal, attacher); err != nil {
+			return fmt.Errorf("%w; the terminal was created; retry with: atc terminal attach %s", err, terminal.ID)
+		}
+	}
+	return nil
 }
 
 func newTerminalGetCmd() *cobra.Command {

--- a/cmd/atc/terminal_test.go
+++ b/cmd/atc/terminal_test.go
@@ -81,12 +81,8 @@ func startTestServer(t *testing.T) *cliAdapter {
 		Terminals:  db.Terminals(),
 		Hub:        hub,
 	})
-	catalog, err := agents.NewCatalog(claude.Entry(), codex.Entry())
-	if err != nil {
-		t.Fatal(err)
-	}
-	agentService := agents.NewService(agents.Options{
-		Catalog:   catalog,
+	agentService, err := agents.NewService(agents.Options{
+		Entries:   []agents.Entry{claude.Entry(), codex.Entry()},
 		Terminals: service,
 		// The probe never consults this machine's PATH: claude "exists",
 		// codex does not.
@@ -97,6 +93,9 @@ func startTestServer(t *testing.T) *cliAdapter {
 			return "", errors.New("executable file not found in $PATH")
 		},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	handler := server.NewHandler(server.Options{
 		Verify:    func(authorization string) bool { return authorization == "Bearer "+cliTestToken },
 		Version:   "v0.0.0-test",

--- a/cmd/atc/terminal_test.go
+++ b/cmd/atc/terminal_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http/httptest"
@@ -13,6 +14,9 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/jeremytondo/atc/internal/agents"
+	"github.com/jeremytondo/atc/internal/agents/claude"
+	"github.com/jeremytondo/atc/internal/agents/codex"
 	"github.com/jeremytondo/atc/internal/events"
 	"github.com/jeremytondo/atc/internal/projects"
 	"github.com/jeremytondo/atc/internal/server"
@@ -77,11 +81,28 @@ func startTestServer(t *testing.T) *cliAdapter {
 		Terminals:  db.Terminals(),
 		Hub:        hub,
 	})
+	catalog, err := agents.NewCatalog(claude.Entry(), codex.Entry())
+	if err != nil {
+		t.Fatal(err)
+	}
+	agentService := agents.NewService(agents.Options{
+		Catalog:   catalog,
+		Terminals: service,
+		// The probe never consults this machine's PATH: claude "exists",
+		// codex does not.
+		LookPath: func(name string) (string, error) {
+			if name == "claude" {
+				return "/bin/claude", nil
+			}
+			return "", errors.New("executable file not found in $PATH")
+		},
+	})
 	handler := server.NewHandler(server.Options{
 		Verify:    func(authorization string) bool { return authorization == "Bearer "+cliTestToken },
 		Version:   "v0.0.0-test",
 		Terminals: service,
 		Projects:  projectService,
+		Agents:    agentService,
 		Events:    hub,
 	})
 	srv := httptest.NewServer(handler)

--- a/internal/agents/agents.go
+++ b/internal/agents/agents.go
@@ -14,8 +14,6 @@
 // agents (ATC-251 doctrine).
 package agents
 
-import "fmt"
-
 // CapabilityTUI is the one capability in ATC-254: the agent can be
 // launched as a TUI in an ATC-managed terminal.
 const CapabilityTUI = "tui"
@@ -42,38 +40,4 @@ type Entry struct {
 	ID   string
 	Name string
 	TUI  TUIAdapter
-}
-
-// Catalog is the compiled-in registry: fixed at construction, listed in
-// registration order, no create/update/delete.
-type Catalog struct {
-	entries []Entry
-	index   map[string]int
-}
-
-// NewCatalog assembles the catalog from built-in registrations. A
-// duplicate id is a startup error — the composition root fails the boot.
-func NewCatalog(entries ...Entry) (*Catalog, error) {
-	catalog := &Catalog{entries: entries, index: make(map[string]int, len(entries))}
-	for i, entry := range entries {
-		if _, taken := catalog.index[entry.ID]; taken {
-			return nil, fmt.Errorf("duplicate agent id %q", entry.ID)
-		}
-		catalog.index[entry.ID] = i
-	}
-	return catalog, nil
-}
-
-// Entries returns the catalog in registration order.
-func (c *Catalog) Entries() []Entry {
-	return c.entries
-}
-
-// Get returns the entry for id, if registered.
-func (c *Catalog) Get(id string) (Entry, bool) {
-	i, ok := c.index[id]
-	if !ok {
-		return Entry{}, false
-	}
-	return c.entries[i], true
 }

--- a/internal/agents/agents.go
+++ b/internal/agents/agents.go
@@ -1,0 +1,79 @@
+// Package agents is the Agents domain (ATC-254): a compiled-in, read-only
+// catalog of the coding agents ATC can work with, and the launch glue that
+// turns an agent reference into a terminal create. The catalog has no
+// storage and emits no events; entries are assembled at startup from
+// built-in registrations — one package per agent under internal/agents/,
+// one registration line in the composition root — and availability is
+// probed against the machine on every read.
+//
+// Capabilities are derived from which adapters an entry registers, never
+// declared separately, and their names align with access methods (tui
+// today, direct later); protocol names stay out of the vocabulary. The
+// dependency direction is one-way: this package calls into terminals to
+// create launch terminals, and the terminals domain never depends on
+// agents (ATC-251 doctrine).
+package agents
+
+import "fmt"
+
+// CapabilityTUI is the one capability in ATC-254: the agent can be
+// launched as a TUI in an ATC-managed terminal.
+const CapabilityTUI = "tui"
+
+// TUIAdapter is the per-tool seam behind the tui capability, written once
+// and implemented per agent. Launch-only in this ticket; the threads
+// effort owns extending it with status wiring.
+type TUIAdapter interface {
+	// Command is the command string a launch terminal runs through the
+	// user's login shell. It never appears in the API contract, so flags
+	// can change without a wire-visible change.
+	Command() string
+	// Binary is the executable name the availability probe resolves on the
+	// server's PATH.
+	Binary() string
+	// InstallHint tells the user how to install the tool.
+	InstallHint() string
+}
+
+// Entry is one catalog registration: a stable id (persisted by terminals
+// and later threads — never renamed), a display name, and the tool's
+// adapters. A nil adapter simply means the entry lacks that capability.
+type Entry struct {
+	ID   string
+	Name string
+	TUI  TUIAdapter
+}
+
+// Catalog is the compiled-in registry: fixed at construction, listed in
+// registration order, no create/update/delete.
+type Catalog struct {
+	entries []Entry
+	index   map[string]int
+}
+
+// NewCatalog assembles the catalog from built-in registrations. A
+// duplicate id is a startup error — the composition root fails the boot.
+func NewCatalog(entries ...Entry) (*Catalog, error) {
+	catalog := &Catalog{entries: entries, index: make(map[string]int, len(entries))}
+	for i, entry := range entries {
+		if _, taken := catalog.index[entry.ID]; taken {
+			return nil, fmt.Errorf("duplicate agent id %q", entry.ID)
+		}
+		catalog.index[entry.ID] = i
+	}
+	return catalog, nil
+}
+
+// Entries returns the catalog in registration order.
+func (c *Catalog) Entries() []Entry {
+	return c.entries
+}
+
+// Get returns the entry for id, if registered.
+func (c *Catalog) Get(id string) (Entry, bool) {
+	i, ok := c.index[id]
+	if !ok {
+		return Entry{}, false
+	}
+	return c.entries[i], true
+}

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -1,0 +1,142 @@
+package agents
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/jeremytondo/atc/internal/api"
+)
+
+type fakeTUI struct{ command, binary, hint string }
+
+func (a fakeTUI) Command() string     { return a.command }
+func (a fakeTUI) Binary() string      { return a.binary }
+func (a fakeTUI) InstallHint() string { return a.hint }
+
+// fakeCreator records the create the launch composition hands the
+// terminals domain.
+type fakeCreator struct {
+	params api.TerminalCreateParams
+	agent  string
+}
+
+func (c *fakeCreator) CreateForAgent(_ context.Context, params api.TerminalCreateParams, agent string) (api.Terminal, error) {
+	c.params, c.agent = params, agent
+	return api.Terminal{ID: "term-aaaaa", Name: params.Name, Command: params.Command, Agent: agent}, nil
+}
+
+func testEntries() []Entry {
+	return []Entry{
+		{ID: "alpha", Name: "Alpha", TUI: fakeTUI{command: "alpha --tui", binary: "alpha", hint: "install alpha"}},
+		{ID: "beta", Name: "Beta", TUI: fakeTUI{command: "beta", binary: "beta-bin", hint: "install beta"}},
+		// No adapters: no capabilities, launch refused.
+		{ID: "gamma", Name: "Gamma"},
+	}
+}
+
+func newTestService(t *testing.T, available ...string) (*Service, *fakeCreator) {
+	t.Helper()
+	catalog, err := NewCatalog(testEntries()...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	creator := &fakeCreator{}
+	return NewService(Options{
+		Catalog:   catalog,
+		Terminals: creator,
+		LookPath: func(name string) (string, error) {
+			if slices.Contains(available, name) {
+				return "/bin/" + name, nil
+			}
+			return "", errors.New("executable file not found in $PATH")
+		},
+	}), creator
+}
+
+func TestNewCatalogRejectsDuplicateIDs(t *testing.T) {
+	_, err := NewCatalog(Entry{ID: "alpha"}, Entry{ID: "alpha"})
+	if err == nil || !strings.Contains(err.Error(), `duplicate agent id "alpha"`) {
+		t.Errorf("NewCatalog(duplicate) = %v, want the duplicate-id error", err)
+	}
+}
+
+// List is registration order with capabilities derived from the adapters
+// each entry registers, availability probed per capability.
+func TestListDerivesCapabilitiesInRegistrationOrder(t *testing.T) {
+	service, _ := newTestService(t, "alpha")
+	want := []api.Agent{
+		{ID: "alpha", Name: "Alpha", Capabilities: []api.AgentCapability{
+			{Capability: "tui", Available: true, InstallHint: "install alpha"},
+		}},
+		{ID: "beta", Name: "Beta", Capabilities: []api.AgentCapability{
+			{Capability: "tui", Available: false, InstallHint: "install beta"},
+		}},
+		{ID: "gamma", Name: "Gamma", Capabilities: []api.AgentCapability{}},
+	}
+	if diff := cmp.Diff(want, service.List()); diff != "" {
+		t.Errorf("List() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestGetUnknownAgent(t *testing.T) {
+	service, _ := newTestService(t)
+	if _, err := service.Get("nonexistent"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get(unknown) = %v, want ErrNotFound", err)
+	}
+}
+
+// Launch composes the create: the adapter's command, the entry's display
+// name as the default, and the catalog id as the recorded agent label.
+func TestLaunchComposesTheTerminalCreate(t *testing.T) {
+	service, creator := newTestService(t, "alpha")
+	terminal, err := service.Launch(context.Background(), "alpha", api.AgentLaunchParams{ProjectID: "proj-aaaaa"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantParams := api.TerminalCreateParams{ProjectID: "proj-aaaaa", Name: "Alpha", Command: "alpha --tui"}
+	if diff := cmp.Diff(wantParams, creator.params); diff != "" {
+		t.Errorf("create params (-want +got):\n%s", diff)
+	}
+	if creator.agent != "alpha" || terminal.Agent != "alpha" {
+		t.Errorf("agent label = %q on create, %q on terminal; want alpha", creator.agent, terminal.Agent)
+	}
+
+	// A caller-supplied name wins over the display-name default.
+	if _, err := service.Launch(context.Background(), "alpha", api.AgentLaunchParams{ProjectID: "proj-aaaaa", Name: "pair session"}); err != nil {
+		t.Fatal(err)
+	}
+	if creator.params.Name != "pair session" {
+		t.Errorf("name = %q, want the caller's", creator.params.Name)
+	}
+}
+
+func TestLaunchRefusals(t *testing.T) {
+	service, creator := newTestService(t, "alpha")
+
+	if _, err := service.Launch(context.Background(), "nonexistent", api.AgentLaunchParams{ProjectID: "proj-aaaaa"}); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Launch(unknown) = %v, want ErrNotFound", err)
+	}
+
+	// A missing binary refuses before any terminal exists, naming the
+	// command and its install hint.
+	_, err := service.Launch(context.Background(), "beta", api.AgentLaunchParams{ProjectID: "proj-aaaaa"})
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("Launch(missing binary) = %v, want ErrUnavailable", err)
+	}
+	if !strings.Contains(err.Error(), `"beta-bin"`) || !strings.Contains(err.Error(), "install beta") {
+		t.Errorf("refusal names neither command nor hint: %v", err)
+	}
+
+	if _, err := service.Launch(context.Background(), "gamma", api.AgentLaunchParams{ProjectID: "proj-aaaaa"}); !errors.Is(err, ErrUnavailable) {
+		t.Errorf("Launch(no tui adapter) = %v, want ErrUnavailable", err)
+	}
+
+	if creator.agent != "" || creator.params.ProjectID != "" {
+		t.Errorf("a refused launch reached the terminals domain: %+v", creator)
+	}
+}

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -41,13 +41,9 @@ func testEntries() []Entry {
 
 func newTestService(t *testing.T, available ...string) (*Service, *fakeCreator) {
 	t.Helper()
-	catalog, err := NewCatalog(testEntries()...)
-	if err != nil {
-		t.Fatal(err)
-	}
 	creator := &fakeCreator{}
-	return NewService(Options{
-		Catalog:   catalog,
+	service, err := NewService(Options{
+		Entries:   testEntries(),
 		Terminals: creator,
 		LookPath: func(name string) (string, error) {
 			if slices.Contains(available, name) {
@@ -55,18 +51,23 @@ func newTestService(t *testing.T, available ...string) (*Service, *fakeCreator) 
 			}
 			return "", errors.New("executable file not found in $PATH")
 		},
-	}), creator
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return service, creator
 }
 
-func TestNewCatalogRejectsDuplicateIDs(t *testing.T) {
-	_, err := NewCatalog(Entry{ID: "alpha"}, Entry{ID: "alpha"})
+func TestNewServiceRejectsDuplicateIDs(t *testing.T) {
+	_, err := NewService(Options{
+		Entries:   []Entry{{ID: "alpha"}, {ID: "alpha"}},
+		Terminals: &fakeCreator{},
+	})
 	if err == nil || !strings.Contains(err.Error(), `duplicate agent id "alpha"`) {
-		t.Errorf("NewCatalog(duplicate) = %v, want the duplicate-id error", err)
+		t.Errorf("NewService(duplicate) = %v, want the duplicate-id error", err)
 	}
 }
 
-// List is registration order with capabilities derived from the adapters
-// each entry registers, availability probed per capability.
 func TestListDerivesCapabilitiesInRegistrationOrder(t *testing.T) {
 	service, _ := newTestService(t, "alpha")
 	want := []api.Agent{

--- a/internal/agents/claude/claude.go
+++ b/internal/agents/claude/claude.go
@@ -1,0 +1,17 @@
+// Package claude is the built-in catalog registration for Claude Code
+// (ATC-254). The id is persisted by terminals and later threads — never
+// rename it.
+package claude
+
+import "github.com/jeremytondo/atc/internal/agents"
+
+// Entry is Claude Code's catalog registration.
+func Entry() agents.Entry {
+	return agents.Entry{ID: "claude", Name: "Claude Code", TUI: tui{}}
+}
+
+type tui struct{}
+
+func (tui) Command() string     { return "claude" }
+func (tui) Binary() string      { return "claude" }
+func (tui) InstallHint() string { return "npm install -g @anthropic-ai/claude-code" }

--- a/internal/agents/codex/codex.go
+++ b/internal/agents/codex/codex.go
@@ -1,0 +1,16 @@
+// Package codex is the built-in catalog registration for Codex (ATC-254).
+// The id is persisted by terminals and later threads — never rename it.
+package codex
+
+import "github.com/jeremytondo/atc/internal/agents"
+
+// Entry is Codex's catalog registration.
+func Entry() agents.Entry {
+	return agents.Entry{ID: "codex", Name: "Codex", TUI: tui{}}
+}
+
+type tui struct{}
+
+func (tui) Command() string     { return "codex" }
+func (tui) Binary() string      { return "codex" }
+func (tui) InstallHint() string { return "npm install -g @openai/codex" }

--- a/internal/agents/service.go
+++ b/internal/agents/service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"slices"
 
 	"github.com/jeremytondo/atc/internal/api"
 )
@@ -30,7 +31,9 @@ type TerminalCreator interface {
 
 // Options wires a Service.
 type Options struct {
-	Catalog   *Catalog
+	// Entries is the compiled-in catalog, one registration per built-in
+	// agent, listed in registration order.
+	Entries   []Entry
 	Terminals TerminalCreator
 	// LookPath resolves a binary name on the server's PATH — the
 	// availability probe's injectable seam, so tests control which binaries
@@ -38,34 +41,51 @@ type Options struct {
 	LookPath func(name string) (string, error)
 }
 
-// Service serves the catalog and owns the launch composition: resolve the
-// entry, probe its binary, compose the command, and hand the terminals
-// domain a normal create. Reads re-probe availability on every call — no
-// cache, no version probing.
+// Service is the read-only catalog plus the launch composition: resolve
+// the entry, probe its binary, compose the command, and hand the
+// terminals domain a normal create. Reads re-probe availability on every
+// call — no cache, no version probing.
 type Service struct {
-	catalog   *Catalog
+	entries   []Entry
+	index     map[string]int
 	terminals TerminalCreator
 	lookPath  func(name string) (string, error)
 }
 
-func NewService(opts Options) *Service {
-	if opts.Catalog == nil || opts.Terminals == nil {
-		// Either nil would panic on the first request; fail at construction
-		// instead (the server.NewHandler Verify precedent).
-		panic("agents.NewService: Catalog and Terminals must not be nil")
+// NewService assembles the catalog. A duplicate id is an error — the
+// composition root fails the boot.
+func NewService(opts Options) (*Service, error) {
+	if opts.Terminals == nil {
+		// A nil terminals service would panic on the first launch request;
+		// fail at construction instead (the server.NewHandler Verify
+		// precedent).
+		panic("agents.NewService: Terminals must not be nil")
 	}
 	if opts.LookPath == nil {
 		opts.LookPath = exec.LookPath
 	}
-	return &Service{catalog: opts.Catalog, terminals: opts.Terminals, lookPath: opts.LookPath}
+	service := &Service{
+		// Cloned so no caller-held slice can mutate the catalog after the
+		// duplicate check.
+		entries:   slices.Clone(opts.Entries),
+		index:     make(map[string]int, len(opts.Entries)),
+		terminals: opts.Terminals,
+		lookPath:  opts.LookPath,
+	}
+	for i, entry := range service.entries {
+		if _, taken := service.index[entry.ID]; taken {
+			return nil, fmt.Errorf("duplicate agent id %q", entry.ID)
+		}
+		service.index[entry.ID] = i
+	}
+	return service, nil
 }
 
 // List returns every catalog entry in registration order, availability
 // freshly probed.
 func (s *Service) List() []api.Agent {
-	entries := s.catalog.Entries()
-	agents := make([]api.Agent, 0, len(entries))
-	for _, entry := range entries {
+	agents := make([]api.Agent, 0, len(s.entries))
+	for _, entry := range s.entries {
 		agents = append(agents, s.agent(entry))
 	}
 	return agents
@@ -73,7 +93,7 @@ func (s *Service) List() []api.Agent {
 
 // Get returns one catalog entry, availability freshly probed.
 func (s *Service) Get(id string) (api.Agent, error) {
-	entry, ok := s.catalog.Get(id)
+	entry, ok := s.entry(id)
 	if !ok {
 		return api.Agent{}, ErrNotFound
 	}
@@ -86,7 +106,7 @@ func (s *Service) Get(id string) (api.Agent, error) {
 // the normal terminal create path — persistence, wrapper, verification
 // window, status, and events all belong to the terminals domain.
 func (s *Service) Launch(ctx context.Context, id string, params api.AgentLaunchParams) (api.Terminal, error) {
-	entry, ok := s.catalog.Get(id)
+	entry, ok := s.entry(id)
 	if !ok {
 		return api.Terminal{}, ErrNotFound
 	}
@@ -106,6 +126,14 @@ func (s *Service) Launch(ctx context.Context, id string, params api.AgentLaunchP
 		Name:      name,
 		Command:   entry.TUI.Command(),
 	}, entry.ID)
+}
+
+func (s *Service) entry(id string) (Entry, bool) {
+	i, ok := s.index[id]
+	if !ok {
+		return Entry{}, false
+	}
+	return s.entries[i], true
 }
 
 // agent converts an entry to its wire shape, probing availability per

--- a/internal/agents/service.go
+++ b/internal/agents/service.go
@@ -1,0 +1,124 @@
+package agents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+
+	"github.com/jeremytondo/atc/internal/api"
+)
+
+// ErrNotFound reports an id with no catalog entry; the API layer maps it
+// to 404.
+var ErrNotFound = errors.New("agent not found")
+
+// ErrUnavailable refuses a launch whose tui binary does not resolve on
+// the server's PATH; the message names the missing command and its
+// install hint, and no terminal record is created. The probe is a
+// best-effort early gate — the daemon's PATH and the login shell's can
+// disagree — so past it, launch failures surface as exit evidence through
+// the normal terminal status machinery, never a separate error path.
+var ErrUnavailable = errors.New("agent unavailable")
+
+// TerminalCreator is the seam into the terminals domain: CreateForAgent
+// with a resolved command and the agent label (terminals.Service in
+// production).
+type TerminalCreator interface {
+	CreateForAgent(ctx context.Context, params api.TerminalCreateParams, agent string) (api.Terminal, error)
+}
+
+// Options wires a Service.
+type Options struct {
+	Catalog   *Catalog
+	Terminals TerminalCreator
+	// LookPath resolves a binary name on the server's PATH — the
+	// availability probe's injectable seam, so tests control which binaries
+	// exist. Nil defaults to exec.LookPath.
+	LookPath func(name string) (string, error)
+}
+
+// Service serves the catalog and owns the launch composition: resolve the
+// entry, probe its binary, compose the command, and hand the terminals
+// domain a normal create. Reads re-probe availability on every call — no
+// cache, no version probing.
+type Service struct {
+	catalog   *Catalog
+	terminals TerminalCreator
+	lookPath  func(name string) (string, error)
+}
+
+func NewService(opts Options) *Service {
+	if opts.Catalog == nil || opts.Terminals == nil {
+		// Either nil would panic on the first request; fail at construction
+		// instead (the server.NewHandler Verify precedent).
+		panic("agents.NewService: Catalog and Terminals must not be nil")
+	}
+	if opts.LookPath == nil {
+		opts.LookPath = exec.LookPath
+	}
+	return &Service{catalog: opts.Catalog, terminals: opts.Terminals, lookPath: opts.LookPath}
+}
+
+// List returns every catalog entry in registration order, availability
+// freshly probed.
+func (s *Service) List() []api.Agent {
+	entries := s.catalog.Entries()
+	agents := make([]api.Agent, 0, len(entries))
+	for _, entry := range entries {
+		agents = append(agents, s.agent(entry))
+	}
+	return agents
+}
+
+// Get returns one catalog entry, availability freshly probed.
+func (s *Service) Get(id string) (api.Agent, error) {
+	entry, ok := s.catalog.Get(id)
+	if !ok {
+		return api.Agent{}, ErrNotFound
+	}
+	return s.agent(entry), nil
+}
+
+// Launch resolves the agent, probes its binary, and creates the terminal
+// that runs its TUI: the adapter supplies the command, the entry's display
+// name is the default terminal name, and everything from the record on is
+// the normal terminal create path — persistence, wrapper, verification
+// window, status, and events all belong to the terminals domain.
+func (s *Service) Launch(ctx context.Context, id string, params api.AgentLaunchParams) (api.Terminal, error) {
+	entry, ok := s.catalog.Get(id)
+	if !ok {
+		return api.Terminal{}, ErrNotFound
+	}
+	if entry.TUI == nil {
+		return api.Terminal{}, fmt.Errorf("%w: %s has no tui capability", ErrUnavailable, entry.ID)
+	}
+	if _, err := s.lookPath(entry.TUI.Binary()); err != nil {
+		return api.Terminal{}, fmt.Errorf("%w: command %q not found on the server's PATH; install with: %s",
+			ErrUnavailable, entry.TUI.Binary(), entry.TUI.InstallHint())
+	}
+	name := params.Name
+	if name == "" {
+		name = entry.Name
+	}
+	return s.terminals.CreateForAgent(ctx, api.TerminalCreateParams{
+		ProjectID: params.ProjectID,
+		Name:      name,
+		Command:   entry.TUI.Command(),
+	}, entry.ID)
+}
+
+// agent converts an entry to its wire shape, probing availability per
+// capability. The install hint is present whether or not the binary is.
+func (s *Service) agent(entry Entry) api.Agent {
+	agent := api.Agent{ID: entry.ID, Name: entry.Name, Capabilities: []api.AgentCapability{}}
+	if entry.TUI != nil {
+		_, err := s.lookPath(entry.TUI.Binary())
+		agent.Capabilities = append(agent.Capabilities, api.AgentCapability{
+			Capability:  CapabilityTUI,
+			Available:   err == nil,
+			InstallHint: entry.TUI.InstallHint(),
+		})
+	}
+	return agent
+}

--- a/internal/api/agent.go
+++ b/internal/api/agent.go
@@ -1,0 +1,33 @@
+package api
+
+// Agent is one entry of the /v1/agents catalog (ATC-254): a compiled-in,
+// read-only registry of the coding agents ATC can work with. The resolved
+// launch command never appears on the wire — clients launch by id and the
+// server composes the command through the agent's adapters.
+type Agent struct {
+	ID           string            `json:"id" doc:"Stable catalog id; recorded on terminals launched for this agent and never renamed."`
+	Name         string            `json:"name" doc:"Display name."`
+	Capabilities []AgentCapability `json:"capabilities" doc:"Derived from the adapters the entry registers, with availability probed against the server's machine on every read."`
+}
+
+// AgentCapability reports one capability's availability. Availability is
+// advisory: the launch-time probe and the terminal's exit evidence are the
+// operative checks.
+type AgentCapability struct {
+	Capability  string `json:"capability" enum:"tui" doc:"Capability name; tui means the agent can be launched in an ATC-managed terminal."`
+	Available   bool   `json:"available" doc:"Whether the capability's binary resolves on the server's PATH right now."`
+	InstallHint string `json:"installHint" doc:"How to install the tool backing this capability; present whether or not it is available."`
+}
+
+// AgentList is the GET /v1/agents response body, in registration order.
+type AgentList struct {
+	Agents []Agent `json:"agents"`
+}
+
+// AgentLaunchParams is the POST /v1/agents/{id}/launch request body: the
+// same params as terminal create minus command and agent. The route is a
+// pure alias for POST /v1/terminals with an agent reference.
+type AgentLaunchParams struct {
+	ProjectID string `json:"projectId" minLength:"1" doc:"Project the terminal belongs to; its directory becomes the terminal's working directory."`
+	Name      string `json:"name,omitempty" doc:"Display name; defaults to the agent's display name."`
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -98,6 +98,29 @@ func (c *Client) DeleteTerminal(ctx context.Context, id string) error {
 	return c.do(ctx, http.MethodDelete, "/v1/terminals/"+id, nil, nil)
 }
 
+// Agents lists the agent catalog with per-capability availability, probed
+// against the server's machine at request time.
+func (c *Client) Agents(ctx context.Context) ([]Agent, error) {
+	var list AgentList
+	err := c.do(ctx, http.MethodGet, "/v1/agents", nil, &list)
+	return list.Agents, err
+}
+
+// Agent fetches one agent catalog entry by id.
+func (c *Client) Agent(ctx context.Context, id string) (Agent, error) {
+	var agent Agent
+	err := c.do(ctx, http.MethodGet, "/v1/agents/"+id, nil, &agent)
+	return agent, err
+}
+
+// LaunchAgent launches the agent's TUI in a new terminal and returns the
+// terminal — equivalent to CreateTerminal with an agent reference.
+func (c *Client) LaunchAgent(ctx context.Context, id string, params AgentLaunchParams) (Terminal, error) {
+	var terminal Terminal
+	err := c.do(ctx, http.MethodPost, "/v1/agents/"+id+"/launch", params, &terminal)
+	return terminal, err
+}
+
 // CreateProject registers a project rooted at a directory.
 func (c *Client) CreateProject(ctx context.Context, params ProjectCreateParams) (Project, error) {
 	var project Project

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -106,10 +106,12 @@ func (c *Client) Agents(ctx context.Context) ([]Agent, error) {
 	return list.Agents, err
 }
 
-// Agent fetches one agent catalog entry by id.
+// Agent fetches one agent catalog entry by id. The id is user-typed on
+// the CLI, so it is escaped: reserved characters make an unknown id, not
+// a different route.
 func (c *Client) Agent(ctx context.Context, id string) (Agent, error) {
 	var agent Agent
-	err := c.do(ctx, http.MethodGet, "/v1/agents/"+id, nil, &agent)
+	err := c.do(ctx, http.MethodGet, "/v1/agents/"+url.PathEscape(id), nil, &agent)
 	return agent, err
 }
 
@@ -117,7 +119,7 @@ func (c *Client) Agent(ctx context.Context, id string) (Agent, error) {
 // terminal — equivalent to CreateTerminal with an agent reference.
 func (c *Client) LaunchAgent(ctx context.Context, id string, params AgentLaunchParams) (Terminal, error) {
 	var terminal Terminal
-	err := c.do(ctx, http.MethodPost, "/v1/agents/"+id+"/launch", params, &terminal)
+	err := c.do(ctx, http.MethodPost, "/v1/agents/"+url.PathEscape(id)+"/launch", params, &terminal)
 	return terminal, err
 }
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -368,3 +368,59 @@ func TestProblemErrorFallbacks(t *testing.T) {
 		}
 	}
 }
+
+// The agent methods are thin typed wrappers; the id path segment is
+// escaped so a user-typed id with reserved characters stays one unknown
+// segment instead of changing the route.
+func TestAgentMethods(t *testing.T) {
+	type call struct {
+		Method, Path, Body string
+	}
+	var got call
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		got = call{Method: r.Method, Path: r.URL.EscapedPath(), Body: strings.TrimSpace(string(body))}
+		switch {
+		case r.URL.Path == "/v1/agents":
+			_ = json.NewEncoder(w).Encode(AgentList{Agents: []Agent{{ID: "claude"}}})
+		case strings.HasSuffix(r.URL.Path, "/launch"):
+			_ = json.NewEncoder(w).Encode(Terminal{ID: "term-x7k2f", Agent: "claude"})
+		default:
+			_ = json.NewEncoder(w).Encode(Agent{ID: "claude"})
+		}
+	}))
+	defer srv.Close()
+	client := NewClient(srv.URL, testToken, testClientVersion, nil, nil)
+	ctx := context.Background()
+
+	agents, err := client.Agents(ctx)
+	if err != nil || len(agents) != 1 {
+		t.Fatalf("Agents = %+v, %v", agents, err)
+	}
+	if got.Method != http.MethodGet || got.Path != "/v1/agents" {
+		t.Errorf("list request = %+v", got)
+	}
+
+	if _, err := client.Agent(ctx, "claude"); err != nil {
+		t.Fatal(err)
+	}
+	if got.Path != "/v1/agents/claude" {
+		t.Errorf("get path = %q", got.Path)
+	}
+
+	terminal, err := client.LaunchAgent(ctx, "claude", AgentLaunchParams{ProjectID: "proj-x7k2f"})
+	if err != nil || terminal.Agent != "claude" {
+		t.Fatalf("LaunchAgent = %+v, %v", terminal, err)
+	}
+	want := call{http.MethodPost, "/v1/agents/claude/launch", `{"projectId":"proj-x7k2f"}`}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("launch request (-want +got):\n%s", diff)
+	}
+
+	if _, err := client.Agent(ctx, "claude/launch?x"); err != nil {
+		t.Fatal(err)
+	}
+	if got.Path != "/v1/agents/claude%2Flaunch%3Fx" {
+		t.Errorf("escaped get path = %q", got.Path)
+	}
+}

--- a/internal/api/terminal.go
+++ b/internal/api/terminal.go
@@ -27,6 +27,7 @@ type Terminal struct {
 	ProjectID string         `json:"projectId" doc:"Project the terminal belongs to. Immutable; terminals never move between projects."`
 	Directory string         `json:"directory" doc:"Working directory the session started in, copied from the project at create time. Immutable."`
 	Command   string         `json:"command,omitempty" doc:"Command launched in the session; empty means a plain shell. Immutable."`
+	Agent     string         `json:"agent,omitempty" doc:"Agent catalog id the terminal was launched for; omitted for plain terminals. Server-set launch intent only, immutable, no liveness meaning."`
 	Status    TerminalStatus `json:"status" enum:"running,exited,unreachable,missing" doc:"Server-owned session state."`
 	ExitCode  *int           `json:"exitCode,omitempty" doc:"Recorded exit evidence: exit code, 128+signal for signal deaths, 127 for launch failure. Omitted while running and for ATC-initiated stops."`
 	CreatedAt time.Time      `json:"createdAt"`
@@ -40,6 +41,7 @@ type TerminalCreateParams struct {
 	ProjectID string `json:"projectId" minLength:"1" doc:"Project the terminal belongs to; its directory becomes the terminal's working directory."`
 	Name      string `json:"name,omitempty" doc:"Display name; defaults from command, else \"Shell\"."`
 	Command   string `json:"command,omitempty" doc:"Free-form command run through the user's shell; empty starts a plain interactive shell."`
+	Agent     string `json:"agent,omitempty" doc:"Agent catalog id to launch; the server resolves the launch command through the agent's tui adapter and records the id on the terminal. Mutually exclusive with command."`
 }
 
 // TerminalUpdateParams is the PATCH /v1/terminals/{id} request body. Name

--- a/internal/server/agents.go
+++ b/internal/server/agents.go
@@ -1,0 +1,82 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"github.com/jeremytondo/atc/internal/agents"
+	"github.com/jeremytondo/atc/internal/api"
+)
+
+// Exactly three routes on /v1/agents (ATC-254): the catalog surface is
+// GET-only, and launch is an action producing a terminal, not a mutation
+// of the catalog. Availability is re-probed on every read and the catalog
+// emits no events; clients refetch on demand.
+
+type agentOutput struct {
+	Body api.Agent
+}
+
+type agentListOutput struct {
+	Body api.AgentList
+}
+
+func registerAgents(humaAPI huma.API, service *agents.Service) {
+	huma.Register(humaAPI, huma.Operation{
+		OperationID: "list-agents",
+		Method:      http.MethodGet,
+		Path:        "/v1/agents",
+		Summary:     "List agents",
+		Description: "The compiled-in agent catalog in registration order, with per-capability availability probed against this machine's PATH on every request. Availability is advisory; launch re-probes.",
+	}, func(ctx context.Context, _ *struct{}) (*agentListOutput, error) {
+		return &agentListOutput{Body: api.AgentList{Agents: service.List()}}, nil
+	})
+
+	huma.Register(humaAPI, huma.Operation{
+		OperationID: "get-agent",
+		Method:      http.MethodGet,
+		Path:        "/v1/agents/{id}",
+		Summary:     "Get an agent",
+	}, func(ctx context.Context, input *struct {
+		ID string `path:"id" doc:"Agent catalog id."`
+	}) (*agentOutput, error) {
+		agent, err := service.Get(input.ID)
+		if err != nil {
+			return nil, mapAgentError(err)
+		}
+		return &agentOutput{Body: agent}, nil
+	})
+
+	huma.Register(humaAPI, huma.Operation{
+		OperationID:   "launch-agent",
+		Method:        http.MethodPost,
+		Path:          "/v1/agents/{id}/launch",
+		Summary:       "Launch an agent in a new terminal",
+		Description:   "Equivalent to creating a terminal with an agent reference: the server resolves the launch command through the agent's tui adapter and runs the normal terminal create path. A missing binary is refused before any record exists; past that probe, failures surface as terminal exit evidence.",
+		DefaultStatus: http.StatusCreated,
+	}, func(ctx context.Context, input *struct {
+		ID   string `path:"id" doc:"Agent catalog id."`
+		Body api.AgentLaunchParams
+	}) (*terminalOutput, error) {
+		terminal, err := service.Launch(ctx, input.ID, input.Body)
+		if err != nil {
+			return nil, mapAgentError(err)
+		}
+		return &terminalOutput{Body: terminal}, nil
+	})
+}
+
+// mapAgentError adds the agent mappings ahead of the terminal ones, which
+// launch can also surface (unknown project, missing project directory).
+func mapAgentError(err error) error {
+	switch {
+	case errors.Is(err, agents.ErrNotFound):
+		return huma.Error404NotFound("agent not found")
+	case errors.Is(err, agents.ErrUnavailable):
+		return huma.Error409Conflict(err.Error())
+	}
+	return mapError(err)
+}

--- a/internal/server/agents_test.go
+++ b/internal/server/agents_test.go
@@ -58,7 +58,7 @@ func TestAgentCatalogListAndGet(t *testing.T) {
 	}
 
 	// No cache: installing the binary flips the next read's availability.
-	f.lookPath.set("codex", true)
+	f.binaries["codex"] = true
 	if got := decodeAgent(t, f.request(t, http.MethodGet, "/v1/agents/codex", "")); !got.Capabilities[0].Available {
 		t.Errorf("availability not re-probed: %+v", got)
 	}

--- a/internal/server/agents_test.go
+++ b/internal/server/agents_test.go
@@ -119,8 +119,12 @@ func TestLaunchMissingBinaryCreatesNothing(t *testing.T) {
 	f := newFixture(t)
 
 	for name, launch := range map[string]func() *httptest.ResponseRecorder{
-		"alias":           func() *httptest.ResponseRecorder { return f.request(t, http.MethodPost, "/v1/agents/codex/launch", `{"projectId":"`+f.projectID+`"}`) },
-		"terminal create": func() *httptest.ResponseRecorder { return f.request(t, http.MethodPost, "/v1/terminals", f.createTerminalBody(t, api.TerminalCreateParams{Agent: "codex"})) },
+		"alias": func() *httptest.ResponseRecorder {
+			return f.request(t, http.MethodPost, "/v1/agents/codex/launch", `{"projectId":"`+f.projectID+`"}`)
+		},
+		"terminal create": func() *httptest.ResponseRecorder {
+			return f.request(t, http.MethodPost, "/v1/terminals", f.createTerminalBody(t, api.TerminalCreateParams{Agent: "codex"}))
+		},
 	} {
 		rec := launch()
 		if rec.Code != http.StatusConflict {

--- a/internal/server/agents_test.go
+++ b/internal/server/agents_test.go
@@ -1,0 +1,159 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/jeremytondo/atc/internal/api"
+)
+
+// The fixture catalog is the shipped one: claude's binary available,
+// codex's not. Every read re-probes, so flipping availability between
+// requests is visible immediately.
+
+func decodeAgent(t *testing.T, rec *httptest.ResponseRecorder) api.Agent {
+	t.Helper()
+	var agent api.Agent
+	if err := json.Unmarshal(rec.Body.Bytes(), &agent); err != nil {
+		t.Fatalf("decoding %q: %v", rec.Body, err)
+	}
+	return agent
+}
+
+func TestAgentCatalogListAndGet(t *testing.T) {
+	f := newFixture(t)
+
+	rec := f.request(t, http.MethodGet, "/v1/agents", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list: got %d; body %s", rec.Code, rec.Body)
+	}
+	var list api.AgentList
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatal(err)
+	}
+	want := api.AgentList{Agents: []api.Agent{
+		{ID: "claude", Name: "Claude Code", Capabilities: []api.AgentCapability{
+			{Capability: "tui", Available: true, InstallHint: "npm install -g @anthropic-ai/claude-code"},
+		}},
+		{ID: "codex", Name: "Codex", Capabilities: []api.AgentCapability{
+			{Capability: "tui", Available: false, InstallHint: "npm install -g @openai/codex"},
+		}},
+	}}
+	if diff := cmp.Diff(want, list); diff != "" {
+		t.Errorf("list (-want +got):\n%s", diff)
+	}
+
+	rec = f.request(t, http.MethodGet, "/v1/agents/codex", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get: got %d", rec.Code)
+	}
+	if diff := cmp.Diff(want.Agents[1], decodeAgent(t, rec)); diff != "" {
+		t.Errorf("get codex (-want +got):\n%s", diff)
+	}
+
+	// No cache: installing the binary flips the next read's availability.
+	f.lookPath.set("codex", true)
+	if got := decodeAgent(t, f.request(t, http.MethodGet, "/v1/agents/codex", "")); !got.Capabilities[0].Available {
+		t.Errorf("availability not re-probed: %+v", got)
+	}
+
+	if rec := f.request(t, http.MethodGet, "/v1/agents/nonexistent", ""); rec.Code != http.StatusNotFound {
+		t.Errorf("get unknown: got %d, want 404", rec.Code)
+	}
+}
+
+// Launch through both routes: the terminal carries the adapter's command
+// and the agent label, and a plain terminal omits agent entirely.
+func TestAgentLaunchCreatesTheTerminal(t *testing.T) {
+	f := newFixture(t)
+
+	rec := f.request(t, http.MethodPost, "/v1/agents/claude/launch", `{"projectId":"`+f.projectID+`"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("launch: got %d; body %s", rec.Code, rec.Body)
+	}
+	launched := decodeTerminal(t, rec)
+	if launched.Agent != "claude" || launched.Command != "claude" ||
+		launched.Name != "Claude Code" || launched.Status != api.TerminalRunning {
+		t.Errorf("launched = %+v", launched)
+	}
+	if !strings.Contains(rec.Body.String(), `"agent":"claude"`) {
+		t.Errorf("launch body has no agent field: %s", rec.Body)
+	}
+
+	plain := f.request(t, http.MethodPost, "/v1/terminals", f.createTerminalBody(t, api.TerminalCreateParams{}))
+	if strings.Contains(plain.Body.String(), `"agent"`) {
+		t.Errorf("plain terminal carries an agent field: %s", plain.Body)
+	}
+
+	// Get and list show the label the same way the create response did.
+	rec = f.request(t, http.MethodGet, "/v1/terminals/"+launched.ID, "")
+	if got := decodeTerminal(t, rec); got.Agent != "claude" {
+		t.Errorf("get = %+v, want agent claude", got)
+	}
+}
+
+func TestTerminalCreateWithAgentMatchesLaunch(t *testing.T) {
+	f := newFixture(t)
+
+	viaTerminals := decodeTerminal(t, f.request(t, http.MethodPost, "/v1/terminals",
+		f.createTerminalBody(t, api.TerminalCreateParams{Agent: "claude"})))
+	viaAlias := decodeTerminal(t, f.request(t, http.MethodPost, "/v1/agents/claude/launch",
+		`{"projectId":"`+f.projectID+`"}`))
+	// Identity and clock fields necessarily differ; everything the routes
+	// decide must not.
+	ignore := cmpopts.IgnoreFields(api.Terminal{}, "ID", "CreatedAt", "UpdatedAt")
+	if diff := cmp.Diff(viaAlias, viaTerminals, ignore); diff != "" {
+		t.Errorf("routes disagree (-alias +terminals):\n%s", diff)
+	}
+}
+
+// A missing binary refuses with the command and hint, creating nothing —
+// through either route.
+func TestLaunchMissingBinaryCreatesNothing(t *testing.T) {
+	f := newFixture(t)
+
+	for name, launch := range map[string]func() *httptest.ResponseRecorder{
+		"alias":           func() *httptest.ResponseRecorder { return f.request(t, http.MethodPost, "/v1/agents/codex/launch", `{"projectId":"`+f.projectID+`"}`) },
+		"terminal create": func() *httptest.ResponseRecorder { return f.request(t, http.MethodPost, "/v1/terminals", f.createTerminalBody(t, api.TerminalCreateParams{Agent: "codex"})) },
+	} {
+		rec := launch()
+		if rec.Code != http.StatusConflict {
+			t.Fatalf("%s: got %d, want 409; body %s", name, rec.Code, rec.Body)
+		}
+		if body := rec.Body.String(); !strings.Contains(body, `\"codex\"`) || !strings.Contains(body, "npm install -g @openai/codex") {
+			t.Errorf("%s refusal names neither command nor hint: %s", name, body)
+		}
+	}
+	if rec := f.request(t, http.MethodGet, "/v1/terminals", ""); !strings.Contains(rec.Body.String(), `"terminals":[]`) {
+		t.Errorf("a refused launch left a record: %s", rec.Body)
+	}
+}
+
+func TestLaunchUnknownAgent(t *testing.T) {
+	f := newFixture(t)
+	if rec := f.request(t, http.MethodPost, "/v1/agents/nonexistent/launch", `{"projectId":"`+f.projectID+`"}`); rec.Code != http.StatusNotFound {
+		t.Errorf("alias: got %d, want 404", rec.Code)
+	}
+	rec := f.request(t, http.MethodPost, "/v1/terminals", f.createTerminalBody(t, api.TerminalCreateParams{Agent: "nonexistent"}))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("terminal create: got %d, want 404", rec.Code)
+	}
+}
+
+func TestTerminalCreateRejectsAgentWithCommand(t *testing.T) {
+	f := newFixture(t)
+	rec := f.request(t, http.MethodPost, "/v1/terminals",
+		f.createTerminalBody(t, api.TerminalCreateParams{Agent: "claude", Command: "hx"}))
+	if rec.Code != http.StatusUnprocessableEntity || !strings.Contains(rec.Body.String(), "mutually exclusive") {
+		t.Errorf("agent+command: got %d; body %s", rec.Code, rec.Body)
+	}
+	if rec := f.request(t, http.MethodGet, "/v1/terminals", ""); !strings.Contains(rec.Body.String(), `"terminals":[]`) {
+		t.Errorf("a rejected create left a record: %s", rec.Body)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humago"
 
+	"github.com/jeremytondo/atc/internal/agents"
 	"github.com/jeremytondo/atc/internal/api"
 	"github.com/jeremytondo/atc/internal/events"
 	"github.com/jeremytondo/atc/internal/projects"
@@ -44,6 +45,7 @@ type Options struct {
 	Logger    *slog.Logger
 	Terminals *terminals.Service
 	Projects  *projects.Service
+	Agents    *agents.Service
 	Events    *events.Hub
 	// HeartbeatInterval paces SSE heartbeats; zero means the default.
 	HeartbeatInterval time.Duration
@@ -88,10 +90,13 @@ func NewHandler(opts Options) http.Handler {
 	})
 
 	if opts.Terminals != nil {
-		registerTerminals(humaAPI, opts.Terminals)
+		registerTerminals(humaAPI, opts.Terminals, opts.Agents)
 	}
 	if opts.Projects != nil {
 		registerProjects(humaAPI, opts.Projects)
+	}
+	if opts.Agents != nil {
+		registerAgents(humaAPI, opts.Agents)
 	}
 	if opts.Events != nil {
 		registerEvents(humaAPI, opts.Events, opts.HeartbeatInterval)

--- a/internal/server/terminals.go
+++ b/internal/server/terminals.go
@@ -46,10 +46,8 @@ func registerTerminals(humaAPI huma.API, service *terminals.Service, agentServic
 			if agentService == nil {
 				return nil, huma.Error422UnprocessableEntity("this server has no agent catalog")
 			}
-			// The one launch path (ATC-254): the same composition the alias
-			// route runs, so both routes surface identical errors and
-			// terminals. The service, not this handler, records the agent id
-			// it resolved.
+			// The same composition the alias route runs, so both routes
+			// surface identical errors and terminals.
 			terminal, err := agentService.Launch(ctx, input.Body.Agent,
 				api.AgentLaunchParams{ProjectID: input.Body.ProjectID, Name: input.Body.Name})
 			if err != nil {

--- a/internal/server/terminals.go
+++ b/internal/server/terminals.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
+	"github.com/jeremytondo/atc/internal/agents"
 	"github.com/jeremytondo/atc/internal/api"
 	"github.com/jeremytondo/atc/internal/terminals"
 )
@@ -27,17 +28,35 @@ type terminalIDInput struct {
 	ID string `path:"id" doc:"Terminal identifier."`
 }
 
-func registerTerminals(humaAPI huma.API, service *terminals.Service) {
+func registerTerminals(humaAPI huma.API, service *terminals.Service, agentService *agents.Service) {
 	huma.Register(humaAPI, huma.Operation{
 		OperationID:   "create-terminal",
 		Method:        http.MethodPost,
 		Path:          "/v1/terminals",
 		Summary:       "Create a terminal",
-		Description:   "Persists the record, starts the session, and waits a short verification window; a fast-failing command returns exited with its evidence.",
+		Description:   "Persists the record, starts the session, and waits a short verification window; a fast-failing command returns exited with its evidence. An agent reference resolves the command through the agent catalog instead — equivalent to POST /v1/agents/{id}/launch.",
 		DefaultStatus: http.StatusCreated,
 	}, func(ctx context.Context, input *struct {
 		Body api.TerminalCreateParams
 	}) (*terminalOutput, error) {
+		if input.Body.Agent != "" {
+			if input.Body.Command != "" {
+				return nil, huma.Error422UnprocessableEntity("agent and command are mutually exclusive")
+			}
+			if agentService == nil {
+				return nil, huma.Error422UnprocessableEntity("this server has no agent catalog")
+			}
+			// The one launch path (ATC-254): the same composition the alias
+			// route runs, so both routes surface identical errors and
+			// terminals. The service, not this handler, records the agent id
+			// it resolved.
+			terminal, err := agentService.Launch(ctx, input.Body.Agent,
+				api.AgentLaunchParams{ProjectID: input.Body.ProjectID, Name: input.Body.Name})
+			if err != nil {
+				return nil, mapAgentError(err)
+			}
+			return &terminalOutput{Body: terminal}, nil
+		}
 		terminal, err := service.Create(ctx, input.Body)
 		if err != nil {
 			return nil, mapError(err)

--- a/internal/server/terminals_test.go
+++ b/internal/server/terminals_test.go
@@ -79,40 +79,18 @@ func (a *fakeAdapter) Kill(_ context.Context, id string) error {
 	return nil
 }
 
-// fakeLookPath is the agents domain's injectable binary probe: only
-// binaries a test marks available "exist", never the developer machine's
-// PATH.
-type fakeLookPath struct {
-	mu        sync.Mutex
-	available map[string]bool
-}
-
-func (l *fakeLookPath) look(name string) (string, error) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	if l.available[name] {
-		return "/bin/" + name, nil
-	}
-	return "", errors.New("executable file not found in $PATH")
-}
-
-func (l *fakeLookPath) set(name string, available bool) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	l.available[name] = available
-}
-
 // fixture is a full chassis over fakes: real store in a temp dir, real
 // hub, fake adapter, fake clock — the server's existing test seam. One
 // project rooted at a real temp directory exists for terminals to belong
-// to; the agent catalog is the shipped one (claude, codex) with claude's
-// binary available by default.
+// to; the agent catalog is the shipped one (claude, codex), probing
+// binaries against the fixture map (claude available by default), never
+// the developer machine's PATH.
 type fixture struct {
 	handler    http.Handler
 	adapter    *fakeAdapter
 	hub        *events.Hub
 	service    *terminals.Service
-	lookPath   *fakeLookPath
+	binaries   map[string]bool
 	markers    string
 	projectID  string
 	projectDir string
@@ -157,16 +135,20 @@ func newFixture(t *testing.T) *fixture {
 		Hub:        hub,
 		Now:        now,
 	})
-	lookPath := &fakeLookPath{available: map[string]bool{"claude": true}}
-	catalog, err := agents.NewCatalog(claude.Entry(), codex.Entry())
+	binaries := map[string]bool{"claude": true}
+	agentService, err := agents.NewService(agents.Options{
+		Entries:   []agents.Entry{claude.Entry(), codex.Entry()},
+		Terminals: service,
+		LookPath: func(name string) (string, error) {
+			if binaries[name] {
+				return "/bin/" + name, nil
+			}
+			return "", errors.New("executable file not found in $PATH")
+		},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	agentService := agents.NewService(agents.Options{
-		Catalog:   catalog,
-		Terminals: service,
-		LookPath:  lookPath.look,
-	})
 	handler := NewHandler(Options{
 		Verify:            testVerify,
 		Version:           testVersion,
@@ -177,7 +159,7 @@ func newFixture(t *testing.T) *fixture {
 		Events:            hub,
 		HeartbeatInterval: 50 * time.Millisecond,
 	})
-	f := &fixture{handler: handler, adapter: adapter, hub: hub, service: service, lookPath: lookPath, markers: markers}
+	f := &fixture{handler: handler, adapter: adapter, hub: hub, service: service, binaries: binaries, markers: markers}
 	// Planted through the repository, not the API: the fixture project must
 	// not consume an event sequence number the SSE assertions rely on.
 	f.projectDir = t.TempDir()

--- a/internal/server/terminals_test.go
+++ b/internal/server/terminals_test.go
@@ -19,6 +19,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/jeremytondo/atc/internal/agents"
+	"github.com/jeremytondo/atc/internal/agents/claude"
+	"github.com/jeremytondo/atc/internal/agents/codex"
 	"github.com/jeremytondo/atc/internal/api"
 	"github.com/jeremytondo/atc/internal/events"
 	"github.com/jeremytondo/atc/internal/projects"
@@ -76,15 +79,40 @@ func (a *fakeAdapter) Kill(_ context.Context, id string) error {
 	return nil
 }
 
+// fakeLookPath is the agents domain's injectable binary probe: only
+// binaries a test marks available "exist", never the developer machine's
+// PATH.
+type fakeLookPath struct {
+	mu        sync.Mutex
+	available map[string]bool
+}
+
+func (l *fakeLookPath) look(name string) (string, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.available[name] {
+		return "/bin/" + name, nil
+	}
+	return "", errors.New("executable file not found in $PATH")
+}
+
+func (l *fakeLookPath) set(name string, available bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.available[name] = available
+}
+
 // fixture is a full chassis over fakes: real store in a temp dir, real
 // hub, fake adapter, fake clock — the server's existing test seam. One
 // project rooted at a real temp directory exists for terminals to belong
-// to.
+// to; the agent catalog is the shipped one (claude, codex) with claude's
+// binary available by default.
 type fixture struct {
 	handler    http.Handler
 	adapter    *fakeAdapter
 	hub        *events.Hub
 	service    *terminals.Service
+	lookPath   *fakeLookPath
 	markers    string
 	projectID  string
 	projectDir string
@@ -129,16 +157,27 @@ func newFixture(t *testing.T) *fixture {
 		Hub:        hub,
 		Now:        now,
 	})
+	lookPath := &fakeLookPath{available: map[string]bool{"claude": true}}
+	catalog, err := agents.NewCatalog(claude.Entry(), codex.Entry())
+	if err != nil {
+		t.Fatal(err)
+	}
+	agentService := agents.NewService(agents.Options{
+		Catalog:   catalog,
+		Terminals: service,
+		LookPath:  lookPath.look,
+	})
 	handler := NewHandler(Options{
 		Verify:            testVerify,
 		Version:           testVersion,
 		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
 		Terminals:         service,
 		Projects:          projectService,
+		Agents:            agentService,
 		Events:            hub,
 		HeartbeatInterval: 50 * time.Millisecond,
 	})
-	f := &fixture{handler: handler, adapter: adapter, hub: hub, service: service, markers: markers}
+	f := &fixture{handler: handler, adapter: adapter, hub: hub, service: service, lookPath: lookPath, markers: markers}
 	// Planted through the repository, not the API: the fixture project must
 	// not consume an event sequence number the SSE assertions rely on.
 	f.projectDir = t.TempDir()
@@ -264,6 +303,7 @@ func TestUpdateRejectsUnknownAndImmutableFields(t *testing.T) {
 	for name, body := range map[string]string{
 		"immutable directory": `{"name":"x","directory":"/elsewhere"}`,
 		"immutable command":   `{"command":"vim"}`,
+		"immutable agent":     `{"name":"x","agent":"claude"}`,
 		"unknown field":       `{"name":"x","frobnicate":true}`,
 		"missing name":        `{}`,
 	} {

--- a/internal/store/gen/models.go
+++ b/internal/store/gen/models.go
@@ -27,4 +27,5 @@ type Terminal struct {
 	StopRequestedAt sql.NullString
 	ExitedAt        sql.NullString
 	ExitCode        sql.NullInt64
+	Agent           sql.NullString
 }

--- a/internal/store/gen/queries.sql.go
+++ b/internal/store/gen/queries.sql.go
@@ -81,8 +81,8 @@ func (q *Queries) InsertProject(ctx context.Context, arg InsertProjectParams) (i
 
 const insertTerminal = `-- name: InsertTerminal :execrows
 
-INSERT INTO terminals (id, project_id, name, directory, command, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?, ?)
+INSERT INTO terminals (id, project_id, name, directory, command, agent, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (id) DO NOTHING
 `
 
@@ -92,6 +92,7 @@ type InsertTerminalParams struct {
 	Name      string
 	Directory string
 	Command   sql.NullString
+	Agent     sql.NullString
 	CreatedAt string
 	UpdatedAt string
 }
@@ -109,6 +110,7 @@ func (q *Queries) InsertTerminal(ctx context.Context, arg InsertTerminalParams) 
 		arg.Name,
 		arg.Directory,
 		arg.Command,
+		arg.Agent,
 		arg.CreatedAt,
 		arg.UpdatedAt,
 	)
@@ -180,7 +182,7 @@ func (q *Queries) ListTerminalIDsByProject(ctx context.Context, projectID string
 }
 
 const listTerminals = `-- name: ListTerminals :many
-SELECT id, project_id, name, directory, command, created_at, updated_at, stop_requested_at, exited_at, exit_code FROM terminals ORDER BY created_at, id
+SELECT id, project_id, name, directory, command, created_at, updated_at, stop_requested_at, exited_at, exit_code, agent FROM terminals ORDER BY created_at, id
 `
 
 func (q *Queries) ListTerminals(ctx context.Context) ([]Terminal, error) {
@@ -203,6 +205,7 @@ func (q *Queries) ListTerminals(ctx context.Context) ([]Terminal, error) {
 			&i.StopRequestedAt,
 			&i.ExitedAt,
 			&i.ExitCode,
+			&i.Agent,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/migrations/00004_terminal_agent.sql
+++ b/internal/store/migrations/00004_terminal_agent.sql
@@ -1,0 +1,7 @@
+-- Terminals record the agent they were launched for (ATC-254): the agent
+-- catalog id, set only when the server itself resolved the launch command
+-- through the catalog. NULL means a plain terminal. Launch intent only —
+-- liveness stays with the derived status, and an id absent from a future
+-- catalog still renders as a normal terminal.
+-- +goose Up
+ALTER TABLE terminals ADD COLUMN agent TEXT;

--- a/internal/store/queries.sql
+++ b/internal/store/queries.sql
@@ -6,8 +6,8 @@
 -- inserts zero rows and the caller re-rolls, with no check-then-insert
 -- window.
 -- name: InsertTerminal :execrows
-INSERT INTO terminals (id, project_id, name, directory, command, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?, ?)
+INSERT INTO terminals (id, project_id, name, directory, command, agent, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (id) DO NOTHING;
 
 -- name: ListTerminals :many

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -38,6 +38,7 @@ func TestTerminalsRoundTrip(t *testing.T) {
 	records := []TerminalRecord{
 		{ID: "term-aaaaa", ProjectID: "proj-aaaaa", Name: "Shell", Directory: "/home/x", CreatedAt: at(0), UpdatedAt: at(0)},
 		{ID: "term-bbbbb", ProjectID: "proj-aaaaa", Name: "hx", Directory: "/home/x/proj", Command: "hx .", CreatedAt: at(1), UpdatedAt: at(1)},
+		{ID: "term-ccccc", ProjectID: "proj-aaaaa", Name: "Claude Code", Directory: "/home/x", Command: "claude", Agent: "claude", CreatedAt: at(2), UpdatedAt: at(2)},
 	}
 	for _, record := range records {
 		if ok, err := terminals.Insert(ctx, record); err != nil || !ok {

--- a/internal/store/terminals.go
+++ b/internal/store/terminals.go
@@ -21,7 +21,11 @@ type TerminalRecord struct {
 	Directory string
 	// Command is the free-form command the terminal was created with;
 	// empty means a plain interactive shell.
-	Command   string
+	Command string
+	// Agent is the agent catalog id the terminal was launched for, set only
+	// when the server resolved the launch (ATC-254); empty means a plain
+	// terminal. Immutable launch intent, no liveness meaning.
+	Agent     string
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	// StopRequestedAt is the persisted stop intent (set before the kill is
@@ -51,6 +55,7 @@ func (t *Terminals) Insert(ctx context.Context, record TerminalRecord) (bool, er
 		Name:      record.Name,
 		Directory: record.Directory,
 		Command:   nullString(record.Command),
+		Agent:     nullString(record.Agent),
 		CreatedAt: formatTime(record.CreatedAt),
 		UpdatedAt: formatTime(record.UpdatedAt),
 	})
@@ -125,6 +130,7 @@ func recordFrom(row gen.Terminal) (TerminalRecord, error) {
 		Name:      row.Name,
 		Directory: row.Directory,
 		Command:   row.Command.String,
+		Agent:     row.Agent.String,
 	}
 	var err error
 	if record.CreatedAt, err = parseTime(row.CreatedAt); err != nil {

--- a/internal/terminals/service.go
+++ b/internal/terminals/service.go
@@ -321,6 +321,20 @@ func (s *Service) reconcile(ctx context.Context, reap bool) {
 // real evidence. Failures after the record exists surface through the
 // normal status machinery — there is no separate launch-error path.
 func (s *Service) Create(ctx context.Context, params api.TerminalCreateParams) (api.Terminal, error) {
+	return s.create(ctx, params, "")
+}
+
+// CreateForAgent is Create for a launch the API layer resolved through the
+// agent catalog (ATC-254): params.Command carries the adapter-composed
+// command and agent is the catalog id recorded on the terminal — this is
+// the only writer of the immutable agent field. The domain stays
+// agent-agnostic: the id is an opaque label here, and everything past the
+// label is the normal create path.
+func (s *Service) CreateForAgent(ctx context.Context, params api.TerminalCreateParams, agent string) (api.Terminal, error) {
+	return s.create(ctx, params, agent)
+}
+
+func (s *Service) create(ctx context.Context, params api.TerminalCreateParams, agent string) (api.Terminal, error) {
 	project, ok, err := s.projects.Get(ctx, params.ProjectID)
 	if err != nil {
 		return api.Terminal{}, err
@@ -345,6 +359,7 @@ func (s *Service) Create(ctx context.Context, params api.TerminalCreateParams) (
 	now := s.now()
 	record := store.TerminalRecord{
 		ProjectID: project.ID, Name: name, Directory: project.Directory, Command: params.Command,
+		Agent:     agent,
 		CreatedAt: now, UpdatedAt: now,
 	}
 	s.ops.Lock()
@@ -551,6 +566,7 @@ func (e *entry) terminal() api.Terminal {
 		ProjectID: e.record.ProjectID,
 		Directory: e.record.Directory,
 		Command:   e.record.Command,
+		Agent:     e.record.Agent,
 		Status:    e.status,
 		CreatedAt: e.record.CreatedAt,
 		UpdatedAt: e.record.UpdatedAt,


### PR DESCRIPTION
Implements [ATC-254](https://linear.app/elevenideas/issue/ATC-254/agents): ATC's first notion of agents.

## What's here

- **`internal/agents`** — a compiled-in, read-only agent catalog assembled at startup (`claude`, `codex`), with the `TUIAdapter` seam (command, binary, install hint) implemented once per tool in `internal/agents/claude` and `internal/agents/codex`. Capabilities are derived from which adapters an entry registers; a duplicate id fails the boot. Availability is a PATH probe on every read (injectable seam for tests, no cache, no version probing).
- **API** — `GET /v1/agents`, `GET /v1/agents/{id}`, `POST /v1/agents/{id}/launch`. Launch is server-side composition: resolve → probe (missing binary → 409 naming the command and install hint, no record created) → compose via the adapter → the normal terminal create path. `POST /v1/terminals` gains an optional `agent` param, mutually exclusive with `command` (422); both routes run the identical `agents.Service.Launch` path, so errors and terminals match. The resolved command never appears in the API contract.
- **Terminals** — one migration adds a nullable `agent` column. The field is server-set only (`CreateForAgent` is its single writer), immutable, omitted from responses when empty. The terminals domain does not depend on the agents domain; the dependency runs agents → terminals only.
- **CLI** — `atc agent list | get | launch` (`--name`, `--project`, `--attach`), speaking only the shared API client. Launch is the one CLI way to start an agent; `atc terminal create` gains no `--agent` flag. Unavailable capabilities show their install hint directly in `list`.

## Decisions worth noting

- No `--dir` flag on `atc agent launch`: the spec's mention predates ATC-256, which made the project supply the working directory. Launch mirrors terminal create's real params (`--name`, `--project`, `--attach`).
- A launched terminal's name defaults to the agent's display name ("Claude Code") rather than the command string — agent-first labeling, identical through both routes.
- Missing binary maps to 409 (machine state, the `ErrProjectDirectoryMissing` precedent); unknown agent id maps to 404 through both launch routes per the spec's launch lifecycle.
- Agent ids are path-escaped in the client, so a user-typed id with reserved characters is an unknown id, not a different route.

## Testing

Catalog unit tests (duplicate id, capability derivation, launch composition and refusals), server contract tests through the existing seam (shapes, 404, launch success, missing-binary 409 with no record, mutual exclusion, alias equivalence, agent immutability on update), client method tests including escaping, and CLI tests against the fake-backend test server. `mise run check` (build, lint, sqlc diff, race-enabled tests) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an agent catalog with Claude Code and Codex entries.
  * Added commands to list agents, view details, and launch agents in new terminals.
  * Added API support for browsing and launching agents.
  * Added project selection, custom terminal names, and optional immediate attachment.
  * Terminal details now show the associated agent.

* **Bug Fixes**
  * Added clear availability and installation guidance for unavailable agents.
  * Prevented terminal creation when launches are invalid or attachment is attempted without a TTY.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->