### PR TITLE
ATC-277 | threads: the thread resource — store, domain, API, events, and CLI

### DIFF
--- a/cmd/atc/main.go
+++ b/cmd/atc/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/jeremytondo/atc/internal/tailscale"
 	"github.com/jeremytondo/atc/internal/terminals"
 	"github.com/jeremytondo/atc/internal/terminals/zmx"
+	"github.com/jeremytondo/atc/internal/threads"
 	"github.com/jeremytondo/atc/internal/upgrade"
 	"github.com/jeremytondo/atc/internal/version"
 )
@@ -88,7 +89,7 @@ expose on the tailnet without the flag.`,
 			return cmd.Help()
 		},
 	}
-	root.AddCommand(newAgentCmd(), newTerminalCmd(), newProjectCmd(), newAPICmd(), newVersionCmd(),
+	root.AddCommand(newAgentCmd(), newThreadCmd(), newTerminalCmd(), newProjectCmd(), newAPICmd(), newVersionCmd(),
 		newUpgradeCmd(), newServerCmd(), newChildCmd())
 	return root
 }
@@ -526,6 +527,18 @@ func serverRunUntilCancelled(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	// Threads load after terminals so the boot-time status coercion and
+	// the sweep read a settled terminal view.
+	threadService := threads.NewService(threads.Options{
+		Repository: database.Threads(),
+		Terminals:  terminalService,
+		Hub:        hub,
+		Logger:     logger,
+	})
+	if err := threadService.Load(ctx); err != nil {
+		return err
+	}
+
 	handler := server.NewHandler(server.Options{
 		Verify:    tokens.Verify,
 		Version:   versionValue,
@@ -533,6 +546,7 @@ func serverRunUntilCancelled(cmd *cobra.Command, _ []string) error {
 		Terminals: terminalService,
 		Projects:  projectService,
 		Agents:    agentService,
+		Threads:   threadService,
 		Events:    hub,
 	})
 
@@ -549,6 +563,7 @@ func serverRunUntilCancelled(cmd *cobra.Command, _ []string) error {
 	defer stopLoop()
 	var background sync.WaitGroup
 	background.Go(func() { terminalService.Run(loopCtx) })
+	background.Go(func() { threadService.Run(loopCtx) })
 
 	// The exposure supervisor fronts the actual bound port (they are one
 	// port by contract) and is waited on so shutdown reaps the serve

--- a/cmd/atc/terminal_test.go
+++ b/cmd/atc/terminal_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jeremytondo/atc/internal/server"
 	"github.com/jeremytondo/atc/internal/store"
 	"github.com/jeremytondo/atc/internal/terminals"
+	"github.com/jeremytondo/atc/internal/threads"
 )
 
 // cliAdapter is the fake session backend behind the CLI tests' server.
@@ -61,6 +62,15 @@ const cliTestToken = "atc_cli-test-token"
 // remote client uses.
 func startTestServer(t *testing.T) *cliAdapter {
 	t.Helper()
+	adapter, _ := startTestServerWithThreads(t)
+	return adapter
+}
+
+// startTestServerWithThreads additionally exposes the threads service so
+// thread tests can plant observed conversations — the seam providers use
+// in production; there is no create verb on the wire.
+func startTestServerWithThreads(t *testing.T) (*cliAdapter, *threads.Service) {
+	t.Helper()
 	db, err := store.Open(context.Background(), filepath.Join(t.TempDir(), "atc.db"))
 	if err != nil {
 		t.Fatal(err)
@@ -96,19 +106,28 @@ func startTestServer(t *testing.T) *cliAdapter {
 	if err != nil {
 		t.Fatal(err)
 	}
+	threadService := threads.NewService(threads.Options{
+		Repository: db.Threads(),
+		Terminals:  service,
+		Hub:        hub,
+	})
+	if err := threadService.Load(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 	handler := server.NewHandler(server.Options{
 		Verify:    func(authorization string) bool { return authorization == "Bearer "+cliTestToken },
 		Version:   "v0.0.0-test",
 		Terminals: service,
 		Projects:  projectService,
 		Agents:    agentService,
+		Threads:   threadService,
 		Events:    hub,
 	})
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 	t.Setenv("ATC_SERVER", srv.URL)
 	t.Setenv("ATC_TOKEN", cliTestToken)
-	return adapter
+	return adapter, threadService
 }
 
 func runCLI(t *testing.T, args ...string) (string, string, error) {

--- a/cmd/atc/thread.go
+++ b/cmd/atc/thread.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jeremytondo/atc/internal/api"
+)
+
+// The atc thread family (ATC-255): reads and the two mutations over
+// observed agent conversations. There is deliberately no create or open —
+// threads are observed into existence inside agent TUIs, and resume
+// happens inside the TUI via /resume. archive/unarchive are thin sugar
+// over PATCH.
+
+func newThreadCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "thread",
+		Short: "See and manage observed agent conversations",
+		Args:  cobra.NoArgs,
+		RunE: func(*cobra.Command, []string) error {
+			return fmt.Errorf("usage: atc thread <list|get|update|archive|unarchive|delete>")
+		},
+	}
+	cmd.AddCommand(newThreadListCmd(), newThreadGetCmd(), newThreadUpdateCmd(),
+		newThreadArchiveCmd(), newThreadUnarchiveCmd(), newThreadDeleteCmd())
+	return cmd
+}
+
+func newThreadListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List threads, most recent activity first",
+		Long: `List every observed agent conversation (pass --project to scope to one
+project). Archived threads are hidden unless --archived.`,
+		Args: cobra.NoArgs,
+		RunE: runWithClient(func(cmd *cobra.Command, _ []string, client *api.Client, _ string) error {
+			flags := cmd.Flags()
+			archived, err := flags.GetBool("archived")
+			if err != nil {
+				return err
+			}
+			project, err := flags.GetString("project")
+			if err != nil {
+				return err
+			}
+			threads, err := client.Threads(cmd.Context(), project, "", archived)
+			if err != nil {
+				return err
+			}
+			out := cmd.OutOrStdout()
+			if len(threads) == 0 {
+				_, err := fmt.Fprintln(out, "no threads")
+				return err
+			}
+			// Most recent activity first: evidence time when there is any,
+			// else the record's last update.
+			sort.SliceStable(threads, func(i, j int) bool {
+				return activityTime(threads[i]).After(activityTime(threads[j]))
+			})
+			w := tabwriter.NewWriter(out, 2, 8, 2, ' ', 0)
+			_, _ = fmt.Fprintln(w, "ID\tSTATUS\tAGENT\tTERMINAL\tTITLE")
+			for _, thread := range threads {
+				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+					thread.ID, threadStatusLabel(thread), thread.Agent, thread.TerminalID, thread.Title)
+			}
+			return w.Flush()
+		}),
+	}
+	cmd.Flags().String("project", "", "only threads belonging to this project")
+	cmd.Flags().Bool("archived", false, "include archived threads")
+	return cmd
+}
+
+func newThreadGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <id>",
+		Short: "Show one thread",
+		Args:  cobra.ExactArgs(1),
+		RunE: runWithClient(func(cmd *cobra.Command, args []string, client *api.Client, _ string) error {
+			thread, err := client.Thread(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			printThread(cmd.OutOrStdout(), thread)
+			return nil
+		}),
+	}
+}
+
+func newThreadUpdateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a thread (title is the editable field)",
+		Long: `Set a thread's title. A title set here is yours: observation never
+overwrites it afterwards.`,
+		Args: cobra.ExactArgs(1),
+		RunE: runWithClient(func(cmd *cobra.Command, args []string, client *api.Client, _ string) error {
+			title, err := cmd.Flags().GetString("title")
+			if err != nil {
+				return err
+			}
+			thread, err := client.UpdateThread(cmd.Context(), args[0], api.ThreadUpdateParams{Title: &title})
+			if err != nil {
+				return err
+			}
+			printThread(cmd.OutOrStdout(), thread)
+			return nil
+		}),
+	}
+	cmd.Flags().String("title", "", "new display title")
+	_ = cmd.MarkFlagRequired("title")
+	return cmd
+}
+
+func newThreadArchiveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "archive <id>",
+		Short: "Archive a thread (reversible; hides it from lists)",
+		Long: `Archive a thread — sugar over PATCH of archived. Archived threads are
+hidden from lists unless requested and restored with unarchive. A thread
+a terminal currently has open is refused.`,
+		Args: cobra.ExactArgs(1),
+		RunE: setThreadArchived(true),
+	}
+}
+
+func newThreadUnarchiveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "unarchive <id>",
+		Short: "Restore an archived thread",
+		Args:  cobra.ExactArgs(1),
+		RunE:  setThreadArchived(false),
+	}
+}
+
+func setThreadArchived(archived bool) func(*cobra.Command, []string) error {
+	return runWithClient(func(cmd *cobra.Command, args []string, client *api.Client, _ string) error {
+		thread, err := client.UpdateThread(cmd.Context(), args[0], api.ThreadUpdateParams{Archived: &archived})
+		if err != nil {
+			return err
+		}
+		printThread(cmd.OutOrStdout(), thread)
+		return nil
+	})
+}
+
+func newThreadDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete ATC's record of a conversation",
+		Long: `Delete the thread record and its identity mapping. The provider-side
+conversation is never touched — it stays resumable inside the agent's own
+tooling, and resuming it later creates a fresh record. A thread a terminal
+currently has open is refused.`,
+		Args: cobra.ExactArgs(1),
+		RunE: runWithClient(func(cmd *cobra.Command, args []string, client *api.Client, _ string) error {
+			if err := client.DeleteThread(cmd.Context(), args[0]); err != nil {
+				return err
+			}
+			_, err := fmt.Fprintf(cmd.OutOrStdout(), "deleted %s\n", args[0])
+			return err
+		}),
+	}
+}
+
+func threadStatusLabel(thread api.Thread) string {
+	if thread.Archived {
+		return string(thread.Status) + " (archived)"
+	}
+	return string(thread.Status)
+}
+
+func activityTime(thread api.Thread) time.Time {
+	if thread.LastEvidenceAt != nil {
+		return *thread.LastEvidenceAt
+	}
+	return thread.UpdatedAt
+}
+
+func printThread(out io.Writer, thread api.Thread) {
+	w := tabwriter.NewWriter(out, 2, 8, 2, ' ', 0)
+	_, _ = fmt.Fprintf(w, "id\t%s\n", thread.ID)
+	_, _ = fmt.Fprintf(w, "agent\t%s\n", thread.Agent)
+	_, _ = fmt.Fprintf(w, "status\t%s\n", threadStatusLabel(thread))
+	if thread.Title != "" {
+		_, _ = fmt.Fprintf(w, "title\t%s\n", thread.Title)
+	}
+	_, _ = fmt.Fprintf(w, "project\t%s\n", thread.ProjectID)
+	if thread.TerminalID != "" {
+		_, _ = fmt.Fprintf(w, "terminal\t%s\n", thread.TerminalID)
+	}
+	if thread.Model != "" {
+		_, _ = fmt.Fprintf(w, "model\t%s\n", thread.Model)
+	}
+	if thread.Effort != "" {
+		_, _ = fmt.Fprintf(w, "effort\t%s\n", thread.Effort)
+	}
+	if thread.Cwd != "" {
+		_, _ = fmt.Fprintf(w, "cwd\t%s\n", thread.Cwd)
+	}
+	if thread.PermissionMode != "" {
+		_, _ = fmt.Fprintf(w, "permission mode\t%s\n", thread.PermissionMode)
+	}
+	if thread.LastError != "" {
+		_, _ = fmt.Fprintf(w, "last error\t%s\n", thread.LastError)
+	}
+	if thread.LastEvidenceAt != nil {
+		_, _ = fmt.Fprintf(w, "last evidence\t%s\n", thread.LastEvidenceAt.Format("2006-01-02 15:04:05 MST"))
+	}
+	_, _ = fmt.Fprintf(w, "created\t%s\n", thread.CreatedAt.Format("2006-01-02 15:04:05 MST"))
+	_ = w.Flush()
+}

--- a/cmd/atc/thread_test.go
+++ b/cmd/atc/thread_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/jeremytondo/atc/internal/api"
+	"github.com/jeremytondo/atc/internal/threads"
+)
+
+// observeThreadCLI plants an observed conversation behind the test server
+// and returns its thread id — the seam providers use in production; the
+// wire has no create verb.
+func observeThreadCLI(t *testing.T, service *threads.Service, terminalID, projectID, providerID string) string {
+	t.Helper()
+	id, err := service.ObserveSession(context.Background(), threads.SessionObservation{
+		Agent:      "claude",
+		ProviderID: providerID,
+		TerminalID: terminalID,
+		ProjectID:  projectID,
+		Status:     api.ThreadIdle,
+		Metadata:   threads.Metadata{Title: "fix the build"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+// createTerminalCLI creates a terminal over the wire and returns its id.
+func createTerminalCLI(t *testing.T, projectID string) string {
+	t.Helper()
+	stdout, _, err := runCLI(t, "terminal", "create", "--command", "claude", "--project", projectID)
+	if err != nil {
+		t.Fatalf("terminal create: %v", err)
+	}
+	id := regexp.MustCompile(`term-[a-z2-9]{5}`).FindString(stdout)
+	if id == "" {
+		t.Fatalf("terminal create output has no id:\n%s", stdout)
+	}
+	return id
+}
+
+func TestThreadCLILifecycle(t *testing.T) {
+	_, threadService := startTestServerWithThreads(t)
+	projectID := createProjectCLI(t, t.TempDir())
+	terminalID := createTerminalCLI(t, projectID)
+	id := observeThreadCLI(t, threadService, terminalID, projectID, "sess-1")
+
+	stdout, _, err := runCLI(t, "thread", "list", "--project", projectID)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(stdout, id) || !strings.Contains(stdout, "idle") ||
+		!strings.Contains(stdout, "claude") || !strings.Contains(stdout, "fix the build") {
+		t.Errorf("list output:\n%s", stdout)
+	}
+
+	if stdout, _, err = runCLI(t, "thread", "get", id); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, id) || !strings.Contains(stdout, terminalID) ||
+		!strings.Contains(stdout, projectID) || !strings.Contains(stdout, "fix the build") {
+		t.Errorf("get output:\n%s", stdout)
+	}
+
+	if stdout, _, err = runCLI(t, "thread", "update", id, "--title", "my title"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "my title") {
+		t.Errorf("update output:\n%s", stdout)
+	}
+
+	// The conversation is still open in the terminal: archive and delete
+	// are refused with a conflict naming it.
+	if _, _, err := runCLI(t, "thread", "archive", id); err == nil || !strings.Contains(err.Error(), terminalID) {
+		t.Errorf("archive active = %v; want a conflict naming %s", err, terminalID)
+	}
+	if _, _, err := runCLI(t, "thread", "delete", id); err == nil || !strings.Contains(err.Error(), terminalID) {
+		t.Errorf("delete active = %v; want a conflict naming %s", err, terminalID)
+	}
+
+	// Switch the terminal to another conversation; the first thread is now
+	// inactive and archivable.
+	observeThreadCLI(t, threadService, terminalID, projectID, "sess-2")
+	if stdout, _, err = runCLI(t, "thread", "archive", id); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "archived") {
+		t.Errorf("archive output:\n%s", stdout)
+	}
+
+	// Hidden by default, shown with --archived, restored by unarchive.
+	if stdout, _, err = runCLI(t, "thread", "list", "--project", projectID); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stdout, id) {
+		t.Errorf("archived thread still listed:\n%s", stdout)
+	}
+	if stdout, _, err = runCLI(t, "thread", "list", "--project", projectID, "--archived"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, id) {
+		t.Errorf("--archived list misses the thread:\n%s", stdout)
+	}
+	if stdout, _, err = runCLI(t, "thread", "unarchive", id); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stdout, "archived") {
+		t.Errorf("unarchive output still marked archived:\n%s", stdout)
+	}
+
+	if stdout, _, err = runCLI(t, "thread", "delete", id); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "deleted "+id) {
+		t.Errorf("delete output:\n%s", stdout)
+	}
+	if stdout, _, err = runCLI(t, "thread", "list", "--project", projectID); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stdout, id) {
+		t.Errorf("deleted thread still listed:\n%s", stdout)
+	}
+}
+
+func TestThreadListUnfiltered(t *testing.T) {
+	_, threadService := startTestServerWithThreads(t)
+	projectID := createProjectCLI(t, t.TempDir())
+	terminalID := createTerminalCLI(t, projectID)
+	id := observeThreadCLI(t, threadService, terminalID, projectID, "sess-1")
+
+	// Like terminal list: unfiltered means everything, no project
+	// resolution.
+	stdout, _, err := runCLI(t, "thread", "list")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(stdout, id) {
+		t.Errorf("list output:\n%s", stdout)
+	}
+}
+
+func TestThreadGetUnknownIsError(t *testing.T) {
+	startTestServer(t)
+	if _, _, err := runCLI(t, "thread", "get", "thrd-zzzzz"); err == nil || !strings.Contains(err.Error(), "404") {
+		t.Errorf("get unknown = %v, want a 404 problem", err)
+	}
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -123,6 +123,49 @@ func (c *Client) LaunchAgent(ctx context.Context, id string, params AgentLaunchP
 	return terminal, err
 }
 
+// Threads lists threads, newest-created last. Non-empty projectID and
+// terminalID filter; archived threads are included only when asked.
+func (c *Client) Threads(ctx context.Context, projectID, terminalID string, includeArchived bool) ([]Thread, error) {
+	query := url.Values{}
+	if projectID != "" {
+		query.Set("project", projectID)
+	}
+	if terminalID != "" {
+		query.Set("terminal", terminalID)
+	}
+	if includeArchived {
+		query.Set("includeArchived", "true")
+	}
+	path := "/v1/threads"
+	if len(query) > 0 {
+		path += "?" + query.Encode()
+	}
+	var list ThreadList
+	err := c.do(ctx, http.MethodGet, path, nil, &list)
+	return list.Threads, err
+}
+
+// Thread fetches one thread by ID.
+func (c *Client) Thread(ctx context.Context, id string) (Thread, error) {
+	var thread Thread
+	err := c.do(ctx, http.MethodGet, "/v1/threads/"+id, nil, &thread)
+	return thread, err
+}
+
+// UpdateThread mutates a thread's title and/or archived flag — archive
+// and unarchive are this PATCH, there are no action routes.
+func (c *Client) UpdateThread(ctx context.Context, id string, params ThreadUpdateParams) (Thread, error) {
+	var thread Thread
+	err := c.do(ctx, http.MethodPatch, "/v1/threads/"+id, params, &thread)
+	return thread, err
+}
+
+// DeleteThread removes ATC's record of the conversation; the
+// provider-side conversation is untouched.
+func (c *Client) DeleteThread(ctx context.Context, id string) error {
+	return c.do(ctx, http.MethodDelete, "/v1/threads/"+id, nil, nil)
+}
+
 // CreateProject registers a project rooted at a directory.
 func (c *Client) CreateProject(ctx context.Context, params ProjectCreateParams) (Project, error) {
 	var project Project

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -14,6 +14,9 @@ const (
 	EventProjectCreated  = "project.created"
 	EventProjectUpdated  = "project.updated"
 	EventProjectDeleted  = "project.deleted"
+	EventThreadCreated   = "thread.created"
+	EventThreadUpdated   = "thread.updated"
+	EventThreadDeleted   = "thread.deleted"
 	EventResync          = "resync"
 )
 
@@ -43,6 +46,17 @@ type ProjectUpdatedEvent struct{ ChangeEvent }
 
 // ProjectDeletedEvent is the project.deleted payload.
 type ProjectDeletedEvent struct{ ChangeEvent }
+
+// ThreadCreatedEvent is the thread.created payload.
+type ThreadCreatedEvent struct{ ChangeEvent }
+
+// ThreadUpdatedEvent is the thread.updated payload. It fires only on
+// meaningful change (status, terminal linkage, title, archived,
+// metadata); a lastEvidenceAt refresh alone updates silently.
+type ThreadUpdatedEvent struct{ ChangeEvent }
+
+// ThreadDeletedEvent is the thread.deleted payload.
+type ThreadDeletedEvent struct{ ChangeEvent }
 
 // ResyncEvent tells a reconnecting client its cursor has fallen off the
 // backlog: refetch snapshots once, then resume from the live stream.

--- a/internal/api/terminal.go
+++ b/internal/api/terminal.go
@@ -22,16 +22,19 @@ const (
 // Terminal is the /v1/terminals resource. The id doubles as the zmx
 // session name; records stay listed after exit until explicitly deleted.
 type Terminal struct {
-	ID        string         `json:"id" doc:"Server-minted identifier; also the zmx session name."`
-	Name      string         `json:"name" doc:"Display name; the only mutable field."`
-	ProjectID string         `json:"projectId" doc:"Project the terminal belongs to. Immutable; terminals never move between projects."`
-	Directory string         `json:"directory" doc:"Working directory the session started in, copied from the project at create time. Immutable."`
-	Command   string         `json:"command,omitempty" doc:"Command launched in the session; empty means a plain shell. Immutable."`
-	Agent     string         `json:"agent,omitempty" doc:"Agent catalog id the terminal was launched for; omitted for plain terminals. Server-set launch intent only, immutable, no liveness meaning."`
-	Status    TerminalStatus `json:"status" enum:"running,exited,unreachable,missing" doc:"Server-owned session state."`
-	ExitCode  *int           `json:"exitCode,omitempty" doc:"Recorded exit evidence: exit code, 128+signal for signal deaths, 127 for launch failure. Omitted while running and for ATC-initiated stops."`
-	CreatedAt time.Time      `json:"createdAt"`
-	UpdatedAt time.Time      `json:"updatedAt"`
+	ID        string `json:"id" doc:"Server-minted identifier; also the zmx session name."`
+	Name      string `json:"name" doc:"Display name; the only mutable field."`
+	ProjectID string `json:"projectId" doc:"Project the terminal belongs to. Immutable; terminals never move between projects."`
+	Directory string `json:"directory" doc:"Working directory the session started in, copied from the project at create time. Immutable."`
+	Command   string `json:"command,omitempty" doc:"Command launched in the session; empty means a plain shell. Immutable."`
+	Agent     string `json:"agent,omitempty" doc:"Agent catalog id the terminal was launched for; omitted for plain terminals. Server-set launch intent only, immutable, no liveness meaning."`
+	// ActiveThreadID is a projection from the threads domain (ATC-255),
+	// not terminal state: the terminals domain never sets it.
+	ActiveThreadID string         `json:"activeThreadId,omitempty" doc:"Thread whose conversation is currently open in this terminal; omitted when no conversation is observed."`
+	Status         TerminalStatus `json:"status" enum:"running,exited,unreachable,missing" doc:"Server-owned session state."`
+	ExitCode       *int           `json:"exitCode,omitempty" doc:"Recorded exit evidence: exit code, 128+signal for signal deaths, 127 for launch failure. Omitted while running and for ATC-initiated stops."`
+	CreatedAt      time.Time      `json:"createdAt"`
+	UpdatedAt      time.Time      `json:"updatedAt"`
 }
 
 // TerminalCreateParams is the POST /v1/terminals request body. The project

--- a/internal/api/thread.go
+++ b/internal/api/thread.go
@@ -1,0 +1,74 @@
+package api
+
+import "time"
+
+// ThreadStatus is the server-owned state of an agent conversation
+// (ATC-255), derived only from structured provider evidence — never
+// guessed, never screen-parsed. Unknown means no evidence.
+type ThreadStatus string
+
+const (
+	// ThreadUnknown: no current evidence. Live states coerce here when the
+	// thread stops being observed (TUI closed, conversation switched away,
+	// server restart).
+	ThreadUnknown ThreadStatus = "unknown"
+	// ThreadIdle: the agent finished its last turn. Idle persists while
+	// the thread is inactive — a resumable conversation at rest.
+	ThreadIdle ThreadStatus = "idle"
+	// ThreadWorking: the agent is doing work right now. Claude fires no
+	// hook on user interrupt, so working can overstay by up to roughly a
+	// minute until the next prompt or idle notification (accepted
+	// limitation).
+	ThreadWorking ThreadStatus = "working"
+	// ThreadWaitingForInput: the agent asked the user a question and is
+	// blocked on the answer.
+	ThreadWaitingForInput ThreadStatus = "waiting_for_input"
+	// ThreadWaitingForPermission: the agent is blocked on a permission
+	// approval.
+	ThreadWaitingForPermission ThreadStatus = "waiting_for_permission"
+	// ThreadError: the thread itself is faulted. A merely failed turn is
+	// idle with the detail in lastError.
+	ThreadError ThreadStatus = "error"
+)
+
+// Thread is the /v1/threads resource: one exact provider conversation
+// observed inside an ATC-launched agent TUI. Threads are observed into
+// existence — there is no create verb — and persist as the durable index
+// of resumable conversations until deleted. The provider's own
+// conversation id never appears here; the ATC thread id is the public
+// identity.
+type Thread struct {
+	ID    string `json:"id" doc:"Server-minted identifier; the public identity of the conversation."`
+	Agent string `json:"agent" doc:"Agent catalog id that owns the conversation. Immutable."`
+	// ProjectID comes from the terminal that first observed the
+	// conversation and never changes afterwards.
+	ProjectID  string `json:"projectId" doc:"Project the thread belongs to, set from the observing terminal at first observation. Immutable."`
+	TerminalID string `json:"terminalId,omitempty" doc:"Last terminal observed holding the conversation; omitted once that terminal is deleted. Whether the conversation is open right now is the terminal's activeThreadId, not this field."`
+	Title      string `json:"title,omitempty" doc:"Display title: user-editable, with an observed default. Once set through ATC, observation never overwrites it."`
+	Model      string `json:"model,omitempty" doc:"Observed model, best-effort."`
+	Effort     string `json:"effort,omitempty" doc:"Observed reasoning effort, best-effort."`
+	Cwd        string `json:"cwd,omitempty" doc:"Provider-reported working directory, best-effort; a resumed conversation can run from a different directory than the terminal's."`
+	// PermissionMode is provider-native and read-only; ATC imposes no
+	// normalized vocabulary on it.
+	PermissionMode string       `json:"permissionMode,omitempty" doc:"Provider-native permission mode string, read-only."`
+	Status         ThreadStatus `json:"status" enum:"unknown,idle,working,waiting_for_input,waiting_for_permission,error" doc:"What the agent is doing right now, derived from provider evidence; unknown means no evidence."`
+	LastError      string       `json:"lastError,omitempty" doc:"Detail of the most recent failed turn; the thread itself stays idle."`
+	LastEvidenceAt *time.Time   `json:"lastEvidenceAt,omitempty" doc:"When the most recent provider evidence for this thread arrived."`
+	Archived       bool         `json:"archived" doc:"Reversible soft-hide; archived threads are excluded from lists unless requested."`
+	ArchivedAt     *time.Time   `json:"archivedAt,omitempty" doc:"When the thread was archived; server-managed."`
+	CreatedAt      time.Time    `json:"createdAt"`
+	UpdatedAt      time.Time    `json:"updatedAt"`
+}
+
+// ThreadUpdateParams is the PATCH /v1/threads/{id} request body. Title
+// and archived are the only mutable fields; archive/unarchive is a PATCH
+// of archived, with no custom action routes.
+type ThreadUpdateParams struct {
+	Title    *string `json:"title,omitempty" minLength:"1" doc:"New display title. Observation never overwrites a title set here."`
+	Archived *bool   `json:"archived,omitempty" doc:"true archives the thread, false unarchives it. Archiving an active thread is refused."`
+}
+
+// ThreadList is the GET /v1/threads response body.
+type ThreadList struct {
+	Threads []Thread `json:"threads"`
+}

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -92,6 +92,9 @@ func registerEvents(humaAPI huma.API, hub *events.Hub, heartbeat time.Duration) 
 		api.EventProjectCreated:  api.ProjectCreatedEvent{},
 		api.EventProjectUpdated:  api.ProjectUpdatedEvent{},
 		api.EventProjectDeleted:  api.ProjectDeletedEvent{},
+		api.EventThreadCreated:   api.ThreadCreatedEvent{},
+		api.EventThreadUpdated:   api.ThreadUpdatedEvent{},
+		api.EventThreadDeleted:   api.ThreadDeletedEvent{},
 		api.EventResync:          api.ResyncEvent{},
 	}, func(ctx context.Context, input *eventsInput, send sse.Sender) {
 		after, hasCursor := uint64(0), false
@@ -166,6 +169,12 @@ func sendChange(send sse.Sender, change events.Change) error {
 		data = api.ProjectUpdatedEvent{ChangeEvent: body}
 	case api.EventProjectDeleted:
 		data = api.ProjectDeletedEvent{ChangeEvent: body}
+	case api.EventThreadCreated:
+		data = api.ThreadCreatedEvent{ChangeEvent: body}
+	case api.EventThreadUpdated:
+		data = api.ThreadUpdatedEvent{ChangeEvent: body}
+	case api.EventThreadDeleted:
+		data = api.ThreadDeletedEvent{ChangeEvent: body}
 	default:
 		// An unmapped type would panic Huma's type lookup; drop it loudly
 		// in tests via the OpenAPI event map instead.

--- a/internal/server/projects.go
+++ b/internal/server/projects.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jeremytondo/atc/internal/api"
 	"github.com/jeremytondo/atc/internal/projects"
+	"github.com/jeremytondo/atc/internal/threads"
 )
 
 // The five standard verbs on /v1/projects — exactly these, mirroring the
@@ -27,7 +28,7 @@ type projectIDInput struct {
 	ID string `path:"id" doc:"Project identifier."`
 }
 
-func registerProjects(humaAPI huma.API, service *projects.Service) {
+func registerProjects(humaAPI huma.API, service *projects.Service, threadService *threads.Service) {
 	huma.Register(humaAPI, huma.Operation{
 		OperationID:   "create-project",
 		Method:        http.MethodPost,
@@ -93,11 +94,18 @@ func registerProjects(humaAPI huma.API, service *projects.Service) {
 		Method:        http.MethodDelete,
 		Path:          "/v1/projects/{id}",
 		Summary:       "Delete a project",
-		Description:   "Refused while any terminal still belongs to the project, reporting what remains. No cascade.",
+		Description:   "Refused while any terminal still belongs to the project, reporting what remains. The project's thread records are deleted with it.",
 		DefaultStatus: http.StatusNoContent,
 	}, func(ctx context.Context, input *projectIDInput) (*struct{}, error) {
 		if err := service.Delete(ctx, input.ID); err != nil {
 			return nil, mapProjectError(err)
+		}
+		if threadService != nil {
+			// The schema cascade already removed the project's thread rows
+			// and identity mappings; this converges the threads view and
+			// publishes their deletion. Wired here because the projects
+			// domain must not know threads exist.
+			threadService.ProjectRemoved(input.ID)
 		}
 		return nil, nil
 	})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jeremytondo/atc/internal/events"
 	"github.com/jeremytondo/atc/internal/projects"
 	"github.com/jeremytondo/atc/internal/terminals"
+	"github.com/jeremytondo/atc/internal/threads"
 )
 
 // HealthOutput is Huma routing machinery around the shared body; the
@@ -46,6 +47,7 @@ type Options struct {
 	Terminals *terminals.Service
 	Projects  *projects.Service
 	Agents    *agents.Service
+	Threads   *threads.Service
 	Events    *events.Hub
 	// HeartbeatInterval paces SSE heartbeats; zero means the default.
 	HeartbeatInterval time.Duration
@@ -90,13 +92,16 @@ func NewHandler(opts Options) http.Handler {
 	})
 
 	if opts.Terminals != nil {
-		registerTerminals(humaAPI, opts.Terminals, opts.Agents)
+		registerTerminals(humaAPI, opts.Terminals, opts.Agents, opts.Threads)
 	}
 	if opts.Projects != nil {
-		registerProjects(humaAPI, opts.Projects)
+		registerProjects(humaAPI, opts.Projects, opts.Threads)
 	}
 	if opts.Agents != nil {
 		registerAgents(humaAPI, opts.Agents)
+	}
+	if opts.Threads != nil {
+		registerThreads(humaAPI, opts.Threads)
 	}
 	if opts.Events != nil {
 		registerEvents(humaAPI, opts.Events, opts.HeartbeatInterval)

--- a/internal/server/terminals.go
+++ b/internal/server/terminals.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jeremytondo/atc/internal/agents"
 	"github.com/jeremytondo/atc/internal/api"
 	"github.com/jeremytondo/atc/internal/terminals"
+	"github.com/jeremytondo/atc/internal/threads"
 )
 
 // The five standard verbs on /v1/terminals — exactly these, no custom
@@ -28,7 +29,16 @@ type terminalIDInput struct {
 	ID string `path:"id" doc:"Terminal identifier."`
 }
 
-func registerTerminals(humaAPI huma.API, service *terminals.Service, agentService *agents.Service) {
+func registerTerminals(humaAPI huma.API, service *terminals.Service, agentService *agents.Service, threadService *threads.Service) {
+	// The terminals domain is agent-agnostic, so the activeThreadId
+	// projection is grafted onto its wire shape here, from the threads
+	// service that owns it (ATC-255).
+	decorate := func(terminal api.Terminal) api.Terminal {
+		if threadService != nil {
+			terminal.ActiveThreadID = threadService.ActiveThreadID(terminal.ID)
+		}
+		return terminal
+	}
 	huma.Register(humaAPI, huma.Operation{
 		OperationID:   "create-terminal",
 		Method:        http.MethodPost,
@@ -53,13 +63,13 @@ func registerTerminals(humaAPI huma.API, service *terminals.Service, agentServic
 			if err != nil {
 				return nil, mapAgentError(err)
 			}
-			return &terminalOutput{Body: terminal}, nil
+			return &terminalOutput{Body: decorate(terminal)}, nil
 		}
 		terminal, err := service.Create(ctx, input.Body)
 		if err != nil {
 			return nil, mapError(err)
 		}
-		return &terminalOutput{Body: terminal}, nil
+		return &terminalOutput{Body: decorate(terminal)}, nil
 	})
 
 	huma.Register(humaAPI, huma.Operation{
@@ -71,7 +81,11 @@ func registerTerminals(humaAPI huma.API, service *terminals.Service, agentServic
 	}, func(ctx context.Context, input *struct {
 		Project string `query:"project" doc:"Only terminals belonging to this project."`
 	}) (*terminalListOutput, error) {
-		return &terminalListOutput{Body: api.TerminalList{Terminals: service.List(input.Project)}}, nil
+		terminals := service.List(input.Project)
+		for i, terminal := range terminals {
+			terminals[i] = decorate(terminal)
+		}
+		return &terminalListOutput{Body: api.TerminalList{Terminals: terminals}}, nil
 	})
 
 	huma.Register(humaAPI, huma.Operation{
@@ -84,7 +98,7 @@ func registerTerminals(humaAPI huma.API, service *terminals.Service, agentServic
 		if err != nil {
 			return nil, mapError(err)
 		}
-		return &terminalOutput{Body: terminal}, nil
+		return &terminalOutput{Body: decorate(terminal)}, nil
 	})
 
 	huma.Register(humaAPI, huma.Operation{
@@ -101,7 +115,7 @@ func registerTerminals(humaAPI huma.API, service *terminals.Service, agentServic
 		if err != nil {
 			return nil, mapError(err)
 		}
-		return &terminalOutput{Body: terminal}, nil
+		return &terminalOutput{Body: decorate(terminal)}, nil
 	})
 
 	huma.Register(humaAPI, huma.Operation{
@@ -114,6 +128,15 @@ func registerTerminals(humaAPI huma.API, service *terminals.Service, agentServic
 	}, func(ctx context.Context, input *terminalIDInput) (*struct{}, error) {
 		if err := service.Delete(ctx, input.ID); err != nil {
 			return nil, mapError(err)
+		}
+		if threadService != nil {
+			// The schema's ON DELETE SET NULL already cleared the rows;
+			// this converges the threads view and publishes the linkage
+			// change. Wired here because the terminals domain must not
+			// know threads exist. Detached like the delete itself: a
+			// client disconnect after the commit must not leave the view
+			// linked to a deleted terminal.
+			threadService.TerminalRemoved(context.WithoutCancel(ctx), input.ID)
 		}
 		return nil, nil
 	})

--- a/internal/server/terminals_test.go
+++ b/internal/server/terminals_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/jeremytondo/atc/internal/store"
 	"github.com/jeremytondo/atc/internal/terminals"
 	"github.com/jeremytondo/atc/internal/terminals/exitmarker"
+	"github.com/jeremytondo/atc/internal/threads"
 )
 
 // fakeAdapter is the hand-written session backend for API-contract tests:
@@ -90,6 +91,7 @@ type fixture struct {
 	adapter    *fakeAdapter
 	hub        *events.Hub
 	service    *terminals.Service
+	threads    *threads.Service
 	binaries   map[string]bool
 	markers    string
 	projectID  string
@@ -149,6 +151,15 @@ func newFixture(t *testing.T) *fixture {
 	if err != nil {
 		t.Fatal(err)
 	}
+	threadService := threads.NewService(threads.Options{
+		Repository: db.Threads(),
+		Terminals:  service,
+		Hub:        hub,
+		Now:        now,
+	})
+	if err := threadService.Load(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 	handler := NewHandler(Options{
 		Verify:            testVerify,
 		Version:           testVersion,
@@ -156,10 +167,11 @@ func newFixture(t *testing.T) *fixture {
 		Terminals:         service,
 		Projects:          projectService,
 		Agents:            agentService,
+		Threads:           threadService,
 		Events:            hub,
 		HeartbeatInterval: 50 * time.Millisecond,
 	})
-	f := &fixture{handler: handler, adapter: adapter, hub: hub, service: service, binaries: binaries, markers: markers}
+	f := &fixture{handler: handler, adapter: adapter, hub: hub, service: service, threads: threadService, binaries: binaries, markers: markers}
 	// Planted through the repository, not the API: the fixture project must
 	// not consume an event sequence number the SSE assertions rely on.
 	f.projectDir = t.TempDir()

--- a/internal/server/threads.go
+++ b/internal/server/threads.go
@@ -1,0 +1,102 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"github.com/jeremytondo/atc/internal/api"
+	"github.com/jeremytondo/atc/internal/threads"
+)
+
+// Four verbs on /v1/threads (ATC-255): deliberately no POST — threads are
+// observed into existence, not created — and no custom action routes;
+// archive/unarchive is a PATCH of archived. Handlers are thin Huma
+// wrappers around the shared wire structs; policy lives in the threads
+// service.
+
+type threadOutput struct {
+	Body api.Thread
+}
+
+type threadListOutput struct {
+	Body api.ThreadList
+}
+
+type threadIDInput struct {
+	ID string `path:"id" doc:"Thread identifier."`
+}
+
+func registerThreads(humaAPI huma.API, service *threads.Service) {
+	huma.Register(humaAPI, huma.Operation{
+		OperationID: "list-threads",
+		Method:      http.MethodGet,
+		Path:        "/v1/threads",
+		Summary:     "List threads",
+		Description: "Served from the in-memory view. Archived threads are hidden unless includeArchived; unfiltered, returns every unarchived thread.",
+	}, func(ctx context.Context, input *struct {
+		Project         string `query:"project" doc:"Only threads belonging to this project."`
+		Terminal        string `query:"terminal" doc:"Only threads whose last observed terminal is this one."`
+		IncludeArchived bool   `query:"includeArchived" doc:"Include archived threads."`
+	}) (*threadListOutput, error) {
+		return &threadListOutput{Body: api.ThreadList{
+			Threads: service.List(input.Project, input.Terminal, input.IncludeArchived),
+		}}, nil
+	})
+
+	huma.Register(humaAPI, huma.Operation{
+		OperationID: "get-thread",
+		Method:      http.MethodGet,
+		Path:        "/v1/threads/{id}",
+		Summary:     "Get a thread",
+	}, func(ctx context.Context, input *threadIDInput) (*threadOutput, error) {
+		thread, err := service.Get(input.ID)
+		if err != nil {
+			return nil, mapThreadError(err)
+		}
+		return &threadOutput{Body: thread}, nil
+	})
+
+	huma.Register(humaAPI, huma.Operation{
+		OperationID: "update-thread",
+		Method:      http.MethodPatch,
+		Path:        "/v1/threads/{id}",
+		Summary:     "Update a thread",
+		Description: "Title and archived are the only mutable fields. A title set here is never overwritten by observation. Archiving a thread a terminal has open is refused, naming the terminal.",
+	}, func(ctx context.Context, input *struct {
+		ID   string `path:"id" doc:"Thread identifier."`
+		Body api.ThreadUpdateParams
+	}) (*threadOutput, error) {
+		thread, err := service.Update(ctx, input.ID, input.Body)
+		if err != nil {
+			return nil, mapThreadError(err)
+		}
+		return &threadOutput{Body: thread}, nil
+	})
+
+	huma.Register(humaAPI, huma.Operation{
+		OperationID:   "delete-thread",
+		Method:        http.MethodDelete,
+		Path:          "/v1/threads/{id}",
+		Summary:       "Delete a thread",
+		Description:   "Removes ATC's record and its private identity mapping only; the provider-side conversation is never touched. A thread a terminal has open is refused, naming the terminal.",
+		DefaultStatus: http.StatusNoContent,
+	}, func(ctx context.Context, input *threadIDInput) (*struct{}, error) {
+		if err := service.Delete(ctx, input.ID); err != nil {
+			return nil, mapThreadError(err)
+		}
+		return nil, nil
+	})
+}
+
+func mapThreadError(err error) error {
+	switch {
+	case errors.Is(err, threads.ErrNotFound):
+		return huma.Error404NotFound("thread not found")
+	case errors.Is(err, threads.ErrActive):
+		return huma.Error409Conflict(err.Error())
+	}
+	return err
+}

--- a/internal/server/threads_test.go
+++ b/internal/server/threads_test.go
@@ -1,0 +1,290 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/jeremytondo/atc/internal/api"
+	"github.com/jeremytondo/atc/internal/threads"
+)
+
+// observeThread plants an observed conversation in the fixture's threads
+// service — the seam the provider observers use in production (there is
+// deliberately no POST /v1/threads to do it over the wire).
+func (f *fixture) observeThread(t *testing.T, terminalID, providerID string, status api.ThreadStatus) string {
+	t.Helper()
+	id, err := f.threads.ObserveSession(context.Background(), threads.SessionObservation{
+		Agent:      "claude",
+		ProviderID: providerID,
+		TerminalID: terminalID,
+		ProjectID:  f.projectID,
+		Status:     status,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+// createRunningTerminal creates a terminal over the wire for threads to
+// belong to.
+func (f *fixture) createRunningTerminal(t *testing.T) api.Terminal {
+	t.Helper()
+	rec := f.request(t, http.MethodPost, "/v1/terminals", f.createTerminalBody(t, api.TerminalCreateParams{Command: "claude"}))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create terminal: got %d; body %s", rec.Code, rec.Body)
+	}
+	return decodeTerminal(t, rec)
+}
+
+func decodeThread(t *testing.T, rec *httptest.ResponseRecorder) api.Thread {
+	t.Helper()
+	var thread api.Thread
+	if err := json.Unmarshal(rec.Body.Bytes(), &thread); err != nil {
+		t.Fatalf("decoding %q: %v", rec.Body, err)
+	}
+	return thread
+}
+
+func TestThreadReadsOverTheWire(t *testing.T) {
+	f := newFixture(t)
+	terminal := f.createRunningTerminal(t)
+
+	rec := f.request(t, http.MethodGet, "/v1/threads", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("empty list: got %d", rec.Code)
+	}
+	var list api.ThreadList
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatal(err)
+	}
+	if list.Threads == nil || len(list.Threads) != 0 {
+		t.Errorf("empty list body = %s; want an empty array, not null", rec.Body)
+	}
+
+	id := f.observeThread(t, terminal.ID, "sess-1", api.ThreadWorking)
+	rec = f.request(t, http.MethodGet, "/v1/threads/"+id, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get: got %d; body %s", rec.Code, rec.Body)
+	}
+	thread := decodeThread(t, rec)
+	if thread.ID != id || thread.Agent != "claude" || thread.Status != api.ThreadWorking || thread.TerminalID != terminal.ID {
+		t.Errorf("thread = %+v", thread)
+	}
+
+	// Filters ride the query string.
+	for path, want := range map[string]int{
+		"/v1/threads":                         1,
+		"/v1/threads?project=" + f.projectID:  1,
+		"/v1/threads?project=proj-nope":       0,
+		"/v1/threads?terminal=" + terminal.ID: 1,
+		"/v1/threads?terminal=term-nope":      0,
+	} {
+		rec := f.request(t, http.MethodGet, path, "")
+		if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+			t.Fatal(err)
+		}
+		if len(list.Threads) != want {
+			t.Errorf("%s = %d threads; want %d", path, len(list.Threads), want)
+		}
+	}
+
+	if rec := f.request(t, http.MethodGet, "/v1/threads/thrd-zzzzz", ""); rec.Code != http.StatusNotFound {
+		t.Errorf("get unknown: got %d, want 404", rec.Code)
+	}
+
+	// The terminal wire shape carries the activeThreadId projection.
+	rec = f.request(t, http.MethodGet, "/v1/terminals/"+terminal.ID, "")
+	if got := decodeTerminal(t, rec); got.ActiveThreadID != id {
+		t.Errorf("terminal.activeThreadId = %q; want %q", got.ActiveThreadID, id)
+	}
+}
+
+func TestThreadUpdateAndArchiveOverTheWire(t *testing.T) {
+	f := newFixture(t)
+	terminal := f.createRunningTerminal(t)
+	id := f.observeThread(t, terminal.ID, "sess-1", api.ThreadIdle)
+
+	// Title is mutable while active.
+	rec := f.request(t, http.MethodPatch, "/v1/threads/"+id, `{"title":"my title"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch title: got %d; body %s", rec.Code, rec.Body)
+	}
+	if thread := decodeThread(t, rec); thread.Title != "my title" {
+		t.Errorf("title = %q", thread.Title)
+	}
+	// An empty title fails validation.
+	if rec := f.request(t, http.MethodPatch, "/v1/threads/"+id, `{"title":""}`); rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("empty title: got %d, want 422", rec.Code)
+	}
+
+	// Archiving the active thread is refused, naming the holding terminal.
+	rec = f.request(t, http.MethodPatch, "/v1/threads/"+id, `{"archived":true}`)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("archive active: got %d; body %s", rec.Code, rec.Body)
+	}
+	if !strings.Contains(rec.Body.String(), terminal.ID) {
+		t.Errorf("conflict body %s does not name the terminal", rec.Body)
+	}
+
+	// Once the conversation is switched away, archive works and the thread
+	// disappears from the default list, returning with the opt-in flag.
+	f.observeThread(t, terminal.ID, "sess-2", api.ThreadIdle)
+	rec = f.request(t, http.MethodPatch, "/v1/threads/"+id, `{"archived":true}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("archive inactive: got %d; body %s", rec.Code, rec.Body)
+	}
+	if thread := decodeThread(t, rec); !thread.Archived || thread.ArchivedAt == nil {
+		t.Errorf("archived thread = %+v", thread)
+	}
+	var list api.ThreadList
+	rec = f.request(t, http.MethodGet, "/v1/threads", "")
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Threads) != 1 {
+		t.Errorf("default list = %d threads; want 1 (archived hidden)", len(list.Threads))
+	}
+	rec = f.request(t, http.MethodGet, "/v1/threads?includeArchived=true", "")
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Threads) != 2 {
+		t.Errorf("includeArchived list = %d threads; want 2", len(list.Threads))
+	}
+
+	// Unarchive is the same PATCH.
+	rec = f.request(t, http.MethodPatch, "/v1/threads/"+id, `{"archived":false}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unarchive: got %d", rec.Code)
+	}
+	if thread := decodeThread(t, rec); thread.Archived || thread.ArchivedAt != nil {
+		t.Errorf("unarchived thread = %+v", thread)
+	}
+
+	if rec := f.request(t, http.MethodPatch, "/v1/threads/thrd-zzzzz", `{"title":"x"}`); rec.Code != http.StatusNotFound {
+		t.Errorf("patch unknown: got %d, want 404", rec.Code)
+	}
+}
+
+func TestThreadDeleteOverTheWire(t *testing.T) {
+	f := newFixture(t)
+	terminal := f.createRunningTerminal(t)
+	id := f.observeThread(t, terminal.ID, "sess-1", api.ThreadIdle)
+
+	rec := f.request(t, http.MethodDelete, "/v1/threads/"+id, "")
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("delete active: got %d; body %s", rec.Code, rec.Body)
+	}
+	if !strings.Contains(rec.Body.String(), terminal.ID) {
+		t.Errorf("conflict body %s does not name the terminal", rec.Body)
+	}
+
+	f.observeThread(t, terminal.ID, "sess-2", api.ThreadIdle)
+	if rec := f.request(t, http.MethodDelete, "/v1/threads/"+id, ""); rec.Code != http.StatusNoContent {
+		t.Fatalf("delete inactive: got %d; body %s", rec.Code, rec.Body)
+	}
+	if rec := f.request(t, http.MethodGet, "/v1/threads/"+id, ""); rec.Code != http.StatusNotFound {
+		t.Errorf("get after delete: got %d, want 404", rec.Code)
+	}
+	if rec := f.request(t, http.MethodDelete, "/v1/threads/"+id, ""); rec.Code != http.StatusNotFound {
+		t.Errorf("second delete: got %d, want 404", rec.Code)
+	}
+}
+
+// Deleting a terminal clears thread linkage; deleting the project then
+// removes the records — the wire-level referential lifecycle.
+func TestThreadReferentialLifecycleOverTheWire(t *testing.T) {
+	f := newFixture(t)
+	terminal := f.createRunningTerminal(t)
+	id := f.observeThread(t, terminal.ID, "sess-1", api.ThreadWorking)
+
+	if rec := f.request(t, http.MethodDelete, "/v1/terminals/"+terminal.ID, ""); rec.Code != http.StatusNoContent {
+		t.Fatalf("delete terminal: got %d", rec.Code)
+	}
+	rec := f.request(t, http.MethodGet, "/v1/threads/"+id, "")
+	thread := decodeThread(t, rec)
+	if thread.TerminalID != "" {
+		t.Errorf("terminalId = %q; want cleared after terminal delete", thread.TerminalID)
+	}
+	if thread.Status != api.ThreadUnknown {
+		t.Errorf("status = %s; want unknown after its terminal left", thread.Status)
+	}
+
+	// The other fixture terminals are gone too, so the project can go; its
+	// threads go with it (unlike terminals, which block).
+	if rec := f.request(t, http.MethodDelete, "/v1/projects/"+f.projectID, ""); rec.Code != http.StatusNoContent {
+		t.Fatalf("delete project: got %d; body %s", rec.Code, rec.Body)
+	}
+	if rec := f.request(t, http.MethodGet, "/v1/threads/"+id, ""); rec.Code != http.StatusNotFound {
+		t.Errorf("thread survived project delete: got %d, want 404", rec.Code)
+	}
+}
+
+// A client that cancels its delete request after the commit must not
+// leave threads linked to the deleted terminal: the cleanup runs
+// detached, like the delete itself.
+func TestTerminalDeleteConvergesThreadsDespiteCancel(t *testing.T) {
+	f := newFixture(t)
+	terminal := f.createRunningTerminal(t)
+	id := f.observeThread(t, terminal.ID, "sess-1", api.ThreadWorking)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := httptest.NewRequest(http.MethodDelete, "/v1/terminals/"+terminal.ID, nil).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	rec := httptest.NewRecorder()
+	f.handler.ServeHTTP(rec, req)
+
+	thread := decodeThread(t, f.request(t, http.MethodGet, "/v1/threads/"+id, ""))
+	if thread.TerminalID != "" || thread.Status != api.ThreadUnknown {
+		t.Errorf("thread after cancelled delete = %+v; want cleared linkage and unknown", thread)
+	}
+}
+
+// The thread change events ride the same SSE feed with their own names.
+func TestThreadEventsOnTheFeed(t *testing.T) {
+	f := newFixture(t)
+	srv := httptest.NewServer(f.handler)
+	t.Cleanup(srv.Close)
+
+	client := dialSSE(t, srv.URL, "")
+	if opening := client.next(t); opening.Comment != "connected" {
+		t.Fatalf("opening message = %+v", opening)
+	}
+
+	terminal := f.createRunningTerminal(t)
+	id := f.observeThread(t, terminal.ID, "sess-1", api.ThreadIdle)
+
+	var seen []string
+	for range 4 {
+		event := client.next(t)
+		seen = append(seen, event.Event+" "+resourceID(t, event.Data))
+	}
+	// The middle terminal.updated is the create settling to running; the
+	// last is the activeThreadId projection moving.
+	want := []string{
+		"terminal.created " + terminal.ID,
+		"terminal.updated " + terminal.ID,
+		"thread.created " + id,
+		"terminal.updated " + terminal.ID,
+	}
+	if diff := cmp.Diff(want, seen); diff != "" {
+		t.Errorf("feed (-want +got):\n%s", diff)
+	}
+}
+
+func resourceID(t *testing.T, data string) string {
+	t.Helper()
+	var change api.ChangeEvent
+	if err := json.Unmarshal([]byte(data), &change); err != nil {
+		t.Fatalf("decoding %q: %v", data, err)
+	}
+	return change.ID
+}

