### PR TITLE
ATC-278 | claude: hook injection, the internal ingest route, and the status reducer

### DIFF
--- a/cmd/atc/main.go
+++ b/cmd/atc/main.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
@@ -381,6 +382,21 @@ func printToken(stdout io.Writer, issue func(*authtoken.Store) (string, error)) 
 	return err
 }
 
+// hookHost is the address hook deliveries dial. Hooks always run on the
+// server's own machine, so an unspecified bind means plain loopback; a
+// specific bind (including ::1, which would make 127.0.0.1 unreachable)
+// is dialed as bound, bracketed for IPv6 literals.
+func hookHost(bind string) string {
+	ip := net.ParseIP(bind)
+	if ip == nil || ip.IsUnspecified() {
+		return "127.0.0.1"
+	}
+	if ip.To4() == nil {
+		return "[" + bind + "]"
+	}
+	return bind
+}
+
 // serverRun runs the server in the foreground until the command context is
 // cancelled. A SIGINT that lands during boot (migrations, the startup
 // reconcile) is the same clean shutdown as one that lands while serving.
@@ -517,16 +533,6 @@ func serverRunUntilCancelled(cmd *cobra.Command, _ []string) error {
 	// observes pre-reconcile state (legacy's rule).
 	terminalService.Reconcile(ctx)
 
-	// One registration line per built-in agent; a duplicate id fails the
-	// boot.
-	agentService, err := agents.NewService(agents.Options{
-		Entries:   []agents.Entry{claude.Entry(), codex.Entry()},
-		Terminals: terminalService,
-	})
-	if err != nil {
-		return err
-	}
-
 	// Threads load after terminals so the boot-time status coercion and
 	// the sweep read a settled terminal view.
 	threadService := threads.NewService(threads.Options{
@@ -539,6 +545,45 @@ func serverRunUntilCancelled(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	// The listener binds before the handler exists: the hook plumbing
+	// bakes the actual bound port into every launch's settings file.
+	listener, err := net.Listen("tcp", net.JoinHostPort(cfg.Bind, strconv.Itoa(cfg.Port)))
+	if err != nil {
+		return err
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	// Claude hook plumbing (ATC-255): per-launch settings under the state
+	// dir, POSTing to the loopback ingest route. Registrations reload so
+	// TUIs launched by an earlier server process keep validating.
+	hookDir, err := paths.HookDir()
+	if err != nil {
+		return err
+	}
+	claudeHooks, err := claude.NewHooks(claude.HooksOptions{
+		Dir:       hookDir,
+		BaseURL:   fmt.Sprintf("http://%s:%d", hookHost(cfg.Bind), port),
+		Threads:   threadService,
+		Terminals: terminalService,
+		Logger:    logger,
+	})
+	if err != nil {
+		return err
+	}
+	if err := claudeHooks.LoadRegistrations(); err != nil {
+		return err
+	}
+
+	// One registration line per built-in agent; a duplicate id fails the
+	// boot.
+	agentService, err := agents.NewService(agents.Options{
+		Entries:   []agents.Entry{claude.Entry(claudeHooks), codex.Entry()},
+		Terminals: terminalService,
+	})
+	if err != nil {
+		return err
+	}
+
 	handler := server.NewHandler(server.Options{
 		Verify:    tokens.Verify,
 		Version:   versionValue,
@@ -548,12 +593,10 @@ func serverRunUntilCancelled(cmd *cobra.Command, _ []string) error {
 		Agents:    agentService,
 		Threads:   threadService,
 		Events:    hub,
+		InternalRoutes: map[string]http.Handler{
+			"POST " + claude.HooksPath: claudeHooks.Handler(),
+		},
 	})
-
-	listener, err := net.Listen("tcp", net.JoinHostPort(cfg.Bind, strconv.Itoa(cfg.Port)))
-	if err != nil {
-		return err
-	}
 	// The reconcile loop is waited on before the deferred database close,
 	// so shutdown never races an in-flight pass against it. The wait is
 	// cheap: every step of the loop is context-aware, and the loop's

--- a/cmd/atc/terminal_test.go
+++ b/cmd/atc/terminal_test.go
@@ -91,8 +91,25 @@ func startTestServerWithThreads(t *testing.T) (*cliAdapter, *threads.Service) {
 		Terminals:  db.Terminals(),
 		Hub:        hub,
 	})
+	threadService := threads.NewService(threads.Options{
+		Repository: db.Threads(),
+		Terminals:  service,
+		Hub:        hub,
+	})
+	if err := threadService.Load(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	claudeHooks, err := claude.NewHooks(claude.HooksOptions{
+		Dir:       t.TempDir(),
+		BaseURL:   "http://127.0.0.1:0",
+		Threads:   threadService,
+		Terminals: service,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	agentService, err := agents.NewService(agents.Options{
-		Entries:   []agents.Entry{claude.Entry(), codex.Entry()},
+		Entries:   []agents.Entry{claude.Entry(claudeHooks), codex.Entry()},
 		Terminals: service,
 		// The probe never consults this machine's PATH: claude "exists",
 		// codex does not.
@@ -104,14 +121,6 @@ func startTestServerWithThreads(t *testing.T) (*cliAdapter, *threads.Service) {
 		},
 	})
 	if err != nil {
-		t.Fatal(err)
-	}
-	threadService := threads.NewService(threads.Options{
-		Repository: db.Threads(),
-		Terminals:  service,
-		Hub:        hub,
-	})
-	if err := threadService.Load(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	handler := server.NewHandler(server.Options{

--- a/internal/agents/agents.go
+++ b/internal/agents/agents.go
@@ -14,18 +14,38 @@
 // agents (ATC-251 doctrine).
 package agents
 
+import (
+	"context"
+	"strings"
+)
+
 // CapabilityTUI is the one capability in ATC-254: the agent can be
 // launched as a TUI in an ATC-managed terminal.
 const CapabilityTUI = "tui"
 
+// LaunchContext is the per-launch context the composition injects into an
+// adapter's command (ATC-255): the minted terminal identity and its
+// working directory. Adapters use it to wire observation — Claude hook
+// settings, the Codex --remote socket — without any of it appearing in
+// the API contract.
+type LaunchContext struct {
+	// TerminalID is the terminal being created for this launch.
+	TerminalID string
+	// Directory is the terminal's working directory (the project's).
+	Directory string
+}
+
 // TUIAdapter is the per-tool seam behind the tui capability, written once
-// and implemented per agent. Launch-only in this ticket; the threads
-// effort owns extending it with status wiring.
+// and implemented per agent.
 type TUIAdapter interface {
-	// Command is the command string a launch terminal runs through the
-	// user's login shell. It never appears in the API contract, so flags
-	// can change without a wire-visible change.
-	Command() string
+	// Command composes the command string a launch terminal runs through
+	// the user's login shell. It never appears in the API contract, so
+	// flags can change without a wire-visible change. Any injected path
+	// must be shell-quoted (Quote) — the command is a single string run
+	// through the user's login shell. An error refuses the launch before
+	// the terminal record exists; the context bounds launch-time work
+	// like starting the shared Codex app-server.
+	Command(ctx context.Context, launch LaunchContext) (string, error)
 	// Binary is the executable name the availability probe resolves on the
 	// server's PATH.
 	Binary() string
@@ -34,10 +54,18 @@ type TUIAdapter interface {
 }
 
 // Entry is one catalog registration: a stable id (persisted by terminals
-// and later threads — never renamed), a display name, and the tool's
-// adapters. A nil adapter simply means the entry lacks that capability.
+// and threads — never renamed), a display name, and the tool's adapters.
+// A nil adapter simply means the entry lacks that capability.
 type Entry struct {
 	ID   string
 	Name string
 	TUI  TUIAdapter
+}
+
+// Quote wraps a string in single quotes for the user's login shell, the
+// one quoting that is safe across POSIX shells: injected paths ride a
+// single command string, and an unquoted space or metacharacter would
+// split or execute.
+func Quote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -14,20 +14,32 @@ import (
 
 type fakeTUI struct{ command, binary, hint string }
 
-func (a fakeTUI) Command() string     { return a.command }
+// Command echoes the launch context so tests can assert the composition
+// forwarded the minted identity and directory.
+func (a fakeTUI) Command(_ context.Context, launch LaunchContext) (string, error) {
+	return a.command + " --for " + launch.TerminalID + ":" + launch.Directory, nil
+}
 func (a fakeTUI) Binary() string      { return a.binary }
 func (a fakeTUI) InstallHint() string { return a.hint }
 
 // fakeCreator records the create the launch composition hands the
-// terminals domain.
+// terminals domain, running the compose factory the way the real service
+// does — after minting the terminal identity.
 type fakeCreator struct {
-	params api.TerminalCreateParams
-	agent  string
+	params  api.TerminalCreateParams
+	agent   string
+	command string
 }
 
-func (c *fakeCreator) CreateForAgent(_ context.Context, params api.TerminalCreateParams, agent string) (api.Terminal, error) {
+func (c *fakeCreator) CreateForAgent(_ context.Context, params api.TerminalCreateParams, agent string,
+	compose func(terminalID, directory string) (string, error)) (api.Terminal, error) {
 	c.params, c.agent = params, agent
-	return api.Terminal{ID: "term-aaaaa", Name: params.Name, Command: params.Command, Agent: agent}, nil
+	command, err := compose("term-aaaaa", "/proj")
+	if err != nil {
+		return api.Terminal{}, err
+	}
+	c.command = command
+	return api.Terminal{ID: "term-aaaaa", Name: params.Name, Command: command, Agent: agent}, nil
 }
 
 func testEntries() []Entry {
@@ -99,9 +111,14 @@ func TestLaunchComposesTheTerminalCreate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantParams := api.TerminalCreateParams{ProjectID: "proj-aaaaa", Name: "Alpha", Command: "alpha --tui"}
+	wantParams := api.TerminalCreateParams{ProjectID: "proj-aaaaa", Name: "Alpha"}
 	if diff := cmp.Diff(wantParams, creator.params); diff != "" {
 		t.Errorf("create params (-want +got):\n%s", diff)
+	}
+	// The composed command carries the per-launch context the terminals
+	// domain fed the factory.
+	if creator.command != "alpha --tui --for term-aaaaa:/proj" {
+		t.Errorf("composed command = %q", creator.command)
 	}
 	if creator.agent != "alpha" || terminal.Agent != "alpha" {
 		t.Errorf("agent label = %q on create, %q on terminal; want alpha", creator.agent, terminal.Agent)

--- a/internal/agents/claude/claude.go
+++ b/internal/agents/claude/claude.go
@@ -1,17 +1,39 @@
 // Package claude is the built-in catalog registration for Claude Code
-// (ATC-254). The id is persisted by terminals and later threads — never
-// rename it.
+// (ATC-254) and its thread-evidence wiring (ATC-255): per-launch hook
+// settings that make Claude's lifecycle hooks POST structured events to
+// an internal ATC route, and the stateful reducer that turns those events
+// into thread observations. The id is persisted by terminals and threads
+// — never rename it.
 package claude
 
-import "github.com/jeremytondo/atc/internal/agents"
+import (
+	"context"
 
-// Entry is Claude Code's catalog registration.
-func Entry() agents.Entry {
-	return agents.Entry{ID: "claude", Name: "Claude Code", TUI: tui{}}
+	"github.com/jeremytondo/atc/internal/agents"
+)
+
+// Entry is Claude Code's catalog registration. hooks wires thread
+// observation into every launch and is required — a Claude launch
+// without evidence wiring would silently produce a thread-less TUI.
+func Entry(hooks *Hooks) agents.Entry {
+	if hooks == nil {
+		panic("claude.Entry: hooks must not be nil")
+	}
+	return agents.Entry{ID: "claude", Name: "Claude Code", TUI: tui{hooks: hooks}}
 }
 
-type tui struct{}
+type tui struct{ hooks *Hooks }
 
-func (tui) Command() string     { return "claude" }
+// Command composes the launch: hook settings are prepared under the
+// terminal's identity and injected with --settings, shell-quoted — the
+// command is one string through the user's login shell.
+func (t tui) Command(_ context.Context, launch agents.LaunchContext) (string, error) {
+	settings, err := t.hooks.Prepare(launch.TerminalID)
+	if err != nil {
+		return "", err
+	}
+	return "claude --settings " + agents.Quote(settings), nil
+}
+
 func (tui) Binary() string      { return "claude" }
 func (tui) InstallHint() string { return "npm install -g @anthropic-ai/claude-code" }

--- a/internal/agents/claude/hooks.go
+++ b/internal/agents/claude/hooks.go
@@ -1,0 +1,502 @@
+package claude
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/jeremytondo/atc/internal/agents"
+	"github.com/jeremytondo/atc/internal/api"
+	"github.com/jeremytondo/atc/internal/threads"
+)
+
+// SecretHeader carries the per-launch hook secret. It rides an HTTP
+// header sourced from a 0600 file (curl -H @file), so the secret never
+// appears in argv or a URL.
+const SecretHeader = "x-atc-hook-secret"
+
+// HooksPath is the internal ingest route. It sits outside the public API
+// contract and outside bearer auth — the per-launch secret is its whole
+// authentication; the bearer token must never be used for hook delivery.
+const HooksPath = "/internal/claude/hooks"
+
+// hookEvents are the lifecycle hooks every launch wires (the legacy
+// product's proven set). Each POSTs its full payload to HooksPath; the
+// reducer reads what it understands and ignores the rest.
+var hookEvents = []string{
+	"SessionStart", "SessionEnd", "UserPromptSubmit", "PreToolUse", "PostToolUse",
+	"PostToolUseFailure", "Stop", "StopFailure", "SubagentStart", "SubagentStop",
+	"TaskCreated", "TaskCompleted", "Notification", "PermissionRequest", "PermissionDenied",
+}
+
+// maxPayloadBytes bounds one hook payload read.
+const maxPayloadBytes = 1 << 20
+
+// ThreadObserver is the seam into the threads domain: neutral
+// observations in, no provider vocabulary out.
+type ThreadObserver interface {
+	ObserveSession(ctx context.Context, o threads.SessionObservation) (string, error)
+	ObserveStatus(ctx context.Context, o threads.StatusObservation) error
+	Deactivate(ctx context.Context, terminalID string)
+	LookupIdentity(agent, providerID string) (threadID, terminalID string, ok bool)
+}
+
+// TerminalReader resolves a terminal's record — the observing terminal's
+// project is copied onto a thread at first observation.
+type TerminalReader interface {
+	Get(id string) (api.Terminal, error)
+}
+
+// HooksOptions wires a Hooks.
+type HooksOptions struct {
+	// Dir is where the per-launch settings and secret files live
+	// (paths.HookDir), created 0700.
+	Dir string
+	// BaseURL is where hooks POST, e.g. "http://127.0.0.1:4779" — always
+	// loopback: the hook runs on the server's own machine.
+	BaseURL   string
+	Threads   ThreadObserver
+	Terminals TerminalReader
+	Logger    *slog.Logger
+	Now       func() time.Time
+}
+
+// Hooks owns Claude's thread evidence: per-launch secret registrations,
+// the settings files injected into launches, the internal ingest
+// endpoint, and the per-session reducers. Events run through a stateful
+// reducer — individual hook events are not a state machine.
+type Hooks struct {
+	dir       string
+	baseURL   string
+	threads   ThreadObserver
+	terminals TerminalReader
+	logger    *slog.Logger
+	now       func() time.Time
+
+	mu         sync.Mutex
+	bySecret   map[string]*registration
+	byTerminal map[string]*registration
+}
+
+// registration binds one launch's secret to its terminal. sessionID is
+// the provider session the terminal currently has open, learned only from
+// SessionStart (or the post-restart seed check); a payload whose session
+// disagrees with it is dropped. mu serializes delivery per launch end to
+// end — validation, reduction, and observation move as one unit, so a
+// concurrent SessionStart cannot reset the tracker under an in-flight
+// event or reorder observations.
+type registration struct {
+	mu         sync.Mutex
+	secret     string
+	terminalID string
+	sessionID  string
+	// established records that the threads domain has accepted the
+	// session observation. A transient failure leaves it false, and the
+	// next event retries instead of silently dropping the whole session.
+	established bool
+	// ended records a SessionEnd: stragglers for the departed session are
+	// dropped rather than re-seeded, until the next SessionStart.
+	ended   bool
+	tracker *tracker
+}
+
+// NewHooks prepares the hook directory and an empty registry. Call
+// LoadRegistrations at boot so launches that predate this server process
+// keep validating.
+func NewHooks(opts HooksOptions) (*Hooks, error) {
+	if opts.Threads == nil || opts.Terminals == nil {
+		panic("claude.NewHooks: Threads and Terminals must not be nil")
+	}
+	if opts.Logger == nil {
+		opts.Logger = slog.New(slog.DiscardHandler)
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	// Private: the files grant status-injection on the user's threads.
+	// MkdirAll's mode only applies on creation, so a pre-existing
+	// permissive directory is tightened.
+	if err := os.MkdirAll(opts.Dir, 0o700); err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(opts.Dir, 0o700); err != nil {
+		return nil, err
+	}
+	return &Hooks{
+		dir:        opts.Dir,
+		baseURL:    strings.TrimSuffix(opts.BaseURL, "/"),
+		threads:    opts.Threads,
+		terminals:  opts.Terminals,
+		logger:     opts.Logger,
+		now:        opts.Now,
+		bySecret:   map[string]*registration{},
+		byTerminal: map[string]*registration{},
+	}, nil
+}
+
+func (h *Hooks) settingsPath(terminalID string) string {
+	return filepath.Join(h.dir, terminalID+".json")
+}
+
+func (h *Hooks) headerPath(terminalID string) string {
+	return filepath.Join(h.dir, terminalID+".header")
+}
+
+// Prepare mints this launch's secret, writes the header and settings
+// files (0600), and registers the secret for the terminal. It returns the
+// settings path for the --settings flag. Files are keyed by terminal id,
+// so a re-run for the same id simply replaces them.
+func (h *Hooks) Prepare(terminalID string) (string, error) {
+	secret, err := newSecret()
+	if err != nil {
+		return "", err
+	}
+	header := SecretHeader + ": " + secret
+	if err := writePrivateFile(h.headerPath(terminalID), []byte(header)); err != nil {
+		return "", err
+	}
+	settings, err := json.Marshal(hookSettings(h.command(terminalID)))
+	if err != nil {
+		return "", err
+	}
+	if err := writePrivateFile(h.settingsPath(terminalID), settings); err != nil {
+		return "", err
+	}
+	h.mu.Lock()
+	h.register(&registration{secret: secret, terminalID: terminalID})
+	h.mu.Unlock()
+	return h.settingsPath(terminalID), nil
+}
+
+// register indexes a registration, dropping any earlier one for the same
+// terminal (a new launch's secret invalidates the old). Callers hold mu.
+func (h *Hooks) register(reg *registration) {
+	if previous, ok := h.byTerminal[reg.terminalID]; ok {
+		delete(h.bySecret, previous.secret)
+	}
+	h.bySecret[reg.secret] = reg
+	h.byTerminal[reg.terminalID] = reg
+}
+
+// command is the hook command line: curl POSTing the payload from stdin,
+// with the secret ridden in from the header file — never argv, never the
+// URL. Paths are shell-quoted; Claude runs the command through a shell.
+func (h *Hooks) command(terminalID string) string {
+	return "curl -fsS -m 5 -X POST -H 'Content-Type: application/json' -H @" +
+		agents.Quote(h.headerPath(terminalID)) + " --data-binary @- " + agents.Quote(h.baseURL+HooksPath)
+}
+
+// hookSettings is the --settings document: every lifecycle event wired to
+// the one command.
+func hookSettings(command string) map[string]any {
+	hook := []map[string]any{{
+		"hooks": []map[string]any{{"type": "command", "command": command}},
+	}}
+	events := make(map[string]any, len(hookEvents))
+	for _, event := range hookEvents {
+		events[event] = hook
+	}
+	return map[string]any{"hooks": events}
+}
+
+// LoadRegistrations rebuilds the secret registry from the hook directory
+// at boot, so TUIs launched by an earlier server process keep validating.
+// Files whose terminal no longer exists are launch leftovers (deleted
+// terminals, abandoned launch candidates) and are removed. Session
+// bindings are not persisted: the first payload after a restart re-seeds
+// through the identity mapping or the next SessionStart.
+func (h *Hooks) LoadRegistrations() error {
+	entries, err := os.ReadDir(h.dir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".header") {
+			continue
+		}
+		terminalID := strings.TrimSuffix(name, ".header")
+		remove := func() {
+			_ = os.Remove(h.headerPath(terminalID))
+			_ = os.Remove(h.settingsPath(terminalID))
+		}
+		terminal, err := h.terminals.Get(terminalID)
+		if err != nil || terminal.Agent != "claude" {
+			remove()
+			continue
+		}
+		content, err := os.ReadFile(h.headerPath(terminalID))
+		if err != nil {
+			h.logger.Warn("unreadable hook secret", "terminal", terminalID, "error", err)
+			continue
+		}
+		secret, ok := strings.CutPrefix(string(content), SecretHeader+": ")
+		if !ok || secret == "" {
+			remove()
+			continue
+		}
+		h.mu.Lock()
+		h.register(&registration{secret: secret, terminalID: terminalID})
+		h.mu.Unlock()
+	}
+	return nil
+}
+
+// payload is the slice of a hook event the reducer reads; everything else
+// in the POST body is ignored. Pointer slices distinguish an absent level
+// snapshot from an empty one — an empty background_tasks array is the
+// authoritative "no background work".
+type payload struct {
+	SessionID        string             `json:"session_id"`
+	HookEventName    string             `json:"hook_event_name"`
+	AgentID          string             `json:"agent_id"`
+	TaskID           string             `json:"task_id"`
+	BackgroundTasks  *[]task            `json:"background_tasks"`
+	SessionCrons     *[]json.RawMessage `json:"session_crons"`
+	NotificationType string             `json:"notification_type"`
+	ToolName         string             `json:"tool_name"`
+	Prompt           string             `json:"prompt"`
+	Reason           string             `json:"reason"`
+	Cwd              string             `json:"cwd"`
+	PermissionMode   string             `json:"permission_mode"`
+	Effort           struct {
+		Level string `json:"level"`
+	} `json:"effort"`
+}
+
+type task struct {
+	ID string `json:"id"`
+}
+
+// Handler is the ingest endpoint. Responses deliberately say nothing
+// about why a delivery was refused: 404 for an unknown secret, 400 for a
+// payload that cannot be honored, 204 for accepted (including events the
+// reducer has no opinion about).
+func (h *Hooks) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		// The route sits outside bearer auth, so an unknown peer must not
+		// get to hold a handler open by trickling a body: bounded bytes
+		// and a bounded read window.
+		_ = http.NewResponseController(w).SetReadDeadline(time.Now().Add(10 * time.Second))
+		secret := r.Header.Get(SecretHeader)
+		body, err := io.ReadAll(io.LimitReader(r.Body, maxPayloadBytes))
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(h.deliver(r.Context(), secret, body))
+	})
+}
+
+// deliver validates and applies one hook payload, returning the response
+// status.
+func (h *Hooks) deliver(ctx context.Context, secret string, body []byte) int {
+	var p payload
+	if err := json.Unmarshal(body, &p); err != nil || p.SessionID == "" || p.HookEventName == "" {
+		return http.StatusBadRequest
+	}
+
+	h.mu.Lock()
+	reg, ok := h.bySecret[secret]
+	h.mu.Unlock()
+	if !ok {
+		return http.StatusNotFound
+	}
+
+	// One launch's events are serialized end to end from here.
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+
+	// Re-verified under the registration lock: a delivery that looked the
+	// registration up just before a replacement must not mutate lifecycle
+	// state the replacement now owns.
+	h.mu.Lock()
+	current := h.bySecret[secret] == reg
+	h.mu.Unlock()
+	if !current {
+		return http.StatusNotFound
+	}
+
+	if p.HookEventName != "SessionStart" {
+		if reg.ended {
+			// The session ended; stragglers are dropped rather than
+			// re-seeded. The next SessionStart opens the next chapter.
+			return http.StatusBadRequest
+		}
+		if reg.sessionID == "" {
+			// Post-restart seed: accept evidence only for a conversation the
+			// identity mapping already ties to this same terminal.
+			_, terminalID, known := h.threads.LookupIdentity("claude", p.SessionID)
+			if !known || terminalID != reg.terminalID {
+				return http.StatusBadRequest
+			}
+			reg.sessionID = p.SessionID
+			reg.tracker = seededTracker()
+			reg.established = false
+		} else if p.SessionID != reg.sessionID {
+			// A payload whose session disagrees with the registration is
+			// dropped — delayed evidence from a conversation this terminal
+			// no longer displays, or a forgery.
+			return http.StatusBadRequest
+		}
+	}
+
+	switch p.HookEventName {
+	case "SessionStart":
+		reg.ended = false
+		if p.SessionID != reg.sessionID {
+			// A genuinely new conversation: fresh reducer, at its prompt.
+			reg.sessionID = p.SessionID
+			reg.tracker = newTracker()
+			reg.established = h.observe(ctx, reg.terminalID, p, api.ThreadIdle)
+		} else {
+			// The same session re-announced (compact): identity and
+			// reducer state stand — an active turn may well continue, so
+			// no idle claim.
+			reg.established = h.observe(ctx, reg.terminalID, p, "")
+		}
+	case "SessionEnd":
+		h.sessionEnd(ctx, reg, p)
+	default:
+		if !reg.established {
+			// (Re-)establish the session before its evidence: the threads
+			// domain accepts live statuses only for a conversation some
+			// terminal holds, and the secret+session agreement is exactly
+			// that proof. On failure the event is dropped and the next one
+			// retries — a transient error must not silence the session.
+			if !h.observe(ctx, reg.terminalID, p, "") {
+				return http.StatusNoContent
+			}
+			reg.established = true
+		}
+		h.reduce(ctx, reg, p)
+	}
+	return http.StatusNoContent
+}
+
+// observe records a session observation for the terminal, reporting
+// success. status "" keeps whatever the thread already shows (a seed or
+// compact must not claim idle for a possibly mid-turn conversation).
+func (h *Hooks) observe(ctx context.Context, terminalID string, p payload, status api.ThreadStatus) bool {
+	terminal, err := h.terminals.Get(terminalID)
+	if err != nil {
+		// The terminal vanished mid-flight; there is nothing honest to
+		// record the conversation against.
+		h.logger.Warn("hook event for a missing terminal dropped", "terminal", terminalID)
+		return false
+	}
+	threadID, err := h.threads.ObserveSession(ctx, threads.SessionObservation{
+		Agent:      "claude",
+		ProviderID: p.SessionID,
+		TerminalID: terminalID,
+		ProjectID:  terminal.ProjectID,
+		At:         h.now(),
+		Status:     status,
+		Metadata:   metadataFrom(p),
+	})
+	if err != nil || threadID == "" {
+		h.logger.Warn("recording session observation", "terminal", terminalID, "error", err)
+		return false
+	}
+	return true
+}
+
+// sessionEnd closes the reducer's book on the session. A clear or resume
+// is a switch — the successor's SessionStart is already on its way and
+// moves the active thread itself; anything else means the TUI is leaving
+// the conversation without a successor, so the terminal deactivates.
+// Caller holds reg.mu.
+func (h *Hooks) sessionEnd(ctx context.Context, reg *registration, p payload) {
+	reg.tracker = nil
+	reg.ended = true
+	if err := h.threads.ObserveStatus(ctx, threads.StatusObservation{
+		Agent: "claude", ProviderID: p.SessionID, At: h.now(),
+		Status: api.ThreadIdle, Metadata: metadataFrom(p),
+	}); err != nil {
+		h.logger.Warn("recording session end", "terminal", reg.terminalID, "error", err)
+	}
+	if p.Reason != "clear" && p.Reason != "resume" {
+		h.threads.Deactivate(ctx, reg.terminalID)
+	}
+}
+
+// reduce runs one ordinary event through the session's reducer and
+// forwards the resulting evidence. Caller holds reg.mu.
+func (h *Hooks) reduce(ctx context.Context, reg *registration, p payload) {
+	if reg.tracker == nil {
+		reg.tracker = seededTracker()
+	}
+	status, signal, lastError := reg.tracker.apply(p)
+	if !signal {
+		return
+	}
+	metadata := metadataFrom(p)
+	if p.HookEventName == "UserPromptSubmit" && p.AgentID == "" {
+		// The first-prompt title fallback: an observed title only ever
+		// fills an untitled thread, so sending it on every prompt is safe.
+		metadata.Title = titleFrom(p.Prompt)
+	}
+	if err := h.threads.ObserveStatus(ctx, threads.StatusObservation{
+		Agent: "claude", ProviderID: p.SessionID, At: h.now(),
+		Status: status, LastError: lastError, Metadata: metadata,
+	}); err != nil {
+		h.logger.Warn("recording status observation", "error", err)
+	}
+}
+
+func metadataFrom(p payload) threads.Metadata {
+	return threads.Metadata{
+		Cwd:            p.Cwd,
+		PermissionMode: p.PermissionMode,
+		Effort:         p.Effort.Level,
+	}
+}
+
+// titleFrom condenses a first prompt into an observed default title,
+// cutting on a word boundary, else a rune boundary — never mid-character.
+func titleFrom(prompt string) string {
+	const limit = 50
+	title := strings.Join(strings.Fields(prompt), " ")
+	if len(title) <= limit {
+		return title
+	}
+	if cut := strings.LastIndexByte(title[:limit], ' '); cut > 0 {
+		return title[:cut]
+	}
+	cut := limit
+	for cut > 0 && !utf8.RuneStart(title[cut]) {
+		cut--
+	}
+	return title[:cut]
+}
+
+func newSecret() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// writePrivateFile writes content at mode 0600 and enforces the mode on a
+// pre-existing file too — os.WriteFile applies its mode only on creation.
+func writePrivateFile(path string, content []byte) error {
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o600)
+}

--- a/internal/agents/claude/hooks_test.go
+++ b/internal/agents/claude/hooks_test.go
@@ -1,0 +1,415 @@
+package claude
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/jeremytondo/atc/internal/agents"
+	"github.com/jeremytondo/atc/internal/api"
+	"github.com/jeremytondo/atc/internal/threads"
+)
+
+// fakeObserver records what reaches the threads seam.
+type fakeObserver struct {
+	mu       sync.Mutex
+	sessions []threads.SessionObservation
+	statuses []threads.StatusObservation
+	inactive []string
+	// identity is the mapping LookupIdentity serves: provider id →
+	// terminal id.
+	identity map[string]string
+}
+
+func (f *fakeObserver) ObserveSession(_ context.Context, o threads.SessionObservation) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sessions = append(f.sessions, o)
+	return "thrd-aaaaa", nil
+}
+
+func (f *fakeObserver) ObserveStatus(_ context.Context, o threads.StatusObservation) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.statuses = append(f.statuses, o)
+	return nil
+}
+
+func (f *fakeObserver) Deactivate(_ context.Context, terminalID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.inactive = append(f.inactive, terminalID)
+}
+
+func (f *fakeObserver) LookupIdentity(_, providerID string) (string, string, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	terminalID, ok := f.identity[providerID]
+	return "thrd-aaaaa", terminalID, ok
+}
+
+func (f *fakeObserver) lastStatus(t *testing.T) threads.StatusObservation {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.statuses) == 0 {
+		t.Fatal("no status observation recorded")
+	}
+	return f.statuses[len(f.statuses)-1]
+}
+
+// fakeTerminals serves terminal records for project resolution and boot
+// reload.
+type fakeTerminals struct {
+	mu        sync.Mutex
+	terminals map[string]api.Terminal
+}
+
+func (f *fakeTerminals) Get(id string) (api.Terminal, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	terminal, ok := f.terminals[id]
+	if !ok {
+		return api.Terminal{}, errors.New("terminal not found")
+	}
+	return terminal, nil
+}
+
+type hookFixture struct {
+	hooks     *Hooks
+	observer  *fakeObserver
+	terminals *fakeTerminals
+	dir       string
+}
+
+func newHookFixture(t *testing.T) *hookFixture {
+	t.Helper()
+	observer := &fakeObserver{identity: map[string]string{}}
+	terminals := &fakeTerminals{terminals: map[string]api.Terminal{
+		"term-aaaaa": {ID: "term-aaaaa", ProjectID: "proj-aaaaa", Agent: "claude", Status: api.TerminalRunning},
+	}}
+	dir := t.TempDir()
+	hooks, err := NewHooks(HooksOptions{
+		Dir:       dir,
+		BaseURL:   "http://127.0.0.1:4779",
+		Threads:   observer,
+		Terminals: terminals,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &hookFixture{hooks: hooks, observer: observer, terminals: terminals, dir: dir}
+}
+
+// prepare runs the launch composition and returns the minted secret.
+func (f *hookFixture) prepare(t *testing.T, terminalID string) string {
+	t.Helper()
+	if _, err := f.hooks.Prepare(terminalID); err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(f.hooks.headerPath(terminalID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret, ok := strings.CutPrefix(string(content), SecretHeader+": ")
+	if !ok {
+		t.Fatalf("header file %q lacks the header prefix", content)
+	}
+	return secret
+}
+
+// post delivers one hook payload and returns the status code.
+func (f *hookFixture) post(t *testing.T, secret, body string) int {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, HooksPath, strings.NewReader(body))
+	if secret != "" {
+		req.Header.Set(SecretHeader, secret)
+	}
+	rec := httptest.NewRecorder()
+	f.hooks.Handler().ServeHTTP(rec, req)
+	return rec.Code
+}
+
+func TestPrepareWritesPrivateFiles(t *testing.T) {
+	f := newHookFixture(t)
+	settings, err := f.hooks.Prepare("term-aaaaa")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range []string{settings, f.hooks.headerPath("term-aaaaa")} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Errorf("%s mode = %o, want 0600", path, info.Mode().Perm())
+		}
+	}
+
+	content, err := os.ReadFile(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	header, err := os.ReadFile(f.hooks.headerPath("term-aaaaa"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret := strings.TrimPrefix(string(header), SecretHeader+": ")
+	// The secret rides only the header file: never argv (the settings
+	// command), never a URL.
+	if strings.Contains(string(content), secret) {
+		t.Error("settings file leaks the secret")
+	}
+	for _, want := range []string{
+		`"SessionStart"`, `"Stop"`, `"Notification"`, `"PermissionRequest"`,
+		"curl -fsS -m 5", "-H @'", "http://127.0.0.1:4779" + HooksPath,
+	} {
+		if !strings.Contains(string(content), want) {
+			t.Errorf("settings file missing %q:\n%s", want, content)
+		}
+	}
+}
+
+func TestDeliverySecretEnforcement(t *testing.T) {
+	f := newHookFixture(t)
+	secret := f.prepare(t, "term-aaaaa")
+	start := `{"session_id":"s1","hook_event_name":"SessionStart","source":"startup"}`
+
+	if code := f.post(t, "", start); code != http.StatusNotFound {
+		t.Errorf("no secret: got %d, want 404", code)
+	}
+	if code := f.post(t, "wrong", start); code != http.StatusNotFound {
+		t.Errorf("wrong secret: got %d, want 404", code)
+	}
+	if code := f.post(t, secret, `{not json`); code != http.StatusBadRequest {
+		t.Errorf("malformed payload: got %d, want 400", code)
+	}
+	if code := f.post(t, secret, start); code != http.StatusNoContent {
+		t.Errorf("valid delivery: got %d, want 204", code)
+	}
+
+	// A payload whose session disagrees with the registration is dropped.
+	if code := f.post(t, secret, `{"session_id":"s-other","hook_event_name":"Stop"}`); code != http.StatusBadRequest {
+		t.Errorf("mismatched session: got %d, want 400", code)
+	}
+	if len(f.observer.statuses) != 0 {
+		t.Errorf("dropped payload still observed: %+v", f.observer.statuses)
+	}
+
+	// A relaunch mints a new secret; the old one stops validating.
+	fresh := f.prepare(t, "term-aaaaa")
+	if code := f.post(t, secret, start); code != http.StatusNotFound {
+		t.Errorf("stale secret: got %d, want 404", code)
+	}
+	if code := f.post(t, fresh, start); code != http.StatusNoContent {
+		t.Errorf("fresh secret: got %d, want 204", code)
+	}
+}
+
+func TestSessionLifecycleObservations(t *testing.T) {
+	f := newHookFixture(t)
+	secret := f.prepare(t, "term-aaaaa")
+
+	f.post(t, secret, `{"session_id":"s1","hook_event_name":"SessionStart","source":"startup","cwd":"/proj","permission_mode":"default","effort":{"level":"high"}}`)
+	if len(f.observer.sessions) != 1 {
+		t.Fatalf("sessions = %+v", f.observer.sessions)
+	}
+	session := f.observer.sessions[0]
+	if session.Agent != "claude" || session.ProviderID != "s1" || session.TerminalID != "term-aaaaa" ||
+		session.ProjectID != "proj-aaaaa" || session.Status != api.ThreadIdle {
+		t.Errorf("session observation = %+v", session)
+	}
+	if session.Metadata.Cwd != "/proj" || session.Metadata.PermissionMode != "default" || session.Metadata.Effort != "high" {
+		t.Errorf("session metadata = %+v", session.Metadata)
+	}
+
+	// The first prompt supplies the title fallback and starts the turn.
+	f.post(t, secret, `{"session_id":"s1","hook_event_name":"UserPromptSubmit","prompt":"fix the flaky build on CI so releases stop breaking every night"}`)
+	status := f.observer.lastStatus(t)
+	if status.Status != api.ThreadWorking {
+		t.Errorf("prompt status = %s", status.Status)
+	}
+	if status.Metadata.Title == "" || len(status.Metadata.Title) > 50 {
+		t.Errorf("title fallback = %q", status.Metadata.Title)
+	}
+
+	// /clear: SessionEnd(reason=clear) does not deactivate — the new
+	// SessionStart moves the terminal itself.
+	f.post(t, secret, `{"session_id":"s1","hook_event_name":"SessionEnd","reason":"clear"}`)
+	if len(f.observer.inactive) != 0 {
+		t.Errorf("clear deactivated the terminal: %v", f.observer.inactive)
+	}
+	f.post(t, secret, `{"session_id":"s2","hook_event_name":"SessionStart","source":"clear"}`)
+	if len(f.observer.sessions) != 2 || f.observer.sessions[1].ProviderID != "s2" {
+		t.Fatalf("sessions after clear = %+v", f.observer.sessions)
+	}
+
+	// Evidence for the departed session is now dropped.
+	if code := f.post(t, secret, `{"session_id":"s1","hook_event_name":"Stop"}`); code != http.StatusBadRequest {
+		t.Errorf("stale session evidence: got %d, want 400", code)
+	}
+
+	// TUI exit: SessionEnd with any other reason deactivates.
+	f.post(t, secret, `{"session_id":"s2","hook_event_name":"SessionEnd","reason":"other"}`)
+	if len(f.observer.inactive) != 1 || f.observer.inactive[0] != "term-aaaaa" {
+		t.Errorf("exit did not deactivate: %v", f.observer.inactive)
+	}
+
+	// The ended session's stragglers are dropped, never re-seeded; the
+	// next SessionStart opens the next chapter.
+	before := len(f.observer.statuses)
+	if code := f.post(t, secret, `{"session_id":"s2","hook_event_name":"Stop"}`); code != http.StatusBadRequest {
+		t.Errorf("straggler after end: got %d, want 400", code)
+	}
+	if len(f.observer.statuses) != before {
+		t.Errorf("straggler observed: %+v", f.observer.statuses[before:])
+	}
+	if code := f.post(t, secret, `{"session_id":"s3","hook_event_name":"SessionStart","source":"startup"}`); code != http.StatusNoContent {
+		t.Errorf("SessionStart after end: got %d, want 204", code)
+	}
+}
+
+// A compact re-announces the same session id: identity and reducer state
+// stand, and no idle is claimed for a possibly mid-turn conversation.
+func TestSessionStartCompactIsIdempotent(t *testing.T) {
+	f := newHookFixture(t)
+	secret := f.prepare(t, "term-aaaaa")
+
+	f.post(t, secret, `{"session_id":"s1","hook_event_name":"SessionStart","source":"startup"}`)
+	f.post(t, secret, `{"session_id":"s1","hook_event_name":"UserPromptSubmit","prompt":"go"}`)
+	f.post(t, secret, `{"session_id":"s1","hook_event_name":"SessionStart","source":"compact"}`)
+	// The compact's session observation claims no status...
+	last := f.observer.sessions[len(f.observer.sessions)-1]
+	if last.Status != "" {
+		t.Errorf("compact session status = %q; want no claim", last.Status)
+	}
+	// ...and the reducer still believes the turn is running: the next
+	// evidence continues from working, not from a reset.
+	f.post(t, secret, `{"session_id":"s1","hook_event_name":"PostToolUse","tool_name":"Bash"}`)
+	if got := f.observer.lastStatus(t); got.Status != api.ThreadWorking {
+		t.Errorf("status after compact = %s; want working preserved", got.Status)
+	}
+}
+
+// A transient failure recording the session must not silence it: the next
+// event retries the session observation before its evidence.
+func TestSessionObservationFailureRetries(t *testing.T) {
+	f := newHookFixture(t)
+	secret := f.prepare(t, "term-aaaaa")
+
+	// The terminal record is briefly unavailable at SessionStart.
+	f.terminals.mu.Lock()
+	saved := f.terminals.terminals["term-aaaaa"]
+	delete(f.terminals.terminals, "term-aaaaa")
+	f.terminals.mu.Unlock()
+	if code := f.post(t, secret, `{"session_id":"s1","hook_event_name":"SessionStart","source":"startup"}`); code != http.StatusNoContent {
+		t.Fatalf("SessionStart during outage: got %d", code)
+	}
+	if len(f.observer.sessions) != 0 {
+		t.Fatalf("sessions during outage = %+v", f.observer.sessions)
+	}
+
+	// The outage heals; the next ordinary event re-establishes and lands.
+	f.terminals.mu.Lock()
+	f.terminals.terminals["term-aaaaa"] = saved
+	f.terminals.mu.Unlock()
+	if code := f.post(t, secret, `{"session_id":"s1","hook_event_name":"UserPromptSubmit","prompt":"go"}`); code != http.StatusNoContent {
+		t.Fatalf("event after outage: got %d", code)
+	}
+	if len(f.observer.sessions) != 1 || f.observer.sessions[0].ProviderID != "s1" {
+		t.Errorf("session not re-established: %+v", f.observer.sessions)
+	}
+	if got := f.observer.lastStatus(t); got.Status != api.ThreadWorking {
+		t.Errorf("evidence after retry = %s", got.Status)
+	}
+}
+
+// After a server restart the registration has no session. Evidence for a
+// conversation the identity mapping ties to the same terminal re-seeds —
+// re-establishing the session first — and anything else is dropped.
+func TestPostRestartSeeding(t *testing.T) {
+	f := newHookFixture(t)
+	f.prepare(t, "term-aaaaa")
+	if err := f.hooks.LoadRegistrations(); err != nil {
+		t.Fatal(err)
+	}
+	secret := f.prepare(t, "term-aaaaa") // fresh handle to the same terminal
+	f.observer.identity["s1"] = "term-aaaaa"
+	f.observer.identity["s9"] = "term-other"
+
+	// Unmapped and wrong-terminal sessions are dropped.
+	if code := f.post(t, secret, `{"session_id":"s404","hook_event_name":"Stop"}`); code != http.StatusBadRequest {
+		t.Errorf("unmapped seed: got %d, want 400", code)
+	}
+	if code := f.post(t, secret, `{"session_id":"s9","hook_event_name":"Stop"}`); code != http.StatusBadRequest {
+		t.Errorf("wrong-terminal seed: got %d, want 400", code)
+	}
+
+	// A mapped session for this terminal seeds: session re-established,
+	// then the evidence lands.
+	if code := f.post(t, secret, `{"session_id":"s1","hook_event_name":"Stop"}`); code != http.StatusNoContent {
+		t.Errorf("mapped seed: got %d, want 204", code)
+	}
+	if len(f.observer.sessions) != 1 || f.observer.sessions[0].ProviderID != "s1" || f.observer.sessions[0].Status != "" {
+		t.Fatalf("seed session observation = %+v", f.observer.sessions)
+	}
+	if got := f.observer.lastStatus(t); got.Status != api.ThreadIdle {
+		t.Errorf("seeded evidence status = %s", got.Status)
+	}
+}
+
+func TestLoadRegistrationsCleansStaleFiles(t *testing.T) {
+	f := newHookFixture(t)
+	secret := f.prepare(t, "term-aaaaa")
+	// A leftover for a terminal that no longer exists (deleted, or an
+	// abandoned launch candidate).
+	f.prepare(t, "term-zzzzz")
+
+	reloaded, err := NewHooks(HooksOptions{
+		Dir: f.dir, BaseURL: "http://127.0.0.1:4779",
+		Threads: f.observer, Terminals: f.terminals,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reloaded.LoadRegistrations(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(reloaded.headerPath("term-zzzzz")); !os.IsNotExist(err) {
+		t.Error("stale hook files survived the reload")
+	}
+	if _, err := os.Stat(reloaded.headerPath("term-aaaaa")); err != nil {
+		t.Error("live hook files were removed")
+	}
+	// The reloaded registry accepts the persisted secret.
+	req := httptest.NewRequest(http.MethodPost, HooksPath,
+		strings.NewReader(`{"session_id":"s1","hook_event_name":"SessionStart","source":"startup"}`))
+	req.Header.Set(SecretHeader, secret)
+	rec := httptest.NewRecorder()
+	reloaded.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("reloaded secret: got %d, want 204", rec.Code)
+	}
+}
+
+func TestCommandComposition(t *testing.T) {
+	f := newHookFixture(t)
+	entry := Entry(f.hooks)
+	command, err := entry.TUI.Command(context.Background(), agents.LaunchContext{TerminalID: "term-aaaaa", Directory: "/proj"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if command != "claude --settings "+agents.Quote(f.hooks.settingsPath("term-aaaaa")) {
+		t.Errorf("command = %q", command)
+	}
+	if _, err := os.Stat(f.hooks.settingsPath("term-aaaaa")); err != nil {
+		t.Errorf("Command did not prepare the settings file: %v", err)
+	}
+}

--- a/internal/agents/claude/tracker.go
+++ b/internal/agents/claude/tracker.go
@@ -1,0 +1,192 @@
+package claude
+
+import "github.com/jeremytondo/atc/internal/api"
+
+// tracker is one session's stateful reducer: root status, agent-owned
+// background work (subagents, backgrounded shells, crons), and the
+// aggregation between them. Individual hook events are not a state
+// machine — level snapshots are authoritative wherever they appear, and
+// edge events fill the gaps between them.
+//
+// Known limitation, accepted (ATC-255): Claude fires no hook on user
+// interrupt, so working can overstay by up to roughly a minute until the
+// next prompt or the idle notification.
+type tracker struct {
+	root       api.ThreadStatus
+	background map[string]api.ThreadStatus
+	crons      int
+}
+
+// newTracker starts at idle — SessionStart means a fresh conversation at
+// its prompt.
+func newTracker() *tracker {
+	return &tracker{root: api.ThreadIdle, background: map[string]api.ThreadStatus{}}
+}
+
+// seededTracker starts at unknown: the session was adopted mid-flight
+// (post-restart), so nothing about the root is established until
+// evidence says so.
+func seededTracker() *tracker {
+	return &tracker{root: api.ThreadUnknown, background: map[string]api.ThreadStatus{}}
+}
+
+// rank orders statuses for aggregation: a blocked prompt outranks work,
+// work outranks ignorance, and idle requires every member known-inactive.
+// A specific question outranks a generic permission prompt, so a pending
+// question is never papered over by later permission evidence.
+func rank(status api.ThreadStatus) int {
+	switch status {
+	case api.ThreadWaitingForInput:
+		return 4
+	case api.ThreadWaitingForPermission:
+		return 3
+	case api.ThreadWorking:
+		return 2
+	case api.ThreadUnknown:
+		return 1
+	}
+	return 0 // idle
+}
+
+func (t *tracker) aggregate() api.ThreadStatus {
+	status := t.root
+	for _, member := range t.background {
+		if rank(member) > rank(status) {
+			status = member
+		}
+	}
+	if t.crons > 0 && rank(api.ThreadWorking) > rank(status) {
+		status = api.ThreadWorking
+	}
+	return status
+}
+
+// waiting reports a status that blocks on the user.
+func waiting(status api.ThreadStatus) bool {
+	return status == api.ThreadWaitingForInput || status == api.ThreadWaitingForPermission
+}
+
+// apply folds one hook payload in and reports the aggregate, whether the
+// payload carried a signal worth forwarding (unrecognized events without
+// a snapshot are never guessed at), and a lastError change when the
+// payload proves one.
+func (t *tracker) apply(p payload) (status api.ThreadStatus, signal bool, lastError *string) {
+	// Level snapshots first — authoritative wherever they appear. A
+	// retained id keeps its waiting flavor: the coarse snapshot status
+	// cannot see prompts.
+	if p.BackgroundTasks != nil {
+		replaced := make(map[string]api.ThreadStatus, len(*p.BackgroundTasks))
+		for _, entry := range *p.BackgroundTasks {
+			if entry.ID == "" {
+				continue
+			}
+			status := api.ThreadWorking
+			if previous, ok := t.background[entry.ID]; ok && waiting(previous) {
+				status = previous
+			}
+			replaced[entry.ID] = status
+		}
+		t.background = replaced
+		signal = true
+	}
+	if p.SessionCrons != nil {
+		t.crons = len(*p.SessionCrons)
+		signal = true
+	}
+
+	root := p.AgentID == ""
+	set := func(status api.ThreadStatus) {
+		if root {
+			t.root = status
+		} else {
+			t.background[p.AgentID] = status
+		}
+	}
+	// A generic permission prompt never downgrades a pending question on
+	// the same member — the specific evidence stands until the turn moves.
+	setPermission := func() {
+		if root {
+			if t.root != api.ThreadWaitingForInput {
+				t.root = api.ThreadWaitingForPermission
+			}
+		} else if t.background[p.AgentID] != api.ThreadWaitingForInput {
+			t.background[p.AgentID] = api.ThreadWaitingForPermission
+		}
+	}
+
+	switch p.HookEventName {
+	case "UserPromptSubmit":
+		set(api.ThreadWorking)
+		if root {
+			// A new turn supersedes the previous turn's failure detail.
+			cleared := ""
+			lastError = &cleared
+		}
+		return t.aggregate(), true, lastError
+	case "PreToolUse", "PostToolUse", "PostToolUseFailure", "PermissionDenied":
+		// The failure and denial events also resolve a descendant's
+		// pending prompt — the turn moved on.
+		set(api.ThreadWorking)
+		return t.aggregate(), true, nil
+	case "Stop":
+		if root {
+			t.root = api.ThreadIdle
+			return t.aggregate(), true, nil
+		}
+		return t.aggregate(), signal, nil
+	case "StopFailure":
+		if root {
+			t.root = api.ThreadIdle
+			failed := "the last turn failed"
+			return t.aggregate(), true, &failed
+		}
+		return t.aggregate(), signal, nil
+	case "SubagentStart":
+		if p.AgentID != "" {
+			t.background[p.AgentID] = api.ThreadWorking
+		}
+		return t.aggregate(), true, nil
+	case "SubagentStop":
+		// The payload's level snapshot still contains the stopping agent
+		// (probed 2026-08-10); this subtraction lands the last-child idle
+		// transition.
+		delete(t.background, p.AgentID)
+		return t.aggregate(), true, nil
+	case "TaskCreated":
+		if p.TaskID != "" {
+			t.background[p.TaskID] = api.ThreadWorking
+		}
+		return t.aggregate(), true, nil
+	case "TaskCompleted":
+		delete(t.background, p.TaskID)
+		return t.aggregate(), true, nil
+	case "PermissionRequest":
+		// AskUserQuestion arrives through the permission machinery but is
+		// a question — the split the spec keeps.
+		if p.ToolName == "AskUserQuestion" {
+			set(api.ThreadWaitingForInput)
+		} else {
+			setPermission()
+		}
+		return t.aggregate(), true, nil
+	case "Notification":
+		switch p.NotificationType {
+		case "idle_prompt":
+			// The idle nudge is root-only evidence; from a descendant it
+			// proves nothing.
+			if root {
+				t.root = api.ThreadIdle
+				return t.aggregate(), true, nil
+			}
+			return t.aggregate(), signal, nil
+		case "permission_prompt":
+			setPermission()
+			return t.aggregate(), true, nil
+		case "elicitation_dialog", "agent_needs_input":
+			set(api.ThreadWaitingForInput)
+			return t.aggregate(), true, nil
+		}
+		return t.aggregate(), signal, nil
+	}
+	return t.aggregate(), signal, nil
+}

--- a/internal/agents/claude/tracker_test.go
+++ b/internal/agents/claude/tracker_test.go
@@ -1,0 +1,156 @@
+package claude
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/jeremytondo/atc/internal/api"
+)
+
+// event builds a payload the way the wire delivers it, so the tests read
+// like recorded hook sequences.
+func event(raw string) payload {
+	var p payload
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		panic(err)
+	}
+	return p
+}
+
+// step applies one event and asserts the aggregate and signal.
+func step(t *testing.T, tr *tracker, raw string, wantStatus api.ThreadStatus, wantSignal bool) {
+	t.Helper()
+	status, signal, _ := tr.apply(event(raw))
+	if signal != wantSignal {
+		t.Fatalf("%s: signal = %v, want %v", raw, signal, wantSignal)
+	}
+	if wantSignal && status != wantStatus {
+		t.Fatalf("%s: status = %s, want %s", raw, status, wantStatus)
+	}
+}
+
+const sess = `"session_id":"s1",`
+
+func TestTrackerFullTurn(t *testing.T) {
+	tr := newTracker()
+	if got := tr.aggregate(); got != api.ThreadIdle {
+		t.Fatalf("fresh session = %s, want idle", got)
+	}
+	step(t, tr, `{`+sess+`"hook_event_name":"UserPromptSubmit","prompt":"fix it"}`, api.ThreadWorking, true)
+	step(t, tr, `{`+sess+`"hook_event_name":"PreToolUse","tool_name":"Bash"}`, api.ThreadWorking, true)
+	step(t, tr, `{`+sess+`"hook_event_name":"PostToolUse","tool_name":"Bash"}`, api.ThreadWorking, true)
+	step(t, tr, `{`+sess+`"hook_event_name":"Stop","background_tasks":[]}`, api.ThreadIdle, true)
+}
+
+func TestTrackerPermissionAndQuestion(t *testing.T) {
+	tr := newTracker()
+	step(t, tr, `{`+sess+`"hook_event_name":"UserPromptSubmit"}`, api.ThreadWorking, true)
+	step(t, tr, `{`+sess+`"hook_event_name":"PermissionRequest","tool_name":"Bash"}`, api.ThreadWaitingForPermission, true)
+	// AskUserQuestion rides the permission machinery but is a question.
+	step(t, tr, `{`+sess+`"hook_event_name":"PermissionRequest","tool_name":"AskUserQuestion"}`, api.ThreadWaitingForInput, true)
+	// Denial resolves the prompt; the turn keeps going.
+	step(t, tr, `{`+sess+`"hook_event_name":"PermissionDenied"}`, api.ThreadWorking, true)
+	step(t, tr, `{`+sess+`"hook_event_name":"Notification","notification_type":"permission_prompt"}`, api.ThreadWaitingForPermission, true)
+	// A question outranks a permission prompt — a pending question is
+	// never papered over by later generic permission evidence, in either
+	// arrival order.
+	step(t, tr, `{`+sess+`"hook_event_name":"Notification","notification_type":"elicitation_dialog"}`, api.ThreadWaitingForInput, true)
+	step(t, tr, `{`+sess+`"hook_event_name":"Notification","notification_type":"permission_prompt"}`, api.ThreadWaitingForInput, true)
+	step(t, tr, `{`+sess+`"hook_event_name":"PermissionRequest","tool_name":"Bash"}`, api.ThreadWaitingForInput, true)
+	step(t, tr, `{`+sess+`"hook_event_name":"UserPromptSubmit"}`, api.ThreadWorking, true)
+	step(t, tr, `{`+sess+`"hook_event_name":"Stop"}`, api.ThreadIdle, true)
+}
+
+func TestTrackerFailedTurn(t *testing.T) {
+	tr := newTracker()
+	step(t, tr, `{`+sess+`"hook_event_name":"UserPromptSubmit"}`, api.ThreadWorking, true)
+	status, signal, lastError := tr.apply(event(`{` + sess + `"hook_event_name":"StopFailure"}`))
+	if !signal || status != api.ThreadIdle {
+		t.Fatalf("StopFailure: status=%s signal=%v; want idle signal", status, signal)
+	}
+	if lastError == nil || *lastError == "" {
+		t.Fatal("StopFailure carried no lastError detail")
+	}
+	// The next prompt clears the failure detail.
+	_, _, cleared := tr.apply(event(`{` + sess + `"hook_event_name":"UserPromptSubmit"}`))
+	if cleared == nil || *cleared != "" {
+		t.Fatalf("UserPromptSubmit lastError = %v; want a clear", cleared)
+	}
+}
+
+// The recorded subagent shape (ATC-158 probe): the root turn completes
+// while a background subagent runs, the SubagentStop snapshot still
+// contains the stopping agent, and the wake turn's empty snapshot lands
+// idle.
+func TestTrackerSubagentActivity(t *testing.T) {
+	tr := newTracker()
+	step(t, tr, `{`+sess+`"hook_event_name":"UserPromptSubmit"}`, api.ThreadWorking, true)
+	step(t, tr, `{`+sess+`"hook_event_name":"SubagentStart","agent_id":"a1"}`, api.ThreadWorking, true)
+	// Root Stop with a running subagent snapshot: not idle.
+	step(t, tr, `{`+sess+`"hook_event_name":"Stop","background_tasks":[{"id":"a1","type":"subagent","status":"running"}]}`, api.ThreadWorking, true)
+	// The stopping agent is still in its own stop snapshot; the
+	// subtraction lands the transition.
+	step(t, tr, `{`+sess+`"hook_event_name":"SubagentStop","agent_id":"a1","background_tasks":[{"id":"a1","type":"subagent","status":"running"}]}`, api.ThreadIdle, true)
+}
+
+// A descendant's events never mark the root working, and its prompts are
+// tracked per agent id.
+func TestTrackerDescendantEvents(t *testing.T) {
+	tr := newTracker()
+	step(t, tr, `{`+sess+`"hook_event_name":"Stop"}`, api.ThreadIdle, true)
+	step(t, tr, `{`+sess+`"hook_event_name":"PreToolUse","agent_id":"a1"}`, api.ThreadWorking, true)
+	step(t, tr, `{`+sess+`"hook_event_name":"PermissionRequest","agent_id":"a1"}`, api.ThreadWaitingForPermission, true)
+	// The descendant's snapshot retains the prompt through a coarse
+	// running status.
+	step(t, tr, `{`+sess+`"hook_event_name":"Stop","background_tasks":[{"id":"a1","type":"subagent","status":"running"}]}`, api.ThreadWaitingForPermission, true)
+	step(t, tr, `{`+sess+`"hook_event_name":"PostToolUse","agent_id":"a1"}`, api.ThreadWorking, true)
+	step(t, tr, `{`+sess+`"hook_event_name":"SubagentStop","agent_id":"a1"}`, api.ThreadIdle, true)
+}
+
+// The interrupt gap (accepted limitation): no hook fires on user
+// interrupt, so working stands until the idle notification or the next
+// prompt resolves it.
+func TestTrackerInterruptGap(t *testing.T) {
+	tr := newTracker()
+	step(t, tr, `{`+sess+`"hook_event_name":"UserPromptSubmit"}`, api.ThreadWorking, true)
+	if got := tr.aggregate(); got != api.ThreadWorking {
+		t.Fatalf("after interrupt (no hook): %s, want the stale working", got)
+	}
+	step(t, tr, `{`+sess+`"hook_event_name":"Notification","notification_type":"idle_prompt"}`, api.ThreadIdle, true)
+}
+
+func TestTrackerBackgroundShellAndCrons(t *testing.T) {
+	tr := newTracker()
+	step(t, tr, `{`+sess+`"hook_event_name":"TaskCreated","task_id":"t1"}`, api.ThreadWorking, true)
+	step(t, tr, `{`+sess+`"hook_event_name":"Stop","background_tasks":[{"id":"t1","type":"shell","status":"running"}]}`, api.ThreadWorking, true)
+	step(t, tr, `{`+sess+`"hook_event_name":"TaskCompleted","task_id":"t1","background_tasks":[]}`, api.ThreadIdle, true)
+	// A scheduled cron holds the session at working until its snapshot
+	// empties.
+	step(t, tr, `{`+sess+`"hook_event_name":"Stop","session_crons":[{"id":"c1"}]}`, api.ThreadWorking, true)
+	step(t, tr, `{`+sess+`"hook_event_name":"Stop","session_crons":[]}`, api.ThreadIdle, true)
+}
+
+// Unrecognized events without a level snapshot carry no signal — the
+// reducer never guesses.
+func TestTrackerUnrecognizedEvents(t *testing.T) {
+	tr := newTracker()
+	if _, signal, _ := tr.apply(event(`{` + sess + `"hook_event_name":"SomethingNew"}`)); signal {
+		t.Error("unrecognized event produced a signal")
+	}
+	if _, signal, _ := tr.apply(event(`{` + sess + `"hook_event_name":"Notification","notification_type":"mystery"}`)); signal {
+		t.Error("unknown notification produced a signal")
+	}
+	// With a snapshot aboard, the snapshot is the signal.
+	if status, signal, _ := tr.apply(event(`{` + sess + `"hook_event_name":"SomethingNew","background_tasks":[{"id":"a1"}]}`)); !signal || status != api.ThreadWorking {
+		t.Errorf("snapshot on unrecognized event: status=%s signal=%v", status, signal)
+	}
+}
+
+// A seeded (post-restart) tracker claims nothing until evidence arrives.
+func TestTrackerSeededStartsUnknown(t *testing.T) {
+	tr := seededTracker()
+	if got := tr.aggregate(); got != api.ThreadUnknown {
+		t.Fatalf("seeded tracker = %s, want unknown", got)
+	}
+	step(t, tr, `{`+sess+`"hook_event_name":"Stop"}`, api.ThreadIdle, true)
+}

--- a/internal/agents/codex/codex.go
+++ b/internal/agents/codex/codex.go
@@ -1,8 +1,12 @@
 // Package codex is the built-in catalog registration for Codex (ATC-254).
-// The id is persisted by terminals and later threads — never rename it.
+// The id is persisted by terminals and threads — never rename it.
 package codex
 
-import "github.com/jeremytondo/atc/internal/agents"
+import (
+	"context"
+
+	"github.com/jeremytondo/atc/internal/agents"
+)
 
 // Entry is Codex's catalog registration.
 func Entry() agents.Entry {
@@ -11,6 +15,8 @@ func Entry() agents.Entry {
 
 type tui struct{}
 
-func (tui) Command() string     { return "codex" }
-func (tui) Binary() string      { return "codex" }
-func (tui) InstallHint() string { return "npm install -g @openai/codex" }
+// Command is the plain TUI launch; the ATC-279 follow-up wires the shared
+// app-server (--remote) through the launch context.
+func (tui) Command(context.Context, agents.LaunchContext) (string, error) { return "codex", nil }
+func (tui) Binary() string                                                { return "codex" }
+func (tui) InstallHint() string                                           { return "npm install -g @openai/codex" }

--- a/internal/agents/service.go
+++ b/internal/agents/service.go
@@ -23,10 +23,14 @@ var ErrNotFound = errors.New("agent not found")
 var ErrUnavailable = errors.New("agent unavailable")
 
 // TerminalCreator is the seam into the terminals domain: CreateForAgent
-// with a resolved command and the agent label (terminals.Service in
-// production).
+// with the agent label and a command factory (terminals.Service in
+// production). The factory runs once the terminal identity is minted —
+// per-launch context like hook settings needs the id before the session
+// starts — and stays an opaque function there, so the terminals domain
+// never learns agent vocabulary.
 type TerminalCreator interface {
-	CreateForAgent(ctx context.Context, params api.TerminalCreateParams, agent string) (api.Terminal, error)
+	CreateForAgent(ctx context.Context, params api.TerminalCreateParams, agent string,
+		compose func(terminalID, directory string) (string, error)) (api.Terminal, error)
 }
 
 // Options wires a Service.
@@ -124,8 +128,9 @@ func (s *Service) Launch(ctx context.Context, id string, params api.AgentLaunchP
 	return s.terminals.CreateForAgent(ctx, api.TerminalCreateParams{
 		ProjectID: params.ProjectID,
 		Name:      name,
-		Command:   entry.TUI.Command(),
-	}, entry.ID)
+	}, entry.ID, func(terminalID, directory string) (string, error) {
+		return entry.TUI.Command(ctx, LaunchContext{TerminalID: terminalID, Directory: directory})
+	})
 }
 
 func (s *Service) entry(id string) (Entry, bool) {

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -9,6 +9,7 @@
 //	state   $XDG_STATE_HOME/atc/atc.log       (~/.local/state/atc/atc.log)
 //	state   $XDG_STATE_HOME/atc/terminals     (~/.local/state/atc/terminals)
 //	state   $XDG_STATE_HOME/atc/exits         (~/.local/state/atc/exits)
+//	state   $XDG_STATE_HOME/atc/hooks         (~/.local/state/atc/hooks)
 //
 // It also owns CanonicalDir, the one rule for canonicalizing user-supplied
 // directories (ATC-256) — project identity and CLI project resolution must
@@ -80,6 +81,13 @@ func TerminalSocketDir() (string, error) {
 // <terminal-id>.json per session (ATC-251).
 func ExitMarkerDir() (string, error) {
 	return resolve("XDG_STATE_HOME", []string{".local", "state"}, "exits")
+}
+
+// HookDir holds the per-launch agent hook files (ATC-255): for each
+// Claude launch, <terminal-id>.json hook settings and <terminal-id>.header
+// carrying the hook secret, both mode 0600.
+func HookDir() (string, error) {
+	return resolve("XDG_STATE_HOME", []string{".local", "state"}, "hooks")
 }
 
 func resolve(envVar string, fallback []string, file string) (string, error) {

--- a/internal/server/agents_test.go
+++ b/internal/server/agents_test.go
@@ -78,9 +78,13 @@ func TestAgentLaunchCreatesTheTerminal(t *testing.T) {
 		t.Fatalf("launch: got %d; body %s", rec.Code, rec.Body)
 	}
 	launched := decodeTerminal(t, rec)
-	if launched.Agent != "claude" || launched.Command != "claude" ||
-		launched.Name != "Claude Code" || launched.Status != api.TerminalRunning {
+	if launched.Agent != "claude" || launched.Name != "Claude Code" || launched.Status != api.TerminalRunning {
 		t.Errorf("launched = %+v", launched)
+	}
+	// The composed command injects this launch's hook settings (ATC-255),
+	// quoted, keyed by the minted terminal id.
+	if !strings.HasPrefix(launched.Command, "claude --settings '") || !strings.Contains(launched.Command, launched.ID+".json") {
+		t.Errorf("launch command = %q", launched.Command)
 	}
 	if !strings.Contains(rec.Body.String(), `"agent":"claude"`) {
 		t.Errorf("launch body has no agent field: %s", rec.Body)
@@ -105,11 +109,17 @@ func TestTerminalCreateWithAgentMatchesLaunch(t *testing.T) {
 		f.createTerminalBody(t, api.TerminalCreateParams{Agent: "claude"})))
 	viaAlias := decodeTerminal(t, f.request(t, http.MethodPost, "/v1/agents/claude/launch",
 		`{"projectId":"`+f.projectID+`"}`))
-	// Identity and clock fields necessarily differ; everything the routes
-	// decide must not.
-	ignore := cmpopts.IgnoreFields(api.Terminal{}, "ID", "CreatedAt", "UpdatedAt")
+	// Identity and clock fields necessarily differ, and the command embeds
+	// the per-launch settings path (so it differs by id); everything else
+	// the routes decide must not.
+	ignore := cmpopts.IgnoreFields(api.Terminal{}, "ID", "CreatedAt", "UpdatedAt", "Command")
 	if diff := cmp.Diff(viaAlias, viaTerminals, ignore); diff != "" {
 		t.Errorf("routes disagree (-alias +terminals):\n%s", diff)
+	}
+	for _, terminal := range []api.Terminal{viaTerminals, viaAlias} {
+		if !strings.HasPrefix(terminal.Command, "claude --settings '") {
+			t.Errorf("command = %q; want the composed launch", terminal.Command)
+		}
 	}
 }
 

--- a/internal/server/hooks_test.go
+++ b/internal/server/hooks_test.go
@@ -1,0 +1,149 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/jeremytondo/atc/internal/agents/claude"
+	"github.com/jeremytondo/atc/internal/api"
+)
+
+// hookSecret digs this launch's secret out of its header file — the same
+// file the settings' curl command reads. The command carries only the
+// settings path; the header file sits beside it.
+func hookSecret(t *testing.T, terminal api.Terminal) string {
+	t.Helper()
+	match := regexp.MustCompile(`--settings '([^']+)\.json'`).FindStringSubmatch(terminal.Command)
+	if match == nil {
+		t.Fatalf("launch command has no settings file: %q", terminal.Command)
+	}
+	content, err := os.ReadFile(match[1] + ".header")
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret, ok := strings.CutPrefix(string(content), claude.SecretHeader+": ")
+	if !ok {
+		t.Fatalf("header file %q lacks the header prefix", content)
+	}
+	return secret
+}
+
+// postHook delivers one payload to the internal route — deliberately with
+// no bearer token: the per-launch secret is the route's whole
+// authentication.
+func (f *fixture) postHook(t *testing.T, secret, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, claude.HooksPath, strings.NewReader(body))
+	if secret != "" {
+		req.Header.Set(claude.SecretHeader, secret)
+	}
+	rec := httptest.NewRecorder()
+	f.handler.ServeHTTP(rec, req)
+	return rec
+}
+
+// The full evidence path over the wire: launch composes hook wiring, a
+// SessionStart births the thread, status evidence moves it, and the
+// terminal exposes the projection — while the route stays outside bearer
+// auth and the public contract.
+func TestClaudeHooksDriveThreads(t *testing.T) {
+	f := newFixture(t)
+
+	rec := f.request(t, http.MethodPost, "/v1/agents/claude/launch", `{"projectId":"`+f.projectID+`"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("launch: got %d; body %s", rec.Code, rec.Body)
+	}
+	terminal := decodeTerminal(t, rec)
+	secret := hookSecret(t, terminal)
+
+	// The internal route ignores the bearer token entirely: no token
+	// needed with a valid secret, and the bearer token is no substitute
+	// for one.
+	if rec := f.postHook(t, "", `{"session_id":"s1","hook_event_name":"SessionStart"}`); rec.Code != http.StatusNotFound {
+		t.Fatalf("hook without secret: got %d, want 404", rec.Code)
+	}
+	if rec := f.postHook(t, secret, `{"session_id":"s1","hook_event_name":"SessionStart","source":"startup","cwd":"/somewhere"}`); rec.Code != http.StatusNoContent {
+		t.Fatalf("hook delivery: got %d", rec.Code)
+	}
+
+	// The thread exists, linked and idle, and the terminal projects it.
+	var list api.ThreadList
+	rec = f.request(t, http.MethodGet, "/v1/threads", "")
+	decodeInto(t, rec, &list)
+	if len(list.Threads) != 1 {
+		t.Fatalf("threads = %+v", list.Threads)
+	}
+	thread := list.Threads[0]
+	if thread.Agent != "claude" || thread.TerminalID != terminal.ID || thread.Status != api.ThreadIdle || thread.Cwd != "/somewhere" {
+		t.Errorf("thread = %+v", thread)
+	}
+	if got := decodeTerminal(t, f.request(t, http.MethodGet, "/v1/terminals/"+terminal.ID, "")); got.ActiveThreadID != thread.ID {
+		t.Errorf("activeThreadId = %q, want %q", got.ActiveThreadID, thread.ID)
+	}
+
+	// A turn: prompt evidence marks it working and titles it.
+	f.postHook(t, secret, `{"session_id":"s1","hook_event_name":"UserPromptSubmit","prompt":"fix the build"}`)
+	rec = f.request(t, http.MethodGet, "/v1/threads/"+thread.ID, "")
+	got := decodeThread(t, rec)
+	if got.Status != api.ThreadWorking || got.Title != "fix the build" {
+		t.Errorf("after prompt: %+v", got)
+	}
+
+	// /clear mid-flight: the old thread persists inactive (working
+	// coerces), the new one takes the projection.
+	f.postHook(t, secret, `{"session_id":"s1","hook_event_name":"SessionEnd","reason":"clear"}`)
+	f.postHook(t, secret, `{"session_id":"s2","hook_event_name":"SessionStart","source":"clear"}`)
+	rec = f.request(t, http.MethodGet, "/v1/threads", "")
+	decodeInto(t, rec, &list)
+	if len(list.Threads) != 2 {
+		t.Fatalf("threads after clear = %+v", list.Threads)
+	}
+	if got := decodeThread(t, f.request(t, http.MethodGet, "/v1/threads/"+thread.ID, "")); got.Status != api.ThreadIdle {
+		t.Errorf("old thread after clear = %s, want idle (SessionEnd evidence)", got.Status)
+	}
+	active := decodeTerminal(t, f.request(t, http.MethodGet, "/v1/terminals/"+terminal.ID, "")).ActiveThreadID
+	if active == thread.ID || active == "" {
+		t.Errorf("activeThreadId after clear = %q", active)
+	}
+
+	// The public contract never mentions the internal route.
+	rec = f.request(t, http.MethodGet, "/openapi.json", "")
+	if strings.Contains(rec.Body.String(), "internal/claude") {
+		t.Error("openapi document leaks the internal hook route")
+	}
+}
+
+// The internal mount must not weaken the public surface: everything else
+// still demands the bearer token.
+func TestInternalMountKeepsAuthIntact(t *testing.T) {
+	f := newFixture(t)
+	req := httptest.NewRequest(http.MethodGet, "/v1/threads", nil)
+	rec := httptest.NewRecorder()
+	f.handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("tokenless /v1/threads with internal mount: got %d, want 401", rec.Code)
+	}
+	// GET on the hook path is not a mounted pattern and must not leak
+	// route existence to tokenless callers.
+	req = httptest.NewRequest(http.MethodGet, claude.HooksPath, nil)
+	rec = httptest.NewRecorder()
+	f.handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("GET on hook path: got %d, want 401", rec.Code)
+	}
+}
+
+func decodeInto(t *testing.T, rec *httptest.ResponseRecorder, out any) {
+	t.Helper()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got %d; body %s", rec.Code, rec.Body)
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), out); err != nil {
+		t.Fatalf("decoding %q: %v", rec.Body, err)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,9 +13,11 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -49,6 +51,12 @@ type Options struct {
 	Agents    *agents.Service
 	Threads   *threads.Service
 	Events    *events.Hub
+	// InternalRoutes are handlers mounted outside the public /v1 contract
+	// and outside bearer auth (ATC-255): each authenticates itself — the
+	// Claude hook route validates its per-launch secret, and the bearer
+	// token is deliberately never used for hook delivery. Keys are
+	// http.ServeMux patterns, e.g. "POST /internal/claude/hooks".
+	InternalRoutes map[string]http.Handler
 	// HeartbeatInterval paces SSE heartbeats; zero means the default.
 	HeartbeatInterval time.Duration
 }
@@ -107,7 +115,22 @@ func NewHandler(opts Options) http.Handler {
 		registerEvents(humaAPI, opts.Events, opts.HeartbeatInterval)
 	}
 
-	return withVersionHeaders(opts.Version, opts.Logger, withAuth(opts.Verify, withWriteDeadlines(mux)))
+	handler := withAuth(opts.Verify, withWriteDeadlines(mux))
+	if len(opts.InternalRoutes) > 0 {
+		root := http.NewServeMux()
+		for pattern, route := range opts.InternalRoutes {
+			// The bearer bypass is exactly as wide as /internal/: a
+			// pattern that could shadow the public surface is a wiring
+			// bug, refused at construction.
+			if !strings.HasPrefix(pattern, "POST /internal/") {
+				panic(fmt.Sprintf("server.NewHandler: internal route %q outside POST /internal/", pattern))
+			}
+			root.Handle(pattern, route)
+		}
+		root.Handle("/", handler)
+		handler = root
+	}
+	return withVersionHeaders(opts.Version, opts.Logger, handler)
 }
 
 func withVersionHeaders(version string, logger *slog.Logger, next http.Handler) http.Handler {

--- a/internal/server/terminals_test.go
+++ b/internal/server/terminals_test.go
@@ -137,9 +137,28 @@ func newFixture(t *testing.T) *fixture {
 		Hub:        hub,
 		Now:        now,
 	})
+	threadService := threads.NewService(threads.Options{
+		Repository: db.Threads(),
+		Terminals:  service,
+		Hub:        hub,
+		Now:        now,
+	})
+	if err := threadService.Load(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	claudeHooks, err := claude.NewHooks(claude.HooksOptions{
+		Dir:       t.TempDir(),
+		BaseURL:   "http://127.0.0.1:0",
+		Threads:   threadService,
+		Terminals: service,
+		Now:       now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	binaries := map[string]bool{"claude": true}
 	agentService, err := agents.NewService(agents.Options{
-		Entries:   []agents.Entry{claude.Entry(), codex.Entry()},
+		Entries:   []agents.Entry{claude.Entry(claudeHooks), codex.Entry()},
 		Terminals: service,
 		LookPath: func(name string) (string, error) {
 			if binaries[name] {
@@ -151,15 +170,6 @@ func newFixture(t *testing.T) *fixture {
 	if err != nil {
 		t.Fatal(err)
 	}
-	threadService := threads.NewService(threads.Options{
-		Repository: db.Threads(),
-		Terminals:  service,
-		Hub:        hub,
-		Now:        now,
-	})
-	if err := threadService.Load(context.Background()); err != nil {
-		t.Fatal(err)
-	}
 	handler := NewHandler(Options{
 		Verify:            testVerify,
 		Version:           testVersion,
@@ -169,9 +179,11 @@ func newFixture(t *testing.T) *fixture {
 		Agents:            agentService,
 		Threads:           threadService,
 		Events:            hub,
+		InternalRoutes:    map[string]http.Handler{"POST " + claude.HooksPath: claudeHooks.Handler()},
 		HeartbeatInterval: 50 * time.Millisecond,
 	})
-	f := &fixture{handler: handler, adapter: adapter, hub: hub, service: service, threads: threadService, binaries: binaries, markers: markers}
+	f := &fixture{handler: handler, adapter: adapter, hub: hub, service: service, threads: threadService,
+		binaries: binaries, markers: markers}
 	// Planted through the repository, not the API: the fixture project must
 	// not consume an event sequence number the SSE assertions rely on.
 	f.projectDir = t.TempDir()

--- a/internal/terminals/service.go
+++ b/internal/terminals/service.go
@@ -321,20 +321,24 @@ func (s *Service) reconcile(ctx context.Context, reap bool) {
 // real evidence. Failures after the record exists surface through the
 // normal status machinery — there is no separate launch-error path.
 func (s *Service) Create(ctx context.Context, params api.TerminalCreateParams) (api.Terminal, error) {
-	return s.create(ctx, params, "")
+	return s.create(ctx, params, "", nil)
 }
 
 // CreateForAgent is Create for a launch the API layer resolved through the
-// agent catalog (ATC-254): params.Command carries the adapter-composed
-// command and agent is the catalog id recorded on the terminal — this is
-// the only writer of the immutable agent field. The domain stays
-// agent-agnostic: the id is an opaque label here, and everything past the
-// label is the normal create path.
-func (s *Service) CreateForAgent(ctx context.Context, params api.TerminalCreateParams, agent string) (api.Terminal, error) {
-	return s.create(ctx, params, agent)
+// agent catalog (ATC-254): agent is the catalog id recorded on the
+// terminal — this is the only writer of the immutable agent field — and
+// compose supplies the adapter-composed command once the terminal id is
+// minted, so per-launch context (ATC-255 hook settings, --remote wiring)
+// can reference the identity before the session starts. The domain stays
+// agent-agnostic: the id is an opaque label, compose an opaque command
+// factory, and everything past them is the normal create path.
+func (s *Service) CreateForAgent(ctx context.Context, params api.TerminalCreateParams, agent string,
+	compose func(terminalID, directory string) (string, error)) (api.Terminal, error) {
+	return s.create(ctx, params, agent, compose)
 }
 
-func (s *Service) create(ctx context.Context, params api.TerminalCreateParams, agent string) (api.Terminal, error) {
+func (s *Service) create(ctx context.Context, params api.TerminalCreateParams, agent string,
+	compose func(terminalID, directory string) (string, error)) (api.Terminal, error) {
 	project, ok, err := s.projects.Get(ctx, params.ProjectID)
 	if err != nil {
 		return api.Terminal{}, err
@@ -364,9 +368,29 @@ func (s *Service) create(ctx context.Context, params api.TerminalCreateParams, a
 	}
 	s.ops.Lock()
 	// Insertion is the collision check: a taken ID inserts nothing and
-	// re-rolls, with no check-then-insert window.
+	// re-rolls, with no check-then-insert window. compose runs inside the
+	// loop so the composed command always references the id that actually
+	// inserts — but only after the candidate clears the in-memory view
+	// (authoritative under ops), so its side effects (hook files, secret
+	// registrations) can never overwrite a live terminal's. Side effects
+	// for a candidate that still fails to insert are keyed by an id no
+	// session will ever use; boot-time cleanup reaps them.
 	for {
 		record.ID = randomID()
+		s.mu.Lock()
+		_, taken := s.view[record.ID]
+		s.mu.Unlock()
+		if taken {
+			continue
+		}
+		if compose != nil {
+			command, err := compose(record.ID, record.Directory)
+			if err != nil {
+				s.ops.Unlock()
+				return api.Terminal{}, err
+			}
+			record.Command = command
+		}
 		inserted, err := s.repository.Insert(ctx, record)
 		if errors.Is(err, store.ErrForeignKeyViolation) {
 			// The project was deleted between the lookup above and this
@@ -395,7 +419,7 @@ func (s *Service) create(ctx context.Context, params api.TerminalCreateParams, a
 	s.hub.Publish(api.EventTerminalCreated, resource, record.ID)
 	s.ops.Unlock()
 
-	if err := s.adapter.Create(ctx, record.ID, CreateSpec{Directory: record.Directory, Command: params.Command}); err != nil {
+	if err := s.adapter.Create(ctx, record.ID, CreateSpec{Directory: record.Directory, Command: record.Command}); err != nil {
 		// The record stays: the session may have been born after the
 		// client gave up, and the status machinery reports the truth.
 		s.logger.Warn("session create failed", "terminal", record.ID, "error", err)


### PR DESCRIPTION
Second PR of ATC-255 (Threads), stacked on #260 — merge that first, then retarget/merge this. Claude conversations now reach the threads observation seam.

## What's here

- **Launch-context seam**: `TUIAdapter.Command(ctx, LaunchContext)` and a compose factory on `CreateForAgent` — the terminals create loop mints the id, pre-checks it against the in-memory view (so per-launch side effects can never target a live terminal's id), then asks the factory for the command. The terminals domain stays agent-agnostic: the factory is opaque.
- **Hook injection** (`internal/agents/claude`): each launch writes a settings file wiring the legacy-proven 15 lifecycle hooks to one curl command, plus a header file carrying the per-launch secret — both 0600 (enforced on rewrite too). The secret rides `curl -H @file`: never argv, never a URL. The composed command is `claude --settings '<path>'`, shell-quoted.
- **Internal ingest route**: `POST /internal/claude/hooks`, mounted outside the public contract and outside bearer auth (the server refuses any internal pattern outside `POST /internal/`); the secret is its whole authentication, with a bounded read window so unauthenticated peers can't hold handlers open. 404 unknown secret, 400 malformed or session-mismatched payloads, 204 accepted — nothing about *why* leaks.
- **Identity discipline**: SessionStart is the only identity transition (compact — same session id — keeps the reducer state and claims nothing); a payload whose session disagrees with the registration is dropped; delivery per launch is serialized end to end under one lock so observations can't reorder. A failed session observation leaves the registration un-established and the next event retries instead of silencing the session.
- **The reducer**: level snapshots authoritative, edge events between them; the question/permission split via `Notification.notification_type` and `PermissionRequest` (with `AskUserQuestion` classified as a question); failed turns land idle with `lastError`; SubagentStop subtracts the stopping agent from its own stale snapshot; the interrupt gap is documented, not machinery.
- **Restart story**: secret registrations reload from the hook dir at boot (stale files for missing terminals reaped); the first payload after restart re-seeds through the identity mapping, re-establishing the session before live evidence — matching the threads domain's active-gate.
- **IPv6-safe delivery**: the hook URL host derives from the bind address (::1 binds get `[::1]`, unspecified binds get loopback).

## Review notes

Two adversarial Codex reviews ran pre-PR. Adopted: per-launch end-to-end serialization, established/retry on failed session observations, compact idempotency, the AskUserQuestion split, view pre-check before compose, chmod-on-rewrite, rune-safe title truncation, read deadline, the internal-route prefix guard, required (non-nil) hooks at registration, and dead-field cleanup. Rejected with reasons: single-index registry via a second header (legacy-proven secret-keyed shape kept), dropping `Directory` from the launch context and un-exporting `Quote` (ATC-279 consumes both), splitting the ingest mount out of the server package (the server owning the whole surface is deliberate), and modeling `Stop` decision-control/`TaskCreated` differently from the proven legacy reducer (bounded, self-corrects on the next snapshot).

Linear: ATC-278 (part of ATC-255).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Claude session hooks for real-time thread status, lifecycle tracking, permissions, prompts, errors, and background activity.
  * Claude launches now use secure, terminal-specific settings and authentication.
  * Added internal hook routing while preserving authentication for public endpoints.
  * Added support for safely composing agent commands with terminal context and working directories.
* **Bug Fixes**
  * Improved hook persistence, session recovery, secret rotation, and stale registration cleanup.
  * Added safer handling for loopback and IPv6 server bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->