### PR TITLE
ATC-279 | codex: shared app-server lifecycle and passive thread observation

### DIFF
--- a/cmd/atc/main.go
+++ b/cmd/atc/main.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"syscall"
@@ -574,10 +575,42 @@ func serverRunUntilCancelled(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	// Codex thread evidence (ATC-255): the shared app-server supervisor
+	// and the passive observer. Boot re-adopts a running server only when
+	// a persisted identity or running codex terminals suggest live work;
+	// otherwise the server starts lazily at the first codex launch.
+	codexHome, err := codex.CodexHome()
+	if err != nil {
+		return err
+	}
+	codexIdentity, err := paths.CodexServerFile()
+	if err != nil {
+		return err
+	}
+	codexLog, err := paths.CodexServerLogFile()
+	if err != nil {
+		return err
+	}
+	codexObserver := codex.NewObserver(codex.ObserverOptions{
+		Supervisor: codex.NewSupervisor(codex.SupervisorOptions{
+			CodexHome:    codexHome,
+			IdentityFile: codexIdentity,
+			LogFile:      codexLog,
+			SpawnDir:     filepath.Dir(codexIdentity),
+			Logger:       logger,
+		}),
+		Threads:   threadService,
+		Terminals: terminalService,
+		Logger:    logger,
+	})
+	// Async: adoption can wait on a silent pid for ~20s worst case, and boot
+	// must not.
+	go codexObserver.AdoptAtBoot(ctx)
+
 	// One registration line per built-in agent; a duplicate id fails the
 	// boot.
 	agentService, err := agents.NewService(agents.Options{
-		Entries:   []agents.Entry{claude.Entry(claudeHooks), codex.Entry()},
+		Entries:   []agents.Entry{claude.Entry(claudeHooks), codex.Entry(codexObserver)},
 		Terminals: terminalService,
 	})
 	if err != nil {
@@ -607,6 +640,7 @@ func serverRunUntilCancelled(cmd *cobra.Command, _ []string) error {
 	var background sync.WaitGroup
 	background.Go(func() { terminalService.Run(loopCtx) })
 	background.Go(func() { threadService.Run(loopCtx) })
+	background.Go(func() { codexObserver.Run(loopCtx) })
 
 	// The exposure supervisor fronts the actual bound port (they are one
 	// port by contract) and is waited on so shutdown reaps the serve

--- a/cmd/atc/terminal_test.go
+++ b/cmd/atc/terminal_test.go
@@ -108,8 +108,18 @@ func startTestServerWithThreads(t *testing.T) (*cliAdapter, *threads.Service) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	codexObserver := codex.NewObserver(codex.ObserverOptions{
+		Supervisor: codex.NewSupervisor(codex.SupervisorOptions{
+			CodexHome:    t.TempDir(),
+			IdentityFile: filepath.Join(t.TempDir(), "codex-app-server.json"),
+			LogFile:      filepath.Join(t.TempDir(), "codex-app-server.log"),
+			SpawnDir:     t.TempDir(),
+		}),
+		Threads:   threadService,
+		Terminals: service,
+	})
 	agentService, err := agents.NewService(agents.Options{
-		Entries:   []agents.Entry{claude.Entry(claudeHooks), codex.Entry()},
+		Entries:   []agents.Entry{claude.Entry(claudeHooks), codex.Entry(codexObserver)},
 		Terminals: service,
 		// The probe never consults this machine's PATH: claude "exists",
 		// codex does not.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/jeremytondo/atc
 go 1.26.7
 
 require (
+	github.com/coder/websocket v1.8.15
 	github.com/creack/pty v1.1.24
 	github.com/danielgtaylor/huma/v2 v2.39.1
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=

--- a/internal/agents/agents.go
+++ b/internal/agents/agents.go
@@ -17,6 +17,7 @@ package agents
 import (
 	"context"
 	"strings"
+	"unicode/utf8"
 )
 
 // CapabilityTUI is the one capability in ATC-254: the agent can be
@@ -68,4 +69,23 @@ type Entry struct {
 // split or execute.
 func Quote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// CondenseTitle trims provider-reported text (a first prompt, a thread
+// preview) into a one-line observed default title, cutting on a word
+// boundary, else a rune boundary — never mid-character.
+func CondenseTitle(s string) string {
+	const limit = 50
+	title := strings.Join(strings.Fields(s), " ")
+	if len(title) <= limit {
+		return title
+	}
+	if cut := strings.LastIndexByte(title[:limit], ' '); cut > 0 {
+		return title[:cut]
+	}
+	cut := limit
+	for cut > 0 && !utf8.RuneStart(title[cut]) {
+		cut--
+	}
+	return title[:cut]
 }

--- a/internal/agents/claude/hooks.go
+++ b/internal/agents/claude/hooks.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unicode/utf8"
 
 	"github.com/jeremytondo/atc/internal/agents"
 	"github.com/jeremytondo/atc/internal/api"
@@ -448,7 +447,7 @@ func (h *Hooks) reduce(ctx context.Context, reg *registration, p payload) {
 	if p.HookEventName == "UserPromptSubmit" && p.AgentID == "" {
 		// The first-prompt title fallback: an observed title only ever
 		// fills an untitled thread, so sending it on every prompt is safe.
-		metadata.Title = titleFrom(p.Prompt)
+		metadata.Title = agents.CondenseTitle(p.Prompt)
 	}
 	if err := h.threads.ObserveStatus(ctx, threads.StatusObservation{
 		Agent: "claude", ProviderID: p.SessionID, At: h.now(),
@@ -464,24 +463,6 @@ func metadataFrom(p payload) threads.Metadata {
 		PermissionMode: p.PermissionMode,
 		Effort:         p.Effort.Level,
 	}
-}
-
-// titleFrom condenses a first prompt into an observed default title,
-// cutting on a word boundary, else a rune boundary — never mid-character.
-func titleFrom(prompt string) string {
-	const limit = 50
-	title := strings.Join(strings.Fields(prompt), " ")
-	if len(title) <= limit {
-		return title
-	}
-	if cut := strings.LastIndexByte(title[:limit], ' '); cut > 0 {
-		return title[:cut]
-	}
-	cut := limit
-	for cut > 0 && !utf8.RuneStart(title[cut]) {
-		cut--
-	}
-	return title[:cut]
 }
 
 func newSecret() (string, error) {

--- a/internal/agents/codex/codex.go
+++ b/internal/agents/codex/codex.go
@@ -1,5 +1,9 @@
-// Package codex is the built-in catalog registration for Codex (ATC-254).
-// The id is persisted by terminals and threads — never rename it.
+// Package codex is the built-in catalog registration for Codex (ATC-254)
+// and its thread-evidence wiring (ATC-255): the shared app-server
+// lifecycle (adopt-or-start over Codex's well-known control socket) and
+// the passive observer that turns its broadcasts into thread
+// observations. The id is persisted by terminals and threads — never
+// rename it.
 package codex
 
 import (
@@ -8,15 +12,37 @@ import (
 	"github.com/jeremytondo/atc/internal/agents"
 )
 
-// Entry is Codex's catalog registration.
-func Entry() agents.Entry {
-	return agents.Entry{ID: "codex", Name: "Codex", TUI: tui{}}
+// Entry is Codex's catalog registration. observer wires the shared
+// app-server and thread observation into every launch and is required.
+func Entry(observer *Observer) agents.Entry {
+	if observer == nil {
+		panic("codex.Entry: observer must not be nil")
+	}
+	return agents.Entry{ID: "codex", Name: "Codex", TUI: tui{observer: observer}}
 }
 
-type tui struct{}
+type tui struct{ observer *Observer }
 
-// Command is the plain TUI launch; the ATC-279 follow-up wires the shared
-// app-server (--remote) through the launch context.
-func (tui) Command(context.Context, agents.LaunchContext) (string, error) { return "codex", nil }
-func (tui) Binary() string                                                { return "codex" }
-func (tui) InstallHint() string                                           { return "npm install -g @openai/codex" }
+// Prewarm adopts or starts the shared app-server and brings observation
+// up before the terminals domain takes its commit lock — Command then
+// only hits the supervisor's fast path there.
+func (t tui) Prewarm(ctx context.Context) error {
+	return t.observer.Prewarm(ctx)
+}
+
+// Command composes the launch: the shared app-server is adopted or
+// started, this launch's identity capture is armed, and the TUI connects
+// with --remote. --cd is load-bearing: in remote mode the TUI does not
+// forward its own working directory, and without it the server would
+// stamp new threads with its own neutral cwd — breaking the cwd-matched
+// identity capture.
+func (t tui) Command(ctx context.Context, launch agents.LaunchContext) (string, error) {
+	socket, err := t.observer.EnsureForLaunch(ctx, launch.TerminalID, launch.Directory)
+	if err != nil {
+		return "", err
+	}
+	return "codex --cd " + agents.Quote(launch.Directory) + " --remote " + agents.Quote("unix://"+socket), nil
+}
+
+func (tui) Binary() string      { return "codex" }
+func (tui) InstallHint() string { return "npm install -g @openai/codex" }

--- a/internal/agents/codex/observer.go
+++ b/internal/agents/codex/observer.go
@@ -1,0 +1,863 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/jeremytondo/atc/internal/agents"
+	"github.com/jeremytondo/atc/internal/api"
+	"github.com/jeremytondo/atc/internal/threads"
+)
+
+const (
+	// connectTimeout bounds one dial + initialize handshake.
+	connectTimeout = 5 * time.Second
+	// reconnectInterval paces the observer's connection loop.
+	reconnectInterval = time.Second
+	// captureWindow bounds how long a launch waits for its thread/started
+	// broadcast before the armed capture is abandoned.
+	captureWindow = 2 * time.Minute
+	// maxMessageBytes caps one server message.
+	maxMessageBytes = 64 << 20
+)
+
+// ThreadObserver is the seam into the threads domain: neutral
+// observations in, no provider vocabulary out. Codex needs no explicit
+// deactivation — the threads sweep covers exited TUIs, and teardown
+// speaks through status evidence. LookupIdentity gates status broadcasts:
+// the shared server fans out every client's threads, and unmapped ones
+// must never reach the seam.
+type ThreadObserver interface {
+	ObserveSession(ctx context.Context, o threads.SessionObservation) (string, error)
+	ObserveStatus(ctx context.Context, o threads.StatusObservation) error
+	LookupIdentity(agent, providerID string) (threadID, terminalID string, ok bool)
+}
+
+// TerminalReader resolves terminal records: the launch capture copies the
+// observing terminal's project, and unarmed captures match running codex
+// terminals by directory.
+type TerminalReader interface {
+	Get(id string) (api.Terminal, error)
+	List(projectID string) []api.Terminal
+}
+
+// ObserverOptions wires an Observer.
+type ObserverOptions struct {
+	Supervisor *Supervisor
+	Threads    ThreadObserver
+	Terminals  TerminalReader
+	Logger     *slog.Logger
+	Now        func() time.Time
+}
+
+// Observer holds one passive connection to the shared app-server and
+// turns its broadcasts into thread observations. It never originates a
+// conversation method: status is observed by thread id, identity capture
+// follows thread/started broadcasts, and a lost connection coerces every
+// thread it was observing to unknown — honest ignorance rather than a
+// stale busy while the provider moves on unheard.
+type Observer struct {
+	supervisor *Supervisor
+	threads    ThreadObserver
+	terminals  TerminalReader
+	logger     *slog.Logger
+	now        func() time.Time
+
+	// connectMu serializes the connected-check with the dial+install, so
+	// a launch racing the Run tick (or another launch) can never install
+	// two connections — the loser would leak its goroutines and observe
+	// every broadcast twice.
+	connectMu sync.Mutex
+
+	mu       sync.Mutex
+	conn     *rpcConn
+	captures []capture
+	// observed tracks the last status this connection forwarded per
+	// provider thread id: teardown coerces only the live ones — idle
+	// persists when unobserved, matching the threads domain's rule.
+	observed map[string]api.ThreadStatus
+}
+
+// capture is one armed launch: the next non-subagent thread/started whose
+// cwd matches binds to this terminal.
+type capture struct {
+	terminalID string
+	cwd        string
+	armedAt    time.Time
+}
+
+func NewObserver(opts ObserverOptions) *Observer {
+	if opts.Supervisor == nil || opts.Threads == nil || opts.Terminals == nil {
+		panic("codex.NewObserver: Supervisor, Threads, and Terminals must not be nil")
+	}
+	if opts.Logger == nil {
+		opts.Logger = slog.New(slog.DiscardHandler)
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	return &Observer{
+		supervisor: opts.Supervisor,
+		threads:    opts.Threads,
+		terminals:  opts.Terminals,
+		logger:     opts.Logger,
+		now:        opts.Now,
+		observed:   map[string]api.ThreadStatus{},
+	}
+}
+
+// Prewarm adopts or starts the server and brings the observation
+// connection up — the slow once-per-server work, run before the terminals
+// commit lock so a cold start cannot block unrelated terminal mutations.
+func (o *Observer) Prewarm(ctx context.Context) error {
+	socket, err := o.supervisor.Ensure(ctx)
+	if err != nil {
+		return err
+	}
+	return o.ensureConnected(ctx, socket)
+}
+
+// EnsureForLaunch adopts or starts the server, brings observation up, and
+// arms this launch's identity capture, returning the socket path for the
+// --remote flag. The connection is established here, not left to the Run
+// loop's next tick: the TUI starts immediately after, and a
+// thread/started broadcast that beats the connection is permanently lost.
+// A launch without observation would silently produce a thread-less TUI,
+// so a failed connect refuses the launch. After Prewarm this is all fast
+// path.
+func (o *Observer) EnsureForLaunch(ctx context.Context, terminalID, directory string) (string, error) {
+	socket, err := o.supervisor.Ensure(ctx)
+	if err != nil {
+		return "", err
+	}
+	if err := o.ensureConnected(ctx, socket); err != nil {
+		return "", fmt.Errorf("codex app-server observation unavailable: %w", err)
+	}
+	now := o.now()
+	o.mu.Lock()
+	o.pruneCaptures(now)
+	o.captures = append(o.captures, capture{terminalID: terminalID, cwd: directory, armedAt: now})
+	o.mu.Unlock()
+	return socket, nil
+}
+
+// AdoptAtBoot re-adopts a running server so live work returns to
+// observation: only when a persisted identity or running codex terminals
+// suggest there is something to observe, and never starting a server.
+func (o *Observer) AdoptAtBoot(ctx context.Context) {
+	if _, ok := o.supervisor.readIdentity(); !ok && !o.anyRunningCodexTerminal() {
+		return
+	}
+	if _, ok := o.supervisor.Adopt(ctx); !ok {
+		o.logger.Info("no codex app-server answering; observation resumes on demand")
+	}
+}
+
+func (o *Observer) anyRunningCodexTerminal() bool {
+	for _, terminal := range o.terminals.List("") {
+		if terminal.Agent == "codex" && terminal.Status == api.TerminalRunning {
+			return true
+		}
+	}
+	return false
+}
+
+// Run maintains the held connection: whenever the supervisor knows a
+// socket and no connection is up, connect; a dropped connection tears
+// down to unknown and reconnects here. A dead server is deliberately not
+// restarted from here — every attached TUI died with it, so the next
+// launch's Ensure restarts on real demand.
+func (o *Observer) Run(ctx context.Context) {
+	ticker := time.NewTicker(reconnectInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			o.mu.Lock()
+			conn := o.conn
+			o.mu.Unlock()
+			if conn != nil {
+				conn.close()
+			}
+			return
+		case <-ticker.C:
+		}
+		socket := o.supervisor.Socket()
+		if socket == "" {
+			continue
+		}
+		if err := o.ensureConnected(ctx, socket); err != nil {
+			o.logger.Debug("codex app-server connect failed", "error", err)
+		}
+	}
+}
+
+// ensureConnected is the one place a connection is decided: the
+// connected-check and the dial+install run under connectMu, and an
+// already-connected observer returns immediately.
+func (o *Observer) ensureConnected(ctx context.Context, socketPath string) error {
+	o.connectMu.Lock()
+	defer o.connectMu.Unlock()
+	o.mu.Lock()
+	connected := o.conn != nil
+	o.mu.Unlock()
+	if connected {
+		return nil
+	}
+	return o.connect(ctx, socketPath)
+}
+
+// connect dials, runs the initialize handshake, and installs the
+// connection.
+func (o *Observer) connect(ctx context.Context, socketPath string) error {
+	dialCtx, cancel := context.WithTimeout(ctx, connectTimeout)
+	defer cancel()
+	ws, err := dialSocket(dialCtx, socketPath)
+	if err != nil {
+		return err
+	}
+	conn := newRPCConn(ws, o.logger)
+	conn.onNotification = func(method string, params json.RawMessage) {
+		o.handleNotification(context.WithoutCancel(ctx), method, params)
+	}
+	conn.onClose = func(reason error) {
+		o.teardown(context.WithoutCancel(ctx), conn, reason)
+	}
+	// Installed before the loops start: a connection that dies during the
+	// handshake must find itself installed when its teardown runs, or Run
+	// would believe a dead connection is live forever.
+	o.mu.Lock()
+	o.conn = conn
+	o.observed = map[string]api.ThreadStatus{}
+	o.mu.Unlock()
+	conn.start()
+
+	initCtx, cancelInit := context.WithTimeout(ctx, connectTimeout)
+	defer cancelInit()
+	if _, err := conn.call(initCtx, "initialize", map[string]any{
+		"clientInfo":   map[string]any{"name": "atc", "title": "ATC", "version": "1"},
+		"capabilities": map[string]any{"experimentalApi": true},
+	}); err != nil {
+		conn.close()
+		return fmt.Errorf("initialize: %w", err)
+	}
+	if err := conn.notify(initCtx, "initialized", map[string]any{}); err != nil {
+		conn.close()
+		return err
+	}
+	o.logger.Info("codex app-server observation connected")
+	// A fresh connection knows nothing about work already in flight
+	// (boot re-adoption, reconnect after a drop): walk the loaded threads
+	// so live conversations return to observation instead of waiting for
+	// their next broadcast. Async — a launch must not wait behind up to
+	// fifty thread reads — and detached, like the callbacks above: the
+	// walk must outlive the launch request whose connect started it.
+	go o.reconcile(context.WithoutCancel(ctx), conn)
+	return nil
+}
+
+// reconcileCap bounds the loaded-thread walk on one connection.
+const reconcileCap = 50
+
+// reconcile walks the server's loaded threads so work already in flight
+// returns to observation. A root the identity mapping already knows goes
+// straight back to its recorded terminal — the same seed check Claude
+// runs after a restart — which disambiguates layouts cwd alone cannot
+// (two terminals in one directory). Unmapped roots fall back to
+// single-candidate cwd attribution, and when several unmapped roots share
+// one cwd, none is picked: choosing an active conversation among them
+// would be a guess. Armed launch captures are never consumed here — they
+// belong to thread/started broadcasts. Best-effort: any failure leaves
+// threads to recover on their next broadcast.
+func (o *Observer) reconcile(ctx context.Context, conn *rpcConn) {
+	callCtx, cancel := context.WithTimeout(ctx, connectTimeout)
+	defer cancel()
+	result, err := conn.call(callCtx, "thread/loaded/list", map[string]any{})
+	if err != nil {
+		o.logger.Debug("codex loaded-thread walk unavailable", "error", err)
+		return
+	}
+	var loaded struct {
+		Data []string `json:"data"`
+	}
+	if err := json.Unmarshal(result, &loaded); err != nil || len(loaded.Data) == 0 {
+		return
+	}
+	if len(loaded.Data) > reconcileCap {
+		o.logger.Warn("codex loaded-thread walk truncated", "loaded", len(loaded.Data), "cap", reconcileCap)
+		loaded.Data = loaded.Data[:reconcileCap]
+	}
+
+	byCwd := map[string][]loadedRoot{}
+	for _, id := range loaded.Data {
+		readCtx, cancelRead := context.WithTimeout(ctx, connectTimeout)
+		result, err := conn.call(readCtx, "thread/read", map[string]any{"threadId": id})
+		cancelRead()
+		if err != nil {
+			continue
+		}
+		var p struct {
+			Thread struct {
+				ID             string          `json:"id"`
+				Cwd            string          `json:"cwd"`
+				ParentThreadID json.RawMessage `json:"parentThreadId"`
+				Status         json.RawMessage `json:"status"`
+			} `json:"thread"`
+		}
+		if err := json.Unmarshal(result, &p); err != nil || p.Thread.ID == "" || isJSONString(p.Thread.ParentThreadID) {
+			continue
+		}
+		one := loadedRoot{id: p.Thread.ID, cwd: p.Thread.Cwd, status: p.Thread.Status}
+		if o.reattachMapped(ctx, one) {
+			continue
+		}
+		byCwd[p.Thread.Cwd] = append(byCwd[p.Thread.Cwd], one)
+	}
+	for cwd, roots := range byCwd {
+		if len(roots) != 1 {
+			o.logger.Debug("codex loaded threads ambiguous for directory", "cwd", cwd, "roots", len(roots))
+			continue
+		}
+		o.bindThread(ctx, roots[0].id, roots[0].cwd, false)
+		if len(roots[0].status) > 0 {
+			o.observeStatus(ctx, roots[0].id, statusToThreadStatus(roots[0].status))
+		}
+	}
+}
+
+// loadedRoot is one non-subagent thread from the loaded-thread walk.
+type loadedRoot struct {
+	id, cwd string
+	status  json.RawMessage
+}
+
+// reattachMapped re-activates a loaded root the identity mapping already
+// ties to a terminal, reporting whether it was handled. The recorded
+// terminal must still be holdable (not exited, missing, or deleted).
+func (o *Observer) reattachMapped(ctx context.Context, one loadedRoot) bool {
+	_, terminalID, known := o.threads.LookupIdentity("codex", one.id)
+	if !known {
+		return false
+	}
+	if terminalID != "" {
+		terminal, err := o.terminals.Get(terminalID)
+		if err == nil && terminalHoldable(terminal) {
+			if _, err := o.threads.ObserveSession(ctx, threads.SessionObservation{
+				Agent:      "codex",
+				ProviderID: one.id,
+				TerminalID: terminalID,
+				ProjectID:  terminal.ProjectID,
+				At:         o.now(),
+				Metadata:   threads.Metadata{Cwd: one.cwd},
+			}); err != nil {
+				o.logger.Warn("recording codex session observation", "error", err)
+				return true
+			}
+			o.mu.Lock()
+			if _, tracked := o.observed[one.id]; !tracked {
+				o.observed[one.id] = api.ThreadUnknown
+			}
+			o.mu.Unlock()
+			if len(one.status) > 0 {
+				o.observeStatus(ctx, one.id, statusToThreadStatus(one.status))
+			}
+		}
+	}
+	// Mapped but its terminal left: the record persists; nothing honest
+	// to re-activate.
+	return true
+}
+
+// teardown reacts to a lost connection: every thread this connection was
+// observing coerces to unknown, armed captures fail closed, and the Run
+// loop reconnects.
+func (o *Observer) teardown(ctx context.Context, conn *rpcConn, reason error) {
+	o.mu.Lock()
+	if o.conn != conn {
+		// A stale socket must not touch live state.
+		o.mu.Unlock()
+		return
+	}
+	o.conn = nil
+	observed := o.observed
+	o.observed = map[string]api.ThreadStatus{}
+	o.captures = nil
+	o.mu.Unlock()
+	o.logger.Warn("codex app-server connection lost", "error", reason)
+	for providerID, last := range observed {
+		// Only unverifiable live states coerce; idle (and error) persist
+		// when unobserved, the same rule the threads domain applies.
+		if !liveStatus(last) {
+			continue
+		}
+		if err := o.threads.ObserveStatus(ctx, threads.StatusObservation{
+			Agent: "codex", ProviderID: providerID, At: o.now(), Status: api.ThreadUnknown,
+		}); err != nil {
+			o.logger.Warn("coercing codex thread on teardown", "error", err)
+		}
+	}
+}
+
+// terminalHoldable reports whether a terminal can still hold a
+// conversation: anything but definitively gone. Mirrors the threads
+// sweep — unreachable is unverifiable, not evidence of leaving.
+func terminalHoldable(terminal api.Terminal) bool {
+	return terminal.Status != api.TerminalExited && terminal.Status != api.TerminalMissing
+}
+
+func liveStatus(status api.ThreadStatus) bool {
+	switch status {
+	case api.ThreadWorking, api.ThreadWaitingForInput, api.ThreadWaitingForPermission:
+		return true
+	}
+	return false
+}
+
+// handleNotification dispatches one server broadcast.
+func (o *Observer) handleNotification(ctx context.Context, method string, params json.RawMessage) {
+	switch method {
+	case "thread/started":
+		var p struct {
+			Thread struct {
+				ID             string          `json:"id"`
+				Cwd            string          `json:"cwd"`
+				ParentThreadID json.RawMessage `json:"parentThreadId"`
+			} `json:"thread"`
+		}
+		if err := json.Unmarshal(params, &p); err != nil || p.Thread.ID == "" {
+			return
+		}
+		// Subagent guard: a descendant's broadcast must never bind a
+		// terminal.
+		if isJSONString(p.Thread.ParentThreadID) {
+			return
+		}
+		o.bindThread(ctx, p.Thread.ID, p.Thread.Cwd, true)
+	case "thread/status/changed":
+		var p struct {
+			ThreadID string          `json:"threadId"`
+			Status   json.RawMessage `json:"status"`
+		}
+		if err := json.Unmarshal(params, &p); err != nil || p.ThreadID == "" {
+			return
+		}
+		o.observeStatus(ctx, p.ThreadID, statusToThreadStatus(p.Status))
+	}
+}
+
+// captureThread binds a broadcast conversation to a terminal: the oldest
+// armed capture with the exact cwd wins (a launch); with none armed, a
+// single running codex terminal at that directory identifies an in-TUI
+// switch (/new, /fork, /resume). Ambiguity drops the capture — the
+// observer only follows evidence, never guesses between terminals.
+//
+// Accepted looseness: the shared server broadcasts every client's roots,
+// so a non-ATC --remote client working in the same directory as exactly
+// one ATC codex terminal would be attributed to it. Without a per-TUI
+// relay (deliberately out of ATC-255's scope) cwd is the only correlation
+// evidence, and dropping unarmed attribution entirely would forfeit
+// in-TUI switch capture.
+func (o *Observer) bindThread(ctx context.Context, providerID, cwd string, allowArmed bool) {
+	now := o.now()
+	terminalID := ""
+	if allowArmed {
+		o.mu.Lock()
+		o.pruneCaptures(now)
+		for i, armed := range o.captures {
+			if armed.cwd == cwd {
+				terminalID = armed.terminalID
+				o.captures = append(o.captures[:i], o.captures[i+1:]...)
+				break
+			}
+		}
+		o.mu.Unlock()
+	}
+
+	if terminalID == "" {
+		var candidates []string
+		for _, terminal := range o.terminals.List("") {
+			if terminal.Agent == "codex" && terminal.Status == api.TerminalRunning && terminal.Directory == cwd {
+				candidates = append(candidates, terminal.ID)
+			}
+		}
+		if len(candidates) != 1 {
+			o.logger.Debug("codex thread not attributable", "candidates", len(candidates), "cwd", cwd)
+			return
+		}
+		terminalID = candidates[0]
+	}
+
+	terminal, err := o.terminals.Get(terminalID)
+	if err != nil || !terminalHoldable(terminal) {
+		// A capture whose terminal definitively left (failed launch,
+		// exited TUI, deleted record) must not bind a conversation to it.
+		// A transiently unreachable terminal is no evidence of leaving —
+		// the same rule the threads sweep applies.
+		o.logger.Warn("codex capture for a terminal that has left dropped", "terminal", terminalID)
+		return
+	}
+	metadata := threads.Metadata{Cwd: cwd, Title: o.threadPreview(ctx, providerID)}
+	if _, err := o.threads.ObserveSession(ctx, threads.SessionObservation{
+		Agent:      "codex",
+		ProviderID: providerID,
+		TerminalID: terminalID,
+		ProjectID:  terminal.ProjectID,
+		At:         now,
+		Metadata:   metadata,
+	}); err != nil {
+		o.logger.Warn("recording codex session observation", "error", err)
+		return
+	}
+	o.mu.Lock()
+	if _, tracked := o.observed[providerID]; !tracked {
+		o.observed[providerID] = api.ThreadUnknown
+	}
+	o.mu.Unlock()
+}
+
+func (o *Observer) observeStatus(ctx context.Context, providerID string, status api.ThreadStatus) {
+	// The shared server broadcasts every client's threads; only mapped
+	// conversations reach the seam or the teardown set.
+	if _, _, known := o.threads.LookupIdentity("codex", providerID); !known {
+		return
+	}
+	if err := o.threads.ObserveStatus(ctx, threads.StatusObservation{
+		Agent: "codex", ProviderID: providerID, At: o.now(), Status: status,
+	}); err != nil {
+		o.logger.Warn("recording codex status observation", "error", err)
+		return
+	}
+	o.mu.Lock()
+	o.observed[providerID] = status
+	o.mu.Unlock()
+}
+
+// threadPreview reads the thread's preview — the only first-prompt
+// evidence a passive socket can reach — as the observed default title.
+// Best-effort: any failure is an empty title.
+func (o *Observer) threadPreview(ctx context.Context, providerID string) string {
+	o.mu.Lock()
+	conn := o.conn
+	o.mu.Unlock()
+	if conn == nil {
+		return ""
+	}
+	callCtx, cancel := context.WithTimeout(ctx, connectTimeout)
+	defer cancel()
+	result, err := conn.call(callCtx, "thread/read", map[string]any{"threadId": providerID})
+	if err != nil {
+		return ""
+	}
+	var p struct {
+		Thread struct {
+			Preview string `json:"preview"`
+		} `json:"thread"`
+	}
+	if err := json.Unmarshal(result, &p); err != nil {
+		return ""
+	}
+	return agents.CondenseTitle(p.Thread.Preview)
+}
+
+// pruneCaptures drops armed captures past the window. Callers hold mu.
+func (o *Observer) pruneCaptures(now time.Time) {
+	kept := o.captures[:0]
+	for _, armed := range o.captures {
+		if now.Sub(armed.armedAt) <= captureWindow {
+			kept = append(kept, armed)
+		}
+	}
+	o.captures = kept
+}
+
+// statusToThreadStatus maps the wire status shape to the thread
+// vocabulary; anything unrecognized is honestly unknown.
+func statusToThreadStatus(raw json.RawMessage) api.ThreadStatus {
+	var status struct {
+		Type        string   `json:"type"`
+		ActiveFlags []string `json:"activeFlags"`
+	}
+	if err := json.Unmarshal(raw, &status); err != nil {
+		return api.ThreadUnknown
+	}
+	switch status.Type {
+	case "idle":
+		return api.ThreadIdle
+	case "active":
+		for _, flag := range status.ActiveFlags {
+			switch flag {
+			case "waitingOnUserInput":
+				return api.ThreadWaitingForInput
+			case "waitingOnApproval":
+				return api.ThreadWaitingForPermission
+			}
+		}
+		return api.ThreadWorking
+	case "systemError":
+		// A faulted thread is error, not mere lack of evidence.
+		return api.ThreadError
+	}
+	return api.ThreadUnknown
+}
+
+func isJSONString(raw json.RawMessage) bool {
+	var s string
+	return json.Unmarshal(raw, &s) == nil
+}
+
+// probeSocket answers whether anything completes a WebSocket upgrade on
+// the control socket — nothing more; the initialize handshake right after
+// is what gates use.
+func probeSocket(ctx context.Context, socketPath string) bool {
+	probeCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+	ws, err := dialSocket(probeCtx, socketPath)
+	if err != nil {
+		return false
+	}
+	_ = ws.Close(websocket.StatusNormalClosure, "probe")
+	return true
+}
+
+// dialSocket opens the WebSocket over the unix control socket.
+func dialSocket(ctx context.Context, socketPath string) (*websocket.Conn, error) {
+	client := &http.Client{Transport: &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			var dialer net.Dialer
+			return dialer.DialContext(ctx, "unix", socketPath)
+		},
+	}}
+	ws, _, err := websocket.Dial(ctx, "ws://localhost/", &websocket.DialOptions{HTTPClient: client})
+	if err != nil {
+		return nil, err
+	}
+	ws.SetReadLimit(maxMessageBytes)
+	return ws, nil
+}
+
+// rpcConn is the JSON-RPC framing over one WebSocket: numbered requests
+// matched to replies, notifications dispatched to the observer, and a
+// close callback for teardown.
+type rpcConn struct {
+	ws     *websocket.Conn
+	logger *slog.Logger
+
+	onNotification func(method string, params json.RawMessage)
+	onClose        func(reason error)
+	// notifications decouples dispatch from the read loop: a handler may
+	// issue RPCs (thread/read) whose replies the read loop must stay free
+	// to receive, while one dispatcher goroutine preserves broadcast
+	// order. Overflow fails the connection — the observer re-derives on
+	// reconnect rather than silently losing transitions. done ends both
+	// loops; the channel itself is never closed (the read loop must never
+	// race a send against it).
+	notifications chan notification
+	done          chan struct{}
+	// dispatcherDone closes when the dispatch loop has fully exited; fail
+	// joins it before teardown, so no handler can apply evidence after
+	// teardown coerced everything to unknown.
+	dispatcherDone chan struct{}
+
+	writeMu sync.Mutex
+
+	mu      sync.Mutex
+	nextID  int64
+	pending map[int64]chan rpcReply
+	closed  bool
+}
+
+type notification struct {
+	method string
+	params json.RawMessage
+}
+
+// notificationBuffer bounds the dispatch queue.
+const notificationBuffer = 256
+
+type rpcReply struct {
+	result json.RawMessage
+	err    error
+}
+
+type rpcMessage struct {
+	ID     *int64          `json:"id,omitempty"`
+	Method string          `json:"method,omitempty"`
+	Params json.RawMessage `json:"params,omitempty"`
+	Result json.RawMessage `json:"result,omitempty"`
+	Error  *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (e *rpcError) Error() string { return fmt.Sprintf("rpc %d: %s", e.Code, e.Message) }
+
+func newRPCConn(ws *websocket.Conn, logger *slog.Logger) *rpcConn {
+	return &rpcConn{
+		ws: ws, logger: logger, nextID: 1,
+		pending:        map[int64]chan rpcReply{},
+		notifications:  make(chan notification, notificationBuffer),
+		done:           make(chan struct{}),
+		dispatcherDone: make(chan struct{}),
+	}
+}
+
+func (c *rpcConn) start() {
+	go c.readLoop()
+	go c.dispatchLoop()
+}
+
+// dispatchLoop delivers notifications in arrival order until fail ends
+// the connection.
+func (c *rpcConn) dispatchLoop() {
+	defer close(c.dispatcherDone)
+	for {
+		select {
+		case <-c.done:
+			return
+		case n := <-c.notifications:
+			if c.onNotification != nil {
+				c.onNotification(n.method, n.params)
+			}
+		}
+	}
+}
+
+func (c *rpcConn) readLoop() {
+	ctx := context.Background()
+	for {
+		_, data, err := c.ws.Read(ctx)
+		if err != nil {
+			c.fail(err)
+			return
+		}
+		var message rpcMessage
+		if err := json.Unmarshal(data, &message); err != nil {
+			c.fail(fmt.Errorf("invalid frame from codex app-server: %w", err))
+			return
+		}
+		switch {
+		case message.ID != nil && message.Method == "":
+			c.mu.Lock()
+			waiter, ok := c.pending[*message.ID]
+			delete(c.pending, *message.ID)
+			c.mu.Unlock()
+			if ok {
+				reply := rpcReply{result: message.Result}
+				if message.Error != nil {
+					reply.err = message.Error
+				}
+				waiter <- reply
+			}
+		case message.Method != "" && message.ID == nil:
+			select {
+			case c.notifications <- notification{method: message.Method, params: message.Params}:
+			case <-c.done:
+				return
+			default:
+				c.fail(errors.New("codex app-server notifications overflowed the dispatch queue"))
+				return
+			}
+		default:
+			// A server request (id + method). ATC is a passive observer
+			// and answers nothing; codex does not direct requests at
+			// observer connections.
+			c.logger.Debug("unexpected codex server request ignored", "method", message.Method)
+		}
+	}
+}
+
+// fail ends the connection: every pending call errors and onClose fires
+// exactly once.
+func (c *rpcConn) fail(reason error) {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	c.closed = true
+	pending := c.pending
+	c.pending = map[int64]chan rpcReply{}
+	c.mu.Unlock()
+	for _, waiter := range pending {
+		waiter <- rpcReply{err: reason}
+	}
+	close(c.done)
+	_ = c.ws.CloseNow()
+	// Join the dispatcher before teardown: an in-flight handler's RPCs
+	// fail fast (pending was just flushed), so this is bounded, and it
+	// guarantees no evidence lands after teardown coerces to unknown.
+	<-c.dispatcherDone
+	if c.onClose != nil {
+		c.onClose(reason)
+	}
+}
+
+func (c *rpcConn) close() {
+	c.fail(errors.New("connection closed"))
+}
+
+func (c *rpcConn) call(ctx context.Context, method string, params any) (json.RawMessage, error) {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil, errors.New("connection closed")
+	}
+	id := c.nextID
+	c.nextID++
+	waiter := make(chan rpcReply, 1)
+	c.pending[id] = waiter
+	c.mu.Unlock()
+
+	if err := c.write(ctx, rpcMessage{ID: &id, Method: method, Params: mustMarshal(params)}); err != nil {
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return nil, err
+	}
+	// The caller's context is the deadline; every caller bounds it.
+	select {
+	case reply := <-waiter:
+		return reply.result, reply.err
+	case <-ctx.Done():
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return nil, ctx.Err()
+	}
+}
+
+// notify sends one notification; the caller's context bounds the write —
+// a stalled server must not block a launch on an unbounded send.
+func (c *rpcConn) notify(ctx context.Context, method string, params any) error {
+	return c.write(ctx, rpcMessage{Method: method, Params: mustMarshal(params)})
+}
+
+func (c *rpcConn) write(ctx context.Context, message rpcMessage) error {
+	data, err := json.Marshal(message)
+	if err != nil {
+		return err
+	}
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	return c.ws.Write(ctx, websocket.MessageText, data)
+}
+
+func mustMarshal(params any) json.RawMessage {
+	data, err := json.Marshal(params)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}

--- a/internal/agents/codex/observer_test.go
+++ b/internal/agents/codex/observer_test.go
@@ -1,0 +1,442 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/jeremytondo/atc/internal/api"
+	"github.com/jeremytondo/atc/internal/threads"
+)
+
+// fakeAppServer speaks the app-server's wire protocol over a real unix
+// WebSocket: it answers initialize and thread/read, records requests, and
+// broadcasts whatever a test pushes.
+type fakeAppServer struct {
+	t        *testing.T
+	socket   string
+	server   *http.Server
+	listener net.Listener
+
+	mu       sync.Mutex
+	conns    []*websocket.Conn
+	requests []string
+	previews map[string]string
+	loaded   []string
+}
+
+func newFakeAppServer(t *testing.T) *fakeAppServer {
+	t.Helper()
+	socket := filepath.Join(t.TempDir(), "app-server-control.sock")
+	listener, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := &fakeAppServer{t: t, socket: socket, listener: listener, previews: map[string]string{}}
+	f.server = &http.Server{Handler: http.HandlerFunc(f.handle)}
+	go func() { _ = f.server.Serve(listener) }()
+	t.Cleanup(func() { _ = f.server.Close() })
+	return f
+}
+
+func (f *fakeAppServer) handle(w http.ResponseWriter, r *http.Request) {
+	ws, err := websocket.Accept(w, r, nil)
+	if err != nil {
+		return
+	}
+	f.mu.Lock()
+	f.conns = append(f.conns, ws)
+	f.mu.Unlock()
+	ctx := context.Background()
+	for {
+		_, data, err := ws.Read(ctx)
+		if err != nil {
+			return
+		}
+		var message rpcMessage
+		if err := json.Unmarshal(data, &message); err != nil {
+			return
+		}
+		f.mu.Lock()
+		f.requests = append(f.requests, message.Method)
+		previews := f.previews
+		f.mu.Unlock()
+		if message.ID == nil {
+			continue // notification (initialized)
+		}
+		var result any = map[string]any{}
+		if message.Method == "thread/loaded/list" {
+			f.mu.Lock()
+			result = map[string]any{"data": append([]string(nil), f.loaded...)}
+			f.mu.Unlock()
+		}
+		if message.Method == "thread/read" {
+			var params struct {
+				ThreadID string `json:"threadId"`
+			}
+			_ = json.Unmarshal(message.Params, &params)
+			result = map[string]any{"thread": map[string]any{"id": params.ThreadID, "preview": previews[params.ThreadID]}}
+		}
+		reply, _ := json.Marshal(map[string]any{"id": *message.ID, "result": result})
+		_ = ws.Write(ctx, websocket.MessageText, reply)
+	}
+}
+
+// broadcast pushes one notification to every connection.
+func (f *fakeAppServer) broadcast(method string, params any) {
+	data, err := json.Marshal(map[string]any{"method": method, "params": params})
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	f.mu.Lock()
+	conns := append([]*websocket.Conn(nil), f.conns...)
+	f.mu.Unlock()
+	for _, ws := range conns {
+		_ = ws.Write(context.Background(), websocket.MessageText, data)
+	}
+}
+
+func (f *fakeAppServer) closeConns() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, ws := range f.conns {
+		_ = ws.CloseNow()
+	}
+	f.conns = nil
+}
+
+// fakeThreads records observations; fakeTerminalDir serves terminals.
+type fakeThreads struct {
+	mu       sync.Mutex
+	sessions []threads.SessionObservation
+	statuses []threads.StatusObservation
+}
+
+func (f *fakeThreads) ObserveSession(_ context.Context, o threads.SessionObservation) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sessions = append(f.sessions, o)
+	return "thrd-aaaaa", nil
+}
+
+func (f *fakeThreads) ObserveStatus(_ context.Context, o threads.StatusObservation) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.statuses = append(f.statuses, o)
+	return nil
+}
+
+// LookupIdentity mirrors the real mapping: a conversation is known only
+// once a session observation recorded it, bound to that observation's
+// terminal. Tests pre-seed f.sessions to fabricate restart state.
+func (f *fakeThreads) LookupIdentity(_, providerID string) (string, string, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, session := range f.sessions {
+		if session.ProviderID == providerID {
+			return "thrd-aaaaa", session.TerminalID, true
+		}
+	}
+	return "", "", false
+}
+
+func (f *fakeThreads) wait(t *testing.T, check func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		f.mu.Lock()
+		done := check()
+		f.mu.Unlock()
+		if done {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("condition never held")
+}
+
+type fakeTerminalDir struct {
+	mu        sync.Mutex
+	terminals map[string]api.Terminal
+}
+
+func (f *fakeTerminalDir) Get(id string) (api.Terminal, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	terminal, ok := f.terminals[id]
+	if !ok {
+		return api.Terminal{}, errors.New("terminal not found")
+	}
+	return terminal, nil
+}
+
+func (f *fakeTerminalDir) List(string) []api.Terminal {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	list := make([]api.Terminal, 0, len(f.terminals))
+	for _, terminal := range f.terminals {
+		list = append(list, terminal)
+	}
+	return list
+}
+
+type observerFixture struct {
+	observer  *Observer
+	appServer *fakeAppServer
+	threads   *fakeThreads
+	terminals *fakeTerminalDir
+}
+
+func newObserverFixture(t *testing.T) *observerFixture {
+	t.Helper()
+	appServer := newFakeAppServer(t)
+	threadsSeam := &fakeThreads{}
+	terminals := &fakeTerminalDir{terminals: map[string]api.Terminal{
+		"term-aaaaa": {ID: "term-aaaaa", ProjectID: "proj-aaaaa", Agent: "codex", Directory: "/proj-a", Status: api.TerminalRunning},
+	}}
+	observer := NewObserver(ObserverOptions{
+		Supervisor: NewSupervisor(SupervisorOptions{
+			CodexHome:    t.TempDir(),
+			IdentityFile: filepath.Join(t.TempDir(), "id.json"),
+			LogFile:      filepath.Join(t.TempDir(), "log"),
+			SpawnDir:     t.TempDir(),
+		}),
+		Threads:   threadsSeam,
+		Terminals: terminals,
+	})
+	if err := observer.connect(context.Background(), appServer.socket); err != nil {
+		t.Fatal(err)
+	}
+	return &observerFixture{observer: observer, appServer: appServer, threads: threadsSeam, terminals: terminals}
+}
+
+func TestObserverCapturesArmedLaunch(t *testing.T) {
+	f := newObserverFixture(t)
+	f.observer.mu.Lock()
+	f.observer.captures = append(f.observer.captures, capture{terminalID: "term-aaaaa", cwd: "/proj-a", armedAt: time.Now()})
+	f.observer.mu.Unlock()
+	f.appServer.mu.Lock()
+	f.appServer.previews["conv-1"] = "please fix the flaky build"
+	f.appServer.mu.Unlock()
+
+	f.appServer.broadcast("thread/started", map[string]any{"thread": map[string]any{"id": "conv-1", "cwd": "/proj-a"}})
+	f.threads.wait(t, func() bool { return len(f.threads.sessions) == 1 })
+
+	session := f.threads.sessions[0]
+	if session.Agent != "codex" || session.ProviderID != "conv-1" || session.TerminalID != "term-aaaaa" ||
+		session.ProjectID != "proj-aaaaa" || session.Metadata.Cwd != "/proj-a" {
+		t.Errorf("session = %+v", session)
+	}
+	if session.Metadata.Title != "please fix the flaky build" {
+		t.Errorf("title from preview = %q", session.Metadata.Title)
+	}
+	// The capture is consumed: a second broadcast falls back to the
+	// single-candidate rule (still term-aaaaa here).
+	f.observer.mu.Lock()
+	remaining := len(f.observer.captures)
+	f.observer.mu.Unlock()
+	if remaining != 0 {
+		t.Errorf("capture not consumed: %d armed", remaining)
+	}
+}
+
+// A subagent's thread/started (string parentThreadId) never binds a
+// terminal.
+func TestObserverIgnoresSubagentBroadcasts(t *testing.T) {
+	f := newObserverFixture(t)
+	f.appServer.broadcast("thread/started", map[string]any{"thread": map[string]any{
+		"id": "conv-child", "cwd": "/proj-a", "parentThreadId": "conv-parent",
+	}})
+	// Follow with a capturable broadcast so there is a sync point: the
+	// dispatch queue is ordered, so the subagent one was processed first.
+	f.appServer.broadcast("thread/started", map[string]any{"thread": map[string]any{"id": "conv-sync", "cwd": "/proj-a"}})
+	f.threads.wait(t, func() bool { return len(f.threads.sessions) == 1 })
+	if f.threads.sessions[0].ProviderID != "conv-sync" {
+		t.Errorf("subagent broadcast captured: %+v", f.threads.sessions)
+	}
+}
+
+// An in-TUI switch (/new): no armed capture, one running codex terminal
+// at the cwd — attributed; ambiguity drops it.
+func TestObserverUnarmedAttribution(t *testing.T) {
+	f := newObserverFixture(t)
+	f.appServer.broadcast("thread/started", map[string]any{"thread": map[string]any{"id": "conv-2", "cwd": "/proj-a"}})
+	f.threads.wait(t, func() bool { return len(f.threads.sessions) == 1 })
+	if f.threads.sessions[0].TerminalID != "term-aaaaa" {
+		t.Errorf("session = %+v", f.threads.sessions[0])
+	}
+
+	// A second running codex terminal at the same directory makes the next
+	// broadcast ambiguous: dropped, never guessed.
+	f.terminals.mu.Lock()
+	f.terminals.terminals["term-bbbbb"] = api.Terminal{
+		ID: "term-bbbbb", ProjectID: "proj-aaaaa", Agent: "codex", Directory: "/proj-a", Status: api.TerminalRunning,
+	}
+	f.terminals.mu.Unlock()
+	f.appServer.broadcast("thread/started", map[string]any{"thread": map[string]any{"id": "conv-3", "cwd": "/proj-a"}})
+	// Sync on a status for the already-mapped conv-2: ordered dispatch
+	// means conv-3 was decided first.
+	f.appServer.broadcast("thread/status/changed", map[string]any{"threadId": "conv-2", "status": map[string]any{"type": "idle"}})
+	f.threads.wait(t, func() bool { return len(f.threads.statuses) == 1 })
+	if len(f.threads.sessions) != 1 {
+		t.Errorf("ambiguous broadcast attributed: %+v", f.threads.sessions)
+	}
+}
+
+func TestObserverStatusMapping(t *testing.T) {
+	f := newObserverFixture(t)
+	// Map the conversation first: status evidence flows only for known
+	// identities.
+	f.appServer.broadcast("thread/started", map[string]any{"thread": map[string]any{"id": "conv-1", "cwd": "/proj-a"}})
+	f.threads.wait(t, func() bool { return len(f.threads.sessions) == 1 })
+	cases := []struct {
+		status any
+		want   api.ThreadStatus
+	}{
+		{map[string]any{"type": "idle"}, api.ThreadIdle},
+		{map[string]any{"type": "active", "activeFlags": []string{}}, api.ThreadWorking},
+		{map[string]any{"type": "active", "activeFlags": []string{"waitingOnUserInput"}}, api.ThreadWaitingForInput},
+		{map[string]any{"type": "active", "activeFlags": []string{"waitingOnApproval"}}, api.ThreadWaitingForPermission},
+		{map[string]any{"type": "somethingNew"}, api.ThreadUnknown},
+	}
+	for i, c := range cases {
+		f.appServer.broadcast("thread/status/changed", map[string]any{"threadId": "conv-1", "status": c.status})
+		want := i + 1
+		f.threads.wait(t, func() bool { return len(f.threads.statuses) == want })
+		if got := f.threads.statuses[i]; got.Status != c.want || got.ProviderID != "conv-1" {
+			t.Errorf("case %d: %+v; want %s", i, got, c.want)
+		}
+	}
+}
+
+// A lost connection coerces everything this connection observed to
+// unknown — honest ignorance rather than a stale busy.
+func TestObserverTeardownEmitsUnknown(t *testing.T) {
+	f := newObserverFixture(t)
+	f.appServer.broadcast("thread/started", map[string]any{"thread": map[string]any{"id": "conv-1", "cwd": "/proj-a"}})
+	f.appServer.broadcast("thread/started", map[string]any{"thread": map[string]any{"id": "conv-idle", "cwd": "/proj-a"}})
+	f.threads.wait(t, func() bool { return len(f.threads.sessions) == 2 })
+	f.appServer.broadcast("thread/status/changed", map[string]any{"threadId": "conv-1", "status": map[string]any{"type": "active", "activeFlags": []string{}}})
+	f.appServer.broadcast("thread/status/changed", map[string]any{"threadId": "conv-idle", "status": map[string]any{"type": "idle"}})
+	f.threads.wait(t, func() bool { return len(f.threads.statuses) == 2 })
+
+	f.appServer.closeConns()
+	// Only the live thread coerces; the idle one persists as idle — the
+	// same rule the threads domain applies to inactive threads.
+	f.threads.wait(t, func() bool { return len(f.threads.statuses) == 3 })
+	last := f.threads.statuses[2]
+	if last.ProviderID != "conv-1" || last.Status != api.ThreadUnknown {
+		t.Errorf("teardown observation = %+v; want unknown for conv-1 only", last)
+	}
+	f.observer.mu.Lock()
+	conn := f.observer.conn
+	f.observer.mu.Unlock()
+	if conn != nil {
+		t.Error("connection still installed after teardown")
+	}
+}
+
+// A fresh connection reconciles the server's loaded threads: boot
+// re-adoption returns live work to observation without waiting for the
+// next broadcast.
+func TestObserverReconcilesLoadedThreadsOnConnect(t *testing.T) {
+	appServer := newFakeAppServer(t)
+	appServer.mu.Lock()
+	appServer.loaded = []string{"conv-9"}
+	appServer.previews["conv-9"] = "resume the migration work"
+	appServer.mu.Unlock()
+	threadsSeam := &fakeThreads{}
+	terminals := &fakeTerminalDir{terminals: map[string]api.Terminal{
+		"term-aaaaa": {ID: "term-aaaaa", ProjectID: "proj-aaaaa", Agent: "codex", Directory: "", Status: api.TerminalRunning},
+	}}
+	observer := NewObserver(ObserverOptions{
+		Supervisor: NewSupervisor(SupervisorOptions{
+			CodexHome:    t.TempDir(),
+			IdentityFile: filepath.Join(t.TempDir(), "id.json"),
+			LogFile:      filepath.Join(t.TempDir(), "log"),
+			SpawnDir:     t.TempDir(),
+		}),
+		Threads:   threadsSeam,
+		Terminals: terminals,
+	})
+	// The fake's thread/read reports no cwd, matching the terminal whose
+	// Directory is empty — the single-candidate rule still decides.
+	if err := observer.connect(context.Background(), appServer.socket); err != nil {
+		t.Fatal(err)
+	}
+	threadsSeam.wait(t, func() bool { return len(threadsSeam.sessions) == 1 })
+	session := threadsSeam.sessions[0]
+	if session.ProviderID != "conv-9" || session.TerminalID != "term-aaaaa" {
+		t.Errorf("reconciled session = %+v", session)
+	}
+	if session.Metadata.Title != "resume the migration work" {
+		t.Errorf("reconciled title = %q", session.Metadata.Title)
+	}
+}
+
+// Status broadcasts for conversations the identity mapping does not know
+// (other clients on the shared server) never reach the threads seam.
+func TestObserverDropsForeignStatusBroadcasts(t *testing.T) {
+	f := newObserverFixture(t)
+	f.appServer.broadcast("thread/started", map[string]any{"thread": map[string]any{"id": "conv-1", "cwd": "/proj-a"}})
+	f.threads.wait(t, func() bool { return len(f.threads.sessions) == 1 })
+	f.appServer.broadcast("thread/status/changed", map[string]any{"threadId": "foreign-1", "status": map[string]any{"type": "active", "activeFlags": []string{}}})
+	f.appServer.broadcast("thread/status/changed", map[string]any{"threadId": "conv-1", "status": map[string]any{"type": "systemError"}})
+	f.threads.wait(t, func() bool { return len(f.threads.statuses) == 1 })
+	got := f.threads.statuses[0]
+	if got.ProviderID != "conv-1" || got.Status != api.ThreadError {
+		t.Errorf("status = %+v; want conv-1 error (foreign dropped, systemError mapped)", got)
+	}
+}
+
+// A loaded root the identity mapping already knows goes straight back to
+// its recorded terminal — the restart seed check — even when cwd alone
+// could not disambiguate.
+func TestObserverReconcileReattachesMapped(t *testing.T) {
+	appServer := newFakeAppServer(t)
+	appServer.mu.Lock()
+	appServer.loaded = []string{"conv-a", "conv-b"}
+	appServer.mu.Unlock()
+	threadsSeam := &fakeThreads{}
+	// Two running codex terminals in one directory: cwd attribution alone
+	// would drop both roots as ambiguous.
+	terminals := &fakeTerminalDir{terminals: map[string]api.Terminal{
+		"term-aaaaa": {ID: "term-aaaaa", ProjectID: "proj-aaaaa", Agent: "codex", Directory: "", Status: api.TerminalRunning},
+		"term-bbbbb": {ID: "term-bbbbb", ProjectID: "proj-aaaaa", Agent: "codex", Directory: "", Status: api.TerminalRunning},
+	}}
+	// The persisted mapping from before the restart: conv-a was held by
+	// term-aaaaa, conv-b by term-bbbbb.
+	threadsSeam.sessions = []threads.SessionObservation{
+		{Agent: "codex", ProviderID: "conv-a", TerminalID: "term-aaaaa"},
+		{Agent: "codex", ProviderID: "conv-b", TerminalID: "term-bbbbb"},
+	}
+	observer := NewObserver(ObserverOptions{
+		Supervisor: NewSupervisor(SupervisorOptions{
+			CodexHome:    t.TempDir(),
+			IdentityFile: filepath.Join(t.TempDir(), "id.json"),
+			LogFile:      filepath.Join(t.TempDir(), "log"),
+			SpawnDir:     t.TempDir(),
+		}),
+		Threads:   threadsSeam,
+		Terminals: terminals,
+	})
+	if err := observer.connect(context.Background(), appServer.socket); err != nil {
+		t.Fatal(err)
+	}
+	threadsSeam.wait(t, func() bool { return len(threadsSeam.sessions) == 4 })
+	got := map[string]string{}
+	for _, session := range threadsSeam.sessions[2:] {
+		got[session.ProviderID] = session.TerminalID
+	}
+	if got["conv-a"] != "term-aaaaa" || got["conv-b"] != "term-bbbbb" {
+		t.Errorf("reattached bindings = %v; want the persisted mapping honored", got)
+	}
+}

--- a/internal/agents/codex/server.go
+++ b/internal/agents/codex/server.go
@@ -1,0 +1,441 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// The shared app-server lifecycle follows the proven legacy playbook:
+// adopt whatever answers on Codex's well-known control socket, start one
+// only if nothing does, spawn detached so the server survives ATC
+// restarts, re-verify a persisted pid against its command line before
+// ever trusting or signaling it, and never signal a server ATC did not
+// start. A codex TUI launched with --remote dies the instant its
+// app-server dies, so ATC shutdown deliberately leaves the server
+// running.
+
+const (
+	// probeTimeout bounds one "does anything answer" WebSocket upgrade.
+	probeTimeout = time.Second
+	// readyTimeout is how long a freshly spawned server gets to answer.
+	readyTimeout = 15 * time.Second
+	// adoptTimeout is how long our own already-running but silent server
+	// gets — deliberately generous: wrongly declaring it dead would kill
+	// every attached TUI.
+	adoptTimeout = 10 * time.Second
+	// awaitInterval paces probes while waiting on a pid.
+	awaitInterval = 250 * time.Millisecond
+	// argvToken is the exact whitespace-delimited word a trusted pid's
+	// command line must contain (substring matching would hit any path
+	// containing it).
+	argvToken = "app-server"
+)
+
+// errServerExited reports a pid that died while we waited on its socket.
+var errServerExited = errors.New("codex app-server exited before answering")
+
+// ControlSocketPath is Codex's own well-known control socket, one per
+// CODEX_HOME. ATC never binds any other address and never runs a private
+// server.
+func ControlSocketPath(codexHome string) string {
+	return filepath.Join(codexHome, "app-server-control", "app-server-control.sock")
+}
+
+// CodexHome resolves the CODEX_HOME the spawned server (and every codex
+// TUI) will use: codex's own variable, never an ATC setting.
+func CodexHome() (string, error) {
+	if home := os.Getenv("CODEX_HOME"); home != "" {
+		return home, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".codex"), nil
+}
+
+// identity is the persisted claim "we started pid at startedAt". Absent
+// or corrupt means "no server of ours" — never trusted.
+type identity struct {
+	PID       int    `json:"pid"`
+	StartedAt string `json:"startedAt"`
+}
+
+// SupervisorOptions wires a Supervisor. The function fields are seams for
+// tests; nil selects the real implementation.
+type SupervisorOptions struct {
+	// CodexHome locates the well-known control socket.
+	CodexHome string
+	// IdentityFile persists {pid, startedAt} (paths.CodexServerFile).
+	IdentityFile string
+	// LogFile captures the detached server's output (paths.CodexServerLogFile).
+	LogFile string
+	// SpawnDir is the neutral cwd the server starts in: codex stamps
+	// threads whose client sent no cwd with the server's own cwd, so an
+	// inherited launch directory would leak into threads.
+	SpawnDir string
+	// Executable is the codex binary name, resolved on PATH at spawn.
+	Executable string
+	Logger     *slog.Logger
+
+	Probe        func(ctx context.Context, socketPath string) bool
+	Spawn        func(ctx context.Context) (int, error)
+	ProcessAlive func(pid int) bool
+	HasArgvToken func(pid int, token string) bool
+	Terminate    func(pid int) error
+}
+
+// Supervisor owns adopt-or-start over the shared app-server. All entry
+// points serialize on mu, so concurrent launches cannot race two spawns.
+type Supervisor struct {
+	opts SupervisorOptions
+	// readyWindow and adoptWindow are readyTimeout/adoptTimeout in
+	// production; tests shrink them.
+	readyWindow, adoptWindow time.Duration
+
+	mu sync.Mutex
+	// socket is the adopted socket path once any acquire succeeded; pid is
+	// nonzero only for a server we started (the only pid ever signaled).
+	socket string
+	pid    int
+}
+
+func NewSupervisor(opts SupervisorOptions) *Supervisor {
+	if opts.Executable == "" {
+		opts.Executable = "codex"
+	}
+	if opts.Logger == nil {
+		opts.Logger = slog.New(slog.DiscardHandler)
+	}
+	s := &Supervisor{opts: opts, readyWindow: readyTimeout, adoptWindow: adoptTimeout}
+	if s.opts.Probe == nil {
+		s.opts.Probe = probeSocket
+	}
+	if s.opts.Spawn == nil {
+		s.opts.Spawn = s.spawnDetached
+	}
+	if s.opts.ProcessAlive == nil {
+		s.opts.ProcessAlive = processAlive
+	}
+	if s.opts.HasArgvToken == nil {
+		s.opts.HasArgvToken = hasArgvToken
+	}
+	if s.opts.Terminate == nil {
+		s.opts.Terminate = terminate
+	}
+	return s
+}
+
+func (s *Supervisor) socketPath() string {
+	return ControlSocketPath(s.opts.CodexHome)
+}
+
+// Ensure adopts or starts the shared server and returns its socket path —
+// the first codex launch's lazy start, and every later launch's fast
+// path.
+func (s *Supervisor) Ensure(ctx context.Context) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.socket != "" && (s.pid == 0 || s.opts.ProcessAlive(s.pid)) && s.opts.Probe(ctx, s.socket) {
+		return s.socket, nil
+	}
+	s.socket, s.pid = "", 0
+	return s.acquire(ctx, true)
+}
+
+// Adopt is the boot-time re-adoption: connect to whatever is there so
+// live work returns to observation, but never start a server no demand
+// asked for. False means nothing answered.
+func (s *Supervisor) Adopt(ctx context.Context) (string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	socket, err := s.acquire(ctx, false)
+	if err != nil {
+		s.opts.Logger.Debug("no codex app-server to adopt", "error", err)
+		return "", false
+	}
+	return socket, true
+}
+
+// Socket reports the last acquired socket path, empty when no server has
+// ever been acquired this process. The observer keys its connection loop
+// on it.
+func (s *Supervisor) Socket() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.socket
+}
+
+// OwnedPID reports the pid of a server this process started, zero for an
+// adopted (foreign) server.
+func (s *Supervisor) OwnedPID() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.pid
+}
+
+// acquire implements adopt-or-start. Caller holds mu.
+func (s *Supervisor) acquire(ctx context.Context, allowSpawn bool) (string, error) {
+	socketPath := s.socketPath()
+
+	// Something answers: adopt it. It is "ours" only when the persisted
+	// identity's pid re-verifies against its command line — pid recycling
+	// defense before the pid is ever trusted.
+	if s.opts.Probe(ctx, socketPath) {
+		if pid, ok := s.readIdentity(); ok && s.isOurServer(pid) {
+			s.socket, s.pid = socketPath, pid
+			s.opts.Logger.Info("codex app-server re-adopted", "pid", pid)
+		} else {
+			s.clearIdentity()
+			s.socket, s.pid = socketPath, 0
+			s.opts.Logger.Info("codex app-server adopted (not started by atc)")
+		}
+		return s.socket, nil
+	}
+
+	// Silent socket but a persisted pid of ours: it may still be booting.
+	if pid, ok := s.readIdentity(); ok {
+		if s.isOurServer(pid) {
+			answered, err := s.awaitAnswer(ctx, socketPath, pid, s.adoptWindow)
+			if answered {
+				s.socket, s.pid = socketPath, pid
+				return s.socket, nil
+			}
+			// Our own pid, alive or not, that will not answer: reap it so
+			// a fresh start can take the socket. This is the only signal
+			// path besides spawn cleanup; the argv token is re-verified
+			// right here — the wait window is exactly where a recycled
+			// pid could otherwise inherit the earlier blessing.
+			if err == nil || errors.Is(err, errServerExited) {
+				if s.opts.ProcessAlive(pid) && s.isOurServerPID(pid) {
+					if err := s.opts.Terminate(pid); err != nil {
+						return "", fmt.Errorf("codex app-server pid %d not answering and not terminable: %w", pid, err)
+					}
+				}
+			} else {
+				return "", err
+			}
+		}
+		s.clearIdentity()
+	}
+
+	if !allowSpawn {
+		return "", errors.New("no codex app-server answering")
+	}
+	return s.start(ctx, socketPath)
+}
+
+// start spawns the detached server and waits for it to answer. Caller
+// holds mu.
+func (s *Supervisor) start(ctx context.Context, socketPath string) (string, error) {
+	pid, err := s.opts.Spawn(ctx)
+	if err != nil {
+		return "", err
+	}
+	// Identity first: a crash between spawn and readiness must still leave
+	// the pid re-verifiable at the next boot.
+	if err := s.writeIdentity(pid); err != nil {
+		s.reap(pid)
+		return "", err
+	}
+	answered, waitErr := s.awaitAnswer(ctx, socketPath, pid, s.readyWindow)
+	switch {
+	case answered && s.opts.ProcessAlive(pid):
+		s.socket, s.pid = socketPath, pid
+		s.opts.Logger.Info("codex app-server started", "pid", pid)
+		return s.socket, nil
+	case answered:
+		// Raced: another client's server took the socket and ours exited
+		// "already in use". Adopt the winner.
+		s.clearIdentity()
+		s.socket, s.pid = socketPath, 0
+		s.opts.Logger.Info("codex app-server adopted (another client started it first)")
+		return s.socket, nil
+	default:
+		s.reap(pid)
+		detail := s.logTail()
+		if waitErr == nil {
+			waitErr = fmt.Errorf("codex app-server pid %d never answered on %s", pid, socketPath)
+		}
+		if detail != "" {
+			waitErr = fmt.Errorf("%w (%s)", waitErr, detail)
+		}
+		return "", waitErr
+	}
+}
+
+// awaitAnswer probes until the socket answers, the pid dies, or the
+// window closes. (false, nil) means the window closed with the pid alive.
+func (s *Supervisor) awaitAnswer(ctx context.Context, socketPath string, pid int, window time.Duration) (bool, error) {
+	deadline := time.Now().Add(window)
+	for {
+		if s.opts.Probe(ctx, socketPath) {
+			return true, nil
+		}
+		if !s.opts.ProcessAlive(pid) {
+			// Fail immediately rather than burning the window: the probe
+			// answering right after is the "raced" case the caller checks.
+			if s.opts.Probe(ctx, socketPath) {
+				return true, nil
+			}
+			return false, fmt.Errorf("%w: pid %d", errServerExited, pid)
+		}
+		if time.Now().After(deadline) {
+			return false, nil
+		}
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-time.After(awaitInterval):
+		}
+	}
+}
+
+// reap terminates a pid we spawned but could not use, after the argv
+// re-verification — otherwise failed starts accumulate servers.
+func (s *Supervisor) reap(pid int) {
+	if s.isOurServerPID(pid) {
+		if err := s.opts.Terminate(pid); err != nil {
+			s.opts.Logger.Warn("reaping failed codex app-server", "pid", pid, "error", err)
+		}
+	}
+	s.clearIdentity()
+}
+
+// isOurServer re-verifies a persisted pid against its live command line.
+func (s *Supervisor) isOurServer(pid int) bool {
+	return s.isOurServerPID(pid)
+}
+
+func (s *Supervisor) isOurServerPID(pid int) bool {
+	return pid > 0 && s.opts.HasArgvToken(pid, argvToken)
+}
+
+func (s *Supervisor) readIdentity() (int, bool) {
+	content, err := os.ReadFile(s.opts.IdentityFile)
+	if err != nil {
+		return 0, false
+	}
+	var id identity
+	if err := json.Unmarshal(content, &id); err != nil || id.PID <= 0 {
+		return 0, false
+	}
+	return id.PID, true
+}
+
+func (s *Supervisor) writeIdentity(pid int) error {
+	content, err := json.MarshalIndent(identity{PID: pid, StartedAt: time.Now().UTC().Format(time.RFC3339)}, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(s.opts.IdentityFile), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(s.opts.IdentityFile, content, 0o600)
+}
+
+func (s *Supervisor) clearIdentity() {
+	if err := os.Remove(s.opts.IdentityFile); err != nil && !errors.Is(err, os.ErrNotExist) {
+		s.opts.Logger.Warn("clearing codex app-server identity", "error", err)
+	}
+}
+
+// logTail is the last few log lines for failure diagnostics.
+func (s *Supervisor) logTail() string {
+	content, err := os.ReadFile(s.opts.LogFile)
+	if err != nil {
+		return ""
+	}
+	lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+	if len(lines) > 10 {
+		lines = lines[len(lines)-10:]
+	}
+	return strings.Join(lines, " · ")
+}
+
+// spawnDetached starts the server through an intermediate /bin/sh so it
+// reparents to init: nohup, output to the log file, stdin from /dev/null
+// (the server must never see EOF when ATC exits), and the child's single
+// stdout line is the detached pid. `--listen unix://` carries no path —
+// codex derives the well-known socket from the CODEX_HOME it inherits.
+func (s *Supervisor) spawnDetached(ctx context.Context) (int, error) {
+	executable, err := exec.LookPath(s.opts.Executable)
+	if err != nil {
+		return 0, fmt.Errorf("codex executable not found on PATH: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(s.opts.LogFile), 0o700); err != nil {
+		return 0, err
+	}
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c",
+		`nohup "$1" app-server --listen unix:// >"$2" 2>&1 </dev/null & echo $!`,
+		"sh", executable, s.opts.LogFile)
+	cmd.Dir = s.opts.SpawnDir
+	if env := os.Getenv("CODEX_HOME"); env == "" && s.opts.CodexHome != "" {
+		// Tests point CODEX_HOME at a private directory; production
+		// inherits the user's own.
+		cmd.Env = append(os.Environ(), "CODEX_HOME="+s.opts.CodexHome)
+	}
+	output, err := cmd.Output()
+	if err != nil {
+		return 0, fmt.Errorf("spawning codex app-server: %w", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(output)))
+	if err != nil || pid <= 0 {
+		return 0, fmt.Errorf("codex app-server spawn reported no pid: %q", output)
+	}
+	return pid, nil
+}
+
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	return syscall.Kill(pid, 0) == nil
+}
+
+// hasArgvToken requires an exact whitespace-delimited argv word. Any
+// failure means "not ours": the pid is never trusted, never signaled.
+func hasArgvToken(pid int, token string) bool {
+	output, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "command=").Output()
+	if err != nil {
+		return false
+	}
+	return slices.Contains(strings.Fields(string(output)), token)
+}
+
+// terminate is SIGTERM, wait, SIGKILL, wait. Callers gate it behind the
+// argv re-verification.
+func terminate(pid int) error {
+	_ = syscall.Kill(pid, syscall.SIGTERM)
+	if waitForExit(pid, 5*time.Second) {
+		return nil
+	}
+	_ = syscall.Kill(pid, syscall.SIGKILL)
+	if waitForExit(pid, 5*time.Second) {
+		return nil
+	}
+	return fmt.Errorf("process %d survived SIGTERM and SIGKILL", pid)
+}
+
+func waitForExit(pid int, window time.Duration) bool {
+	deadline := time.Now().Add(window)
+	for time.Now().Before(deadline) {
+		if !processAlive(pid) {
+			return true
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return !processAlive(pid)
+}

--- a/internal/agents/codex/server_test.go
+++ b/internal/agents/codex/server_test.go
@@ -1,0 +1,239 @@
+package codex
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeProcess scripts the supervision seams: which pids are alive, which
+// carry the app-server argv token, whether the socket answers, and what
+// spawning yields.
+type fakeProcess struct {
+	mu         sync.Mutex
+	answering  bool
+	alive      map[int]bool
+	ours       map[int]bool
+	spawnPID   int
+	spawnErr   error
+	spawned    int
+	terminated []int
+	// onSpawn runs before the spawn returns, e.g. to make the socket
+	// answer.
+	onSpawn func()
+}
+
+func (f *fakeProcess) probe(context.Context, string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.answering
+}
+
+func (f *fakeProcess) processAlive(pid int) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.alive[pid]
+}
+
+func (f *fakeProcess) hasArgvToken(pid int, _ string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.ours[pid]
+}
+
+func (f *fakeProcess) spawn(context.Context) (int, error) {
+	f.mu.Lock()
+	onSpawn := f.onSpawn
+	f.mu.Unlock()
+	if onSpawn != nil {
+		onSpawn()
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.spawned++
+	return f.spawnPID, f.spawnErr
+}
+
+func (f *fakeProcess) terminate(pid int) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.terminated = append(f.terminated, pid)
+	delete(f.alive, pid)
+	return nil
+}
+
+func (f *fakeProcess) set(fn func(f *fakeProcess)) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	fn(f)
+}
+
+func newTestSupervisor(t *testing.T, process *fakeProcess) *Supervisor {
+	t.Helper()
+	dir := t.TempDir()
+	s := NewSupervisor(SupervisorOptions{
+		CodexHome:    filepath.Join(dir, "codex-home"),
+		IdentityFile: filepath.Join(dir, "codex-app-server.json"),
+		LogFile:      filepath.Join(dir, "codex-app-server.log"),
+		SpawnDir:     dir,
+		Probe:        process.probe,
+		Spawn:        process.spawn,
+		ProcessAlive: process.processAlive,
+		HasArgvToken: process.hasArgvToken,
+		Terminate:    process.terminate,
+	})
+	// Waiting windows shrink so failure paths resolve in test time.
+	s.readyWindow, s.adoptWindow = 50*time.Millisecond, 50*time.Millisecond
+	return s
+}
+
+func writeIdentity(t *testing.T, s *Supervisor, pid int) {
+	t.Helper()
+	if err := s.writeIdentity(pid); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAdoptOrStartDecisionTable(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("answering server with our verified pid is re-adopted", func(t *testing.T) {
+		process := &fakeProcess{answering: true, alive: map[int]bool{42: true}, ours: map[int]bool{42: true}}
+		s := newTestSupervisor(t, process)
+		writeIdentity(t, s, 42)
+		socket, err := s.Ensure(ctx)
+		if err != nil || socket != s.socketPath() {
+			t.Fatalf("Ensure = %q, %v", socket, err)
+		}
+		if s.OwnedPID() != 42 || process.spawned != 0 {
+			t.Errorf("pid = %d, spawned = %d; want re-adoption", s.OwnedPID(), process.spawned)
+		}
+	})
+
+	t.Run("answering server with a recycled pid is adopted as foreign", func(t *testing.T) {
+		// The persisted pid is alive but its command line no longer carries
+		// the token: never trusted, never signaled.
+		process := &fakeProcess{answering: true, alive: map[int]bool{42: true}, ours: map[int]bool{}}
+		s := newTestSupervisor(t, process)
+		writeIdentity(t, s, 42)
+		if _, err := s.Ensure(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if s.OwnedPID() != 0 {
+			t.Errorf("recycled pid trusted: %d", s.OwnedPID())
+		}
+		if len(process.terminated) != 0 {
+			t.Errorf("recycled pid signaled: %v", process.terminated)
+		}
+		if _, ok := s.readIdentity(); ok {
+			t.Error("stale identity survived adoption")
+		}
+	})
+
+	t.Run("silent socket with our dead pid spawns fresh", func(t *testing.T) {
+		process := &fakeProcess{alive: map[int]bool{}, ours: map[int]bool{}, spawnPID: 77}
+		process.onSpawn = func() {
+			process.set(func(f *fakeProcess) { f.answering = true; f.alive[77] = true })
+		}
+		s := newTestSupervisor(t, process)
+		writeIdentity(t, s, 42)
+		if _, err := s.Ensure(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if s.OwnedPID() != 77 || process.spawned != 1 {
+			t.Errorf("pid = %d, spawned = %d; want a fresh start", s.OwnedPID(), process.spawned)
+		}
+		if pid, ok := s.readIdentity(); !ok || pid != 77 {
+			t.Errorf("identity = %d, %v; want the new pid persisted", pid, ok)
+		}
+	})
+
+	t.Run("losing the start race adopts the winner", func(t *testing.T) {
+		// Our spawn's pid exits ("address already in use") while the socket
+		// answers — another client's server won.
+		process := &fakeProcess{alive: map[int]bool{}, ours: map[int]bool{}, spawnPID: 77}
+		process.onSpawn = func() {
+			process.set(func(f *fakeProcess) { f.answering = true })
+		}
+		s := newTestSupervisor(t, process)
+		if _, err := s.Ensure(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if s.OwnedPID() != 0 {
+			t.Errorf("raced pid claimed as ours: %d", s.OwnedPID())
+		}
+		if _, ok := s.readIdentity(); ok {
+			t.Error("raced identity survived")
+		}
+	})
+
+	t.Run("a spawn that never answers is reaped", func(t *testing.T) {
+		process := &fakeProcess{alive: map[int]bool{77: true}, ours: map[int]bool{77: true}, spawnPID: 77}
+		s := newTestSupervisor(t, process)
+		if _, err := s.Ensure(ctx); err == nil {
+			t.Fatal("Ensure succeeded with nothing answering")
+		}
+		process.mu.Lock()
+		terminated := append([]int(nil), process.terminated...)
+		process.mu.Unlock()
+		if len(terminated) != 1 || terminated[0] != 77 {
+			t.Errorf("terminated = %v; want the failed spawn reaped", terminated)
+		}
+	})
+
+	t.Run("adopt-only never spawns", func(t *testing.T) {
+		process := &fakeProcess{alive: map[int]bool{}, ours: map[int]bool{}, spawnPID: 77}
+		s := newTestSupervisor(t, process)
+		if _, ok := s.Adopt(ctx); ok {
+			t.Error("Adopt claimed success with nothing answering")
+		}
+		if process.spawned != 0 {
+			t.Errorf("Adopt spawned %d servers", process.spawned)
+		}
+		// With something answering, adopt-only connects.
+		process.set(func(f *fakeProcess) { f.answering = true })
+		if _, ok := s.Adopt(ctx); !ok {
+			t.Error("Adopt missed an answering server")
+		}
+	})
+
+	t.Run("corrupt identity is never trusted", func(t *testing.T) {
+		process := &fakeProcess{answering: true, alive: map[int]bool{}, ours: map[int]bool{}}
+		s := newTestSupervisor(t, process)
+		if err := os.WriteFile(s.opts.IdentityFile, []byte("{broken"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := s.Ensure(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if s.OwnedPID() != 0 {
+			t.Errorf("corrupt identity yielded pid %d", s.OwnedPID())
+		}
+	})
+}
+
+func TestEnsureFastPathAndSpawnFailure(t *testing.T) {
+	ctx := context.Background()
+	process := &fakeProcess{answering: true, alive: map[int]bool{}, ours: map[int]bool{}}
+	s := newTestSupervisor(t, process)
+	if _, err := s.Ensure(ctx); err != nil {
+		t.Fatal(err)
+	}
+	// The fast path re-probes but never re-acquires.
+	if _, err := s.Ensure(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if process.spawned != 0 {
+		t.Errorf("fast path spawned %d servers", process.spawned)
+	}
+
+	// The server goes away and spawning fails: the error surfaces.
+	process.set(func(f *fakeProcess) { f.answering = false; f.spawnErr = errors.New("no codex") })
+	if _, err := s.Ensure(ctx); err == nil {
+		t.Fatal("Ensure succeeded with a failing spawn")
+	}
+}

--- a/internal/agents/service.go
+++ b/internal/agents/service.go
@@ -125,6 +125,17 @@ func (s *Service) Launch(ctx context.Context, id string, params api.AgentLaunchP
 	if name == "" {
 		name = entry.Name
 	}
+	// Prewarm runs slow launch-time work (starting and connecting the
+	// shared Codex app-server) before the terminals domain takes its
+	// commit lock — compose runs under that lock, and a cold provider
+	// start there would block every terminal mutation server-wide.
+	if warmer, ok := entry.TUI.(interface {
+		Prewarm(ctx context.Context) error
+	}); ok {
+		if err := warmer.Prewarm(ctx); err != nil {
+			return api.Terminal{}, fmt.Errorf("%w: %w", ErrUnavailable, err)
+		}
+	}
 	return s.terminals.CreateForAgent(ctx, api.TerminalCreateParams{
 		ProjectID: params.ProjectID,
 		Name:      name,

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -90,6 +90,18 @@ func HookDir() (string, error) {
 	return resolve("XDG_STATE_HOME", []string{".local", "state"}, "hooks")
 }
 
+// CodexServerFile persists the shared Codex app-server identity
+// ({pid, startedAt}, ATC-255) — re-verified against the live process
+// before it is ever trusted or signaled.
+func CodexServerFile() (string, error) {
+	return resolve("XDG_STATE_HOME", []string{".local", "state"}, "codex-app-server.json")
+}
+
+// CodexServerLogFile captures the detached Codex app-server's output.
+func CodexServerLogFile() (string, error) {
+	return resolve("XDG_STATE_HOME", []string{".local", "state"}, "codex-app-server.log")
+}
+
 func resolve(envVar string, fallback []string, file string) (string, error) {
 	if dir := os.Getenv(envVar); dir != "" {
 		return filepath.Join(dir, "atc", file), nil

--- a/internal/server/terminals_test.go
+++ b/internal/server/terminals_test.go
@@ -156,9 +156,23 @@ func newFixture(t *testing.T) *fixture {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// A codex observer over a private temp CODEX_HOME: constructed for
+	// registration only — codex stays unavailable in the fixture, so no
+	// launch ever reaches the supervisor.
+	codexObserver := codex.NewObserver(codex.ObserverOptions{
+		Supervisor: codex.NewSupervisor(codex.SupervisorOptions{
+			CodexHome:    t.TempDir(),
+			IdentityFile: filepath.Join(t.TempDir(), "codex-app-server.json"),
+			LogFile:      filepath.Join(t.TempDir(), "codex-app-server.log"),
+			SpawnDir:     t.TempDir(),
+		}),
+		Threads:   threadService,
+		Terminals: service,
+		Now:       now,
+	})
 	binaries := map[string]bool{"claude": true}
 	agentService, err := agents.NewService(agents.Options{
-		Entries:   []agents.Entry{claude.Entry(claudeHooks), codex.Entry()},
+		Entries:   []agents.Entry{claude.Entry(claudeHooks), codex.Entry(codexObserver)},
 		Terminals: service,
 		LookPath: func(name string) (string, error) {
 			if binaries[name] {


### PR DESCRIPTION
Third PR of ATC-255 (Threads), stacked on #261 (which stacks on #260) — merge in order. Codex conversations now reach the threads observation seam through the shared app-server.

## What's here

- **Supervisor** (`internal/agents/codex/server.go`), the proven legacy playbook: adopt whatever answers on Codex's well-known control socket (`$CODEX_HOME/app-server-control/app-server-control.sock`, probe = WebSocket upgrade); start only if nothing does, via a detached `nohup` spawn through `/bin/sh` (reparented to init, stdin from /dev/null, neutral cwd so the server's own directory never leaks into threads); persist `{pid, startedAt}` and re-verify the pid against its `ps -o command=` argv token before it is ever trusted or signaled — including a second re-verification at the one signal path, closing the await-window recycling gap; adopt the winner of a start race; never signal a server ATC did not start. Deliberately no auto-restart watcher: every `--remote` TUI dies with its server, so `Ensure` restarts lazily on the next launch instead of keeping an idle replacement warm.
- **Observer** (`observer.go`): one passive WebSocket (coder/websocket over the unix socket), minimal JSON-RPC (`initialize` handshake, `thread/read`, `thread/loaded/list`). Notifications flow through an ordered dispatch queue so handlers can issue RPCs while the read loop stays free for replies; `fail` joins the dispatcher before teardown so no evidence lands after everything coerces to `unknown`. `thread/started` drives identity capture (armed launch captures first, then single-running-terminal cwd attribution; subagent broadcasts with a string `parentThreadId` never bind; the terminal must be *running* at fire time); `thread/status/changed` maps `{idle, active, waitingOnUserInput, waitingOnApproval, systemError}` onto the thread vocabulary, gated through the identity mapping so foreign clients' broadcasts never reach the seam. Each fresh connection reconciles the server's loaded threads under the same single-candidate doctrine, so boot re-adoption returns live work to observation without waiting for the next broadcast. Thread titles default from `thread/read`'s preview via the shared UTF-8-safe condenser.
- **Launch composition** (`codex.go`): `EnsureForLaunch` adopts-or-starts, brings the observation connection up inline (a broadcast that beats the connection would be lost forever — a failed connect refuses the launch), arms the capture, and returns `codex --cd '<dir>' --remote 'unix://<socket>'` (`--cd` is load-bearing: remote TUIs don't forward their own cwd).
- **Boot**: `AdoptAtBoot` re-adopts only when a persisted identity or running codex terminals suggest live work; otherwise nothing happens until demand.
- **Tests**: the adopt-or-start decision table over scripted process seams (re-adopt, recycled-pid-as-foreign, spawn-after-death, race-adoption, reap-on-silent-spawn, adopt-only, corrupt identity), and observer tests against a fake app-server speaking the real wire protocol over a real unix WebSocket (armed capture with preview title, subagent guard, unarmed attribution + ambiguity drop, status mapping incl. `systemError`, foreign-broadcast gate, loaded-thread reconcile, teardown-to-unknown). Race detector on.

## Review notes

Two adversarial Codex reviews ran pre-PR, plus my own pass (which caught a dispatch/RPC deadlock and a connect-ordering bug before the reviews did). Adopted across them: inline connect at launch, dispatcher join before teardown, running-status check at capture fire, the loaded-thread reconcile, `systemError` mapping, the identity-mapping gate on broadcasts, pid re-verification at the signal path, watcher removal, shared title helper, and seam trims. Rejected with reasons, documented in code: the cwd-correlation looseness (a non-ATC `--remote` client sharing a directory with exactly one ATC codex terminal would be attributed to it, and same-cwd concurrent launches can theoretically swap — the per-TUI relay that would fix both is deliberately out of ATC-255's scope); the argv-token identity check and unused `startedAt` are the legacy playbook verbatim; the general pending-map RPC core stays because reply/notification interleaving needs it anyway. Known V1 limitation, also documented: only root threads are tracked — a parent briefly reports idle while a Codex subagent still runs, until its next status transition.

Linear: ATC-279 (part of ATC-255).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Codex session monitoring with live status updates and session discovery.
  - Codex can reuse an existing app server or start one automatically when needed.
  - Running Codex sessions can be recognized and continued after application restarts.
  - Launches preserve the selected working directory and connect through the shared server.
  - Added concise session titles with UTF-8 support.

- **Reliability**
  - Improved reconnection, shutdown handling, and recovery from interrupted Codex sessions.
  - Codex launch failures are detected earlier with clearer availability handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->