--- a/internal/store/gen/models.go
+++ b/internal/store/gen/models.go
@@ -29,3 +29,29 @@ type Terminal struct {
 	ExitCode        sql.NullInt64
 	Agent           sql.NullString
 }
+
+type Thread struct {
+	ID             string
+	Agent          string
+	ProjectID      string
+	TerminalID     sql.NullString
+	Title          sql.NullString
+	TitleUserSet   int64
+	Model          sql.NullString
+	Effort         sql.NullString
+	Cwd            sql.NullString
+	PermissionMode sql.NullString
+	Status         string
+	LastError      sql.NullString
+	LastEvidenceAt sql.NullString
+	Archived       int64
+	ArchivedAt     sql.NullString
+	CreatedAt      string
+	UpdatedAt      string
+}
+
+type ThreadIdentity struct {
+	Agent                  string
+	ProviderConversationID string
+	ThreadID               string
+}

--- a/internal/store/gen/queries.sql.go
+++ b/internal/store/gen/queries.sql.go
@@ -34,6 +34,18 @@ func (q *Queries) DeleteTerminal(ctx context.Context, id string) (int64, error) 
 	return result.RowsAffected()
 }
 
+const deleteThread = `-- name: DeleteThread :execrows
+DELETE FROM threads WHERE id = ?
+`
+
+func (q *Queries) DeleteThread(ctx context.Context, id string) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteThread, id)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const getProject = `-- name: GetProject :one
 SELECT id, name, directory, created_at, updated_at FROM projects WHERE id = ?
 `
@@ -114,6 +126,80 @@ func (q *Queries) InsertTerminal(ctx context.Context, arg InsertTerminalParams) 
 		arg.CreatedAt,
 		arg.UpdatedAt,
 	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const insertThread = `-- name: InsertThread :execrows
+INSERT INTO threads (id, agent, project_id, terminal_id, title, title_user_set, model, effort,
+    cwd, permission_mode, status, last_error, last_evidence_at, archived, archived_at,
+    created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT (id) DO NOTHING
+`
+
+type InsertThreadParams struct {
+	ID             string
+	Agent          string
+	ProjectID      string
+	TerminalID     sql.NullString
+	Title          sql.NullString
+	TitleUserSet   int64
+	Model          sql.NullString
+	Effort         sql.NullString
+	Cwd            sql.NullString
+	PermissionMode sql.NullString
+	Status         string
+	LastError      sql.NullString
+	LastEvidenceAt sql.NullString
+	Archived       int64
+	ArchivedAt     sql.NullString
+	CreatedAt      string
+	UpdatedAt      string
+}
+
+func (q *Queries) InsertThread(ctx context.Context, arg InsertThreadParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, insertThread,
+		arg.ID,
+		arg.Agent,
+		arg.ProjectID,
+		arg.TerminalID,
+		arg.Title,
+		arg.TitleUserSet,
+		arg.Model,
+		arg.Effort,
+		arg.Cwd,
+		arg.PermissionMode,
+		arg.Status,
+		arg.LastError,
+		arg.LastEvidenceAt,
+		arg.Archived,
+		arg.ArchivedAt,
+		arg.CreatedAt,
+		arg.UpdatedAt,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const insertThreadIdentity = `-- name: InsertThreadIdentity :execrows
+INSERT INTO thread_identities (agent, provider_conversation_id, thread_id)
+VALUES (?, ?, ?)
+ON CONFLICT (agent, provider_conversation_id) DO NOTHING
+`
+
+type InsertThreadIdentityParams struct {
+	Agent                  string
+	ProviderConversationID string
+	ThreadID               string
+}
+
+func (q *Queries) InsertThreadIdentity(ctx context.Context, arg InsertThreadIdentityParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, insertThreadIdentity, arg.Agent, arg.ProviderConversationID, arg.ThreadID)
 	if err != nil {
 		return 0, err
 	}
@@ -220,6 +306,78 @@ func (q *Queries) ListTerminals(ctx context.Context) ([]Terminal, error) {
 	return items, nil
 }
 
+const listThreadIdentities = `-- name: ListThreadIdentities :many
+SELECT agent, provider_conversation_id, thread_id FROM thread_identities
+`
+
+func (q *Queries) ListThreadIdentities(ctx context.Context) ([]ThreadIdentity, error) {
+	rows, err := q.db.QueryContext(ctx, listThreadIdentities)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ThreadIdentity
+	for rows.Next() {
+		var i ThreadIdentity
+		if err := rows.Scan(&i.Agent, &i.ProviderConversationID, &i.ThreadID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listThreads = `-- name: ListThreads :many
+SELECT id, agent, project_id, terminal_id, title, title_user_set, model, effort, cwd, permission_mode, status, last_error, last_evidence_at, archived, archived_at, created_at, updated_at FROM threads ORDER BY created_at, id
+`
+
+func (q *Queries) ListThreads(ctx context.Context) ([]Thread, error) {
+	rows, err := q.db.QueryContext(ctx, listThreads)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Thread
+	for rows.Next() {
+		var i Thread
+		if err := rows.Scan(
+			&i.ID,
+			&i.Agent,
+			&i.ProjectID,
+			&i.TerminalID,
+			&i.Title,
+			&i.TitleUserSet,
+			&i.Model,
+			&i.Effort,
+			&i.Cwd,
+			&i.PermissionMode,
+			&i.Status,
+			&i.LastError,
+			&i.LastEvidenceAt,
+			&i.Archived,
+			&i.ArchivedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const recordTerminalExit = `-- name: RecordTerminalExit :execrows
 UPDATE terminals SET exited_at = ?, exit_code = ?, updated_at = ?
 WHERE id = ? AND exited_at IS NULL
@@ -303,6 +461,56 @@ type UpdateTerminalNameParams struct {
 
 func (q *Queries) UpdateTerminalName(ctx context.Context, arg UpdateTerminalNameParams) (int64, error) {
 	result, err := q.db.ExecContext(ctx, updateTerminalName, arg.Name, arg.UpdatedAt, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const updateThread = `-- name: UpdateThread :execrows
+UPDATE threads SET terminal_id = ?, title = ?, title_user_set = ?, model = ?, effort = ?,
+    cwd = ?, permission_mode = ?, status = ?, last_error = ?, last_evidence_at = ?,
+    archived = ?, archived_at = ?, updated_at = ?
+WHERE id = ?
+`
+
+type UpdateThreadParams struct {
+	TerminalID     sql.NullString
+	Title          sql.NullString
+	TitleUserSet   int64
+	Model          sql.NullString
+	Effort         sql.NullString
+	Cwd            sql.NullString
+	PermissionMode sql.NullString
+	Status         string
+	LastError      sql.NullString
+	LastEvidenceAt sql.NullString
+	Archived       int64
+	ArchivedAt     sql.NullString
+	UpdatedAt      string
+	ID             string
+}
+
+// One broad update: the domain service owns the view and serializes
+// mutations, so every mutable column is written from the record as one
+// statement instead of a query per verb.
+func (q *Queries) UpdateThread(ctx context.Context, arg UpdateThreadParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, updateThread,
+		arg.TerminalID,
+		arg.Title,
+		arg.TitleUserSet,
+		arg.Model,
+		arg.Effort,
+		arg.Cwd,
+		arg.PermissionMode,
+		arg.Status,
+		arg.LastError,
+		arg.LastEvidenceAt,
+		arg.Archived,
+		arg.ArchivedAt,
+		arg.UpdatedAt,
+		arg.ID,
+	)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/store/migrations/00005_threads.sql
+++ b/internal/store/migrations/00005_threads.sql
@@ -1,0 +1,52 @@
+-- Threads (ATC-255): one row per observed provider conversation, the
+-- durable index of resumable conversations. Rows are observed into
+-- existence and leave only through the delete verb or a project cascade —
+-- no time-based cleanup. Live statuses (working, waiting_*) are evidence
+-- about a running observation and are coerced to 'unknown' at boot; idle,
+-- error, and unknown persist as recorded. Timestamps are fixed-width RFC
+-- 3339 UTC text (store.TimeFormat).
+-- +goose Up
+CREATE TABLE threads (
+    id TEXT PRIMARY KEY,
+    -- Agent catalog id that owns the conversation; immutable.
+    agent TEXT NOT NULL,
+    -- Set from the observing terminal at first observation; immutable.
+    -- Deleting a project cascade-deletes its thread records (unlike
+    -- terminals, which block the delete).
+    project_id TEXT NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    -- Last terminal observed holding the conversation; NULL once that
+    -- terminal is deleted. Liveness (the active thread) is derived at
+    -- runtime, never stored.
+    terminal_id TEXT REFERENCES terminals (id) ON DELETE SET NULL,
+    -- Observed best-effort metadata; NULL means never observed.
+    title TEXT,
+    -- Once a user sets the title through ATC, observation never
+    -- overwrites it. Internal flag, not wire-visible.
+    title_user_set INTEGER NOT NULL DEFAULT 0,
+    model TEXT,
+    effort TEXT,
+    -- Provider-reported working directory — resume can happen from a
+    -- different directory than the terminal's.
+    cwd TEXT,
+    -- Provider-native permission-mode string, read-only, no normalized
+    -- vocabulary.
+    permission_mode TEXT,
+    status TEXT NOT NULL,
+    last_error TEXT,
+    last_evidence_at TEXT,
+    archived INTEGER NOT NULL DEFAULT 0,
+    archived_at TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+) STRICT;
+
+-- The private identity mapping: (agent, provider conversation id) to
+-- thread. Provider conversation ids never leave the server; deleting a
+-- thread removes its mapping, so a later observation of the same provider
+-- conversation deliberately mints a fresh record.
+CREATE TABLE thread_identities (
+    agent TEXT NOT NULL,
+    provider_conversation_id TEXT NOT NULL,
+    thread_id TEXT NOT NULL REFERENCES threads (id) ON DELETE CASCADE,
+    PRIMARY KEY (agent, provider_conversation_id)
+) STRICT;

--- a/internal/store/queries.sql
+++ b/internal/store/queries.sql
@@ -51,3 +51,33 @@ UPDATE projects SET name = ?, updated_at = ? WHERE id = ? RETURNING *;
 
 -- name: DeleteProject :execrows
 DELETE FROM projects WHERE id = ?;
+
+-- name: InsertThread :execrows
+INSERT INTO threads (id, agent, project_id, terminal_id, title, title_user_set, model, effort,
+    cwd, permission_mode, status, last_error, last_evidence_at, archived, archived_at,
+    created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT (id) DO NOTHING;
+
+-- name: ListThreads :many
+SELECT * FROM threads ORDER BY created_at, id;
+
+-- One broad update: the domain service owns the view and serializes
+-- mutations, so every mutable column is written from the record as one
+-- statement instead of a query per verb.
+-- name: UpdateThread :execrows
+UPDATE threads SET terminal_id = ?, title = ?, title_user_set = ?, model = ?, effort = ?,
+    cwd = ?, permission_mode = ?, status = ?, last_error = ?, last_evidence_at = ?,
+    archived = ?, archived_at = ?, updated_at = ?
+WHERE id = ?;
+
+-- name: DeleteThread :execrows
+DELETE FROM threads WHERE id = ?;
+
+-- name: InsertThreadIdentity :execrows
+INSERT INTO thread_identities (agent, provider_conversation_id, thread_id)
+VALUES (?, ?, ?)
+ON CONFLICT (agent, provider_conversation_id) DO NOTHING;
+
+-- name: ListThreadIdentities :many
+SELECT * FROM thread_identities;

--- a/internal/store/threads.go
+++ b/internal/store/threads.go
@@ -1,0 +1,268 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/jeremytondo/atc/internal/store/gen"
+)
+
+// ThreadRecord is one threads row in domain terms: pointers for the
+// nullable facts, time.Time for the text timestamps. The SQL row shape
+// never leaves this package. Status is the persisted status string; the
+// threads domain owns its vocabulary and the boot-time coercion of live
+// states.
+type ThreadRecord struct {
+	ID string
+	// Agent is the agent catalog id that owns the conversation; immutable.
+	Agent string
+	// ProjectID is set from the observing terminal at first observation;
+	// immutable. Project deletion cascade-deletes the row.
+	ProjectID string
+	// TerminalID is the last terminal observed holding the conversation;
+	// nil once that terminal is deleted (ON DELETE SET NULL). A pointer
+	// because NULL and "" differ to the foreign key.
+	TerminalID *string
+	// Title and the rest of the observed metadata are best-effort; empty
+	// means never observed (stored NULL). TitleUserSet records that a user
+	// set the title through ATC, after which observation never overwrites
+	// it.
+	Title          string
+	TitleUserSet   bool
+	Model          string
+	Effort         string
+	Cwd            string
+	PermissionMode string
+	Status         string
+	LastError      string
+	LastEvidenceAt *time.Time
+	Archived       bool
+	ArchivedAt     *time.Time
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+// ThreadIdentity is one row of the private identity mapping: (agent,
+// provider conversation id) → thread. Provider conversation ids never
+// leave the server.
+type ThreadIdentity struct {
+	Agent                  string
+	ProviderConversationID string
+	ThreadID               string
+}
+
+// Threads is the repository for thread records and their identity
+// mappings. Reads go to the read pool, mutations to the single-writer
+// pool; db is that pool's handle, for the one multi-statement write.
+type Threads struct {
+	reads  *gen.Queries
+	writes *gen.Queries
+	db     *sql.DB
+}
+
+// Threads returns the threads repository.
+func (s *Store) Threads() *Threads {
+	return &Threads{reads: gen.New(s.reads), writes: gen.New(s.writes), db: s.writes}
+}
+
+func insertThreadParams(record ThreadRecord) gen.InsertThreadParams {
+	return gen.InsertThreadParams{
+		ID:             record.ID,
+		Agent:          record.Agent,
+		ProjectID:      record.ProjectID,
+		TerminalID:     nullStringPtr(record.TerminalID),
+		Title:          nullString(record.Title),
+		TitleUserSet:   boolInt(record.TitleUserSet),
+		Model:          nullString(record.Model),
+		Effort:         nullString(record.Effort),
+		Cwd:            nullString(record.Cwd),
+		PermissionMode: nullString(record.PermissionMode),
+		Status:         record.Status,
+		LastError:      nullString(record.LastError),
+		LastEvidenceAt: nullTime(record.LastEvidenceAt),
+		Archived:       boolInt(record.Archived),
+		ArchivedAt:     nullTime(record.ArchivedAt),
+		CreatedAt:      formatTime(record.CreatedAt),
+		UpdatedAt:      formatTime(record.UpdatedAt),
+	}
+}
+
+// Insert persists a new record; false reports an ID collision (the caller
+// re-rolls), and a vanished project or terminal surfaces as
+// ErrForeignKeyViolation.
+func (t *Threads) Insert(ctx context.Context, record ThreadRecord) (bool, error) {
+	n, err := t.writes.InsertThread(ctx, insertThreadParams(record))
+	return n > 0, foreignKeyError(err)
+}
+
+// InsertObserved persists a new record together with its identity mapping
+// in one transaction — a thread must never exist without its mapping, or
+// the next observation of the conversation would mint a duplicate. False
+// reports an ID collision (the caller re-rolls); an already-mapped
+// identity is an error, since the caller resolves identities before
+// minting.
+func (t *Threads) InsertObserved(ctx context.Context, record ThreadRecord, identity ThreadIdentity) (bool, error) {
+	tx, err := t.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	queries := gen.New(tx)
+	n, err := queries.InsertThread(ctx, insertThreadParams(record))
+	if err != nil {
+		return false, foreignKeyError(err)
+	}
+	if n == 0 {
+		return false, nil
+	}
+	n, err = queries.InsertThreadIdentity(ctx, gen.InsertThreadIdentityParams{
+		Agent:                  identity.Agent,
+		ProviderConversationID: identity.ProviderConversationID,
+		ThreadID:               identity.ThreadID,
+	})
+	if err != nil {
+		return false, foreignKeyError(err)
+	}
+	if n == 0 {
+		return false, fmt.Errorf("identity for thread %s already mapped", identity.ThreadID)
+	}
+	return true, tx.Commit()
+}
+
+// Update writes every mutable column from the record; false means no such
+// record. A terminal deleted since the record was read surfaces as
+// ErrForeignKeyViolation.
+func (t *Threads) Update(ctx context.Context, record ThreadRecord) (bool, error) {
+	n, err := t.writes.UpdateThread(ctx, gen.UpdateThreadParams{
+		TerminalID:     nullStringPtr(record.TerminalID),
+		Title:          nullString(record.Title),
+		TitleUserSet:   boolInt(record.TitleUserSet),
+		Model:          nullString(record.Model),
+		Effort:         nullString(record.Effort),
+		Cwd:            nullString(record.Cwd),
+		PermissionMode: nullString(record.PermissionMode),
+		Status:         record.Status,
+		LastError:      nullString(record.LastError),
+		LastEvidenceAt: nullTime(record.LastEvidenceAt),
+		Archived:       boolInt(record.Archived),
+		ArchivedAt:     nullTime(record.ArchivedAt),
+		UpdatedAt:      formatTime(record.UpdatedAt),
+		ID:             record.ID,
+	})
+	return n > 0, foreignKeyError(err)
+}
+
+// List returns every record in creation order.
+func (t *Threads) List(ctx context.Context) ([]ThreadRecord, error) {
+	rows, err := t.reads.ListThreads(ctx)
+	if err != nil {
+		return nil, err
+	}
+	records := make([]ThreadRecord, 0, len(rows))
+	for _, row := range rows {
+		record, err := threadFrom(row)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+	return records, nil
+}
+
+// Delete removes the record; false means no such record. The identity
+// mapping goes with it (ON DELETE CASCADE).
+func (t *Threads) Delete(ctx context.Context, id string) (bool, error) {
+	n, err := t.writes.DeleteThread(ctx, id)
+	return n > 0, err
+}
+
+// InsertIdentity persists one identity mapping; false reports the key
+// already mapped.
+func (t *Threads) InsertIdentity(ctx context.Context, identity ThreadIdentity) (bool, error) {
+	n, err := t.writes.InsertThreadIdentity(ctx, gen.InsertThreadIdentityParams{
+		Agent:                  identity.Agent,
+		ProviderConversationID: identity.ProviderConversationID,
+		ThreadID:               identity.ThreadID,
+	})
+	return n > 0, foreignKeyError(err)
+}
+
+// ListIdentities returns every identity mapping.
+func (t *Threads) ListIdentities(ctx context.Context) ([]ThreadIdentity, error) {
+	rows, err := t.reads.ListThreadIdentities(ctx)
+	if err != nil {
+		return nil, err
+	}
+	identities := make([]ThreadIdentity, 0, len(rows))
+	for _, row := range rows {
+		identities = append(identities, ThreadIdentity{
+			Agent:                  row.Agent,
+			ProviderConversationID: row.ProviderConversationID,
+			ThreadID:               row.ThreadID,
+		})
+	}
+	return identities, nil
+}
+
+func threadFrom(row gen.Thread) (ThreadRecord, error) {
+	record := ThreadRecord{
+		ID:             row.ID,
+		Agent:          row.Agent,
+		ProjectID:      row.ProjectID,
+		TerminalID:     stringPtr(row.TerminalID),
+		Title:          row.Title.String,
+		TitleUserSet:   row.TitleUserSet != 0,
+		Model:          row.Model.String,
+		Effort:         row.Effort.String,
+		Cwd:            row.Cwd.String,
+		PermissionMode: row.PermissionMode.String,
+		Status:         row.Status,
+		LastError:      row.LastError.String,
+		Archived:       row.Archived != 0,
+	}
+	var err error
+	if record.CreatedAt, err = parseTime(row.CreatedAt); err != nil {
+		return ThreadRecord{}, fmt.Errorf("thread %s created_at: %w", row.ID, err)
+	}
+	if record.UpdatedAt, err = parseTime(row.UpdatedAt); err != nil {
+		return ThreadRecord{}, fmt.Errorf("thread %s updated_at: %w", row.ID, err)
+	}
+	if record.LastEvidenceAt, err = parseNullTime(row.LastEvidenceAt); err != nil {
+		return ThreadRecord{}, fmt.Errorf("thread %s last_evidence_at: %w", row.ID, err)
+	}
+	if record.ArchivedAt, err = parseNullTime(row.ArchivedAt); err != nil {
+		return ThreadRecord{}, fmt.Errorf("thread %s archived_at: %w", row.ID, err)
+	}
+	return record, nil
+}
+
+func nullStringPtr(value *string) sql.NullString {
+	if value == nil {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: *value, Valid: true}
+}
+
+func stringPtr(value sql.NullString) *string {
+	if !value.Valid {
+		return nil
+	}
+	s := value.String
+	return &s
+}
+
+func nullTime(value *time.Time) sql.NullString {
+	if value == nil {
+		return sql.NullString{}
+	}
+	return nullString(formatTime(*value))
+}
+
+func boolInt(value bool) int64 {
+	if value {
+		return 1
+	}
+	return 0
+}

--- a/internal/store/threads_test.go
+++ b/internal/store/threads_test.go
@@ -1,0 +1,256 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func errorsIsForeignKey(err error) bool { return errors.Is(err, ErrForeignKeyViolation) }
+
+func TestThreadsRoundTrip(t *testing.T) {
+	s, _ := openStore(t)
+	ctx := context.Background()
+	threads := s.Threads()
+	insertProject(t, s, "proj-aaaaa", "/home/x")
+	if ok, err := s.Terminals().Insert(ctx, TerminalRecord{
+		ID: "term-aaaaa", ProjectID: "proj-aaaaa", Name: "Claude Code", Directory: "/home/x",
+		Agent: "claude", CreatedAt: at(0), UpdatedAt: at(0),
+	}); err != nil || !ok {
+		t.Fatalf("planting terminal = %v, %v", ok, err)
+	}
+
+	evidence := at(3)
+	records := []ThreadRecord{
+		{
+			ID: "thrd-aaaaa", Agent: "claude", ProjectID: "proj-aaaaa", TerminalID: new("term-aaaaa"),
+			Title: "fix the build", Model: "claude-opus-5", Effort: "high",
+			Cwd: "/home/x", PermissionMode: "default",
+			Status: "idle", LastEvidenceAt: &evidence,
+			CreatedAt: at(1), UpdatedAt: at(3),
+		},
+		{
+			ID: "thrd-bbbbb", Agent: "codex", ProjectID: "proj-aaaaa",
+			Status: "unknown", CreatedAt: at(2), UpdatedAt: at(2),
+		},
+	}
+	for _, record := range records {
+		if ok, err := threads.Insert(ctx, record); err != nil || !ok {
+			t.Fatalf("Insert = %v, %v; want true", ok, err)
+		}
+	}
+
+	got, err := threads.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(records, got); diff != "" {
+		t.Errorf("List() mismatch (-want +got):\n%s", diff)
+	}
+
+	// Insertion is the ID collision check.
+	if ok, err := threads.Insert(ctx, ThreadRecord{
+		ID: "thrd-aaaaa", Agent: "claude", ProjectID: "proj-aaaaa", Status: "unknown",
+		CreatedAt: at(9), UpdatedAt: at(9),
+	}); err != nil || ok {
+		t.Fatalf("Insert(collision) = %v, %v; want false", ok, err)
+	}
+
+	// A thread referencing a missing project or terminal is refused by the
+	// schema, surfaced as the typed foreign-key error.
+	if _, err := threads.Insert(ctx, ThreadRecord{
+		ID: "thrd-ccccc", Agent: "claude", ProjectID: "proj-nope", Status: "unknown",
+		CreatedAt: at(4), UpdatedAt: at(4),
+	}); !errorsIsForeignKey(err) {
+		t.Errorf("Insert(missing project) error = %v; want ErrForeignKeyViolation", err)
+	}
+	if _, err := threads.Insert(ctx, ThreadRecord{
+		ID: "thrd-ddddd", Agent: "claude", ProjectID: "proj-aaaaa", TerminalID: new("term-nope"),
+		Status: "unknown", CreatedAt: at(4), UpdatedAt: at(4),
+	}); !errorsIsForeignKey(err) {
+		t.Errorf("Insert(missing terminal) error = %v; want ErrForeignKeyViolation", err)
+	}
+
+	// Update writes every mutable column.
+	archived := at(5)
+	updated := records[0]
+	updated.TerminalID = nil
+	updated.Title = "renamed"
+	updated.TitleUserSet = true
+	updated.Status = "unknown"
+	updated.LastError = "turn failed"
+	updated.Archived = true
+	updated.ArchivedAt = &archived
+	updated.UpdatedAt = at(6)
+	if ok, err := threads.Update(ctx, updated); err != nil || !ok {
+		t.Fatalf("Update = %v, %v; want true", ok, err)
+	}
+	if ok, err := threads.Update(ctx, ThreadRecord{ID: "thrd-zzzzz", Status: "idle"}); err != nil || ok {
+		t.Fatalf("Update(absent) = %v, %v; want false", ok, err)
+	}
+	got, err = threads.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff([]ThreadRecord{updated, records[1]}, got); diff != "" {
+		t.Errorf("after update (-want +got):\n%s", diff)
+	}
+
+	if ok, err := threads.Delete(ctx, "thrd-bbbbb"); err != nil || !ok {
+		t.Fatalf("Delete = %v, %v; want true", ok, err)
+	}
+	if ok, err := threads.Delete(ctx, "thrd-bbbbb"); err != nil || ok {
+		t.Fatalf("second Delete = %v, %v; want false", ok, err)
+	}
+}
+
+// InsertObserved commits the record and its mapping together: a thread
+// must never exist unmapped, or the next observation would duplicate it.
+func TestInsertObservedIsAtomic(t *testing.T) {
+	s, _ := openStore(t)
+	ctx := context.Background()
+	threads := s.Threads()
+	insertProject(t, s, "proj-aaaaa", "/")
+
+	record := ThreadRecord{
+		ID: "thrd-aaaaa", Agent: "claude", ProjectID: "proj-aaaaa", Status: "idle",
+		CreatedAt: at(0), UpdatedAt: at(0),
+	}
+	identity := ThreadIdentity{Agent: "claude", ProviderConversationID: "sess-1", ThreadID: "thrd-aaaaa"}
+	if ok, err := threads.InsertObserved(ctx, record, identity); err != nil || !ok {
+		t.Fatalf("InsertObserved = %v, %v; want true", ok, err)
+	}
+
+	// An ID collision inserts neither half.
+	collision := record
+	collision.Agent = "codex"
+	if ok, err := threads.InsertObserved(ctx, collision, ThreadIdentity{
+		Agent: "codex", ProviderConversationID: "sess-2", ThreadID: "thrd-aaaaa",
+	}); err != nil || ok {
+		t.Fatalf("InsertObserved(collision) = %v, %v; want false", ok, err)
+	}
+
+	// A failing identity write rolls the record back too.
+	fresh := record
+	fresh.ID = "thrd-bbbbb"
+	if ok, err := threads.InsertObserved(ctx, fresh, identity); err == nil || ok {
+		t.Fatalf("InsertObserved(mapped identity) = %v, %v; want an error", ok, err)
+	}
+	records, err := threads.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identities, err := threads.ListIdentities(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || len(identities) != 1 {
+		t.Errorf("after refused inserts: %d records, %d identities; want 1 and 1", len(records), len(identities))
+	}
+}
+
+func TestThreadIdentities(t *testing.T) {
+	s, _ := openStore(t)
+	ctx := context.Background()
+	threads := s.Threads()
+	insertProject(t, s, "proj-aaaaa", "/")
+	if ok, err := threads.Insert(ctx, ThreadRecord{
+		ID: "thrd-aaaaa", Agent: "claude", ProjectID: "proj-aaaaa", Status: "idle",
+		CreatedAt: at(0), UpdatedAt: at(0),
+	}); err != nil || !ok {
+		t.Fatalf("Insert = %v, %v", ok, err)
+	}
+
+	identity := ThreadIdentity{Agent: "claude", ProviderConversationID: "sess-1", ThreadID: "thrd-aaaaa"}
+	if ok, err := threads.InsertIdentity(ctx, identity); err != nil || !ok {
+		t.Fatalf("InsertIdentity = %v, %v; want true", ok, err)
+	}
+	// The identity key is (agent, provider conversation id): a duplicate
+	// inserts nothing, and the same provider id under another agent is a
+	// distinct identity.
+	if ok, err := threads.InsertIdentity(ctx, identity); err != nil || ok {
+		t.Fatalf("InsertIdentity(duplicate) = %v, %v; want false", ok, err)
+	}
+	if _, err := threads.InsertIdentity(ctx, ThreadIdentity{
+		Agent: "codex", ProviderConversationID: "sess-1", ThreadID: "thrd-zzzzz",
+	}); !errorsIsForeignKey(err) {
+		t.Errorf("InsertIdentity(missing thread) error = %v; want ErrForeignKeyViolation", err)
+	}
+
+	got, err := threads.ListIdentities(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff([]ThreadIdentity{identity}, got); diff != "" {
+		t.Errorf("ListIdentities (-want +got):\n%s", diff)
+	}
+
+	// Deleting the thread cascades its identity mapping.
+	if ok, err := threads.Delete(ctx, "thrd-aaaaa"); err != nil || !ok {
+		t.Fatalf("Delete = %v, %v", ok, err)
+	}
+	got, err = threads.ListIdentities(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("identities after thread delete = %v; want none", got)
+	}
+}
+
+// The referential lifecycle lives in the schema: terminal deletion clears
+// thread linkage, project deletion cascades thread records and their
+// identity mappings.
+func TestThreadReferentialLifecycle(t *testing.T) {
+	s, _ := openStore(t)
+	ctx := context.Background()
+	threads := s.Threads()
+	insertProject(t, s, "proj-aaaaa", "/")
+	if ok, err := s.Terminals().Insert(ctx, TerminalRecord{
+		ID: "term-aaaaa", ProjectID: "proj-aaaaa", Name: "Claude Code", Directory: "/",
+		CreatedAt: at(0), UpdatedAt: at(0),
+	}); err != nil || !ok {
+		t.Fatalf("planting terminal = %v, %v", ok, err)
+	}
+	if ok, err := threads.Insert(ctx, ThreadRecord{
+		ID: "thrd-aaaaa", Agent: "claude", ProjectID: "proj-aaaaa", TerminalID: new("term-aaaaa"),
+		Status: "idle", CreatedAt: at(1), UpdatedAt: at(1),
+	}); err != nil || !ok {
+		t.Fatalf("Insert = %v, %v", ok, err)
+	}
+	if ok, err := threads.InsertIdentity(ctx, ThreadIdentity{
+		Agent: "claude", ProviderConversationID: "sess-1", ThreadID: "thrd-aaaaa",
+	}); err != nil || !ok {
+		t.Fatalf("InsertIdentity = %v, %v", ok, err)
+	}
+
+	// ON DELETE SET NULL: the thread record survives its terminal.
+	if ok, err := s.Terminals().Delete(ctx, "term-aaaaa"); err != nil || !ok {
+		t.Fatalf("terminal Delete = %v, %v", ok, err)
+	}
+	records, err := threads.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || records[0].TerminalID != nil {
+		t.Fatalf("after terminal delete: %+v; want one record with nil TerminalID", records)
+	}
+
+	// ON DELETE CASCADE: the project takes its threads and mappings with it.
+	if ok, err := s.Projects().Delete(ctx, "proj-aaaaa"); err != nil || !ok {
+		t.Fatalf("project Delete = %v, %v", ok, err)
+	}
+	records, err = threads.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identities, err := threads.ListIdentities(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 0 || len(identities) != 0 {
+		t.Errorf("after project delete: %d records, %d identities; want none", len(records), len(identities))
+	}
+}

--- a/internal/threads/service.go
+++ b/internal/threads/service.go
@@ -1,0 +1,808 @@
+package threads
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/jeremytondo/atc/internal/api"
+	"github.com/jeremytondo/atc/internal/events"
+	"github.com/jeremytondo/atc/internal/store"
+)
+
+// ErrNotFound reports an id with no record; the API layer maps it to 404.
+var ErrNotFound = errors.New("thread not found")
+
+// ErrActive refuses archiving or deleting a thread some terminal has open
+// (deleting an active thread would silently re-mint a fresh record on the
+// next evidence). The message names the holding terminal; the API layer
+// maps it to 409.
+var ErrActive = errors.New("thread is active")
+
+// Event-payload resource kinds. The service publishes terminal.updated
+// when a terminal's activeThreadId projection changes — the terminals
+// domain knows nothing about threads, so the change is announced here.
+const (
+	resource         = "thread"
+	terminalResource = "terminal"
+)
+
+// TerminalReader is the read-only seam into the terminals domain the
+// background sweep uses to notice terminals leaving (terminals.Service in
+// production). The dependency is one-way: terminals never depends back.
+type TerminalReader interface {
+	Get(id string) (api.Terminal, error)
+}
+
+// Options wires a Service. Now defaults to time.Now; Logger to discard.
+type Options struct {
+	Repository *store.Threads
+	Terminals  TerminalReader
+	Hub        *events.Hub
+	Logger     *slog.Logger
+	Now        func() time.Time
+}
+
+// Service owns the in-memory view and the observation policy. Construct
+// with NewService, Load once at boot before serving reads, then Run for
+// the background sweep.
+//
+// Locks follow the terminals discipline, outermost first; no database IO
+// happens under mu, and every mutation persists before it changes the
+// view or publishes — reads and events never advertise state the database
+// refused:
+//
+//	ops serializes each mutation's commit — database write, view change,
+//	    and event publish move as one unit.
+//	mu  guards the view, identity, and active maps only.
+type Service struct {
+	repository *store.Threads
+	terminals  TerminalReader
+	hub        *events.Hub
+	logger     *slog.Logger
+	now        func() time.Time
+
+	ops sync.Mutex
+
+	mu   sync.Mutex
+	view map[string]*store.ThreadRecord
+	// identities is the in-memory copy of the private identity mapping.
+	identities map[identityKey]string
+	// active maps terminal id → the thread whose conversation that
+	// terminal has open. Derived from evidence, never stored: it starts
+	// empty at boot and is re-established by observation.
+	active map[string]string
+}
+
+type identityKey struct {
+	agent      string
+	providerID string
+}
+
+func NewService(opts Options) *Service {
+	if opts.Terminals == nil {
+		// A nil terminals reader would panic on the first sweep rather
+		// than at boot; fail at construction instead (the server.NewHandler
+		// Verify precedent).
+		panic("threads.NewService: Terminals must not be nil")
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	if opts.Logger == nil {
+		opts.Logger = slog.New(slog.DiscardHandler)
+	}
+	return &Service{
+		repository: opts.Repository,
+		terminals:  opts.Terminals,
+		hub:        opts.Hub,
+		logger:     opts.Logger,
+		now:        opts.Now,
+		view:       make(map[string]*store.ThreadRecord),
+		identities: make(map[identityKey]string),
+		active:     make(map[string]string),
+	}
+}
+
+// Load rebuilds the view and identity mapping from the database at boot.
+// Live statuses (working, waiting_*) are unverifiable claims about an
+// observation that no longer exists, so they coerce to unknown — persisted
+// immediately, so the database never claims liveness it cannot back. Idle,
+// error, and unknown persist as recorded.
+func (s *Service) Load(ctx context.Context) error {
+	records, err := s.repository.List(ctx)
+	if err != nil {
+		return err
+	}
+	identities, err := s.repository.ListIdentities(ctx)
+	if err != nil {
+		return err
+	}
+	now := s.now()
+	for i := range records {
+		if !isLive(api.ThreadStatus(records[i].Status)) {
+			continue
+		}
+		records[i].Status = string(api.ThreadUnknown)
+		records[i].UpdatedAt = now
+		if _, err := s.repository.Update(ctx, records[i]); err != nil {
+			return err
+		}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, record := range records {
+		entry := record
+		s.view[entry.ID] = &entry
+	}
+	for _, identity := range identities {
+		s.identities[identityKey{identity.Agent, identity.ProviderConversationID}] = identity.ThreadID
+	}
+	return nil
+}
+
+// Run is the background sweep loop.
+func (s *Service) Run(ctx context.Context) {
+	ticker := time.NewTicker(SweepInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.Sweep(ctx)
+		}
+	}
+}
+
+// Sweep deactivates threads whose terminal has definitively left: the TUI
+// exited without provider evidence (kill -9), the terminal vanished, or
+// its record was deleted. A merely unreachable terminal is left alone —
+// unreachable means liveness cannot currently be verified, which is no
+// evidence of leaving. A closed TUI never marks threads done — the
+// conversations remain resumable.
+func (s *Service) Sweep(ctx context.Context) {
+	s.mu.Lock()
+	terminals := make([]string, 0, len(s.active))
+	for terminalID := range s.active {
+		terminals = append(terminals, terminalID)
+	}
+	s.mu.Unlock()
+	for _, terminalID := range terminals {
+		terminal, err := s.terminals.Get(terminalID)
+		switch {
+		case err != nil:
+			// No record at all: the terminal was deleted and the linkage
+			// clears with it.
+			s.TerminalRemoved(ctx, terminalID)
+		case terminal.Status == api.TerminalExited || terminal.Status == api.TerminalMissing:
+			s.Deactivate(ctx, terminalID)
+		}
+	}
+}
+
+// ObserveSession is the identity transition: the terminal has the given
+// provider conversation open. A known identity reattaches to its thread
+// (never a duplicate); an unknown one creates a record with the observing
+// terminal's project. Only session observations move a terminal's active
+// thread — delayed status evidence never selects a stale conversation. If
+// two terminals observe the same conversation, the last observer wins.
+// Returns the thread id.
+func (s *Service) ObserveSession(ctx context.Context, o SessionObservation) (string, error) {
+	s.ops.Lock()
+	defer s.ops.Unlock()
+	at := o.At
+	if at.IsZero() {
+		at = s.now()
+	}
+	key := identityKey{o.Agent, o.ProviderID}
+
+	s.mu.Lock()
+	threadID, known := s.identities[key]
+	var record store.ThreadRecord
+	if known {
+		entry, ok := s.view[threadID]
+		if !ok {
+			// Impossible while ops serializes commits; refuse to guess.
+			s.mu.Unlock()
+			return "", fmt.Errorf("identity for thread %s has no record", threadID)
+		}
+		record = *entry
+	}
+	s.mu.Unlock()
+
+	if !known {
+		return s.createObserved(ctx, o, at)
+	}
+
+	changed := false
+	if record.TerminalID == nil || *record.TerminalID != o.TerminalID {
+		terminalID := o.TerminalID
+		record.TerminalID = &terminalID
+		changed = true
+	}
+	if o.Status != "" && record.Status != string(o.Status) {
+		record.Status = string(o.Status)
+		changed = true
+	}
+	changed = applyMetadata(&record, o.Metadata) || changed
+	record.LastEvidenceAt = &at
+	if changed {
+		record.UpdatedAt = at
+	}
+	// Evidence always persists (a restart must not rewind lastEvidenceAt),
+	// but only meaningful change publishes.
+	updated, err := s.repository.Update(ctx, record)
+	if err != nil {
+		return "", err
+	}
+	if !updated {
+		// The row was cascade-deleted since the view lookup; the pending
+		// ProjectRemoved converges the view, and this observation has
+		// nothing to record against.
+		s.logger.Debug("observation for a deleted thread dropped", "thread", threadID)
+		return "", nil
+	}
+	s.commit(ctx, record, threadID, o.TerminalID, changed)
+	return threadID, nil
+}
+
+// createObserved mints and persists a new thread record with its identity
+// mapping (one transaction — a thread must never exist unmapped). Caller
+// holds ops.
+func (s *Service) createObserved(ctx context.Context, o SessionObservation, at time.Time) (string, error) {
+	status := o.Status
+	if status == "" {
+		status = api.ThreadUnknown
+	}
+	terminalID := o.TerminalID
+	record := store.ThreadRecord{
+		Agent:          o.Agent,
+		ProjectID:      o.ProjectID,
+		TerminalID:     &terminalID,
+		Status:         string(status),
+		LastEvidenceAt: &at,
+		CreatedAt:      at,
+		UpdatedAt:      at,
+	}
+	applyMetadata(&record, o.Metadata)
+	// Insertion is the collision check: a taken ID inserts nothing and
+	// re-rolls. A vanished project or terminal surfaces as a foreign-key
+	// error — the observation is refused rather than recorded against
+	// nothing.
+	for {
+		record.ID = randomID()
+		inserted, err := s.repository.InsertObserved(ctx, record, store.ThreadIdentity{
+			Agent: o.Agent, ProviderConversationID: o.ProviderID, ThreadID: record.ID,
+		})
+		if err != nil {
+			return "", err
+		}
+		if inserted {
+			break
+		}
+	}
+	s.mu.Lock()
+	entry := record
+	s.view[record.ID] = &entry
+	s.identities[identityKey{o.Agent, o.ProviderID}] = record.ID
+	s.mu.Unlock()
+	s.hub.Publish(api.EventThreadCreated, resource, record.ID)
+	s.commit(ctx, record, record.ID, o.TerminalID, false)
+	return record.ID, nil
+}
+
+// commit applies a session observation's record to the view and moves the
+// active projection, publishing what meaningfully changed: the previous
+// occupant of the terminal coerces inactive, a previous holder of this
+// thread releases it, and terminal.updated announces every projection
+// move. Caller holds ops.
+func (s *Service) commit(ctx context.Context, record store.ThreadRecord, threadID, terminalID string, changed bool) {
+	var terminalsChanged []string
+	var displaced string
+
+	s.mu.Lock()
+	if entry, ok := s.view[threadID]; ok {
+		*entry = record
+	}
+	// Last observer wins: release the thread from any other terminal that
+	// held it.
+	for otherTerminal, otherThread := range s.active {
+		if otherThread == threadID && otherTerminal != terminalID {
+			delete(s.active, otherTerminal)
+			terminalsChanged = append(terminalsChanged, otherTerminal)
+		}
+	}
+	if previous, ok := s.active[terminalID]; ok && previous != threadID {
+		displaced = previous
+	}
+	if s.active[terminalID] != threadID {
+		s.active[terminalID] = threadID
+		terminalsChanged = append(terminalsChanged, terminalID)
+	}
+	s.mu.Unlock()
+
+	if displaced != "" && s.coerceInactive(ctx, displaced) {
+		s.hub.Publish(api.EventThreadUpdated, resource, displaced)
+	}
+	if changed {
+		s.hub.Publish(api.EventThreadUpdated, resource, threadID)
+	}
+	for _, id := range terminalsChanged {
+		s.hub.Publish(api.EventTerminalUpdated, terminalResource, id)
+	}
+}
+
+// ObserveStatus applies fresh status evidence to a known conversation.
+// Evidence for an unmapped identity is dropped, and a live status for a
+// thread no terminal holds is ignored — delayed evidence must not revive
+// a conversation nothing displays (the provider layer re-establishes the
+// session first). An evidence-only refresh persists lastEvidenceAt
+// silently: no event, no updatedAt bump.
+func (s *Service) ObserveStatus(ctx context.Context, o StatusObservation) error {
+	s.ops.Lock()
+	defer s.ops.Unlock()
+	at := o.At
+	if at.IsZero() {
+		at = s.now()
+	}
+
+	s.mu.Lock()
+	threadID, known := s.identities[identityKey{o.Agent, o.ProviderID}]
+	var record store.ThreadRecord
+	active := false
+	if known {
+		entry, ok := s.view[threadID]
+		known = ok
+		if ok {
+			record = *entry
+		}
+		active = s.activeHolder(threadID) != ""
+	}
+	s.mu.Unlock()
+	if !known {
+		s.logger.Debug("status evidence for unmapped conversation dropped", "agent", o.Agent)
+		return nil
+	}
+
+	changed := false
+	if o.Status != "" && record.Status != string(o.Status) {
+		if isLive(o.Status) && !active {
+			s.logger.Debug("live status for an inactive thread ignored", "thread", threadID, "status", o.Status)
+		} else {
+			record.Status = string(o.Status)
+			changed = true
+		}
+	}
+	if o.LastError != nil && record.LastError != *o.LastError {
+		record.LastError = *o.LastError
+		changed = true
+	}
+	changed = applyMetadata(&record, o.Metadata) || changed
+	record.LastEvidenceAt = &at
+	if changed {
+		record.UpdatedAt = at
+	}
+	updated, err := s.repository.Update(ctx, record)
+	if err != nil {
+		return err
+	}
+	if !updated {
+		s.logger.Debug("observation for a deleted thread dropped", "thread", threadID)
+		return nil
+	}
+	s.mu.Lock()
+	if entry, ok := s.view[threadID]; ok {
+		*entry = record
+	}
+	s.mu.Unlock()
+	if changed {
+		s.hub.Publish(api.EventThreadUpdated, resource, threadID)
+	}
+	return nil
+}
+
+// Deactivate clears a terminal's active thread: the TUI closed or the
+// provider reported the conversation left without a successor. Idle
+// persists; unverifiable live states coerce to unknown. On a failed
+// persist the active entry stays, so the sweep retries.
+func (s *Service) Deactivate(ctx context.Context, terminalID string) {
+	s.ops.Lock()
+	defer s.ops.Unlock()
+	s.mu.Lock()
+	threadID, ok := s.active[terminalID]
+	var record store.ThreadRecord
+	if ok {
+		if entry, exists := s.view[threadID]; exists {
+			record = *entry
+		} else {
+			ok = false
+		}
+	}
+	s.mu.Unlock()
+	if !ok {
+		return
+	}
+	coerced := false
+	if isLive(api.ThreadStatus(record.Status)) {
+		record.Status = string(api.ThreadUnknown)
+		record.UpdatedAt = s.now()
+		updated, err := s.repository.Update(ctx, record)
+		if err != nil || !updated {
+			// The active entry stays, so the sweep retries the coercion.
+			s.logger.Warn("coercing thread status", "thread", threadID, "error", err)
+			return
+		}
+		s.mu.Lock()
+		if entry, exists := s.view[threadID]; exists {
+			*entry = record
+		}
+		s.mu.Unlock()
+		coerced = true
+	}
+	s.mu.Lock()
+	delete(s.active, terminalID)
+	s.mu.Unlock()
+	if coerced {
+		s.hub.Publish(api.EventThreadUpdated, resource, threadID)
+	}
+	s.hub.Publish(api.EventTerminalUpdated, terminalResource, terminalID)
+}
+
+// coerceInactive coerces a thread's live status to unknown —
+// persist-first, then the view — reporting whether it changed. A failed
+// persist changes nothing (boot-time coercion is the backstop). Caller
+// holds ops.
+func (s *Service) coerceInactive(ctx context.Context, threadID string) bool {
+	s.mu.Lock()
+	entry, ok := s.view[threadID]
+	var record store.ThreadRecord
+	if ok {
+		record = *entry
+	}
+	s.mu.Unlock()
+	if !ok || !isLive(api.ThreadStatus(record.Status)) {
+		return false
+	}
+	record.Status = string(api.ThreadUnknown)
+	record.UpdatedAt = s.now()
+	updated, err := s.repository.Update(ctx, record)
+	if err != nil || !updated {
+		s.logger.Warn("coercing thread status", "thread", threadID, "error", err)
+		return false
+	}
+	s.mu.Lock()
+	if entry, ok := s.view[threadID]; ok {
+		*entry = record
+	}
+	s.mu.Unlock()
+	return true
+}
+
+// TerminalRemoved reacts to a terminal deletion: threads pointing at it
+// lose their terminalId (the database foreign key already cleared the
+// column) and become inactive with the usual coercion. Wired by the
+// composition root after the terminals domain commits the delete — the
+// domains stay decoupled. A thread whose persist fails keeps the active
+// entry, so the sweep retries.
+func (s *Service) TerminalRemoved(ctx context.Context, terminalID string) {
+	s.ops.Lock()
+	defer s.ops.Unlock()
+	now := s.now()
+
+	s.mu.Lock()
+	var affected []store.ThreadRecord
+	for _, entry := range s.view {
+		if entry.TerminalID != nil && *entry.TerminalID == terminalID {
+			record := *entry
+			record.TerminalID = nil
+			if isLive(api.ThreadStatus(record.Status)) {
+				record.Status = string(api.ThreadUnknown)
+			}
+			record.UpdatedAt = now
+			affected = append(affected, record)
+		}
+	}
+	activeThread := s.active[terminalID]
+	s.mu.Unlock()
+
+	cleared := true
+	for _, record := range affected {
+		updated, err := s.repository.Update(ctx, record)
+		if err != nil || !updated {
+			s.logger.Warn("clearing thread linkage", "thread", record.ID, "error", err)
+			if record.ID == activeThread {
+				cleared = false
+			}
+			continue
+		}
+		s.mu.Lock()
+		if entry, ok := s.view[record.ID]; ok {
+			*entry = record
+		}
+		s.mu.Unlock()
+		s.hub.Publish(api.EventThreadUpdated, resource, record.ID)
+	}
+	if cleared {
+		s.mu.Lock()
+		delete(s.active, terminalID)
+		s.mu.Unlock()
+	}
+}
+
+// ProjectRemoved reacts to a project deletion: the database cascade has
+// already removed the project's thread rows and identity mappings, so
+// only the in-memory state and the deletion events remain. Wired by the
+// composition root after the projects domain commits the delete.
+func (s *Service) ProjectRemoved(projectID string) {
+	s.ops.Lock()
+	defer s.ops.Unlock()
+	removed := make(map[string]bool)
+	s.mu.Lock()
+	for id, entry := range s.view {
+		if entry.ProjectID == projectID {
+			removed[id] = true
+			delete(s.view, id)
+		}
+	}
+	for key, threadID := range s.identities {
+		if removed[threadID] {
+			delete(s.identities, key)
+		}
+	}
+	for terminalID, threadID := range s.active {
+		if removed[threadID] {
+			delete(s.active, terminalID)
+		}
+	}
+	s.mu.Unlock()
+	for id := range removed {
+		s.hub.Publish(api.EventThreadDeleted, resource, id)
+	}
+}
+
+// Get serves one thread from the in-memory view.
+func (s *Service) Get(id string) (api.Thread, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.view[id]
+	if !ok {
+		return api.Thread{}, ErrNotFound
+	}
+	return threadFrom(*entry), nil
+}
+
+// List serves threads from the in-memory view in creation order.
+// Non-empty projectID/terminalID filter; archived threads are hidden
+// unless includeArchived (the opt-in the spec requires).
+func (s *Service) List(projectID, terminalID string, includeArchived bool) []api.Thread {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	threads := make([]api.Thread, 0, len(s.view))
+	for _, entry := range s.view {
+		if entry.Archived && !includeArchived {
+			continue
+		}
+		if projectID != "" && entry.ProjectID != projectID {
+			continue
+		}
+		if terminalID != "" && (entry.TerminalID == nil || *entry.TerminalID != terminalID) {
+			continue
+		}
+		threads = append(threads, threadFrom(*entry))
+	}
+	sort.Slice(threads, func(i, j int) bool {
+		if !threads[i].CreatedAt.Equal(threads[j].CreatedAt) {
+			return threads[i].CreatedAt.Before(threads[j].CreatedAt)
+		}
+		return threads[i].ID < threads[j].ID
+	})
+	return threads
+}
+
+// LookupIdentity resolves a private identity to its thread and that
+// thread's last observed terminal. Provider observers use it as the seed
+// check after a server restart: evidence for an already-mapped
+// conversation still held by the same terminal may be accepted before a
+// fresh identity transition arrives.
+func (s *Service) LookupIdentity(agent, providerID string) (threadID, terminalID string, ok bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id, known := s.identities[identityKey{agent, providerID}]
+	if !known {
+		return "", "", false
+	}
+	entry, exists := s.view[id]
+	if !exists {
+		return "", "", false
+	}
+	if entry.TerminalID != nil {
+		terminalID = *entry.TerminalID
+	}
+	return id, terminalID, true
+}
+
+// ActiveThreadID is the projection terminals expose: the thread whose
+// conversation the terminal has open, or empty. The server layer decorates
+// terminal responses with it.
+func (s *Service) ActiveThreadID(terminalID string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.active[terminalID]
+}
+
+// Update mutates the two writable fields. A user-set title is protected
+// from observation from then on. Archiving an active thread is refused
+// with the holding terminal; unarchiving clears the timestamp.
+func (s *Service) Update(ctx context.Context, id string, params api.ThreadUpdateParams) (api.Thread, error) {
+	s.ops.Lock()
+	defer s.ops.Unlock()
+	s.mu.Lock()
+	entry, ok := s.view[id]
+	var record store.ThreadRecord
+	if ok {
+		record = *entry
+	}
+	holder := s.activeHolder(id)
+	s.mu.Unlock()
+	if !ok {
+		return api.Thread{}, ErrNotFound
+	}
+
+	changed, persist := false, false
+	if params.Title != nil {
+		if record.Title != *params.Title {
+			record.Title = *params.Title
+			changed = true
+		}
+		if !record.TitleUserSet {
+			record.TitleUserSet = true
+			persist = true
+		}
+	}
+	if params.Archived != nil && *params.Archived != record.Archived {
+		if *params.Archived {
+			if holder != "" {
+				return api.Thread{}, fmt.Errorf("%w in terminal %s", ErrActive, holder)
+			}
+			at := s.now()
+			record.Archived = true
+			record.ArchivedAt = &at
+		} else {
+			record.Archived = false
+			record.ArchivedAt = nil
+		}
+		changed = true
+	}
+	if changed || persist {
+		record.UpdatedAt = s.now()
+		updated, err := s.repository.Update(ctx, record)
+		if err != nil {
+			return api.Thread{}, err
+		}
+		if !updated {
+			return api.Thread{}, ErrNotFound
+		}
+		s.mu.Lock()
+		if entry, ok := s.view[id]; ok {
+			*entry = record
+		}
+		s.mu.Unlock()
+	}
+	if changed {
+		s.hub.Publish(api.EventThreadUpdated, resource, id)
+	}
+	return threadFrom(record), nil
+}
+
+// Delete removes the record and its identity mapping only — the
+// provider-side conversation is never touched. An active thread is
+// refused: deleting it would silently re-mint a fresh record on the next
+// evidence.
+func (s *Service) Delete(ctx context.Context, id string) error {
+	s.ops.Lock()
+	defer s.ops.Unlock()
+	s.mu.Lock()
+	_, ok := s.view[id]
+	holder := s.activeHolder(id)
+	s.mu.Unlock()
+	if !ok {
+		return ErrNotFound
+	}
+	if holder != "" {
+		return fmt.Errorf("%w in terminal %s", ErrActive, holder)
+	}
+	deleted, err := s.repository.Delete(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !deleted {
+		return ErrNotFound
+	}
+	s.mu.Lock()
+	delete(s.view, id)
+	for key, threadID := range s.identities {
+		if threadID == id {
+			delete(s.identities, key)
+		}
+	}
+	s.mu.Unlock()
+	s.hub.Publish(api.EventThreadDeleted, resource, id)
+	return nil
+}
+
+// activeHolder returns the terminal currently holding the thread, or
+// empty. Callers hold mu.
+func (s *Service) activeHolder(threadID string) string {
+	for terminalID, id := range s.active {
+		if id == threadID {
+			return terminalID
+		}
+	}
+	return ""
+}
+
+// applyMetadata folds non-empty observed metadata into the record,
+// reporting whether anything changed. An observed title is a default: it
+// fills an untitled thread once and never replaces an existing title —
+// user-set or previously observed.
+func applyMetadata(record *store.ThreadRecord, metadata Metadata) bool {
+	changed := false
+	if metadata.Title != "" && !record.TitleUserSet && record.Title == "" {
+		record.Title = metadata.Title
+		changed = true
+	}
+	set := func(field *string, value string) {
+		if value != "" && *field != value {
+			*field = value
+			changed = true
+		}
+	}
+	set(&record.Model, metadata.Model)
+	set(&record.Effort, metadata.Effort)
+	set(&record.Cwd, metadata.Cwd)
+	set(&record.PermissionMode, metadata.PermissionMode)
+	return changed
+}
+
+func isLive(status api.ThreadStatus) bool {
+	switch status {
+	case api.ThreadWorking, api.ThreadWaitingForInput, api.ThreadWaitingForPermission:
+		return true
+	}
+	return false
+}
+
+func threadFrom(record store.ThreadRecord) api.Thread {
+	thread := api.Thread{
+		ID:             record.ID,
+		Agent:          record.Agent,
+		ProjectID:      record.ProjectID,
+		Title:          record.Title,
+		Model:          record.Model,
+		Effort:         record.Effort,
+		Cwd:            record.Cwd,
+		PermissionMode: record.PermissionMode,
+		Status:         api.ThreadStatus(record.Status),
+		LastError:      record.LastError,
+		Archived:       record.Archived,
+		CreatedAt:      record.CreatedAt,
+		UpdatedAt:      record.UpdatedAt,
+	}
+	if record.TerminalID != nil {
+		thread.TerminalID = *record.TerminalID
+	}
+	if record.LastEvidenceAt != nil {
+		at := *record.LastEvidenceAt
+		thread.LastEvidenceAt = &at
+	}
+	if record.ArchivedAt != nil {
+		at := *record.ArchivedAt
+		thread.ArchivedAt = &at
+	}
+	return thread
+}

--- a/internal/threads/service_test.go
+++ b/internal/threads/service_test.go
@@ -1,0 +1,840 @@
+package threads
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/jeremytondo/atc/internal/api"
+	"github.com/jeremytondo/atc/internal/events"
+	"github.com/jeremytondo/atc/internal/store"
+)
+
+// fakeTerminals is the hand-written read seam into the terminals domain:
+// the sweep asks it whether a terminal is still running.
+type fakeTerminals struct {
+	mu       sync.Mutex
+	statuses map[string]api.TerminalStatus
+}
+
+func (f *fakeTerminals) Get(id string) (api.Terminal, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	status, ok := f.statuses[id]
+	if !ok {
+		return api.Terminal{}, errors.New("terminal not found")
+	}
+	return api.Terminal{ID: id, Status: status}, nil
+}
+
+func (f *fakeTerminals) set(id string, status api.TerminalStatus) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.statuses[id] = status
+}
+
+func (f *fakeTerminals) remove(id string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.statuses, id)
+}
+
+type fixture struct {
+	service   *Service
+	store     *store.Store
+	terminals *fakeTerminals
+	hub       *events.Hub
+	sub       *events.Subscription
+	clock     *fakeClock
+}
+
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(time.Millisecond) // strictly monotonic
+	return c.now
+}
+
+func newFixture(t *testing.T) *fixture {
+	t.Helper()
+	s, err := store.Open(context.Background(), filepath.Join(t.TempDir(), "atc.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	terminals := &fakeTerminals{statuses: map[string]api.TerminalStatus{}}
+	hub := events.NewHubAt(64, 1)
+	clock := &fakeClock{now: time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)}
+	service := NewService(Options{
+		Repository: s.Threads(),
+		Terminals:  terminals,
+		Hub:        hub,
+		Now:        clock.Now,
+	})
+	if err := service.Load(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	f := &fixture{service: service, store: s, terminals: terminals, hub: hub, clock: clock}
+	f.sub = hub.Subscribe(0, false)
+	t.Cleanup(f.sub.Close)
+	return f
+}
+
+// plant registers a project (and optionally a running terminal) so thread
+// rows satisfy their foreign keys.
+func (f *fixture) plant(t *testing.T, projectID string, terminalIDs ...string) {
+	t.Helper()
+	ctx := context.Background()
+	now := f.clock.Now()
+	if ok, err := f.store.Projects().Insert(ctx, store.ProjectRecord{
+		ID: projectID, Name: "p", Directory: "/" + projectID, CreatedAt: now, UpdatedAt: now,
+	}); err != nil || !ok {
+		t.Fatalf("planting project = %v, %v", ok, err)
+	}
+	for _, id := range terminalIDs {
+		if ok, err := f.store.Terminals().Insert(ctx, store.TerminalRecord{
+			ID: id, ProjectID: projectID, Name: "tui", Directory: "/" + projectID,
+			Agent: "claude", CreatedAt: now, UpdatedAt: now,
+		}); err != nil || !ok {
+			t.Fatalf("planting terminal = %v, %v", ok, err)
+		}
+		f.terminals.set(id, api.TerminalRunning)
+	}
+}
+
+// drain collects every event published so far as "type id" strings.
+func (f *fixture) drain() []string {
+	var got []string
+	for {
+		select {
+		case change := <-f.sub.C:
+			got = append(got, change.Type+" "+change.ID)
+		default:
+			return got
+		}
+	}
+}
+
+func observation(terminal, providerID string) SessionObservation {
+	return SessionObservation{
+		Agent:      "claude",
+		ProviderID: providerID,
+		TerminalID: terminal,
+		ProjectID:  "proj-aaaaa",
+		Status:     api.ThreadIdle,
+	}
+}
+
+func TestObserveSessionCreatesOnce(t *testing.T) {
+	f := newFixture(t)
+	f.plant(t, "proj-aaaaa", "term-aaaaa")
+	ctx := context.Background()
+
+	id, err := f.service.ObserveSession(ctx, SessionObservation{
+		Agent: "claude", ProviderID: "sess-1", TerminalID: "term-aaaaa", ProjectID: "proj-aaaaa",
+		Status:   api.ThreadWorking,
+		Metadata: Metadata{Title: "fix the build", Model: "claude-opus-5", Cwd: "/proj-aaaaa", PermissionMode: "default"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(id, "thrd-") {
+		t.Errorf("thread id = %q; want thrd- prefix", id)
+	}
+
+	thread, err := f.service.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if thread.Agent != "claude" || thread.ProjectID != "proj-aaaaa" || thread.TerminalID != "term-aaaaa" {
+		t.Errorf("thread = %+v; wrong identity fields", thread)
+	}
+	if thread.Status != api.ThreadWorking || thread.Title != "fix the build" || thread.Model != "claude-opus-5" {
+		t.Errorf("thread = %+v; wrong observed fields", thread)
+	}
+	if thread.LastEvidenceAt == nil {
+		t.Error("LastEvidenceAt not recorded")
+	}
+	if got := f.service.ActiveThreadID("term-aaaaa"); got != id {
+		t.Errorf("ActiveThreadID = %q; want %q", got, id)
+	}
+	want := []string{"thread.created " + id, "terminal.updated term-aaaaa"}
+	if diff := cmp.Diff(want, f.drain()); diff != "" {
+		t.Errorf("events (-want +got):\n%s", diff)
+	}
+
+	// The same provider conversation reattaches; it never mints a duplicate.
+	again, err := f.service.ObserveSession(ctx, observation("term-aaaaa", "sess-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again != id {
+		t.Errorf("reattach minted %q; want %q", again, id)
+	}
+	if got := f.service.List("", "", true); len(got) != 1 {
+		t.Errorf("List after reattach = %d threads; want 1", len(got))
+	}
+}
+
+func TestSwitchingConversationsMovesActive(t *testing.T) {
+	f := newFixture(t)
+	f.plant(t, "proj-aaaaa", "term-aaaaa")
+	ctx := context.Background()
+
+	first, err := f.service.ObserveSession(ctx, SessionObservation{
+		Agent: "claude", ProviderID: "sess-1", TerminalID: "term-aaaaa", ProjectID: "proj-aaaaa",
+		Status: api.ThreadWorking,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.drain()
+
+	// /clear: a new conversation appears in the same terminal. The old
+	// thread persists inactive; its unverifiable live status coerces.
+	second, err := f.service.ObserveSession(ctx, observation("term-aaaaa", "sess-2"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second == first {
+		t.Fatal("new conversation reused the old thread")
+	}
+	if got := f.service.ActiveThreadID("term-aaaaa"); got != second {
+		t.Errorf("ActiveThreadID = %q; want %q", got, second)
+	}
+	old, err := f.service.Get(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if old.Status != api.ThreadUnknown {
+		t.Errorf("displaced thread status = %s; want unknown (working is unverifiable once unobserved)", old.Status)
+	}
+	want := []string{
+		"thread.created " + second,
+		"thread.updated " + first,
+		"terminal.updated term-aaaaa",
+	}
+	if diff := cmp.Diff(want, f.drain()); diff != "" {
+		t.Errorf("events (-want +got):\n%s", diff)
+	}
+
+	// /resume of the first conversation reactivates the existing thread.
+	resumed, err := f.service.ObserveSession(ctx, observation("term-aaaaa", "sess-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resumed != first {
+		t.Errorf("resume minted %q; want %q", resumed, first)
+	}
+	if got := f.service.ActiveThreadID("term-aaaaa"); got != first {
+		t.Errorf("ActiveThreadID after resume = %q; want %q", got, first)
+	}
+}
+
+func TestLastObserverWins(t *testing.T) {
+	f := newFixture(t)
+	f.plant(t, "proj-aaaaa", "term-aaaaa", "term-bbbbb")
+	ctx := context.Background()
+
+	id, err := f.service.ObserveSession(ctx, observation("term-aaaaa", "sess-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.drain()
+	again, err := f.service.ObserveSession(ctx, observation("term-bbbbb", "sess-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again != id {
+		t.Fatalf("second observer minted %q; want %q", again, id)
+	}
+	if got := f.service.ActiveThreadID("term-bbbbb"); got != id {
+		t.Errorf("new observer ActiveThreadID = %q; want %q", got, id)
+	}
+	if got := f.service.ActiveThreadID("term-aaaaa"); got != "" {
+		t.Errorf("old observer still holds %q; want released", got)
+	}
+	thread, err := f.service.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if thread.TerminalID != "term-bbbbb" {
+		t.Errorf("TerminalID = %q; want the last observer", thread.TerminalID)
+	}
+}
+
+func TestObserveStatusTransitionsAndSilence(t *testing.T) {
+	f := newFixture(t)
+	f.plant(t, "proj-aaaaa", "term-aaaaa")
+	ctx := context.Background()
+
+	id, err := f.service.ObserveSession(ctx, observation("term-aaaaa", "sess-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.drain()
+
+	if err := f.service.ObserveStatus(ctx, StatusObservation{
+		Agent: "claude", ProviderID: "sess-1", Status: api.ThreadWorking,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	thread, err := f.service.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if thread.Status != api.ThreadWorking {
+		t.Errorf("status = %s; want working", thread.Status)
+	}
+	if diff := cmp.Diff([]string{"thread.updated " + id}, f.drain()); diff != "" {
+		t.Errorf("transition events (-want +got):\n%s", diff)
+	}
+
+	// An evidence-only refresh updates lastEvidenceAt silently: no event,
+	// no updatedAt bump — it rides along on the next fetch.
+	before := thread
+	if err := f.service.ObserveStatus(ctx, StatusObservation{
+		Agent: "claude", ProviderID: "sess-1", Status: api.ThreadWorking,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	after, err := f.service.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := f.drain(); len(got) != 0 {
+		t.Errorf("evidence-only refresh published %v; want nothing", got)
+	}
+	if !after.LastEvidenceAt.After(*before.LastEvidenceAt) {
+		t.Error("evidence-only refresh did not advance LastEvidenceAt")
+	}
+	if !after.UpdatedAt.Equal(before.UpdatedAt) {
+		t.Error("evidence-only refresh bumped UpdatedAt")
+	}
+
+	// A failed turn: idle with the detail in lastError.
+	detail := "provider rejected the request"
+	if err := f.service.ObserveStatus(ctx, StatusObservation{
+		Agent: "claude", ProviderID: "sess-1", Status: api.ThreadIdle, LastError: &detail,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	thread, err = f.service.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if thread.Status != api.ThreadIdle || thread.LastError != detail {
+		t.Errorf("failed turn: status=%s lastError=%q; want idle with detail", thread.Status, thread.LastError)
+	}
+
+	// Evidence for an unmapped conversation is dropped, never minted.
+	if err := f.service.ObserveStatus(ctx, StatusObservation{
+		Agent: "claude", ProviderID: "sess-unknown", Status: api.ThreadWorking,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := f.service.List("", "", true); len(got) != 1 {
+		t.Errorf("unmapped status evidence minted a thread: %d threads", len(got))
+	}
+}
+
+func TestUserTitleWinsOverObservation(t *testing.T) {
+	f := newFixture(t)
+	f.plant(t, "proj-aaaaa", "term-aaaaa")
+	ctx := context.Background()
+
+	id, err := f.service.ObserveSession(ctx, SessionObservation{
+		Agent: "claude", ProviderID: "sess-1", TerminalID: "term-aaaaa", ProjectID: "proj-aaaaa",
+		Metadata: Metadata{Title: "observed default"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	title := "my title"
+	if _, err := f.service.Update(ctx, id, api.ThreadUpdateParams{Title: &title}); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.service.ObserveStatus(ctx, StatusObservation{
+		Agent: "claude", ProviderID: "sess-1", Metadata: Metadata{Title: "later observation"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	thread, err := f.service.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if thread.Title != "my title" {
+		t.Errorf("title = %q; observation overwrote the user's title", thread.Title)
+	}
+}
+
+func TestArchiveAndDeleteRefusedWhileActive(t *testing.T) {
+	f := newFixture(t)
+	f.plant(t, "proj-aaaaa", "term-aaaaa")
+	ctx := context.Background()
+
+	id, err := f.service.ObserveSession(ctx, observation("term-aaaaa", "sess-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	archived := true
+	if _, err := f.service.Update(ctx, id, api.ThreadUpdateParams{Archived: &archived}); !errors.Is(err, ErrActive) {
+		t.Fatalf("archive active = %v; want ErrActive", err)
+	} else if !strings.Contains(err.Error(), "term-aaaaa") {
+		t.Errorf("refusal %q does not name the holding terminal", err)
+	}
+	if err := f.service.Delete(ctx, id); !errors.Is(err, ErrActive) {
+		t.Fatalf("delete active = %v; want ErrActive", err)
+	}
+
+	// Once inactive, both verbs work.
+	f.service.Deactivate(ctx, "term-aaaaa")
+	f.drain()
+	thread, err := f.service.Update(ctx, id, api.ThreadUpdateParams{Archived: &archived})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !thread.Archived || thread.ArchivedAt == nil {
+		t.Errorf("archived thread = %+v; want archived with timestamp", thread)
+	}
+	if diff := cmp.Diff([]string{"thread.updated " + id}, f.drain()); diff != "" {
+		t.Errorf("archive events (-want +got):\n%s", diff)
+	}
+
+	// Hidden by default, present on opt-in; unarchive clears the timestamp.
+	if got := f.service.List("", "", false); len(got) != 0 {
+		t.Errorf("default list shows archived thread: %v", got)
+	}
+	if got := f.service.List("", "", true); len(got) != 1 {
+		t.Errorf("opt-in list = %d threads; want 1", len(got))
+	}
+	unarchived := false
+	thread, err = f.service.Update(ctx, id, api.ThreadUpdateParams{Archived: &unarchived})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if thread.Archived || thread.ArchivedAt != nil {
+		t.Errorf("unarchived thread = %+v; want timestamp cleared", thread)
+	}
+
+	if err := f.service.Delete(ctx, id); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.service.Get(id); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get after delete = %v; want ErrNotFound", err)
+	}
+
+	// The identity mapping died with the record: the same provider
+	// conversation observed again deliberately mints a fresh thread.
+	fresh, err := f.service.ObserveSession(ctx, observation("term-aaaaa", "sess-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fresh == id {
+		t.Error("deleted thread id was resurrected")
+	}
+}
+
+func TestUpdateUnknownAndNoopPatch(t *testing.T) {
+	f := newFixture(t)
+	f.plant(t, "proj-aaaaa", "term-aaaaa")
+	ctx := context.Background()
+
+	if _, err := f.service.Update(ctx, "thrd-zzzzz", api.ThreadUpdateParams{}); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Update(unknown) = %v; want ErrNotFound", err)
+	}
+	if err := f.service.Delete(ctx, "thrd-zzzzz"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Delete(unknown) = %v; want ErrNotFound", err)
+	}
+
+	id, err := f.service.ObserveSession(ctx, observation("term-aaaaa", "sess-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.drain()
+	before, _ := f.service.Get(id)
+	after, err := f.service.Update(ctx, id, api.ThreadUpdateParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := f.drain(); len(got) != 0 {
+		t.Errorf("empty patch published %v; want nothing", got)
+	}
+	if !after.UpdatedAt.Equal(before.UpdatedAt) {
+		t.Error("empty patch bumped UpdatedAt")
+	}
+}
+
+func TestSweepDeactivatesWhenTerminalLeaves(t *testing.T) {
+	f := newFixture(t)
+	f.plant(t, "proj-aaaaa", "term-aaaaa")
+	ctx := context.Background()
+
+	id, err := f.service.ObserveSession(ctx, SessionObservation{
+		Agent: "claude", ProviderID: "sess-1", TerminalID: "term-aaaaa", ProjectID: "proj-aaaaa",
+		Status: api.ThreadWaitingForInput,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.drain()
+
+	// Running terminal: the sweep leaves everything alone.
+	f.service.Sweep(ctx)
+	if got := f.service.ActiveThreadID("term-aaaaa"); got != id {
+		t.Fatalf("sweep deactivated a running terminal's thread")
+	}
+
+	// The TUI exits without provider evidence (kill -9): the sweep is the
+	// backstop. The thread persists, inactive, its live status coerced.
+	f.terminals.set("term-aaaaa", api.TerminalExited)
+	f.service.Sweep(ctx)
+	if got := f.service.ActiveThreadID("term-aaaaa"); got != "" {
+		t.Errorf("ActiveThreadID after exit = %q; want none", got)
+	}
+	thread, err := f.service.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if thread.Status != api.ThreadUnknown {
+		t.Errorf("status after exit = %s; want unknown", thread.Status)
+	}
+	if thread.TerminalID != "term-aaaaa" {
+		t.Errorf("TerminalID = %q; an exited (not deleted) terminal keeps the linkage", thread.TerminalID)
+	}
+	want := []string{"thread.updated " + id, "terminal.updated term-aaaaa"}
+	if diff := cmp.Diff(want, f.drain()); diff != "" {
+		t.Errorf("sweep events (-want +got):\n%s", diff)
+	}
+}
+
+// A merely unreachable terminal (inventory hiccup) is no evidence the TUI
+// left; only exited, missing, or deleted deactivate.
+func TestSweepLeavesUnreachableAlone(t *testing.T) {
+	f := newFixture(t)
+	f.plant(t, "proj-aaaaa", "term-aaaaa")
+	ctx := context.Background()
+
+	id, err := f.service.ObserveSession(ctx, SessionObservation{
+		Agent: "claude", ProviderID: "sess-1", TerminalID: "term-aaaaa", ProjectID: "proj-aaaaa",
+		Status: api.ThreadWorking,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.terminals.set("term-aaaaa", api.TerminalUnreachable)
+	f.service.Sweep(ctx)
+	if got := f.service.ActiveThreadID("term-aaaaa"); got != id {
+		t.Errorf("unreachable terminal lost its active thread")
+	}
+	thread, err := f.service.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if thread.Status != api.ThreadWorking {
+		t.Errorf("status = %s; an unreachable terminal must not coerce", thread.Status)
+	}
+}
+
+// Delayed live evidence for a conversation nothing displays must not
+// revive it; idle evidence is always honest.
+func TestLiveStatusIgnoredWhileInactive(t *testing.T) {
+	f := newFixture(t)
+	f.plant(t, "proj-aaaaa", "term-aaaaa")
+	ctx := context.Background()
+
+	id, err := f.service.ObserveSession(ctx, observation("term-aaaaa", "sess-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.service.Deactivate(ctx, "term-aaaaa")
+	if err := f.service.ObserveStatus(ctx, StatusObservation{
+		Agent: "claude", ProviderID: "sess-1", Status: api.ThreadWorking,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	thread, err := f.service.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if thread.Status != api.ThreadIdle {
+		t.Errorf("status = %s; delayed working revived an inactive thread", thread.Status)
+	}
+}
+
+// Evidence refreshes persist silently, so a restart never rewinds
+// lastEvidenceAt.
+func TestEvidenceSurvivesReload(t *testing.T) {
+	f := newFixture(t)
+	f.plant(t, "proj-aaaaa", "term-aaaaa")
+	ctx := context.Background()
+
+	id, err := f.service.ObserveSession(ctx, observation("term-aaaaa", "sess-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.service.ObserveStatus(ctx, StatusObservation{
+		Agent: "claude", ProviderID: "sess-1", Status: api.ThreadIdle,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	before, err := f.service.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reloaded := NewService(Options{
+		Repository: f.store.Threads(),
+		Terminals:  f.terminals,
+		Hub:        events.NewHubAt(8, 1),
+		Now:        f.clock.Now,
+	})
+	if err := reloaded.Load(ctx); err != nil {
+		t.Fatal(err)
+	}
+	after, err := reloaded.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.LastEvidenceAt == nil || !after.LastEvidenceAt.Equal(*before.LastEvidenceAt) {
+		t.Errorf("LastEvidenceAt after reload = %v; want %v", after.LastEvidenceAt, before.LastEvidenceAt)
+	}
+}
+
+func TestIdlePersistsWhenInactive(t *testing.T) {
+	f := newFixture(t)
+	f.plant(t, "proj-aaaaa", "term-aaaaa")
+	ctx := context.Background()
+
+	id, err := f.service.ObserveSession(ctx, observation("term-aaaaa", "sess-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.drain()
+	f.terminals.set("term-aaaaa", api.TerminalExited)
+	f.service.Sweep(ctx)
+	thread, err := f.service.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if thread.Status != api.ThreadIdle {
+		t.Errorf("status = %s; idle must persist when the thread goes inactive", thread.Status)
+	}
+	// Only the projection changed, so only the terminal event fires.
+	if diff := cmp.Diff([]string{"terminal.updated term-aaaaa"}, f.drain()); diff != "" {
+		t.Errorf("events (-want +got):\n%s", diff)
+	}
+}
+
+func TestTerminalRemovedClearsLinkage(t *testing.T) {
+	f := newFixture(t)
+	f.plant(t, "proj-aaaaa", "term-aaaaa")
+	ctx := context.Background()
+
+	id, err := f.service.ObserveSession(ctx, SessionObservation{
+		Agent: "claude", ProviderID: "sess-1", TerminalID: "term-aaaaa", ProjectID: "proj-aaaaa",
+		Status: api.ThreadWorking,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.drain()
+
+	// The API layer deletes the terminal, then notifies. The row-level
+	// SET NULL already happened; the view converges here.
+	if ok, err := f.store.Terminals().Delete(ctx, "term-aaaaa"); err != nil || !ok {
+		t.Fatalf("terminal delete = %v, %v", ok, err)
+	}
+	f.terminals.remove("term-aaaaa")
+	f.service.TerminalRemoved(ctx, "term-aaaaa")
+
+	thread, err := f.service.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if thread.TerminalID != "" {
+		t.Errorf("TerminalID = %q; want cleared", thread.TerminalID)
+	}
+	if thread.Status != api.ThreadUnknown {
+		t.Errorf("status = %s; want unknown", thread.Status)
+	}
+	if got := f.service.ActiveThreadID("term-aaaaa"); got != "" {
+		t.Errorf("ActiveThreadID = %q; want none", got)
+	}
+	if diff := cmp.Diff([]string{"thread.updated " + id}, f.drain()); diff != "" {
+		t.Errorf("events (-want +got):\n%s", diff)
+	}
+}
+
+func TestProjectRemovedDropsThreads(t *testing.T) {
+	f := newFixture(t)
+	f.plant(t, "proj-aaaaa", "term-aaaaa")
+	ctx := context.Background()
+
+	id, err := f.service.ObserveSession(ctx, observation("term-aaaaa", "sess-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.service.Deactivate(ctx, "term-aaaaa")
+	f.drain()
+
+	// The API layer deletes the project (terminal already gone), then
+	// notifies; the schema cascade removed the rows.
+	if ok, err := f.store.Terminals().Delete(ctx, "term-aaaaa"); err != nil || !ok {
+		t.Fatalf("terminal delete = %v, %v", ok, err)
+	}
+	f.service.TerminalRemoved(ctx, "term-aaaaa")
+	if ok, err := f.store.Projects().Delete(ctx, "proj-aaaaa"); err != nil || !ok {
+		t.Fatalf("project delete = %v, %v", ok, err)
+	}
+	f.drain()
+	f.service.ProjectRemoved("proj-aaaaa")
+
+	if _, err := f.service.Get(id); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get after project removal = %v; want ErrNotFound", err)
+	}
+	if diff := cmp.Diff([]string{"thread.deleted " + id}, f.drain()); diff != "" {
+		t.Errorf("events (-want +got):\n%s", diff)
+	}
+}
+
+func TestListFilters(t *testing.T) {
+	f := newFixture(t)
+	f.plant(t, "proj-aaaaa", "term-aaaaa")
+	f.plant(t, "proj-bbbbb", "term-bbbbb")
+	ctx := context.Background()
+
+	first, err := f.service.ObserveSession(ctx, observation("term-aaaaa", "sess-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := f.service.ObserveSession(ctx, SessionObservation{
+		Agent: "claude", ProviderID: "sess-2", TerminalID: "term-bbbbb", ProjectID: "proj-bbbbb",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ids := func(threads []api.Thread) []string {
+		var got []string
+		for _, thread := range threads {
+			got = append(got, thread.ID)
+		}
+		return got
+	}
+	if diff := cmp.Diff([]string{first, second}, ids(f.service.List("", "", false))); diff != "" {
+		t.Errorf("unfiltered list (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff([]string{first}, ids(f.service.List("proj-aaaaa", "", false))); diff != "" {
+		t.Errorf("project filter (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff([]string{second}, ids(f.service.List("", "term-bbbbb", false))); diff != "" {
+		t.Errorf("terminal filter (-want +got):\n%s", diff)
+	}
+}
+
+// Restart discipline: idle and error persist; live statuses are claims
+// about an observation that no longer exists and coerce to unknown, in
+// the database too.
+func TestLoadCoercesLiveStatuses(t *testing.T) {
+	f := newFixture(t)
+	f.plant(t, "proj-aaaaa", "term-aaaaa")
+	ctx := context.Background()
+
+	idle, err := f.service.ObserveSession(ctx, observation("term-aaaaa", "sess-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	working, err := f.service.ObserveSession(ctx, SessionObservation{
+		Agent: "claude", ProviderID: "sess-2", TerminalID: "term-aaaaa", ProjectID: "proj-aaaaa",
+		Status: api.ThreadWaitingForPermission,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reloaded := NewService(Options{
+		Repository: f.store.Threads(),
+		Terminals:  f.terminals,
+		Hub:        events.NewHubAt(8, 1),
+		Now:        f.clock.Now,
+	})
+	if err := reloaded.Load(ctx); err != nil {
+		t.Fatal(err)
+	}
+	got, err := reloaded.Get(idle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != api.ThreadIdle {
+		t.Errorf("idle thread after reload = %s; want idle", got.Status)
+	}
+	got, err = reloaded.Get(working)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != api.ThreadUnknown {
+		t.Errorf("live thread after reload = %s; want unknown", got.Status)
+	}
+	if reloaded.ActiveThreadID("term-aaaaa") != "" {
+		t.Error("active projection survived a reload; it must be re-derived from evidence")
+	}
+
+	// The coercion is persisted: a third load finds unknown already stored.
+	records, err := f.store.Threads().List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, record := range records {
+		if record.ID == working && record.Status != string(api.ThreadUnknown) {
+			t.Errorf("database still claims %s after reload", record.Status)
+		}
+	}
+}
+
+func TestReattachUpdatesMetadataAndTerminalOnly(t *testing.T) {
+	f := newFixture(t)
+	f.plant(t, "proj-aaaaa", "term-aaaaa")
+	f.plant(t, "proj-bbbbb", "term-bbbbb")
+	ctx := context.Background()
+
+	id, err := f.service.ObserveSession(ctx, SessionObservation{
+		Agent: "claude", ProviderID: "sess-1", TerminalID: "term-aaaaa", ProjectID: "proj-aaaaa",
+		Metadata: Metadata{Cwd: "/proj-aaaaa"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Resumed from a terminal in another project: the terminal linkage and
+	// provider-reported cwd move, the project deliberately does not.
+	if _, err := f.service.ObserveSession(ctx, SessionObservation{
+		Agent: "claude", ProviderID: "sess-1", TerminalID: "term-bbbbb", ProjectID: "proj-bbbbb",
+		Metadata: Metadata{Cwd: "/proj-bbbbb"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	thread, err := f.service.Get(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if thread.ProjectID != "proj-aaaaa" {
+		t.Errorf("ProjectID = %q; first observation is immutable", thread.ProjectID)
+	}
+	if thread.TerminalID != "term-bbbbb" || thread.Cwd != "/proj-bbbbb" {
+		t.Errorf("thread = %+v; want moved terminal and cwd", thread)
+	}
+}

--- a/internal/threads/threads.go
+++ b/internal/threads/threads.go
@@ -1,0 +1,87 @@
+// Package threads is the Threads domain (ATC-255): the resource behind
+// /v1/threads. A thread is one exact provider conversation, observed into
+// existence inside an ATC-launched agent TUI — there is no create verb.
+// Records persist in the ATC-262 store as the durable index of resumable
+// conversations; the private identity mapping (agent, provider
+// conversation id) → thread never leaves the server.
+//
+// The package owns policy: capture and reattach, the six-status model and
+// its inactive coercion, archive/delete with their active refusals, and
+// the activeThreadId projection onto terminals. Provider observation —
+// Claude hooks, the shared Codex app-server — lives with the agents side
+// and feeds this service only neutral observations; no provider
+// vocabulary enters here. Statuses come from evidence, never guesses:
+// unknown means no evidence, and a thread that stops being observed keeps
+// idle but coerces the unverifiable live states back to unknown.
+package threads
+
+import (
+	"time"
+
+	"github.com/jeremytondo/atc/internal/api"
+	"github.com/jeremytondo/atc/internal/ids"
+)
+
+// SweepInterval is the cadence of the background sweep that notices
+// terminals leaving (exited, missing, deleted) and coerces their threads'
+// live statuses.
+const SweepInterval = 2 * time.Second
+
+const idPrefix = "thrd-"
+
+// randomID mints one candidate ID; the caller collision-checks it against
+// the database and re-rolls.
+func randomID() string {
+	return ids.New(idPrefix)
+}
+
+// Metadata is the observed best-effort thread metadata. Empty fields mean
+// "not observed this time" and never clear a previously observed value.
+type Metadata struct {
+	Title          string
+	Model          string
+	Effort         string
+	Cwd            string
+	PermissionMode string
+}
+
+// SessionObservation reports that a terminal has a provider conversation
+// open: the identity transition providers derive from their authoritative
+// signals (Claude SessionStart, Codex thread adoption). Only session
+// observations move a terminal's active thread — delayed status evidence
+// never selects a stale conversation.
+type SessionObservation struct {
+	// Agent is the catalog id; with ProviderID it forms the private
+	// identity key.
+	Agent string
+	// ProviderID is the provider's own conversation id. It never appears
+	// in the public API.
+	ProviderID string
+	// TerminalID is the observing terminal; ProjectID is copied onto the
+	// record at first observation only (immutable afterwards).
+	TerminalID string
+	ProjectID  string
+	// At is when the evidence arrived; zero means now.
+	At time.Time
+	// Status is the initial status evidence riding on the transition;
+	// empty means unknown.
+	Status   api.ThreadStatus
+	Metadata Metadata
+}
+
+// StatusObservation reports fresh evidence about what a known
+// conversation's agent is doing. Evidence for an unmapped identity is
+// dropped: without a session observation there is no terminal context to
+// create an honest record from.
+type StatusObservation struct {
+	Agent      string
+	ProviderID string
+	// At is when the evidence arrived; zero means now.
+	At     time.Time
+	Status api.ThreadStatus
+	// LastError sets the thread's lastError detail: nil leaves it alone,
+	// a pointer to "" clears it, anything else records it (a failed turn
+	// leaves the thread idle with the detail here).
+	LastError *string
+	Metadata  Metadata
+}


### PR DESCRIPTION
First PR of ATC-255 (Threads). Implements the thread resource end to end with no providers wired; the Claude (ATC-278) and Codex (ATC-279) evidence PRs attach to the observation seam this introduces.

## What's here

- **Migration + store**: `threads` table (project FK `ON DELETE CASCADE`, terminal FK `ON DELETE SET NULL`) and the private `thread_identities` mapping keyed by (agent, provider conversation id). Provider conversation ids never appear on the wire. `InsertObserved` commits a record and its mapping in one transaction — a thread must never exist unmapped.
- **Threads domain** (`internal/threads`): in-memory view over the store following the terminals lock discipline, with persist-first mutations so reads and events never advertise state the database refused. The observation seam (`ObserveSession` / `ObserveStatus`) implements capture, reattach-on-resume (never a duplicate), last-observer-wins terminal linkage, and the six-status model: live statuses coerce to `unknown` at boot and whenever a thread stops being observed; `idle` persists; delayed live evidence for a thread nothing displays is ignored.
- **Lifecycle**: archive (writable `archived`, server-managed `archivedAt`) and delete both refuse while a terminal holds the thread, naming it (409). Terminal deletion clears linkage; project deletion cascades the records; a background sweep deactivates threads whose terminal definitively left (`exited`/`missing`/deleted — a transient `unreachable` is not evidence of leaving).
- **API**: `GET/PATCH/DELETE /v1/threads[...]` with `project`/`terminal`/`includeArchived` filters; deliberately no POST and no action routes. Terminals gain a nullable `activeThreadId` projection, decorated at the server layer so the terminals domain stays agent-agnostic.
- **Events**: `thread.created/updated/deleted` on the existing feed; `thread.updated` only on meaningful change — evidence-only refreshes persist `lastEvidenceAt` silently (no event, no `updatedAt` bump). The service also publishes `terminal.updated` when a terminal's `activeThreadId` moves.
- **CLI**: `atc thread <list|get|update|archive|unarchive|delete>`; list sorts by most recent activity, hides archived unless `--archived`, and follows the terminal-list precedent (optional `--project` filter, no cwd resolution).

## Review notes

Two adversarial Codex reviews (correctness, simplicity) ran before this PR; adopted: transactional insert of record+mapping, persist-first mutation ordering, silent persistence of evidence refreshes, the live-status/active gate, sweep tolerance for `unreachable`, honoring update-row-missing results, flattened nullable text fields, and the simpler CLI list. Deliberately kept: the single broad `UpdateThread` query (observation updates touch most columns and the service owns full records under one lock), and the spec'd project-cascade behavior even though a cross-project-resumed active thread can be cascaded away with its original project — documented trade-off, re-mints into the observing project on next evidence.

Linear: ATC-277 (part of ATC-255).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added durable tracking for agent conversation threads.
  - Added commands to list, view, update, archive, unarchive, and delete threads.
  - Added filtering by project, terminal, and archive status, with activity-based sorting.
  - Added thread status, metadata, error, and evidence details.
  - Terminals now show their currently active thread.
  - Added API support and live events for thread creation, updates, and deletion.

- **Bug Fixes**
  - Prevented archiving or deleting active threads.
  - Removing terminals or projects now cleans up associated thread records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->